### PR TITLE
build(bazel): revert back to yarn 1.12.1 under Bazel to fix Windows file-in-use issues

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ node_repositories(
     node_version = "10.9.0",
     package_json = ["//:package.json"],
     preserve_symlinks = True,
-    yarn_version = "1.13.0",
+    yarn_version = "1.12.1",
 )
 
 yarn_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,6 +48,14 @@ node_repositories(
     node_version = "10.9.0",
     package_json = ["//:package.json"],
     preserve_symlinks = True,
+    # yarn 1.13.0 under Bazel has a regression on Windows that causes build errors on rebuilds:
+    # ```
+    # ERROR: Source forest creation failed: C:/.../fyuc5c3n/execroot/angular/external (Directory not empty)
+    # ```
+    # See https://github.com/angular/angular/pull/29431 for more information.
+    # It possible that versions of yarn past 1.13.0 do not have this issue, however, before
+    # advancing this version we need to test manually on Windows that the above error does not
+    # happen as the issue is not caught by CI.
     yarn_version = "1.12.1",
 )
 

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -37,7 +37,7 @@ Try running `yarn bazel` instead.
 # Setup the Node.js toolchain
 node_repositories(
     node_version = "10.9.0",
-    yarn_version = "1.13.0",
+    yarn_version = "1.12.1",
 )
 
 # Install our npm dependencies into @npm


### PR DESCRIPTION
It turns out the issues on Windows observed after https://github.com/bazelbuild/rules_nodejs/issues/588:

```

ERROR: Source forest creation failed: C:/users/olivier/_bazel_olivier/fyuc5c3n/execroot/angular/external (Directory not empty)
```

were not due to vendored_yarn but due to yarn 1.13.0.

This reverts back to safety of yarn 1.12.1 until we can find the root cause and fix it.