### PR TITLE
build: add moduleName to ngFactory sourcefiles

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -369,10 +369,15 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
         /* emitSourceMaps */ false);
     const sf = ts.createSourceFile(
         genFile.genFileUrl, sourceText, this.options.target || ts.ScriptTarget.Latest);
-    if ((this.options.module === ts.ModuleKind.AMD || this.options.module === ts.ModuleKind.UMD) &&
-        this.context.amdModuleName) {
-      const moduleName = this.context.amdModuleName(sf);
-      if (moduleName) sf.moduleName = moduleName;
+    if (this.options.module === ts.ModuleKind.AMD || this.options.module === ts.ModuleKind.UMD) {
+      if (this.context.amdModuleName) {
+        const moduleName = this.context.amdModuleName(sf);
+        if (moduleName) sf.moduleName = moduleName;
+      } else if (/node_modules/.test(genFile.genFileUrl)) {
+        // If we are generating an ngModule file under node_modules, we know the right module name
+        // We don't need the host to supply a function in this case.
+        sf.moduleName = stripNodeModulesPrefix(genFile.genFileUrl.replace(EXT, ''));
+      }
     }
     this.generatedSourceFiles.set(genFile.genFileUrl, {
       sourceFile: sf,

--- a/packages/compiler-cli/test/transformers/compiler_host_spec.ts
+++ b/packages/compiler-cli/test/transformers/compiler_host_spec.ts
@@ -213,6 +213,40 @@ describe('NgCompilerHost', () => {
     });
   });
 
+  describe('addGeneratedFile', () => {
+    function generate(path: string, files: {}) {
+      codeGenerator.findGeneratedFileNames.and.returnValue([`${path}.ngfactory.ts`]);
+      codeGenerator.generateFile.and.returnValue(
+          new compiler.GeneratedFile(`${path}.ts`, `${path}.ngfactory.ts`, []));
+      const host = createHost({
+        files,
+        options: {
+          basePath: '/tmp',
+          moduleResolution: ts.ModuleResolutionKind.NodeJs,
+          // Request UMD, which should get default module names
+          module: ts.ModuleKind.UMD
+        },
+      });
+      return host.getSourceFile(`${path}.ngfactory.ts`, ts.ScriptTarget.Latest);
+    }
+
+    it('should include a moduleName when the file is in node_modules', () => {
+      const genSf = generate(
+          '/tmp/node_modules/@angular/core/core',
+          {'tmp': {'node_modules': {'@angular': {'core': {'core.ts': `// some content`}}}}});
+      expect(genSf.moduleName).toBe('@angular/core/core.ngfactory');
+    });
+
+    it('should not get tripped on nested node_modules', () => {
+      const genSf = generate('/tmp/node_modules/lib1/node_modules/lib2/thing', {
+        'tmp': {
+          'node_modules': {'lib1': {'node_modules': {'lib2': {'thing.ts': `// some content`}}}}
+        }
+      });
+      expect(genSf.moduleName).toBe('lib2/thing.ngfactory');
+    });
+  });
+
   describe('getSourceFile', () => {
     it('should cache source files by name', () => {
       const host = createHost({files: {'tmp': {'src': {'index.ts': ``}}}});


### PR DESCRIPTION
This allows the concatjs bundler to work with ngc-amended third party libraries