### PR TITLE
fix(forms): make FormControlName#name a number in addition to string

### DIFF
--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -36,7 +36,7 @@ export abstract class NgControl extends AbstractControlDirective {
    * @description
    * The name for the control
    */
-  name: string|null = null;
+  name: string|number|null = null;
 
   /**
    * @description

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -147,7 +147,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * to a key in the parent `FormGroup` or `FormArray`.
    */
   // TODO(issue/24571): remove '!'.
-  @Input('formControlName') name !: string;
+  @Input('formControlName') name !: string | number;
 
   /**
    * @description
@@ -238,7 +238,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * Returns an array that represents the path from the top-level form to this control.
    * Each index is the string name of the control on that level.
    */
-  get path(): string[] { return controlPath(this.name, this._parent !); }
+  get path(): string[] { return controlPath(String(this.name), this._parent !); }
 
   /**
    * @description


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

FormControlName directive's `name` field has only `string` as a type. However according to documentation https://angular.io/api/forms/FormArrayName, `formControlName` input accepts number as well. 

This is causing issue when type validation of Angular expressions is enabled in WebStorm IDE
(https://youtrack.jetbrains.com/issue/WEB-37897).

## What is the new behavior?
Typing of `name` field of FormControlName directive is corrected to `string|number`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
