### PR TITLE
refactor(ivy): remove forEach usage in ApplicationRef.tick

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -630,9 +630,13 @@ export class ApplicationRef {
     const scope = ApplicationRef._tickScope();
     try {
       this._runningTick = true;
-      this._views.forEach((view) => view.detectChanges());
+      for (let view of this._views) {
+        view.detectChanges();
+      }
       if (this._enforceNoNewChanges) {
-        this._views.forEach((view) => view.checkNoChanges());
+        for (let view of this._views) {
+          view.checkNoChanges();
+        }
       }
     } catch (e) {
       // Attention: Don't rethrow as it could cancel subscriptions to Observables!

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -54,7 +54,7 @@ function NgOnChangesFeatureImpl<T>(definition: DirectiveDef<T>): void {
 }
 
 function wrapOnChanges() {
-  return function(this: OnChanges) {
+  return function wrapOnChangesHook_inPreviousChangesStorage(this: OnChanges) {
     const simpleChangesStore = getSimpleChangesStore(this);
     const current = simpleChangesStore && simpleChangesStore.current;
 


### PR DESCRIPTION
forEach is slower as compared to a regular loop but more importantly
this change removes an anonymous function and thus makes stack traces
shorter and easier to read (important for perf analysis).
