### PR TITLE
fix(core): static-query schematic should detect queries in "ngDoCheck" and "ngOnChanges"

### DIFF
--- a/packages/core/schematics/migrations/static-queries/angular/analyze_query_usage.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/analyze_query_usage.ts
@@ -19,8 +19,9 @@ import {NgQueryDefinition, QueryTiming, QueryType} from './query-definition';
  * could be used to access such a query statically.
  */
 const STATIC_QUERY_LIFECYCLE_HOOKS = {
-  [QueryType.ViewChild]: ['ngOnInit', 'ngAfterContentInit', 'ngAfterContentChecked'],
-  [QueryType.ContentChild]: ['ngOnInit'],
+  [QueryType.ViewChild]:
+      ['ngOnChanges', 'ngOnInit', 'ngDoCheck', 'ngAfterContentInit', 'ngAfterContentChecked'],
+  [QueryType.ContentChild]: ['ngOnChanges', 'ngOnInit', 'ngDoCheck'],
 };
 
 /**

--- a/packages/core/schematics/test/static_queries_migration_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_spec.ts
@@ -161,6 +161,26 @@ describe('static-queries migration', () => {
           .toContain(`@${queryType}('dynamic', { static: false }) dynamic: any`);
     });
 
+    it('should mark queries used in "ngOnChanges" as static', () => {
+      writeFile('/index.ts', `
+        import {Component, ${queryType}} from '@angular/core';
+        
+        @Component({template: '<span #test></span>'})
+        export class MyComp {
+          @${queryType}('test') query: any;
+          
+          ngOnChanges() {
+            this.query.classList.add('test'); 
+          }
+        }
+      `);
+
+      runMigration();
+
+      expect(tree.readContent('/index.ts'))
+          .toContain(`@${queryType}('test', { static: true }) query: any;`);
+    });
+
     it('should mark queries used in "ngOnInit" as static', () => {
       writeFile('/index.ts', `
         import {Component, ${queryType}} from '@angular/core';
@@ -170,6 +190,26 @@ describe('static-queries migration', () => {
           @${queryType}('test') query: any;
           
           ngOnInit() {
+            this.query.classList.add('test'); 
+          }
+        }
+      `);
+
+      runMigration();
+
+      expect(tree.readContent('/index.ts'))
+          .toContain(`@${queryType}('test', { static: true }) query: any;`);
+    });
+
+    it('should mark queries used in "ngDoCheck" as static', () => {
+      writeFile('/index.ts', `
+        import {Component, ${queryType}} from '@angular/core';
+        
+        @Component({template: '<span #test></span>'})
+        export class MyComp {
+          @${queryType}('test') query: any;
+          
+          ngDoCheck() {
             this.query.classList.add('test'); 
           }
         }


### PR DESCRIPTION
Queries can be also used statically within the "ngDoCheck" and "ngOnChanges" lifecylce hook.
In order to properly detect all queries, we need to also respect these lifecycle hooks.

Resolves FW-1192