### PR TITLE
ci: do not cache modified "node_modules" in "material-unit-tests" job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,16 +581,22 @@ jobs:
           command: ./scripts/ci/clone_angular_material_repo.sh
       - restore_cache:
           keys:
-            - v1-angular-material-{{ checksum "material_repo_sha" }}
-            - v1-angular-material-
+            - v2-angular-material-{{ checksum "material_repo_sha" }}
+            - v2-angular-material-
       - run:
-          name: "Running Material unit tests"
-          command: ./scripts/ci/run_angular_material_unit_tests.sh
+          name: Installing Material dependencies.
+          command: yarn --cwd ${MATERIAL_REPO_TMP_DIR} install --frozen-lockfile --non-interactive
+      # Save the cache before we run the Material unit tests script. This is necessary
+      # because we don't want to cache the node modules which have been modified to contain
+      # the attached Ivy package output.
       - save_cache:
-          key: v1-angular-material-{{ checksum "material_repo_sha" }}
+          key: v2-angular-material-{{ checksum "material_repo_sha" }}
           paths:
             # Needs to be hardcoded because environment variables are not interpolated here.
             - "/tmp/material2/node_modules"
+      - run:
+          name: "Running Material unit tests"
+          command: ./scripts/ci/run_angular_material_unit_tests.sh
 
 workflows:
   version: 2

--- a/scripts/ci/run_angular_material_unit_tests.sh
+++ b/scripts/ci/run_angular_material_unit_tests.sh
@@ -9,9 +9,6 @@ angular_dir=$(pwd)
 # Switch into Material directory.
 cd ${MATERIAL_REPO_TMP_DIR}
 
-# Install dependencies for the freshly cloned repo.
-yarn install --frozen-lockfile --non-interactive
-
 # Install this version of Angular into the freshly cloned repo.
 rm -rf ./node_modules/@angular/*
 cp -r ${angular_dir}/dist/packages-dist-ivy-aot/* ./node_modules/@angular/


### PR DESCRIPTION
Fixes that the `material-unit-tests` job currently fails. This now
surfaces because yesterday we rebased the `ivy-2019` branch
which now contains a `postinstall` hook needed for Bazel.

Currently we cache the Material `node_modules` after
the `run_angular_material_unit_tests.sh` completed. This
means that the cache will incorrectly contain the Ivy NPM
package output which might be incompatible with the
other Material dependencies. e.g. the Material postinstall
command now uses a different NGC version that does not
work with the `typescript` version that has been specified in
the Material project.