### PR TITLE
fix(ivy): allow TestBed to recompile AOT-compiled components in case of template overrides

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ErrorHandler, Inject, InjectionToken, NgModule, Optional, Pipe} from '@angular/core';
-import {defineComponent, setClassMetadata, text} from '@angular/core/src/render3';
+import {Component, Directive, ErrorHandler, Inject, InjectionToken, NgModule, Optional, Pipe, ɵdefineComponent as defineComponent, ɵsetClassMetadata as setClassMetadata, ɵtext as text} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ResourceLoader} from '@angular/compiler';
-import {Component, Directive, ErrorHandler, Inject, InjectionToken, NgModule, Optional, Pipe, ɵNG_COMPONENT_DEF as NG_COMPONENT_DEF} from '@angular/core';
+import {Component, Directive, ErrorHandler, Inject, InjectionToken, NgModule, Optional, Pipe} from '@angular/core';
+import {defineComponent, setClassMetadata, text} from '@angular/core/src/render3';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -269,6 +269,60 @@ describe('TestBed', () => {
 
     expect(TestBed.get(ErrorHandler)).toEqual(jasmine.any(CustomErrorHandler));
   });
+
+  onlyInIvy('TestBed should handle AOT pre-compiled Components')
+      .describe('AOT pre-compiled components', () => {
+        /**
+         * Function returns a class that represents AOT-compiled version of the following Component:
+         *
+         * @Component({
+         *  selector: 'comp',
+         *  templateUrl: './template.ng.html',
+         *  styleUrls: ['./style.css']
+         * })
+         * class ComponentClass {}
+         *
+         * This is needed to closer match the behavior of AOT pre-compiled components (compiled
+         * outside of TestBed) without changing TestBed state and/or Component metadata to compile
+         * them via TestBed with external resources.
+         */
+        const getAOTCompiledComponent = () => {
+          class ComponentClass {
+            static ngComponentDef = defineComponent({
+              type: ComponentClass,
+              selectors: [['comp']],
+              factory: () => new ComponentClass(),
+              consts: 1,
+              vars: 0,
+              template: (rf: any, ctx: any) => {
+                if (rf & 1) {
+                  text(0, 'Some template');
+                }
+              },
+              styles: ['body { margin: 0; }']
+            });
+          }
+          setClassMetadata(
+              ComponentClass, [{
+                type: Component,
+                args: [{
+                  selector: 'comp',
+                  templateUrl: './template.ng.html',
+                  styleUrls: ['./style.css'],
+                }]
+              }],
+              null, null);
+          return ComponentClass;
+        };
+
+        it('should have an ability to override template', () => {
+          const SomeComponent = getAOTCompiledComponent();
+          TestBed.configureTestingModule({declarations: [SomeComponent]});
+          TestBed.overrideTemplateUsingTestingModule(SomeComponent, 'Template override');
+          const fixture = TestBed.createComponent(SomeComponent);
+          expect(fixture.nativeElement.innerHTML).toBe('Template override');
+        });
+      });
 
   onlyInIvy('patched ng defs should be removed after resetting TestingModule')
       .describe('resetting ng defs', () => {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -211,7 +211,8 @@ export class R3TestBedCompiler {
     this.overrideComponent(type, {set: override});
 
     const def = (type as any)[NG_COMPONENT_DEF];
-    if (hasStyleUrls && def.styles && def.styles.length > 0) {
+    if (hasStyleUrls && !!def && !isComponentDefPendingResolution(type) && def.styles &&
+        def.styles.length > 0) {
       this.existingComponentStyles.set(type, def.styles);
     }
 
@@ -248,9 +249,9 @@ export class R3TestBedCompiler {
 
     this.applyProviderOverrides();
 
-    // Restore previously saved `styles` property value for Components with template overrides and
-    // styleUrls present.
-    this.restoreExistingComponentStyling();
+    // Patch previously stored `styles` Component values (taken from ngComponentDef), in case these
+    // Components have `styleUrls` fields defined and template override was requested.
+    this.patchComponentsWithExistingStyles();
 
     // Clear the componentToModuleScope map, so that future compilations don't reset the scope of
     // every component.
@@ -390,7 +391,7 @@ export class R3TestBedCompiler {
     }
   }
 
-  private restoreExistingComponentStyling(): void {
+  private patchComponentsWithExistingStyles(): void {
     this.existingComponentStyles.forEach(
         (styles, type) => (type as any)[NG_COMPONENT_DEF].styles = styles);
     this.existingComponentStyles.clear();


### PR DESCRIPTION
Prior to this change, recompilation of AOT-compiled components in TestBed may fail when template override is requested. That was happening due to the `styleUrls` field defined for a Component, thus switching its state to "requires resolution" (i.e. having external resources) at compile time. This change avoids this issue by storing styles and resetting `styleUrls` field before recompilation. Once compilation is done, saved styles are patched back onto Component def.

This PR is a followup fix for FW-1178.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No