### PR TITLE
fix(bazel): correct regexp test for self-references in metadata

### DIFF
--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -415,7 +415,7 @@ export * from '${srcDirRelative(inputPath, typingsFile.replace(/\.d\.tsx?$/, '')
     if (metadata.exports) {
       // Strip re-exports which are now self-references
       metadata.exports =
-          metadata.exports.filter((e: {from: string}) => !relativePathRegex.test(e.from));
+          metadata.exports.filter((e: {from: string}) => !e.from.match(relativePathRegex));
     }
     return JSON.stringify(metadata).replace(relativePathRegex, typingsRelativePath);
   }

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -89,6 +89,8 @@ describe('@angular/core ng_package', () => {
         .describe('angular metadata', () => {
           it('should have metadata.json files',
              () => { expect(shx.cat('core.metadata.json')).toContain(`"__symbolic":"module"`); });
+          it('should not have self-references in metadata.json',
+             () => { expect(shx.cat('core.metadata.json')).not.toContain(`"from":"./core"`); });
         });
 
     describe('fesm2015', () => {


### PR DESCRIPTION
Add a test that catches the mistake, should have had this in the previous change