### PR TITLE
ci: lock chrome and firefox versions for saucelabs

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -14,9 +14,9 @@
 var CIconfiguration = {
   'Chrome': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Firefox': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  // Temporarily disabled because Saucelabs now runs Chrome v74 as beta version. Unfortunately
-  // Saucelabs doesn't provide a Chromedriver version that works for that beta version though.
-  // TODO(FW-1205): Re-enable once Saucelabs supports Chromedriver v74.0.3729.6.
+  // Disabled because using the "beta" channel of Chrome can cause non-deterministic CI results.
+  // e.g. a new chrome beta version has been released, but the Saucelabs selenium server does
+  // not provide a chromedriver version that is compatible with the new beta.
   'ChromeBeta': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: false}},
   'ChromeDev': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   // FirefoxBeta and FirefoxDev should be target:'BS' or target:'SL', and required:true
@@ -46,10 +46,10 @@ var customLaunchers = {
   'DartiumWithWebPlatform':
       {base: 'Dartium', flags: ['--enable-experimental-web-platform-features']},
   'ChromeNoSandbox': {base: 'Chrome', flags: ['--no-sandbox']},
-  'SL_CHROME': {base: 'SauceLabs', browserName: 'chrome', version: 'latest'},
+  'SL_CHROME': {base: 'SauceLabs', browserName: 'chrome', version: '73'},
   'SL_CHROMEBETA': {base: 'SauceLabs', browserName: 'chrome', version: 'beta'},
   'SL_CHROMEDEV': {base: 'SauceLabs', browserName: 'chrome', version: 'dev'},
-  'SL_FIREFOX': {base: 'SauceLabs', browserName: 'firefox', version: 'latest'},
+  'SL_FIREFOX': {base: 'SauceLabs', browserName: 'firefox', version: '65'},
   'SL_FIREFOXBETA':
       {base: 'SauceLabs', platform: 'Windows 10', browserName: 'firefox', version: 'beta'},
   'SL_FIREFOXDEV':


### PR DESCRIPTION
With 0f1da49b867af60748570b10997fee9d9511424a the Chrome beta job has been disabled because
a new Chrome beta has been released, but Saucelabs didn't support a
chromedriver that is compatible with that given beta version.

Now the topic of pinning these external browsers to a specific version came up.
In order to make the build less prone to unexpected new versions, we need to
_permanently_ disable the Chrome beta browser. Otherwise pinning `SL_CHROME`
or `SL_FIREFOX` to a specific version does not statisfy the requirement of making the
CI jobs more deterministic.

See original discussion: https://github.com/angular/angular/pull/29518#discussion_r269140676

---

* Chrome can be pinned to Chrome v73 (latest stable version at time of this PR)
* Firefox can be pinned to Firefox v65 (latest stable version available in Saucelabs platform)