### PR TITLE
fix(router): support NgFactory promise in loadChildren typings

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -97,8 +97,8 @@ export type ResolveData = {
  * @see `Route#loadChildren`.
  * @publicApi
  */
-export type LoadChildrenCallback = () =>
-    Type<any>| NgModuleFactory<any>| Promise<Type<any>>| Observable<Type<any>>;
+export type LoadChildrenCallback = () => Type<any>| NgModuleFactory<any>|
+    Promise<NgModuleFactory<any>>| Promise<Type<any>>| Observable<Type<any>>;
 
 /**
  *

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -147,7 +147,7 @@ export declare class GuardsCheckStart extends RouterEvent {
 
 export declare type LoadChildren = string | LoadChildrenCallback;
 
-export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Promise<Type<any>> | Observable<Type<any>>;
+export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Promise<NgModuleFactory<any>> | Promise<Type<any>> | Observable<Type<any>>;
 
 export declare type Navigation = {
     id: number;


### PR DESCRIPTION
The router loadChildren property already supports a promise that returnes a NgModuleFactory, but the typings cause the compilation to fail.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The router loadChildren property already supports a promise that returns a NgModuleFactory, but the typings cause the compilation to fail.


## What is the new behavior?
Typings contain the correct supported types.



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
