### PR TITLE
docs: address some comments in #28343

### DIFF
--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
@@ -6,9 +6,9 @@
 // #enddocregion collection
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
-    "copy:schemas": "cp --parents schematics/*/schema.json ../../dist/my-lib/",
-    "copy:files": "cp --parents -p schematics/*/files/** ../../dist/my-lib/",
-    "copy:collection": "cp schematics/collection.json ../../dist/my-lib/schematics/collection.json",
+    "copy:schemas": "find schematics -type f -name 'schema.json' -exec rsync -R {} ../../dist/my-lib/ \\;",
+    "copy:files": "find schematics/*/files/** -exec rsync -R {} ../../dist/my-lib/ \\;",
+    "copy:collection": "cp schematics/collection.json ../../dist/my-lib/schematics",
     "postbuild": "npm run copy:schemas && npm run copy:files && npm run copy:collection"
   },
   "peerDependencies": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes _(P.S. I wouldn't really consider this as a "documentation content change")_
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Addresses concerns that I had in the PR that introduced the Schematics docs (#28343) where the `--parents` flag of `cp` was not supported on certain platforms such as macOS.

Issue Number: N/A

## What is the new behavior?

The scripts now use the `find` and `rsync` commands respectively which should not break any existing copying functionality.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR also has minor documentation fixes in the Schematics for Libraries document such as the removal of extra whitespaces and typo fixes.

P.S. I can try to address the other reviews and comments made in the PR that I linked above such as mentioning schematics utilities in the document that the community have made.