### PR TITLE
fix(ivy): properly check LView array size in binding asserts

### DIFF
--- a/packages/core/src/render3/bindings.ts
+++ b/packages/core/src/render3/bindings.ts
@@ -25,7 +25,7 @@ export function updateBinding(lView: LView, bindingIndex: number, value: any): a
 
 /** Gets the current binding value. */
 export function getBinding(lView: LView, bindingIndex: number): any {
-  ngDevMode && assertDataInRange(lView, lView[bindingIndex]);
+  ngDevMode && assertDataInRange(lView, bindingIndex);
   ngDevMode &&
       assertNotEqual(lView[bindingIndex], NO_CHANGE, 'Stored value should never be NO_CHANGE.');
   return lView[bindingIndex];


### PR DESCRIPTION
This fix corrects a bug where we were passing a binding _value_
in place of an expected binding index. This resulted in the binding
value being compared to an array length and buggy type coercion.

Fixing this bug speeds up test scenario by ~10-15%.