### PR TITLE
refactor(ivy): add new view container api

### DIFF
--- a/packages/core/src/render3/api/view.ts
+++ b/packages/core/src/render3/api/view.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {assertDomNode} from '../../util/assert';
+import {assertLContainer, assertLView, assertLViewOrUndefined} from '../assert';
+import {getLContext} from '../context_discovery';
+import {TNode} from '../interfaces/node';
+import {RComment, RElement} from '../interfaces/renderer';
+import {LView, TVIEW} from '../interfaces/view';
+import {destroyLView} from '../node_manipulation';
+import {lContainerToViewContainer, viewContainerToLContainer, viewToLView} from '../util/view_utils';
+import {getEmbeddedViewFactoryInternal, getLContainerViewIndex, getLContainerViewsCount, getLViewFromLContainerAt, getOrPromoteLViewChildToLContainer, insertLViewIntoLContainerBefore, removeLViewFromLContainer} from '../view';
+import {EmbeddedViewFactory, View, ViewContainer} from './view_interface';
+
+// TODO: The example below needs to be put in a proper `{@example}`.
+
+/**
+ * Gets an {@link EmbeddedViewFactory} that will produce an embedded view.
+ * The DOM node that is provided should be a comment looking like `<!-- container -->`.
+ * This is rendered to the DOM for an instruction such as `<ng-template>`.
+ *
+ * For example, given the following template...
+ *
+ * ```html
+ * <div id="foo">
+ *   <ng-template>I am from a template</ng-template>
+ *   <span>{{someText}}</span>
+ * </div>
+ * ```
+ *
+ * ... you might have the following rendered DOM (represented here in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *  <!-- container -->
+ *  <span>some text</span>
+ * </div>
+ * ```
+ *
+ * You can select the container's anchor node, and retrieve an embedded view factory:
+ *
+ * ```ts
+ * const foo = document.querySelector('#foo');
+ * const containerComment = foo.firstChild;
+ * const embeddedViewFactory = getEmbeddedViewFactory(containerComment);
+ * ```
+ *
+ * From there you can create a {@link View} by calling the factory with any valid
+ * context for that view.
+ *
+ * ```ts
+ * const view: View = viewFactory({ foo: 'bar' });
+ * ```
+ *
+ * To insert this view, you would use {@link getViewContainer} to get a {@link ViewContainer}.
+ * Then use {@link viewContainerInsertBefore} to insert the `view` into the `ViewContainer` instance.
+ *
+ * You retrieve a `ViewContainer` by getting passing a DOM element or comment to `getViewContainer`.
+ * This will either retrieve an existing `ViewContainer` from that node, or attach a
+ * new `ViewContainer` to that node and return that.
+ *
+ * Note that an element may already have a container sitting on it, and directives that are accessing
+ * that container. Directives may access containers for the purpose of adding and removing views.
+ *
+ * Below we are just reusing the `containerComment` and attaching a new `ViewContainer` to it.
+ *
+ * ```ts
+ * const viewContainer = getViewContainer(containerComment);
+ * ```
+ * Now we can insert the `View` into the `ViewContainer` with {@link viewContainerInsertBefore}.
+ * This will insert all DOM for that view. Below we are appending the `view` as the
+ * last view in `viewContainer`. Note that `viewContainer` was empty, but we're inserting
+ * before `null`, which acts as an append.
+ *
+ * ```ts
+ * // Append the view to the container.
+ * viewContainerInsertBefore(viewContainer, view, null);
+ * ```
+ *
+ * The resulting rendered DOM will look as follows (shown in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *   I am from a template.
+ *   <span>some text</span>
+ * </div>
+ * ```
+ *
+ * @see viewContainerInsertBefore
+ * @see getViewContainer
+ * @see viewContainerRemove
+ *
+ * @param containerComment The DOM node to get the embedded view factory for.
+ * @returns A function that will produce an embedded view.
+ */
+export function getEmbeddedViewFactory<T extends{}>(containerComment: RComment):
+    EmbeddedViewFactory<T>|null {
+  ngDevMode && assertDomNode(containerComment);
+  const lContext = getLContext(containerComment);
+  if (lContext) {
+    const declarationLView = lContext.lView;
+    const declarationTView = declarationLView[TVIEW];
+    const declarationTNode = declarationTView.data[lContext.nodeIndex] as TNode;
+    return getEmbeddedViewFactoryInternal<T>(declarationTNode, declarationLView) as any;
+  }
+  return null;
+}
+
+/**
+ * Gets or creates an Angular view container from a DOM node
+ *
+ * Gets or creates a {@link ViewContainer} instance from a DOM node (e,g. `<!-- container -->`),
+ * this is something generally added to the DOM by template instructions and other mechanisms that
+ * use embedded views such as {@link ngIf} or {@link ngForOf}.
+ * @param containerNative The DOM node to use to find the view container instance.
+ */
+export function getViewContainer(containerNative: RElement | RComment): ViewContainer|null {
+  ngDevMode && assertDomNode(containerNative);
+  const lContext = getLContext(containerNative);
+  let viewContainer: ViewContainer|null = null;
+  if (lContext) {
+    const lView = lContext.lView;
+    const nodeIndex = lContext.nodeIndex;
+    const lContainer = getOrPromoteLViewChildToLContainer(lView, nodeIndex, containerNative);
+    viewContainer = lContainerToViewContainer(lContainer);
+  }
+  return viewContainer;
+}
+
+/**
+ * Inserts or appends a {@link View} into a {@link ViewContainer}.
+ *
+ * @param viewContainer The container to insert the view into.
+ * @param view The view to insert into the container.
+ * @param insertBeforeView The view in the container the inserted view should be inserted before. If
+ * `null`, this will just append the `view` as the first view in the `viewContainer`.
+ */
+export function viewContainerInsertBefore(
+    viewContainer: ViewContainer, view: View, insertBeforeView: View | null): void {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+  ngDevMode && assertLViewOrUndefined(insertBeforeView);
+
+  return insertLViewIntoLContainerBefore(
+      viewContainerToLContainer(viewContainer), viewToLView(view),
+      insertBeforeView as any as LView | null);
+}
+
+/**
+ * Finds the index of an Angular view in an Angular view container.
+ *
+ * Searches the `viewContainer` for a given `view` and returns its index
+ * within the container, if the `view` is not found, it returns `-1`.
+ * @param viewContainer The container to search
+ * @param view The view to search for
+ * @returns The index of the view, or -1 if it's not found.
+ */
+export function viewContainerIndexOf(viewContainer: ViewContainer, view: View): number {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+  return getLContainerViewIndex(viewContainer as any, view as any);
+}
+
+/**
+ * Gets the number of Angular views in an Angular view Container
+ *
+ * Given a {@link ViewContainer}, will analyze the container and return the number of {@link View}s
+ * it contains.
+ *
+ * @param viewContainer The view container to examine for length.
+ */
+export function viewContainerLength(viewContainer: ViewContainer): number {
+  ngDevMode && assertLContainer(viewContainer);
+  return getLContainerViewsCount(viewContainer as any);
+}
+
+/**
+ * Retrieves an Angular view from an Angular view container by index.
+ *
+ * Gets an instance of an Angular {@link View} from an Angular {@link ViewContainer}
+ * that exists at a given index within the container. If no view is found at that index,
+ * will return `null`.
+ *
+ * @param viewContainer The container to get the view from
+ * @param index The index of the view to retrieve within the container.
+ * @returns The view at the index, or null if the index is out of range or no view is found.
+ */
+export function viewContainerGetAt(viewContainer: ViewContainer, index: number): View|null {
+  ngDevMode && assertLContainer(viewContainer);
+  return getLViewFromLContainerAt(viewContainer as any, index) as any;
+}
+
+
+/**
+ * Removes an Angular view from an Angular view container
+ *
+ * Used to remove (embedded) views from a container. Will detach the view and destroy it, and will
+ * also remove all DOM nodes associated with the view.
+ *
+ * By default, this will execute destruction logic for the view. This includes executing `onDestroy`
+ * hooks associated with the view. To remove the view without executing destruction logic, pass
+ * `false` to `shouldDestroy`. You may wish to do this if you are removing the view as part of the
+ * process of simply moving the view to a new location in the view container.
+ *
+ * @param viewContainer The container to remove the view from
+ * @param view The view to remove from the container
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function viewContainerRemove(
+    viewContainer: ViewContainer, view: View, shouldDestroy: boolean): void {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+  removeLViewFromLContainer(
+      viewContainerToLContainer(viewContainer), viewToLView(view), shouldDestroy);
+}
+
+/**
+ * Execute destruction logic for an Angular View
+ *
+ * Destroys the view and cleans up accompanying data structures Ivy uses to optimize
+ * performance. Will also execute associated `onDestroy` hooks.
+ *
+ * @param view The view to destroy.
+ */
+export function viewDestroy(view: View): void {
+  destroyLView(viewToLView(view));
+}

--- a/packages/core/src/render3/api/view_interface.ts
+++ b/packages/core/src/render3/api/view_interface.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// This interface replaces the real `LView` interface if it is an argument or the return value
+// of a public API. This ensures we don't expose implementation details.
+/**
+ * Represents Angular View.
+ *
+ * This view can be found, inserted, or removed from a {@link ViewContainer} using methods
+ * such as {@link viewContainerGetAt}, {@link viewContainerInsertAfter},
+ * or {@link viewContainerRemove}
+ *
+ * @see ViewContainer
+ */
+export interface View<T extends{} = {}> {
+  __ng_brand__: 'Angular opaque reference representing a View. DO NOT READ/MANIPULATE!';
+}
+
+// This interface replaces the real `LContainer` interface if it is an argument or the return
+// value of a public API. This ensures we don't expose implementation details.
+/**
+ * Represents Angular View container.
+ *
+ * An Angular View container is associated with views created by directives and components that
+ * dynamically add and remove views, such as `<ng-template>`, `*ngIf`, `*ngFor`, et al.
+ *
+ * A container can be selected by passing a `<!-- container -->` DOM element to {@link getViewContainer}.
+ *
+ * Individual views within the container are instances of {@link View} and may be found, inserted or
+ * removed using methods such as {@link viewContainerGetAt}, {@link viewContainerInsertAfter},
+ * or {@link viewContainerRemove}
+ *
+ * @see View
+ */
+export interface ViewContainer {
+  __ng_brand__: 'Angular opaque reference representing a ViewContainer. DO NOT READ/MANIPULATE!';
+}
+
+/**
+ * Creates a {@link View} instance by instantiating all view data and passing the provided `context`
+ * to the view's template without attaching the view to the DOM or inserting it into a {@link
+ * ViewContainer}, in order to do that please see {@link viewContainerInsertAfter}.
+ *
+ * @see getEmbeddedViewFactory
+ */
+export interface EmbeddedViewFactory<T extends{}> {
+  /**
+   * Creates an embedded view.
+   * @param context The context to give to the embedded view
+   */
+  (context: T): View<T>;
+}

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertDefined, assertEqual, throwError} from '../util/assert';
+import {assertDefined, assertDomNode, assertEqual, throwError} from '../util/assert';
 
 import {getComponentDef, getNgModuleDef} from './definition';
-import {TNode} from './interfaces/node';
-import {LView} from './interfaces/view';
-import {isLContainer, isLView} from './util/view_utils';
+import {LContainer, NATIVE, VIEWS} from './interfaces/container';
+import {TNode, TNodeType} from './interfaces/node';
+import {RNode} from './interfaces/renderer';
+import {LView, TVIEW} from './interfaces/view';
+import {getNativeByTNode, isLContainer, isLView, unwrapLView} from './util/view_utils';
 
 
 export function assertComponentType(
@@ -62,4 +64,64 @@ export function assertLViewOrUndefined(value: any): void {
 export function assertLView(value: any) {
   assertDefined(value, 'LView must be defined');
   assertEqual(isLView(value), true, 'Expecting LView');
+}
+
+export function assertRNodeIsInView(lView: LView, rNode: RNode) {
+  assertEqual(isRNodeInLView(lView, rNode), true, 'RNode is not in LView');
+}
+
+/**
+ * Searches the lView by traversing it's TNodes looking for a specific RNode
+ * @param lView The lView to search
+ * @param rNode The RNode to look for
+ * @returns true if the RNode is found anywhere under the LView
+ */
+function isRNodeInLView(lView: LView, rNode: RNode): boolean {
+  assertLView(lView);
+  assertDomNode(rNode);
+  const tView = lView[TVIEW];
+  let tNode = tView.firstChild;
+  let tNodeStack: TNode[] = [];
+  while (tNode) {
+    switch (tNode.type) {
+      case TNodeType.Element:
+      case TNodeType.ElementContainer:
+        // An element type, let's check it
+        if (rNode === getNativeByTNode(tNode, lView)) {
+          return true;
+        }
+        break;
+      case TNodeType.View:
+        // We found a view, crawl in an look
+        return isRNodeInLView(unwrapLView(lView[tNode.index]) !, rNode);
+      case TNodeType.Container:
+        // For a container, we're going to crawl into each of its views
+        const lContainer = lView[tNode.index] as LContainer;
+        if (lContainer[NATIVE] === rNode) {
+          return true;
+        }
+        const views = lContainer[VIEWS];
+        if (views.some(view => isRNodeInLView(view, rNode))) {
+          return true;
+        }
+        break;
+      case TNodeType.Projection:
+      case TNodeType.IcuContainer:
+        // These two types don't have any RNodes that actually exist in DOM yet.
+        break;
+    }
+    if (tNode.child) {
+      // If we have children, crawl in
+      tNodeStack.push(tNode);
+      tNode = tNode.child;
+    } else {
+      // Move to the next sibling
+      tNode = tNode.next;
+      if (!tNode) {
+        // If we don't have a next sibling, try the parent's next sibling
+        tNode = (tNodeStack.length > 0) ? tNodeStack.pop() !.next : null;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/core/src/render3/debug.ts
+++ b/packages/core/src/render3/debug.ts
@@ -11,7 +11,7 @@ import {assertDefined} from '../util/assert';
 import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
 import {TNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
-import {RComment, RElement} from './interfaces/renderer';
+import {RComment, RElement, RNode} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTENT_QUERIES, CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, INJECTOR, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, TVIEW, TView, T_HOST} from './interfaces/view';
 import {unwrapRNode} from './util/view_utils';
@@ -208,7 +208,7 @@ export class LContainerDebug {
   get parent(): LViewDebug|LContainerDebug|null { return toDebug(this._raw_lContainer[PARENT]); }
   get queries(): LQueries|null { return this._raw_lContainer[QUERIES]; }
   get host(): RElement|RComment|StylingContext|LView { return this._raw_lContainer[HOST]; }
-  get native(): RComment { return this._raw_lContainer[NATIVE]; }
+  get native(): RNode { return this._raw_lContainer[NATIVE]; }
   get __other__() {
     return {
       next: toDebug(this._raw_lContainer[NEXT]),

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -376,10 +376,11 @@ function i18nStartFirstPass(
   const createOpCodes: I18nMutateOpCodes = [];
   // If the previous node wasn't the direct parent then we have a translation without top level
   // element and we need to keep a reference of the previous element if there is one
-  if (index > 0 && previousOrParentTNode !== parentTNode) {
+  if (index > 0 && parentTNode !== null && previousOrParentTNode !== parentTNode) {
     // Create an OpCode to select the previous TNode
     createOpCodes.push(
-        previousOrParentTNode.index << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select);
+        previousOrParentTNode.index - HEADER_OFFSET << I18nMutateOpCode.SHIFT_REF |
+        I18nMutateOpCode.Select);
   }
   const updateOpCodes: I18nUpdateOpCodes = [];
   const icuExpressions: TIcu[] = [];

--- a/packages/core/src/render3/instructions/instructions.ts
+++ b/packages/core/src/render3/instructions/instructions.ts
@@ -16,6 +16,7 @@ import {Sanitizer} from '../../sanitization/security';
 import {assertDataInRange, assertDefined, assertDomNode, assertEqual, assertLessThan, assertNotEqual} from '../../util/assert';
 import {isObservable} from '../../util/lang';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
+import {View} from '../api/view_interface';
 import {assertHasParent, assertLContainerOrUndefined, assertLView, assertPreviousIsParent} from '../assert';
 import {bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4} from '../bindings';
 import {attachPatchData, getComponentViewByInstance} from '../context_discovery';
@@ -29,10 +30,10 @@ import {INJECTOR_BLOOM_PARENT_SIZE, NodeInjectorFactory} from '../interfaces/inj
 import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
 import {CssSelectorList} from '../interfaces/projection';
 import {LQueries} from '../interfaces/query';
-import {GlobalTargetResolver, RComment, RElement, RText, Renderer3, RendererFactory3, isProceduralRenderer} from '../interfaces/renderer';
+import {GlobalTargetResolver, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, isProceduralRenderer} from '../interfaces/renderer';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {StylingContext} from '../interfaces/styling';
-import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
+import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from '../node_assert';
 import {appendChild, appendProjectedNodes, createTextNode, insertView, removeView} from '../node_manipulation';
 import {isNodeMatchingSelectorList, matchingProjectionSelectorIndex} from '../node_selector_matcher';
@@ -208,7 +209,7 @@ export function createNodeAtIndex(
     index: number, type: TNodeType.Element, native: RElement | RText | null, name: string | null,
     attrs: TAttributes | null): TElementNode;
 export function createNodeAtIndex(
-    index: number, type: TNodeType.Container, native: RComment, name: string | null,
+    index: number, type: TNodeType.Container, native: RElement | RComment, name: string | null,
     attrs: TAttributes | null): TContainerNode;
 export function createNodeAtIndex(
     index: number, type: TNodeType.Projection, native: null, name: null,
@@ -1951,7 +1952,7 @@ function generateInitialInputs(
  * @returns LContainer
  */
 export function createLContainer(
-    hostNative: RElement | RComment | StylingContext | LView, currentView: LView, native: RComment,
+    hostNative: RElement | RComment | StylingContext | LView, currentView: LView, native: RNode,
     tNode: TNode, isForViewContainerRef?: boolean): LContainer {
   ngDevMode && assertDomNode(native);
   ngDevMode && assertLView(currentView);
@@ -3077,14 +3078,14 @@ function initializeTNodeInputs(tNode: TNode | null): PropertyAliases|null {
 
 
 /**
- * Returns the current OpaqueViewState instance.
+ * Returns the current public api `View` instance.
  *
  * Used in conjunction with the restoreView() instruction to save a snapshot
  * of the current view and restore it when listeners are invoked. This allows
  * walking the declaration view tree in listeners to get vars from parent views.
  */
-export function getCurrentView(): OpaqueViewState {
-  return getLView() as any as OpaqueViewState;
+export function getCurrentView(): View {
+  return getLView() as any as View;
 }
 
 function getCleanup(view: LView): any[] {

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -8,7 +8,7 @@
 
 import {TNode} from './node';
 import {LQueries} from './query';
-import {RComment, RElement} from './renderer';
+import {RComment, RElement, RNode} from './renderer';
 import {StylingContext} from './styling';
 import {HOST, LView, NEXT, PARENT, QUERIES, T_HOST} from './view';
 
@@ -89,17 +89,22 @@ export interface LContainer extends Array<any> {
    */
   [T_HOST]: TNode;
 
-  /** The comment element that serves as an anchor for this LContainer. */
+  /**
+   * The DOM Node that serves as an anchor for this LContainer.
+   *
+   * This is usually a comment like `<!--container-->`, but may be another type of node for
+   * containers that were created programmatically via {@link viewContainerGet}.
+   */
   readonly[NATIVE]:
-      RComment;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
+      RNode;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
 
   /**
-*A list of the container's currently active child views. Views will be inserted
-*here as they are added and spliced from here when they are removed. We need
-*to keep a record of current views so we know which views are already in the DOM
-*(and don't need to be re-added) and so we can remove views from the DOM when they
-*are no longer required.
-*/
+   * A list of the container's currently active child views. Views will be inserted
+   * here as they are added and spliced from here when they are removed. We need
+   * to keep a record of current views so we know which views are already in the DOM
+   * (and don't need to be re-added) and so we can remove views from the DOM when they
+   * are no longer required.
+   */
   [VIEWS]: LView[];
 }
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -49,14 +49,17 @@ export const PREORDER_HOOK_FLAGS = 18;
 /** Size of LView's header. Necessary to adjust for it when setting slots.  */
 export const HEADER_OFFSET = 20;
 
-
-// This interface replaces the real LView interface if it is an arg or a
-// return value of a public instruction. This ensures we don't need to expose
-// the actual interface, which should be kept private.
-export interface OpaqueViewState {
-  '__brand__': 'Brand for OpaqueViewState that nothing will match';
+/**
+ * Creates an {@link LView} instance by instantiating appropriate view data, and executing the
+ * template function with a given context.
+ */
+export interface EmbeddedViewFactoryInternal<T extends{}> {
+  /**
+   * The internal method for creating an {@link LView} for an embedded view.
+   * @param context
+   */
+  (context: T): LView;
 }
-
 
 /**
  * `LView` stores all of the information needed to process the instructions as
@@ -366,7 +369,7 @@ export interface TView {
    * If this is a `TElementNode`, this is the view of a root component. It has exactly one
    * root TNode.
    *
-   * If this is null, this is the view of a component that is not at root. We do not store
+   * If this is `null`, this is the view of a component that is not at root. We do not store
    * the host TNodes for child component views because they can potentially have several
    * different host TNodes, depending on where the component is being used. These host
    * TNodes cannot be shared (due to different indices, etc).

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertDataInRange, assertDefined, assertGreaterThan, assertLessThan} from '../../util/assert';
+import {assertDataInRange, assertDefined, assertEqual, assertGreaterOrEqual, assertGreaterThan, assertLessThan} from '../../util/assert';
+import {View, ViewContainer} from '../api/view_interface';
 import {LContainer, TYPE} from '../interfaces/container';
 import {LContext, MONKEY_PATCH_KEY_NAME} from '../interfaces/context';
 import {ComponentDef, DirectiveDef} from '../interfaces/definition';
@@ -15,7 +16,36 @@ import {RNode} from '../interfaces/renderer';
 import {StylingContext} from '../interfaces/styling';
 import {FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, PARENT, PREORDER_HOOK_FLAGS, TData, TVIEW} from '../interfaces/view';
 
+/**
+ * Converts a public api `View` to an `LView`
+ * @param view the view to convert
+ */
+export function viewToLView(view: View): LView {
+  ngDevMode && assertDefined(view, 'LView must be defined');
+  ngDevMode && assertEqual(isLView(view), true, 'Expecting LView');
+  return view as any;
+}
 
+/**
+ * Converts an `LView` to a public api `View`.
+ */
+export const lViewToView: (view: LView) => View = viewToLView as any;
+
+/**
+ * Converts a public api `ViewContainer` to an `LContainer`.
+ * @param viewContainer The lContainer to convert
+ */
+export function viewContainerToLContainer(viewContainer: ViewContainer): LContainer {
+  ngDevMode && assertDefined(viewContainer, 'LContainer must be defined');
+  ngDevMode && assertEqual(isLContainer(viewContainer), true, 'Expecting LContainer');
+  return viewContainer as any;
+}
+
+/**
+ * Converts an `LContainer` to a public api `ViewContainer`.
+ */
+export const lContainerToViewContainer: (container: LContainer) => ViewContainer =
+    viewContainerToLContainer as any;
 
 /**
  * For efficiency reasons we often put several different data types (`RNode`, `LView`, `LContainer`,
@@ -133,7 +163,8 @@ export function getNativeByTNode(tNode: TNode, hostView: LView): RNode {
 
 export function getTNode(index: number, view: LView): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
-  ngDevMode && assertLessThan(index, view[TVIEW].data.length, 'wrong index for TNode');
+  ngDevMode &&
+      assertLessThan(index + HEADER_OFFSET, view[TVIEW].data.length, 'wrong index for TNode');
   return view[TVIEW].data[index + HEADER_OFFSET] as TNode;
 }
 

--- a/packages/core/src/render3/view.ts
+++ b/packages/core/src/render3/view.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertEqual, assertGreaterOrEqual} from '../util/assert';
+
+import {assertLContainer, assertRNodeIsInView} from './assert';
+import {assignTViewNodeToLView, createLContainer, createLView, createNodeAtIndex, renderEmbeddedTemplate} from './instructions/all';
+import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
+import {TNode, TNodeType} from './interfaces/node';
+import {RComment, RElement, RNode} from './interfaces/renderer';
+import {EmbeddedViewFactoryInternal, LView, LViewFlags, QUERIES, RENDERER, TVIEW} from './interfaces/view';
+import {addRemoveViewFromContainer, attachLContainerToParentLView, destroyLView, detachView, getViewFirstNative, getViewLastNative, insertView, nativeNextSibling} from './node_manipulation';
+import {getAddingEmbeddedRootChild, getIsParent, getPreviousOrParentTNode, setAddingEmbeddedRootChild, setIsParent, setPreviousOrParentTNode, shouldUseIvyAnimationCheck} from './state';
+import {unwrapLContainer} from './util/view_utils';
+
+
+
+/**
+ * The internal implementation for {@link getEmbeddedViewFactory}.
+ *
+ * @param declarationTNode The template node where the embedded template was declared
+ * @param declarationLView The local view where the embedded template was declared
+ */
+export function getEmbeddedViewFactoryInternal<T extends{}>(
+    declarationTNode: TNode, declarationLView: LView): EmbeddedViewFactoryInternal<T>|null {
+  const templateTView = declarationTNode.tViews;
+  if (templateTView) {
+    if (Array.isArray(templateTView)) {
+      // We are currently not supporting inline views.
+      throw new Error('Array of TViews not supported');
+    }
+
+    return function embeddedViewFactory(context: T) {
+      const _isParent = getIsParent();
+      const _previousOrParentTNode = getPreviousOrParentTNode();
+      const _useIvyAnimationCheck = shouldUseIvyAnimationCheck();
+      const _addingEmbeddedRootChild = _useIvyAnimationCheck && getAddingEmbeddedRootChild();
+      try {
+        setIsParent(true);
+        setPreviousOrParentTNode(null !);
+        setAddingEmbeddedRootChild(true);
+
+        const lView = createLView(
+            declarationLView, templateTView, context, LViewFlags.CheckAlways, null, null);
+
+        ngDevMode && assertEqual(
+                         declarationTNode.type, TNodeType.Container,
+                         'TNode type should be Container for embedded views');
+
+        const declarationContainer = unwrapLContainer(declarationLView[declarationTNode.index]) !;
+        ngDevMode && assertLContainer(declarationContainer);
+        const declarationQueries = declarationContainer[QUERIES];
+        if (declarationQueries) {
+          lView[QUERIES] = declarationQueries.createView();
+        }
+
+        assignTViewNodeToLView(templateTView, null, -1, lView);
+
+        if (templateTView.firstTemplatePass) {
+          templateTView.node !.injectorIndex = declarationTNode.injectorIndex;
+        }
+
+        renderEmbeddedTemplate(lView, templateTView, context);
+
+        return lView;
+      } finally {
+        _useIvyAnimationCheck && setAddingEmbeddedRootChild(_addingEmbeddedRootChild);
+        setIsParent(_isParent);
+        setPreviousOrParentTNode(_previousOrParentTNode);
+      }
+    };
+  }
+  return null;
+}
+
+/**
+ * Looks for a container at a given index in an LView, if something other than an `LContainer` is
+ * found, we create a new `LContainer` and wrap that item in it, then place that container at the
+ * provided index in the `LView`.
+ * @param lView The view containing the item to promote or get a container from
+ * @param nodeIndex The index of the item to promote or get a container from
+ * @param containerNative The RNode to use as the container's native anchor, if we happen to create
+ * a container here
+ */
+export function getOrPromoteLViewChildToLContainer(
+    lView: LView, nodeIndex: number, containerNative: RElement | RComment): LContainer {
+  ngDevMode && assertRNodeIsInView(lView, containerNative);
+  const lViewContainerOrElement = lView[nodeIndex];
+  let lContainer = unwrapLContainer(lViewContainerOrElement);
+  if (!lContainer) {
+    const tHost = lView[TVIEW].data[nodeIndex] as TNode;
+    lContainer = lView[nodeIndex] =
+        createLContainer(lViewContainerOrElement, lView, containerNative, tHost, true);
+    attachLContainerToParentLView(lView, lContainer);
+    const queries = lView[QUERIES];
+    if (queries) {
+      lContainer[QUERIES] = queries.container();
+    }
+  }
+  return lContainer;
+}
+
+/**
+ * Inserts an `LView` before a given `LView` in an `LContainer`'s `VIEWS`
+ *
+ * The internal implementation of {@link viewContainerInsertBefore}
+ *
+ * @param lContainer The container to insert the view into
+ * @param lViewToInsert The view to insert into the container
+ * @param insertBeforeLView The optional view in the container that the inserted view should be
+ * inserted behind. If `null`, it will insert the view at the front of the container as the first
+ * child.
+ */
+export function insertLViewIntoLContainerBefore(
+    lContainer: LContainer, lViewToInsert: LView, insertBeforeLView: LView | null) {
+  const _addingEmbeddedRootChild = getAddingEmbeddedRootChild();
+  try {
+    // If the view already exists in the container, we're moving it.
+    const existingIndex = getLContainerViewIndex(lContainer, lViewToInsert);
+    if (existingIndex >= 0) {
+      removeLViewFromLContainer(lContainer, lViewToInsert, false);
+    }
+
+    // Set state so that the Animation Renderer knows what we're doing.
+    setAddingEmbeddedRootChild(true);
+
+    // Because we're dynamically adding a view to the container, we reset the ACTIVE_INDEX to ensure
+    // the container is updated.
+    lContainer[ACTIVE_INDEX] = -1;
+
+    // We must get the insertion node *before* we insert the LView into the container's VIEWS,
+    // because the current VIEWS, as they stand in the container, are needed to find the appropriate
+    // before RNode.
+    const beforeNode = getInsertBeforeRNode(lContainer, lViewToInsert, insertBeforeLView);
+
+    // Insert the view into VIEWS (does not add RNodes)
+    const index = insertBeforeLView ? getLContainerViewIndex(lContainer, insertBeforeLView) :
+                                      getLContainerViewsCount(lContainer);
+    insertView(lViewToInsert, lContainer, index);
+
+    ngDevMode && assertEqual(
+                     lViewToInsert[TVIEW].firstChild && lViewToInsert[TVIEW].firstChild !.parent,
+                     null, 'tNode parent should be null');
+
+    // Add RNodes to DOM.
+    addRemoveViewFromContainer(lViewToInsert, true, beforeNode);
+  } finally {
+    setAddingEmbeddedRootChild(_addingEmbeddedRootChild);
+  }
+}
+
+/**
+ * Finds the appropriate RNode to use in an native insertBefore when inserting a view into a
+ * container.
+ * @param lContainer The lContainer to insert nodes into
+ * @param lViewToInsert The view with the nodes to insert
+ * @param insertBeforeLView The view to insert nodes in front of
+ */
+function getInsertBeforeRNode(
+    lContainer: LContainer, lViewToInsert: LView, insertBeforeLView: LView | null) {
+  let beforeNode: RNode|null = null;
+  const viewCount = getLContainerViewsCount(lContainer);
+  const renderer = lViewToInsert[RENDERER];
+
+  if (viewCount > 0) {
+    if (insertBeforeLView) {
+      // If an insert before view was provided, insert in front of it's first RNode.
+      ngDevMode && assertGreaterOrEqual(
+                       getLContainerViewIndex(lContainer, insertBeforeLView), 0,
+                       'insertBeforeLView must be in LContainer');
+      beforeNode = getViewFirstNative(insertBeforeLView);
+    } else {
+      // No insert before view was provided, so we're inserting at the end of the container.
+      const lastView = getLastContainedLView(lContainer);
+      if (lastView) {
+        // The container isn't empty, and we have a last view, so get RNode *right after* the last
+        // RNode from that view.
+        beforeNode = nativeNextSibling(renderer, getViewLastNative(lastView));
+      }
+    }
+  } else {
+    // There are no other views, so just insert it at the front of the container.
+    const containerNative = lContainer[NATIVE];
+    beforeNode = nativeNextSibling(renderer, containerNative);
+  }
+  // If before node is still nell, that's okay, it's an append
+  return beforeNode;
+}
+
+/**
+ * Gets the last view in a container
+ * @param lContainer The container to get the last view from
+ */
+function getLastContainedLView(lContainer: LContainer) {
+  return getLViewFromLContainerAt(lContainer, getLContainerViewsCount(lContainer) - 1);
+}
+
+/**
+ * Finds the first index of a given `LView` in an `LContainer`.
+ * @param lContainer the lContainer whose views to search
+ * @param lView The view to find in the lContainer
+ * @returns The index of the view, or -1 if it's not found.
+ */
+export function getLContainerViewIndex(lContainer: LContainer, lView: LView) {
+  return lContainer[VIEWS].indexOf(lView);
+}
+
+/**
+ * The internal implementation of {@link viewContainerRemove}
+ * @param lContainer The container to remove the view from
+ * @param lView The view to remove
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function removeLViewFromLContainer(
+    lContainer: LContainer, lView: LView, shouldDestroy: boolean): void {
+  const index = getLContainerViewIndex(lContainer, lView);
+  if (index >= 0) {
+    detachView(lContainer, index);
+    shouldDestroy && destroyLView(lView);
+  }
+}
+
+/**
+ * Returns the total number of views in the container.
+ * @param lContainer the container whose views to count
+ */
+export function getLContainerViewsCount(lContainer: LContainer): number {
+  return lContainer[VIEWS].length;
+}
+
+/**
+ * Gets an `LView` from an `LContainer` by index.
+ * @param lContainer the lContainer to get the view from
+ * @param index The index of the view to get from the lContainer
+ * @returns The view at the index, or null if the index is out of range or no view is found.
+ */
+export function getLViewFromLContainerAt(lContainer: LContainer, index: number): LView|null {
+  return lContainer[VIEWS][index] || null;
+}

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -52,6 +52,12 @@ export function assertNotDefined<T>(actual: T, msg: string) {
   }
 }
 
+export function assertGreaterOrEqual<T>(actual: T, expected: T, msg: string) {
+  if (actual < expected) {
+    throwError(msg);
+  }
+}
+
 export function assertDefined<T>(actual: T, msg: string) {
   if (actual == null) {
     throwError(msg);

--- a/packages/core/test/acceptance/view_spec.ts
+++ b/packages/core/test/acceptance/view_spec.ts
@@ -1,0 +1,581 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {Component, NgModule} from '@angular/core';
+import {getEmbeddedViewFactory, getViewContainer, viewContainerGetAt, viewContainerIndexOf, viewContainerInsertBefore, viewContainerLength, viewContainerRemove} from '@angular/core/src/render3/api/view';
+import {CHILD_HEAD, CHILD_TAIL, NEXT} from '@angular/core/src/render3/interfaces/view';
+import {readPatchedLView} from '@angular/core/src/render3/util/view_utils';
+import {TestBed} from '@angular/core/testing';
+import {onlyInIvy} from '@angular/private/testing';
+
+onlyInIvy('This is an ivy-specific means of manipulating containers and views')
+    .describe('ViewContainer manipulation commands', () => {
+      it('should get the embedded view from a comment added by ng-template and be able to insert it',
+         () => {
+           @Component({
+             selector: 'dynamic-cpt',
+             template: `
+              <div></div>
+              <ng-template let-name="name">
+                <b>Hello </b>
+                <i>{{name}}</i>
+              </ng-template>
+             `
+           })
+           class App {
+           }
+
+           @NgModule({declarations: [App]})
+           class MyTestModule {
+           }
+
+           TestBed.configureTestingModule({imports: [MyTestModule]});
+           const fixture = TestBed.createComponent(App);
+           fixture.detectChanges();
+
+           const comment = fixture.nativeElement.lastChild;
+           expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+           const embeddedViewFactory = getEmbeddedViewFactory(comment) !;
+           expect(typeof embeddedViewFactory).toEqual('function');
+
+           const commentViewContainer = getViewContainer(comment) !;
+
+           const bView = embeddedViewFactory({name: 'B'});
+           // Putting this in the very front.
+           viewContainerInsertBefore(commentViewContainer, bView, null);
+
+           // Now putting this in front of B (because it's in the very front).
+           viewContainerInsertBefore(commentViewContainer, embeddedViewFactory({name: 'A'}), bView);
+
+           // Putting this one after B
+           viewContainerInsertBefore(commentViewContainer, embeddedViewFactory({name: 'C'}), null);
+
+           // Putting this one right after that initial <div></div>
+           const divViewContainer = getViewContainer(fixture.nativeElement.firstChild !) !;
+           viewContainerInsertBefore(divViewContainer, embeddedViewFactory({name: 'X'}), null);
+
+           fixture.detectChanges();
+
+           expect(fixture.nativeElement.innerHTML)
+               .toEqual(
+                   '<div></div><b>Hello </b><i>X</i><!--container--><b>Hello </b><i>A</i><b>Hello </b><i>B</i><b>Hello </b><i>C</i>');
+         });
+
+      it('should get the embedded view from a comment added by ng-template and be able to insert it, where last node of inserted view is also a container',
+         () => {
+           @Component({
+             selector: 'dynamic-cpt',
+             template: `
+                  <div></div>
+                  <ng-template let-name="name">
+                    <b>Hello </b>
+                    <i *ngIf="true">{{name}}</i>
+                  </ng-template>
+                 `
+           })
+           class App {
+           }
+
+           @NgModule({declarations: [App], imports: [CommonModule]})
+           class MyTestModule {
+           }
+
+           TestBed.configureTestingModule({imports: [MyTestModule]});
+           const fixture = TestBed.createComponent(App);
+           fixture.detectChanges();
+
+           const comment = fixture.nativeElement.lastChild;
+           expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+           const embeddedViewFactory = getEmbeddedViewFactory(comment) !;
+
+           const commentViewContainer = getViewContainer(comment) !;
+
+           const bView = embeddedViewFactory({name: 'B'});
+           // Putting this in the very front.
+           viewContainerInsertBefore(commentViewContainer, bView, null);
+           fixture.detectChanges();
+
+           // Now putting this in front of B (because it's in the very front).
+           viewContainerInsertBefore(commentViewContainer, embeddedViewFactory({name: 'A'}), bView);
+           fixture.detectChanges();
+
+           // Putting this one after B
+           viewContainerInsertBefore(commentViewContainer, embeddedViewFactory({name: 'C'}), null);
+           fixture.detectChanges();
+
+           // Putting this one right after that initial <div></div>
+           const divViewContainer = getViewContainer(fixture.nativeElement.firstChild !) !;
+           viewContainerInsertBefore(divViewContainer, embeddedViewFactory({name: 'X'}), null);
+           fixture.detectChanges();
+
+           expect(fixture.nativeElement.innerHTML.replace(/<!--bindings[.\s\S]*?-->/g, ''))
+               .toEqual(
+                   '<div></div><b>Hello </b><i>X</i><!--container--><b>Hello </b><i>A</i><b>Hello </b><i>B</i><b>Hello </b><i>C</i>');
+         });
+
+      it('should use the provided node to create the container, not the parent view host', () => {
+        @Component({
+          selector: 'dynamic-cpt',
+          template: `
+               <div class="container1"></div>
+               <ng-template let-name="name">
+                 <i *ngIf="true">{{name}}</i>
+                 <div class="container2"></div>
+               </ng-template>
+              `
+        })
+        class App {
+        }
+
+        @NgModule({declarations: [App], imports: [CommonModule]})
+        class MyTestModule {
+        }
+
+        TestBed.configureTestingModule({imports: [MyTestModule]});
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+
+        const comment = fixture.nativeElement.lastChild;
+        expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+
+        const embeddedViewFactory = getEmbeddedViewFactory(comment) !;
+
+        const container1Element = fixture.nativeElement.querySelector('.container1');
+        const viewContainer1 = getViewContainer(container1Element) !;
+
+        // Insert a view that has a container in it.
+        viewContainerInsertBefore(viewContainer1, embeddedViewFactory({name: 'A'}), null);
+
+        // Get another container from *inside* the view we just inserted.
+        const container2Element = fixture.nativeElement.querySelector('.container2');
+        const viewContainer2 = getViewContainer(container2Element) !;
+
+        // Insert into the inner container.
+        viewContainerInsertBefore(viewContainer2, embeddedViewFactory({name: 'B'}), null);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.innerHTML.replace(/<!--bindings[.\s\S]*?-->/g, ''))
+            .toEqual(
+                '<div class="container1"></div><i>A</i><div class="container2"></div><i>B</i><div class="container2"></div><!--container-->');
+
+      });
+
+      describe('getViewContainer', () => {
+        it('should lazily create LContainers and add them to the internal linked list in the order of DOM',
+           () => {
+             @Component({
+               selector: 'test',
+               template: `
+                <ng-template>one</ng-template>
+                <ng-template>two</ng-template>
+                <ng-template>three</ng-template>
+                <ng-template>four</ng-template>
+               `
+             })
+             class App {
+             }
+
+             @NgModule({declarations: [App]})
+             class MyTestModule {
+             }
+
+             TestBed.configureTestingModule({imports: [MyTestModule]});
+             const fixture = TestBed.createComponent(App);
+             fixture.detectChanges();
+
+             const one = fixture.nativeElement.firstChild !;
+             const two = one.nextSibling;
+             const three = two.nextSibling;
+             const four = three.nextSibling;
+
+             // This is adding to the CHILD_HEAD and CHILD_TAIL
+             const threeContainer = getViewContainer(three);
+             // This is inserting to CHILD_HEAD infront of existing CHILD_HEAD
+             const oneContainer = getViewContainer(one);
+             // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+             const fourContainer = getViewContainer(four);
+             // This is inserting in the middle of the list
+             const twoContainer = getViewContainer(two);
+
+             const hostView = readPatchedLView(fixture.nativeElement.firstChild) !;
+
+             let cursor = hostView[CHILD_HEAD];
+
+             expect(cursor).toBe(oneContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(twoContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(threeContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(fourContainer as any);
+
+             expect(hostView[CHILD_TAIL]).toBe(cursor);
+             expect(cursor ![NEXT]).toEqual(null);
+           });
+
+        it('should lazily create LContainers and add them to the internal linked list in order of DOM, depth first',
+           () => {
+             @Component({
+               selector: 'test',
+               template: `
+                <div>
+                  <ng-template>
+                  </ng-template>
+                  <div>
+                    <ng-template>
+                    </ng-template>
+                    <div>
+                      <ng-template>
+                      </ng-template>
+                      <div>
+                        <ng-template>
+                        </ng-template>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              `
+             })
+             class App {
+             }
+
+             @NgModule({declarations: [App], imports: [CommonModule]})
+             class MyTestModule {
+             }
+
+             TestBed.configureTestingModule({imports: [MyTestModule]});
+             const fixture = TestBed.createComponent(App);
+             fixture.detectChanges();
+
+             const divs = fixture.nativeElement.querySelectorAll('div');
+             const one = divs[0].firstChild;
+             const two = divs[1].firstChild;
+             const three = divs[2].firstChild;
+             const four = divs[3].firstChild;
+
+             // This is adding to the CHILD_HEAD and CHILD_TAIL
+             const threeContainer = getViewContainer(three);
+             // This is inserting to CHILD_HEAD in front of existing CHILD_HEAD
+             const oneContainer = getViewContainer(one);
+             // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+             const fourContainer = getViewContainer(four);
+             // This is inserting in the middle of the list
+             const twoContainer = getViewContainer(two);
+
+             const hostView = readPatchedLView(fixture.nativeElement.firstChild) !;
+
+             let cursor = hostView[CHILD_HEAD];
+
+             expect(cursor).toBe(oneContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(twoContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(threeContainer as any);
+
+             cursor = cursor ![NEXT];
+             expect(cursor).toBe(fourContainer as any);
+
+             expect(hostView[CHILD_TAIL]).toBe(cursor);
+             expect(cursor ![NEXT]).toEqual(null);
+           });
+      });
+
+      describe('viewContainerRemove', () => {
+        it('should remove views from a container', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <div></div>
+              <ng-template><span></span></ng-template>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+          expect(fixture.nativeElement.innerHTML).toEqual('<div></div><!--container-->');
+          const containerComment = fixture.nativeElement.lastChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const view = embeddedViewFactory({});
+          const container = getViewContainer(containerComment) !;
+          viewContainerInsertBefore(container, view, null);
+          fixture.detectChanges();
+
+          expect(fixture.nativeElement.innerHTML)
+              .toEqual('<div></div><!--container--><span></span>');
+          viewContainerRemove(container, view, true);
+          fixture.detectChanges();
+
+          expect(fixture.nativeElement.innerHTML).toEqual('<div></div><!--container-->');
+        });
+
+        it('should remove all dom elements for a view, as there could be more than one', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <ul>
+                <ng-template>
+                  <li>one</li>
+                  <li>two</li>
+                  <li>three</li>
+                </ng-template>
+              </ul>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+
+          expect(fixture.nativeElement.innerHTML).toEqual('<ul><!--container--></ul>');
+          const containerComment = fixture.nativeElement.firstChild !.firstChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const container = getViewContainer(containerComment) !;
+
+          const view = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view, null);
+          fixture.detectChanges();
+
+          expect(fixture.nativeElement.innerHTML)
+              .toEqual('<ul><!--container--><li>one</li><li>two</li><li>three</li></ul>');
+          viewContainerRemove(container, view, true);
+          fixture.detectChanges();
+
+          expect(fixture.nativeElement.innerHTML).toEqual('<ul><!--container--></ul>');
+        });
+      });
+
+      describe('viewContainerInsertAfter', () => {
+        it('should insert views in the container', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <div></div><ng-template><span></span></ng-template>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+          const containerComment = fixture.nativeElement.lastChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const container = getViewContainer(containerComment) !;
+
+          expect(viewContainerLength(container)).toBe(0);
+
+          const view1 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view1, null);
+
+          expect(viewContainerLength(container)).toBe(1);
+          expect(viewContainerGetAt(container, 0)).toBe(view1);
+
+          const view2 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view2, null);
+
+          expect(viewContainerLength(container)).toBe(2);
+          expect(viewContainerGetAt(container, 1)).toBe(view2);
+
+          const view3 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view3, null);
+
+          expect(viewContainerLength(container)).toBe(3);
+          expect(viewContainerGetAt(container, 2)).toBe(view3);
+
+          const viewA = embeddedViewFactory({});
+          viewContainerInsertBefore(container, viewA, view1);
+
+          expect(viewContainerLength(container)).toBe(4);
+          expect(viewContainerGetAt(container, 0)).toBe(viewA);
+          expect(viewContainerGetAt(container, 1)).toBe(view1);
+          expect(viewContainerGetAt(container, 2)).toBe(view2);
+          expect(viewContainerGetAt(container, 3)).toBe(view3);
+        });
+
+        it('should move the view around if you insert the same view twice', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <div></div><ng-template><span></span></ng-template>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+
+          const containerComment = fixture.nativeElement.lastChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const container = getViewContainer(containerComment) !;
+
+          expect(viewContainerLength(container)).toBe(0);
+
+          const view1 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view1, null);
+          fixture.detectChanges();
+
+          expect(viewContainerLength(container)).toBe(1);
+          expect(viewContainerGetAt(container, 0)).toBe(view1);
+
+          const view2 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view2, null);
+          fixture.detectChanges();
+
+          expect(viewContainerLength(container)).toBe(2);
+          expect(viewContainerGetAt(container, 1)).toBe(view2);
+
+          // Move view1 after view2 (it was before)
+          viewContainerInsertBefore(container, view1, null);
+          fixture.detectChanges();
+
+          expect(viewContainerLength(container)).toBe(2);
+          expect(viewContainerGetAt(container, 0)).toBe(view2);
+          expect(viewContainerGetAt(container, 1)).toBe(view1);
+        });
+      });
+
+      describe('viewContainerIndexOf', () => {
+        it('should find the first index of a container within a view, and return -1 if it cannot find it',
+           () => {
+             @Component({
+               selector: 'test',
+               template: `
+                 <div></div><ng-template><span></span></ng-template>
+               `
+             })
+             class App {
+             }
+
+             @NgModule({declarations: [App]})
+             class MyTestModule {
+             }
+
+             TestBed.configureTestingModule({imports: [MyTestModule]});
+             const fixture = TestBed.createComponent(App);
+             fixture.detectChanges();
+
+             const containerComment = fixture.nativeElement.lastChild !;
+             const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+             const view1 = embeddedViewFactory({});
+             const container = getViewContainer(containerComment) !;
+
+             expect(viewContainerIndexOf(container, view1))
+                 .toBe(-1);  // not found because it's not inserted yet.
+
+             viewContainerInsertBefore(container, view1, null);
+             expect(viewContainerIndexOf(container, view1)).toBe(0);
+
+             const view2 = embeddedViewFactory({});
+             viewContainerInsertBefore(container, view2, null);
+             expect(viewContainerIndexOf(container, view2)).toBe(1);
+           });
+      });
+
+      describe('viewContainerGetAt', () => {
+        it('should get a view by index from the container', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <div></div><ng-template><span></span></ng-template>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+          const containerComment = fixture.nativeElement.lastChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const container = getViewContainer(containerComment) !;
+
+          const view1 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view1, null);
+
+
+          const view2 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view2, null);
+
+          expect(viewContainerGetAt(container, 0)).toBe(view1);
+          expect(viewContainerGetAt(container, 1)).toBe(view2);
+        });
+      });
+
+      describe('viewContainerLength', () => {
+        it('should get the current length of the container, by contained view count', () => {
+          @Component({
+            selector: 'test',
+            template: `
+              <div></div><ng-template><span></span></ng-template>
+            `
+          })
+          class App {
+          }
+
+          @NgModule({declarations: [App]})
+          class MyTestModule {
+          }
+
+          TestBed.configureTestingModule({imports: [MyTestModule]});
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+
+          const containerComment = fixture.nativeElement.lastChild !;
+          const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+          const container = getViewContainer(containerComment) !;
+          expect(viewContainerLength(container)).toBe(0);
+
+          const view1 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view1, null);
+          expect(viewContainerLength(container)).toBe(1);
+
+
+          const view2 = embeddedViewFactory({});
+          viewContainerInsertBefore(container, view2, null);
+          expect(viewContainerLength(container)).toBe(2);
+        });
+      });
+    });


### PR DESCRIPTION
- Adds view container API in preparation to refactor how we insert embedded views (#29031)
- Fixes minor issue with `i18n` that was revealed by an added assertion.