### PR TITLE
build: hide @angular/http for Angular v8

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -88,8 +88,9 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
       'core/testing/index.ts',
       'elements/index.ts',
       'forms/index.ts',
-      'http/index.ts',
-      'http/testing/index.ts',
+      // Current plan for Angular v8 is to hide documentation for the @angular/http package
+      // 'http/index.ts',
+      // 'http/testing/index.ts',
       'platform-browser/index.ts',
       'platform-browser/animations/index.ts',
       'platform-browser/testing/index.ts',

--- a/aio/tools/transforms/authors-package/api-package.js
+++ b/aio/tools/transforms/authors-package/api-package.js
@@ -15,7 +15,8 @@ const packageMap = {
   core: ['core/index.ts', 'core/testing/index.ts'],
   elements: ['elements/index.ts'],
   forms: ['forms/index.ts'],
-  http: ['http/index.ts', 'http/testing/index.ts'],
+  // Current plan for Angular v8 is to hide the @angular/http package
+  // http: ['http/index.ts', 'http/testing/index.ts'],
   'platform-browser': ['platform-browser/index.ts', 'platform-browser/animations/index.ts', 'platform-browser/testing/index.ts'],
   'platform-browser-dynamic': ['platform-browser-dynamic/index.ts', 'platform-browser-dynamic/testing/index.ts'],
   'platform-server': ['platform-server/index.ts', 'platform-server/testing/index.ts'],

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world-ivy-compat/yarn.lock
+++ b/integration/cli-hello-world-ivy-compat/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world-ivy-minimal/yarn.lock
+++ b/integration/cli-hello-world-ivy-minimal/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -19,7 +19,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",

--- a/integration/cli-hello-world/yarn.lock
+++ b/integration/cli-hello-world/yarn.lock
@@ -174,11 +174,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "8.0.0-beta.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "8.0.0-beta.0"
 

--- a/integration/injectable-def/package.json
+++ b/integration/injectable-def/package.json
@@ -8,7 +8,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/core": "file:../../dist/packages-dist/core",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/integration/injectable-def/yarn.lock
+++ b/integration/injectable-def/yarn.lock
@@ -30,11 +30,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "6.0.0-beta.7-8203e0365a"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "6.0.0-beta.7-8203e0365a"
   dependencies:

--- a/integration/ng_update/package.json
+++ b/integration/ng_update/package.json
@@ -13,7 +13,6 @@
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/language-service": "file:../../dist/packages-dist/language-service",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",

--- a/integration/ng_update/yarn.lock
+++ b/integration/ng_update/yarn.lock
@@ -35,11 +35,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "6.0.0-rc.0-b32e6343a3"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "6.0.0-rc.0-b32e6343a3"
 

--- a/integration/ngcc/package.json
+++ b/integration/ngcc/package.json
@@ -10,7 +10,6 @@
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/material": "7.0.0-rc.1",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",

--- a/integration/ngcc/yarn.lock
+++ b/integration/ngcc/yarn.lock
@@ -51,11 +51,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "7.2.0-rc.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/material@7.0.0-rc.1":
   version "7.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@angular/material/-/material-7.0.0-rc.1.tgz#e9a88c8b6f6b48b87ed3d1da3037d14a0e3e8290"

--- a/integration/platform-server/package.json
+++ b/integration/platform-server/package.json
@@ -13,7 +13,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/core": "file:../../dist/packages-dist/core",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/integration/platform-server/yarn.lock
+++ b/integration/platform-server/yarn.lock
@@ -37,11 +37,6 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@file:../../dist/packages-dist/http":
-  version "7.2.0-rc.0"
-  dependencies:
-    tslib "^1.9.0"
-
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "7.2.0-rc.0"
   dependencies:

--- a/integration/typings_test_ts33/include-all.ts
+++ b/integration/typings_test_ts33/include-all.ts
@@ -21,8 +21,9 @@ import * as core from '@angular/core';
 import * as coreTesting from '@angular/core/testing';
 import * as elements from '@angular/elements';
 import * as forms from '@angular/forms';
-import * as http from '@angular/http';
-import * as httpTesting from '@angular/http/testing';
+// Current plan for Angular 8 is to stop building the @angular/http package
+// import * as http from '@angular/http';
+// import * as httpTesting from '@angular/http/testing';
 import * as platformBrowser from '@angular/platform-browser';
 import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
 import * as platformBrowserDynamicTesting from '@angular/platform-browser-dynamic/testing';
@@ -53,8 +54,9 @@ export default {
   coreTesting,
   elements,
   forms,
-  http,
-  httpTesting,
+  // See above
+  // http,
+  // httpTesting,
   platformBrowser,
   platformBrowserTesting,
   platformBrowserDynamic,

--- a/integration/typings_test_ts33/package.json
+++ b/integration/typings_test_ts33/package.json
@@ -11,7 +11,6 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/elements": "file:../../dist/packages-dist/elements",
     "@angular/forms": "file:../../dist/packages-dist/forms",
-    "@angular/http": "file:../../dist/packages-dist/http",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -25,7 +25,8 @@ ng_package(
     ],
     entry_point = "packages/http/index.js",
     tags = [
-        "release-with-framework",
+        # Currently the plan for Angular v8 is to exclude @angular/http package from publishing
+        # "release-with-framework",
     ],
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -29,7 +29,8 @@ ANGULAR_SCOPED_PACKAGES = ["@angular/%s" % p for p in [
     "platform-browser",
     "platform-browser-dynamic",
     "forms",
-    "http",
+    # Current plan for Angular v8 is to not include @angular/http in ng update
+    # "http",
     "platform-server",
     "platform-webworker",
     "platform-webworker-dynamic",


### PR DESCRIPTION
Currently our plan is to skip the publish, docgen, and update steps for this package.
During RC, we'll determine if the breaking change is too difficult for users, in which case we might restore the package for another major.