### PR TITLE
fix(forms): MinLength Validator treats 0 as zero length

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -231,7 +231,7 @@ export class Validators {
       if (isEmptyInputValue(control.value)) {
         return null;  // don't validate empty values to allow optional controls
       }
-      const length: number = control.value ? control.value.length : 0;
+      const length: number = control.value.length;
       return length < minLength ?
           {'minlength': {'requiredLength': minLength, 'actualLength': length}} :
           null;

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -199,6 +199,10 @@ import {first, map} from 'rxjs/operators';
           'minlength': {'requiredLength': 2, 'actualLength': 1}
         });
       });
+
+      it('should not error when 0 is checked against minlength 1',
+         () => { expect(Validators.minLength(1)(new FormControl(0))).toBeNull(); });
+
     });
 
     describe('maxLength', () => {


### PR DESCRIPTION
remove truthy statement for assessing value existence because:
- it is already checked previously
- evaluating truthy value of 0 resolves to false which is not the desired behavior.

all that we need is to check the length property of the value

Closes #23749

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #23749


## What is the new behavior?
MinLength Validator no longer treats 0 as zero length

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
