### PR TITLE
fix(ivy): include className in DebugNode.properties

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -257,7 +257,14 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
 
     const properties = collectPropertyBindings(tNode, lView, tData);
     const hostProperties = collectHostPropertyBindings(tNode, lView, tData);
-    return {...properties, ...hostProperties};
+    const className = collectClassNames(this);
+    const output = {...properties, ...hostProperties};
+
+    if (className) {
+      output['className'] = output['className'] ? output['className'] + ` ${className}` : className;
+    }
+
+    return output;
   }
 
   get attributes(): {[key: string]: string | null;} {
@@ -478,6 +485,20 @@ function collectHostPropertyBindings(
     propMetadata = tData[++hostPropIndex];
   }
   return properties;
+}
+
+
+function collectClassNames(debugElement: DebugElement__POST_R3__): string {
+  const classes = debugElement.classes;
+  let output = '';
+
+  for (const className of Object.keys(classes)) {
+    if (classes[className]) {
+      output = output ? output + ` ${className}` : className;
+    }
+  }
+
+  return output;
 }
 
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {Component, Directive, EventEmitter, Injectable, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {Component, Directive, EventEmitter, HostBinding, Injectable, Input, NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -175,6 +175,12 @@ class TestApp {
 class TestCmpt {
 }
 
+@Component({selector: 'host-class-binding', template: ''})
+class HostClassBindingCmp {
+  @HostBinding('class')
+  hostClasses = 'class-one class-two';
+}
+
 {
   describe('debug element', () => {
     let fixture: ComponentFixture<any>;
@@ -195,6 +201,7 @@ class TestCmpt {
           UsingFor,
           BankAccount,
           TestCmpt,
+          HostClassBindingCmp,
         ],
         providers: [Logger],
         schemas: [NO_ERRORS_SCHEMA],
@@ -406,6 +413,25 @@ class TestCmpt {
       fixture.debugElement.children[1].triggerEventHandler('myevent', <Event>{});
       expect(fixture.componentInstance.customed).toBe(true);
 
+    });
+
+    it('should include classes in properties.className', () => {
+      fixture = TestBed.createComponent(HostClassBindingCmp);
+      fixture.detectChanges();
+
+      const debugElement = fixture.debugElement;
+
+      expect(debugElement.properties.className).toBe('class-one class-two');
+
+      fixture.componentInstance.hostClasses = 'class-three';
+      fixture.detectChanges();
+
+      expect(debugElement.properties.className).toBe('class-three');
+
+      fixture.componentInstance.hostClasses = '';
+      fixture.detectChanges();
+
+      expect(debugElement.properties.className).toBeFalsy();
     });
 
     describe('componentInstance on DebugNode', () => {


### PR DESCRIPTION
Fixes the node's class bindings not being included under `DebugNode.properties.className` like in ViewEngine.

This PR resolves FW-1196.
