### PR TITLE
refactor(ivy): rename flushHooksUpTo to select

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -798,7 +798,7 @@ describe('compiler compliance', () => {
           if (rf & 2) {
             const $myComp$ = $r3$.ɵnextContext();
             const $foo$ = $r3$.ɵreference(1);
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵtextBinding(1, $r3$.ɵinterpolation2("", $myComp$.salutation, " ", $foo$, ""));
           }
         }
@@ -1257,7 +1257,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               $r3$.ɵelementProperty(0, "ngIf", $r3$.ɵbind(ctx.visible));
-              $r3$.ɵflushHooksUpTo(1);
+              $r3$.ɵselect(1);
               $r3$.ɵelementProperty(1, "ngIf", $r3$.ɵbind(ctx.visible));
             }
           }
@@ -1950,7 +1950,7 @@ describe('compiler compliance', () => {
                 }
                 if (rf & 2) {
                   $r3$.ɵtextBinding(0, $r3$.ɵinterpolation1("", $r3$.ɵpipeBind2(1, 3, $r3$.ɵpipeBind2(2, 6, ctx.name, ctx.size), ctx.size), ""));
-                  $r3$.ɵflushHooksUpTo(4);
+                  $r3$.ɵselect(4);
                   $r3$.ɵtextBinding(4, $r3$.ɵinterpolation2("", $r3$.ɵpipeBindV(5, 9, $r3$.ɵpureFunction1(18, $c0$, ctx.name)), " ", (ctx.name ? 1 : $r3$.ɵpipeBind1(6, 16, 2)), ""));
                 }
               },
@@ -2065,7 +2065,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $user$ = $r3$.ɵreference(1);
-              $r3$.ɵflushHooksUpTo(2);
+              $r3$.ɵselect(2);
               $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1("Hello ", $user$.value, "!"));
             }
           },
@@ -2128,7 +2128,7 @@ describe('compiler compliance', () => {
             $r3$.ɵnextContext();
             const $foo$ = $r3$.ɵreference(1);
             const $baz$ = $r3$.ɵreference(5);
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵtextBinding(1, $r3$.ɵinterpolation3("", $foo$, "-", $bar$, "-", $baz$, ""));
           }
         }
@@ -2144,7 +2144,7 @@ describe('compiler compliance', () => {
             const $bar$ = $r3$.ɵreference(4);
             $r3$.ɵnextContext();
             const $foo$ = $r3$.ɵreference(1);
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵtextBinding(1, $r3$.ɵinterpolation2(" ", $foo$, "-", $bar$, " "));
           }
         }
@@ -2164,7 +2164,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $foo$ = $r3$.ɵreference(1);
-              $r3$.ɵflushHooksUpTo(2);
+              $r3$.ɵselect(2);
               $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1(" ", $foo$, " "));
             }
           },
@@ -2217,7 +2217,7 @@ describe('compiler compliance', () => {
         if (rf & 2) {
           const $item$ = $i0$.ɵnextContext().$implicit;
           const $foo$ = $i0$.ɵreference(2);
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation2(" ", $foo$, " - ", $item$, " "));
         }
       }
@@ -2231,7 +2231,7 @@ describe('compiler compliance', () => {
         }
         if (rf & 2) {
           const $app$ = $i0$.ɵnextContext();
-          $r3$.ɵflushHooksUpTo(3);
+          $r3$.ɵselect(3);
           $i0$.ɵelementProperty(3, "ngIf", $i0$.ɵbind($app$.showing));
         }
       }
@@ -2323,7 +2323,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵelementProperty(0, "name", $r3$.ɵbind(ctx.name1));
-                $r3$.ɵflushHooksUpTo(1);
+                $r3$.ɵselect(1);
                 $r3$.ɵelementProperty(1, "name", $r3$.ɵbind(ctx.name2));
               }
             },
@@ -2455,7 +2455,7 @@ describe('compiler compliance', () => {
                     $r3$.ɵelementEnd();
                   }
                   if (rf & 2) {
-                    $r3$.ɵflushHooksUpTo(1);
+                    $r3$.ɵselect(1);
                     $r3$.ɵelementProperty(1,"forOf",$r3$.ɵbind(ctx.items));
                   }
                 },
@@ -2519,7 +2519,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $item$ = ctx.$implicit;
-              $r3$.ɵflushHooksUpTo(1);
+              $r3$.ɵselect(1);
               $r3$.ɵtextBinding(1, $r3$.ɵinterpolation1("", $item$.name, ""));
             }
           }
@@ -2537,7 +2537,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementEnd();
               }
               if (rf & 2) {
-                $r3$.ɵflushHooksUpTo(1);
+                $r3$.ɵselect(1);
                 $r3$.ɵelementProperty(1, "forOf", $r3$.ɵbind(ctx.items));
               }
             },
@@ -2602,7 +2602,7 @@ describe('compiler compliance', () => {
             if (rf & 2) {
               const $info$ = ctx.$implicit;
               const $item$ = $r3$.ɵnextContext().$implicit;
-              $r3$.ɵflushHooksUpTo(1);
+              $r3$.ɵselect(1);
               $r3$.ɵtextBinding(1, $r3$.ɵinterpolation2(" ", $item$.name, ": ", $info$.description, " "));
             }
           }
@@ -2620,9 +2620,9 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $item$ = ctx.$implicit;
-              $r3$.ɵflushHooksUpTo(2);
+              $r3$.ɵselect(2);
               $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1("", IDENT.name, ""));
-              $r3$.ɵflushHooksUpTo(4);
+              $r3$.ɵselect(4);
               $r3$.ɵelementProperty(4, "forOf", $r3$.ɵbind(IDENT.infos));
             }
           }
@@ -2641,7 +2641,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementEnd();
               }
               if (rf & 2) {
-                $r3$.ɵflushHooksUpTo(1);
+                $r3$.ɵselect(1);
                 $r3$.ɵelementProperty(1, "forOf", $r3$.ɵbind(ctx.items));
               }
             },

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -44,7 +44,7 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵelementEnd();
         }
         if (rf & 2) {
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation1("Hello ", $ctx$.name, ""));
         }
       }`;
@@ -474,7 +474,7 @@ describe('compiler compliance: bindings', () => {
           }
           if (rf & 2) {
             const $_r0$ = $i0$.ɵreference(1);
-            $r3$.ɵflushHooksUpTo(4);
+            $r3$.ɵselect(4);
             $i0$.ɵtextBinding(4, $i0$.ɵinterpolation1(" ", $_r0$.id, " "));
           }
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -369,7 +369,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nApply(2);
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nExp($r3$.ɵbind((ctx.valueA + ctx.valueB)));
@@ -437,7 +437,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(2, 0, $outer_r1$)));
             $r3$.ɵi18nApply(3);
           }
@@ -527,7 +527,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nApply(2);
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nExp($r3$.ɵbind((ctx.valueA + ctx.valueB)));
@@ -568,7 +568,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(2, 0, $outer_r1$)));
             $r3$.ɵi18nApply(3);
           }
@@ -734,7 +734,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nApply(1);
           }
@@ -761,7 +761,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nApply(1);
           }
@@ -792,7 +792,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(2, 2, ctx.valueA)));
             $r3$.ɵi18nExp($r3$.ɵbind(((ctx.valueA == null) ? null : ((ctx.valueA.a == null) ? null : ctx.valueA.a.b))));
             $r3$.ɵi18nApply(1);
@@ -836,13 +836,13 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.one));
             $r3$.ɵi18nApply(1);
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(4, 3, ctx.two)));
             $r3$.ɵi18nApply(3);
-            $r3$.ɵflushHooksUpTo(6);
+            $r3$.ɵselect(6);
             $r3$.ɵi18nExp($r3$.ɵbind(((ctx.three + ctx.four) + ctx.five)));
             $r3$.ɵi18nApply(6);
           }
@@ -907,10 +907,10 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.one));
             $r3$.ɵi18nApply(1);
-            $r3$.ɵflushHooksUpTo(4);
+            $r3$.ɵselect(4);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(5, 3, ctx.two)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.nestedInBlockTwo));
             $r3$.ɵi18nApply(4);
@@ -977,13 +977,13 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueC));
             $r3$.ɵi18nApply(3);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nApply(1);
-            $r3$.ɵflushHooksUpTo(7);
+            $r3$.ɵselect(7);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueE));
             $r3$.ɵi18nApply(8);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(6, 5, ctx.valueD)));
@@ -1032,7 +1032,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.valueA));
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(4, 2, $ctx_r0$.valueB)));
             $r3$.ɵi18nApply(2);
@@ -1049,7 +1049,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
           }
         }
@@ -1100,9 +1100,9 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(2, MyComponent_img_2_Template, 2, 1, "img", $_c2$);
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵelementProperty(1, "ngIf", $r3$.ɵbind(ctx.visible));
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
           }
         }
@@ -1166,7 +1166,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
-            $r3$.ɵflushHooksUpTo(4);
+            $r3$.ɵselect(4);
             $r3$.ɵelementProperty(4, "ngIf", $r3$.ɵbind($ctx_r0$.exists));
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.valueA));
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(3, 3, $ctx_r0$.valueB)));
@@ -1216,9 +1216,9 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵelementProperty(3, "ngIf", $r3$.ɵbind(!ctx.visible));
           }
         }
@@ -1250,7 +1250,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
               const $ctx_r0$ = $r3$.ɵnextContext();
-              $r3$.ɵflushHooksUpTo(1);
+              $r3$.ɵselect(1);
               $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.valueA));
               $r3$.ɵi18nApply(1);
           }
@@ -1335,7 +1335,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nApply(1);
           }
@@ -1424,7 +1424,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(2, 1, ctx.valueA)));
             $r3$.ɵi18nApply(1);
           }
@@ -1509,7 +1509,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(4, 1, ctx.valueB)));
             $r3$.ɵi18nApply(1);
           }
@@ -1555,7 +1555,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nApply(2);
           }
@@ -1677,7 +1677,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(2, MyComponent_ng_template_2_Template, 1, 1, "ng-template");
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nApply(1);
           }
@@ -1821,7 +1821,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nApply(1);
           }
@@ -1902,7 +1902,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.age));
             $r3$.ɵi18nApply(1);
           }
@@ -1924,7 +1924,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵnextContext();
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r1$.count));
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r1$.count));
             $r3$.ɵi18nApply(2);
@@ -1942,12 +1942,12 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", $_c1$);
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nApply(1);
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵelementProperty(3, "ngIf", $r3$.ɵbind(ctx.available));
           }
         }
@@ -1974,7 +1974,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.other));
             $r3$.ɵi18nApply(1);
@@ -2062,7 +2062,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nExp($r3$.ɵbind(((ctx.ageA + ctx.ageB) + ctx.ageC)));
             $r3$.ɵi18nApply(1);
@@ -2104,7 +2104,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nApply(1);
@@ -2176,7 +2176,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(3);
+            $r3$.ɵselect(3);
             $r3$.ɵelementProperty(3, "ngIf", $r3$.ɵbind(ctx.visible));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
@@ -2218,7 +2218,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nApply(1);
@@ -2282,7 +2282,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.ageVisible));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nApply(1);
@@ -2349,7 +2349,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(2);
+            $r3$.ɵselect(2);
             $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.ageVisible));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.weight));
@@ -2392,7 +2392,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵflushHooksUpTo(1);
+            $r3$.ɵselect(1);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.gender));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.weight));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.height));

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -227,9 +227,9 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵelementProperty(0, "@foo", $r3$.ɵbind(ctx.exp));
-              $r3$.ɵflushHooksUpTo(1);
+              $r3$.ɵselect(1);
               $r3$.ɵelementProperty(1, "@bar", $r3$.ɵbind(undefined));
-              $r3$.ɵflushHooksUpTo(2);
+              $r3$.ɵselect(2);
               $r3$.ɵelementProperty(2, "@baz", $r3$.ɵbind(undefined));
             }
           },
@@ -932,7 +932,7 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵelementStyleProp(0, 1, $r3$.ɵpipeBind2(3, 7, $ctx$.bazExp, 4000));
               $r3$.ɵelementClassProp(0, 0, $r3$.ɵpipeBind2(4, 10, $ctx$.fooExp, 2000));
               $r3$.ɵelementStylingApply(0);
-              $r3$.ɵflushHooksUpTo(5);
+              $r3$.ɵselect(5);
               $r3$.ɵtextBinding(5, $r3$.ɵinterpolation1(" ", $ctx$.item, ""));
             }
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -76,7 +76,7 @@ describe('compiler compliance: template', () => {
           const $outer1$ = $i0$.ɵnextContext().$implicit;
           const $myComp1$ = $i0$.ɵnextContext();
           $i0$.ɵelementProperty(0, "title", $i0$.ɵbind($myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component)));
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation1(" ", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component), " "));
         }
       }
@@ -89,7 +89,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $myComp2$ = $i0$.ɵnextContext(2);
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵelementProperty(1, "ngForOf", $i0$.ɵbind($myComp2$.items));
         }
       }
@@ -102,7 +102,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $outer2$ = ctx.$implicit;
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵelementProperty(1, "ngForOf", $i0$.ɵbind($outer2$.items));
         }
       }
@@ -211,7 +211,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $item$ = ctx.$implicit;
           const $i$ = ctx.index;
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation2(" ", $i$, " - ", $item$, " "));
         }
       }
@@ -267,7 +267,7 @@ describe('compiler compliance: template', () => {
           const $div$ = $i0$.ɵnextContext();
           const $i$ = $div$.index;
           const $item$ = $div$.$implicit;
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation2(" ", $i$, " - ", $item$, " "));
         }
       }
@@ -280,7 +280,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $app$ = $i0$.ɵnextContext();
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵelementProperty(1, "ngIf", $i0$.ɵbind($app$.showing));
         }
       }
@@ -337,7 +337,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $middle$ = $i0$.ɵnextContext().$implicit;
           const $myComp$ = $i0$.ɵnextContext(2);
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation2(" ", $middle$.value, " - ", $myComp$.name, " "));
         }
       }
@@ -350,7 +350,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $middle$ = ctx.$implicit;
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵelementProperty(1, "ngForOf", $i0$.ɵbind($middle$.items));
         }
       }
@@ -363,7 +363,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $outer$ = ctx.$implicit;
-          $r3$.ɵflushHooksUpTo(1);
+          $r3$.ɵselect(1);
           $i0$.ɵelementProperty(1, "ngForOf", $i0$.ɵbind($outer$.items));
         }
       }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -31,7 +31,7 @@ export class Identifiers {
 
   static elementProperty: o.ExternalReference = {name: 'ɵelementProperty', moduleName: CORE};
 
-  static flushHooksUpTo: o.ExternalReference = {name: 'ɵflushHooksUpTo', moduleName: CORE};
+  static select: o.ExternalReference = {name: 'ɵselect', moduleName: CORE};
 
   static componentHostSyntheticProperty:
       o.ExternalReference = {name: 'ɵcomponentHostSyntheticProperty', moduleName: CORE};

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -121,8 +121,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
    */
   private _updateCodeFns: (() => o.Statement)[] = [];
   /**
-   * Memorizes the last node index for which a flushHooksUpTo instruction has been generated.
-   * Initialized to 0 to avoid generating a useless flushHooksUpTo(0).
+   * Memorizes the last node index for which a select instruction has been generated.
+   * Initialized to 0 to avoid generating a useless select(0).
    */
   private _lastNodeIndexWithFlush: number = 0;
   /** Temporary variable declarations generated from visiting pipes, literals, etc. */
@@ -999,7 +999,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       nodeIndex: number, span: ParseSourceSpan|null, reference: o.ExternalReference,
       paramsOrFn?: o.Expression[]|(() => o.Expression[])) {
     if (this._lastNodeIndexWithFlush < nodeIndex) {
-      this.instructionFn(this._updateCodeFns, span, R3.flushHooksUpTo, [o.literal(nodeIndex)]);
+      this.instructionFn(this._updateCodeFns, span, R3.select, [o.literal(nodeIndex)]);
       this._lastNodeIndexWithFlush = nodeIndex;
     }
     this.instructionFn(this._updateCodeFns, span, reference, paramsOrFn || []);

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -111,7 +111,7 @@ export {
   elementHostClassProp as ɵelementHostClassProp,
   elementHostStylingApply as ɵelementHostStylingApply,
 
-  flushHooksUpTo as ɵflushHooksUpTo,
+  select as ɵselect,
   textBinding as ɵtextBinding,
   template as ɵtemplate,
   embeddedViewEnd as ɵembeddedViewEnd,

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -130,7 +130,7 @@ export function registerPostOrderHooks(tView: TView, tNode: TNode): void {
  * [[onInit1, onInit2], [afterContentInit1], [afterViewInit1, afterViewInit2, afterViewInit3]]
  * They are are stored as flags in LView[FLAGS].
  *
- * 2. Pre-order hooks can be executed in batches, because of the flushHooksUpTo instruction.
+ * 2. Pre-order hooks can be executed in batches, because of the select instruction.
  * To be able to pause and resume their execution, we also need some state about the hook's array
  * that is being processed:
  * - the index of the next hook to be executed
@@ -151,7 +151,7 @@ export function registerPostOrderHooks(tView: TView, tNode: TNode): void {
  * - undefined: execute hooks only from the saved index until the end of the array (pre-order case,
  * when flushing the remaining hooks)
  * - number: execute hooks only from the saved index until that node index exclusive (pre-order
- * case, when executing flushHooksUpTo(number))
+ * case, when executing select(number))
  */
 export function executePreOrderHooks(
     currentView: LView, tView: TView, checkNoChangesMode: boolean,
@@ -178,7 +178,7 @@ export function executePreOrderHooks(
  * - null: execute hooks only from the saved index until the end of the array (pre-order case, when
  * flushing the remaining hooks)
  * - number: execute hooks only from the saved index until that node index exclusive (pre-order
- * case, when executing flushHooksUpTo(number))
+ * case, when executing select(number))
  */
 export function executeHooks(
     currentView: LView, firstPassHooks: HookData | null, checkHooks: HookData | null,
@@ -212,7 +212,7 @@ export function executeHooks(
  * - null: execute hooks only from the saved index until the end of the array (pre-order case, when
  * flushing the remaining hooks)
  * - number: execute hooks only from the saved index until that node index exclusive (pre-order
- * case, when executing flushHooksUpTo(number))
+ * case, when executing select(number))
  */
 function callHooks(
     currentView: LView, arr: HookData, initPhase: InitPhaseState,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -63,7 +63,7 @@ export {
   elementHostClassProp,
   elementHostStylingApply,
 
-  select as select,
+  select,
 
   listener,
   store,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -63,7 +63,7 @@ export {
   elementHostClassProp,
   elementHostStylingApply,
 
-  flushHooksUpTo,
+  select as select,
 
   listener,
   store,

--- a/packages/core/src/render3/instructions/instructions.ts
+++ b/packages/core/src/render3/instructions/instructions.ts
@@ -1097,7 +1097,7 @@ export function elementEnd(): void {
  *
  * @param index The index of the element in the `LView`
  */
-export function flushHooksUpTo(index: number): void {
+export function select(index: number): void {
   const lView = getLView();
   executePreOrderHooks(lView, lView[TVIEW], getCheckNoChangesMode(), index);
 }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -104,7 +104,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵelementHostStyleProp': r3.elementHostStyleProp,
   'ɵelementHostStylingApply': r3.elementHostStylingApply,
   'ɵelementHostClassProp': r3.elementHostClassProp,
-  'ɵflushHooksUpTo': r3.flushHooksUpTo,
+  'ɵselect': r3.select,
   'ɵtemplate': r3.template,
   'ɵtext': r3.text,
   'ɵtextBinding': r3.textBinding,

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -645,7 +645,7 @@
     "name": "findViaComponent"
   },
   {
-    "name": "flushHooksUpTo"
+    "name": "select"
   },
   {
     "name": "forwardRef"

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -9,7 +9,7 @@
 import {ComponentFactoryResolver, OnDestroy, SimpleChange, SimpleChanges, ViewContainerRef} from '../../src/core';
 import {AttributeMarker, ComponentTemplate, LifecycleHooksFeature, NO_CHANGE, NgOnChangesFeature, defineComponent, defineDirective, injectComponentFactoryResolver} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, flushHooksUpTo, listener, markDirty, projection, projectionDef, store, template, text} from '../../src/render3/instructions/all';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, select, listener, markDirty, projection, projectionDef, store, template, text} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -139,7 +139,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 2);
         }
       }, 2, 0, directives);
@@ -290,11 +290,11 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 2);
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val', 2);
         }
       }, 4, 0, directives);
@@ -349,7 +349,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 5);
           containerRefreshStart(1);
           {
@@ -390,7 +390,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 5);
           containerRefreshStart(1);
           {
@@ -629,7 +629,7 @@ describe('lifecycles', () => {
       }
       if (rf & RenderFlags.Update) {
         elementProperty(0, 'val', 1);
-        flushHooksUpTo(3);
+        select(3);
         elementProperty(3, 'val', 4);
         containerRefreshStart(2);
         {
@@ -753,7 +753,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 2);
         }
       }, 4, 0, directives);
@@ -822,11 +822,11 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 1);
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val', 2);
-          flushHooksUpTo(4);
+          select(4);
           elementProperty(4, 'val', 2);
         }
       }, 6, 0, directives);
@@ -855,7 +855,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val', 4);
           containerRefreshStart(2);
           {
@@ -1103,7 +1103,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 2);
         }
       }, 2, 0, defs);
@@ -1151,11 +1151,11 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 2);
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val', 2);
         }
       }, 4, 0, defs);
@@ -1178,7 +1178,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', bind(ctx.val));
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', bind(ctx.val));
         }
       }, 2, 2, [Comp, ProjectedComp]);
@@ -1194,7 +1194,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 2);
         }
       }, 2, 0, [ParentComp]);
@@ -1219,7 +1219,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 4);
           containerRefreshStart(1);
           {
@@ -1259,7 +1259,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', 4);
           containerRefreshStart(1);
           {
@@ -1345,7 +1345,7 @@ describe('lifecycles', () => {
           }
           if (rf & RenderFlags.Update) {
             elementProperty(0, 'val', 1);
-            flushHooksUpTo(2);
+            select(2);
             elementProperty(2, 'val', 4);
             containerRefreshStart(1);
             {
@@ -1507,7 +1507,7 @@ describe('lifecycles', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 elementProperty(0, 'val', bind('1'));
-                flushHooksUpTo(1);
+                select(1);
                 elementProperty(1, 'val', bind('2'));
               }
               embeddedViewEnd();
@@ -1624,11 +1624,11 @@ describe('lifecycles', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 elementProperty(0, 'val', 1);
-                flushHooksUpTo(1);
+                select(1);
                 elementProperty(1, 'val', 1);
-                flushHooksUpTo(2);
+                select(2);
                 elementProperty(2, 'val', 2);
-                flushHooksUpTo(3);
+                select(3);
                 elementProperty(3, 'val', 2);
               }
               embeddedViewEnd();
@@ -1673,7 +1673,7 @@ describe('lifecycles', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 elementProperty(0, 'val', bind('1'));
-                flushHooksUpTo(2);
+                select(2);
                 elementProperty(2, 'val', bind('3'));
                 containerRefreshStart(1);
                 {
@@ -1767,7 +1767,7 @@ describe('lifecycles', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 elementProperty(0, 'val', bind('1'));
-                flushHooksUpTo(2);
+                select(2);
                 elementProperty(2, 'val', bind('5'));
                 containerRefreshStart(1);
                 {
@@ -2161,7 +2161,7 @@ describe('lifecycles', () => {
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val1', bind(1));
           elementProperty(0, 'publicVal2', bind(1));
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val1', bind(2));
           elementProperty(1, 'publicVal2', bind(2));
         }
@@ -2299,7 +2299,7 @@ describe('lifecycles', () => {
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val1', bind(1));
           elementProperty(0, 'publicVal2', bind(1));
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val1', bind(2));
           elementProperty(1, 'publicVal2', bind(2));
         }
@@ -2347,13 +2347,13 @@ describe('lifecycles', () => {
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val1', bind(1));
           elementProperty(0, 'publicVal2', bind(1));
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val1', bind(2));
           elementProperty(1, 'publicVal2', bind(2));
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val1', bind(3));
           elementProperty(2, 'publicVal2', bind(3));
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val1', bind(4));
           elementProperty(3, 'publicVal2', bind(4));
         }
@@ -2484,7 +2484,7 @@ describe('lifecycles', () => {
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val1', bind(1));
           elementProperty(0, 'publicVal2', bind(1));
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val1', bind(5));
           elementProperty(2, 'publicVal2', bind(5));
           containerRefreshStart(1);
@@ -2571,7 +2571,7 @@ describe('lifecycles', () => {
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val1', bind(1));
           elementProperty(0, 'publicVal2', bind(1));
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val1', bind(5));
           elementProperty(2, 'publicVal2', bind(5));
           containerRefreshStart(1);
@@ -2791,7 +2791,7 @@ describe('lifecycles', () => {
         // even though the *value* itself never changed.
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 2);
         }
       }, 2, 0, [Comp]);
@@ -2835,7 +2835,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', 1);
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', 2);
         }
       }, 2, 0, [Parent]);
@@ -2879,7 +2879,7 @@ describe('lifecycles', () => {
           element(1, 'view');
         }
         if (rf & RenderFlags.Update) {
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', bind(ctx.val));
         }
       }, 2, 1, [View]);
@@ -2903,11 +2903,11 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           elementProperty(0, 'val', bind(1));
-          flushHooksUpTo(1);
+          select(1);
           elementProperty(1, 'val', bind(1));
-          flushHooksUpTo(2);
+          select(2);
           elementProperty(2, 'val', bind(2));
-          flushHooksUpTo(3);
+          select(3);
           elementProperty(3, 'val', bind(2));
         }
       }, 4, 4, [Parent, Content]);


### PR DESCRIPTION
Just renames `flushHooksUpTo` to `select` in preperation for work outlined [here](https://hackmd.io/c/BkDUxaW84/%2Fdi2r3ZeuSQ284ttBUPoLBg)