### PR TITLE
fix(ivy): ChangeDetectorRef should be injectable on ng-container

### DIFF
--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -349,7 +349,9 @@ export function createViewRef(
     const componentIndex = hostTNode.directiveStart;
     const componentView = getComponentViewByIndex(hostTNode.index, hostView);
     return new ViewRef(componentView, context, componentIndex);
-  } else if (hostTNode.type === TNodeType.Element || hostTNode.type === TNodeType.Container) {
+  } else if (
+      hostTNode.type === TNodeType.Element || hostTNode.type === TNodeType.Container ||
+      hostTNode.type === TNodeType.ElementContainer) {
     const hostComponentView = findComponentView(hostView);
     return new ViewRef(hostComponentView, hostComponentView[CONTEXT], -1);
   }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -39,6 +39,28 @@ describe('di', () => {
       fixture.detectChanges();
       expect((pipeInstance !.cdr as ViewRef<MyApp>).context).toBe(fixture.componentInstance);
     });
+
+    it('should inject host component ChangeDetectorRef into directives on ng-container', () => {
+      let dirInstance: MyDirective;
+
+      @Directive({selector: '[getCDR]'})
+      class MyDirective {
+        constructor(public cdr: ChangeDetectorRef) { dirInstance = this; }
+      }
+
+      @Component({
+        selector: 'my-app',
+        template: `<ng-container getCDR>Visible</ng-container>`,
+      })
+      class MyApp {
+        constructor(public cdr: ChangeDetectorRef) {}
+      }
+
+      TestBed.configureTestingModule({declarations: [MyApp, MyDirective]});
+      const fixture = TestBed.createComponent(MyApp);
+      fixture.detectChanges();
+      expect((dirInstance !.cdr as ViewRef<MyApp>).context).toBe(fixture.componentInstance);
+    });
   });
 
   it('should not cause cyclic dependency if same token is requested in deps with @SkipSelf', () => {

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -17,10 +17,6 @@
 // tslint:disable
 
 window.testBlocklist = {
-  "CdkDrag standalone draggable should throw if attached to an ng-container": {
-    "error": "Error: Expected function to throw an exception with a message matching /^cdkDrag must be attached to an element node/, but it threw an exception with message 'No provider for ChangeDetectorRef!'.",
-    "notes": "Unknown"
-  },
   "MatBadge should clear any pre-existing badges": {
     "error": "Error: Expected 2 to be 1.",
     "notes": "Unknown"


### PR DESCRIPTION
Small fix for an issue found in material tests.