### PR TITLE
fix(ivy): ViewContainerRef.destroy should properly clean the DOM

### DIFF
--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Attribute, Component, Directive} from '@angular/core';
+import {Attribute, Component, Directive, TemplateRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -26,7 +26,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        declarations: [TestComponent],
+        declarations: [TestComponent, ComplexComponent],
         imports: [CommonModule],
       });
     });
@@ -171,6 +171,20 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         getComponent().switchValue = 'b';
         detectChangesAndExpectText('when b1;when b2;');
       });
+
+      it('should support nested NgSwitch on ng-container with ngTemplateOutlet', () => {
+        fixture = TestBed.createComponent(ComplexComponent);
+        detectChangesAndExpectText('Foo');
+
+        fixture.componentInstance.state = 'case2';
+        detectChangesAndExpectText('Bar');
+
+        fixture.componentInstance.state = 'notACase';
+        detectChangesAndExpectText('Default');
+
+        fixture.componentInstance.state = 'case1';
+        detectChangesAndExpectText('Foo');
+      });
     });
   });
 }
@@ -180,6 +194,38 @@ class TestComponent {
   switchValue: any = null;
   when1: any = null;
   when2: any = null;
+}
+
+@Component({
+  selector: 'complex-cmp',
+  template: `
+<div [ngSwitch]="state">
+  <ng-container *ngSwitchCase="'case1'" [ngSwitch]="true">
+    <ng-container *ngSwitchCase="true" [ngTemplateOutlet]="foo"></ng-container>
+    <span *ngSwitchDefault>Should never render</span>
+  </ng-container>
+  <ng-container *ngSwitchCase="'case2'" [ngSwitch]="true">
+    <ng-container *ngSwitchCase="true" [ngTemplateOutlet]="bar"></ng-container>
+    <span *ngSwitchDefault>Should never render</span>
+  </ng-container>
+  <ng-container *ngSwitchDefault [ngSwitch]="false">
+    <ng-container *ngSwitchCase="true" [ngTemplateOutlet]="foo"></ng-container>
+    <span *ngSwitchDefault>Default</span>
+  </ng-container>
+</div>
+
+<ng-template #foo>
+  <span>Foo</span>
+</ng-template>
+<ng-template #bar>
+  <span>Bar</span>
+</ng-template>
+`
+})
+class ComplexComponent {
+  @ViewChild('foo') foo !: TemplateRef<any>;
+  @ViewChild('bar') bar !: TemplateRef<any>;
+  state: string = 'case1';
 }
 
 function createTestComponent(template: string): ComponentFixture<TestComponent> {

--- a/packages/core/src/render3/instructions/instructions.ts
+++ b/packages/core/src/render3/instructions/instructions.ts
@@ -1952,7 +1952,7 @@ function generateInitialInputs(
  */
 export function createLContainer(
     hostNative: RElement | RComment | StylingContext | LView, currentView: LView, native: RComment,
-    isForViewContainerRef?: boolean): LContainer {
+    tNode: TNode, isForViewContainerRef?: boolean): LContainer {
   ngDevMode && assertDomNode(native);
   ngDevMode && assertLView(currentView);
   const lContainer: LContainer = [
@@ -1962,8 +1962,9 @@ export function createLContainer(
     currentView,                     // parent
     null,                            // next
     null,                            // queries
-    [],                              // views
+    tNode,                           // t_host
     native,                          // native
+    [],                              // views
   ];
   ngDevMode && attachLContainerDebug(lContainer);
   return lContainer;
@@ -2037,7 +2038,8 @@ function containerInternal(
   const comment = lView[RENDERER].createComment(ngDevMode ? 'container' : '');
   ngDevMode && ngDevMode.rendererCreateComment++;
   const tNode = createNodeAtIndex(index, TNodeType.Container, comment, tagName, attrs);
-  const lContainer = lView[adjustedIndex] = createLContainer(lView[adjustedIndex], lView, comment);
+  const lContainer = lView[adjustedIndex] =
+      createLContainer(lView[adjustedIndex], lView, comment, tNode);
 
   appendChild(comment, tNode, lView);
 

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TNode} from './node';
 import {LQueries} from './query';
 import {RComment, RElement} from './renderer';
 import {StylingContext} from './styling';
-import {HOST, LView, NEXT, PARENT, QUERIES} from './view';
+import {HOST, LView, NEXT, PARENT, QUERIES, T_HOST} from './view';
+
 
 /**
  * Special location which allows easy identification of type. If we have an array which was
@@ -23,10 +25,10 @@ export const TYPE = 1;
  * Uglify will inline these when minifying so there shouldn't be a cost.
  */
 export const ACTIVE_INDEX = 2;
-// PARENT, NEXT, and QUERIES are indices 3, 4, and 5.
+// PARENT, NEXT, QUERIES and T_HOST are indices 3, 4, 5 and 6.
 // As we already have these constants in LView, we don't need to re-create them.
-export const VIEWS = 6;
 export const NATIVE = 7;
+export const VIEWS = 8;
 
 /**
  * The state associated with a container.
@@ -83,17 +85,22 @@ export interface LContainer extends Array<any> {
   // `[QUERIES]` in it which are not needed for `LContainer` (only needed for Template)
 
   /**
-   * A list of the container's currently active child views. Views will be inserted
-   * here as they are added and spliced from here when they are removed. We need
-   * to keep a record of current views so we know which views are already in the DOM
-   * (and don't need to be re-added) and so we can remove views from the DOM when they
-   * are no longer required.
+   * Pointer to the `TNode` which represents the host of the container.
    */
-  [VIEWS]: LView[];
+  [T_HOST]: TNode;
 
   /** The comment element that serves as an anchor for this LContainer. */
   readonly[NATIVE]:
       RComment;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
+
+  /**
+*A list of the container's currently active child views. Views will be inserted
+*here as they are added and spliced from here when they are removed. We need
+*to keep a record of current views so we know which views are already in the DOM
+*(and don't need to be re-added) and so we can remove views from the DOM when they
+*are no longer required.
+*/
+  [VIEWS]: LView[];
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -321,7 +321,7 @@ export function createContainerRef(
     }
 
     hostView[hostTNode.index] = lContainer =
-        createLContainer(slotValue, hostView, commentNode, true);
+        createLContainer(slotValue, hostView, commentNode, hostTNode, true);
 
     addToViewTree(hostView, lContainer);
   }

--- a/packages/core/test/render3/view_utils_spec.ts
+++ b/packages/core/test/render3/view_utils_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createLContainer, createLView, createTView} from '@angular/core/src/render3/instructions/all';
+import {createLContainer, createLView, createTNode, createTView} from '@angular/core/src/render3/instructions/all';
 import {createEmptyStylingContext} from '@angular/core/src/render3/styling/util';
 import {isLContainer, isLView, isStylingContext, unwrapLContainer, unwrapLView, unwrapRNode, unwrapStylingContext} from '@angular/core/src/render3/util/view_utils';
 
@@ -15,7 +15,8 @@ describe('view_utils', () => {
     const div = document.createElement('div');
     const tView = createTView(0, null, 0, 0, null, null, null, null);
     const lView = createLView(null, tView, {}, 0, div, null, {} as any, {} as any, null, null);
-    const lContainer = createLContainer(lView, lView, div, true);
+    const tNode = createTNode(null, 3, 0, 'div', []);
+    const lContainer = createLContainer(lView, lView, div, tNode, true);
     const styleContext = createEmptyStylingContext(lContainer, null, null, null);
 
     expect(unwrapRNode(styleContext)).toBe(div);

--- a/packages/private/testing/src/goog_get_msg.ts
+++ b/packages/private/testing/src/goog_get_msg.ts
@@ -17,7 +17,8 @@ export function polyfillGoogGetMsg(translations: {[key: string]: string} = {}): 
   const glob = (global as any);
   glob.goog = glob.goog || {};
   glob.goog.getMsg = function(input: string, placeholders: {[key: string]: string} = {}) {
-    if (typeof translations[input] !== 'undefined') {  // to account for empty string
+    if (typeof translations[input] !== 'undefined') {  // to account for
+                                                       // empty string
       input = translations[input];
     }
     return Object.keys(placeholders).length ?


### PR DESCRIPTION
Investigating an issue in one material example (FW-1171) showed that the DOM was not properly cleaned when using `ViewContainerRef.destroy()`. In particular:
- the comment for ng-container was not removed
- views of nested `ViewContainerRef` were not cleaned

The changes make the `walkTNodeTree()` even more complex, but it remains non recursive.