### PR TITLE
fix(ivy): prevent templateOverrides from causing infinite loop

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -822,7 +822,8 @@ export class TestBedRender3 implements Injector, TestBed {
           // if we have template override via `TestBed.overrideTemplateUsingTestingModule` -
           // define Component scope as TestingModule scope, instead of the scope of NgModule
           // where this Component was declared
-          calcTransitiveScopesFor(this._testModuleType) :
+          // TODO: This is only a partial fix. Should be fixed completely with FW-1178 refactor.
+          transitiveScopesFor(this._testModuleType) :
           transitiveScope;
       patchComponentDefWithScope((cmp as any).ngComponentDef, scope);
     });


### PR DESCRIPTION
Previously, the transitive scope calculation could lead into re-compiling
the same module multiple times. This fix ensures we cannot get into this loop.
It should be fixed more completely (e.g. more cases) once FW-1178 is resolved.
