### PR TITLE
build: Remove --watchfs from bazelrc file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,8 +35,9 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # See https://github.com/bazelbuild/bazel/issues/4603
 build --symlink_prefix=dist/
 
-# Performance: avoid stat'ing input files
-build --watchfs
+# Disable watchfs as it causes tests to be flaky on Windows
+# https://github.com/angular/angular/issues/29541
+build --nowatchfs
 
 # Turn off legacy external runfiles
 run --nolegacy_external_runfiles

--- a/.codefresh/bazel.rc
+++ b/.codefresh/bazel.rc
@@ -36,10 +36,6 @@ build --verbose_failures=true
 build --action_env=PATH
 test --action_env=PATH --test_env=PATH
 
-# Disable watchfs on Windows as it causes tests to be flaky
-# https://github.com/angular/angular/issues/29541
-build --nowatchfs
-
 # Exclude tests known to not work on Windows.
 
 # Chrome web tests are currently broken.


### PR DESCRIPTION
--watchfs is causing the build to be flaky on Windows because Bazel
doesn't have proper support for watchfs on Windows, but it doesn't seem
to bring much performance on Linux, either.

Fixes: https://github.com/angular/angular/issues/29541

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
We enables watchfs by default on all platform, which is causing the build to be flaky on Windows.

Issue Number: https://github.com/angular/angular/issues/29541


## What is the new behavior?
We disable watchfs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

