### PR TITLE
fix(ivy): ensure parent/sub-class components evaluate styling correctly

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 14106,
+        "main": 14287,
         "polyfills": 43567
       }
     }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -23,7 +23,7 @@ import {PlayerHandler} from './interfaces/player';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {CONTEXT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, RENDERER, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
 import {applyOnCreateInstructions} from './node_util';
-import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState} from './state';
+import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState, setActiveHostElement} from './state';
 import {renderInitialClasses, renderInitialStyles} from './styling/class_and_style_bindings';
 import {publishDefaultGlobalUtils} from './util/global_utils';
 import {defaultScheduler, renderStringify} from './util/misc_utils';
@@ -210,10 +210,15 @@ export function createRootComponent<T>(
 
   const rootTNode = getPreviousOrParentTNode();
   if (tView.firstTemplatePass && componentDef.hostBindings) {
+    const elementIndex = rootTNode.index - HEADER_OFFSET;
+    setActiveHostElement(elementIndex);
+
     const expando = tView.expandoInstructions !;
     invokeHostBindingsInCreationMode(
         componentDef, expando, component, rootTNode, tView.firstTemplatePass);
     rootTNode.onElementCreationFns && applyOnCreateInstructions(rootTNode);
+
+    setActiveHostElement(null);
   }
 
   if (rootTNode.stylingTemplate) {

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -10,7 +10,7 @@ import {Type} from '../../interface/type';
 import {fillProperties} from '../../util/property';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
 import {ComponentDef, DirectiveDef, DirectiveDefFeature, RenderFlags} from '../interfaces/definition';
-import {setActiveDirectiveSuperClassDepthPosition} from '../state';
+import {adjustActiveDirectiveSuperClassDepthPosition} from '../state';
 import {isComponentDef} from '../util/view_utils';
 
 import {NgOnChangesFeature} from './ng_onchanges_feature';
@@ -76,11 +76,11 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
             // The reason why we increment first and then decrement is so that parent
             // hostBindings calls have a higher id value compared to sub-class hostBindings
             // calls (this way the leaf directive is always at a super-class depth of 0).
-            setActiveDirectiveSuperClassDepthPosition(1);
+            adjustActiveDirectiveSuperClassDepthPosition(1);
             try {
               superHostBindings(rf, ctx, elementIndex);
             } finally {
-              setActiveDirectiveSuperClassDepthPosition(-1);
+              adjustActiveDirectiveSuperClassDepthPosition(-1);
             }
             prevHostBindings(rf, ctx, elementIndex);
           };

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -10,6 +10,7 @@ import {Type} from '../../interface/type';
 import {fillProperties} from '../../util/property';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
 import {ComponentDef, DirectiveDef, DirectiveDefFeature, RenderFlags} from '../interfaces/definition';
+import {setActiveDirectiveSuperClassDepthPosition} from '../state';
 import {isComponentDef} from '../util/view_utils';
 
 import {NgOnChangesFeature} from './ng_onchanges_feature';
@@ -63,8 +64,24 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
       const superHostBindings = superDef.hostBindings;
       if (superHostBindings) {
         if (prevHostBindings) {
+          // because inheritance is unknown during compile time, the runtime code
+          // needs to be informed of the super-class depth so that instruction code
+          // can distinguish one host bindings function from another. The reason why
+          // relying on the directive uniqueId exclusively is not enough is because the
+          // uniqueId value and the directive instance stay the same between hostBindings
+          // calls throughout the directive inheritance chain. This means that without
+          // a super-class depth value, there is no way to know whether a parent or
+          // sub-class host bindings function is currently being executed.
           definition.hostBindings = (rf: RenderFlags, ctx: any, elementIndex: number) => {
-            superHostBindings(rf, ctx, elementIndex);
+            // The reason why we increment first and then decrement is so that parent
+            // hostBindings calls have a higher id value compared to sub-class hostBindings
+            // calls (this way the leaf directive is always at a super-class depth of 0).
+            setActiveDirectiveSuperClassDepthPosition(1);
+            try {
+              superHostBindings(rf, ctx, elementIndex);
+            } finally {
+              setActiveDirectiveSuperClassDepthPosition(-1);
+            }
             prevHostBindings(rf, ctx, elementIndex);
           };
         } else {

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -13,6 +13,7 @@ import {TAttributes, TNodeType} from '../interfaces/node';
 import {BINDING_INDEX, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
+import {applyOnCreateInstructions} from '../node_util';
 import {getIsParent, getLView, getPreviousOrParentTNode, setIsParent, setPreviousOrParentTNode} from '../state';
 import {createDirectivesAndLocals, createNodeAtIndex, executeContentQueries, setNodeStylingTemplate} from './shared';
 
@@ -82,6 +83,10 @@ export function elementContainerEnd(): void {
   if (currentQueries) {
     lView[QUERIES] = currentQueries.parent;
   }
+
+  // this is required for all host-level styling-related instructions to run
+  // in the correct order
+  previousOrParentTNode.onElementCreationFns && applyOnCreateInstructions(previousOrParentTNode);
 
   registerPostOrderHooks(tView, previousOrParentTNode);
 }

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -129,7 +129,27 @@ export function getLView(): LView {
 const MIN_DIRECTIVE_ID = 1;
 
 let activeDirectiveId = MIN_DIRECTIVE_ID;
+
+/**
+ * Position depth (with respect from leaf to root) in a directive sub-class inheritance chain.
+ */
 let activeDirectiveSuperClassDepthPosition = 0;
+
+/**
+ * Total count of how many directives are a part of an inheritance chain.
+ *
+ * When directives are sub-classed (extended) from one to another, Angular
+ * needs to keep track of exactly how many were encountered so it can accurately
+ * generate the next directive id (once the next directive id is visited).
+ * Normally the next directive id just a single incremented value from the
+ * previous one, however, if the previous directive is a part of an inheritance
+ * chain (a series of sub-classed directives) then the incremented value must
+ * also take into account the total amount of sub-classed values.
+ *
+ * Note that this value resets back to zero once the next directive is
+ * visited (when `incrementActiveDirectiveId` or `setActiveHostElement`
+ * is called).
+ */
 let activeDirectiveSuperClassHeight = 0;
 
 /**
@@ -212,6 +232,10 @@ export function incrementActiveDirectiveId() {
  */
 export function adjustActiveDirectiveSuperClassDepthPosition(delta: number) {
   activeDirectiveSuperClassDepthPosition += delta;
+
+  // we keep track of the height value so that when the next directive is visited
+  // then Angular knows to generate a new directive id value which has taken into
+  // account how many sub-class directives were a part of the previous directive.
   activeDirectiveSuperClassHeight =
       Math.max(activeDirectiveSuperClassHeight, activeDirectiveSuperClassDepthPosition);
 }

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -210,7 +210,7 @@ export function incrementActiveDirectiveId() {
  *
  * Note that this is only active when `hostBinding` functions are being processed.
  */
-export function setActiveDirectiveSuperClassDepthPosition(delta: number) {
+export function adjustActiveDirectiveSuperClassDepthPosition(delta: number) {
   activeDirectiveSuperClassDepthPosition += delta;
   activeDirectiveSuperClassHeight =
       Math.max(activeDirectiveSuperClassHeight, activeDirectiveSuperClassDepthPosition);

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -119,27 +119,115 @@ export function getLView(): LView {
   return lView;
 }
 
-let activeHostContext: {}|null = null;
-let activeHostElementIndex: number|null = null;
+/**
+ * Used as the starting directive id value.
+ *
+ * All subsequent directives are incremented from this value onwards.
+ * The reason why this value is `1` instead of `0` is because the `0`
+ * value is reserved for the template.
+ */
+const MIN_DIRECTIVE_ID = 1;
+
+let activeDirectiveId = MIN_DIRECTIVE_ID;
+let activeDirectiveSuperClassDepthPosition = 0;
+let activeDirectiveSuperClassHeight = 0;
 
 /**
- * Sets the active host context (the directive/component instance) and its host element index.
+ * Sets the active directive host element and resets the directive id value
+ * (when the provided elementIndex value has changed).
  *
- * @param host the directive/component instance
- * @param index the element index value for the host element where the directive/component instance
- * lives
+ * @param elementIndex the element index value for the host element where
+ *                     the directive/component instance lives
  */
-export function setActiveHost(host: {} | null, index: number | null = null) {
-  activeHostContext = host;
-  activeHostElementIndex = index;
+export function setActiveHostElement(elementIndex: number | null = null) {
+  if (_selectedIndex !== elementIndex) {
+    setSelectedIndex(elementIndex == null ? -1 : elementIndex);
+    activeDirectiveId = MIN_DIRECTIVE_ID;
+    activeDirectiveSuperClassDepthPosition = 0;
+    activeDirectiveSuperClassHeight = 0;
+  }
 }
 
-export function getActiveHostContext() {
-  return activeHostContext;
+/**
+ * Returns the current id value of the current directive.
+ *
+ * For example we have an element that has two directives on it:
+ * <div dir-one dir-two></div>
+ *
+ * dirOne->hostBindings() (id == 1)
+ * dirTwo->hostBindings() (id == 2)
+ *
+ * Note that this is only active when `hostBinding` functions are being processed.
+ *
+ * Note that directive id values are specific to an element (this means that
+ * the same id value could be present on another element with a completely
+ * different set of directives).
+ */
+export function getActiveDirectiveId() {
+  return activeDirectiveId;
 }
 
-export function getActiveHostElementIndex() {
-  return activeHostElementIndex;
+/**
+ * Increments the current directive id value.
+ *
+ * For example we have an element that has two directives on it:
+ * <div dir-one dir-two></div>
+ *
+ * dirOne->hostBindings() (index = 1)
+ * // increment
+ * dirTwo->hostBindings() (index = 2)
+ *
+ * Depending on whether or not a previous directive had any inherited
+ * directives present, that value will be incremented in addition
+ * to the id jumping up by one.
+ *
+ * Note that this is only active when `hostBinding` functions are being processed.
+ *
+ * Note that directive id values are specific to an element (this means that
+ * the same id value could be present on another element with a completely
+ * different set of directives).
+ */
+export function incrementActiveDirectiveId() {
+  activeDirectiveId += 1 + activeDirectiveSuperClassHeight;
+
+  // because we are dealing with a new directive this
+  // means we have exited out of the inheritance chain
+  activeDirectiveSuperClassDepthPosition = 0;
+  activeDirectiveSuperClassHeight = 0;
+}
+
+/**
+ * Set the current super class (reverse inheritance) position depth for a directive.
+ *
+ * For example we have two directives: Child and Other (but Child is a sub-class of Parent)
+ * <div child-dir other-dir></div>
+ *
+ * // increment
+ * parentInstance->hostBindings() (depth = 1)
+ * // decrement
+ * childInstance->hostBindings() (depth = 0)
+ * otherInstance->hostBindings() (depth = 0 b/c it's a different directive)
+ *
+ * Note that this is only active when `hostBinding` functions are being processed.
+ */
+export function setActiveDirectiveSuperClassDepthPosition(delta: number) {
+  activeDirectiveSuperClassDepthPosition += delta;
+  activeDirectiveSuperClassHeight =
+      Math.max(activeDirectiveSuperClassHeight, activeDirectiveSuperClassDepthPosition);
+}
+
+/**
+ * Returns the current super class (reverse inheritance) depth for a directive.
+ *
+ * This is designed to help instruction code distinguish different hostBindings
+ * calls from each other when a directive has extended from another directive.
+ * Normally using the directive id value is enough, but with the case
+ * of parent/sub-class directive inheritance more information is required.
+ *
+ * Note that this is only active when `hostBinding` functions are being processed.
+ */
+export function getActiveDirectiveSuperClassDepth() {
+  return activeDirectiveSuperClassDepthPosition;
 }
 
 /**

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -10,14 +10,14 @@ import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
 import {AttributeMarker, TAttributes} from '../interfaces/node';
 import {BindingStore, BindingType, Player, PlayerBuilder, PlayerFactory, PlayerIndex} from '../interfaces/player';
 import {RElement, Renderer3, RendererStyleFlags3, isProceduralRenderer} from '../interfaces/renderer';
-import {DirectiveOwnerAndPlayerBuilderIndex, DirectiveRegistryValues, DirectiveRegistryValuesIndex, InitialStylingValues, InitialStylingValuesIndex, MapBasedOffsetValues, MapBasedOffsetValuesIndex, SinglePropOffsetValues, SinglePropOffsetValuesIndex, StylingContext, StylingFlags, StylingIndex} from '../interfaces/styling';
+import {DirectiveOwnerAndPlayerBuilderIndex, DirectiveRegistryValuesIndex, InitialStylingValues, InitialStylingValuesIndex, MapBasedOffsetValues, MapBasedOffsetValuesIndex, SinglePropOffsetValues, SinglePropOffsetValuesIndex, StylingContext, StylingFlags, StylingIndex} from '../interfaces/styling';
 import {LView, RootContext} from '../interfaces/view';
 import {NO_CHANGE} from '../tokens';
 import {getRootContext} from '../util/view_traversal_utils';
 
+import {allowFlush as allowHostInstructionsQueueFlush, flushQueue as flushHostInstructionsQueue} from './host_instructions_queue';
 import {BoundPlayerFactory} from './player_factory';
-import {addPlayerInternal, allocPlayerContext, allocateDirectiveIntoContext, createEmptyStylingContext, getPlayerContext} from './util';
-
+import {addPlayerInternal, allocPlayerContext, allocateOrUpdateDirectiveIntoContext, createEmptyStylingContext, getPlayerContext} from './util';
 
 
 /**
@@ -42,9 +42,9 @@ import {addPlayerInternal, allocPlayerContext, allocateDirectiveIntoContext, cre
  * Creates a new StylingContext an fills it with the provided static styling attribute values.
  */
 export function initializeStaticContext(
-    attrs: TAttributes, stylingStartIndex: number, directiveRef?: any | null): StylingContext {
+    attrs: TAttributes, stylingStartIndex: number, directiveIndex: number = 0): StylingContext {
   const context = createEmptyStylingContext();
-  patchContextWithStaticAttrs(context, attrs, stylingStartIndex, directiveRef);
+  patchContextWithStaticAttrs(context, attrs, stylingStartIndex, directiveIndex);
   return context;
 }
 
@@ -57,25 +57,14 @@ export function initializeStaticContext(
  *              assigned to the context
  * @param attrsStylingStartIndex what index to start iterating within the
  *              provided `attrs` array to start reading style and class values
- * @param directiveRef the directive instance with which static data is associated with.
  */
 export function patchContextWithStaticAttrs(
     context: StylingContext, attrs: TAttributes, attrsStylingStartIndex: number,
-    directiveRef?: any | null): void {
+    directiveIndex: number): void {
   // this means the context has already been set and instantiated
   if (context[StylingIndex.MasterFlagPosition] & StylingFlags.BindingAllocationLocked) return;
 
-  // If the styling context has already been patched with the given directive's bindings,
-  // then there is no point in doing it again. The reason why this may happen (the directive
-  // styling being patched twice) is because the `stylingBinding` function is called each time
-  // an element is created (both within a template function and within directive host bindings).
-  const directives = context[StylingIndex.DirectiveRegistryPosition];
-  let detectedIndex = getDirectiveRegistryValuesIndexOf(directives, directiveRef || null);
-  if (detectedIndex === -1) {
-    // this is a new directive which we have not seen yet.
-    detectedIndex = allocateDirectiveIntoContext(context, directiveRef);
-  }
-  const directiveIndex = detectedIndex / DirectiveRegistryValuesIndex.Size;
+  allocateOrUpdateDirectiveIntoContext(context, directiveIndex);
 
   let initialClasses: InitialStylingValues|null = null;
   let initialStyles: InitialStylingValues|null = null;
@@ -199,7 +188,6 @@ export function allowNewBindingsForStylingContext(context: StylingContext): bool
  * reference the provided directive.
  *
  * @param context the existing styling context
- * @param directiveRef the directive that the new bindings will reference
  * @param classBindingNames an array of class binding names that will be added to the context
  * @param styleBindingNames an array of style binding names that will be added to the context
  * @param styleSanitizer an optional sanitizer that handle all sanitization on for each of
@@ -207,13 +195,14 @@ export function allowNewBindingsForStylingContext(context: StylingContext): bool
  *    instance will only be active if and when the directive updates the bindings that it owns.
  */
 export function updateContextWithBindings(
-    context: StylingContext, directiveRef: any | null, classBindingNames?: string[] | null,
+    context: StylingContext, directiveIndex: number, classBindingNames?: string[] | null,
     styleBindingNames?: string[] | null, styleSanitizer?: StyleSanitizeFn | null) {
   if (context[StylingIndex.MasterFlagPosition] & StylingFlags.BindingAllocationLocked) return;
 
   // this means the context has already been patched with the directive's bindings
-  const directiveIndex = findOrPatchDirectiveIntoRegistry(context, directiveRef, styleSanitizer);
-  if (directiveIndex === -1) {
+  const isNewDirective =
+      findOrPatchDirectiveIntoRegistry(context, directiveIndex, false, styleSanitizer);
+  if (!isNewDirective) {
     // this means the directive has already been patched in ... No point in doing anything
     return;
   }
@@ -470,46 +459,22 @@ export function updateContextWithBindings(
  * Searches through the existing registry of directives
  */
 export function findOrPatchDirectiveIntoRegistry(
-    context: StylingContext, directiveRef: any, styleSanitizer?: StyleSanitizeFn | null) {
-  const directiveRefs = context[StylingIndex.DirectiveRegistryPosition];
-  const nextOffsetInsertionIndex = context[StylingIndex.SinglePropOffsetPositions].length;
+    context: StylingContext, directiveIndex: number, staticModeOnly: boolean,
+    styleSanitizer?: StyleSanitizeFn | null): boolean {
+  const directiveRegistry = context[StylingIndex.DirectiveRegistryPosition];
+  const index = directiveIndex * DirectiveRegistryValuesIndex.Size;
+  const singlePropStartPosition = index + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset;
 
-  let directiveIndex: number;
-  let detectedIndex = getDirectiveRegistryValuesIndexOf(directiveRefs, directiveRef);
+  // this means that the directive has already been registered into the registry
+  if (index < directiveRegistry.length &&
+      (directiveRegistry[singlePropStartPosition] as number) >= 0)
+    return false;
 
-  if (detectedIndex === -1) {
-    detectedIndex = directiveRefs.length;
-    directiveIndex = directiveRefs.length / DirectiveRegistryValuesIndex.Size;
-
-    allocateDirectiveIntoContext(context, directiveRef);
-    directiveRefs[detectedIndex + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset] =
-        nextOffsetInsertionIndex;
-    directiveRefs[detectedIndex + DirectiveRegistryValuesIndex.StyleSanitizerOffset] =
-        styleSanitizer || null;
-  } else {
-    const singlePropStartPosition =
-        detectedIndex + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset;
-    if (directiveRefs[singlePropStartPosition] ! >= 0) {
-      // the directive has already been patched into the context
-      return -1;
-    }
-
-    directiveIndex = detectedIndex / DirectiveRegistryValuesIndex.Size;
-
-    // because the directive already existed this means that it was set during elementHostAttrs or
-    // elementStart which means that the binding values were not here. Therefore, the values below
-    // need to be applied so that single class and style properties can be assigned later.
-    const singlePropPositionIndex =
-        detectedIndex + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset;
-    directiveRefs[singlePropPositionIndex] = nextOffsetInsertionIndex;
-
-    // the sanitizer is also apart of the binding process and will be used when bindings are
-    // applied.
-    const styleSanitizerIndex = detectedIndex + DirectiveRegistryValuesIndex.StyleSanitizerOffset;
-    directiveRefs[styleSanitizerIndex] = styleSanitizer || null;
-  }
-
-  return directiveIndex;
+  const singlePropsStartIndex =
+      staticModeOnly ? -1 : context[StylingIndex.SinglePropOffsetPositions].length;
+  allocateOrUpdateDirectiveIntoContext(
+      context, directiveIndex, singlePropsStartIndex, styleSanitizer);
+  return true;
 }
 
 function getMatchingBindingIndex(
@@ -543,18 +508,13 @@ function getMatchingBindingIndex(
  *    newly provided style values.
  * @param classesInput The key/value map of CSS class names that will be used for the update.
  * @param stylesInput The key/value map of CSS styles that will be used for the update.
- * @param directiveRef an optional reference to the directive responsible
- *    for this binding change. If present then style binding will only
- *    actualize if the directive has ownership over this binding
- *    (see styling.ts#directives for more information about the algorithm).
  */
 export function updateStylingMap(
     context: StylingContext, classesInput: {[key: string]: any} | string |
         BoundPlayerFactory<null|string|{[key: string]: any}>| null,
     stylesInput?: {[key: string]: any} | BoundPlayerFactory<null|{[key: string]: any}>| null,
-    directiveRef?: any): void {
-  const directiveIndex = getDirectiveIndexFromRegistry(context, directiveRef || null);
-
+    directiveIndex: number = 0): void {
+  assertValidDirectiveIndex(context, directiveIndex);
   classesInput = classesInput || null;
   stylesInput = stylesInput || null;
   const ignoreAllClassUpdates = isMultiValueCacheHit(context, true, directiveIndex, classesInput);
@@ -887,7 +847,6 @@ function patchStylingMapIntoContext(
 
   if (dirty) {
     setContextDirty(context, true);
-    setDirectiveDirty(context, directiveIndex, true);
   }
 
   return totalNewAllocatedSlots;
@@ -901,18 +860,14 @@ function patchStylingMapIntoContext(
  *    newly provided class value.
  * @param offset The index of the CSS class which is being updated.
  * @param addOrRemove Whether or not to add or remove the CSS class
- * @param directiveRef an optional reference to the directive responsible
- *    for this binding change. If present then style binding will only
- *    actualize if the directive has ownership over this binding
- *    (see styling.ts#directives for more information about the algorithm).
  * @param forceOverride whether or not to skip all directive prioritization
  *    and just apply the value regardless.
  */
 export function updateClassProp(
     context: StylingContext, offset: number,
-    input: boolean | BoundPlayerFactory<boolean|null>| null, directiveRef?: any,
+    input: boolean | BoundPlayerFactory<boolean|null>| null, directiveIndex: number = 0,
     forceOverride?: boolean): void {
-  updateSingleStylingValue(context, offset, input, true, directiveRef, forceOverride);
+  updateSingleStylingValue(context, offset, input, true, directiveIndex, forceOverride);
 }
 
 /**
@@ -928,25 +883,21 @@ export function updateClassProp(
  *    newly provided style value.
  * @param offset The index of the property which is being updated.
  * @param value The CSS style value that will be assigned
- * @param directiveRef an optional reference to the directive responsible
- *    for this binding change. If present then style binding will only
- *    actualize if the directive has ownership over this binding
- *    (see styling.ts#directives for more information about the algorithm).
  * @param forceOverride whether or not to skip all directive prioritization
  *    and just apply the value regardless.
  */
 export function updateStyleProp(
     context: StylingContext, offset: number,
-    input: string | boolean | null | BoundPlayerFactory<string|boolean|null>, directiveRef?: any,
-    forceOverride?: boolean): void {
-  updateSingleStylingValue(context, offset, input, false, directiveRef, forceOverride);
+    input: string | boolean | null | BoundPlayerFactory<string|boolean|null>,
+    directiveIndex: number = 0, forceOverride?: boolean): void {
+  updateSingleStylingValue(context, offset, input, false, directiveIndex, forceOverride);
 }
 
 function updateSingleStylingValue(
     context: StylingContext, offset: number,
     input: string | boolean | null | BoundPlayerFactory<string|boolean|null>, isClassBased: boolean,
-    directiveRef: any, forceOverride?: boolean): void {
-  const directiveIndex = getDirectiveIndexFromRegistry(context, directiveRef || null);
+    directiveIndex: number, forceOverride?: boolean): void {
+  assertValidDirectiveIndex(context, directiveIndex);
   const singleIndex = getSinglePropIndexValue(context, directiveIndex, offset, isClassBased);
   const currValue = getValue(context, singleIndex);
   const currFlag = getPointers(context, singleIndex);
@@ -1001,7 +952,6 @@ function updateSingleStylingValue(
 
       setDirty(context, indexForMulti, multiDirty);
       setDirty(context, singleIndex, singleDirty);
-      setDirectiveDirty(context, directiveIndex, true);
       setContextDirty(context, true);
     }
 
@@ -1029,120 +979,128 @@ function updateSingleStylingValue(
  *    to this key/value map instead of being renderered via the renderer.
  * @param stylesStore if provided, the updated style values will be applied
  *    to this key/value map instead of being renderered via the renderer.
- * @param directiveRef an optional directive that will be used to target which
- *    styling values are rendered. If left empty, only the bindings that are
- *    registered on the template will be rendered.
  * @returns number the total amount of players that got queued for animation (if any)
  */
 export function renderStyling(
-    context: StylingContext, renderer: Renderer3, rootOrView: RootContext | LView,
+    context: StylingContext, renderer: Renderer3 | null, rootOrView: RootContext | LView,
     isFirstRender: boolean, classesStore?: BindingStore | null, stylesStore?: BindingStore | null,
-    directiveRef?: any): number {
+    directiveIndex: number = 0): number {
   let totalPlayersQueued = 0;
-  const targetDirectiveIndex = getDirectiveIndexFromRegistry(context, directiveRef || null);
 
-  if (isContextDirty(context) && isDirectiveDirty(context, targetDirectiveIndex)) {
-    const flushPlayerBuilders: any =
-        context[StylingIndex.MasterFlagPosition] & StylingFlags.PlayerBuildersDirty;
-    const native = context[StylingIndex.ElementPosition] !;
-    const multiStartIndex = getMultiStylesStartIndex(context);
+  // this prevents multiple attempts to render style/class values on
+  // the same element...
+  if (allowHostInstructionsQueueFlush(context, directiveIndex)) {
+    // all styling instructions present within any hostBindings functions
+    // do not update the context immediately when called. They are instead
+    // queued up and applied to the context right at this point. Why? This
+    // is because Angular evaluates component/directive and directive
+    // sub-class code at different points and it's important that the
+    // styling values are applied to the context in the right order
+    // (see `interfaces/styling.ts` for more information).
+    flushHostInstructionsQueue(context);
 
-    let stillDirty = false;
-    for (let i = StylingIndex.SingleStylesStartPosition; i < context.length;
-         i += StylingIndex.Size) {
-      // there is no point in rendering styles that have not changed on screen
-      if (isDirty(context, i)) {
-        const flag = getPointers(context, i);
-        const directiveIndex = getDirectiveIndexFromEntry(context, i);
-        if (targetDirectiveIndex !== directiveIndex) {
-          stillDirty = true;
-          continue;
-        }
+    if (isContextDirty(context)) {
+      // this is here to prevent things like <ng-container [style] [class]>...</ng-container>
+      // or if there are any host style or class bindings present in a directive set on
+      // a container node
+      const native = context[StylingIndex.ElementPosition] !as HTMLElement;
 
-        const prop = getProp(context, i);
-        const value = getValue(context, i);
-        const styleSanitizer =
-            (flag & StylingFlags.Sanitize) ? getStyleSanitizer(context, directiveIndex) : null;
-        const playerBuilder = getPlayerBuilder(context, i);
-        const isClassBased = flag & StylingFlags.Class ? true : false;
-        const isInSingleRegion = i < multiStartIndex;
+      const flushPlayerBuilders: any =
+          context[StylingIndex.MasterFlagPosition] & StylingFlags.PlayerBuildersDirty;
+      const multiStartIndex = getMultiStylesStartIndex(context);
 
-        let valueToApply: string|boolean|null = value;
+      for (let i = StylingIndex.SingleStylesStartPosition; i < context.length;
+           i += StylingIndex.Size) {
+        // there is no point in rendering styles that have not changed on screen
+        if (isDirty(context, i)) {
+          const flag = getPointers(context, i);
+          const directiveIndex = getDirectiveIndexFromEntry(context, i);
+          const prop = getProp(context, i);
+          const value = getValue(context, i);
+          const styleSanitizer =
+              (flag & StylingFlags.Sanitize) ? getStyleSanitizer(context, directiveIndex) : null;
+          const playerBuilder = getPlayerBuilder(context, i);
+          const isClassBased = flag & StylingFlags.Class ? true : false;
+          const isInSingleRegion = i < multiStartIndex;
 
-        // VALUE DEFER CASE 1: Use a multi value instead of a null single value
-        // this check implies that a single value was removed and we
-        // should now defer to a multi value and use that (if set).
-        if (isInSingleRegion && !valueExists(valueToApply, isClassBased)) {
-          // single values ALWAYS have a reference to a multi index
-          const multiIndex = getMultiOrSingleIndex(flag);
-          valueToApply = getValue(context, multiIndex);
-        }
+          let valueToApply: string|boolean|null = value;
 
-        // VALUE DEFER CASE 2: Use the initial value if all else fails (is falsy)
-        // the initial value will always be a string or null,
-        // therefore we can safely adopt it in case there's nothing else
-        // note that this should always be a falsy check since `false` is used
-        // for both class and style comparisons (styles can't be false and false
-        // classes are turned off and should therefore defer to their initial values)
-        // Note that we ignore class-based deferals because otherwise a class can never
-        // be removed in the case that it exists as true in the initial classes list...
-        if (!valueExists(valueToApply, isClassBased)) {
-          valueToApply = getInitialValue(context, flag);
-        }
-
-        // if the first render is true then we do not want to start applying falsy
-        // values to the DOM element's styling. Otherwise then we know there has
-        // been a change and even if it's falsy then it's removing something that
-        // was truthy before.
-        const doApplyValue = isFirstRender ? valueToApply : true;
-        if (doApplyValue) {
-          if (isClassBased) {
-            setClass(
-                native, prop, valueToApply ? true : false, renderer, classesStore, playerBuilder);
-          } else {
-            setStyle(
-                native, prop, valueToApply as string | null, renderer, styleSanitizer, stylesStore,
-                playerBuilder);
+          // VALUE DEFER CASE 1: Use a multi value instead of a null single value
+          // this check implies that a single value was removed and we
+          // should now defer to a multi value and use that (if set).
+          if (isInSingleRegion && !valueExists(valueToApply, isClassBased)) {
+            // single values ALWAYS have a reference to a multi index
+            const multiIndex = getMultiOrSingleIndex(flag);
+            valueToApply = getValue(context, multiIndex);
           }
-        }
 
-        setDirty(context, i, false);
-      }
-    }
+          // VALUE DEFER CASE 2: Use the initial value if all else fails (is falsy)
+          // the initial value will always be a string or null,
+          // therefore we can safely adopt it in case there's nothing else
+          // note that this should always be a falsy check since `false` is used
+          // for both class and style comparisons (styles can't be false and false
+          // classes are turned off and should therefore defer to their initial values)
+          // Note that we ignore class-based deferals because otherwise a class can never
+          // be removed in the case that it exists as true in the initial classes list...
+          if (!valueExists(valueToApply, isClassBased)) {
+            valueToApply = getInitialValue(context, flag);
+          }
 
-    if (flushPlayerBuilders) {
-      const rootContext =
-          Array.isArray(rootOrView) ? getRootContext(rootOrView) : rootOrView as RootContext;
-      const playerContext = getPlayerContext(context) !;
-      const playersStartIndex = playerContext[PlayerIndex.NonBuilderPlayersStart];
-      for (let i = PlayerIndex.PlayerBuildersStartPosition; i < playersStartIndex;
-           i += PlayerIndex.PlayerAndPlayerBuildersTupleSize) {
-        const builder = playerContext[i] as ClassAndStylePlayerBuilder<any>| null;
-        const playerInsertionIndex = i + PlayerIndex.PlayerOffsetPosition;
-        const oldPlayer = playerContext[playerInsertionIndex] as Player | null;
-        if (builder) {
-          const player = builder.buildPlayer(oldPlayer, isFirstRender);
-          if (player !== undefined) {
-            if (player != null) {
-              const wasQueued = addPlayerInternal(
-                  playerContext, rootContext, native as HTMLElement, player, playerInsertionIndex);
-              wasQueued && totalPlayersQueued++;
-            }
-            if (oldPlayer) {
-              oldPlayer.destroy();
+          // if the first render is true then we do not want to start applying falsy
+          // values to the DOM element's styling. Otherwise then we know there has
+          // been a change and even if it's falsy then it's removing something that
+          // was truthy before.
+          const doApplyValue = renderer && (isFirstRender ? valueToApply : true);
+          if (doApplyValue) {
+            if (isClassBased) {
+              setClass(
+                  native, prop, valueToApply ? true : false, renderer !, classesStore,
+                  playerBuilder);
+            } else {
+              setStyle(
+                  native, prop, valueToApply as string | null, renderer !, styleSanitizer,
+                  stylesStore, playerBuilder);
             }
           }
-        } else if (oldPlayer) {
-          // the player builder has been removed ... therefore we should delete the associated
-          // player
-          oldPlayer.destroy();
+
+          setDirty(context, i, false);
         }
       }
-      setContextPlayersDirty(context, false);
-    }
 
-    setDirectiveDirty(context, targetDirectiveIndex, false);
-    setContextDirty(context, stillDirty);
+      if (flushPlayerBuilders) {
+        const rootContext =
+            Array.isArray(rootOrView) ? getRootContext(rootOrView) : rootOrView as RootContext;
+        const playerContext = getPlayerContext(context) !;
+        const playersStartIndex = playerContext[PlayerIndex.NonBuilderPlayersStart];
+        for (let i = PlayerIndex.PlayerBuildersStartPosition; i < playersStartIndex;
+             i += PlayerIndex.PlayerAndPlayerBuildersTupleSize) {
+          const builder = playerContext[i] as ClassAndStylePlayerBuilder<any>| null;
+          const playerInsertionIndex = i + PlayerIndex.PlayerOffsetPosition;
+          const oldPlayer = playerContext[playerInsertionIndex] as Player | null;
+          if (builder) {
+            const player = builder.buildPlayer(oldPlayer, isFirstRender);
+            if (player !== undefined) {
+              if (player != null) {
+                const wasQueued = addPlayerInternal(
+                    playerContext, rootContext, native as HTMLElement, player,
+                    playerInsertionIndex);
+                wasQueued && totalPlayersQueued++;
+              }
+              if (oldPlayer) {
+                oldPlayer.destroy();
+              }
+            }
+          } else if (oldPlayer) {
+            // the player builder has been removed ... therefore we should delete the associated
+            // player
+            oldPlayer.destroy();
+          }
+        }
+        setContextPlayersDirty(context, false);
+      }
+
+      setContextDirty(context, false);
+    }
   }
 
   return totalPlayersQueued;
@@ -1622,43 +1580,6 @@ export function getDirectiveIndexFromEntry(context: StylingContext, index: numbe
   return value & DirectiveOwnerAndPlayerBuilderIndex.BitMask;
 }
 
-function getDirectiveIndexFromRegistry(context: StylingContext, directiveRef: any) {
-  let directiveIndex: number;
-
-  const dirs = context[StylingIndex.DirectiveRegistryPosition];
-  let index = getDirectiveRegistryValuesIndexOf(dirs, directiveRef);
-  if (index === -1) {
-    // if the directive was not allocated then this means that styling is
-    // being applied in a dynamic way AFTER the element was already instantiated
-    index = dirs.length;
-    directiveIndex = index > 0 ? index / DirectiveRegistryValuesIndex.Size : 0;
-
-    dirs.push(null, null, null, null);
-    dirs[index + DirectiveRegistryValuesIndex.DirectiveValueOffset] = directiveRef;
-    dirs[index + DirectiveRegistryValuesIndex.DirtyFlagOffset] = false;
-    dirs[index + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset] = -1;
-
-    const classesStartIndex =
-        getMultiClassesStartIndex(context) || StylingIndex.SingleStylesStartPosition;
-    registerMultiMapEntry(context, directiveIndex, true, context.length);
-    registerMultiMapEntry(context, directiveIndex, false, classesStartIndex);
-  } else {
-    directiveIndex = index > 0 ? index / DirectiveRegistryValuesIndex.Size : 0;
-  }
-
-  return directiveIndex;
-}
-
-function getDirectiveRegistryValuesIndexOf(
-    directives: DirectiveRegistryValues, directive: {}): number {
-  for (let i = 0; i < directives.length; i += DirectiveRegistryValuesIndex.Size) {
-    if (directives[i] === directive) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 function getInitialStylingValuesIndexOf(keyValues: InitialStylingValues, key: string): number {
   for (let i = InitialStylingValuesIndex.KeyValueStartPosition; i < keyValues.length;
        i += InitialStylingValuesIndex.Size) {
@@ -1722,21 +1643,6 @@ function getStyleSanitizer(context: StylingContext, directiveIndex: number): Sty
                      DirectiveRegistryValuesIndex.StyleSanitizerOffset] ||
       dirs[DirectiveRegistryValuesIndex.StyleSanitizerOffset] || null;
   return value as StyleSanitizeFn | null;
-}
-
-function isDirectiveDirty(context: StylingContext, directiveIndex: number): boolean {
-  const dirs = context[StylingIndex.DirectiveRegistryPosition];
-  return dirs
-      [directiveIndex * DirectiveRegistryValuesIndex.Size +
-       DirectiveRegistryValuesIndex.DirtyFlagOffset] as boolean;
-}
-
-function setDirectiveDirty(
-    context: StylingContext, directiveIndex: number, dirtyYes: boolean): void {
-  const dirs = context[StylingIndex.DirectiveRegistryPosition];
-  dirs
-      [directiveIndex * DirectiveRegistryValuesIndex.Size +
-       DirectiveRegistryValuesIndex.DirtyFlagOffset] = dirtyYes;
 }
 
 function allowValueChange(
@@ -1993,4 +1899,13 @@ function addOrUpdateStaticStyle(
   staticStyles[index + InitialStylingValuesIndex.ValueOffset] = value;
   staticStyles[index + InitialStylingValuesIndex.DirectiveOwnerOffset] = directiveOwnerIndex;
   return index;
+}
+
+function assertValidDirectiveIndex(context: StylingContext, directiveIndex: number) {
+  const dirs = context[StylingIndex.DirectiveRegistryPosition];
+  const index = directiveIndex * DirectiveRegistryValuesIndex.Size;
+  if (index >= dirs.length ||
+      dirs[index + DirectiveRegistryValuesIndex.SinglePropValuesIndexOffset] === -1) {
+    throw new Error('The provided directive is not registered with the styling context');
+  }
 }

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -514,7 +514,7 @@ export function updateStylingMap(
         BoundPlayerFactory<null|string|{[key: string]: any}>| null,
     stylesInput?: {[key: string]: any} | BoundPlayerFactory<null|{[key: string]: any}>| null,
     directiveIndex: number = 0): void {
-  assertValidDirectiveIndex(context, directiveIndex);
+  ngDevMode && assertValidDirectiveIndex(context, directiveIndex);
   classesInput = classesInput || null;
   stylesInput = stylesInput || null;
   const ignoreAllClassUpdates = isMultiValueCacheHit(context, true, directiveIndex, classesInput);
@@ -897,7 +897,7 @@ function updateSingleStylingValue(
     context: StylingContext, offset: number,
     input: string | boolean | null | BoundPlayerFactory<string|boolean|null>, isClassBased: boolean,
     directiveIndex: number, forceOverride?: boolean): void {
-  assertValidDirectiveIndex(context, directiveIndex);
+  ngDevMode && assertValidDirectiveIndex(context, directiveIndex);
   const singleIndex = getSinglePropIndexValue(context, directiveIndex, offset, isClassBased);
   const currValue = getValue(context, singleIndex);
   const currFlag = getPointers(context, singleIndex);

--- a/packages/core/src/render3/styling/host_instructions_queue.ts
+++ b/packages/core/src/render3/styling/host_instructions_queue.ts
@@ -1,0 +1,95 @@
+/**
+* @license
+* Copyright Google Inc. All Rights Reserved.
+*
+* Use of this source code is governed by an MIT-style license that can be
+* found in the LICENSE file at https://angular.io/license
+*/
+import {HostInstructionsQueue, HostInstructionsQueueIndex, StylingContext, StylingIndex} from '../interfaces/styling';
+import {DEFAULT_TEMPLATE_DIRECTIVE_INDEX} from '../styling/shared';
+
+/*
+ * This file contains the logic to defer all hostBindings-related styling code to run
+ * at a later point, instead of immediately (as is the case with how template-level
+ * styling instructions are run).
+ *
+ * Certain styling instructions, present within directives, components and sub-classed
+ * directives, are evaluated at different points (depending on priority) and will therefore
+ * not be applied to the styling context of an element immediately. They are instead
+ * designed to be applied just before styling is applied to an element.
+ *
+ * (The priority for when certain host-related styling operations are executed is discussed
+ * more within `interfaces/styling.ts`.)
+ */
+
+export function registerHostDirective(context: StylingContext, directiveIndex: number) {
+  let buffer = context[StylingIndex.HostInstructionsQueue];
+  if (!buffer) {
+    buffer = context[StylingIndex.HostInstructionsQueue] = [DEFAULT_TEMPLATE_DIRECTIVE_INDEX];
+  }
+  buffer[HostInstructionsQueueIndex.LastRegisteredDirectiveIndexPosition] = directiveIndex;
+}
+
+/**
+ * Queues a styling instruction to be run just before `renderStyling()` is executed.
+ */
+export function enqueueHostInstruction<T extends Function>(
+    context: StylingContext, priority: number, instructionFn: T, instructionFnArgs: ParamsOf<T>) {
+  const buffer: HostInstructionsQueue = context[StylingIndex.HostInstructionsQueue] !;
+  const index = findNextInsertionIndex(buffer, priority);
+  buffer.splice(index, 0, priority, instructionFn, instructionFnArgs);
+}
+
+/**
+ * Figures out where exactly to to insert the next host instruction queue entry.
+ */
+function findNextInsertionIndex(buffer: HostInstructionsQueue, priority: number): number {
+  for (let i = HostInstructionsQueueIndex.ValuesStartPosition; i < buffer.length;
+       i += HostInstructionsQueueIndex.Size) {
+    const p = buffer[i + HostInstructionsQueueIndex.DirectiveIndexOffset] as number;
+    if (p > priority) {
+      return i;
+    }
+  }
+  return buffer.length;
+}
+
+/**
+ * Iterates through the host instructions queue (if present within the provided
+ * context) and executes each queued instruction entry.
+ */
+export function flushQueue(context: StylingContext): void {
+  const buffer = context[StylingIndex.HostInstructionsQueue];
+  if (buffer) {
+    for (let i = HostInstructionsQueueIndex.ValuesStartPosition; i < buffer.length;
+         i += HostInstructionsQueueIndex.Size) {
+      const fn = buffer[i + HostInstructionsQueueIndex.InstructionFnOffset] as Function;
+      const args = buffer[i + HostInstructionsQueueIndex.ParamsOffset] as any[];
+      fn(...args);
+    }
+    buffer.length = HostInstructionsQueueIndex.ValuesStartPosition;
+  }
+}
+
+/**
+ * Determines whether or not to allow the host instructions queue to be flushed or not.
+ *
+ * Because the hostBindings function code is unaware of the presence of other host bindings
+ * (as well as the template function) then styling is evaluated multiple times per element.
+ * To prevent style and class values from being applied to the element multiple times, a
+ * flush is only allowed when the last directive (the directive that was registered into
+ * the styling context) attempts to render its styling.
+ */
+export function allowFlush(context: StylingContext, directiveIndex: number): boolean {
+  const buffer = context[StylingIndex.HostInstructionsQueue];
+  if (buffer) {
+    return buffer[HostInstructionsQueueIndex.LastRegisteredDirectiveIndexPosition] ===
+        directiveIndex;
+  }
+  return true;
+}
+
+/**
+ * Infers the parameters of a given function into a typed array.
+ */
+export type ParamsOf<T> = T extends(...args: infer T) => any ? T : never;

--- a/packages/core/src/render3/styling/shared.ts
+++ b/packages/core/src/render3/styling/shared.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * The default directive styling index value for template-based bindings.
+ *
+ * All host-level bindings (e.g. `hostStyleProp` and `hostStylingMap`) are
+ * assigned a directive styling index value based on the current directive
+ * uniqueId and the directive super-class inheritance depth. But for template
+ * bindings they always have the same directive styling index value.
+ */
+export const DEFAULT_TEMPLATE_DIRECTIVE_INDEX = 0;

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -30,6 +30,9 @@
     "name": "DECLARATION_VIEW"
   },
   {
+    "name": "DEFAULT_TEMPLATE_DIRECTIVE_INDEX"
+  },
+  {
     "name": "DepComponent"
   },
   {
@@ -159,6 +162,9 @@
     "name": "_renderCompCount"
   },
   {
+    "name": "_selectedIndex"
+  },
+  {
     "name": "addComponentLogic"
   },
   {
@@ -171,7 +177,7 @@
     "name": "allocStylingContext"
   },
   {
-    "name": "allocateDirectiveIntoContext"
+    "name": "allocateOrUpdateDirectiveIntoContext"
   },
   {
     "name": "allowValueChange"
@@ -339,9 +345,6 @@
     "name": "getDirectiveDef"
   },
   {
-    "name": "getDirectiveRegistryValuesIndexOf"
-  },
-  {
     "name": "getElementDepthCount"
   },
   {
@@ -448,6 +451,9 @@
   },
   {
     "name": "increaseElementDepthCount"
+  },
+  {
+    "name": "incrementActiveDirectiveId"
   },
   {
     "name": "initNodeFlags"
@@ -627,7 +633,7 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "setActiveHost"
+    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"
@@ -667,6 +673,9 @@
   },
   {
     "name": "setPreviousOrParentTNode"
+  },
+  {
+    "name": "setSelectedIndex"
   },
   {
     "name": "setStyle"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -135,6 +135,9 @@
     "name": "_renderCompCount"
   },
   {
+    "name": "_selectedIndex"
+  },
+  {
     "name": "addToViewTree"
   },
   {
@@ -324,6 +327,9 @@
     "name": "includeViewProviders"
   },
   {
+    "name": "incrementActiveDirectiveId"
+  },
+  {
     "name": "initNodeFlags"
   },
   {
@@ -435,7 +441,7 @@
     "name": "resetPreOrderHookFlags"
   },
   {
-    "name": "setActiveHost"
+    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"
@@ -463,6 +469,9 @@
   },
   {
     "name": "setPreviousOrParentTNode"
+  },
+  {
+    "name": "setSelectedIndex"
   },
   {
     "name": "setStyle"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -45,6 +45,9 @@
     "name": "DECLARATION_VIEW"
   },
   {
+    "name": "DEFAULT_TEMPLATE_DIRECTIVE_INDEX"
+  },
+  {
     "name": "DefaultIterableDiffer"
   },
   {
@@ -372,6 +375,9 @@
     "name": "_renderCompCount"
   },
   {
+    "name": "_selectedIndex"
+  },
+  {
     "name": "_symbolIterator"
   },
   {
@@ -399,7 +405,10 @@
     "name": "allocStylingContext"
   },
   {
-    "name": "allocateDirectiveIntoContext"
+    "name": "allocateOrUpdateDirectiveIntoContext"
+  },
+  {
+    "name": "allowFlush"
   },
   {
     "name": "allowValueChange"
@@ -412,6 +421,9 @@
   },
   {
     "name": "assertTemplate"
+  },
+  {
+    "name": "assertValidDirectiveIndex"
   },
   {
     "name": "assignTViewNodeToLView"
@@ -573,9 +585,6 @@
     "name": "elementClassProp"
   },
   {
-    "name": "elementClassPropInternal"
-  },
-  {
     "name": "elementCreate"
   },
   {
@@ -645,6 +654,9 @@
     "name": "findViaComponent"
   },
   {
+    "name": "flushQueue"
+  },
+  {
     "name": "forwardRef"
   },
   {
@@ -699,12 +711,6 @@
     "name": "getDirectiveIndexFromEntry"
   },
   {
-    "name": "getDirectiveIndexFromRegistry"
-  },
-  {
-    "name": "getDirectiveRegistryValuesIndexOf"
-  },
-  {
     "name": "getElementDepthCount"
   },
   {
@@ -754,9 +760,6 @@
   },
   {
     "name": "getMatchingBindingIndex"
-  },
-  {
-    "name": "getMultiClassesStartIndex"
   },
   {
     "name": "getMultiOrSingleIndex"
@@ -909,6 +912,9 @@
     "name": "increaseElementDepthCount"
   },
   {
+    "name": "incrementActiveDirectiveId"
+  },
+  {
     "name": "initElementStyling"
   },
   {
@@ -982,9 +988,6 @@
   },
   {
     "name": "isDifferent"
-  },
-  {
-    "name": "isDirectiveDirty"
   },
   {
     "name": "isDirty"
@@ -1224,7 +1227,7 @@
     "name": "select"
   },
   {
-    "name": "setActiveHost"
+    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"
@@ -1246,9 +1249,6 @@
   },
   {
     "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setDirectiveDirty"
   },
   {
     "name": "setDirty"
@@ -1291,6 +1291,9 @@
   },
   {
     "name": "setSanitizeFlag"
+  },
+  {
+    "name": "setSelectedIndex"
   },
   {
     "name": "setStyle"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -423,9 +423,6 @@
     "name": "assertTemplate"
   },
   {
-    "name": "assertValidDirectiveIndex"
-  },
-  {
     "name": "assignTViewNodeToLView"
   },
   {

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -16,14 +16,5 @@
 // clang-format off
 // tslint:disable
 
-window.testBlocklist = {
-  "MatSidenav should be fixed position when in fixed mode": {
-    "error": "Error: Expected ng-tns-c380-0 ng-trigger ng-trigger-transform mat-drawer mat-sidenav mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
-    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
-  },
-  "MatSidenav should set fixed bottom and top when in fixed mode": {
-    "error": "Error: Expected '' to be '20px'.",
-    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
-  }
-};
+window.testBlocklist = {};
 // clang-format on


### PR DESCRIPTION
The new styling algorithm in angular is designed to evaluate host
bindings stylinh priority in order of directive evaluation order. This,
however, does not work with respect to parent/sub-class directives
because sub-class host bindings are run after the parent host bindings
but still have priority. This patch ensures that the host styling bindings
for parent and sub-class components/directives are executed with respect
to the styling algorithm prioritization.

Jira Issue: FW-1132