### PR TITLE
feat(ivy): emit module scope metadata using pure function call

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 212976,
+        "main": 155609,
         "polyfills": 43567
       }
     }

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -486,16 +486,15 @@ export function renderDefinitions(
   const name = compiledClass.declaration.name;
   const translate = (stmt: Statement) =>
       translateStatement(stmt, imports, NOOP_DEFAULT_IMPORT_RECORDER);
-  const definitions =
-      compiledClass.compilation
-          .map(
-              c => c.statements.map(statement => translate(statement))
-                       .concat(translate(createAssignmentStatement(name, c.name, c.initializer)))
-                       .map(
-                           statement =>
-                               printer.printNode(ts.EmitHint.Unspecified, statement, sourceFile))
-                       .join('\n'))
-          .join('\n');
+  const print = (stmt: Statement) =>
+      printer.printNode(ts.EmitHint.Unspecified, translate(stmt), sourceFile);
+  const definitions = compiledClass.compilation
+                          .map(
+                              c => [createAssignmentStatement(name, c.name, c.initializer)]
+                                       .concat(c.statements)
+                                       .map(print)
+                                       .join('\n'))
+                          .join('\n');
   return definitions;
 }
 

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -147,16 +147,17 @@ describe('Renderer', () => {
           moduleWithProvidersAnalyses);
       const addDefinitionsSpy = renderer.addDefinitions as jasmine.Spy;
       expect(addDefinitionsSpy.calls.first().args[2])
-          .toEqual(`/*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
-        type: Component,
-        args: [{ selector: 'a', template: '{{ person!.name }}' }]
-    }], null, null);
-A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
+          .toEqual(
+              `A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵtext(0);
     } if (rf & 2) {
         ɵngcc0.ɵselect(0);
         ɵngcc0.ɵtextBinding(0, ɵngcc0.ɵinterpolation1("", ctx.person.name, ""));
-    } }, encapsulation: 2 });`);
+    } }, encapsulation: 2 });
+/*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
+        type: Component,
+        args: [{ selector: 'a', template: '{{ person!.name }}' }]
+    }], null, null);`);
     });
 
 
@@ -191,11 +192,12 @@ A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], fact
              decorators: [jasmine.objectContaining({name: 'Directive'})],
            }));
            expect(addDefinitionsSpy.calls.first().args[2])
-               .toEqual(`/*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
+               .toEqual(
+                   `A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });
+/*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Directive,
         args: [{ selector: '[a]' }]
-    }], null, { foo: [] });
-A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });`);
+    }], null, { foo: [] });`);
          });
 
       it('should call removeDecorators with the source code, a map of class decorators that have been analyzed',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -158,10 +158,8 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
       schemas: [],
     };
 
-    const providers: Expression = ngModule.has('providers') ?
-        new WrappedNodeExpr(ngModule.get('providers') !) :
-        new LiteralArrayExpr([]);
     const rawProviders = ngModule.has('providers') ? ngModule.get('providers') ! : null;
+    const providers = rawProviders !== null ? new WrappedNodeExpr(rawProviders) : null;
 
     // At this point, only add the module's imports as the injectors' imports. Any exported modules
     // are added during `resolve`, as we need scope information to be able to filter out directives

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -14,7 +14,7 @@ import {DefaultImportRecorder, Reference, ReferenceEmitter} from '../../imports'
 import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
 import {NgModuleRouteAnalyzer} from '../../routing';
-import {LocalModuleScopeRegistry} from '../../scope';
+import {LocalModuleScopeRegistry, ScopeData} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence, ResolveResult} from '../../transform';
 import {getSourceFile} from '../../util/src/typescript';
 
@@ -27,6 +27,7 @@ export interface NgModuleAnalysis {
   ngInjectorDef: R3InjectorMetadata;
   metadataStmt: Statement|null;
   declarations: Reference<ClassDeclaration>[];
+  exports: Reference<ClassDeclaration>[];
 }
 
 /**
@@ -162,12 +163,12 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
         new LiteralArrayExpr([]);
     const rawProviders = ngModule.has('providers') ? ngModule.get('providers') ! : null;
 
+    // At this point, only add the module's imports as the injectors' imports. Any exported modules
+    // are added during `resolve`, as we need scope information to be able to filter out directives
+    // and pipes from the module exports.
     const injectorImports: WrappedNodeExpr<ts.Expression>[] = [];
     if (ngModule.has('imports')) {
       injectorImports.push(new WrappedNodeExpr(ngModule.get('imports') !));
-    }
-    if (ngModule.has('exports')) {
-      injectorImports.push(new WrappedNodeExpr(ngModule.get('exports') !));
     }
 
     if (this.routeAnalyzer !== null) {
@@ -180,7 +181,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
       deps: getValidConstructorDependencies(
           node, this.reflector, this.defaultImportRecorder, this.isCore),
       providers,
-      imports: new LiteralArrayExpr(injectorImports),
+      imports: injectorImports,
     };
 
     return {
@@ -188,6 +189,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
         ngModuleDef,
         ngInjectorDef,
         declarations: declarationRefs,
+        exports: exportRefs,
         metadataStmt: generateSetClassMetadataCall(
             node, this.reflector, this.defaultImportRecorder, this.isCore),
       },
@@ -198,6 +200,18 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
   resolve(node: ClassDeclaration, analysis: NgModuleAnalysis): ResolveResult {
     const scope = this.scopeRegistry.getScopeOfModule(node);
     const diagnostics = this.scopeRegistry.getDiagnosticsOfModule(node) || undefined;
+
+    // Using the scope information, extend the injector's imports using the modules that are
+    // specified as module exports.
+    if (scope !== null) {
+      const context = getSourceFile(node);
+      for (const exportRef of analysis.exports) {
+        if (isNgModule(exportRef.node, scope.compilation)) {
+          analysis.ngInjectorDef.imports.push(this.refEmitter.emit(exportRef, context));
+        }
+      }
+    }
+
     if (scope === null || scope.reexports === null) {
       return {diagnostics};
     } else {
@@ -385,6 +399,11 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
 
     return refList;
   }
+}
+
+function isNgModule(node: ClassDeclaration, compilation: ScopeData): boolean {
+  return !compilation.directives.some(directive => directive.ref.node === node) &&
+      !compilation.pipes.some(pipe => pipe.ref.node === node);
 }
 
 function isDeclarationReference(ref: any): ref is Reference<ts.Declaration> {

--- a/packages/compiler-cli/src/ngtsc/imports/src/core.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/core.ts
@@ -51,6 +51,7 @@ const CORE_SUPPORTED_SYMBOLS = new Map<string, string>([
   ['defineInjectable', 'defineInjectable'],
   ['defineInjector', 'defineInjector'],
   ['ɵdefineNgModule', 'defineNgModule'],
+  ['ɵsetNgModuleScope', 'setNgModuleScope'],
   ['inject', 'inject'],
   ['ɵsetClassMetadata', 'setClassMetadata'],
   ['ɵInjectableDef', 'InjectableDef'],

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -442,10 +442,9 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
+    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule, bootstrap: [TestCmp] });');
     expect(jsContents)
-        .toContain(
-            'i0.ɵdefineNgModule({ type: TestModule, bootstrap: [TestCmp], ' +
-            'declarations: [TestCmp] })');
+        .toContain('/*@__PURE__*/ i0.ɵsetNgModuleScope(TestModule, { declarations: [TestCmp] });');
 
     const dtsContents = env.getContents('test.d.ts');
     expect(dtsContents)
@@ -455,6 +454,22 @@ describe('ngtsc behavioral tests', () => {
         .toContain(
             'static ngModuleDef: i0.ɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], never, never>');
     expect(dtsContents).not.toContain('__decorate');
+  });
+
+  it('should not emit a setNgModuleScope call when no scope metadata is present', () => {
+    env.tsconfig();
+    env.write('test.ts', `
+        import {NgModule} from '@angular/core';
+
+        @NgModule({})
+        export class TestModule {}
+    `);
+
+    env.driveMain();
+
+    const jsContents = env.getContents('test.js');
+    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
+    expect(jsContents).not.toContain('ɵsetNgModuleScope(TestModule,');
   });
 
   it('should compile NgModules with services without errors', () => {
@@ -484,7 +499,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule,');
+    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
     expect(jsContents)
         .toContain(
             `TestModule.ngInjectorDef = i0.defineInjector({ factory: ` +
@@ -525,7 +540,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule,');
+    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
     expect(jsContents)
         .toContain(
             `TestModule.ngInjectorDef = i0.defineInjector({ factory: ` +
@@ -570,7 +585,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule,');
+    expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
     expect(jsContents)
         .toContain(
             `TestModule.ngInjectorDef = i0.defineInjector({ factory: ` +

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -445,6 +445,10 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule, bootstrap: [TestCmp] });');
     expect(jsContents)
         .toContain('/*@__PURE__*/ i0.ɵsetNgModuleScope(TestModule, { declarations: [TestCmp] });');
+    expect(jsContents)
+        .toContain(
+            'i0.defineInjector({ factory: ' +
+            'function TestModule_Factory(t) { return new (t || TestModule)(); } });');
 
     const dtsContents = env.getContents('test.d.ts');
     expect(dtsContents)
@@ -528,8 +532,8 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents)
         .toContain(
             'i0.defineInjector({ factory: function TestModule_Factory(t) ' +
-            '{ return new (t || TestModule)(); }, providers: [], ' +
-            'imports: [[OtherModule, RouterModule.forRoot()],\n            OtherModule,\n            RouterModule] });');
+            '{ return new (t || TestModule)(); }, imports: [[OtherModule, RouterModule.forRoot()],' +
+            '\n            OtherModule,\n            RouterModule] });');
   });
 
   it('should compile NgModules with services without errors', () => {

--- a/packages/compiler-cli/test/ngtsc/scope_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/scope_spec.ts
@@ -21,6 +21,32 @@ describe('ngtsc module scopes', () => {
 
   describe('diagnostics', () => {
     describe('imports', () => {
+      it('should emit imports in a pure function call', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+  
+          @NgModule({})
+          export class OtherModule {}
+  
+          @NgModule({imports: [OtherModule]})
+          export class TestModule {}
+        `);
+
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
+        expect(jsContents)
+            .toContain(
+                '/*@__PURE__*/ i0.ɵsetNgModuleScope(TestModule, { imports: [OtherModule] });');
+
+        const dtsContents = env.getContents('test.d.ts');
+        expect(dtsContents)
+            .toContain(
+                'static ngModuleDef: i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof OtherModule], never>');
+      });
+
       it('should produce an error when an invalid class is imported', () => {
         env.write('test.ts', `
           import {NgModule} from '@angular/core';
@@ -57,6 +83,32 @@ describe('ngtsc module scopes', () => {
     });
 
     describe('exports', () => {
+      it('should emit exports in a pure function call', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+  
+          @NgModule({})
+          export class OtherModule {}
+  
+          @NgModule({exports: [OtherModule]})
+          export class TestModule {}
+        `);
+
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(jsContents).toContain('i0.ɵdefineNgModule({ type: TestModule });');
+        expect(jsContents)
+            .toContain(
+                '/*@__PURE__*/ i0.ɵsetNgModuleScope(TestModule, { exports: [OtherModule] });');
+
+        const dtsContents = env.getContents('test.d.ts');
+        expect(dtsContents)
+            .toContain(
+                'static ngModuleDef: i0.ɵNgModuleDefWithMeta<TestModule, never, never, [typeof OtherModule]>');
+      });
+
       it('should produce an error when a non-NgModule class is exported', () => {
         env.write('test.ts', `
           import {NgModule} from '@angular/core';

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -110,8 +110,8 @@ export interface R3InjectorMetadataFacade {
   name: string;
   type: any;
   deps: R3DependencyMetadataFacade[]|null;
-  providers: any;
-  imports: any;
+  providers: any[];
+  imports: any[];
 }
 
 export interface R3DirectiveMetadataFacade {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -73,7 +73,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       type: new WrappedNodeExpr(facade.type),
       deps: convertR3DependencyMetadataArray(facade.deps),
       providers: new WrappedNodeExpr(facade.providers),
-      imports: new WrappedNodeExpr(facade.imports),
+      imports: facade.imports.map(i => new WrappedNodeExpr(i)),
     };
     const res = compileInjector(meta);
     return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, res.statements);

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -195,6 +195,7 @@ export class Identifiers {
   };
 
   static defineNgModule: o.ExternalReference = {name: 'ɵdefineNgModule', moduleName: CORE};
+  static setNgModuleScope: o.ExternalReference = {name: 'ɵsetNgModuleScope', moduleName: CORE};
 
   static PipeDefWithMeta: o.ExternalReference = {name: 'ɵPipeDefWithMeta', moduleName: CORE};
 

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -190,7 +190,7 @@ export interface R3InjectorMetadata {
   name: string;
   type: o.Expression;
   deps: R3DependencyMetadata[]|null;
-  providers: o.Expression;
+  providers: o.Expression|null;
   imports: o.Expression[];
 }
 
@@ -201,11 +201,19 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
     deps: meta.deps,
     injectFn: R3.inject,
   });
-  const expression = o.importExpr(R3.defineInjector).callFn([mapToMapExpression({
+  const definitionMap = {
     factory: result.factory,
-    providers: meta.providers,
-    imports: o.literalArr(meta.imports),
-  })]);
+  } as{factory: o.Expression, providers: o.Expression, imports: o.Expression};
+
+  if (meta.providers !== null) {
+    definitionMap.providers = meta.providers;
+  }
+
+  if (meta.imports.length > 0) {
+    definitionMap.imports = o.literalArr(meta.imports);
+  }
+
+  const expression = o.importExpr(R3.defineInjector).callFn([mapToMapExpression(definitionMap)]);
   const type =
       new o.ExpressionType(o.importExpr(R3.InjectorDef, [new o.ExpressionType(meta.type)]));
   return {expression, type, statements: result.statements};

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -80,9 +80,11 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
     imports,
     exports,
     schemas,
-    containsForwardDecls
+    containsForwardDecls,
+    emitInline
   } = meta;
 
+  const additionalStatements: o.Statement[] = [];
   const definitionMap = {
     type: moduleType
   } as{
@@ -99,16 +101,29 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
     definitionMap.bootstrap = refsToArray(bootstrap, containsForwardDecls);
   }
 
-  if (declarations.length) {
-    definitionMap.declarations = refsToArray(declarations, containsForwardDecls);
+  // If requested to emit scope information inline, pass the declarations, imports and exports to
+  // the `defineNgModule` call. The JIT compilation uses this.
+  if (emitInline) {
+    if (declarations.length) {
+      definitionMap.declarations = refsToArray(declarations, containsForwardDecls);
+    }
+
+    if (imports.length) {
+      definitionMap.imports = refsToArray(imports, containsForwardDecls);
+    }
+
+    if (exports.length) {
+      definitionMap.exports = refsToArray(exports, containsForwardDecls);
+    }
   }
 
-  if (imports.length) {
-    definitionMap.imports = refsToArray(imports, containsForwardDecls);
-  }
-
-  if (exports.length) {
-    definitionMap.exports = refsToArray(exports, containsForwardDecls);
+  // If not emitting inline, the scope information is not passed into `defineNgModule` as it would
+  // prevent tree-shaking of the declarations, imports and exports references.
+  else {
+    const setNgModuleScopeCall = generateSetNgModuleScopeCall(meta);
+    if (setNgModuleScopeCall !== null) {
+      additionalStatements.push(setNgModuleScopeCall);
+    }
   }
 
   if (schemas && schemas.length) {
@@ -121,8 +136,48 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
     tupleTypeOf(exports)
   ]));
 
-  const additionalStatements: o.Statement[] = [];
+
   return {expression, type, additionalStatements};
+}
+
+/**
+ * Generates a function call to `setNgModuleScope` with all necessary information so that the
+ * transitive module scope can be computed during runtime in JIT mode. This call is marked pure
+ * such that the references to declarations, imports and exports may be elided causing these
+ * symbols to become tree-shakeable.
+ */
+function generateSetNgModuleScopeCall(meta: R3NgModuleMetadata): o.Statement|null {
+  const {type: moduleType, declarations, imports, exports, containsForwardDecls} = meta;
+
+  const scopeMap = {} as{
+    declarations: o.Expression,
+    imports: o.Expression,
+    exports: o.Expression,
+  };
+
+  if (declarations.length) {
+    scopeMap.declarations = refsToArray(declarations, containsForwardDecls);
+  }
+
+  if (imports.length) {
+    scopeMap.imports = refsToArray(imports, containsForwardDecls);
+  }
+
+  if (exports.length) {
+    scopeMap.exports = refsToArray(exports, containsForwardDecls);
+  }
+
+  if (Object.keys(scopeMap).length === 0) {
+    return null;
+  }
+
+  const fnCall = new o.InvokeFunctionExpr(
+      /* fn */ o.importExpr(R3.setNgModuleScope),
+      /* args */[moduleType, mapToMapExpression(scopeMap)],
+      /* type */ undefined,
+      /* sourceSpan */ undefined,
+      /* pure */ true);
+  return fnCall.toStmt();
 }
 
 export interface R3InjectorDef {

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -191,7 +191,7 @@ export interface R3InjectorMetadata {
   type: o.Expression;
   deps: R3DependencyMetadata[]|null;
   providers: o.Expression;
-  imports: o.Expression;
+  imports: o.Expression[];
 }
 
 export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
@@ -204,7 +204,7 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
   const expression = o.importExpr(R3.defineInjector).callFn([mapToMapExpression({
     factory: result.factory,
     providers: meta.providers,
-    imports: meta.imports,
+    imports: o.literalArr(meta.imports),
   })]);
   const type =
       new o.ExpressionType(o.importExpr(R3.InjectorDef, [new o.ExpressionType(meta.type)]));

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -26,6 +26,7 @@ export {
   getFactoryOf as ɵgetFactoryOf,
   getInheritedFactory as ɵgetInheritedFactory,
   setComponentScope as ɵsetComponentScope,
+  setNgModuleScope as ɵsetNgModuleScope,
   templateRefExtractor as ɵtemplateRefExtractor,
   ProvidersFeature as ɵProvidersFeature,
   InheritDefinitionFeature as ɵInheritDefinitionFeature,

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -327,7 +327,28 @@ export function extractPipeDef(type: PipeType<any>): PipeDef<any> {
   return def !;
 }
 
-export function defineNgModule<T>(def: {type: T} & Partial<NgModuleDef<T>>): never {
+export function defineNgModule<T>(def: {
+  /** Token representing the module. Used by DI. */
+  type: T;
+
+  /** List of components to bootstrap. */
+  bootstrap?: Type<any>[] | (() => Type<any>[]);
+
+  /** List of components, directives, and pipes declared by this module. */
+  declarations?: Type<any>[] | (() => Type<any>[]);
+
+  /** List of modules or `ModuleWithProviders` imported by this module. */
+  imports?: Type<any>[] | (() => Type<any>[]);
+
+  /**
+   * List of modules, `ModuleWithProviders`, components, directives, or pipes exported by this
+   * module.
+   */
+  exports?: Type<any>[] | (() => Type<any>[]);
+
+  /** The set of schemas that declare elements to be allowed in the NgModule. */
+  schemas?: SchemaMetadata[] | null;
+}): never {
   const res: NgModuleDef<T> = {
     type: def.type,
     bootstrap: def.bootstrap || EMPTY_ARRAY,
@@ -338,6 +359,33 @@ export function defineNgModule<T>(def: {type: T} & Partial<NgModuleDef<T>>): nev
     schemas: def.schemas || null,
   };
   return res as never;
+}
+
+/**
+ * Adds the module metadata that is necessary to compute the module's transitive scope to an
+ * existing module definition.
+ *
+ * Scope metadata of modules is not used in production builds, so calls to this function can be
+ * marked pure to tree-shake it from the bundle, allowing for all referenced declarations
+ * to become eligible for tree-shaking as well.
+ */
+export function setNgModuleScope(type: any, scope: {
+  /** List of components, directives, and pipes declared by this module. */
+  declarations?: Type<any>[] | (() => Type<any>[]);
+
+  /** List of modules or `ModuleWithProviders` imported by this module. */
+  imports?: Type<any>[] | (() => Type<any>[]);
+
+  /**
+   * List of modules, `ModuleWithProviders`, components, directives, or pipes exported by this
+   * module.
+   */
+  exports?: Type<any>[] | (() => Type<any>[]);
+}): void {
+  const ngModuleDef = getNgModuleDef(type, true);
+  ngModuleDef.declarations = scope.declarations || EMPTY_ARRAY;
+  ngModuleDef.imports = scope.imports || EMPTY_ARRAY;
+  ngModuleDef.exports = scope.exports || EMPTY_ARRAY;
 }
 
 /**

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {LifecycleHooksFeature, renderComponent, whenRendered} from './component';
-import {defineBase, defineComponent, defineDirective, defineNgModule, definePipe, setComponentScope} from './definition';
+import {defineBase, defineComponent, defineDirective, defineNgModule, definePipe, setComponentScope, setNgModuleScope} from './definition';
 import {InheritDefinitionFeature} from './features/inherit_definition_feature';
 import {NgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ProvidersFeature} from './features/providers_feature';
@@ -186,6 +186,7 @@ export {
   getRenderedText,
   renderComponent,
   setComponentScope,
+  setNgModuleScope,
   whenRendered,
 };
 

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -121,6 +121,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵresolveDocument': r3.resolveDocument,
   'ɵresolveBody': r3.resolveBody,
   'ɵsetComponentScope': r3.setComponentScope,
+  'ɵsetNgModuleScope': r3.setNgModuleScope,
 
   'ɵsanitizeHtml': sanitization.sanitizeHtml,
   'ɵsanitizeStyle': sanitization.sanitizeStyle,


### PR DESCRIPTION
Prior to this change, all module metadata would be included in the
`defineNgModule` call that is set as the `ngModuleDef` field of module
types. Part of the metadata is scope information like declarations,
imports and exports that is used for computing the transitive module
scope in JIT environments, preventing those references from being
tree-shaken for production builds.

This change moves the metadata for scope computations to a pure function
call that patches the scope references onto the module type. Because the
function is marked pure, it may be tree-shaken out during production builds
such that references to declarations and exports are dropped, which in turn
allows for tree-shaken any declaration that is not otherwise referenced.

Fixes #28077, FW-1035

<hr>

**feat(ivy): exclude declarations from injector imports**
Prior to this change, a module's imports and exports would be used verbatim
as an injectors' imports. This is detrimental for tree-shaking, as a
module's exports could reference declarations that would then prevent such
declarations from being eligible for tree-shaking.

Since an injector actually only needs NgModule references as its imports,
we may safely filter out any declarations from the list of module exports.
This makes them eligible for tree-shaking once again.

<hr>

**feat(ivy): do not emit empty providers/imports for defineInjector**
The defineInjector function specifies its providers and imports array to
be optional, so if no providers/imports are present these keys may be
omitted. This commit updates the compiler to only generate the keys when
necessary.