### PR TITLE
build(bazel): back out of @bazel/jasmine 0.27.7 with shard count

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular-devkit/core": "^7.3.2",
     "@angular-devkit/schematics": "^7.3.2",
     "@angular/bazel": "file:./tools/npm/@angular_bazel",
-    "@bazel/jasmine": "0.27.7",
+    "@bazel/jasmine": "0.26.0",
     "@bazel/karma": "0.27.7",
     "@bazel/typescript": "0.27.7",
     "@microsoft/api-extractor": "^7.0.21",

--- a/packages/compiler-cli/test/compliance/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/BUILD.bazel
@@ -21,7 +21,6 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
-    shard_count = 4,
     tags = [
         "ivy-only",
     ],

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -23,7 +23,6 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
-    shard_count = 4,
     deps = [
         ":ngtsc_lib",
         "//tools/testing:node_no_angular",

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -58,7 +58,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    shard_count = 4,
     deps = [
         ":test_lib",
         ":test_node_only_lib",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -275,6 +275,7 @@ def jasmine_node_test(deps = [], **kwargs):
         # Very common dependencies for tests
         "@npm//chokidar",
         "@npm//domino",
+        "@npm//jasmine-core",
         "@npm//mock-fs",
         "@npm//reflect-metadata",
         "@npm//source-map-support",

--- a/tools/testing/init_node_spec.ts
+++ b/tools/testing/init_node_spec.ts
@@ -15,9 +15,14 @@ import 'zone.js/dist/fake-async-test.js';
 import 'zone.js/dist/task-tracking.js';
 import 'reflect-metadata/Reflect';
 
-// Initialize jasmine with @bazel/jasmine boot() function. This will initialize
-// global.jasmine so that it can be patched by zone.js jasmine-patch.js.
-require('@bazel/jasmine').boot();
+// We must first initialize jasmine-core before calling
+// requiring `zone.js/dist/jasmine-patch.js` which patches
+// jasmine ENV with code which understands ProxyZone.
+// jasmine_node_test under Bazel will check if `jasmineCore.boot(jasmineCore)`
+// has been called and re-use the env if it has.
+// See https://github.com/bazelbuild/rules_nodejs/pull/539
+const jasmineCore: any = require('jasmine-core');
+jasmineCore.boot(jasmineCore);
 import 'zone.js/dist/jasmine-patch.js';
 
 (global as any).isNode = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,10 +127,10 @@
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.9.0.tgz#fd60023acd36313d304cc2f8c2e181b88b5445cd"
   integrity sha512-E31cefDcdJsx/oii6p/gqKZXSVw0kEg1O73DD2McFcSvnf/p1GYWcQtVgdRQmlviBEytJkJgdX8rtThitRvcow==
 
-"@bazel/jasmine@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.27.7.tgz#3b57a733d30e3786d13f124d25b50d938e5d5187"
-  integrity sha512-neFY+H6QYuysTAmtIXkF8aAFf1/aRABwZyLUI6Q5eODRegm5udZ1nqcxPB/wdGtENdpkaKVUr9B4YkaJsiiwIg==
+"@bazel/jasmine@0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.26.0.tgz#f7aed169b057b5af547d2573657b394ecbda0b5d"
+  integrity sha512-lkvzPHdbSEe1zitnV1hIBwodriXqp/ClHSZQJ5Y486UaLQ6Sm7k7gV2phOwtg7LqLVZnElZDmFLSI0/O1UYYyQ==
   dependencies:
     jasmine "~3.3.1"
 


### PR DESCRIPTION
See discussion in slack #dev-infra

Similar to https://github.com/angular/angular/pull/29442 but also rolls @bazel/jasmine npm package back to 0.26.0.