### PR TITLE
Insert after comment

### DIFF
--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -62,8 +62,9 @@ export class AnimationEngine {
     this._transitionEngine.destroy(namespaceId, context);
   }
 
-  onInsert(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
-    this._transitionEngine.insertNode(namespaceId, element, parent, insertBefore);
+  onInsert(namespaceId: string, element: any, parent: any, shouldCollectEnterElement: boolean):
+      void {
+    this._transitionEngine.insertNode(namespaceId, element, parent, shouldCollectEnterElement);
   }
 
   onRemove(namespaceId: string, element: any, context: any, isHostElement?: boolean): void {

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -657,7 +657,8 @@ export class TransitionAnimationEngine {
     return false;
   }
 
-  insertNode(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
+  insertNode(namespaceId: string, element: any, parent: any, shouldCollectEnterElement: boolean):
+      void {
     if (!isElementNode(element)) return;
 
     // special case for when an element is removed and reinserted (move operation)
@@ -688,8 +689,8 @@ export class TransitionAnimationEngine {
       }
     }
 
-    // only *directives and host elements are inserted before
-    if (insertBefore) {
+    // For embedded views (*directives)
+    if (shouldCollectEnterElement) {
       this.collectEnterElement(element);
     }
   }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -376,7 +376,7 @@ function i18nStartFirstPass(
   const createOpCodes: I18nMutateOpCodes = [];
   // If the previous node wasn't the direct parent then we have a translation without top level
   // element and we need to keep a reference of the previous element if there is one
-  if (index > 0 && previousOrParentTNode !== parentTNode) {
+  if (index > 0 && parentTNode !== null && previousOrParentTNode !== parentTNode) {
     // Create an OpCode to select the previous TNode
     createOpCodes.push(
         previousOrParentTNode.index << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select);

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -9,17 +9,18 @@
 import {SRCSET_ATTRS, URI_ATTRS, VALID_ATTRS, VALID_ELEMENTS, getTemplateContent} from '../sanitization/html_sanitizer';
 import {InertBodyHelper} from '../sanitization/inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from '../sanitization/url_sanitizer';
-import {assertDefined, assertEqual, assertGreaterThan} from '../util/assert';
+import {assertDefined, assertDomNode, assertEqual, assertGreaterThan, isDomNode} from '../util/assert';
+
 import {attachPatchData} from './context_discovery';
 import {allocExpando, createNodeAtIndex, elementAttribute, load, textBinding} from './instructions';
 import {LContainer, NATIVE} from './interfaces/container';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, IcuType, TI18n, TIcu} from './interfaces/i18n';
 import {TElementNode, TIcuContainerNode, TNode, TNodeType} from './interfaces/node';
-import {RComment, RElement, RText} from './interfaces/renderer';
+import {RComment, RElement, RNode, RText} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {StylingContext} from './interfaces/styling';
 import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, TView, T_HOST} from './interfaces/view';
-import {appendChild, createTextNode, nativeRemoveNode} from './node_manipulation';
+import {appendChild, createTextNode, getRenderParent, nativeInsertBefore, nativeParentNode, nativeRemoveNode} from './node_manipulation';
 import {getIsParent, getLView, getPreviousOrParentTNode, setIsParent, setPreviousOrParentTNode} from './state';
 import {NO_CHANGE} from './tokens';
 import {addAllToArray} from './util/array_utils';
@@ -497,7 +498,22 @@ function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode |
     cursor = cursor.next;
   }
 
-  appendChild(getNativeByTNode(tNode, viewData), tNode, viewData);
+  // Insert before this node
+  let beforeNode: RNode|null = null;
+  if (tNode.parent && tNode.parent.type === TNodeType.IcuContainer) {
+    beforeNode = getNativeByTNode(tNode.parent, viewData);
+
+    // HACK(benlesh): In some cases, ICU comment nodes were not appropriately added to the intended
+    // parent. This forces them to be added, so insertion of what's important below does not error.
+    // This is highly suspect, IMO, but it seems to have things working.
+    const renderer = viewData[RENDERER];
+    const renderParent = getRenderParent(tNode, viewData) !;
+    if (nativeParentNode(renderer, beforeNode) !== renderParent) {
+      nativeInsertBefore(renderer, renderParent, beforeNode, null);
+    }
+  }
+
+  appendChild(getNativeByTNode(tNode, viewData), tNode, viewData, beforeNode);
 
   const slotValue = viewData[tNode.index];
   if (tNode.type !== TNodeType.Container && isLContainer(slotValue)) {
@@ -660,6 +676,7 @@ function createDynamicNodeAtIndex(
     index: number, type: TNodeType, native: RElement | RText | null,
     name: string | null): TElementNode|TIcuContainerNode {
   const previousOrParentTNode = getPreviousOrParentTNode();
+  ngDevMode && assertDefined(previousOrParentTNode, 'parent TNode required');
   const tNode = createNodeAtIndex(index, type as any, native, name, null);
 
   // We are creating a dynamic node, the previous tNode might not be pointing at this node.
@@ -869,6 +886,7 @@ function removeNode(index: number, viewData: LView) {
   const removedPhTNode = getTNode(index, viewData);
   const removedPhRNode = getNativeByIndex(index, viewData);
   if (removedPhRNode) {
+    ngDevMode && assertDomNode(removedPhRNode);
     nativeRemoveNode(viewData[RENDERER], removedPhRNode);
   }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -35,7 +35,7 @@ import {LQueries} from './interfaces/query';
 import {GlobalTargetResolver, RComment, RElement, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {StylingContext} from './interfaces/styling';
-import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST, View} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {appendChild, appendProjectedNodes, createTextNode, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingProjectionSelectorIndex} from './node_selector_matcher';
@@ -3305,8 +3305,8 @@ function initializeTNodeInputs(tNode: TNode | null): PropertyAliases|null {
  * of the current view and restore it when listeners are invoked. This allows
  * walking the declaration view tree in listeners to get vars from parent views.
  */
-export function getCurrentView(): OpaqueViewState {
-  return getLView() as any as OpaqueViewState;
+export function getCurrentView(): View {
+  return getLView() as any as View;
 }
 
 function getCleanup(view: LView): any[] {

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -49,14 +49,42 @@ export const PREORDER_HOOK_FLAGS = 18;
 /** Size of LView's header. Necessary to adjust for it when setting slots.  */
 export const HEADER_OFFSET = 20;
 
-
-// This interface replaces the real LView interface if it is an arg or a
-// return value of a public instruction. This ensures we don't need to expose
-// the actual interface, which should be kept private.
-export interface OpaqueViewState {
-  '__brand__': 'Brand for OpaqueViewState that nothing will match';
+/**
+ * This interface replaces the real {@link LView} interface if it is an argument or the return value
+ * of a public API. This ensures we don't expose implementation details.
+ */
+export interface View<T extends{} = {}> {
+  __ng_brand__: 'Angular opaque reference representing a View. DO NOT READ/MANIPULATE!';
 }
 
+/**
+ * This interface replaces the real {@link LContainer} interface if it is an argument or the return
+ * value of a public API. This ensures we don't expose implementation details.
+ */
+export interface ViewContainer {
+  __ng_brand__: 'Angular opaque reference representing a ViewContainer. DO NOT READ/MANIPULATE!';
+}
+
+/**
+ * The public API for creating an embedded view.
+ *
+ * @see getEmbeddedViewFactory
+ */
+export interface EmbeddedViewFactory<T extends{}> {
+  /**
+   * Creates an embedded view.
+   * @param context The context to give to the embedded view
+   */
+  (context: T): View<T>;
+}
+
+export interface EmbeddedViewFactoryInternal<T extends{}> {
+  /**
+   * The internal method for creating an {@link LView} for an embedded view.
+   * @param context
+   */
+  (context: T): LView;
+}
 
 /**
  * `LView` stores all of the information needed to process the instructions as
@@ -366,7 +394,7 @@ export interface TView {
    * If this is a `TElementNode`, this is the view of a root component. It has exactly one
    * root TNode.
    *
-   * If this is null, this is the view of a component that is not at root. We do not store
+   * If this is `null`, this is the view of a component that is not at root. We do not store
    * the host TNodes for child component views because they can potentially have several
    * different host TNodes, depending on where the component is being used. These host
    * TNodes cannot be shared (due to different indices, etc).

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -7,7 +7,7 @@
  */
 
 import {ViewEncapsulation} from '../metadata/view';
-import {assertDefined} from '../util/assert';
+import {assertDefined, assertDomNode, assertGreaterOrEqual, assertNotSame} from '../util/assert';
 
 import {assertLContainer, assertLView} from './assert';
 import {attachPatchData} from './context_discovery';
@@ -289,12 +289,12 @@ export function destroyViewTree(rootView: LView): void {
     if (!next) {
       // Only clean up view when moving to the side or up, as destroy hooks
       // should be called in order from the bottom up.
-      while (lViewOrLContainer && !lViewOrLContainer ![NEXT] && lViewOrLContainer !== rootView) {
+      while (lViewOrLContainer && !lViewOrLContainer[NEXT] && lViewOrLContainer !== rootView) {
         cleanUpView(lViewOrLContainer);
         lViewOrLContainer = getParentState(lViewOrLContainer, rootView);
       }
       cleanUpView(lViewOrLContainer || rootView);
-      next = lViewOrLContainer && lViewOrLContainer ![NEXT];
+      next = lViewOrLContainer && lViewOrLContainer[NEXT];
     }
     lViewOrLContainer = next;
   }
@@ -531,7 +531,9 @@ function executeOnDestroys(view: LView): void {
  *   of a View which has not be inserted or is made for projection but has not been inserted
  *   into destination.
  */
-function getRenderParent(tNode: TNode, currentView: LView): RElement|null {
+export function getRenderParent(tNode: TNode, currentView: LView): RElement|null {
+  ngDevMode && assertLView(currentView);
+
   // Nodes of the top-most view can be inserted eagerly.
   if (isRootView(currentView)) {
     return nativeParentNode(currentView[RENDERER], getNativeByTNode(tNode, currentView));
@@ -600,33 +602,32 @@ function getHostNative(currentView: LView): RElement|null {
  * actual renderer being used.
  */
 export function nativeInsertBefore(
-    renderer: Renderer3, parent: RElement, child: RNode, beforeNode: RNode | null): void {
+    renderer: Renderer3, parent: RNode, child: RNode, beforeNode: RNode | null): void {
+  ngDevMode && assertNotSame(beforeNode, undefined, 'beforeNode must be a node or null');
+  ngDevMode && assertDefined(parent, 'parent node must be defined');
   if (isProceduralRenderer(renderer)) {
-    renderer.insertBefore(parent, child, beforeNode);
+    if (beforeNode) {
+      renderer.insertBefore(parent, child, beforeNode);
+    } else {
+      // Because the animation renderer has special handling that differs between appendChild and
+      // insertChildBefore, we have to use appendChild, even though insertChildBefore with a null
+      // anchor is the same thing as appendChild in terms of actual DOM manipulation
+      renderer.appendChild(parent as RElement, child);
+    }
   } else {
     parent.insertBefore(child, beforeNode, true);
   }
 }
 
-function nativeAppendChild(renderer: Renderer3, parent: RElement, child: RNode): void {
-  if (isProceduralRenderer(renderer)) {
-    renderer.appendChild(parent, child);
-  } else {
-    parent.appendChild(child);
-  }
-}
-
-function nativeAppendOrInsertBefore(
-    renderer: Renderer3, parent: RElement, child: RNode, beforeNode: RNode | null) {
-  if (beforeNode) {
-    nativeInsertBefore(renderer, parent, child, beforeNode);
-  } else {
-    nativeAppendChild(renderer, parent, child);
-  }
-}
-
-/** Removes a node from the DOM given its native parent. */
-function nativeRemoveChild(
+/**
+ * Removes a native child node from a given native parent node.
+ * @param renderer The renderer instance to use to do the manipulation
+ * @param parent The parent node to remove the child from
+ * @param child The node to remove
+ * @param isHostElement A boolean indicating whether or not the element is a host element for a
+ * view.
+ */
+export function nativeRemoveChild(
     renderer: Renderer3, parent: RElement, child: RNode, isHostElement?: boolean): void {
   if (isProceduralRenderer(renderer)) {
     renderer.removeChild(parent, child, isHostElement);
@@ -636,62 +637,107 @@ function nativeRemoveChild(
 }
 
 /**
- * Returns a native parent of a given native node.
+ * Returns a native parent of a given DOM node.
+ * NOTE: This is `parentNode`, not `parentElement`.
+ *
+ * @param renderer The renderer instance to use to do the introspection
+ * @param node The node from which to find the parent node
  */
 export function nativeParentNode(renderer: Renderer3, node: RNode): RElement|null {
-  return (isProceduralRenderer(renderer) ? renderer.parentNode(node) : node.parentNode) as RElement;
+  ngDevMode && assertDomNode(node);
+  return isProceduralRenderer(renderer) ? renderer.parentNode(node) : node.parentElement;
 }
 
 /**
- * Returns a native sibling of a given native node.
+ * Gets the `nextSibling` of a given DOM node.
+ *
+ * @param renderer The renderer instance to use to introspect on the provided node
+ * @param node The node to retrieve the `nextSibling` of.
  */
 export function nativeNextSibling(renderer: Renderer3, node: RNode): RNode|null {
+  ngDevMode && assertDefined(node, 'node must be provided');
   return isProceduralRenderer(renderer) ? renderer.nextSibling(node) : node.nextSibling;
 }
 
 /**
- * Finds a native "anchor" node for cases where we can't append a native child directly
- * (`appendChild`) and need to use a reference (anchor) node for the `insertBefore` operation.
- * @param parentTNode
- * @param lView
+ * Appends {@link RNode}(s) to the render parent found in the parent {@link LView}.
+ * @param childRNodeOrNodes the nodes to append
+ * @param childTNode A {@link TNode} used with the `parentLView` to get the renderParent
+ * @param lView The {@link LView} to append nodes in.
+ * @param insertBefore Optional anchor node
  */
-function getNativeAnchorNode(parentTNode: TNode, lView: LView): RNode|null {
-  if (parentTNode.type === TNodeType.View) {
-    const lContainer = getLContainer(parentTNode as TViewNode, lView) !;
-    const views = lContainer[VIEWS];
-    const index = views.indexOf(lView);
-    return getBeforeNodeForView(index, views, lContainer[NATIVE]);
-  } else if (
-      parentTNode.type === TNodeType.ElementContainer ||
-      parentTNode.type === TNodeType.IcuContainer) {
-    return getNativeByTNode(parentTNode, lView);
+export function appendChild(
+    childRNodeOrNodes: RNode | RNode[], childTNode: TNode, lView: LView,
+    insertBefore: RNode | null = null): void {
+  if (childTNode.parent === null) {
+    // if we don't have a parent then our parent could be an LViewContainer which may
+    // want us to insert at a specific location.
+    const lContainer = lView[PARENT] !;
+    if (isLContainer(lContainer)) {
+      insertBefore = getBeforeNodeForContainedView(lContainer, lView);
+    }
   }
-  return null;
+  insertChildBefore(childRNodeOrNodes, childTNode, lView, insertBefore);
 }
 
 /**
- * Appends the `child` native node (or a collection of nodes) to the `parent`.
+* Inserts {@link RNode}(s) to the render parent found in the parent {@link LView} before the
+* provided `insertBeforeNode`.
+* @param childRNodeOrNodes the nodes to append
+* @param childTNode A {@link TNode} used with the `parentLView` to get the renderParent
+* @param parentLView The parent {@link LView} to insert the node(s) in.
+* @param insertBeforeNode The {@link RNode} to insert the child node(s) before. If `null`, will
+* append
+* the node(s).
+*/
+export function insertChildBefore(
+    childRNodeOrNodes: RNode | RNode[], childTNode: TNode, parentLView: LView,
+    insertBeforeNode: RNode | null): void {
+  const renderParent = getRenderParent(childTNode, parentLView);
+  renderChild(childRNodeOrNodes, parentLView, insertBeforeNode, renderParent);
+}
+
+/**
+ * Appends or inserts child nodes into a parent node using the `parentLView`'s renderer.
  *
- * The element insertion might be delayed {@link canInsertNativeNode}.
+ * As an exported function, this is a shortcut used for projections.
  *
- * @param childEl The native child (or children) that should be appended
- * @param childTNode The TNode of the child element
- * @param currentView The current LView
- * @returns Whether or not the child was appended
+ * @param childRNodeOrNodes The node or nodes to insert
+ * @param parentLView The parent LView to insert the node(s) in
+ * @param insertBeforeNode The DOM node to insert the node(s) before, if `null`, it will append
+ * the
+ * node(s) to the end.
+ * @param renderParent The parent node to append or insert the child node(s) into. If `null`, this
+ * function is a noop.
  */
-export function appendChild(childEl: RNode | RNode[], childTNode: TNode, currentView: LView): void {
-  const renderParent = getRenderParent(childTNode, currentView);
-  if (renderParent != null) {
-    const renderer = currentView[RENDERER];
-    const parentTNode: TNode = childTNode.parent || currentView[T_HOST] !;
-    const anchorNode = getNativeAnchorNode(parentTNode, currentView);
-    if (Array.isArray(childEl)) {
-      for (let nativeNode of childEl) {
-        nativeAppendOrInsertBefore(renderer, renderParent, nativeNode, anchorNode);
-      }
-    } else {
-      nativeAppendOrInsertBefore(renderer, renderParent, childEl, anchorNode);
+export function renderChild(
+    childRNodeOrNodes: RNode | RNode[], parentLView: LView, insertBeforeNode: RNode | null,
+    renderParent: RNode | null): void {
+  if (renderParent) {
+    const renderer = parentLView[RENDERER];
+    insertNodeOrNodesBefore(renderer, childRNodeOrNodes, renderParent, insertBeforeNode);
+  }
+}
+
+/**
+ * Inserts DOM nodes before a provided `insertBeforeNode`. If the `insertBeforeNode` is `null`, then
+ * this will append the DOM nodes as children of the `renderParent`.
+ * @param renderer The renderer to use to do the DOM manipulation
+ * @param childRNodeOrNodes The DOM node or nodes to insert
+ * @param renderParent The parent DOM node (must be the parent of `insertBeforeNode`, if it's
+ * provided)
+ * @param insertBeforeNode The node to insert the `childRNodeOrNodes` in front of. If `null`, this
+ * function will perform an append.
+ */
+function insertNodeOrNodesBefore(
+    renderer: Renderer3, childRNodeOrNodes: RNode | RNode[], renderParent: RNode,
+    insertBeforeNode: RNode | null) {
+  if (Array.isArray(childRNodeOrNodes)) {
+    for (let i = 0; i < childRNodeOrNodes.length; i++) {
+      nativeInsertBefore(renderer, renderParent, childRNodeOrNodes[i], insertBeforeNode);
     }
+  } else {
+    nativeInsertBefore(renderer, renderParent, childRNodeOrNodes, insertBeforeNode);
   }
 }
 
@@ -709,7 +755,19 @@ function getHighestElementOrICUContainer(tNode: TNode): TNode {
   return tNode;
 }
 
-export function getBeforeNodeForView(index: number, views: LView[], containerNative: RComment) {
+/**
+ * Finds the DOM node that we should insert in front of when we insert DOM for a view we're
+ * inserting into a container.
+ * @param lContainer The container that holds the view we are inserting DOM for.
+ * @param lViewInContainer The view in the container we are going to insert DOM nodes for.
+ */
+export function getBeforeNodeForContainedView(lContainer: LContainer, lViewInContainer: LView) {
+  ngDevMode && assertLContainer(lContainer);
+  ngDevMode && assertLView(lViewInContainer);
+  const views = lContainer[VIEWS];
+  const index = views.indexOf(lViewInContainer);
+  ngDevMode && assertGreaterOrEqual(index, 0, 'view must be in container');
+  const containerNative = lContainer[NATIVE];
   if (index + 1 < views.length) {
     const view = views[index + 1] as LView;
     const viewTNode = view[T_HOST] as TViewNode;
@@ -738,32 +796,35 @@ export function nativeRemoveNode(renderer: Renderer3, rNode: RNode, isHostElemen
 /**
  * Appends nodes to a target projection place. Nodes to insert were previously re-distribution and
  * stored on a component host level.
- * @param lView A LView where nodes are inserted (target VLview)
+ * @param targetLView The view where nodes are to be inserted
  * @param tProjectionNode A projection node where previously re-distribution should be appended
  * (target insertion place)
  * @param selectorIndex A bucket from where nodes to project should be taken
  * @param componentView A where projectable nodes were initially created (source view)
+ * @param renderParent The DOM node to insert child nodes into
+ * @param insertBefore The DOM node to insert nodes in front of, defaults to appending if `null`.
  */
 export function appendProjectedNodes(
-    lView: LView, tProjectionNode: TProjectionNode, selectorIndex: number,
-    componentView: LView): void {
+    targetLView: LView, tProjectionNode: TProjectionNode, selectorIndex: number,
+    componentView: LView, renderParent: RElement, insertBefore: RNode | null): void {
   const projectedView = componentView[PARENT] !as LView;
   const componentNode = componentView[T_HOST] as TElementNode;
   let nodeToProject = (componentNode.projection as(TNode | null)[])[selectorIndex];
 
   if (Array.isArray(nodeToProject)) {
-    appendChild(nodeToProject, tProjectionNode, lView);
+    renderChild(nodeToProject, targetLView, insertBefore, renderParent);
   } else {
     while (nodeToProject) {
       if (nodeToProject.type === TNodeType.Projection) {
         appendProjectedNodes(
-            lView, tProjectionNode, (nodeToProject as TProjectionNode).projection,
-            findComponentView(projectedView));
+            targetLView, tProjectionNode, (nodeToProject as TProjectionNode).projection,
+            findComponentView(projectedView), renderParent, insertBefore);
       } else {
         // This flag must be set now or we won't know that this node is projected
         // if the nodes are inserted into a container later.
         nodeToProject.flags |= TNodeFlags.isProjected;
-        appendProjectedNode(nodeToProject, tProjectionNode, lView, projectedView);
+        appendProjectedNode(
+            nodeToProject, tProjectionNode, targetLView, projectedView, renderParent, insertBefore);
       }
       nodeToProject = nodeToProject.projectionNext;
     }
@@ -778,12 +839,14 @@ export function appendProjectedNodes(
  * @param tProjectionNode The projection (ng-content) TNode
  * @param currentView Current LView
  * @param projectionView Projection view (view above current)
+ * @param renderParent The parent DOM node to insert child nodes into
+ * @param insertBefore The DOM node to insert nodes in front of, defaults to appending if `null`.
  */
 function appendProjectedNode(
-    projectedTNode: TNode, tProjectionNode: TNode, currentView: LView,
-    projectionView: LView): void {
+    projectedTNode: TNode, tProjectionNode: TNode, currentView: LView, projectionView: LView,
+    renderParent: RElement, insertBefore: RNode | null): void {
   const native = getNativeByTNode(projectedTNode, projectionView);
-  appendChild(native, tProjectionNode, currentView);
+  renderChild(native, currentView, insertBefore, renderParent);
 
   // the projected contents are processed while in the shadow view (which is the currentView)
   // therefore we need to extract the view where the host element lives since it's the
@@ -805,13 +868,15 @@ function appendProjectedNode(
     if (projectedTNode.type === TNodeType.ElementContainer) {
       let ngContainerChildTNode: TNode|null = projectedTNode.child as TNode;
       while (ngContainerChildTNode) {
-        appendProjectedNode(ngContainerChildTNode, tProjectionNode, currentView, projectionView);
+        appendProjectedNode(
+            ngContainerChildTNode, tProjectionNode, currentView, projectionView, renderParent,
+            insertBefore);
         ngContainerChildTNode = ngContainerChildTNode.next;
       }
     }
 
     if (isLContainer(nodeOrContainer)) {
-      appendChild(nodeOrContainer[NATIVE], tProjectionNode, currentView);
+      renderChild(nodeOrContainer[NATIVE], currentView, insertBefore, renderParent);
     }
   }
 }
@@ -873,4 +938,31 @@ export function insertLContainerIntoParentLView(
       lastLContainerOrLView = item;
     }
   }
+}
+
+/**
+ * Adds an {@link LView} or {@link LContainer} to the END of the current view tree.
+ *
+ * This structure will be used to traverse through nested views to remove listeners
+ * and call onDestroy callbacks.
+ *
+ * For dynamic insertion use {@link insertLContainerIntoParentLView}
+ *
+ * @see insertLContainerIntoParentLView
+ * @see LView[CHILD_HEAD]
+ * @see LView[CHILD_TAIL]
+ * @see LView[NEXT]
+ *
+ * @param lView The view where LView or LContainer should be added
+ * @param lViewOrLContainer The LView or LContainer to add to the view tree
+ * @returns The same `LView` or `LContainer` passed to `lViewOrContainer`.
+ */
+export function appendChildView<T extends LView|LContainer>(lView: LView, lViewOrLContainer: T): T {
+  if (lView[CHILD_HEAD]) {
+    lView[CHILD_TAIL] ![NEXT] = lViewOrLContainer;
+  } else {
+    lView[CHILD_HEAD] = lViewOrLContainer;
+  }
+  lView[CHILD_TAIL] = lViewOrLContainer;
+  return lViewOrLContainer;
 }

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -6,16 +6,47 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertDefined} from '../util/assert';
+import {assertDefined, assertEqual} from '../util/assert';
 
 import {assertLViewOrUndefined} from './assert';
 import {executeHooks} from './hooks';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {TElementNode, TNode, TViewNode} from './interfaces/node';
-import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, TVIEW} from './interfaces/view';
+import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, TVIEW, View} from './interfaces/view';
 import {resetPreOrderHookFlags} from './util/view_utils';
 
 
+let _addingEmbeddedRootChild = false;
+let _useIvyAnimationCheck = false;
+
+/**
+ * Returns whether or not we're adding children at the root of an embedded view.
+ *
+ * This is used primarily to tell {@link AnimationRenderer} how to handle insertions appropriately.
+ */
+export function getAddingEmbeddedRootChild() {
+  ngDevMode && assertEqual(_useIvyAnimationCheck, true, 'Call setAddingEmbeddedRootChild first');
+  return _addingEmbeddedRootChild;
+}
+
+/**
+ * Sets whether or not the node being added is a root child of an embedded view.
+ * When we start adding nodes as direct children to embedded views, this flag should be flipped on.
+ *
+ * This is used to tell {@link AnimationRenderer} how to handle insertions appropriately.
+ */
+export function setAddingEmbeddedRootChild(value: boolean) {
+  _useIvyAnimationCheck = true;
+  _addingEmbeddedRootChild = value;
+}
+
+/**
+ * Returns true if Ivy path has been touched and {@link AnimationRenderer} needs to take the
+ * appropriate path on `appendChild` or `insertBefore`.
+ */
+export function shouldUseIvyAnimationCheck() {
+  return _useIvyAnimationCheck;
+}
 
 /**
  * Store the element depth count. This is used to identify the root elements of the template
@@ -128,7 +159,7 @@ export function getLView(): LView {
  *
  * @param viewToRestore The OpaqueViewState instance to restore.
  */
-export function restoreView(viewToRestore: OpaqueViewState) {
+export function restoreView(viewToRestore: View) {
   contextLView = viewToRestore as any as LView;
 }
 

--- a/packages/core/src/render3/view.ts
+++ b/packages/core/src/render3/view.ts
@@ -1,0 +1,344 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertDomNode, assertEqual} from '../util/assert';
+
+import {assertLContainer, assertLView, assertLViewOrUndefined} from './assert';
+import {getLContext} from './context_discovery';
+import {assignTViewNodeToLView, createLContainer, createLView, renderEmbeddedTemplate} from './instructions';
+import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
+import {TNode, TNodeType} from './interfaces/node';
+import {RComment, RElement, RNode} from './interfaces/renderer';
+import {DECLARATION_VIEW, EmbeddedViewFactory, EmbeddedViewFactoryInternal, HOST, LView, LViewFlags, QUERIES, RENDERER, TVIEW, View, ViewContainer} from './interfaces/view';
+import {addRemoveViewFromContainer, destroyLView, detachView, insertLContainerIntoParentLView, insertView, nativeNextSibling} from './node_manipulation';
+import {getAddingEmbeddedRootChild, getIsParent, getPreviousOrParentTNode, setAddingEmbeddedRootChild, setIsParent, setPreviousOrParentTNode, shouldUseIvyAnimationCheck} from './state';
+import {getLastRootElementFromView, lContainerToViewContainer, unwrapLContainer, unwrapRNode, viewContainerToLContainer, viewToLView} from './util/view_utils';
+
+
+
+// TODO: The example below needs to be put in a proper `{@example}`.
+
+/**
+ * Gets an {@link EmbeddedViewFactory} that will produce an embedded view.
+ * The DOM node that is provided should be a comment looking like `<!-- container -->`.
+ * This is rendered to the DOM for an instruction such as `<ng-template>`.
+ *
+ * For example, given the following template:
+ *
+ * ```html
+ * <div id="foo">
+ *   <ng-template>I am from a template</ng-template>
+ *   <span>{{someText}}</span>
+ * </div>
+ * ```
+ *
+ * ... you might have the following rendered DOM (represented here in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *  <!-- container -->
+ *  <span>some text</span>
+ * </div>
+ * ```
+ *
+ * You can select the container's anchor node, and retrieve an embedded view factory like so:
+ *
+ * ```ts
+ * const foo = document.querySelector('#foo');
+ * const containerComment = foo.firstChild;
+ * const embeddedViewFactory = getEmbeddedViewFactory(containerComment);
+ * ```
+ *
+ * From there you can get an embedded {@link View} by calling the factory with any valid context for that view.
+ *
+ * ```ts
+ * const embeddedView: View = embeddedViewFactory({ foo: 'bar' });
+ * ```
+ *
+ * To insert or review this embedded view, you would use {@link getViewContainer} to get a {@link ViewContainer}.
+ * Then use {@link viewContainerInsertAfter} to insert the `embeddedView` into the `ViewContainer` instance.
+ *
+ * You retrieve a `ViewContainer` similarly from a `<!-- container -->` comment node.
+ * In this example we can just reuse the one comment node we already have:
+ *
+ * ```ts
+ * const viewContainer = getViewContainer(containerComment);
+ * ```
+ *
+ * ...now we can insert the embedded view's DOM like so:
+ *
+ * ```ts
+ * // Append the view to the container.
+ * viewContainerInsertAfter(viewContainer, embeddedView, null);
+ * ```
+ *
+ * The resulting rendered DOM will look as follows (shown in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *   I am from a template.
+ *   <span>some text</span>
+ * </div>
+ * ```
+ *
+ * @see viewContainerInsertAfter
+ * @see getViewContainer
+ * @see viewContainerRemove
+ *
+ * @param containerComment The DOM node to get the embedded view factory for.
+ * @returns A function that will produce an embedded view.
+ */
+export function getEmbeddedViewFactory<T extends{}>(containerComment: RComment):
+    EmbeddedViewFactory<T>|null {
+  ngDevMode && assertDomNode(containerComment);
+  const lContext = getLContext(containerComment);
+  if (lContext) {
+    const declarationLView = lContext.lView;
+    const declarationTView = declarationLView[TVIEW];
+    const declarationTNode = declarationTView.data[lContext.nodeIndex] as TNode;
+    return getEmbeddedViewFactoryInternal<T>(declarationTNode, declarationLView) as any;
+  }
+  return null;
+}
+
+/**
+ * The internal implementation for {@link getEmbeddedViewFactory}.
+ *
+ * @param declarationTNode The template node where the embedded template was declared
+ * @param declarationLView The local view where the embedded template was declared
+ */
+export function getEmbeddedViewFactoryInternal<T extends{}>(
+    declarationTNode: TNode, declarationLView: LView): EmbeddedViewFactoryInternal<T>|null {
+  const templateTView = declarationTNode.tViews;
+  if (templateTView) {
+    if (Array.isArray(templateTView)) {
+      throw new Error('Array of TViews not supported');
+    }
+
+    return function embeddedViewFactory(context: T) {
+      const _isParent = getIsParent();
+      const _previousOrParentTNode = getPreviousOrParentTNode();
+      const _useIvyAnimationCheck = shouldUseIvyAnimationCheck();
+      const _addingEmbeddedRootChild = _useIvyAnimationCheck && getAddingEmbeddedRootChild();
+      try {
+        setIsParent(true);
+        setPreviousOrParentTNode(null !);
+        setAddingEmbeddedRootChild(true);
+        const lView = createLView(
+            declarationLView, templateTView, context, LViewFlags.CheckAlways, null, null);
+        lView[DECLARATION_VIEW] = declarationLView;
+
+        // TODO: Because the embedded view is always embedded into a container, this should be
+        // always true. Perhaps the declarationTNode type should be adjusted to be TContainerNode
+        if (declarationTNode.type === TNodeType.Container) {
+          const declarationContainer = unwrapLContainer(declarationLView[declarationTNode.index]) !;
+          ngDevMode && assertLContainer(declarationContainer);
+          const declarationQueries = declarationContainer[QUERIES];
+          if (declarationQueries) {
+            lView[QUERIES] = declarationQueries.createView();
+          }
+        }
+
+        assignTViewNodeToLView(templateTView, null, -1, lView);
+
+        if (templateTView.firstTemplatePass) {
+          templateTView.node !.injectorIndex = declarationTNode.injectorIndex;
+        }
+
+        renderEmbeddedTemplate(lView, templateTView, context);
+
+        return lView;
+      } finally {
+        _useIvyAnimationCheck && setAddingEmbeddedRootChild(_addingEmbeddedRootChild);
+        setIsParent(_isParent);
+        setPreviousOrParentTNode(_previousOrParentTNode);
+      }
+    };
+  }
+  return null;
+}
+
+/**
+ * Gets a {@link ViewContainer} instance from a container comment DOM node (`<!-- container -->`),
+ * this is something generally added to the DOM by template instructions and other mechanisms that
+ * use embedded views such as {@link ngIf} or {@link ngForOf}.
+ * @param containerComment The DOM node to use to find the view container instance.
+ */
+export function getViewContainer(containerComment: RComment): ViewContainer|null {
+  ngDevMode && assertDomNode(containerComment);
+  const lContext = getLContext(containerComment);
+  let viewContainer: ViewContainer|null = null;
+  if (lContext) {
+    const lView = lContext.lView;
+    const nodeIndex = lContext.nodeIndex;
+    const lViewContainerOrElement: LContainer|RNode = lView[nodeIndex];
+    let lContainer = unwrapLContainer(lViewContainerOrElement);
+    if (!lContainer) {
+      lContainer = lView[nodeIndex] = createLContainer(
+          lViewContainerOrElement as RElement | RComment, lView,
+          lViewContainerOrElement as RComment, true);
+      insertLContainerIntoParentLView(lView, lContainer);
+      const queries = lView[QUERIES];
+      if (queries) {
+        lContainer[QUERIES] = queries.container();
+      }
+    }
+    viewContainer = lContainerToViewContainer(lContainer);
+  }
+  return viewContainer;
+}
+
+
+/**
+ * Inserts or appends a {@link View} into a {@link ViewContainer}.
+ *
+ * @param viewContainer The container to insert the view into.
+ * @param view The view to insert into the container.
+ * @param insertAfterView The view in the container the inserted view should be inserted after. If
+ * `null`, this will just append the `view` as the last view in the `viewContainer`.
+ */
+export function viewContainerInsertAfter(
+    viewContainer: ViewContainer, view: View, insertAfterView: View | null): void {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+  ngDevMode && assertLViewOrUndefined(insertAfterView);
+
+  return viewContainerInsertAfterInternal(
+      viewContainerToLContainer(viewContainer), viewToLView(view),
+      insertAfterView as any as LView | null);
+}
+
+/**
+ * The internal implementation of {@link viewContainerInsertAfter}.
+ *
+ * @param lContainer The container to insert the view into
+ * @param lView The view to insert into the container
+ * @param insertAfterLView The optional view in the container that the inserted view should be
+ * inserted behind. If `null`, we will insert the view at the end of the container.
+ */
+function viewContainerInsertAfterInternal(
+    lContainer: LContainer, lView: LView, insertAfterLView: LView | null) {
+  const _inContainer = getAddingEmbeddedRootChild();
+  try {
+    setAddingEmbeddedRootChild(true);
+    const commentNode = lContainer[NATIVE];
+
+    // Because we're dynamically adding a view to the container, we reset the ACTIVE_INDEX to ensure
+    // the container is updated.
+    lContainer[ACTIVE_INDEX] = -1;
+
+    const insertAfterNode =
+        insertAfterLView ? getLastRootElementFromView(insertAfterLView) : commentNode;
+    ngDevMode && assertDomNode(insertAfterNode);
+    const tView = lView[TVIEW];
+    let tNode = tView.firstChild;
+
+    const index =
+        insertAfterLView ? viewContainerIndexOfInternal(lContainer, insertAfterLView) + 1 : 0;
+    insertView(lView, lContainer, index);
+
+    const renderer = lView[RENDERER];
+    const beforeNode = nativeNextSibling(renderer, insertAfterNode);
+    ngDevMode && assertEqual(tNode && tNode.parent, null, 'tNode parent should be null');
+
+    addRemoveViewFromContainer(lView, true, beforeNode);
+  } finally {
+    setAddingEmbeddedRootChild(_inContainer);
+  }
+}
+
+/**
+ * Searches the `viewContainer` for a the first instance of a given `view` and returns its index
+ * within the container, if the `view` is not found, it returns `-1`.
+ * @param viewContainer The container to search
+ * @param view The view to search for
+ */
+export function viewContainerIndexOf(viewContainer: ViewContainer, view: View): number {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+
+  return viewContainerIndexOfInternal(viewContainer as any, view as any);
+}
+
+function viewContainerIndexOfInternal(lContainer: LContainer, lView: LView) {
+  const views = lContainer[VIEWS] as LView[];
+  if (views) {
+    for (let i = 0; i < views.length; i++) {
+      if (lView === views[i]) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Used to remove (embedded) views from a container. Will detach the view and destroy it, and will
+ * also remove all DOM nodes associated with the view.
+ *
+ * @param viewContainer The container to remove the view from
+ * @param view The view to remove from the container
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function viewContainerRemove(
+    viewContainer: ViewContainer, view: View, shouldDestroy: boolean = true): void {
+  viewContainerRemoveInternal(
+      viewContainerToLContainer(viewContainer), viewToLView(view), shouldDestroy);
+}
+
+/**
+ * The internal implementation of {@link viewContainerRemove}
+ * @param lContainer The container to remove the view from
+ * @param lView The view to remove
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function viewContainerRemoveInternal(
+    lContainer: LContainer, lView: LView, shouldDestroy: boolean): void {
+  const index = viewContainerIndexOfInternal(lContainer, lView);
+  if (index >= 0) {
+    detachView(lContainer, index);
+    shouldDestroy && destroyLView(lView);
+  }
+}
+
+/**
+ * Gets the number of views in the container.
+ * @param viewContainer The view container examine for length.
+ */
+export function viewContainerLength(viewContainer: ViewContainer): number {
+  ngDevMode && assertLContainer(viewContainer);
+  return viewContainerLengthInternal(viewContainer as any);
+}
+
+function viewContainerLengthInternal(lContainer: LContainer): number {
+  const views = lContainer[VIEWS];
+  return Array.isArray(views) ? views.length : 0;
+}
+
+/**
+ * Retrieves a view from a container by index.
+ * @param viewContainer The container to get the view from
+ * @param index The index of the view to retrieve within the container.
+ */
+export function viewContainerGet(viewContainer: ViewContainer, index: number): View|null {
+  ngDevMode && assertLContainer(viewContainer);
+  const lView = viewContainerGetInternal(viewContainer as any, index);
+  return lView as any;
+}
+
+function viewContainerGetInternal(lContainer: LContainer, index: number): LView|null {
+  return lContainer[VIEWS][index] || null;
+}
+
+/**
+ * Destroys the view and cleans up accompanying data structures Ivy uses to optimize
+ * performance.
+ *
+ * @param view The view to destroy.
+ */
+export function viewDestroy(view: View): void {
+  destroyLView(viewToLView(view));
+}

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -52,6 +52,12 @@ export function assertNotDefined<T>(actual: T, msg: string) {
   }
 }
 
+export function assertGreaterOrEqual<T>(actual: T, expected: T, msg: string) {
+  if (actual < expected) {
+    throwError(msg);
+  }
+}
+
 export function assertDefined<T>(actual: T, msg: string) {
   if (actual == null) {
     throwError(msg);

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -34,6 +34,12 @@ export function assertSame<T>(actual: T, expected: T, msg: string) {
   }
 }
 
+export function assertNotSame<T>(actual: T, expected: T, msg: string) {
+  if (actual === expected) {
+    throwError(msg);
+  }
+}
+
 export function assertLessThan<T>(actual: T, expected: T, msg: string) {
   if (actual >= expected) {
     throwError(msg);
@@ -46,14 +52,15 @@ export function assertGreaterThan<T>(actual: T, expected: T, msg: string) {
   }
 }
 
-export function assertNotDefined<T>(actual: T, msg: string) {
-  if (actual != null) {
+export function assertGreaterOrEqual<T>(actual: T, expected: T, msg: string) {
+  if (actual < expected) {
     throwError(msg);
   }
 }
 
-export function assertGreaterOrEqual<T>(actual: T, expected: T, msg: string) {
-  if (actual < expected) {
+
+export function assertNotDefined<T>(actual: T, msg: string) {
+  if (actual != null) {
     throwError(msg);
   }
 }
@@ -70,12 +77,14 @@ export function throwError(msg: string): never {
   throw new Error(`ASSERTION ERROR: ${msg}`);
 }
 
+export function isDomNode(node: any): boolean {
+  return (typeof Node !== 'undefined' && node instanceof Node) ||
+      (node != null && typeof node === 'object' && node.constructor.name === 'WebWorkerRenderNode');
+}
+
 export function assertDomNode(node: any) {
   // If we're in a worker, `Node` will not be defined.
-  assertEqual(
-      (typeof Node !== 'undefined' && node instanceof Node) ||
-          (typeof node === 'object' && node.constructor.name === 'WebWorkerRenderNode'),
-      true, 'The provided value must be an instance of a DOM Node');
+  assertEqual(isDomNode(node), true, 'The provided value must be an instance of a DOM Node');
 }
 
 

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -147,9 +147,6 @@
     "name": "ViewEncapsulation"
   },
   {
-    "name": "__values"
-  },
-  {
     "name": "_currentNamespace"
   },
   {
@@ -165,9 +162,6 @@
     "name": "addOrUpdateStaticStyle"
   },
   {
-    "name": "addToViewTree"
-  },
-  {
     "name": "allocStylingContext"
   },
   {
@@ -178,6 +172,9 @@
   },
   {
     "name": "appendChild"
+  },
+  {
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -315,7 +312,7 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getBindingsEnabled"
@@ -376,9 +373,6 @@
   },
   {
     "name": "getNameOnlyMarkerIndex"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByTNode"
@@ -459,6 +453,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "instantiateAllDirectives"
   },
   {
@@ -531,12 +531,6 @@
     "name": "namespaceHTML"
   },
   {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
     "name": "nativeInsertBefore"
   },
   {
@@ -591,6 +585,9 @@
     "name": "registerPreOrderHooks"
   },
   {
+    "name": "renderChild"
+  },
+  {
     "name": "renderComponent"
   },
   {
@@ -622,6 +619,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "setAddingEmbeddedRootChild"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -126,19 +126,16 @@
     "name": "ViewEncapsulation"
   },
   {
-    "name": "__values"
-  },
-  {
     "name": "_global"
   },
   {
     "name": "_renderCompCount"
   },
   {
-    "name": "addToViewTree"
+    "name": "appendChild"
   },
   {
-    "name": "appendChild"
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -228,7 +225,7 @@
     "name": "generateExpandoInstructionBlock"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getCheckNoChangesMode"
@@ -271,9 +268,6 @@
   },
   {
     "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByTNode"
@@ -330,6 +324,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "instantiateRootComponent"
   },
   {
@@ -369,12 +369,6 @@
     "name": "namespaceHTML"
   },
   {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
     "name": "nativeInsertBefore"
   },
   {
@@ -409,6 +403,9 @@
   },
   {
     "name": "refreshDynamicEmbeddedViews"
+  },
+  {
+    "name": "renderChild"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -291,6 +291,9 @@
     "name": "__values"
   },
   {
+    "name": "_addingEmbeddedRootChild"
+  },
+  {
     "name": "_c0"
   },
   {
@@ -375,6 +378,9 @@
     "name": "_symbolIterator"
   },
   {
+    "name": "_useIvyAnimationCheck"
+  },
+  {
     "name": "addComponentLogic"
   },
   {
@@ -390,9 +396,6 @@
     "name": "addTContainerToQueries"
   },
   {
-    "name": "addToViewTree"
-  },
-  {
     "name": "allocPlayerContext"
   },
   {
@@ -406,6 +409,9 @@
   },
   {
     "name": "appendChild"
+  },
+  {
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -484,9 +490,6 @@
   },
   {
     "name": "createElementRef"
-  },
-  {
-    "name": "createEmbeddedViewAndNode"
   },
   {
     "name": "createEmptyStylingContext"
@@ -654,7 +657,10 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getAddingEmbeddedRootChild"
+  },
+  {
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getBindingsEnabled"
@@ -705,6 +711,9 @@
     "name": "getElementDepthCount"
   },
   {
+    "name": "getEmbeddedViewFactoryInternal"
+  },
+  {
     "name": "getErrorLogger"
   },
   {
@@ -750,6 +759,9 @@
     "name": "getLViewParent"
   },
   {
+    "name": "getLastRootElementFromView"
+  },
+  {
     "name": "getMatchingBindingIndex"
   },
   {
@@ -763,9 +775,6 @@
   },
   {
     "name": "getNameOnlyMarkerIndex"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByIndex"
@@ -930,6 +939,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "insertView"
   },
   {
@@ -1023,6 +1038,12 @@
     "name": "iterateListLike"
   },
   {
+    "name": "lContainerToViewContainer"
+  },
+  {
+    "name": "lViewToView"
+  },
+  {
     "name": "leaveView"
   },
   {
@@ -1063,12 +1084,6 @@
   },
   {
     "name": "namespaceHTML"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
   },
   {
     "name": "nativeInsertBefore"
@@ -1158,7 +1173,7 @@
     "name": "removeListeners"
   },
   {
-    "name": "removeView"
+    "name": "renderChild"
   },
   {
     "name": "renderComponent"
@@ -1213,6 +1228,9 @@
   },
   {
     "name": "searchTokensOnInjector"
+  },
+  {
+    "name": "setAddingEmbeddedRootChild"
   },
   {
     "name": "setBindingRoot"
@@ -1293,6 +1311,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "shouldUseIvyAnimationCheck"
+  },
+  {
     "name": "storeBindingMetadata"
   },
   {
@@ -1323,6 +1344,9 @@
     "name": "trackByIdentity"
   },
   {
+    "name": "unwrapLContainer"
+  },
+  {
     "name": "unwrapRNode"
   },
   {
@@ -1342,6 +1366,33 @@
   },
   {
     "name": "viewAttachedToContainer"
+  },
+  {
+    "name": "viewContainerGet"
+  },
+  {
+    "name": "viewContainerGetInternal"
+  },
+  {
+    "name": "viewContainerIndexOfInternal"
+  },
+  {
+    "name": "viewContainerInsertAfter"
+  },
+  {
+    "name": "viewContainerInsertAfterInternal"
+  },
+  {
+    "name": "viewContainerRemove"
+  },
+  {
+    "name": "viewContainerRemoveInternal"
+  },
+  {
+    "name": "viewContainerToLContainer"
+  },
+  {
+    "name": "viewToLView"
   },
   {
     "name": "walkTNodeTree"

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -9,7 +9,7 @@
 import {Component, ContentChild, ContentChildren, Directive, QueryList, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
+import {fixmeIvy, onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
 
 @Directive({
   selector: '[tplRef]',
@@ -230,13 +230,14 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const content = 'Hello {{ name }}';
       const template = `
         <div *ngIf="visible">
-          <div i18n>${content}</div>
+          <div class="test" i18n>${content}</div>
         </div>
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.children[0]).toHaveText('Bonjour John');
+      const element = fixture.nativeElement.querySelector('.test');
+
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should ignore i18n attributes on self-closing tags', () => {
@@ -250,11 +251,11 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
     it('should handle i18n attribute with directives', () => {
       const content = 'Hello {{ name }}';
       const template = `
-        <div *ngIf="visible" i18n>${content}</div>
+        <div class="test" *ngIf="visible" i18n>${content}</div>
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
+      const element = fixture.nativeElement.querySelector('.test');
       expect(element).toHaveText('Bonjour John');
     });
 
@@ -284,8 +285,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText('Bonjour John');
+      expect(fixture.nativeElement.innerHTML).toBe('<!--ng-container-->Bonjour John');
     });
 
     it('should handle single translation message within ng-template', () => {
@@ -460,7 +460,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
     it('should handle multiple ICUs in one block', () => {
       const template = `
             <div i18n>
-              {age, select, 10 {ten} 20 {twenty} other {other}} - 
+              {age, select, 10 {ten} 20 {twenty} other {other}} -
               {count, select, 1 {one} 2 {two} other {more than two}}
             </div>
           `;
@@ -552,8 +552,9 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           .replace(/<!--bindings=\{(\W.*\W\s*)?\}-->/g, '');
     }
 
-    it('detached nodes should still be part of query', () => {
-      const template = `
+    fixmeIvy('FW-1166: i18n not removing TNodes properly')
+        .it('detached nodes should still be part of query', () => {
+          const template = `
           <div-query #q i18n>
             <ng-template>
               <div>
@@ -565,50 +566,50 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           </div-query>
         `;
 
-      @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
-      class TextDirective {
-        // TODO(issue/24571): remove '!'.
-        text !: string;
-        constructor() {}
-      }
+          @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
+          class TextDirective {
+            // TODO(issue/24571): remove '!'.
+            text !: string;
+            constructor() {}
+          }
 
-      @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
-      class DivQuery {
-        // TODO(issue/24571): remove '!'.
-        @ContentChild(TemplateRef) template !: TemplateRef<any>;
+          @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
+          class DivQuery {
+            // TODO(issue/24571): remove '!'.
+            @ContentChild(TemplateRef) template !: TemplateRef<any>;
 
-        // TODO(issue/24571): remove '!'.
-        @ViewChild('vc', {read: ViewContainerRef})
-        vc !: ViewContainerRef;
+            // TODO(issue/24571): remove '!'.
+            @ViewChild('vc', {read: ViewContainerRef})
+            vc !: ViewContainerRef;
 
-        // TODO(issue/24571): remove '!'.
-        @ContentChildren(TextDirective, {descendants: true})
-        query !: QueryList<TextDirective>;
+            // TODO(issue/24571): remove '!'.
+            @ContentChildren(TextDirective, {descendants: true})
+            query !: QueryList<TextDirective>;
 
-        create() { this.vc.createEmbeddedView(this.template); }
+            create() { this.vc.createEmbeddedView(this.template); }
 
-        destroy() { this.vc.clear(); }
-      }
+            destroy() { this.vc.clear(); }
+          }
 
-      TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
-      const fixture = getFixtureWithOverrides({template});
-      const q = fixture.debugElement.children[0].references.q;
-      expect(q.query.length).toEqual(0);
+          TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
+          const fixture = getFixtureWithOverrides({template});
+          const q = fixture.debugElement.children[0].references.q;
+          expect(q.query.length).toEqual(0);
 
-      // Create embedded view
-      q.create();
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(1);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
+          // Create embedded view
+          q.create();
+          fixture.detectChanges();
+          expect(q.query.length).toEqual(1);
+          expect(toHtml(fixture.nativeElement))
+              .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
 
-      // Disable ng-if
-      fixture.componentInstance.visible = false;
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(0);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
-    });
+          // Disable ng-if
+          fixture.componentInstance.visible = false;
+          fixture.detectChanges();
+          expect(q.query.length).toEqual(0);
+          expect(toHtml(fixture.nativeElement))
+              .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
+        });
   });
 
   it('should handle multiple i18n sections', () => {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -477,25 +477,23 @@ describe('projection', () => {
     });
   }
 
-  fixmeIvy('FW-869: debugElement.queryAllNodes returns nodes in the wrong order')
-      .it('should support nested conditionals that contain ng-contents', () => {
-        TestBed.configureTestingModule(
-            {declarations: [ConditionalTextComponent, ManualViewportDirective]});
-        TestBed.overrideComponent(
-            MainComp, {set: {template: `<conditional-text>a</conditional-text>`}});
-        const main = TestBed.createComponent(MainComp);
+  it('should support nested conditionals that contain ng-contents', () => {
+    TestBed.configureTestingModule(
+        {declarations: [ConditionalTextComponent, ManualViewportDirective]});
+    TestBed.overrideComponent(
+        MainComp, {set: {template: `<conditional-text>a</conditional-text>`}});
+    const main = TestBed.createComponent(MainComp);
 
-        expect(main.nativeElement).toHaveText('MAIN()');
+    expect(main.nativeElement).toHaveText('MAIN()');
 
-        let viewportElement =
-            main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[0];
-        viewportElement.injector.get(ManualViewportDirective).show();
-        expect(main.nativeElement).toHaveText('MAIN(FIRST())');
+    let viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[0];
+    viewportElement.injector.get(ManualViewportDirective).show();
+    expect(main.nativeElement).toHaveText('MAIN(FIRST())');
 
-        viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[1];
-        viewportElement.injector.get(ManualViewportDirective).show();
-        expect(main.nativeElement).toHaveText('MAIN(FIRST(SECOND(a)))');
-      });
+    viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[1];
+    viewportElement.injector.get(ManualViewportDirective).show();
+    expect(main.nativeElement).toHaveText('MAIN(FIRST(SECOND(a)))');
+  });
 
   it('should allow to switch the order of nested components via ng-content', () => {
     TestBed.configureTestingModule({declarations: [CmpA, CmpB, CmpD, CmpC]});
@@ -605,49 +603,48 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('ABC');
   });
 
-  fixmeIvy('FW-869: debugElement.queryAllNodes returns nodes in the wrong order')
-      .it('should project filled view containers into a view container', () => {
-        TestBed.configureTestingModule(
-            {declarations: [ConditionalContentComponent, ManualViewportDirective]});
-        TestBed.overrideComponent(MainComp, {
-          set: {
-            template: '<conditional-content>' +
-                '<div class="left">A</div>' +
-                '<ng-template manual class="left">B</ng-template>' +
-                '<div class="left">C</div>' +
-                '<div>D</div>' +
-                '</conditional-content>'
-          }
-        });
-        const main = TestBed.createComponent(MainComp);
+  it('should project filled view containers into a view container', () => {
+    TestBed.configureTestingModule(
+        {declarations: [ConditionalContentComponent, ManualViewportDirective]});
+    TestBed.overrideComponent(MainComp, {
+      set: {
+        template: '<conditional-content>' +
+            '<div class="left">A</div>' +
+            '<ng-template manual class="left">B</ng-template>' +
+            '<div class="left">C</div>' +
+            '<div>D</div>' +
+            '</conditional-content>'
+      }
+    });
+    const main = TestBed.createComponent(MainComp);
 
-        const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
 
-        const viewViewportDir =
-            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
-                ManualViewportDirective);
+    const viewViewportDir =
+        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
+            ManualViewportDirective);
 
-        expect(main.nativeElement).toHaveText('(, D)');
-        expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('(, D)');
 
-        viewViewportDir.show();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(AC, D)');
+    viewViewportDir.show();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(AC, D)');
 
-        const contentViewportDir =
-            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
-                ManualViewportDirective);
+    const contentViewportDir =
+        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
+            ManualViewportDirective);
 
-        contentViewportDir.show();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(ABC, D)');
+    contentViewportDir.show();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(ABC, D)');
 
-        // hide view viewport, and test that it also hides
-        // the content viewport's views
-        viewViewportDir.hide();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(, D)');
-      });
+    // hide view viewport, and test that it also hides
+    // the content viewport's views
+    viewViewportDir.hide();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(, D)');
+  });
 
   describe('projectable nodes', () => {
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -23,6 +23,7 @@ import {NgForOf} from '../../test/render3/common_with_def';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, createComponent, getDirectiveOnNode, TemplateFixture,} from './render_util';
+import {fixmeIvy} from '@angular/private/testing';
 
 const Component: typeof _Component = function(...args: any[]): any {
   // In test we use @Component for documentation only so it's safe to mock out the implementation.
@@ -911,8 +912,21 @@ describe('ViewContainerRef', () => {
         fixture.update();
         expect(fixture.html).toEqual('<p vcref=""></p>ABC');
 
+        /**
+         * Current state of the DOM should be:
+         *
+         * <div>
+         *   <!-- container -->
+         *   <p vcref=""></p>
+         *   <!-- container -->
+         *   A  <-- text node
+         *   B  <-- text node
+         *   C  <-- text node
+         * </div>
+         */
+
         // The DOM is manually modified here to ensure that the text node is actually moved
-        fixture.hostElement.childNodes[2].nodeValue = '**A**';
+        fixture.hostElement.childNodes[3].nodeValue = '**A**';
         expect(fixture.html).toEqual('<p vcref=""></p>**A**BC');
 
         let viewRef = directiveInstance !.vcref.get(0);

--- a/packages/core/test/render3/view_spec.ts
+++ b/packages/core/test/render3/view_spec.ts
@@ -1,0 +1,428 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TemplateFixture} from './render_util';
+import {template, element, RenderFlags, elementEnd, elementStart, text, textBinding, bind} from '@angular/core/src/render3';
+import {getEmbeddedViewFactory, viewContainerInsertAfter, getViewContainer, viewContainerRemove, viewContainerGet, viewContainerIndexOf, viewContainerLength} from '@angular/core/src/render3/view';
+import {CHILD_HEAD, NEXT, CHILD_TAIL} from '@angular/core/src/render3/interfaces/view';
+
+describe('ViewContainer manipulation commands', () => {
+  it('should get the embedded view from a comment added by ng-template and be able to insert it', () => {
+    /*
+    <div></div>
+    <ng-template>
+      <b>Hello </b>
+      <i>{{name}}</i>
+    </ng-template>
+    */
+    const fixture = new TemplateFixture(
+        () => {
+          element(0, 'div');
+          template(1, (rf: RenderFlags, ctx: any) => {
+            if (rf & RenderFlags.Create) {
+              elementStart(0, 'b');
+              text(1, 'Hello ');
+              elementEnd();
+              elementStart(2, 'i');
+              text(3);
+              elementEnd();
+            }
+            if (rf & RenderFlags.Update) {
+              textBinding(3, bind(ctx.name));
+            }
+          }, 4, 1);
+        },
+        () => {
+
+        },
+        2, 0);
+
+    /*
+    <div></div>
+    <!-- container -->
+    */
+    const comment = fixture.hostElement.lastChild !;
+    expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+    const embeddedViewFactory = getEmbeddedViewFactory(comment) !;
+    expect(typeof embeddedViewFactory).toEqual('function');
+
+    const commentViewContainer = getViewContainer(comment) !;
+
+    const bView = embeddedViewFactory({name: 'B'});
+    // Putting this in the very front.
+    viewContainerInsertAfter(commentViewContainer, bView, null);
+
+    // Now putting this in front of B (because it's in the very front).
+    viewContainerInsertAfter(commentViewContainer, embeddedViewFactory({name: 'A'}), null);
+
+    // Putting this one after B
+    viewContainerInsertAfter(commentViewContainer, embeddedViewFactory({name: 'C'}), bView);
+
+    // Putting this one right after that initial <div></div>
+    const divViewContainer = getViewContainer(fixture.hostElement.firstChild !) !;
+    viewContainerInsertAfter(divViewContainer, embeddedViewFactory({name: 'X'}), null);
+
+    fixture.update();
+    expect(fixture.htmlWithContainerComments)
+        .toEqual(
+            '<div></div><b>Hello </b><i>X</i><!--container--><b>Hello </b><i>A</i><b>Hello </b><i>B</i><b>Hello </b><i>C</i>');
+  });
+
+  describe('getViewContainer', () => {
+    it('should lazily create LContainers and add them to the internal linked list in the order of DOM',
+       () => {
+         /*
+          <one/>
+          <two/>
+          <three/>
+          <four/>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               element(0, 'one');
+               element(1, 'two');
+               element(2, 'three');
+               element(3, 'four');
+             },
+             () => {
+
+             },
+             4, 0);
+
+         const one = fixture.hostElement.querySelector('one') !;
+         const two = fixture.hostElement.querySelector('two') !;
+         const three = fixture.hostElement.querySelector('three') !;
+         const four = fixture.hostElement.querySelector('four') !;
+
+         // This is adding to the CHILD_HEAD and CHILD_TAIL
+         const threeContainer = getViewContainer(three);
+         // This is inserting to CHILD_HEAD infront of existing CHILD_HEAD
+         const oneContainer = getViewContainer(one);
+         // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+         const fourContainer = getViewContainer(four);
+         // This is inserting in the middle of the list
+         const twoContainer = getViewContainer(two);
+
+         let cursor = fixture.hostView[CHILD_HEAD];
+
+         expect(cursor).toBe(oneContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(twoContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(threeContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(fourContainer as any);
+
+         expect(fixture.hostView[CHILD_TAIL]).toBe(cursor);
+         expect(cursor ![NEXT]).toEqual(null);
+       });
+
+    it('should lazily create LContainers and add them to the internal linked list in order of DOM, depth first',
+       () => {
+         /*
+           <one>
+             <two>
+               <three>
+                 <four/>
+               </three>
+             </two>
+           </one>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               elementStart(0, 'one');
+               {
+                 elementStart(1, 'two');
+
+                 {
+                   elementStart(2, 'three');
+                   {
+                     element(3, 'four');  //
+                   }
+                   elementEnd();
+                 }
+                 elementEnd();
+               }
+               elementEnd();
+             },
+             () => {
+
+             },
+             4, 0);
+
+         const one = fixture.hostElement.querySelector('one') !;
+         const two = fixture.hostElement.querySelector('two') !;
+         const three = fixture.hostElement.querySelector('three') !;
+         const four = fixture.hostElement.querySelector('four') !;
+
+         // This is adding to the CHILD_HEAD and CHILD_TAIL
+         const threeContainer = getViewContainer(three);
+         // This is inserting to CHILD_HEAD infront of existing CHILD_HEAD
+         const oneContainer = getViewContainer(one);
+         // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+         const fourContainer = getViewContainer(four);
+         // This is inserting in the middle of the list
+         const twoContainer = getViewContainer(two);
+
+         let cursor = fixture.hostView[CHILD_HEAD];
+
+         expect(cursor).toBe(oneContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(twoContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(threeContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(fourContainer as any);
+
+         expect(fixture.hostView[CHILD_TAIL]).toBe(cursor);
+         expect(cursor ![NEXT]).toEqual(null);
+       });
+  });
+
+  describe('viewContainerRemove', () => {
+    it('should remove views from a container', () => {
+      /*
+       <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container-->');
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const view = embeddedViewFactory({});
+      const container = getViewContainer(containerComment) !;
+      viewContainerInsertAfter(container, view, null);
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container--><span></span>');
+      viewContainerRemove(container, view);
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container-->');
+    });
+
+    it('should remove all dom elements for a view, as there could be more than one', () => {
+      /*
+      <ul>
+        <ng-template>
+          <li>one</li>
+          <li>two</li>
+          <li>three</li>
+        </ng-template>
+      </ul>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            elementStart(0, 'ul');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                elementStart(0, 'li');
+                text(1, 'one');
+                elementEnd();
+                elementStart(2, 'li');
+                text(3, 'two');
+                elementEnd();
+                elementStart(4, 'li');
+                text(5, 'three');
+                elementEnd();
+              }
+            }, 6, 0);
+            elementEnd();
+          },
+          () => {
+
+          },
+          2, 0);
+
+      expect(fixture.htmlWithContainerComments).toEqual('<ul><!--container--></ul>');
+      const containerComment = fixture.hostElement.firstChild !.firstChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+      const view = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view, null);
+      expect(fixture.htmlWithContainerComments)
+          .toEqual('<ul><!--container--><li>one</li><li>two</li><li>three</li></ul>');
+      viewContainerRemove(container, view);
+      expect(fixture.htmlWithContainerComments).toEqual('<ul><!--container--></ul>');
+    });
+  });
+
+  describe('viewContainerInsertAfter', () => {
+    it('should insert views in the container', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+
+      expect(viewContainerLength(container)).toBe(0);
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+      expect(viewContainerLength(container)).toBe(1);
+      expect(viewContainerGet(container, 0)).toBe(view1);
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+      expect(viewContainerLength(container)).toBe(2);
+      expect(viewContainerGet(container, 1)).toBe(view2);
+
+      const view3 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view3, view2);
+      expect(viewContainerLength(container)).toBe(3);
+      expect(viewContainerGet(container, 2)).toBe(view3);
+
+      // assure that passing null will prepend even if other views are in there.
+      const viewA = embeddedViewFactory({});
+
+      viewContainerInsertAfter(container, viewA, null);
+      expect(viewContainerLength(container)).toBe(4);
+      expect(viewContainerGet(container, 0)).toBe(viewA);
+      expect(viewContainerGet(container, 1)).toBe(view1);
+      expect(viewContainerGet(container, 2)).toBe(view2);
+      expect(viewContainerGet(container, 3)).toBe(view3);
+    });
+  });
+
+  describe('viewContainerIndexOf', () => {
+    it('should find the first index of a container within a view, and return -1 if it cannot find it',
+       () => {
+         /*
+          <div></div><ng-template><span></span></ng-template>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               element(0, 'div');
+               template(1, (rf: RenderFlags, ctx: any) => {
+                 if (rf & RenderFlags.Create) {
+                   element(0, 'span');
+                 }
+               }, 1, 0);
+             },
+             () => {
+
+             },
+             2, 0);
+
+         const containerComment = fixture.hostElement.lastChild !;
+         const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+         const view = embeddedViewFactory({});
+         const container = getViewContainer(containerComment) !;
+
+         expect(viewContainerIndexOf(container, view))
+             .toBe(-1);  // not found because it's not inserted yet.
+
+         // insert one view and see if an index is returned.
+         viewContainerInsertAfter(container, view, null);
+         expect(viewContainerIndexOf(container, view)).toBe(0);
+
+         // insert the view twice, just to make sure the first index is returned.
+         viewContainerInsertAfter(container, view, null);
+         expect(viewContainerIndexOf(container, view)).toBe(0);
+       });
+  });
+
+  describe('viewContainerGet', () => {
+    it('should get a view by index from the container', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+
+      expect(viewContainerGet(container, 0)).toBe(view1);
+      expect(viewContainerGet(container, 1)).toBe(view2);
+    });
+  });
+
+  describe('viewContainerLength', () => {
+    it('should get the current length of the container, by contained view count', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+      expect(viewContainerLength(container)).toBe(0);
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+      expect(viewContainerLength(container)).toBe(1);
+
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+      expect(viewContainerLength(container)).toBe(2);
+    });
+  });
+});

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -8,6 +8,7 @@
 import {AnimationTriggerMetadata} from '@angular/animations';
 import {ɵAnimationEngine as AnimationEngine} from '@angular/animations/browser';
 import {Injectable, NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '@angular/core';
+import {getAddingEmbeddedRootChild, shouldUseIvyAnimationCheck} from '@angular/core/src/render3/state';
 
 const ANIMATION_PREFIX = '@';
 const DISABLE_ANIMATIONS_FLAG = '@.disabled';
@@ -140,12 +141,16 @@ export class BaseAnimationRenderer implements Renderer2 {
 
   appendChild(parent: any, newChild: any): void {
     this.delegate.appendChild(parent, newChild);
-    this.engine.onInsert(this.namespaceId, newChild, parent, false);
+    const shouldCollectEnterElement =
+        shouldUseIvyAnimationCheck() ? getAddingEmbeddedRootChild() : false;
+    this.engine.onInsert(this.namespaceId, newChild, parent, shouldCollectEnterElement);
   }
 
   insertBefore(parent: any, newChild: any, refChild: any): void {
     this.delegate.insertBefore(parent, newChild, refChild);
-    this.engine.onInsert(this.namespaceId, newChild, parent, true);
+    const shouldCollectEnterElement =
+        shouldUseIvyAnimationCheck() ? getAddingEmbeddedRootChild() : true;
+    this.engine.onInsert(this.namespaceId, newChild, parent, shouldCollectEnterElement);
   }
 
   removeChild(parent: any, oldChild: any, isHostElement: boolean): void {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1630,7 +1630,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/team/22');
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-         const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+         const teamCmp = fixture.debugElement.childNodes[2].componentInstance;
 
          teamCmp.routerLink = ['/team/0'];
          advance(fixture);


### PR DESCRIPTION
- Moves embedded view management to insert nodes *after* the `<!-- container -->` comment, rather than before.
- Updates several tests that were relying on node order in the DOM
- Updates animation renderer to ensure that the proper pathways are invoked if we are inserting embedded views for things like `*ngFor` or `*ngIf`, et al.

This is part of what was #29031.

Blocked waiting for #29339 