### PR TITLE
refactor(ivy): update TNodeType

### DIFF
--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -12,17 +12,33 @@ import {LView, TView} from './view';
 
 
 /**
- * TNodeType corresponds to the TNode.type property. It contains information
- * on how to map a particular set of bits in TNode.flags to the node type.
+ * TNodeType corresponds to the {@link TNode} `type` property.
  */
 export const enum TNodeType {
-  Container = 0b000,
-  Projection = 0b001,
-  View = 0b010,
-  Element = 0b011,
-  ViewOrElement = 0b010,
-  ElementContainer = 0b100,
-  IcuContainer = 0b101,
+  /**
+   * The TNode contains information about an {@link LContainer} for embedded views.
+   */
+  Container = 0,
+  /**
+   * The TNode contains information about an `<ng-content>` projection
+   */
+  Projection = 1,
+  /**
+   * The TNode contains information about an {@link LView}
+   */
+  View = 2,
+  /**
+   * The TNode contains information about a DOM element aka {@link RNode}.
+   */
+  Element = 3,
+  /**
+   * The TNode contains information about a container comment {@link RNode}.
+   */
+  ElementContainer = 4,
+  /**
+   * The TNode contains information about an ICU comment used in `i18n`.
+   */
+  IcuContainer = 5,
 }
 
 /**

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -32,7 +32,7 @@ export const enum TNodeType {
    */
   Element = 3,
   /**
-   * The TNode contains information about a container comment {@link RNode}.
+   * The TNode contains information about an `<ng-container>` element {@link RNode}.
    */
   ElementContainer = 4,
   /**


### PR DESCRIPTION
- Remove an extra type `ViewOrElement`, which even had the same numeric value as `View`.
- Updates comment to remove part about alleged bit-masking that we could be doing here.
  We aren't using this with bitmasks, and if we were, everything would be a `NodeType.Container`,
  because its value was `0`.
- Updates the number values to be simple, human-readable integers, since we're not using these
  with any kind of bit-manipulation.
- Add comments about each type.
