### PR TITLE
Move select instruction in front of relevant update instructions

### DIFF
--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -154,6 +154,7 @@ describe('Renderer', () => {
 A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵtext(0);
     } if (rf & 2) {
+        ɵngcc0.ɵselect(0);
         ɵngcc0.ɵtextBinding(0, ɵngcc0.ɵinterpolation1("", ctx.person.name, ""));
     } }, encapsulation: 2 });`);
     });

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -316,6 +316,7 @@ describe('compiler compliance', () => {
             $r3$.ɵelement(0, "div", $e0_attrs$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "id", $r3$.ɵbind(ctx.id));
           }
         }
@@ -363,6 +364,7 @@ describe('compiler compliance', () => {
             $r3$.ɵpipe(1,"pipe");
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "ternary", $r3$.ɵbind((ctx.cond ? $r3$.ɵpureFunction1(8, $c0$, ctx.a): $c1$)));
             $r3$.ɵelementProperty(0, "pipe", $r3$.ɵbind($r3$.ɵpipeBind3(1, 4, ctx.value, 1, 2)));
             $r3$.ɵelementProperty(0, "and", $r3$.ɵbind((ctx.cond && $r3$.ɵpureFunction1(10, $c0$, ctx.b))));
@@ -877,6 +879,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(0, "my-comp", $e0_attrs$);
               }
               if (rf & 2) {
+                $r3$.ɵselect(0);
                 $r3$.ɵelementProperty(0, "names", $r3$.ɵbind($r3$.ɵpureFunction1(1, $e0_ff$, ctx.customName)));
               }
             },
@@ -959,6 +962,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(0, "my-comp", $e0_attr$);
               }
               if (rf & 2) {
+                $r3$.ɵselect(0);
                 $r3$.ɵelementProperty(
                     0, "names",
                     $r3$.ɵbind($r3$.ɵpureFunctionV(1, $e0_ff$, [ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8])));
@@ -1023,6 +1027,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(0, "object-comp", $e0_attrs$);
               }
               if (rf & 2) {
+                $r3$.ɵselect(0);
                 $r3$.ɵelementProperty(0, "config", $r3$.ɵbind($r3$.ɵpureFunction1(1, $e0_ff$, ctx.name)));
               }
             },
@@ -1091,6 +1096,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(0, "nested-comp", $e0_attrs$);
               }
               if (rf & 2) {
+                $r3$.ɵselect(0);
                 $r3$.ɵelementProperty(
                     0, "config",
                     $r3$.ɵbind($r3$.ɵpureFunction2(5, $e0_ff_2$, ctx.name, $r3$.ɵpureFunction1(3, $e0_ff_1$, $r3$.ɵpureFunction1(1, $e0_ff$, ctx.duration)))));
@@ -1256,6 +1262,7 @@ describe('compiler compliance', () => {
               $r3$.ɵtemplate(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
             }
             if (rf & 2) {
+              $r3$.ɵselect(0);
               $r3$.ɵelementProperty(0, "ngIf", $r3$.ɵbind(ctx.visible));
               $r3$.ɵselect(1);
               $r3$.ɵelementProperty(1, "ngIf", $r3$.ɵbind(ctx.visible));
@@ -1949,6 +1956,7 @@ describe('compiler compliance', () => {
                   $r3$.ɵelementEnd();
                 }
                 if (rf & 2) {
+                  $r3$.ɵselect(0);
                   $r3$.ɵtextBinding(0, $r3$.ɵinterpolation1("", $r3$.ɵpipeBind2(1, 3, $r3$.ɵpipeBind2(2, 6, ctx.name, ctx.size), ctx.size), ""));
                   $r3$.ɵselect(4);
                   $r3$.ɵtextBinding(4, $r3$.ɵinterpolation2("", $r3$.ɵpipeBindV(5, 9, $r3$.ɵpureFunction1(18, $c0$, ctx.name)), " ", (ctx.name ? 1 : $r3$.ɵpipeBind1(6, 16, 2)), ""));
@@ -2013,6 +2021,7 @@ describe('compiler compliance', () => {
                   $r3$.ɵpipe(5, "myPipe");
                 }
                 if (rf & 2) {
+                  $r3$.ɵselect(0);
                   $r3$.ɵtextBinding(0, $r3$.ɵinterpolation5(
                     "0:", i0.ɵpipeBind1(1, 5, ctx.name),
                     "1:", i0.ɵpipeBind2(2, 7, ctx.name, 1),
@@ -2242,6 +2251,7 @@ describe('compiler compliance', () => {
           $i0$.ɵtemplate(0, MyComponent_div_0_Template, 4, 1, "div", $c0$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngForOf", $i0$.ɵbind(ctx.items));
         }
       }`;
@@ -2322,6 +2332,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(1, "lifecycle-comp", $e1_attrs$);
               }
               if (rf & 2) {
+                $r3$.ɵselect(0);
                 $r3$.ɵelementProperty(0, "name", $r3$.ɵbind(ctx.name1));
                 $r3$.ɵselect(1);
                 $r3$.ɵelementProperty(1, "name", $r3$.ɵbind(ctx.name2));

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -81,6 +81,7 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵelement(0, "a", $e0_attrs$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "title", $i0$.ɵbind($ctx$.title));
         }
       }`;
@@ -115,6 +116,7 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵelement(0, "a", $e0_attrs$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "title", $i0$.ɵinterpolation1("Hello ", $ctx$.name, ""));
         }
       }`;
@@ -171,6 +173,7 @@ describe('compiler compliance: bindings', () => {
             $i0$.ɵelement(0, "label", _c0);
         }
         if (rf & 2) {
+            $i0$.ɵselect(0);
             $i0$.ɵelementProperty(0, "for", $i0$.ɵbind(ctx.forValue));
         }
       }`;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -139,6 +139,7 @@ describe('compiler compliance: directives', () => {
                             $r3$.ɵelement(0, "div", _c0);
                         }
                         if (rf & 2) {
+                            $r3$.ɵselect(0);
                             $r3$.ɵelementProperty(0, "someDirective", $r3$.ɵbind(true));
                         }
                     },
@@ -253,6 +254,7 @@ describe('compiler compliance: directives', () => {
               $r3$.ɵtemplate(0, MyComponent_ng_container_0_Template, 2, 0, "ng-container", $_c0$);
             }
             if (rf & 2) {
+              $r3$.ɵselect(0);
               $r3$.ɵelementProperty(0, "ngIf", $r3$.ɵbind(ctx.showing));
             }
           },
@@ -300,6 +302,7 @@ describe('compiler compliance: directives', () => {
                             $r3$.ɵtemplate(0, MyComponent_ng_template_0_Template, 0, 0, "ng-template", $c0_a0$);
                         }
                         if (rf & 2) {
+                            $r3$.ɵselect(0);
                             $r3$.ɵelementProperty(0, "someDirective", $r3$.ɵbind(true));
                         }
                     },

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -366,6 +366,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nApply(2);
@@ -401,6 +402,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
             $r3$.ɵi18nApply(2);
           }
@@ -450,6 +452,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", $_c0$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "ngForOf", $r3$.ɵbind(ctx.items));
           }
         }
@@ -524,6 +527,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nApply(2);
@@ -581,6 +585,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", $_c0$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "ngForOf", $r3$.ɵbind(ctx.items));
           }
         }
@@ -1086,6 +1091,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r1$.id));
             $r3$.ɵi18nApply(1);
           }
@@ -1148,6 +1154,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r2$ = $r3$.ɵnextContext(2);
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r2$.valueC));
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r2$.valueD));
             $r3$.ɵi18nApply(0);
@@ -1198,6 +1205,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind(($ctx_r1$.valueE + $ctx_r1$.valueF)));
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(3, 2, $ctx_r1$.valueG)));
             $r3$.ɵi18nApply(0);
@@ -1263,6 +1271,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵtemplate(0, MyComponent_div_0_Template, 3, 1, "div", $_c0$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "ngIf", $r3$.ɵbind(ctx.visible));
           }
         }
@@ -1449,6 +1458,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵpipe(1, "uppercase");
           } if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 1, $ctx_r0$.valueA)));
             $r3$.ɵi18nApply(0);
           }
@@ -1490,6 +1500,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 1, $ctx_r0$.valueA)));
             $r3$.ɵi18nApply(0);
           }
@@ -1540,6 +1551,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.gender));
             $r3$.ɵi18nApply(0);
           }
@@ -1587,6 +1599,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r2$ = $r3$.ɵnextContext(3);
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r2$.valueC));
             $r3$.ɵi18nApply(0);
           }
@@ -1599,6 +1612,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵnextContext(2);
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r1$.valueB));
             $r3$.ɵi18nApply(0);
           }
@@ -1620,6 +1634,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 1, $ctx_r0$.valueA)));
             $r3$.ɵi18nApply(0);
           }
@@ -1662,6 +1677,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.age));
             $r3$.ɵi18nApply(0);
           }
@@ -1862,6 +1878,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18n(0, $I18N_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.age));
             $r3$.ɵi18nApply(0);
           }
@@ -2159,6 +2176,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.gender));
             $r3$.ɵi18nApply(0);
           }
@@ -2266,6 +2284,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.age));
             $r3$.ɵi18nApply(0);
           }
@@ -2332,6 +2351,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵselect(0);
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.age));
             $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.otherAge));
             $r3$.ɵi18nApply(0);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -163,6 +163,7 @@ describe('compiler compliance: listen()', () => {
             $r3$.ɵtemplate(0, MyComponent_div_0_Template, 3, 0, "div", $c0$);
           }
           if (rf & 2) {
+            $i0$.ɵselect(0);
             $i0$.ɵelementProperty(0, "ngIf", $i0$.ɵbind(ctx.showing));
           }
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
@@ -146,6 +146,7 @@ describe('r3_view_compiler', () => {
           $i0$.ɵelement(0, "div");
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "@attr", …);
           $i0$.ɵelementProperty(0, "@binding", …);
         }
@@ -177,6 +178,7 @@ describe('r3_view_compiler', () => {
         if (rf & 1) {
           $i0$.ɵelementStart(0, "div");
           …
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "@mySelector", …);
         }
       }`;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -226,6 +226,7 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵelement(2, "div");
             }
             if (rf & 2) {
+              $r3$.ɵselect(0);
               $r3$.ɵelementProperty(0, "@foo", $r3$.ɵbind(ctx.exp));
               $r3$.ɵselect(1);
               $r3$.ɵelementProperty(1, "@bar", $r3$.ɵbind(undefined));
@@ -287,6 +288,7 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵlistener("@myAnimation.done", function MyComponent_Template_div_animation_myAnimation_done_0_listener($event) { return ctx.onDone($event); });
               $r3$.ɵelementEnd();
             } if (rf & 2) {
+              $r3$.ɵselect(0);
               $r3$.ɵelementProperty(0, "@myAnimation", $r3$.ɵbind(ctx.exp));
             }
           },
@@ -540,6 +542,7 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelementStyleProp(0, 0, $ctx$.myWidth);
                   $r3$.ɵelementStyleProp(0, 1, $ctx$.myHeight);
                   $r3$.ɵelementStylingApply(0);
+                  $r3$.ɵselect(0);
                   $r3$.ɵelementAttribute(0, "style", $r3$.ɵbind("border-width: 10px"), $r3$.ɵsanitizeStyle);
                 }
               },
@@ -737,6 +740,7 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelementClassProp(0, 0, $ctx$.yesToApple);
                   $r3$.ɵelementClassProp(0, 1, $ctx$.yesToOrange);
                   $r3$.ɵelementStylingApply(0);
+                  $r3$.ɵselect(0);
                   $r3$.ɵelementAttribute(0, "class", $r3$.ɵbind("banana"));
                 }
               },
@@ -786,6 +790,7 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelement(0, "div", $e0_attrs$);
                 }
                 if (rf & 2) {
+                  $r3$.ɵselect(0);
                   $r3$.ɵelementAttribute(0, "class", $r3$.ɵbind("round"));
                   $r3$.ɵelementAttribute(0, "style", $r3$.ɵbind("height:100px"), $r3$.ɵsanitizeStyle);
                 }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -75,6 +75,7 @@ describe('compiler compliance: template', () => {
           const $middle1$ = $i0$.ɵnextContext().$implicit;
           const $outer1$ = $i0$.ɵnextContext().$implicit;
           const $myComp1$ = $i0$.ɵnextContext();
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "title", $i0$.ɵbind($myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component)));
           $r3$.ɵselect(1);
           $i0$.ɵtextBinding(1, $i0$.ɵinterpolation1(" ", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component), " "));
@@ -112,6 +113,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_ul_0_Template, 2, 1, "ul", $c0$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngForOf", $i0$.ɵbind(ctx.items));
         }
       }`;
@@ -168,6 +170,7 @@ describe('compiler compliance: template', () => {
             $r3$.ɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", $t0_attrs$);
           }
           if (rf & 2) {
+            $r3$.ɵselect(0);
             $r3$.ɵelementProperty(0, "ngForOf", $r3$.ɵbind(ctx._data));
           }
         }
@@ -221,6 +224,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_span_0_Template, 2, 2, "span", _c0);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngForOf", $i0$.ɵbind(ctx.items));
         }
       }`;
@@ -291,6 +295,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", $c0$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngForOf", $i0$.ɵbind(ctx.items));
         }
       }`;
@@ -373,6 +378,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", $c0$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngForOf", $i0$.ɵbind(ctx.items));
         }
       }`;
@@ -419,6 +425,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_ng_template_0_Template, 1, 0, "ng-template", $c0$);
         }
         if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "boundAttr", $i0$.ɵbind(ctx.b));
         }
       }`;
@@ -661,6 +668,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", $c0$);
           $i0$.ɵpipe(1, "pipe");
         } if (rf & 2) {
+          $i0$.ɵselect(0);
           $i0$.ɵelementProperty(0, "ngIf", $i0$.ɵbind($i0$.ɵpipeBind1(1, 1, ctx.val)));
         }
       }`;

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -122,7 +122,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private _updateCodeFns: (() => o.Statement)[] = [];
   /**
    * Memorizes the last node index for which a select instruction has been generated.
-   * Initialized to 0 to avoid generating a useless select(0).
+   * We're initializing this to -1 to ensure the `select(0)` instruction is generated before any
+   * relevant update instructions.
    */
   private _lastNodeIndexWithFlush: number = -1;
   /** Temporary variable declarations generated from visiting pipes, literals, etc. */

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -124,7 +124,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
    * Memorizes the last node index for which a select instruction has been generated.
    * Initialized to 0 to avoid generating a useless select(0).
    */
-  private _lastNodeIndexWithFlush: number = 0;
+  private _lastNodeIndexWithFlush: number = -1;
   /** Temporary variable declarations generated from visiting pipes, literals, etc. */
   private _tempVariables: o.Statement[] = [];
   /**


### PR DESCRIPTION
- Simply ensures the `select` instruction (formerly `flushHooksUpTo`) is rendered before the first relevant update instruction found.
- The only real code change to this PR is here: https://github.com/angular/angular/pull/29546/files#diff-a22b5f01f25ce4bc3721ef0d82d6fe1eR127
- The rest are changes to update tests to accommodate the new generated output.

