### PR TITLE
fix(forms): clear parent when removing controls (#29517)

### DIFF
--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -159,6 +159,15 @@ import {of } from 'rxjs';
         expect(g.valid).toBe(false);
       });
 
+      it('should update parent of added control', () => {
+        const g = new FormGroup({});
+        const c = new FormControl();
+
+        g.addControl('c', c);
+
+        expect(c.parent).toBe(g);
+      });
+
       it('should update value and validity when control is removed', () => {
         const g = new FormGroup(
             {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
@@ -169,6 +178,15 @@ import {of } from 'rxjs';
 
         expect(g.value).toEqual({'one': '1'});
         expect(g.valid).toBe(true);
+      });
+
+      it('should update parent of removed control', () => {
+        const c = new FormControl();
+        const g = new FormGroup({c: c});
+
+        g.removeControl('c');
+
+        expect(c.parent).toBe(null);
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?


When a control is removed from a `FormGroup` (`removeControl`), or replaced by another control (`setControl`), that control's parent is not cleared, i.e. the removed control continues to reference the old parent.

Issue Number: #29517 


## What is the new behavior?

When a control is removed or replaced, its `parent` is set to `null`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


If you were relying on the removed/replaced controls to retain the old parent reference, this would be a breaking change. This kind of usage seems like a hack, but to get it working, one could store the old parent reference prior to calling `removeControl`/`setControl` or in an overridden `setParent` method.


## Other information

Docs for the new `unregisterControl` method have been added in the code file (forms/model.ts).