### PR TITLE
fix(ivy): host attributes and @ComponentChild should be supported on …

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -203,6 +203,12 @@ export function createRootComponent<T>(
 
   hostFeatures && hostFeatures.forEach((feature) => feature(component, componentDef));
 
+  // We want to generate an empty QueryList for root content queries for backwards
+  // compatibility with ViewEngine.
+  if (componentDef.contentQueries) {
+    componentDef.contentQueries(RenderFlags.Create, component, rootView.length - 1);
+  }
+
   const rootTNode = getPreviousOrParentTNode();
   if (tView.firstTemplatePass && componentDef.hostBindings) {
     const expando = tView.expandoInstructions !;
@@ -215,12 +221,6 @@ export function createRootComponent<T>(
     const native = componentView[HOST] !as RElement;
     renderInitialClasses(native, rootTNode.stylingTemplate, componentView[RENDERER]);
     renderInitialStyles(native, rootTNode.stylingTemplate, componentView[RENDERER]);
-  }
-
-  // We want to generate an empty QueryList for root content queries for backwards
-  // compatibility with ViewEngine.
-  if (componentDef.contentQueries) {
-    componentDef.contentQueries(RenderFlags.Create, component, rootView.length - 1);
   }
 
   return component;

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, Directive, HostBinding, HostListener, Input, QueryList, ViewChildren} from '@angular/core';
+import {Component, ContentChild, Directive, HostBinding, HostListener, Input, QueryList, TemplateRef, ViewChildren} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -101,5 +101,20 @@ describe('acceptance integration tests', () => {
       fixture = TestBed.createComponent(App);
       fixture.detectChanges();
     }).not.toThrow();
+  });
+
+  it('should support host attribute and @ContentChild on the same component', () => {
+    @Component(
+        {selector: 'test-component', template: `foo`, host: {'[attr.aria-disabled]': 'true'}})
+    class TestComponent {
+      @ContentChild(TemplateRef) tpl !: TemplateRef<any>;
+    }
+
+    TestBed.configureTestingModule({declarations: [TestComponent]});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.tpl).not.toBeNull();
+    expect(fixture.debugElement.nativeElement.getAttribute('aria-disabled')).toBe('true');
   });
 });


### PR DESCRIPTION
…the same component

Spotted while analysing failures in ng-bootstrap tests