### PR TITLE
fix(core): fix Zone usage to compile with strict flags

### DIFF
--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -167,7 +167,7 @@ export class Testability implements PublicTestability {
         // From TaskTrackingZone:
         // https://github.com/angular/zone.js/blob/master/lib/zone-spec/task-tracking.ts#L40
         creationLocation: (t as any).creationLocation as Error,
-        data: t.data
+        data: t.data !
       };
     });
   }

--- a/packages/core/testing/src/async_fallback.ts
+++ b/packages/core/testing/src/async_fallback.ts
@@ -87,7 +87,7 @@ function runInTestZone(
   // If we do it in ProxyZone then we will get to infinite recursion.
   const proxyZone = Zone.current.getZoneWith('ProxyZoneSpec');
   const previousDelegate = proxyZoneSpec.getDelegate();
-  proxyZone.parent.run(() => {
+  proxyZone !.parent !.run(() => {
     const testZoneSpec: ZoneSpec = new AsyncTestZoneSpec(
         () => {
           // Need to restore the original zone.


### PR DESCRIPTION
Needed inside Google to compile with latest Zone.js.

Angular with Zone at head with strict compiler flags inside Google doesn't compile.