### PR TITLE
fix(animations): Adds "zoom" to isNonAnimatableStyle()

### DIFF
--- a/packages/animations/browser/src/render/special_cased_styles.ts
+++ b/packages/animations/browser/src/render/special_cased_styles.ts
@@ -129,5 +129,5 @@ function filterNonAnimatableStyles(styles: {[key: string]: any}) {
 }
 
 function isNonAnimatableStyle(prop: string) {
-  return prop === 'display' || prop === 'position';
+  return prop === 'display' || prop === 'position' || prop === 'zoom';
 }


### PR DESCRIPTION
The zoom CSS property isn't animatable. This commit adds it to `isNonAnimatableStyle()`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In this example app, https://stackblitz.com/edit/nonanimatable-zoom, two boxes are displayed. Click on the box on the right, and it's border becomes too big and it doesn't align with the box on the left, until animation is finished.

Issue Number: N/A

## What is the new behavior?

Click on the box on the right, and it smoothly enlarges itself and merging with the box on the left.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
None.