### PR TITLE
refactor(ivy): use === instead of == in interpolateV

### DIFF
--- a/packages/core/src/render3/instructions/instructions.ts
+++ b/packages/core/src/render3/instructions/instructions.ts
@@ -2741,7 +2741,7 @@ export function interpolationV(values: any[]): string|NO_CHANGE {
   const tData = lView[TVIEW].data;
   let bindingIndex = lView[BINDING_INDEX];
 
-  if (tData[bindingIndex] == null) {
+  if (tData[bindingIndex] === null) {
     // 2 is the index of the first static interstitial value (ie. not prefix)
     for (let i = 2; i < values.length; i += 2) {
       tData[bindingIndex++] = values[i];


### PR DESCRIPTION
Just a minor thing, but in an _extreme corner-case_, code could reset the binding index and incorrectly enter this `if` block if the value at that binding index happened to be falsy. `''` for example.
