### PR TITLE
Revert "build: add a nice Angular-themed color for the vscode status …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,6 @@
     "**/dist/**": true,
     "**/aio/src/generated/**": true,
   },
-  "workbench.colorCustomizations": {
-    "statusBar.background" : "#CB2B38",
-  },
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,


### PR DESCRIPTION
…bar (#29407)"

This reverts commit efcd6af17d360d26accca7a3af5233d1696dcd7b.
Engineers on the team thought that the red color means something is
broken.
See slack discussion in #general
