### PR TITLE
fix(compiler-cli): ensure LogicalProjectPaths always start with a slash

### DIFF
--- a/packages/compiler-cli/src/ngtsc/path/src/logical.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/logical.ts
@@ -81,7 +81,7 @@ export class LogicalFileSystem {
       let logicalFile: LogicalProjectPath|null = null;
       for (const rootDir of this.rootDirs) {
         if (physicalFile.startsWith(rootDir)) {
-          logicalFile = stripExtension(physicalFile.substr(rootDir.length)) as LogicalProjectPath;
+          logicalFile = this.createLogicalProjectPath(physicalFile, rootDir);
           // The logical project does not include any special "node_modules" nested directories.
           if (logicalFile.indexOf('/node_modules/') !== -1) {
             logicalFile = null;
@@ -93,5 +93,11 @@ export class LogicalFileSystem {
       this.cache.set(physicalFile, logicalFile);
     }
     return this.cache.get(physicalFile) !;
+  }
+
+  private createLogicalProjectPath(file: AbsoluteFsPath, rootDir: AbsoluteFsPath):
+      LogicalProjectPath {
+    const logicalPath = stripExtension(file.substr(rootDir.length));
+    return (logicalPath.startsWith('/') ? logicalPath : '/' + logicalPath) as LogicalProjectPath;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/path/test/logical_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/path/test/logical_spec.ts
@@ -31,6 +31,16 @@ describe('logical paths', () => {
       expect(fs.logicalPathOfFile(abs('/test/foo.ts'))).toEqual('/foo' as LogicalProjectPath);
       expect(fs.logicalPathOfFile(abs('/test/dist/foo.ts'))).toEqual('/foo' as LogicalProjectPath);
     });
+
+    it('should always return `/` prefixed logical paths', () => {
+      const rootFs = new LogicalFileSystem([abs('/')]);
+      expect(rootFs.logicalPathOfFile(abs('/foo/foo.ts')))
+          .toEqual('/foo/foo' as LogicalProjectPath);
+
+      const nonRootFs = new LogicalFileSystem([abs('/test/')]);
+      expect(nonRootFs.logicalPathOfFile(abs('/test/foo/foo.ts')))
+          .toEqual('/foo/foo' as LogicalProjectPath);
+    });
   });
 
   describe('utilities', () => {


### PR DESCRIPTION
Previously, if a matching rootDir ended with a slash then the path
returned from `logicalPathOfFile()` would not start with a slash,
which is inconsistent.

