### PR TITLE
refactor: change error message

### DIFF
--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -173,10 +173,10 @@ Options:
 
         --rootDir <dir>                 Specify the root directory of input files
 
-        --useAngularTagRules <boolean>  Whether the Angular specific tag rules should be used.                                        
+        --useAngularTagRules <boolean>  Whether the Angular specific tag rules should be used.
         --stripExportPattern <regexp>   Do not output exports matching the pattern
         --allowModuleIdentifiers <identifier>
-                                        Whitelist identifier for "* as foo" imports`);
+                                        Allow identifier for "* as foo" imports`);
   process.exit(error ? 1 : 0);
 }
 

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -38,14 +38,14 @@ export interface SerializationOptions {
    */
   stripExportPattern?: RegExp|RegExp[];
   /**
-   * Whitelists these identifiers as modules in the output. For example,
+   * Allows these identifiers as modules in the output. For example,
    * ```
    * import * as angular from './angularjs';
    *
    * export class Foo extends angular.Bar {}
    * ```
-   * will produce `export class Foo extends angular.Bar {}` and requires
-   * whitelisting angular.
+   * will produce `export class Foo extends angular.Bar {}` and requires explicitly allowing
+   * `angular` as a module identifier.
    */
   allowModuleIdentifiers?: string[];
 
@@ -242,7 +242,7 @@ class ResolvedDeclarationEmitter {
           message: createErrorMessage(
               firstQualifier,
               `Module identifier "${firstQualifier.text}" is not allowed. Remove it ` +
-                  `from source or whitelist it via --allowModuleIdentifiers.`)
+                  `from source or allow it via --allowModuleIdentifiers.`)
         });
       }
     }

--- a/tools/ts-api-guardian/test/unit_test.ts
+++ b/tools/ts-api-guardian/test/unit_test.ts
@@ -357,28 +357,32 @@ describe('unit test', () => {
     check({'file.d.ts': input}, expected, {stripExportPattern: /^__.*/});
   });
 
-  it('should throw on using non-whitelisted module imports in expression position', () => {
-    const input = `
+  it('should throw on using module imports in expression position that were not explicitly allowed',
+     () => {
+       const input = `
       import * as foo from './foo';
       export declare class A extends foo.A {
       }
     `;
-    checkThrows(
-        {'file.d.ts': input}, 'file.d.ts(2,32): error: Module identifier "foo" is not allowed. ' +
-            'Remove it from source or whitelist it via --allowModuleIdentifiers.');
-  });
+       checkThrows(
+           {'file.d.ts': input},
+           'file.d.ts(2,32): error: Module identifier "foo" is not allowed. ' +
+               'Remove it from source or allow it via --allowModuleIdentifiers.');
+     });
 
-  it('should throw on using non-whitelisted module imports in type position', () => {
-    const input = `
+  it('should throw on using module imports in type position that were not explicitly allowed',
+     () => {
+       const input = `
       import * as foo from './foo';
       export type A = foo.A;
     `;
-    checkThrows(
-        {'file.d.ts': input}, 'file.d.ts(2,17): error: Module identifier "foo" is not allowed. ' +
-            'Remove it from source or whitelist it via --allowModuleIdentifiers.');
-  });
+       checkThrows(
+           {'file.d.ts': input},
+           'file.d.ts(2,17): error: Module identifier "foo" is not allowed. ' +
+               'Remove it from source or allow it via --allowModuleIdentifiers.');
+     });
 
-  it('should not throw on using whitelisted module imports', () => {
+  it('should not throw on using explicitly allowed module imports', () => {
     const input = `
       import * as foo from './foo';
       export declare class A extends foo.A {
@@ -391,7 +395,7 @@ describe('unit test', () => {
     check({'file.d.ts': input}, expected, {allowModuleIdentifiers: ['foo']});
   });
 
-  it('should not throw if non-whitelisted module imports are not written', () => {
+  it('should not throw if module imports, that were not explicitly allowed, are not used', () => {
     const input = `
       import * as foo from './foo';
       export declare class A {


### PR DESCRIPTION
Removes usage of whitelist from error messages, comments and test descriptions in ts_api_guardian

Related to #28529
