### PR TITLE
Debug node query via dom issues

### DIFF
--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -362,6 +362,26 @@ class TestCmpt {
       expect(debugElement).toBeTruthy();
     });
 
+    it('should query directives on containers before directives in a view - FW-869', () => {
+      @Directive({selector: '[text]'})
+      class TextDirective {
+        @Input() text: string|undefined;
+      }
+
+      TestBed.configureTestingModule({declarations: [TextDirective]});
+      TestBed.overrideTemplate(
+          TestApp,
+          `<ng-template text="first" [ngIf]="true"><div text="second"></div></ng-template>`);
+
+      const fixture = TestBed.createComponent(TestApp);
+      fixture.detectChanges();
+
+      const debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+      expect(debugNodes.length).toBe(2);
+      expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
+      expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
+    });
+
     it('should list providerTokens', () => {
       fixture = TestBed.createComponent(ParentComp);
       fixture.detectChanges();


### PR DESCRIPTION
This PR has minimal tests for FW-869 and FW-1059. It aims at illustrating that _both_ issues have the same root cause - basing debug node queries on the DOM. Using DOM is brittle as it can break down when:
* implementation detail changes (placement of a comment node anchoring a container);
* manual DOM manipulation is done.

Even if FW-869 and FW-1059 have the _same_ root cause so far we were trying to solve it differently:
* FW-869 by changing order of DOM nodes (before / after comment node insertion)
* FW-1059 by basing debug node queries on _logical_ tree (instead of the DOM)

Obviously those 2 approaches are not compatible - if we "fix"F W-869 by changing DOM manipulation than the fix for FW-1059 will "undo" everything. 

The goal of this PR is to make sure that we've got a shared understanding of the issue at hand and we can decide on a fix for _both_ FW-869 and FW-1059