### PR TITLE
fix(ivy): Class selector directives execute properly on container ele…

### DIFF
--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -166,5 +166,63 @@ describe('projection', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('inline()ng-template(onetwothree)');
     });
+
+    describe('on containers', () => {
+      it('should work when matching attributes', () => {
+        let xDirectives = 0;
+        @Component({selector: 'selector-proj', template: '<ng-content select="[x]"></ng-content>'})
+        class SelectedNgContentComp {
+        }
+
+        @Directive({selector: '[x]'})
+        class XDirective {
+          constructor() { xDirectives++; }
+        }
+
+        @Component({
+          selector: 'main-selector',
+          template:
+              '<selector-proj><ng-container x="true">Hello world!</ng-container></selector-proj>'
+        })
+        class SelectorMainComp {
+        }
+
+        TestBed.configureTestingModule(
+            {declarations: [XDirective, SelectedNgContentComp, SelectorMainComp]});
+        const fixture = TestBed.createComponent<SelectorMainComp>(SelectorMainComp);
+
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('Hello world!');
+        expect(xDirectives).toEqual(1);
+      });
+
+      it('should work when matching classes', () => {
+        let xDirectives = 0;
+        @Component({selector: 'selector-proj', template: '<ng-content select=".x"></ng-content>'})
+        class SelectedNgContentComp {
+        }
+
+        @Directive({selector: '.x'})
+        class XDirective {
+          constructor() { xDirectives++; }
+        }
+
+        @Component({
+          selector: 'main-selector',
+          template:
+              '<selector-proj><ng-container class="x">Hello world!</ng-container></selector-proj>'
+        })
+        class SelectorMainComp {
+        }
+
+        TestBed.configureTestingModule(
+            {declarations: [XDirective, SelectedNgContentComp, SelectorMainComp]});
+        const fixture = TestBed.createComponent<SelectorMainComp>(SelectorMainComp);
+
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('Hello world!');
+        expect(xDirectives).toEqual(1);
+      });
+    });
   });
 });

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -660,6 +660,9 @@
     "name": "setIsParent"
   },
   {
+    "name": "setNodeStylingTemplate"
+  },
+  {
     "name": "setPreviousOrParentTNode"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1272,6 +1272,9 @@
     "name": "setIsParent"
   },
   {
+    "name": "setNodeStylingTemplate"
+  },
+  {
     "name": "setPlayerBuilder"
   },
   {


### PR DESCRIPTION
…ments

- Adds two tests around directive execution on container elements (`<ng-container>`)
- Resolves an issue where ivy was unable to locate directives with class-based selectors if the class was on a container element.

The issue boiled down to the fact we weren't setting up a styling template for ng-container, because rendering-wise, we didn't need them. However, we *do* need them when it comes to locating directives that may exist on the container element.