### PR TITLE
test(docs-infra): avoid click-related CI flake in e2e test

### DIFF
--- a/aio/tests/e2e/app.e2e-spec.ts
+++ b/aio/tests/e2e/app.e2e-spec.ts
@@ -140,25 +140,31 @@ describe('site App', function() {
       expect(texts).toEqual(['ANGULAR', 'COLLABORATORS', 'GDE']);
     });
 
-    it('should have contributors listed in each group', async () => {
+    it('should have contributors listed in each group', () => {
+      // WebDriver calls `scrollIntoView()` on the element to bring it into the visible area of the
+      // browser, before clicking it. By default, this aligns the top of the element to the top of
+      // the window. As a result, the element may end up behing the fixed top menu, thus being
+      // unclickable. To avoid this, we click the element directly using JavaScript instead.
+      const clickButton = (elementFinder: ElementFinder) => elementFinder.getWebElement().then(
+          webElement => browser.executeScript('arguments[0].click()', webElement));
       const getContributorNames =
           () => contributors.all(by.css('h3')).map<string>(c => c && c.getText());
 
       const names1 = getContributorNames();
       expect(contributors.count()).toBeGreaterThan(1);
 
-      groupButtons.get(1).click();
+      clickButton(groupButtons.get(1));
       const names2 = getContributorNames();
       expect(contributors.count()).toBeGreaterThan(1);
       expect(names2).not.toEqual(names1);
 
-      groupButtons.get(2).click();
+      clickButton(groupButtons.get(2));
       const names3 = getContributorNames();
       expect(contributors.count()).toBeGreaterThan(1);
       expect(names3).not.toEqual(names2);
       expect(names3).not.toEqual(names1);
 
-      groupButtons.get(0).click();
+      clickButton(groupButtons.get(0));
       const names4 = getContributorNames();
       expect(contributors.count()).toBeGreaterThan(1);
       expect(names4).not.toEqual(names3);


### PR DESCRIPTION
One of the tests introduced in #29601 is susceptible to a kind of WebDriver flake related to trying to click elements hidden behind fixed positioned elements.
This PR works around the issue by clicking the elements directly using JavaScript (instead of `WebElement#click()`).

(For reference, here is such a flake: [268227])

[268227]: https://circleci.com/gh/angular/angular/268227