### PR TITLE
Form control directive clean up

### DIFF
--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -10,6 +10,7 @@
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
+import {composeAsyncValidators, composeValidators} from './shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 function unimplemented(): any {
@@ -62,19 +63,49 @@ export abstract class NgControl extends AbstractControlDirective {
 
   /**
    * @description
-   * The registered synchronous validator function for the control
+   * The synchronous validator for the control (composed on the first call of the validator getter)
    *
-   * @throws An exception that this method is not implemented
+   * @internal
    */
-  get validator(): ValidatorFn|null { return <ValidatorFn>unimplemented(); }
+  _validator: ValidatorFn|null|undefined;
+
+  /**
+   * @description
+   * The async validator for the control (composed on the first call of the asyncValidator getter)
+   *
+   * @internal
+   */
+  _asyncValidator: AsyncValidatorFn|null|undefined;
+
+  /**
+   * @description
+   * A function to call to unbind the directive from the form control.
+   *
+   * @internal
+   */
+  _unbind: undefined|(() => void);
+
+  /**
+   * @description
+   * The registered synchronous validator function for the control
+   */
+  get validator(): ValidatorFn|null {
+    if (this._validator === undefined) {
+      this._validator = composeValidators(this._rawValidators);
+    }
+    return this._validator;
+  }
 
   /**
    * @description
    * The registered async validator function for the control
-   *
-   * @throws An exception that this method is not implemented
    */
-  get asyncValidator(): AsyncValidatorFn|null { return <AsyncValidatorFn>unimplemented(); }
+  get asyncValidator(): AsyncValidatorFn|null {
+    if (this._asyncValidator === undefined) {
+      this._asyncValidator = composeAsyncValidators(this._rawAsyncValidators);
+    }
+    return this._asyncValidator;
+  }
 
   /**
    * @description

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -248,22 +248,6 @@ export class NgModel extends NgControl implements OnChanges,
 
               /**
                * @description
-               * Synchronous validator function composed of all the synchronous validators
-               * registered with this directive.
-               */
-              get validator(): ValidatorFn|null { return composeValidators(this._rawValidators); }
-
-              /**
-               * @description
-               * Async validator function composed of all the async validators registered with this
-               * directive.
-               */
-              get asyncValidator(): AsyncValidatorFn|null {
-                return composeAsyncValidators(this._rawAsyncValidators);
-              }
-
-              /**
-               * @description
                * Sets the new value for the view model and emits an `ngModelChange` event.
                *
                * @param newValue The new value emitted by `ngModelChange`.

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -215,22 +215,6 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
 
               /**
                * @description
-               * Synchronous validator function composed of all the synchronous validators
-               * registered with this directive.
-               */
-              get validator(): ValidatorFn|null { return composeValidators(this._rawValidators); }
-
-              /**
-               * @description
-               * Async validator function composed of all the async validators registered with this
-               * directive.
-               */
-              get asyncValidator(): AsyncValidatorFn|null {
-                return composeAsyncValidators(this._rawAsyncValidators);
-              }
-
-              /**
-               * @description
                * The `FormControl` bound to this directive.
                */
               get control(): FormControl { return this.form; }

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, Inject, InjectionToken, Input, OnChanges, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {Directive, EventEmitter, Inject, InjectionToken, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {FormControl} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
-import {_ngModelWarning, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
+import {_ngModelWarning, cleanUpControl, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 
@@ -31,7 +31,7 @@ export const formControlBinding: any = {
 /**
  * @description
  * * Syncs a standalone `FormControl` instance to a form control element.
- * 
+ *
  * @see [Reactive Forms Guide](guide/reactive-forms)
  * @see `FormControl`
  * @see `AbstractControl`
@@ -39,7 +39,7 @@ export const formControlBinding: any = {
  * @usageNotes
  *
  * ### Registering a single form control
- * 
+ *
  * The following examples shows how to register a standalone control and set its value.
  *
  * {@example forms/ts/simpleFormControl/simple_form_control_example.ts region='Component'}
@@ -116,7 +116,7 @@ export const formControlBinding: any = {
  */
 @Directive({selector: '[formControl]', providers: [formControlBinding], exportAs: 'ngForm'})
 
-export class FormControlDirective extends NgControl implements OnChanges {
+export class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
   /**
    * @description
    * Internal reference to the view model value.
@@ -183,6 +183,9 @@ export class FormControlDirective extends NgControl implements OnChanges {
                */
               ngOnChanges(changes: SimpleChanges): void {
                 if (this._isControlChanged(changes)) {
+                  if (changes.form.previousValue != null) {
+                    cleanUpControl(changes.form.previousValue, this);
+                  }
                   setUpControl(this.form, this);
                   if (this.control.disabled && this.valueAccessor !.setDisabledState) {
                     this.valueAccessor !.setDisabledState !(true);
@@ -194,6 +197,12 @@ export class FormControlDirective extends NgControl implements OnChanges {
                       'formControl', FormControlDirective, this, this._ngModelWarningConfig);
                   this.form.setValue(this.model);
                   this.viewModel = this.model;
+                }
+              }
+
+              ngOnDestroy() {
+                if (this.form != null) {
+                  cleanUpControl(this.form, this);
                 }
               }
 

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -246,22 +246,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    */
   get formDirective(): any { return this._parent ? this._parent.formDirective : null; }
 
-  /**
-   * @description
-   * Synchronous validator function composed of all the synchronous validators
-   * registered with this directive.
-   */
-  get validator(): ValidatorFn|null { return composeValidators(this._rawValidators); }
-
-  /**
-   * @description
-   * Async validator function composed of all the async validators registered with this
-   * directive.
-   */
-  get asyncValidator(): AsyncValidatorFn {
-    return composeAsyncValidators(this._rawAsyncValidators) !;
-  }
-
   private _checkParentType(): void {
     if (!(this._parent instanceof FormGroupName) &&
         this._parent instanceof AbstractFormGroupDirective) {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -149,7 +149,10 @@ export class FormGroupDirective extends ControlContainer implements Form,
    *
    * @param dir The `FormControlName` directive instance.
    */
-  removeControl(dir: FormControlName): void { removeDir<FormControlName>(this.directives, dir); }
+  removeControl(dir: FormControlName): void {
+    cleanUpControl(dir.control, dir);
+    removeDir<FormControlName>(this.directives, dir);
+  }
 
   /**
    * Adds a new `FormGroupName` directive instance to the form.

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -312,6 +312,17 @@ export interface ValidatorFn { (control: AbstractControl): ValidationErrors|null
 
 /**
  * @description
+ * A validator function created by calling Validator.compose, which exposes the
+ * validators it contains.
+ *
+ * @publicApi
+ */
+export interface ComposedValidatorFn extends ValidatorFn {
+  composition: (ValidatorFn|ComposedValidatorFn)[];
+}
+
+/**
+ * @description
  * A function that receives a control and returns a Promise or observable
  * that emits validation errors if present, otherwise null.
  *
@@ -319,6 +330,17 @@ export interface ValidatorFn { (control: AbstractControl): ValidationErrors|null
  */
 export interface AsyncValidatorFn {
   (control: AbstractControl): Promise<ValidationErrors|null>|Observable<ValidationErrors|null>;
+}
+
+/**
+ * @description
+ * A validator function created by calling Validator.composeAsync, which exposes the
+ * validators it contains.
+ *
+ * @publicApi
+ */
+export interface ComposedAsyncValidatorFn extends AsyncValidatorFn {
+  composition: (AsyncValidatorFn|ComposedAsyncValidatorFn)[];
 }
 
 /**

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -44,7 +44,7 @@ export {FormGroupName} from './directives/reactive_directives/form_group_name';
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
 export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
-export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
+export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, ComposedAsyncValidatorFn, ComposedValidatorFn, EmailValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -88,6 +88,20 @@ function coerceToAsyncValidator(
                                              origAsyncValidator || null;
 }
 
+function registerFn(array: Function[], fn: Function): () => void {
+  array.push(fn);
+  let registered = true;
+  return () => {
+    if (registered) {
+      let index = array.indexOf(fn);
+      if (index > -1) {
+        array.splice(index, 1);
+        registered = false;
+      }
+    }
+  };
+}
+
 export type FormHooks = 'change' | 'blur' | 'submit';
 
 /**
@@ -1108,8 +1122,10 @@ export class FormControl extends AbstractControl {
    * Register a listener for change events.
    *
    * @param fn The method that is called when the value changes
+   *
+   * @returns A function that unregisters the listener.
    */
-  registerOnChange(fn: Function): void { this._onChange.push(fn); }
+  registerOnChange(fn: Function): () => void { return registerFn(this._onChange, fn); }
 
   /**
    * @internal
@@ -1124,9 +1140,11 @@ export class FormControl extends AbstractControl {
    * Register a listener for disabled events.
    *
    * @param fn The method that is called when the disabled status changes.
+   *
+   * @returns A function that unregisters the listener.
    */
-  registerOnDisabledChange(fn: (isDisabled: boolean) => void): void {
-    this._onDisabledChange.push(fn);
+  registerOnDisabledChange(fn: (isDisabled: boolean) => void): () => void {
+    return registerFn(this._onDisabledChange, fn);
   }
 
   /**

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -312,6 +312,131 @@ import {first, map} from 'rxjs/operators';
       });
     });
 
+    describe('uncompose', () => {
+      it('should return null when the validator to modify is null',
+         () => { expect(Validators.uncompose(null !, null)).toBe(null); });
+
+      it('should return the unmodified validator when the validator to remove is null', () => {
+        const v = () => null;
+        expect(Validators.uncompose(v, null)).toBe(v);
+      });
+
+      it('should return null when the validator to remove is the one to modify', () => {
+        const v = () => null;
+        expect(Validators.uncompose(v, v)).toBe(null);
+      });
+
+      it('should return the first argument unmodified when it is unrelated to the second one',
+         () => {
+           const v1 = Validators.compose([() => null, () => null]);
+           const v2 = () => null;
+           expect(Validators.uncompose(v1, v2)).toBe(v1);
+         });
+
+      it('should return the original validator when it was composed only with the one to remove',
+         () => {
+           const v1 = () => null;
+           const v2 = () => null;
+           const composed = Validators.compose([v1, v2]);
+           expect(Validators.uncompose(composed, v2)).toBe(v1);
+           expect(Validators.uncompose(composed, v1)).toBe(v2);
+         });
+
+      it('should return a modified validator when the first argument is a 1-level composition with the second',
+         () => {
+           const v1 = jasmine.createSpy('v1');
+           const v2 = jasmine.createSpy('v2');
+           const v3 = jasmine.createSpy('v3');
+           const composed = Validators.compose([v1, v2, v3]);
+           const uncomposed = Validators.uncompose(composed, v2);
+           expect(uncomposed).not.toBe(composed);
+           uncomposed !(new FormControl());
+           expect(v1).toHaveBeenCalled();
+           expect(v2).not.toHaveBeenCalled();
+           expect(v3).toHaveBeenCalled();
+         });
+
+      it('should return a modified validator when the first argument is a 2-level composition with the second',
+         () => {
+           const v1 = jasmine.createSpy('v1');
+           const v2 = jasmine.createSpy('v2');
+           const v3 = jasmine.createSpy('v3');
+           const v4 = jasmine.createSpy('v4');
+           const composed = Validators.compose([v1, Validators.compose([v2, v3, v4])]);
+           const uncomposed = Validators.uncompose(composed, v2);
+           expect(uncomposed).not.toBe(composed);
+           uncomposed !(new FormControl());
+           expect(v1).toHaveBeenCalled();
+           expect(v2).not.toHaveBeenCalled();
+           expect(v3).toHaveBeenCalled();
+           expect(v4).toHaveBeenCalled();
+         });
+
+    });
+
+    describe('uncomposeAsync', () => {
+      it('should return null when the validator to modify is null',
+         () => { expect(Validators.uncomposeAsync(null !, null)).toBe(null); });
+
+      it('should return the unmodified validator when the validator to remove is null', () => {
+        const v = () => Promise.resolve(null);
+        expect(Validators.uncomposeAsync(v, null)).toBe(v);
+      });
+
+      it('should return null when the validator to remove is the one to modify', () => {
+        const v = () => Promise.resolve(null);
+        expect(Validators.uncomposeAsync(v, v)).toBe(null);
+      });
+
+      it('should return the first argument unmodified when it is unrelated to the second one',
+         () => {
+           const v1 =
+               Validators.composeAsync([() => Promise.resolve(null), () => Promise.resolve(null)]);
+           const v2 = () => Promise.resolve(null);
+           expect(Validators.uncomposeAsync(v1, v2)).toBe(v1);
+         });
+
+
+      it('should return the original validator when it was composed only with the one to remove',
+         () => {
+           const v1 = () => Promise.resolve(null);
+           const v2 = () => Promise.resolve(null);
+           const composed = Validators.composeAsync([v1, v2]);
+           expect(Validators.uncomposeAsync(composed, v2)).toBe(v1);
+           expect(Validators.uncomposeAsync(composed, v1)).toBe(v2);
+         });
+
+      it('should return a modified validator when the first argument is a 1-level composition with the second',
+         () => {
+           const v1 = jasmine.createSpy('v1').and.returnValue(Promise.resolve(null));
+           const v2 = jasmine.createSpy('v2').and.returnValue(Promise.resolve(null));
+           const v3 = jasmine.createSpy('v3').and.returnValue(Promise.resolve(null));
+           const composed = Validators.composeAsync([v1, v2, v3]);
+           const uncomposed = Validators.uncomposeAsync(composed, v2);
+           expect(uncomposed).not.toBe(composed);
+           uncomposed !(new FormControl());
+           expect(v1).toHaveBeenCalled();
+           expect(v2).not.toHaveBeenCalled();
+           expect(v3).toHaveBeenCalled();
+         });
+
+      it('should return a modified validator when the first argument is a 2-level composition with the second',
+         () => {
+           const v1 = jasmine.createSpy('v1').and.returnValue(Promise.resolve(null));
+           const v2 = jasmine.createSpy('v2').and.returnValue(Promise.resolve(null));
+           const v3 = jasmine.createSpy('v3').and.returnValue(Promise.resolve(null));
+           const v4 = jasmine.createSpy('v4').and.returnValue(Promise.resolve(null));
+           const composed = Validators.composeAsync([v1, Validators.composeAsync([v2, v3, v4])]);
+           const uncomposed = Validators.uncomposeAsync(composed, v2);
+           expect(uncomposed).not.toBe(composed);
+           uncomposed !(new FormControl());
+           expect(v1).toHaveBeenCalled();
+           expect(v2).not.toHaveBeenCalled();
+           expect(v3).toHaveBeenCalled();
+           expect(v4).toHaveBeenCalled();
+         });
+
+    });
     describe('composeAsync', () => {
 
       describe('promises', () => {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -124,6 +124,14 @@ export declare class CheckboxRequiredValidator extends RequiredValidator {
     validate(control: AbstractControl): ValidationErrors | null;
 }
 
+export interface ComposedAsyncValidatorFn extends AsyncValidatorFn {
+    composition: (AsyncValidatorFn | ComposedAsyncValidatorFn)[];
+}
+
+export interface ComposedValidatorFn extends ValidatorFn {
+    composition: (ValidatorFn | ComposedValidatorFn)[];
+}
+
 export declare const COMPOSITION_BUFFER_MODE: InjectionToken<boolean>;
 
 export declare abstract class ControlContainer extends AbstractControlDirective {
@@ -529,9 +537,12 @@ export interface ValidatorFn {
 }
 
 export declare class Validators {
-    static compose(validators: (ValidatorFn | null | undefined)[]): ValidatorFn | null;
+    static uncompose: (validator: ValidatorFn | null | undefined, validatorToRemove: ValidatorFn | null | undefined) => ValidatorFn | null;
+    static uncomposeAsync: (validator: AsyncValidatorFn | null | undefined, validatorToRemove: AsyncValidatorFn | null | undefined) => AsyncValidatorFn | null;
+    static compose(validators: (ValidatorFn | null | undefined)[]): ComposedValidatorFn | null;
     static compose(validators: null): null;
-    static composeAsync(validators: (AsyncValidatorFn | null)[]): AsyncValidatorFn | null;
+    static composeAsync(validators: (AsyncValidatorFn | null | undefined)[]): ComposedAsyncValidatorFn | null;
+    static composeAsync(validators: null): null;
     static email(control: AbstractControl): ValidationErrors | null;
     static max(max: number): ValidatorFn;
     static maxLength(maxLength: number): ValidatorFn;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -242,7 +242,7 @@ export declare class FormControl extends AbstractControl {
     }): void;
 }
 
-export declare class FormControlDirective extends NgControl implements OnChanges {
+export declare class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
     readonly asyncValidator: AsyncValidatorFn | null;
     readonly control: FormControl;
     form: FormControl;
@@ -254,6 +254,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;
 }
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -228,8 +228,8 @@ export declare class FormControl extends AbstractControl {
         emitModelToViewChange?: boolean;
         emitViewToModelChange?: boolean;
     }): void;
-    registerOnChange(fn: Function): void;
-    registerOnDisabledChange(fn: (isDisabled: boolean) => void): void;
+    registerOnChange(fn: Function): () => void;
+    registerOnDisabledChange(fn: (isDisabled: boolean) => void): () => void;
     reset(formState?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -243,14 +243,12 @@ export declare class FormControl extends AbstractControl {
 }
 
 export declare class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
-    readonly asyncValidator: AsyncValidatorFn | null;
     readonly control: FormControl;
     form: FormControl;
     isDisabled: boolean;
     /** @deprecated */ model: any;
     readonly path: string[];
     /** @deprecated */ update: EventEmitter<{}>;
-    readonly validator: ValidatorFn | null;
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
@@ -259,7 +257,6 @@ export declare class FormControlDirective extends NgControl implements OnChanges
 }
 
 export declare class FormControlName extends NgControl implements OnChanges, OnDestroy {
-    readonly asyncValidator: AsyncValidatorFn;
     readonly control: FormControl;
     readonly formDirective: any;
     isDisabled: boolean;
@@ -267,7 +264,6 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
     name: string;
     readonly path: string[];
     /** @deprecated */ update: EventEmitter<{}>;
-    readonly validator: ValidatorFn | null;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
@@ -412,7 +408,6 @@ export declare class NgFormSelectorWarning {
 }
 
 export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
-    readonly asyncValidator: AsyncValidatorFn | null;
     readonly control: FormControl;
     readonly formDirective: any;
     isDisabled: boolean;
@@ -425,7 +420,6 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     };
     readonly path: string[];
     update: EventEmitter<{}>;
-    readonly validator: ValidatorFn | null;
     viewModel: any;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[]);
     ngOnChanges(changes: SimpleChanges): void;


### PR DESCRIPTION
This PR is a rebase of #22503 which was opened by @devoto13 (and was closed because he lacked time to work on it). I have added tests and fixes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #21434 and #27803 (check also [this comment](https://github.com/angular/angular/issues/27803#issuecomment-451975496) which contains references to other related issues)

As explained in #27803:
> When a component implementing ControlValueAccessor is destroyed, writeValue is still called on patchValue for example. Destroy component multiple times results in multiple writeValue called

## What is the new behavior?

When a component implementing `ControlValueAccessor` is destroyed, `writeValue` is no longer called on `patchValue` or `setValue`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`FormControlDirective` creates a link between a `FormControl` object and itself with `setUpControl`, but did not remove this link at any time, even when the directive is destroyed or the form control changes. This PR adds calls to `cleanUpControl` when the directive is destroyed or when the form control changes.

`FormControlName` properly calls `FromGroupDirective` to register or unregister itself when it is created or destroyed. However, `FromGroupDirective` creates a link between the corresponding `FormControl` object and the `FormControlName` directive with `setUpControl` when the child directive is registered, but did not remove this link when the directive is removed, even though it did it when the form control changes. This PR adds a call to `cleanUpControl` when the directive is destroyed.

`cleanUpControl` did not properly remove the link to validators registered through a directive. This PR adds the `Validators.uncompose` and `Validators.uncomposeAsync` functions and calls them from `cleanUpControl` to properly remove the link to validators registered on a control through a directive.

`cleanUpControl` also removed too many listeners by calling `_clearChangeFns` on the control instead of only unregistering listeners added by `setUpControl`. This PR changes this to avoid issues when multiple `formControlName` or `formControl` directives in a template refer to the same form control object, and one of the directives is destroyed but one other stays and have to continue working.

Note that this PR does not fix similar issues with validators registered through a directive at a form group level (only at a form control level). This should ideally be done later through a separate PR.