### PR TITLE
feat: move legacy Http library out of platform-server w/ compat [POC]

### DIFF
--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -21,7 +21,6 @@
     "@angular/compiler": "^7.0.0",
     "@angular/core": "^7.0.0",
     "@angular/forms": "^7.0.0",
-    "@angular/http": "^7.0.0",
     "@angular/platform-browser": "^7.0.0",
     "@angular/platform-browser-dynamic": "^7.0.0",
     "@angular/router": "^7.0.0",

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -24,7 +24,6 @@
     "@angular/core": "^7.1.0",
     "@angular/elements": "^7.1.0",
     "@angular/forms": "^7.1.0",
-    "@angular/http": "^7.1.0",
     "@angular/platform-browser": "^7.1.0",
     "@angular/platform-browser-dynamic": "^7.1.0",
     "@angular/router": "^7.1.0",

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -199,13 +199,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@^7.1.0":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-7.2.4.tgz#fc151ac15c8c7542cb7242a430ad2319655c2ff5"
-  integrity sha512-kazJREm7MtSCYbE+9zU/CcUXI5Csu53PooeQlAp80/TOHqry6fVKIMHCI892Db9ScY2ds0SzbyTmrxEQo7PP1A==
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@^7.1.0":
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-7.2.4.tgz#db72460040b070410cbff678410c142f4d682af8"

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world-ivy-compat/yarn.lock
+++ b/integration/cli-hello-world-ivy-compat/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world-ivy-minimal/yarn.lock
+++ b/integration/cli-hello-world-ivy-minimal/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world/yarn.lock
+++ b/integration/cli-hello-world/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/platform-server/package.json
+++ b/integration/platform-server/package.json
@@ -13,7 +13,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/core": "file:../../dist/packages-dist/core",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/integration/platform-server/yarn.lock
+++ b/integration/platform-server/yarn.lock
@@ -37,11 +37,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "7.2.0-rc.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "7.2.0-rc.0"
   dependencies:

--- a/modules/benchmarks/src/bootstrap_ng2.ts
+++ b/modules/benchmarks/src/bootstrap_ng2.ts
@@ -34,7 +34,6 @@
               '/packages-dist/platform-browser/bundles/platform-browser.umd.js',
           '@angular/platform-browser-dynamic':
               '/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
-          '@angular/http': '/packages-dist/http/bundles/http.umd.js',
           '@angular/upgrade': '/packages-dist/upgrade/bundles/upgrade.umd.js',
           '@angular/router': '/packages-dist/router/bundles/router.umd.js',
           'rxjs': '/all/benchmarks/vendor/rxjs',

--- a/modules/benchmarks_external/src/bootstrap.ts
+++ b/modules/benchmarks_external/src/bootstrap.ts
@@ -32,7 +32,6 @@
               '/packages-dist/platform-browser/bundles/platform-browser.umd.js',
           '@angular/platform-browser-dynamic':
               '/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
-          '@angular/http': '/packages-dist/http/bundles/http.umd.js',
           '@angular/upgrade': '/packages-dist/upgrade/bundles/upgrade.umd.js',
           '@angular/router': '/packages-dist/router/bundles/router.umd.js',
           '@angular/core/src/facade': '/all/@angular/core/src/facade',

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -15,5 +15,5 @@ export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInter
 export {HttpParameterCodec, HttpParams, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpUserEvent} from './src/response';
-export {HttpXhrBackend, XhrFactory} from './src/xhr';
+export {BrowserXhr, HttpXhrBackend, XhrFactory} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -40,7 +40,7 @@ export abstract class XhrFactory { abstract build(): XMLHttpRequest; }
 /**
  * A factory for @{link HttpXhrBackend} that uses the `XMLHttpRequest` browser API.
  *
- *
+ * @publicApi
  */
 @Injectable()
 export class BrowserXhr implements XhrFactory {

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -21,6 +21,7 @@ ng_package(
     name = "npm_package",
     srcs = [
         "package.json",
+        "//packages/http/server:package.json",
         "//packages/http/testing:package.json",
     ],
     entry_point = "packages/http/index.js",
@@ -34,6 +35,7 @@ ng_package(
     ],
     deps = [
         ":http",
+        "//packages/http/server",
         "//packages/http/testing",
     ],
 )

--- a/packages/http/server/BUILD.bazel
+++ b/packages/http/server/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["package.json"])
+
+ng_module(
+    name = "server",
+    srcs = glob(
+        [
+            "*.ts",
+            "src/**/*.ts",
+        ],
+    ),
+    deps = [
+        "//packages/core",
+        "//packages/http",
+        "@npm//@types/node",
+        "@npm//rxjs",
+        "@npm//zone.js",
+    ],
+)

--- a/packages/http/server/PACKAGE.md
+++ b/packages/http/server/PACKAGE.md
@@ -1,0 +1,6 @@
+Implements an HTTP client API for Angular apps that relies on the `XMLHttpRequest` interface exposed by browsers. 
+
+Includes testability features, typed request and response objects, request and response interception,
+observable APIs, and streamlined error handling.
+
+For usage information, see the [HTTP Client](guide/http) guide.

--- a/packages/http/server/index.ts
+++ b/packages/http/server/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// This file is not used to build this module. It is only used during editing
+// by the TypeScript language service and during build for verification. `ngc`
+// replaces this file with production index.ts when it rewrites private symbol
+// names.
+
+/// <reference types="node" />
+
+export * from './public_api';

--- a/packages/http/server/package.json
+++ b/packages/http/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@angular/common/http",
+  "typings": "./http.d.ts",
+  "main": "../bundles/common-http.umd.js",
+  "module": "../fesm5/http.js",
+  "es2015": "../fesm2015/http.js",
+  "esm5": "../esm5/http/http.js",
+  "esm2015": "../esm2015/http/http.js",
+  "fesm5": "../fesm5/http.js",
+  "fesm2015": "../fesm2015/http.js",
+  "sideEffects": false
+}

--- a/packages/http/server/public_api.ts
+++ b/packages/http/server/public_api.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export {ServerHttpModule} from './src/module';

--- a/packages/http/server/src/module.ts
+++ b/packages/http/server/src/module.ts
@@ -5,16 +5,28 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Injectable, NgModule, Provider} from '@angular/core';
+import {BrowserXhr, Connection, ConnectionBackend, Http, HttpModule, ReadyState, Request, RequestOptions, XHRBackend, XSRFStrategy,} from '@angular/http';
+import {Observable, Observer, Subscription} from 'rxjs';
 
 const xhr2: any = require('xhr2');
 
-import {Injectable, Injector, Optional, Provider, InjectFlags} from '@angular/core';
-import {BrowserXhr, HttpEvent, HttpRequest, HttpHandler, HttpInterceptor, HTTP_INTERCEPTORS, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
-import {Observable, Observer, Subscription} from 'rxjs';
+const isAbsoluteUrl = /^[a-zA-Z\-\+.]+:\/\//;
+
+function validateRequestUrl(url: string): void {
+  if (!isAbsoluteUrl.test(url)) {
+    throw new Error(`URLs requested via Http on the server must be absolute. URL: ${url}`);
+  }
+}
 
 @Injectable()
 export class ServerXhr implements BrowserXhr {
   build(): XMLHttpRequest { return new xhr2.XMLHttpRequest(); }
+}
+
+@Injectable()
+export class ServerXsrfStrategy implements XSRFStrategy {
+  configureRequest(req: Request): void {}
 }
 
 export abstract class ZoneMacroTaskWrapper<S, R> {
@@ -95,26 +107,53 @@ export abstract class ZoneMacroTaskWrapper<S, R> {
   protected abstract delegate(request: S): Observable<R>;
 }
 
-export class ZoneClientBackend extends
-    ZoneMacroTaskWrapper<HttpRequest<any>, HttpEvent<any>> implements HttpBackend {
-  constructor(private backend: HttpBackend) { super(); }
+export class ZoneMacroTaskConnection extends ZoneMacroTaskWrapper<Request, Response> implements
+    Connection {
+  response: Observable<Response>;
+  // TODO(issue/24571): remove '!'.
+  lastConnection !: Connection;
 
-  handle(request: HttpRequest<any>): Observable<HttpEvent<any>> { return this.wrap(request); }
+  constructor(public request: Request, private backend: XHRBackend) {
+    super();
+    validateRequestUrl(request.url);
+    this.response = this.wrap(request);
+  }
 
-  protected delegate(request: HttpRequest<any>): Observable<HttpEvent<any>> {
-    return this.backend.handle(request);
+  delegate(request: Request): Observable<Response> {
+    this.lastConnection = this.backend.createConnection(request);
+    return this.lastConnection.response as Observable<Response>;
+  }
+
+  get readyState(): ReadyState {
+    return !!this.lastConnection ? this.lastConnection.readyState : ReadyState.Unsent;
   }
 }
 
-export function zoneWrappedInterceptingHandler(backend: HttpBackend, injector: Injector) {
-  const realBackend: HttpBackend = new HttpInterceptingHandler(backend, injector);
-  return new ZoneClientBackend(realBackend);
+export class ZoneMacroTaskBackend implements ConnectionBackend {
+  constructor(private backend: XHRBackend) {}
+
+  createConnection(request: any): ZoneMacroTaskConnection {
+    return new ZoneMacroTaskConnection(request, this.backend);
+  }
+}
+
+export function httpFactory(xhrBackend: XHRBackend, options: RequestOptions) {
+  const macroBackend = new ZoneMacroTaskBackend(xhrBackend);
+  return new Http(macroBackend, options);
 }
 
 export const SERVER_HTTP_PROVIDERS: Provider[] = [
-  {provide: XhrFactory, useClass: ServerXhr}, {
-    provide: HttpHandler,
-    useFactory: zoneWrappedInterceptingHandler,
-    deps: [HttpBackend, Injector]
-  }
+  {provide: Http, useFactory: httpFactory, deps: [XHRBackend, RequestOptions]},
+  {provide: BrowserXhr, useClass: ServerXhr},
+  {provide: XSRFStrategy, useClass: ServerXsrfStrategy},
 ];
+
+/**
+ * The ng module for the server.
+ *
+ * @deprecated
+ * @publicApi
+ */
+@NgModule({imports: [HttpModule], providers: SERVER_HTTP_PROVIDERS})
+export class ServerHttpModule {
+}

--- a/packages/http/server/test/BUILD.bazel
+++ b/packages/http/server/test/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library", "ts_web_test_suite")
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    # Visible to //:test_web_all target
+    visibility = ["//:__pkg__"],
+    deps = [
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/http",
+        "//packages/http/server",
+        "//packages/http/testing",
+        "//packages/platform-browser",
+        "//packages/platform-server",
+        "@npm//rxjs",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    deps = [
+        ":test_lib",
+        "//tools/testing:node",
+    ],
+)

--- a/packages/http/server/test/platform_server_spec.ts
+++ b/packages/http/server/test/platform_server_spec.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, NgModule, NgZone, destroyPlatform, getPlatform} from '@angular/core';
+import {async} from '@angular/core/testing';
+import {Http, HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
+import {ServerHttpModule} from '@angular/http/server';
+import {MockBackend, MockConnection} from '@angular/http/testing';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {INITIAL_CONFIG, ServerModule, platformDynamicServer} from '@angular/platform-server';
+
+@Component({selector: 'app', template: `Works!`})
+class MyServerApp {
+}
+
+@NgModule({
+  bootstrap: [MyServerApp],
+  declarations: [MyServerApp],
+  imports: [ServerModule, ServerHttpModule],
+  providers: [
+    MockBackend,
+    {provide: XHRBackend, useExisting: MockBackend},
+  ]
+})
+class ExampleModule {
+}
+
+@NgModule({
+  bootstrap: [MyServerApp],
+  declarations: [MyServerApp],
+  imports: [HttpModule, ServerHttpModule, ServerModule],
+  providers: [
+    MockBackend,
+    {provide: XHRBackend, useExisting: MockBackend},
+  ]
+})
+export class HttpBeforeExampleModule {
+}
+
+@NgModule({
+  bootstrap: [MyServerApp],
+  declarations: [MyServerApp],
+  imports: [ServerModule, HttpModule, ServerHttpModule],
+  providers: [
+    MockBackend,
+    {provide: XHRBackend, useExisting: MockBackend},
+  ]
+})
+export class HttpAfterExampleModule {
+}
+
+(function() {
+  if (getDOM().supportsDOMEvents()) return;  // NODE only
+  describe('platform-server integration', () => {
+    beforeEach(() => {
+      if (getPlatform()) destroyPlatform();
+    });
+
+    describe('http', () => {
+      it('can inject Http', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(ExampleModule).then(ref => {
+             expect(ref.injector.get(Http) instanceof Http).toBeTruthy();
+           });
+         }));
+
+      it('can make Http requests', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(ExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 NgZone.assertInAngularZone();
+                 expect(mc.request.url).toBe('http://localhost/testing');
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
+               });
+               http.get('http://localhost/testing').subscribe(resp => {
+                 NgZone.assertInAngularZone();
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
+
+      it('requests are macrotasks', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(ExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
+               });
+               http.get('http://localhost/testing').subscribe(resp => {
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
+
+      it('works when HttpModule is included before ServerModule', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(HttpBeforeExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
+               });
+               http.get('http://localhost/testing').subscribe(resp => {
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
+
+      it('works when HttpModule is included after ServerModule', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(HttpAfterExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
+               });
+               http.get('http://localhost/testing').subscribe(resp => {
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
+
+      it('throws when given a relative URL', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(ExampleModule).then(ref => {
+             const http = ref.injector.get(Http);
+             expect(() => http.get('/testing'))
+                 .toThrowError(
+                     'URLs requested via Http on the server must be absolute. URL: /testing');
+           });
+         }));
+    });
+  });
+})();

--- a/packages/http/server/tsconfig-build.json
+++ b/packages/http/server/tsconfig-build.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../tsconfig-build.json",
+
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "../",
+    "paths": {
+      "@angular/core": ["../../../dist/packages/core"],
+      "@angular/http": ["../../../dist/packages/http"]
+    },
+    "outDir": "../../../dist/packages/http"
+  },
+
+  "files": [
+    "public_api.ts",
+    "../../node_modules/@types/node/index.d.ts",
+    "../../node_modules/zone.js/dist/zone.js.d.ts"
+  ],
+
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": false,
+    "skipTemplateCodegen": true,
+    "flatModuleOutFile": "server.js",
+    "flatModuleId": "@angular/http/server"
+  }
+}

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -16,7 +16,6 @@ ng_module(
         "//packages/common/http",
         "//packages/compiler",
         "//packages/core",
-        "//packages/http",
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -17,7 +17,6 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/http": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
   },

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -10,7 +10,6 @@ import {ɵAnimationEngine} from '@angular/animations/browser';
 import {DOCUMENT, PlatformLocation, ViewportScroller, ɵNullViewportScroller as NullViewportScroller, ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID} from '@angular/common';
 import {HttpClientModule} from '@angular/common/http';
 import {Injectable, InjectionToken, Injector, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactory2, RootRenderer, StaticProvider, Testability, createPlatformFactory, platformCore, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS} from '@angular/core';
-import {HttpModule} from '@angular/http';
 import {BrowserModule, EVENT_MANAGER_PLUGINS, ɵSharedStylesHost as SharedStylesHost, ɵgetDOM as getDOM} from '@angular/platform-browser';
 import {ɵplatformCoreDynamic as platformCoreDynamic} from '@angular/platform-browser-dynamic';
 import {NoopAnimationsModule, ɵAnimationRendererFactory} from '@angular/platform-browser/animations';
@@ -69,7 +68,7 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
  */
 @NgModule({
   exports: [BrowserModule],
-  imports: [HttpModule, HttpClientModule, NoopAnimationsModule],
+  imports: [HttpClientModule, NoopAnimationsModule],
   providers: [
     SERVER_RENDER_PROVIDERS,
     SERVER_HTTP_PROVIDERS,

--- a/packages/platform-server/tsconfig-build.json
+++ b/packages/platform-server/tsconfig-build.json
@@ -11,7 +11,6 @@
       "@angular/common": ["../../dist/packages/common"],
       "@angular/common/http": ["../../dist/packages/common/http"],
       "@angular/compiler": ["../../dist/packages/compiler"],
-      "@angular/http": ["../../dist/packages/http"],
       "@angular/platform-browser": ["../../dist/packages/platform-browser"],
       "@angular/platform-browser/animations": ["../../dist/packages/platform-browser/animations"],
       "@angular/platform-browser-dynamic": ["../../dist/packages/platform-browser-dynamic"]

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1,3 +1,8 @@
+export declare class BrowserXhr implements XhrFactory {
+    constructor();
+    build(): any;
+}
+
 export declare const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
 
 export declare abstract class HttpBackend implements HttpHandler {


### PR DESCRIPTION
One of the problems with excising `@angular/http` is the heavy dependency by
`@angular/platform-server`. Since that package needs to have wrapper support
for all supported Http libraries, it's difficult to minimize the impact of
removing the legacy Http library altogether.

The solution is to reverse the dependency, and create a compatibility patch
for the legacy Http library when used on the server. We do this by moving the
wrapper code from platform-server to http. That way when we remove the legacy
code entirely, we lessen the code we need to update.

This also allows consumers of platform-server who don't use the legacy library
to remove it now instead of waiting until the library is removed entirely.