### PR TITLE
fix(ivy): generate empty QueryList for root component content queries

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -217,6 +217,12 @@ export function createRootComponent<T>(
     renderInitialStyles(native, rootTNode.stylingTemplate, componentView[RENDERER]);
   }
 
+  // We want to generate an empty QueryList for root content queries for backwards
+  // compatibility with ViewEngine.
+  if (componentDef.contentQueries) {
+    componentDef.contentQueries(RenderFlags.Create, component, rootView.length - 1);
+  }
+
   return component;
 }
 

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -401,6 +401,17 @@ describe('query logic', () => {
 
   });
 
+  // Some root components may have ContentChildren queries if they are also
+  // usable as a child component. We should still generate an empty QueryList
+  // for these queries when they are at root for backwards compatibility with
+  // ViewEngine.
+  it('should generate an empty QueryList for root components', () => {
+    const fixture = TestBed.createComponent(QueryComp);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.contentChildren).toBeAnInstanceOf(QueryList);
+    expect(fixture.componentInstance.contentChildren.length).toBe(0);
+  });
+
   describe('descendants', () => {
 
     it('should match directives on elements that used to be wrapped by a required parent in HTML parser',


### PR DESCRIPTION
In View Engine, we used to generate empty QueryLists for content queries on root
components (though we did not actually support populating these lists). We need
to keep this behavior in Ivy for backwards compatibility. Otherwise, components
that are sometimes used as root will fail if they are relying on content query
results to always be defined.