### PR TITLE
Stacks

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -306,8 +306,7 @@ function getBindingMask(icuExpression: IcuExpression, mask = 0): number {
   return mask;
 }
 
-const i18nIndexStack: number[] = [];
-let i18nIndexStackPointer = -1;
+const i18nIndexStack = new Stack<number>();
 
 /**
  * Convert binding index to mask bit.
@@ -349,7 +348,7 @@ const parentIndexStack = new Stack<number>();
 export function i18nStart(index: number, message: string, subTemplateIndex?: number): void {
   const tView = getLView()[TVIEW];
   ngDevMode && assertDefined(tView, `tView should be defined`);
-  i18nIndexStack[++i18nIndexStackPointer] = index;
+  i18nIndexStack.push(index);
   if (tView.firstTemplatePass && tView.data[index + HEADER_OFFSET] === null) {
     i18nStartFirstPass(tView, index, message, subTemplateIndex);
   }
@@ -638,7 +637,7 @@ function i18nEndFirstPass(tView: TView) {
                    viewData[BINDING_INDEX], viewData[TVIEW].bindingStartIndex,
                    'i18nEnd should be called before any binding');
 
-  const rootIndex = i18nIndexStack[i18nIndexStackPointer--];
+  const rootIndex = i18nIndexStack.pop() !;
   const tI18n = tView.data[rootIndex + HEADER_OFFSET] as TI18n;
   ngDevMode && assertDefined(tI18n, `You should call i18nStart before i18nEnd`);
 

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -401,7 +401,7 @@ function i18nStartFirstPass(
         // The value represents a placeholder that we move to the designated index
         createOpCodes.push(
             phIndex << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select,
-            parentIndexStack.current ! << I18nMutateOpCode.SHIFT_PARENT |
+            parentIndexStack.peek() ! << I18nMutateOpCode.SHIFT_PARENT |
                 I18nMutateOpCode.AppendChild);
 
         if (value.charAt(0) === '#') {
@@ -418,7 +418,7 @@ function i18nStartFirstPass(
           const icuNodeIndex = startIndex + i18nVarsCount++;
           createOpCodes.push(
               COMMENT_MARKER, ngDevMode ? `ICU ${icuNodeIndex}` : '', icuNodeIndex,
-              parentIndexStack.current ! << I18nMutateOpCode.SHIFT_PARENT |
+              parentIndexStack.peek() ! << I18nMutateOpCode.SHIFT_PARENT |
                   I18nMutateOpCode.AppendChild);
 
           // Update codes for the ICU expression
@@ -444,7 +444,7 @@ function i18nStartFirstPass(
           createOpCodes.push(
               // If there is a binding, the value will be set during update
               hasBinding ? '' : text, textNodeIndex,
-              parentIndexStack.current ! << I18nMutateOpCode.SHIFT_PARENT |
+              parentIndexStack.peek() ! << I18nMutateOpCode.SHIFT_PARENT |
                   I18nMutateOpCode.AppendChild);
 
           if (hasBinding) {

--- a/packages/core/src/render3/util/stack.ts
+++ b/packages/core/src/render3/util/stack.ts
@@ -1,3 +1,5 @@
+import {assertGreaterThan} from '../../util/assert';
+
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -23,7 +25,7 @@ export class Stack<T> {
    * Pushes a value onto the top of the stack
    * @param value the value to push onto the top of the stack
    */
-  push(value: T) {
+  push(value: T): void {
     this._stack[++this._pointer] = value;
     this._current = value;
   }
@@ -33,6 +35,7 @@ export class Stack<T> {
    */
   pop(): T|null {
     const currentPointer = this._pointer;
+    ngDevMode && assertGreaterThan(currentPointer, -1, 'Attempted to pop off of an empty stack');
     if (currentPointer === -1) {
       return null;
     }
@@ -47,5 +50,5 @@ export class Stack<T> {
   /**
    * The current top of the stack
    */
-  get current() { return this._current; }
+  peek(): T|null { return this._current; }
 }

--- a/packages/core/src/render3/util/stack.ts
+++ b/packages/core/src/render3/util/stack.ts
@@ -11,7 +11,8 @@ import {assertGreaterThan} from '../../util/assert';
 /**
  * A simple stack implementation
  *
- * This stack will expand to whatever size is required and stay allocated at that size.
+ * This stack will expand to whatever size is required and stay allocated at that size. This is to
+ * avoid resizing the underlying array for performance reasons.
  *
  * Unused spaces in the allocated stack will be set to `null` so we don't retain value references we
  * no longer want.

--- a/packages/core/src/render3/util/stack.ts
+++ b/packages/core/src/render3/util/stack.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A simple stack implementation
+ *
+ * This stack will expand to whatever size is required and stay allocated at that size.
+ *
+ * Unused spaces in the allocated stack will be set to `null` so we don't retain value references we
+ * no longer want.
+ */
+export class Stack<T> {
+  private _current: T|null = null;
+  private _stack: (T|null)[] = [];
+  private _pointer = -1;
+
+  /**
+   * Pushes a value onto the top of the stack
+   * @param value the value to push onto the top of the stack
+   */
+  push(value: T) {
+    this._stack[++this._pointer] = value;
+    this._current = value;
+  }
+
+  /**
+   * Pops a value off of the top of the stack and returns it
+   */
+  pop(): T|null {
+    const currentPointer = this._pointer;
+    if (currentPointer === -1) {
+      return null;
+    }
+    const _stack = this._stack;
+    const popped = this._current;
+    _stack[currentPointer] = null;
+    const newPointer = --this._pointer;
+    this._current = newPointer === -1 ? null : _stack[newPointer];
+    return popped;
+  }
+
+  /**
+   * The current top of the stack
+   */
+  get current() { return this._current; }
+}

--- a/packages/core/test/render3/stack_spec.ts
+++ b/packages/core/test/render3/stack_spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Stack} from '@angular/core/src/render3/util/stack';
+import {onlyInIvy} from '@angular/private/testing';
+
+onlyInIvy('Stacks are only used for Ivy').describe('Stack', () => {
+  it('should push and pop values', () => {
+    const stack = new Stack<number>();
+
+    expect(stack.current).toBe(null);
+    expect(getAllocatedStackSize(stack)).toBe(0);
+
+    stack.push(1);
+    expect(stack.current).toBe(1);
+    expect(getAllocatedStackSize(stack)).toBe(1);
+
+    stack.push(2);
+    expect(stack.current).toBe(2);
+    expect(getAllocatedStackSize(stack)).toBe(2);
+
+    stack.push(3);
+    expect(stack.current).toBe(3);
+    expect(getAllocatedStackSize(stack)).toBe(3);
+
+    let popped = stack.pop();
+    expect(popped).toBe(3);
+    expect(stack.current).toBe(2);
+    expect(getAllocatedStackSize(stack)).toBe(3);
+
+    popped = stack.pop();
+    expect(popped).toBe(2);
+    expect(stack.current).toBe(1);
+    expect(getAllocatedStackSize(stack)).toBe(3);
+
+    popped = stack.pop();
+    expect(popped).toBe(1);
+    expect(stack.current).toBe(null);
+    expect(getAllocatedStackSize(stack)).toBe(3);
+  });
+
+  it('should handle too much pop', () => {
+    const stack = new Stack<number>();
+
+    stack.pop();
+    stack.pop();
+    stack.pop();
+
+    stack.push(42);
+    expect(stack.current).toBe(42);
+    expect(getAllocatedStackSize(stack)).toBe(1);
+  });
+});
+
+function getAllocatedStackSize(stack: any): number {
+  return stack._stack.length;
+}

--- a/packages/core/test/render3/stack_spec.ts
+++ b/packages/core/test/render3/stack_spec.ts
@@ -7,9 +7,8 @@
  */
 
 import {Stack} from '@angular/core/src/render3/util/stack';
-import {onlyInIvy} from '@angular/private/testing';
 
-onlyInIvy('Stacks are only used for Ivy').describe('Stack', () => {
+describe('Stack', () => {
   it('should push and pop values', () => {
     const stack = new Stack<number>();
 

--- a/packages/core/test/render3/stack_spec.ts
+++ b/packages/core/test/render3/stack_spec.ts
@@ -13,46 +13,46 @@ onlyInIvy('Stacks are only used for Ivy').describe('Stack', () => {
   it('should push and pop values', () => {
     const stack = new Stack<number>();
 
-    expect(stack.current).toBe(null);
+    expect(stack.peek()).toBe(null);
     expect(getAllocatedStackSize(stack)).toBe(0);
 
     stack.push(1);
-    expect(stack.current).toBe(1);
+    expect(stack.peek()).toBe(1);
     expect(getAllocatedStackSize(stack)).toBe(1);
 
     stack.push(2);
-    expect(stack.current).toBe(2);
+    expect(stack.peek()).toBe(2);
     expect(getAllocatedStackSize(stack)).toBe(2);
 
     stack.push(3);
-    expect(stack.current).toBe(3);
+    expect(stack.peek()).toBe(3);
     expect(getAllocatedStackSize(stack)).toBe(3);
 
     let popped = stack.pop();
     expect(popped).toBe(3);
-    expect(stack.current).toBe(2);
+    expect(stack.peek()).toBe(2);
     expect(getAllocatedStackSize(stack)).toBe(3);
 
     popped = stack.pop();
     expect(popped).toBe(2);
-    expect(stack.current).toBe(1);
+    expect(stack.peek()).toBe(1);
     expect(getAllocatedStackSize(stack)).toBe(3);
 
     popped = stack.pop();
     expect(popped).toBe(1);
-    expect(stack.current).toBe(null);
+    expect(stack.peek()).toBe(null);
     expect(getAllocatedStackSize(stack)).toBe(3);
   });
 
   it('should handle too much pop', () => {
     const stack = new Stack<number>();
 
-    stack.pop();
-    stack.pop();
-    stack.pop();
+    expect(() => stack.pop()).toThrow();
+    expect(() => stack.pop()).toThrow();
+    expect(() => stack.pop()).toThrow();
 
     stack.push(42);
-    expect(stack.current).toBe(42);
+    expect(stack.peek()).toBe(42);
     expect(getAllocatedStackSize(stack)).toBe(1);
   });
 });


### PR DESCRIPTION
- Adds a simple `Stack` implementation
- Uses said `Stack` in two spots where we were using a stack in `i18n`.
- Notice in [this commit](https://github.com/angular/angular/commit/3a5744771c9b42ebececede930369b5bbcd2b1cf) that it resolves a previously missed (minor) issue that we were leaving unused integers in a stack as we moved "down", but never actually "popped" the value.

### Goals

Since we're using stacks in a few places already, and we're looking at using a stack to track DOM insertion locations, adding a `Stack` type enables a few things:

1. We don't re-implement stacks over and over in different ways. No matter how simple they are.
2. As stacks _could_ have memory pressure implications, centralizing all of our stack use through one type will make tracking our stack usage throughout the codebase easier, and may help track down those issues when/if they arise.
3. Opportunity to build a little more safety into our stack usage.

NOTE: I typed the words "poop" and "pooped" instead of "pop" and "popped" about 20 times during the development of this PR.