### PR TITLE
refactor: uniformly access all index sigs with index access.

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -71,39 +71,40 @@ export function runOneBuild(args: string[], inputs?: {[path: string]: string}): 
     // All user angularCompilerOptions values that a user has control
     // over should be collected here
     if (userConfig.angularCompilerOptions) {
-      angularCompilerOptions.diagnostics =
-          angularCompilerOptions.diagnostics || userConfig.angularCompilerOptions.diagnostics;
-      angularCompilerOptions.trace =
-          angularCompilerOptions.trace || userConfig.angularCompilerOptions.trace;
+      angularCompilerOptions['diagnostics'] =
+          angularCompilerOptions['diagnostics'] || userConfig.angularCompilerOptions.diagnostics;
+      angularCompilerOptions['trace'] =
+          angularCompilerOptions['trace'] || userConfig.angularCompilerOptions.trace;
 
-      angularCompilerOptions.disableExpressionLowering =
-          angularCompilerOptions.disableExpressionLowering ||
+      angularCompilerOptions['disableExpressionLowering'] =
+          angularCompilerOptions['disableExpressionLowering'] ||
           userConfig.angularCompilerOptions.disableExpressionLowering;
-      angularCompilerOptions.disableTypeScriptVersionCheck =
-          angularCompilerOptions.disableTypeScriptVersionCheck ||
+      angularCompilerOptions['disableTypeScriptVersionCheck'] =
+          angularCompilerOptions['disableTypeScriptVersionCheck'] ||
           userConfig.angularCompilerOptions.disableTypeScriptVersionCheck;
 
-      angularCompilerOptions.i18nOutLocale =
-          angularCompilerOptions.i18nOutLocale || userConfig.angularCompilerOptions.i18nOutLocale;
-      angularCompilerOptions.i18nOutFormat =
-          angularCompilerOptions.i18nOutFormat || userConfig.angularCompilerOptions.i18nOutFormat;
-      angularCompilerOptions.i18nOutFile =
-          angularCompilerOptions.i18nOutFile || userConfig.angularCompilerOptions.i18nOutFile;
+      angularCompilerOptions['i18nOutLocale'] = angularCompilerOptions['i18nOutLocale'] ||
+          userConfig.angularCompilerOptions.i18nOutLocale;
+      angularCompilerOptions['i18nOutFormat'] = angularCompilerOptions['i18nOutFormat'] ||
+          userConfig.angularCompilerOptions.i18nOutFormat;
+      angularCompilerOptions['i18nOutFile'] =
+          angularCompilerOptions['i18nOutFile'] || userConfig.angularCompilerOptions.i18nOutFile;
 
-      angularCompilerOptions.i18nInFormat =
-          angularCompilerOptions.i18nInFormat || userConfig.angularCompilerOptions.i18nInFormat;
-      angularCompilerOptions.i18nInLocale =
-          angularCompilerOptions.i18nInLocale || userConfig.angularCompilerOptions.i18nInLocale;
-      angularCompilerOptions.i18nInFile =
-          angularCompilerOptions.i18nInFile || userConfig.angularCompilerOptions.i18nInFile;
+      angularCompilerOptions['i18nInFormat'] =
+          angularCompilerOptions['i18nInFormat'] || userConfig.angularCompilerOptions.i18nInFormat;
+      angularCompilerOptions['i18nInLocale'] =
+          angularCompilerOptions['i18nInLocale'] || userConfig.angularCompilerOptions.i18nInLocale;
+      angularCompilerOptions['i18nInFile'] =
+          angularCompilerOptions['i18nInFile'] || userConfig.angularCompilerOptions.i18nInFile;
 
-      angularCompilerOptions.i18nInMissingTranslations =
-          angularCompilerOptions.i18nInMissingTranslations ||
+      angularCompilerOptions['i18nInMissingTranslations'] =
+          angularCompilerOptions['i18nInMissingTranslations'] ||
           userConfig.angularCompilerOptions.i18nInMissingTranslations;
-      angularCompilerOptions.i18nUseExternalIds = angularCompilerOptions.i18nUseExternalIds ||
+      angularCompilerOptions['i18nUseExternalIds'] = angularCompilerOptions['i18nUseExternalIds'] ||
           userConfig.angularCompilerOptions.i18nUseExternalIds;
 
-      angularCompilerOptions.preserveWhitespaces = angularCompilerOptions.preserveWhitespaces ||
+      angularCompilerOptions['preserveWhitespaces'] =
+          angularCompilerOptions['preserveWhitespaces'] ||
           userConfig.angularCompilerOptions.preserveWhitespaces;
     }
   }


### PR DESCRIPTION
Follow-up to https://github.com/angular/angular/pull/28937

A build-time check to enforce this is part of tsetse -
https://tsetse.info/property-renaming-safe but I don't know how to turn
it on for this repositories bazel builds.
