### PR TITLE
docs(forms): properly convert number to string for formControlName input

### DIFF
--- a/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
+++ b/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
@@ -17,7 +17,7 @@ import {FormArray, FormControl, FormGroup} from '@angular/forms';
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <div formArrayName="cities">
         <div *ngFor="let city of cities.controls; index as i">
-          <input [formControlName]="i" placeholder="City">
+          <input formControlName="{{i}}" placeholder="City">
         </div>
       </div>
       <button>Submit</button>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently documentation https://angular.io/api/forms/FormArrayName for `formArrayName` encourages to pass `number` to a `string` input.


## What is the new behavior?

Documentation will encourage to use `i.toString()` to cast index to `string`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
