### PR TITLE
 ci: cache Material `node_modules` based on the lockfile checksum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,14 +574,13 @@ jobs:
       - *attach_workspace
       - *init_environment
       - run:
-          name: "Determining SHA of Material Ivy branch"
-          command: git ls-remote ${MATERIAL_REPO_URL} ${MATERIAL_REPO_BRANCH} | cut -f1 > material_repo_sha
-      - run:
           name: "Cloning Material repository"
           command: ./scripts/ci/clone_angular_material_repo.sh
       - restore_cache:
+          # Material directory must be kept in sync with the `$MATERIAL_REPO_TMP_DIR` env variable.
+          # It needs to be hardcoded here, because env variables interpolation is not supported.
           keys:
-            - v2-angular-material-{{ checksum "material_repo_sha" }}
+            - v2-angular-material-{{ checksum "/tmp/material2/yarn.lock" }}
             - v2-angular-material-
       - run:
           name: Installing Material dependencies.
@@ -590,9 +589,10 @@ jobs:
       # because we don't want to cache the node modules which have been modified to contain
       # the attached Ivy package output.
       - save_cache:
-          key: v2-angular-material-{{ checksum "material_repo_sha" }}
+          # Material directory must be kept in sync with the `$MATERIAL_REPO_TMP_DIR` env variable.
+          # It needs to be hardcoded here, because env variables interpolation is not supported.
+          key: v2-angular-material-{{ checksum "/tmp/material2/yarn.lock" }}
           paths:
-            # Needs to be hardcoded because environment variables are not interpolated here.
             - "/tmp/material2/node_modules"
       - run:
           name: "Running Material unit tests"


### PR DESCRIPTION
This will increase the cache hit rate for the `material-unit-tests` job.

~~Builds on top of #29416.~~