### PR TITLE
fix(build): Merge script should fail if there are fixups after merge

### DIFF
--- a/scripts/github/merge-pr
+++ b/scripts/github/merge-pr
@@ -7,7 +7,6 @@ set -u -e -E -o pipefail
 
 BASEDIR=$(dirname "$0")
 BASEDIR=`(cd $BASEDIR; pwd)`
-
 PR_NUMBER=0
 PUSH_UPSTREAM=1
 FORCE=0
@@ -109,7 +108,21 @@ SQUASH_PR="git rebase --autosquash --interactive merge_pr_base merge_pr"
 REWRITE_MESSAGE="git filter-branch -f --msg-filter \"$BASEDIR/utils/github_closes.js $PR_NUMBER\" merge_pr_base..merge_pr"
 PUSH_BRANCHES="git push git@github.com:angular/angular.git merge_pr_master:$MASTER_BRANCH merge_pr_patch:$PATCH_BRANCH"
 CHERRY_PICK_PR="git cherry-pick merge_pr_base..merge_pr"
-CHECK_FIXUP_REMAINS="git cherry -v merge_master merge_pr | grep fixup"
+if [[ $MERGE_MASTER == 1 ]]; then
+  CHECK_FIXUP_REMAINS="git cherry -v merge_pr_master merge_pr"
+elif [[ $MERGE_PATCH == 1 ]]; then
+  CHECK_FIXUP_REMAINS="git cherry -v merge_pr_patch merge_pr"
+fi;
+check_cherry_output() {
+  OUTPUT=$( $1 );
+  while read -r line; do
+    COMMIT_MSG=${line:43}
+    if [[ ${COMMIT_MSG:0:6} == "fixup!" ]]; then
+      return 1;
+    fi;
+  done <<< "$OUTPUT";
+  return 0;
+}
 
 # Checks that each PR branch to be merged upstream contains SHAs of commits that significantly changed our CI infrastructure.
 #
@@ -132,6 +145,7 @@ echo "   $FETCH_PR"
 echo "   $BASE_PR"
 echo "   $CHECK_IF_PR_REBASED"
 echo "   $SQUASH_PR"
+echo "   $CHECK_FIXUP_REMAINS"
 echo "   $REWRITE_MESSAGE"
 if [[ $MERGE_MASTER == 1 ]]; then
   echo "   $CHECKOUT_MASTER && $CHERRY_PICK_PR"
@@ -164,10 +178,11 @@ GIT_EDITOR=echo $SQUASH_PR
 
 # Checks if there are fixup commits remaining after merge and throw a friendly error.
 # This would prevent caretakers from accidentally muddying the commit history with a bad squash
-if [[ $($CHECK_FIXUP_REMAINS) ]]; then
+echo ">>> Fixup: check fixup's remains"
+if ! check_cherry_output "$CHECK_FIXUP_REMAINS"; then
   echo ""
   echo ""
-  echo "Failed to merge pull request #${PR_NUMBER} because it has detached fixup commits that can't be seuqashed automatically"
+  echo "Failed to merge pull request #${PR_NUMBER} because it has detached fixup commits that can't be squashed automatically"
   echo ""
   echo "Please fix the PR and try again."
   echo ""

--- a/scripts/github/merge-pr
+++ b/scripts/github/merge-pr
@@ -109,6 +109,7 @@ SQUASH_PR="git rebase --autosquash --interactive merge_pr_base merge_pr"
 REWRITE_MESSAGE="git filter-branch -f --msg-filter \"$BASEDIR/utils/github_closes.js $PR_NUMBER\" merge_pr_base..merge_pr"
 PUSH_BRANCHES="git push git@github.com:angular/angular.git merge_pr_master:$MASTER_BRANCH merge_pr_patch:$PATCH_BRANCH"
 CHERRY_PICK_PR="git cherry-pick merge_pr_base..merge_pr"
+CHECK_FIXUP_REMAINS="git cherry -v merge_master merge_pr | grep fixup"
 
 # Checks that each PR branch to be merged upstream contains SHAs of commits that significantly changed our CI infrastructure.
 #
@@ -160,6 +161,20 @@ else
 fi
 echo ">>> Autosquash: $SQUASH_PR"
 GIT_EDITOR=echo $SQUASH_PR
+
+# Checks if there are fixup commits remaining after merge and throw a friendly error.
+# This would prevent caretakers from accidentally muddying the commit history with a bad squash
+if [[ $($CHECK_FIXUP_REMAINS) ]]; then
+  echo ""
+  echo ""
+  echo "Failed to merge pull request #${PR_NUMBER} because it has detached fixup commits that can't be seuqashed automatically"
+  echo ""
+  echo "Please fix the PR and try again."
+  echo ""
+  $RESTORE_BRANCH
+  exit 1
+fi
+
 echo ">>> Rewrite message: $REWRITE_MESSAGE"
 # Next line should work, but it errors, hence copy paste the command.
 # $REWRITE_MESSAGE


### PR DESCRIPTION
fixes #29268

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [  ] Tests for the changes have been added (for bug fixes / features)
- [  ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #292268


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Finds any fixup commits left after autosquash and prevents any changes on it.
