### PR TITLE
fix(ivy): debug element should support components with ViewContainerRef

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -404,8 +404,8 @@ function _queryAllR3(
   const context = loadLContext(parentElement.nativeNode) !;
   const parentTNode = context.lView[TVIEW].data[context.nodeIndex] as TNode;
   // This the fixture's debug element, so this is always a component view.
-  const lView = context.lView[parentTNode.index];
-  const tNode = lView[TVIEW].firstChild;
+  const lView = getComponentViewByIndex(parentTNode.index, context.lView);
+  const tNode = lView[TVIEW].firstChild !;
   _queryNodeChildrenR3(tNode, lView, predicate, matches, elementsOnly);
 }
 

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -403,7 +403,6 @@ function _queryAllR3(
     elementsOnly: boolean) {
   const context = loadLContext(parentElement.nativeNode) !;
   const parentTNode = context.lView[TVIEW].data[context.nodeIndex] as TNode;
-  // This the fixture's debug element, so this is always a component view.
   const lView = getComponentViewByIndex(parentTNode.index, context.lView);
   const tNode = lView[TVIEW].firstChild !;
   _queryNodeChildrenR3(tNode, lView, predicate, matches, elementsOnly);

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -190,6 +190,11 @@ class HostClassBindingCmp {
   hostClasses = 'class-one class-two';
 }
 
+@Component({selector: 'test-cmpt-vcref', template: `<div></div>`})
+class TestCmptWithViewContainerRef {
+  constructor(private vcref: ViewContainerRef) {}
+}
+
 {
   describe('debug element', () => {
     let fixture: ComponentFixture<any>;
@@ -211,6 +216,7 @@ class HostClassBindingCmp {
           BankAccount,
           TestCmpt,
           HostClassBindingCmp,
+          TestCmptWithViewContainerRef,
           SimpleContentComp,
         ],
         providers: [Logger],
@@ -629,6 +635,13 @@ class HostClassBindingCmp {
       expect(fixture.debugElement.query(By.css('.content'))).toBeTruthy();
 
       getDOM().remove(content);
+    });
+
+    it('should support components with ViewContainerRef', () => {
+      fixture = TestBed.createComponent(TestCmptWithViewContainerRef);
+
+      const divEl = fixture.debugElement.query(By.css('div'));
+      expect(divEl).not.toBeNull();
     });
 
   });

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -644,5 +644,16 @@ class TestCmptWithViewContainerRef {
       expect(divEl).not.toBeNull();
     });
 
+    it('should support querying on any debug element', () => {
+      TestBed.overrideTemplate(TestCmpt, `<span><div id="a"><div id="b"></div></div></span>`);
+      fixture = TestBed.createComponent(TestCmpt);
+
+      const divA = fixture.debugElement.query(By.css('div'));
+      expect(divA.nativeElement.getAttribute('id')).toBe('a');
+
+      const divB = divA.query(By.css('div'));
+      expect(divB.nativeElement.getAttribute('id')).toBe('b');
+    });
+
   });
 }


### PR DESCRIPTION
Without the fix, the added test was throwing an exception:
```
Message:
    TypeError: Cannot read property 'type' of undefined
  Stack:
        at <Jasmine>
        at _queryNodeChildrenR3 (packages/core/src/debug/debug_node.ts:425:13)
        at _queryAllR3 (packages/core/src/debug/debug_node.ts:409:3)
        at DebugElement__POST_R3__.queryAll (packages/core/src/debug/debug_node.ts:374:5)
        at DebugElement__POST_R3__.query (packages/core/src/debug/debug_node.ts:368:26)
        at UserContext.<anonymous> (packages/core/test/debug/debug_node_spec.ts:643:42)
```