### PR TITLE
fix(ivy): TestBed overriding custom ErrorHandler

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Inject, InjectionToken, NgModule, Optional, Pipe} from '@angular/core';
+import {Component, Directive, ErrorHandler, Inject, InjectionToken, NgModule, Optional, Pipe} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -254,6 +254,19 @@ describe('TestBed', () => {
     // Intentionally call `createComponent` before `compileComponents` is resolved. We want this to
     // work for components that don't have any async resources (templateUrl, styleUrls).
     TestBed.createComponent(ComponentWithInlineTemplate);
+  });
+
+  it('should be able to override the ErrorHandler via an import', () => {
+    class CustomErrorHandler {}
+
+    @NgModule({providers: [{provide: ErrorHandler, useClass: CustomErrorHandler}]})
+    class ProvidesErrorHandler {
+    }
+
+    getTestBed().resetTestingModule();
+    TestBed.configureTestingModule({imports: [ProvidesErrorHandler, HelloWorldModule]});
+
+    expect(TestBed.get(ErrorHandler)).toEqual(jasmine.any(CustomErrorHandler));
   });
 
   onlyInIvy('patched ng defs should be removed after resetting TestingModule')

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -630,17 +630,22 @@ export class TestBedRender3 implements Injector, TestBed {
     class RootScopeModule {
     }
 
+    @NgModule({providers: [{provide: ErrorHandler, useClass: R3TestErrorHandler}]})
+    class R3ErrorHandlerModule {
+    }
+
     const ngZone = new NgZone({enableLongStackTrace: true});
     const providers = [
       {provide: NgZone, useValue: ngZone},
       {provide: Compiler, useFactory: () => new R3TestCompiler(this)},
-      {provide: ErrorHandler, useClass: R3TestErrorHandler},
       ...this._providers,
       ...this._providerOverrides,
     ];
 
+    // We need to provide the `R3ErrorHandlerModule` after the consumer's NgModule so that we can
+    // override the default ErrorHandler, if the consumer didn't pass in a custom one.
+    const imports = [RootScopeModule, this.ngModule, R3ErrorHandlerModule, this._imports];
     const declarations = this._declarations;
-    const imports = [RootScopeModule, this.ngModule, this._imports];
     const schemas = this._schemas;
 
     @NgModule({providers, declarations, imports, schemas, jit: true})


### PR DESCRIPTION
Fixes TestBed's default ErrorHandler overriding the one provided by the consumer via an `import`.

This PR resolves FW-1193.
