### PR TITLE
fix(ivy): @Component should support entry components from another module

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -14,6 +14,7 @@ import {Type} from '../../interface/type';
 import {registerNgModuleType} from '../../linker/ng_module_factory_loader';
 import {Component} from '../../metadata';
 import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes} from '../../metadata/ng_module';
+import {flatten} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from '../fields';
@@ -463,18 +464,6 @@ export function transitiveScopesFor<T>(
 
   def.transitiveCompileScopes = scopes;
   return scopes;
-}
-
-function flatten<T>(values: any[], mapFn?: (value: T) => any): Type<T>[] {
-  const out: Type<T>[] = [];
-  values.forEach(value => {
-    if (Array.isArray(value)) {
-      out.push(...flatten<T>(value, mapFn));
-    } else {
-      out.push(mapFn ? mapFn(value) : value);
-    }
-  });
-  return out;
 }
 
 function expandModuleWithProviders(value: Type<any>| ModuleWithProviders<{}>): Type<any> {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -158,6 +158,7 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
   const errors: string[] = [];
   const declarations = maybeUnwrapFn(ngModuleDef.declarations);
   const imports = maybeUnwrapFn(ngModuleDef.imports);
+  flatten(imports, unwrapModuleWithProvidersImports).forEach(verifySemanticsOfNgModuleDef);
   const exports = maybeUnwrapFn(ngModuleDef.exports);
   declarations.forEach(verifyDeclarationsHaveDefinitions);
   const combinedDeclarations: Type<any>[] = [

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -21,7 +21,7 @@ export function addAllToArray(items: any[], arr: any[]) {
 /**
  * Flattens an array in non-recursive way. Input arrays are not modified.
  */
-export function flatten(list: any[]): any[] {
+export function flatten(list: any[], mapFn?: (value: any) => any): any[] {
   const result: any[] = [];
   let i = 0;
   while (i < list.length) {
@@ -34,7 +34,7 @@ export function flatten(list: any[]): any[] {
         i++;
       }
     } else {
-      result.push(item);
+      result.push(mapFn ? mapFn(item) : item);
       i++;
     }
   }


### PR DESCRIPTION
Spotted while analysing failures in ng-bootstrap tests