### PR TITLE
docs: fix typo in description of angular.io/index.html

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Angular</title>
   <meta name="Description" content="Angular is a platform for building mobile and desktop web applications.
-    Join the community of millions of developers who build compeling user interfaces with Angular.">
+    Join the community of millions of developers who build compelling user interfaces with Angular.">
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
change "compeling" to "compelling" in description meta tag