### PR TITLE
build: add pre-release check that validates the version name

### DIFF
--- a/scripts/release/pre-check
+++ b/scripts/release/pre-check
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# Runs the Bazel workspace status command in order to ensure that the version placeholder
+# will be replaced with the proper version name when building the release output.
+
+# Ensure that the stamping script is executed within the project directory.
+cd $(dirname ${0})/../..
+
+# The "0.0.0-PLACEHOLDER" is based on the value of the "BUILD_SCM_VERSION" status variable.
+versionName=$(node tools/bazel_stamp_vars.js | grep -e "BUILD_SCM_VERSION" | cut -d " " -f2)
+
+if [[ ! ${versionName} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc).[0-9]+)?$ ]]; then
+  echo "ERROR: The release will currently have the following version: ${versionName}"
+  echo "This does not match the version format for releases to NPM."
+  echo ""
+  echo "Please ensure that the most recent commit in the current branch is tagged"
+  echo "with the proper version tag."
+  exit 1
+fi
+
 # Verify peer deps constraints and package.json before publishing to npm
 # There should be no npm errors
 

--- a/tools/bazel_stamp_vars.js
+++ b/tools/bazel_stamp_vars.js
@@ -18,8 +18,6 @@ function _exec(str) {
   return execSync(str).toString().trim();
 }
 
-console.error('Running', process.argv.join(' '));
-
 function onError() {
   console.error('Failed to execute:,', process.argv.join(' '));
   console.error('');


### PR DESCRIPTION
Currently with the release of "8.0.0-beta.10", the Bazel npm package accidentally
was stamped with an incorrect version placeholder: `8.0.0-beta.10+1.sha-a28b3e3`.

This can happen because the placeholder is based on latest tag that matches the
Semver format. e.g. if `HEAD` equals to the commit that has the latest tag, the
version name will be correct and refer to the tag name (e.g. `8.0.0-beta.10`). Though
if the latest commit is not tagged with the most recent tag, the version
name will also include the SHA of the commit (e.g.  `8.0.0-beta.10+1.sha-a28b3e3`).

We can ensure that we don't accidentally release versions from a more recent commit
that shouldn't be part of the release by adding a pre-release check that ensures that
the `BUILD_SCM_VERSION` Bazel status variable matches the expected version format.