### PR TITLE
build: remove unused dependency from `common` example

### DIFF
--- a/packages/examples/common/BUILD.bazel
+++ b/packages/examples/common/BUILD.bazel
@@ -46,9 +46,6 @@ ts_devserver(
     ],
     static_files = [
         "@npm//node_modules/zone.js:dist/zone.js",
-        # This is needed because the "ngComponentOutlet" test uses the JIT compiler
-        # and needs to be able to read metadata at runtime.
-        "@npm//node_modules/reflect-metadata:Reflect.js",
     ],
     deps = [":common_examples"],
 )


### PR DESCRIPTION
Since 04cf4ef0c, the dependency on `Reflect` is no longer needed.
