### PR TITLE
feat(docs-infra): support contributors belonging to multiple groups (and other improvements)

### DIFF
--- a/aio/content/marketing/README.md
+++ b/aio/content/marketing/README.md
@@ -1,26 +1,28 @@
 # Contributors page
 
-We have an official accounting of who is on the Angular Team, who are "trusted collaborators" (see team.angular.io/collaborators), and so on.
+We have an official accounting of who is on the Angular Team, who are "trusted collaborators" (see https://team.angular.io/collaborators), and so on.
 
-The contributors.json should be maintained to keep our "org chart" in a single consistent place.
+The `contributors.json` should be maintained to keep our "org chart" in a single consistent place.
 
 ## GDE listings
 
 There are two pages:
 
-https://developers.google.com/experts/all/technology/angular
+- https://developers.google.com/experts/all/technology/angular
 (Googlers: source at http://google3/googledata/devsite/content/en/experts/all/technology/angular.html)
 which is maintained by Dawid Ostrowski based on a spreadsheet
-https://docs.google.com/spreadsheets/d/1_Ls2Kle7NxPBIG8f3OEVZ4gJZ8OCTtBxGYwMPb1TUVE/edit#gid=0
+https://docs.google.com/spreadsheets/d/1_Ls2Kle7NxPBIG8f3OEVZ4gJZ8OCTtBxGYwMPb1TUVE/edit#gid=0.
+  <!-- gkalpak: That URL doesn't seem to work any more. New URL: https://developers.google.com/programs/experts/directory/ (?) -->
 
-and ours: https://angular.io/about?group=GDE which is derived from contributors.json.
+- Ours: https://angular.io/about?group=GDE which is derived from `contributors.json`.
 
 Alex Eagle is investigating how to reconcile these two lists.
 
-## Checking the keys
+## About the data
 
-Keys in contributors.json should be GitHub handles. (Most currently are, but not all)
-This will allow us to use GitHub as the default source for things like Name, Avatar, etc.
+- Keys in `contributors.json` should be GitHub handles. (Most currently are, but not all.)
+  This will allow us to use GitHub as the default source for things like name, avatar, etc.
+- Pictures are stored in `aio/content/images/bios/<picture-filename>`.
 
 ## Processing the data
 
@@ -32,3 +34,5 @@ do echo -e "\n$handle\n---------\n"; curl --silent -H "Authorization: token ${TO
  | jq ".message,.name,.company,.blog,.bio" --raw-output
 done
 ```
+
+Relevant scripts are stored in `aio/scripts/contributors/`.

--- a/aio/content/marketing/about.html
+++ b/aio/content/marketing/about.html
@@ -1,8 +1,9 @@
-<h1 class="title center no-toc">Angular Collaborators</h1>
+<h1 class="title center no-toc">Angular Contributors</h1>
 <h2>Building For the Future</h2>
-<p>Angular is built by a team of engineers who share a passion for
-  making web development feel effortless. We believe that writing
-  beautiful apps should be joyful and fun. We're building a
-  platform for the future.</p>
+<p>
+  Angular is built by a team of engineers who share a passion for making web development feel
+  effortless. We believe that writing beautiful apps should be joyful and fun. We're building a
+  platform for the future.
+</p>
 
 <aio-contributor-list></aio-contributor-list>

--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -658,7 +658,7 @@
     "twitter": "samjulien",
     "website": "http://www.samjulien.com/",
     "bio": "Sam Julien builds software, articles, video courses, and campfires. A developer, speaker, writer, and GDE in the Pacific Northwest, Sam's favorite thing in the world is changing someone's life by teaching them to code.",
-    "groups": ["Collaborators"],
+    "groups": ["Collaborators", "GDE"],
     "mentor": "gkalpak"
   },
   "JiaLiPassion": {

--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -658,12 +658,12 @@
     "twitter": "samjulien",
     "website": "http://www.samjulien.com/",
     "bio": "Sam Julien builds software, articles, video courses, and campfires. A developer, speaker, writer, and GDE in the Pacific Northwest, Sam's favorite thing in the world is changing someone's life by teaching them to code.",
-    "group": "Collaborator",
+    "group": "Collaborators",
     "mentor": "gkalpak"
   },
   "JiaLiPassion": {
     "name": "JiaLi Passion",
-    "group": "Collaborator",
+    "group": "Collaborators",
     "mentor": "mhevery",
     "picture": "JiaLiPassion.jpg",
     "bio": "A programmer with passion, angular/zone.js guy! Web frontend engineer @sylabs"
@@ -671,19 +671,19 @@
   "cexbrayat": {
     "name": "Cédric Exbrayat",
     "mentor": "petebacondarwin",
-    "group": "Collaborator",
+    "group": "Collaborators",
     "picture": "cexbrayat.jpg",
     "bio": "Author of `Become a ninja with Angular (2+)` https://books.ninja-squad.com/angular - Angular trainer and @Ninja-Squad co-founder"
   },
   "CaerusKaru": {
     "name": "Adam Plumer",
-    "group": "Collaborator",
+    "group": "Collaborators",
     "mentor": "vikerman",
     "picture": "CaerusKaru.jpg"
   },
   "jbedard": {
     "name": "Jason Bedard",
-    "group": "Collaborator",
+    "group": "Collaborators",
     "mentor": "kyliau",
     "picture": "jbedard.png"
   },

--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -689,7 +689,7 @@
   },
   "JoostK": {
     "name": "Joost Koehoorn",
-    "group": "Collaborator",
+    "groups": ["Collaborator"],
     "mentor": "alxhub",
     "picture": "joostk.jpg",
     "twitter": "devjoost",

--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -5,7 +5,7 @@
     "twitter": "mhevery",
     "website": "http://misko.hevery.com",
     "bio": "Miško Hevery is the creator of AngularJS framework. He has passion for making complex things simple. He currently works at Google, but has previously worked at Adobe, Sun Microsystems, Intel, and Xerox, where he became an expert in building web applications in web related technologies such as Java, JavaScript, Flex and ActionScript.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "igorminar": {
@@ -14,7 +14,7 @@
     "twitter": "IgorMinar",
     "website": "https://google.com/+IgorMinar",
     "bio": "Igor is a software engineer at Google. He is a lead on the Angular project, practitioner of test driven development, open source enthusiast, hacker. In his free time, Igor enjoys spending time with his wife and two kids, doing outdoor activities (including but not limited to sports, gardening and building retaining walls).",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "bradlygreen"
   },
   "bradlygreen": {
@@ -23,7 +23,7 @@
     "twitter": "bradlygreen",
     "website": "https://plus.google.com/+BradGreen",
     "bio": "Brad Green works at Google as an engineering director. Brad manages the Google Sales Platform suite of projects as well as the AngularJS framework. Prior to Google, Brad worked on the early mobile web at AvantGo, founded and sold startups, and spent a few hard years toiling as a caterer. Brad's first job out of school was as lackey to Steve Jobs at NeXT Computer writing demo software and designing his slide presentations. Brad enjoys throwing dinner parties with his wife Heather and putting on plays with his children.",
-    "group": "Angular"
+    "groups": ["Angular"]
   },
   "jelbourn": {
     "name": "Jeremy Elbourn",
@@ -31,7 +31,7 @@
     "twitter": "jelbourn",
     "website": "https://plus.google.com/+JeremyElbourn/",
     "bio": "Angular Material Team Lead. FE Engineer @ Google specializing in AngularJS, component design, and the cleanest of code.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "petebacondarwin": {
@@ -40,7 +40,7 @@
     "twitter": "petebd",
     "website": "http://www.bacondarwin.com",
     "bio": "AngularJS for JS Team Lead. Pete has been working on the core team since 2012 and became the team lead for the AngularJS for JS branch in November 2014. He has co-authored a book on AngularJS and regularly talks about and teaches Angular.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "stephenfluin": {
@@ -49,7 +49,7 @@
     "twitter": "stephenfluin",
     "website": "https://plus.google.com/+stephenfluin",
     "bio": "Stephen is a Developer Advocate working on the Angular team. Before joining Google, he was a Google Expert. Stephen loves to help enterprises use technology more effectively.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "bradlygreen"
   },
   "robwormald": {
@@ -58,7 +58,7 @@
     "twitter": "robwormald",
     "website": "http://github.com/robwormald",
     "bio": "Rob is a Developer Advocate on the Angular team at Google. He's the Angular team's resident reactive programming geek and founded the Reactive Extensions for Angular project, ngrx.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "stephenfluin"
   },
   "rkirov": {
@@ -67,7 +67,7 @@
     "twitter": "radokirov",
     "website": "https://plus.sandbox.google.com/+RadoslavKirov",
     "bio": "Rado has been on the Angular Core team since Summer 2014. Before Angular, he worked on the Adsense serving stack, responsible for serving billions of ads daily. Being passionate about open source, he made contributions to Angular as a Google-20% project, before making the fulltime jump. He is a recovering academic; ask him about error-correcting codes from algebraic curves (or don't).",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "mprobst"
   },
   "alexeagle": {
@@ -76,31 +76,31 @@
     "twitter": "jakeherringbone",
     "website": "http://google.com/+alexeagle",
     "bio": "Alex works on language tooling for JavaScript and TypeScript. Previously Alex spent five years in Google's developer testing tools. He has developed systems including Google's continuous integration service, capturing build&test failures, and explaining them to developers. Before Google, Alex worked at startups including Opower, and consulted for large government IT. In his 20% time, he created the Error-Prone static analysis tool, which detects common Java programming mistakes and reports them as compile errors.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "kyliau": {
     "name": "Keen Yee Liau",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle",
     "picture": "kyliau.jpg"
   },
   "clydin": {
     "name": "Charles Lyding",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle",
     "picture": "clydin.jpg"
   },
   "alan-agius4": {
     "name": "Alan Agius",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle",
     "picture": "alan-agius4.jpg",
     "bio": "Angular CLI Member, Loves TypeScript, Build Tools, Food, Beer & Coffee :)"
   },
   "gregmagolan": {
     "name": "Greg Magolan",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle",
     "picture": "gregmagolan.jpg",
     "bio": "Building great software with Angular and Node.js."
@@ -111,7 +111,7 @@
     "twitter": "martin_probst",
     "website": "http://probst.io",
     "bio": "Martin is a software engineer at Google in the AngularJS team. He holds a MSc in Software Engineering from HPI in Potsdam, Germany. Before joining the AngularJS team at Google, he worked at a database startup in the Netherlands, at EMC, at SAP, and as a freelancer. In his free time, he likes to cook and sail, not necessarily at the same time.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "bradlygreen"
   },
   "alxhub": {
@@ -120,7 +120,7 @@
     "twitter": "synalx",
     "website": "https://plus.google.com/+AlexRickabaugh/about",
     "bio": "Core team member working to optimize the Angular platform for the next generation of applications, including mobile. Before joining the Angular team, Alex worked in the Google sales organization where he helped build the first large Angular application within Google.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "matsko": {
@@ -129,7 +129,7 @@
     "twitter": "yearofmoo",
     "website": "http://yearofmoo.com",
     "bio": "Matias Niemela is a fullstack web developer who has been programming & building websites for over 10 years, and a core team member of AngularJS for two years. In the spring of 2015 Matias joined Angular full time at Google. In his free time Matias loves to build complex things and is always up for public speaking, travelling and tweaking his current Vim setup.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "hansl": {
@@ -138,7 +138,7 @@
     "twitter": "hanslatwork",
     "website": "http://www.codingatwork.com/",
     "bio": "Hans is a software engineer at Google on the Angular team and was previously at Slack. He works everyday to help make it easier for everyone to create beautiful, consistent web applications using Angular, using Material Design components and the CLI tool.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle"
   },
   "kara": {
@@ -147,7 +147,7 @@
     "twitter": "karaforthewin",
     "website": "https://github.com/kara",
     "bio": "Kara is a software engineer on the Angular team at Google and a co-organizer of the Angular-SF Meetup. Prior to Google, she helped build UI components in Angular for guest management systems at OpenTable.  She enjoys snacking indiscriminately and probably other things too.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "vikerman": {
@@ -155,7 +155,7 @@
     "picture": "vikram.jpg",
     "twitter": "vikerman",
     "bio": "Vikram is a Software Engineer on the Angular team focused on Engineering Productivity. That means he makes sure people on the team can move fast and not break things. Vikram enjoys doing Yoga and going on walks with his daughter.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle"
   },
   "pkozlowski-opensource": {
@@ -163,7 +163,7 @@
     "picture": "pawel.jpg",
     "twitter": "pkozlowski_os",
     "bio": "Open source hacker, AngularJS book author, AngularUI lead developer. Pawel is an software-development addict who believes in free, open source software. He is a core contributor to the AngularJS framework, AngularUI, Karma-runner and several other projects. He is the co-author of the \"Mastering Web Application Development with AngularJS\" book. When not coding, Pawel can be spotted speaking at various software development conferences.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "devversion": {
@@ -172,7 +172,7 @@
     "twitter": "DevVersion",
     "website": "https://github.com/DevVersion",
     "bio": "Paul is a 17-year-old developer living in Germany. While he attends school, Paul works as a core team member on Angular Material. Paul focuses on tooling and building components for Angular.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "EladBezalel": {
@@ -180,7 +180,7 @@
     "picture": "eladbezalel.jpg",
     "website": "https://github.com/EladBezalel",
     "bio": "Elad is a fullstack developer with a very strong love for design. Since 8 years old, he's been designing in Photoshop and later on fell in love with programing. This strong bond between design and computer programming gave birth to a new kind of love. And he is currently doing the combination of both, as a core member of the ngMaterial project.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "marclaval": {
     "name": "Marc Laval",
@@ -188,7 +188,7 @@
     "twitter": "marclaval",
     "website": "https://github.com/mlaval",
     "bio": "Marc is a manager at Amadeus where he leads the team in charge of developing and recommending UI frameworks for the company. He is also an open source developer and a contributor to Angular.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "wardbell": {
@@ -197,14 +197,14 @@
     "website": "https://github.com/wardbell",
     "twitter": "wardbell",
     "bio": "Ward is an all-around developer with JavaScript, Node.js®, and .net chops. He's a frequent conference speaker and podcaster, trainer, Google Developer Expert for Angular, Microsoft MVP, and PluralSight author. He is also president of IdeaBlade, an enterprise software consulting firm and the makers of breeze.js. He would like to get more sleep and spend more time in the mountains.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "Narretz": {
     "name": "Martin Staffa",
     "picture": "martinstaffa.jpg",
     "twitter": "Narretz",
     "bio": "Martin is an English major turned web developer who loves frontend stuff. He's been part of the AngularJS team since 2014. If you can't find him roaming the Github issue queues, he's probably out with his camera somewhere.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "petebacondarwin"
   },
   "filipesilva": {
@@ -213,7 +213,7 @@
     "twitter": "filipematossilv",
     "website": "http://github.com/filipesilva",
     "bio": "Filipe is a passion-driven developer that always strives for the most elegant solution for each problem. He is currently an author for Angular.io, a core contributor for Angular-CLI and senior front end engineer at KonnectAgain. When not busy going through PRs, you can find him scouring reddit for new dinner recipes to cook or enjoying a craft beer in Dublin.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle"
   },
   "andrewseguin": {
@@ -221,7 +221,7 @@
     "picture": "andrewseguin.jpg",
     "website": "http://github.com/andrewseguin",
     "bio": "Andrew is an engineer on the Angular Material team working on bringing material components to the world. When he’s not obsessing over pixels and design, he is probably off somewhere having adventures with his wife and daughters.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "jelbourn"
   },
   "crisbeto": {
@@ -229,7 +229,7 @@
     "picture": "crisbeto.jpg",
     "website": "http://crisbeto.com/",
     "bio": "Kristiyan is a front-end developer, passionate open-source contributor and a core team member on Angular Material.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "jelbourn"
   },
   "gkalpak": {
@@ -238,21 +238,21 @@
     "twitter": "gkalpakas",
     "website": "https://github.com/gkalpak",
     "bio": "George is a Software Engineer with a passion for chess, robotics and automating stuff. He has a strong need to know how things work (so if you already know, he'd love to have a talk with you). He has been a member of the AngularJS team since 2014. When not doing geeky stuff, he is probably trying to convince his wife and kids to apply programming principles in real life. (Or is it the other way around?)",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "mmalerba": {
     "name": "Miles Malerba",
     "picture": "mmalerba.jpg",
     "bio": "Miles is a software engineer on the Angular Material team at Google. In addition to Javascripting he enjoys eating food and ogling cute puppies.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "jelbourn"
   },
   "jasonaden": {
     "name": "Jason Aden",
     "picture": "jasonaden.jpg",
     "bio": "Jason is a software engineer at Google on the Angular Core team. He is enthusiastic about Angular and application development in the modern age. In his free time Jason enjoys spending time with his wife and four children and doing outdoor activities (hiking, fishing, snowboarding, etc.).",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "igorminar"
   },
   "jeffwhelpley": {
@@ -261,14 +261,14 @@
     "twitter": "jeffwhelpley",
     "website": "https://medium.com/@jeffwhelpley",
     "bio": "Jeff Whelpley is a Google Developer Expert and the CTO of GetHuman. He is the co-organizer of the Angular Boston meetup group, co-creator of Angular Universal, former host of AngularAir and frequent speaker at Angular events.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "pascalprecht": {
     "name": "Pascal Precht",
     "picture": "pascalprecht.jpg",
     "website": "https://twitter.com/PascalPrecht",
     "bio": "Pascal is a software engineer, author and Google Developer Expert for the Angular team. He loves contributing to open source and is the creator of the popular angular-translate module. In his spare time he’s fiddling with EDM production.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "deborah": {
     "name": "Deborah Kurata",
@@ -276,7 +276,7 @@
     "twitter": "deborahkurata",
     "website": "http://blogs.msmvps.com/deborahk/",
     "bio": "Deborah is a software developer, author, and Google Developer Expert. She is author of several Pluralsight courses including: 'Angular 2: Getting Started' and ‘Angular Routing’",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "alyssa": {
     "name": "Alyssa Nicoll",
@@ -284,14 +284,14 @@
     "twitter": "alyssanicoll",
     "website": "alyssa.io",
     "bio": "I am an energetic, über passionate GDE and Web Dev. I have some Front-End and Angular courses on Egghead.io and Code School. I love to learn new things and share them with others. I Scuba Dive and have a toothless dog named 'Gummy'. My DM is always open, come talk sometime.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "ralph": {
     "name": "Ralph Wang",
     "picture": "ralph.jpg",
     "twitter": "ralph_wang_gde",
     "bio": "Ralph(Zhicheng Wang) is a senior consultant at ThoughtWorks and also a GDE. He is a technology enthusiast and he is a passionate advocate of 'Simplicity, Professionalism and Sharing'. In his eighteen years of R&D career, he worked as tester, R&D engineer, project manager, product manager and CTO. He is immersed in the excitement of the arrival of the baby.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "manekinekko": {
     "name": "Wassim Chegham",
@@ -299,7 +299,7 @@
     "twitter": "manekinekko",
     "website": "https://medium.com/@wassimchegham",
     "bio": "Wassim (aka manekinekko on Twitter/Github) is a Developer Advocate at SFEIR, in Web technologies (Angular, Polymer, PWA, Web Components...). He is also a Developer Expert in Web technologies nominated by Google. He enjoys writing technical articles, meeting developers at events, speaking at conferences and contributing to open source projects. Wassim loves the Web Platform and works hard to move it forward.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "mentor": "filipesilva"
   },
   "chrisnoring": {
@@ -308,7 +308,7 @@
     "twitter": "chris_noring",
     "website": "softchris.github.io",
     "bio": "Chris is a Full Stack Developer at McKinsey. A Google Developer Expert in Web Technologies and Angular. He is also a Nativescript Developer Expert. He is one of the organizers of the Angular conference ngVikings and an author of the book RxJS 5 Ultimate",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "jorgeucano": {
     "name": "Jorge Cano",
@@ -316,7 +316,7 @@
     "twitter": "jorgeucano",
     "website": "https://medium.com/@jorgeucano",
     "bio": "Jorge is a Full Stack Developer in ByteDefault, a professor for several courses related to JavaScript, a speaker, and an author of technical articles and the book \"Entendiendo Angular.\" He is a Google Developer Expert in web technologies (nominated by Google) and a NativeScript Developer Expert (nominated by Telerik).",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "toddmotto": {
     "name": "Todd Motto",
@@ -324,7 +324,7 @@
     "twitter": "toddmotto",
     "website": "https://ultimateangular.com",
     "bio": "Owner and trainer at Ultimate Angular. Lives in England, UK. Has a love for teaching, OSS and speaking at conferences. Google Developer Expert for Web Technologies and Angular.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "michaelprentice": {
     "name": "Michael Prentice",
@@ -332,7 +332,7 @@
     "twitter": "splaktar",
     "website": "https://www.DevIntent.com",
     "bio": "Lead for AngularJS Material. Owner and consultant at DevIntent. Ex-Angular GDE. Founder of the Google Developers Group (GDG) community on the Space Coast of Florida, USA.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "jelbourn"
   },
   "manfredsteyer": {
@@ -341,7 +341,7 @@
     "twitter": "ManfredSteyer",
     "website": "https://www.softwarearchitekt.at",
     "bio": "Trainer and Consultant with focus on Angular. Writes for O'Reilly, the German Java Magazine and Heise. Regularly speaks at conferences.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "maximsalnikov": {
     "name": "Maxim Salnikov",
@@ -349,7 +349,7 @@
     "twitter": "webmaxru",
     "website": "https://medium.com/@webmaxru",
     "bio": "Oslo-based web front-end engineer, a Google Developer Expert in Angular, Web technologies and IoT. Active public speaker & trainer for the developer events. Leader of Norway’s largest meetups dedicated to web front-end and mobile development. Founder of ngVikings and Mobile Era conferences. Progressive Web Apps advocate.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "jeremywilken": {
     "name": "Jeremy Wilken",
@@ -357,7 +357,7 @@
     "twitter": "gnomeontherun",
     "website": "https://gnomeontherun.com",
     "bio": "Based in Austin Texas, Jeremy is an application architect and homebrewer. He is a Google Developer Expert in Web Technologies and Angular, with a focus on speaking and training and author of Angular in Action and Ionic in Action.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "mgechev": {
     "name": "Minko Gechev",
@@ -365,7 +365,7 @@
     "twitter": "mgechev",
     "website": "http://blog.mgechev.com",
     "bio": "Software engineer who enjoys theoretical computer science and its practical applications. Speaker, author of the book 'Switching to Angular', codelyzer, Guess.js, and the Go linter revive. Working for faster and more reliable software.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "alexeagle"
   },
   "urish": {
@@ -374,7 +374,7 @@
     "twitter": "UriShaked",
     "website": "https://urish.org",
     "bio": "Uri Shaked is a Google Developer Expert for Web Technologies. He regularly writes about Web and IoT related technologies in his medium blog, and speaks about these topics in conferences and meetup around the world. Among his interests are reverse engineering, hardware hacking, building 3d-printed robots and games, playing music and Salsa dancing.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "eusoj": {
     "name": "Josue Gutierrez",
@@ -382,7 +382,7 @@
     "twitter": "eusoj",
     "website": "http://techtam.io",
     "bio": "Based in Mexico, Josue has been web developer since the last 10 years, he is part of the Google Developer Expert Program, passionate about teaching and building communities",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "SanderElias": {
     "name": "Sander Elias",
@@ -390,7 +390,7 @@
     "twitter": "esoSanderElias",
     "website": "https://sanderelias.nl",
     "bio": "Sander is a versed developer with over 4 decades of practice under his belt. He is also an Google Developer Expert for web, specializing in Angular. Organizer of meetups and conferences. Helping out others wherever he can. When he is not breathing code, he is fiddling around with IOT, photography, science and anything that might vaguely is gadget-like! Thinks he a master of the grill, but in reality you probably don't get a food-poisoning ;) Also, and actually the most important thing to him, he is a father of 4, and has the most patient girlfriend in the universe.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "filipbech": {
     "name": "Filip Bruun Bech-Larsen",
@@ -398,14 +398,14 @@
     "twitter": "filipbech",
     "website": "http://filipbech.github.io/",
     "bio": "Filip is a Frontend developer from Denmark. He works at IMPACT, delivering large-scale, high-performance e-commerce to international clients - most often build in Angular. He runs the local Angular usergroup - ngAarhus, and gives talks/workshops around and beyond the country of Denmark.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "ocombe": {
     "name": "Olivier Combe",
     "picture": "ocombe.jpg",
     "twitter": "ocombe",
     "bio": "Olivier is a passionate front-end engineer who loves interacting with the community by doing open source projects (ocLazyLoad, ngx-translate…), being a panelist at Angular-Air, giving talks or just chatting on Twitter and Slack. He’s a member of the Angular Core team and works on i18n.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "kara"
   },
   "cironunes": {
@@ -413,21 +413,21 @@
     "picture": "cironunes.jpg",
     "twitter": "cironunesdev",
     "bio": "Ciro is the Lead Front-end Engineer of CrossEngage and Google Developer Expert in Web Technologies.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "elecash": {
     "name": "Raúl Jiménez",
     "picture": "raul.jpg",
     "twitter": "elecash",
     "bio": "Raul works as a CEO and Front-end Architect at Byte Default for companies around the world helping them to build high-performance web apps. In his spare time he's usually working on Videogular, involved in local meetups, speaking at conferences and contributing to open source projects.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "simpulton": {
     "name": "Lukas Ruebbelke",
     "picture": "lukas.jpg",
     "twitter": "simpulton",
     "bio": "Developer. Hacker. Community backer. Author and blogger. Console logger.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "christianweyer": {
     "name": "Christian Weyer",
@@ -435,7 +435,7 @@
     "twitter": "ChristianWeyer",
     "website": "https://www.thinktecture.com",
     "bio": "Co-founder and CTO of Thinktecture AG, as well as Google GDE and Microsoft MVP. Since two decades active as an engaged and passionate speaker on several software conferences and events all over the world. Some people call him 'Mr. Cross-Platform'.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "shairez": {
     "name": "Shai Reznik",
@@ -443,7 +443,7 @@
     "twitter": "shai_reznik",
     "website": "https://www.hirez.io",
     "bio": "Teaches Angular at HiRez.io – the most entertaining online courses on the web. An experienced developer, consultant and speaker also known for his unusual crazy Angular talks such as ng-wat, ng-show, ng-rap, etc. Shai is also the organizer of the largest JavaScript group in Israel and a professional Improv performer.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "danwahlin": {
     "name": "Dan Wahlin",
@@ -451,7 +451,7 @@
     "twitter": "DanWahlin",
     "website": "https://codewithdan.com",
     "bio": "Dan Wahlin founded Wahlin Consulting which provides consulting and onsite/online training services on Web technologies such as JavaScript, Angular, TypeScript, Node.js, C#, ASP.NET Core, Web API, and Docker. He’s also published many developer courses on Pluralsight.com and Udemy.com. Dan is a Google GDE, Docker Captain, and Microsoft MVP and Regional Director and speaks at conferences and user groups around the world.  Dan has written several books on Web technologies, hundreds of technical articles and blog posts (https://blog.codewithdan.com) and runs the 'Code with Dan Web Weekly Newsletter' - a great way to stay up on the latest technologies. Follow Dan on Twitter @DanWahlin.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "joeeames": {
     "name": "Joe Eames",
@@ -459,7 +459,7 @@
     "twitter": "josepheames",
     "website": "https://joeeames.me",
     "bio": "Joe Eames is a developer and educator. He publishes course on Angular and JavaScript on Pluralsight.com. He is an organizer of ng-conf, a Google Developer Expert in Angular, gives lots of talks & workshops, and loves all things web.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "willmendesneto": {
     "name": "Wilson Mendes",
@@ -467,7 +467,7 @@
     "twitter": "willmendesneto",
     "website": "https://willmendesneto.github.io",
     "bio": "GDE (Google Developer Expert) Angular and Web Technologies, GDG Salvador organizer, passionate about technology and active in communities with a focus on web development, including Angular, JavaScript, HTML5, CSS3, Workflow, web performance, security and Internet of things. Participates in events organization, speaker at conferences in Brazil and other countries and contributes to several open source projects.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "jecelynyeen": {
     "name": "Jecelyn Yeen",
@@ -475,7 +475,7 @@
     "twitter": "jecelynyeen",
     "website": "https://developers.google.com/experts/people/jecelyn-yeen",
     "bio": "GDE (Google Developer Expert) Angular and Web Technologies, Women Who Code KL Director, Jecelyn specializes in professional application development with technologies, including Angular, HTML5, Typescript, JavaScript, CSS, C#, NodeJs, Cloud and ASP.NET.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "areai51": {
     "name": "Vinci Rufus",
@@ -483,7 +483,7 @@
     "twitter": "areai51",
     "website": "https://developers.google.com/experts/people/vinci-rufus",
     "bio": "Director of Experience Technology at SapientRazorfish. Consults various brands on their frontend and mobile web architecture. A speaker at various forums and mentor at Launchpad Accelerator and ngGirls India. Spends free time playing with Angular, Preact, web-components  ",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "tchatel": {
     "name": "Thierry Chatel",
@@ -491,7 +491,7 @@
     "twitter": "ThierryChatel",
     "website": "http://www.methotic.com",
     "bio": "Thierry is a senior consultant and trainer, specialized on Angular, and a Google Developer Expert.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "gerardsans": {
     "name": "Gerard Sans",
@@ -499,7 +499,7 @@
     "twitter": "gerardsans",
     "website": "https://medium.com/@gerard.sans",
     "bio": "Gerard is very excited about the future of the Web and JavaScript. Always happy Computer Science Engineer and humble Google Developer Expert. He loves to share his learnings by giving talks, trainings and writing about cool technologies. He loves running AngularZone and GraphQL London, mentoring students and giving back to the community.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "nirkaufman": {
     "name": "Nir Kaufman",
@@ -507,7 +507,7 @@
     "twitter": "nirkaufman",
     "website": "http://ngnir.life/",
     "bio": "Nir is a Principal Frontend Consultant & Head of the Angular department at 500Tech, Google Developer Expert and community leader. He organizes the largest Angular meetup group in Israel (Angular-IL), talks and teaches about front-end technologies around the world. He is also the author of two books about Angular and the founder of the 'Frontend Band'.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "achautard": {
     "name": "Alain Chautard",
@@ -515,7 +515,7 @@
     "twitter": "AlainChautard",
     "website": "http://www.angulartraining.com",
     "bio": "Alain Chautard is a Google Developer Expert in Web Technologies / Angular. He started working with Angular JS in 2011. Since then he has worked with all Angular versions on a daily basis, both as a developer and as a technical trainer. He is the organizer of the Sacramento Angular Meetup group, co-organizer of the Google Developer Group chapter in Sacramento, California, and published author of the Packt video course 'Getting Started with Angular'",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "coryrylan": {
     "name": "Cory Rylan",
@@ -523,7 +523,7 @@
     "twitter": "coryrylan",
     "website": "https://coryrylan.com",
     "bio": "Cory is a full time front end web developer. He works full time building responsive web applications and progressive web apps. When not building web apps he is busy teaching Angular and other web technologies in workshops and conferences. He loves the web and is optimistic of the places it can take us.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "mhartington": {
     "name": "Mike Hartington",
@@ -531,7 +531,7 @@
     "twitter": "mhartington",
     "website": "https://mhartington.io",
     "bio": "Mike is a Developer Advocate for the Ionic Framework and a GDE in Angular. He spends most of his time making fast PWAs and exploring emerging web standards. When not behind a keyboard, you'll probably find him with a guitar and beer.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "juristr": {
     "name": "Juri Strumpflohner",
@@ -539,7 +539,7 @@
     "twitter": "juristr",
     "website": "https://juristr.com",
     "bio": "Juri is a software engineer and freelance trainer and consultant currently mostly focusing on the frontend side using JavaScript, TypeScript and Angular. He has a passion for teaching and sharing his knowledge and experiences with others. This mostly happens by writing tech articles for his personal blog, by creating video courses for Egghead.io, during on-site workshops at companies or by speaking at conferences. In his free time he enjoys practicing Yoseikan Budo, a martial art where he currently owns the 3rd DAN black belt.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "mashhoodr": {
     "name": "Mashhood Rastgar",
@@ -547,7 +547,7 @@
     "twitter": "mashhoodr",
     "website": "http://imars.info/",
     "bio": "Mashhood is the principal technical consultant at Recurship and a Google Developer Expert. He  works with different startups in US and EU to helps them crawl through the technical maze and quickly build amazing products focused around the problems they are trying to solve. He specializes in using the latest web technologies available to execute the best possible solutions.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "kimmaida": {
     "name": "Kim Maida",
@@ -555,14 +555,14 @@
     "twitter": "KimMaida",
     "website": "https://kmaida.io/",
     "bio": "Kim is an an Angular consultant, developer, speaker, writer, and Google Developer Expert. She is passionate about learning from and sharing knowledge with other developers through blogging, speaking, workshops, and open source.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "elanaolson": {
     "name": "Elana Olson",
     "picture": "elanaolson.jpg",
     "twitter": "elanathellama",
     "bio": "Elana is a Developer Relations intern on the Angular team at Google. She is working on migration paths from AngularJS to Angular and would love to chat about your experience with upgrading.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "stephenfluin"
   },
   "kevinyang": {
@@ -571,7 +571,7 @@
     "twitter": "chgc",
     "website": "https://blog.kevinyang.net/",
     "bio": "Kevin is a Angular Taiwan, Angular Girls Taiwan community organzier. He loves sharing knowledge with other developers through blogging, speaking, workshops.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "sajee": {
     "name": "Sajeetharan Sinnathurai",
@@ -579,7 +579,7 @@
     "twitter": "kokkisajee",
     "website": "https://sajeetharan.herokuapp.com/",
     "bio": "Sajeetharan is a Developer, Top contributor on stackoverflow for #Angular, ng-SriLanka organizer. He makes use of his extensive knowledge over the past years to contribute to community to make the world a better place.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "lacolaco": {
     "name": "Suguru Inatomi",
@@ -587,7 +587,7 @@
     "twitter": "laco2net",
     "website": "https://lacolaco.net",
     "bio": "Suguru is a community-loving Frontend developer and a lead of Angular Japan User Group. He organizes the largest Angular event in Japan (ng-japan). And he is a contributor to Angular by sending patches, writing, speaking, and localizing resources in Japanese.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "katerina": {
     "name": "Katerina Skroumpelou",
@@ -595,7 +595,7 @@
     "twitter": "psybercity",
     "website": "https://mandarini.github.io/",
     "bio": "Katerina is a front end software engineer, a conference speaker and AngularAthens meetup organizer. She is obsessed with sharing knowledge about things she loves. She is also trying to support diversity in the community. She lives with her cat in Athens.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "blove": {
     "name": "Brian Love",
@@ -603,7 +603,7 @@
     "twitter": "brian_love",
     "website": "https://brianflove.com",
     "bio": "Brian is a software engineer and GDE in Angular with a passion for learning, writing, speaking, teaching and mentoring. Brian has been building web applications for over 20 years and has long been a fanboy of JavaScript. When not in front of his Macbook Pro Brian is in the Rocky Mountains skiing or hiking.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "jeffbcross": {
     "name": "Jeff Cross",
@@ -611,14 +611,14 @@
     "twitter": "jeffbcross",
     "website": "https://nrwl.io/",
     "bio": "Jeff is an Angular Consultant at nrwl.io where he helps enterprise teams succeed with Angular. Prior to founding Nrwl, Jeff was one of the earliest members of the Angular Core Team at Google, and contributed to many of the early state management and performance efforts of AngularJS and Angular.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "keilla": {
     "name": "Keilla Menezes Fernandes",
     "picture": "keilla.jpg",
     "twitter": "keillamenezes_",
     "bio": "I am Senior Software Development Consultant in ThoughtWorks and GDE in Angular. Graduated in Computer Science from Federal University of Bahia, I have been worked with software development for more than 11 years. Since 2017, I started with Angular Framework and I went deep into front-end ecosystem and became more specialized in this area. I participate in a computer science community, Campinas Front-end, that promotes events in this area. In the end of 2016, I started to do technical talks. The passion for science is the engine that drives me to seek answers to the problems that computing aims to solve. Besides that, sharing knowledge and experiences is the path I choose to democratize the technology for all.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "mira": {
     "name": "Stanimira Vlaeva",
@@ -626,7 +626,7 @@
     "twitter": "StanimiraVlaeva",
     "website": "https://github.com/sis0k0",
     "bio": "Software engineer on the NativeScript team at Progress, focused on NativeScript Angular, NativeScript schematics, and integrating webpack in the {N} build system. Co-organizing the Angular Sofia meetup. Speaking about Angular things at conferences here and there.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "sharondio": {
     "name": "Sharon DiOrio",
@@ -634,7 +634,7 @@
     "twitter": "sharondio",
     "website": "https://medium.com/@sharondio",
     "bio": "Sharon is a mother to four teenagers, wife of a USMC veteran/police officer, and lead front-end engineer for an educational non-profit in Boston. In her spare time, she is the \"Head Instigator\" of the Angular-Boston Meetup and an active member of the Boston meetups community. She occasionally speaks on Angular and related topics at technology conferences across the country. She has a Bachelor of Fine Arts from SMU and a Masters with honors from RTFM.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "leonardozizzamia": {
     "name": "Leonardo Zizzamia",
@@ -642,7 +642,7 @@
     "twitter": "zizzamia",
     "website": "https://medium.com/@zizzamia",
     "bio": "Leonardo is a Senior Software Engineer at Coinbase. He is deeply passionate about web performance and most recently developed Perfume.js to help companies prioritize roadmaps and business, through performance analytics. From 2018, co-organizer of the Angular San Francisco Meetup group and NGRome Conference.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "tomastrajan": {
     "name": "Tomas Trajan",
@@ -650,7 +650,7 @@
     "twitter": "tomastrajan",
     "website": "https://medium.com/@tomastrajan",
     "bio": "Tomas is a Senior Software Engineer with passion for frontend and especially Angular. He always strives to provide lots of value and to empower teams he is working with by sharing know-how, introducing best practices and automating mundane task to enable full focus on creating value for the users! He likes to share his Angular know-how by blogging, speaking and recording video content. He is a co-organizer of Angular Meetup Zurich.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "samjulien": {
     "name": "Sam Julien",
@@ -658,12 +658,12 @@
     "twitter": "samjulien",
     "website": "http://www.samjulien.com/",
     "bio": "Sam Julien builds software, articles, video courses, and campfires. A developer, speaker, writer, and GDE in the Pacific Northwest, Sam's favorite thing in the world is changing someone's life by teaching them to code.",
-    "group": "Collaborators",
+    "groups": ["Collaborators"],
     "mentor": "gkalpak"
   },
   "JiaLiPassion": {
     "name": "JiaLi Passion",
-    "group": "Collaborators",
+    "groups": ["Collaborators"],
     "mentor": "mhevery",
     "picture": "JiaLiPassion.jpg",
     "bio": "A programmer with passion, angular/zone.js guy! Web frontend engineer @sylabs"
@@ -671,19 +671,19 @@
   "cexbrayat": {
     "name": "Cédric Exbrayat",
     "mentor": "petebacondarwin",
-    "group": "Collaborators",
+    "groups": ["Collaborators"],
     "picture": "cexbrayat.jpg",
     "bio": "Author of `Become a ninja with Angular (2+)` https://books.ninja-squad.com/angular - Angular trainer and @Ninja-Squad co-founder"
   },
   "CaerusKaru": {
     "name": "Adam Plumer",
-    "group": "Collaborators",
+    "groups": ["Collaborators"],
     "mentor": "vikerman",
     "picture": "CaerusKaru.jpg"
   },
   "jbedard": {
     "name": "Jason Bedard",
-    "group": "Collaborators",
+    "groups": ["Collaborators"],
     "mentor": "kyliau",
     "picture": "jbedard.png"
   },
@@ -701,7 +701,7 @@
     "twitter": "schwarty",
     "website": "https://schwarty.com",
     "bio": "Justin (aka Schwarty) is a Google Developer Expert in Web Technologies and Angular, the host and maintainer of the weekly AngularAir live video broadcast, educator, writer and content creator. He has Angular courses available on LinkedIn Learning and Pluralsight and loves passing on years of full stack development knowledge to help empower others to find their inner awesomeness!",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "brandonroberts": {
     "name": "Brandon Roberts",
@@ -709,27 +709,27 @@
     "twitter": "brandontroberts",
     "website": "https://brandonroberts.dev",
     "bio": "Brandon is a developer and technical writer working on guides, tutorials, application development, and infrastructure for the Angular docs. He is also a maintainer of the NgRx project, building reactive libraries for Angular.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "dennispbrown"
   },
   "chembu": {
     "name": "Sreevani Sreejith",
     "picture": "sreevani.jpg",
     "bio": "Sreevani is a tech writer with prior programming experience. She writes documentation for the Angular framework team. Outside of work, she likes practicing yoga, honing her skills on classical dance forms, and baking cakes.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "dennispbrown"
   },
   "dennispbrown": {
     "name": "Denny Brown",
     "picture": "denny.jpg",
     "bio": "Denny is founder of Expert Support, a professional services firm specializing in technical communication, and leads the Angular technical writing team. His lifelong passion has been to reduce the time and effort required to understand complex technical information. Early on, he was Associate Chairman of the Computer Science Department at Stanford, where he taught introductory courses in programming. He also plays old-timers baseball in local leagues and national tournaments.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "bradlygreen"
   },
   "jbogarthyde": {
     "name": "Judy Bogart",
     "picture": "judy.png",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "dennispbrown"
   },
   "jenniferfell": {
@@ -737,7 +737,7 @@
     "picture": "jennifer.jpg",
     "website": "http://silverpath.org",
     "bio": "Jennifer is a technical content strategist, architect, designer, and writer. As lead of the Angular docs team, she's always interested in learning more about how developers learn and use Angular. Her offline persona is a horsewoman in Idaho.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "dennispbrown"
   },
   "kapunahelewong": {
@@ -745,7 +745,7 @@
     "picture": "kapunahele.jpg",
     "twitter": "kapunahele",
     "bio": "Kapunahele is a developer and Angular fan who works on the Angular docs writing guides and developing example apps. She also enjoys Native Hawaiian practices, textile arts, and marveling at little, inconspicuous plants growing in forgotten places outdoors.",
-    "group": "Angular",
+    "groups": ["Angular"],
     "lead": "dennispbrown"
   },
   "luixaviles": {
@@ -754,7 +754,7 @@
     "twitter": "luixaviles",
     "website": "https://luixaviles.com",
     "bio": "Luis is an enthusiast of Open Source software and communities, as well as being a public speaker, a technology trainer and an author of courses and technical articles. He is the organizer of the Angular Bolivia community and NG Bolivia conference. When he's not coding, Luis is reading about Astronomy or nerding about outer space, photography or even doing Astrophotography.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "siddajmera": {
     "name": "Siddharth Ajmera",
@@ -762,12 +762,12 @@
     "twitter": "SiddAjmera",
     "website": "https://webstackup.com/",
     "bio": "Siddharth is a Full Stack JavaScript Developer and a GDE in Angular. He's passionate about sharing his knowledge on Angular, Firebase and the Web in general. He's the organizer of WebStack, a local community of developers focused on Web, Mobile, Voice and Server related technologies in general. WebStack hosts free monthly meetups every 2nd or 3rd Saturday of the month. Siddharth is also an avid photographer and loves traveling. Find him anywhere on the Web with `SiddAjmera`.",
-    "group": "GDE"
+    "groups": ["GDE"]
   },
   "bbrennan": {
     "name": "Bonnie Brennan",
     "twitter": "bonnster75",
-    "group": "GDE",
+    "groups": ["GDE"],
     "picture": "bonnie.jpg",
     "bio": "Bonnie has been specializing in Angular since 2013. She is the founder of ngHouston Angular Meetup and a regular panelist on Angular Air. She is also the very proud parent component of @thelittlestdev!"
   }

--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -689,7 +689,7 @@
   },
   "JoostK": {
     "name": "Joost Koehoorn",
-    "groups": ["Collaborator"],
+    "groups": ["Collaborators"],
     "mentor": "alxhub",
     "picture": "joostk.jpg",
     "twitter": "devjoost",

--- a/aio/package.json
+++ b/aio/package.json
@@ -44,7 +44,7 @@
     "check-env": "yarn ~~check-env",
     "postcheck-env": "yarn aio-check-local",
     "payload-size": "scripts/payload.sh",
-    "predocs": "yarn generate-stackblitz && yarn generate-zips",
+    "predocs": "node scripts/contributors/check-pictures && yarn generate-stackblitz && yarn generate-zips",
     "docs": "yarn docs-only",
     "docs-only": "dgeni ./tools/transforms/angular.io-package",
     "docs-watch": "node tools/transforms/authors-package/watchr.js",

--- a/aio/scripts/contributors/check-pictures.js
+++ b/aio/scripts/contributors/check-pictures.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+// Imports
+const {existsSync, readFileSync} = require('fs');
+const {join, resolve} = require('path');
+
+// Constants
+const CONTENT_DIR = resolve(__dirname, '../../content');
+const IMAGES_DIR = join(CONTENT_DIR, 'images/bios');
+const CONTRIBUTORS_PATH = join(CONTENT_DIR, 'marketing/contributors.json');
+
+// Run
+_main();
+
+// Functions - Definitions
+function _main() {
+  const contributors = JSON.parse(readFileSync(CONTRIBUTORS_PATH, 'utf8'));
+  const expectedImages = Object.keys(contributors)
+      .filter(key => !!contributors[key].picture)
+      .map(key => join(IMAGES_DIR, contributors[key].picture));
+  const missingImages = expectedImages.filter(path => !existsSync(path));
+
+  if (missingImages.length > 0) {
+    throw new Error(
+        'The following pictures are referenced in \'contributors.json\' but do not exist:' +
+        missingImages.map(path => `\n  - ${path}`).join(''));
+  }
+}

--- a/aio/scripts/contributors/org_chart.jq
+++ b/aio/scripts/contributors/org_chart.jq
@@ -1,7 +1,7 @@
 # Produces a GraphViz Dot file from the data in the contributors.json file.
 # Documentation for this syntax at https://stedolan.github.io/jq/manual
-to_entries 
-| map(select(.value.group=="Angular" or .value.group=="Collaborator"))
+to_entries
+| map(select(.value.group=="Angular" or .value.group=="Collaborators"))
 | map(.value |= {name: .name, lead: (.lead // .mentor // "")})
 | map(
    "\(.key|tojson) [ label = \(.value.name|tojson) ] ",

--- a/aio/scripts/contributors/org_chart.jq
+++ b/aio/scripts/contributors/org_chart.jq
@@ -1,7 +1,7 @@
 # Produces a GraphViz Dot file from the data in the contributors.json file.
 # Documentation for this syntax at https://stedolan.github.io/jq/manual
 to_entries
-| map(select(.value.group=="Angular" or .value.group=="Collaborators"))
+| map(select((.value.groups | index("Angular")) or (.value.groups | index("Collaborators"))))
 | map(.value |= {name: .name, lead: (.lead // .mentor // "")})
 | map(
    "\(.key|tojson) [ label = \(.value.name|tojson) ] ",

--- a/aio/src/app/custom-elements/contributor/contributor.service.spec.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.service.spec.ts
@@ -49,14 +49,23 @@ describe('ContributorService', () => {
 
     it('should reshape the contributor json to expected result', () => {
       const groupNames = contribs.map(g => g.name).join(',');
-      expect(groupNames).toEqual('Angular,GDE');
+      expect(groupNames).toEqual('Angular,Collaborators,GDE');
     });
 
     it('should have expected "GDE" contribs in order', () => {
-      const gde = contribs[1];
+      const gde = contribs[2];
       const actualAngularNames = gde.contributors.map(l => l.name).join(',');
-      const expectedAngularNames = [testData.jeffcross, testData.kapunahelewong].map(l => l.name).join(',');
+      const expectedAngularNames = [testData.gkalpak, testData.kapunahelewong].map(l => l.name).join(',');
       expect(actualAngularNames).toEqual(expectedAngularNames);
+    });
+
+    it('should support including a contributor in multiple groups', () => {
+      const contributor = testData.gkalpak;
+      const matchedGroups = contribs
+          .filter(group => group.contributors.includes(contributor))
+          .map(group => group.name);
+
+      expect(matchedGroups).toEqual(['Collaborators', 'GDE']);
     });
   });
 
@@ -71,7 +80,7 @@ function getTestContribs() {
       website: 'https://github.com/kapunahelewong',
       twitter: 'kapunahele',
       bio: 'Kapunahele is a front-end developer and contributor to angular.io',
-      group: 'GDE'
+      groups: ['GDE']
     },
     misko: {
       name: 'Miško Hevery',
@@ -79,7 +88,7 @@ function getTestContribs() {
       twitter: 'mhevery',
       website: 'http://misko.hevery.com',
       bio: 'Miško Hevery is the creator of AngularJS framework.',
-      group: 'Angular'
+      groups: ['Angular']
     },
     igor: {
       name: 'Igor Minar',
@@ -87,7 +96,7 @@ function getTestContribs() {
       twitter: 'IgorMinar',
       website: 'https://google.com/+IgorMinar',
       bio: 'Igor is a software engineer at Angular.',
-      group: 'Angular'
+      groups: ['Angular']
     },
     kara: {
       name: 'Kara Erickson',
@@ -95,7 +104,7 @@ function getTestContribs() {
       twitter: 'karaforthewin',
       website: 'https://github.com/kara',
       bio: 'Kara is a software engineer on the Angular team at Angular and a co-organizer of the Angular-SF Meetup. ',
-      group: 'Angular'
+      groups: ['Angular']
     },
     jeffcross: {
       name: 'Jeff Cross',
@@ -103,7 +112,7 @@ function getTestContribs() {
       twitter: 'jeffbcross',
       website: 'https://twitter.com/jeffbcross',
       bio: 'Jeff was one of the earliest core team members on AngularJS.',
-      group: 'GDE'
+      groups: ['Collaborators']
     },
     naomi: {
       name: 'Naomi Black',
@@ -111,7 +120,14 @@ function getTestContribs() {
       twitter: 'naomitraveller',
       website: 'http://google.com/+NaomiBlack',
       bio: 'Naomi is Angular\'s TPM generalist and jack-of-all-trades.',
-      group: 'Angular'
+      groups: ['Angular']
+    },
+    gkalpak: {
+      name: 'George Kalpakas',
+      picture: 'gkalpak.jpg',
+      twitter: 'gkalpakas',
+      bio: 'George wrote this test, so he gets to have his name included here.',
+      groups: ['GDE', 'Collaborators'],
     }
  };
 }

--- a/aio/src/app/custom-elements/contributor/contributor.service.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.service.ts
@@ -10,7 +10,7 @@ import { Contributor, ContributorGroup } from './contributors.model';
 import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
 const contributorsPath = CONTENT_URL_PREFIX + 'contributors.json';
-const knownGroups = ['Angular', 'GDE'];
+const knownGroups = ['Angular', 'Collaborators', 'GDE'];
 
 @Injectable()
 export class ContributorService {

--- a/aio/src/app/custom-elements/contributor/contributor.service.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.service.ts
@@ -27,13 +27,10 @@ export class ContributorService {
         const contribMap: { [name: string]: Contributor[]} = {};
         Object.keys(contribs).forEach(key => {
           const contributor = contribs[key];
-          const group = contributor.group;
-          const contribGroup = contribMap[group];
-          if (contribGroup) {
+          contributor.groups.forEach(group => {
+            const contribGroup = contribMap[group] || (contribMap[group] = []);
             contribGroup.push(contributor);
-          } else {
-            contribMap[group] = [contributor];
-          }
+          });
         });
 
         return contribMap;

--- a/aio/src/app/custom-elements/contributor/contributors.model.ts
+++ b/aio/src/app/custom-elements/contributor/contributors.model.ts
@@ -1,15 +1,15 @@
-export class ContributorGroup {
+export interface ContributorGroup {
   name: string;
   order: number;
   contributors: Contributor[];
 }
 
-export class Contributor {
+export interface Contributor {
   group: string;
   name: string;
   picture?: string;
   website?: string;
   twitter?: string;
   bio?: string;
-  isFlipped ? = false;
+  isFlipped?: boolean;
 }

--- a/aio/src/app/custom-elements/contributor/contributors.model.ts
+++ b/aio/src/app/custom-elements/contributor/contributors.model.ts
@@ -5,7 +5,7 @@ export interface ContributorGroup {
 }
 
 export interface Contributor {
-  group: string;
+  groups: string[];
   name: string;
   picture?: string;
   website?: string;


### PR DESCRIPTION
Several improvements related to the contributors page: 
- docs: change contributor group name (Collaborator --> Collaborators)
- docs: change heading of contributors page to avoid confusion (Collaborators --> Contributors)
- docs: change the order of groups in contributors page
- refactor(docs-infra): change unused classes to interfaces
- feat(docs-infra): support contributors belonging to multiple groups
- docs: add Sam Julien to GDE group as well
- build(docs-infra): add check to ensure all contributor pictures exist

(See individual commits for details.)