### PR TITLE
refactor(forms): Added generic type to the ngSubmit EventEmitter

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -78,7 +78,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
    * @description
    * Emits an event when the form submission has been triggered.
    */
-  @Output() ngSubmit = new EventEmitter();
+  @Output() ngSubmit = new EventEmitter<Event>();
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: any[],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
```
<form [formGroup]="form" novalidate (ngSubmit)="submitForm($event)">
```
With the following code typechecker complains "Argument type {} is not assignable to parameter type Event".

Issue Number: N/A


## What is the new behavior?
ngSubmit emits Event type, however, generic type was not specified when `ngSubmit` instance created.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
