### PR TITLE
fix(compiler-cli): ngcc - cope with processing entry-points multiple …

### DIFF
--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -41,6 +41,7 @@ describe('ngcc main()', () => {
         esm2015: '0.0.0-PLACEHOLDER',
         fesm5: '0.0.0-PLACEHOLDER',
         fesm2015: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
       // * `common` is a dependency of `common/http`, so is compiled.
       expect(loadPackage('@angular/common').__processed_by_ivy_ngcc__).toEqual({
@@ -50,6 +51,7 @@ describe('ngcc main()', () => {
         esm2015: '0.0.0-PLACEHOLDER',
         fesm5: '0.0.0-PLACEHOLDER',
         fesm2015: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
       // * `core` is a dependency of `common`, so is compiled.
       expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({
@@ -59,6 +61,7 @@ describe('ngcc main()', () => {
         esm2015: '0.0.0-PLACEHOLDER',
         fesm5: '0.0.0-PLACEHOLDER',
         fesm2015: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
 
       // * `common/testing` is not a dependency of `common/http` so is not compiled.
@@ -94,21 +97,25 @@ describe('ngcc main()', () => {
            esm5: '0.0.0-PLACEHOLDER',
            module: '0.0.0-PLACEHOLDER',
            fesm5: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
          });
          expect(loadPackage('@angular/common').__processed_by_ivy_ngcc__).toEqual({
            esm5: '0.0.0-PLACEHOLDER',
            module: '0.0.0-PLACEHOLDER',
            fesm5: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
          });
          expect(loadPackage('@angular/common/testing').__processed_by_ivy_ngcc__).toEqual({
            esm5: '0.0.0-PLACEHOLDER',
            module: '0.0.0-PLACEHOLDER',
            fesm5: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
          });
          expect(loadPackage('@angular/common/http').__processed_by_ivy_ngcc__).toEqual({
            esm5: '0.0.0-PLACEHOLDER',
            module: '0.0.0-PLACEHOLDER',
            fesm5: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
          });
        });
   });
@@ -127,20 +134,44 @@ describe('ngcc main()', () => {
       expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({
         fesm5: '0.0.0-PLACEHOLDER',
         module: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
       expect(loadPackage('@angular/common').__processed_by_ivy_ngcc__).toEqual({
         fesm5: '0.0.0-PLACEHOLDER',
         module: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
       expect(loadPackage('@angular/common/testing').__processed_by_ivy_ngcc__).toEqual({
         fesm5: '0.0.0-PLACEHOLDER',
         module: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
       expect(loadPackage('@angular/common/http').__processed_by_ivy_ngcc__).toEqual({
         fesm5: '0.0.0-PLACEHOLDER',
         module: '0.0.0-PLACEHOLDER',
+        typings: '0.0.0-PLACEHOLDER',
       });
     });
+
+    it('should cope with compiling the same entry-point multiple times with different formats',
+       () => {
+         mainNgcc({
+           basePath: '/node_modules',
+           propertiesToConsider: ['module'],
+           compileAllFormats: false
+         });
+         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({
+           module: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
+         });
+         mainNgcc(
+             {basePath: '/node_modules', propertiesToConsider: ['esm5'], compileAllFormats: false});
+         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({
+           esm5: '0.0.0-PLACEHOLDER',
+           module: '0.0.0-PLACEHOLDER',
+           typings: '0.0.0-PLACEHOLDER',
+         });
+       });
   });
 
   describe('with createNewEntryPointFormats', () => {

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -164,6 +164,7 @@ describe('ngcc main()', () => {
            module: '0.0.0-PLACEHOLDER',
            typings: '0.0.0-PLACEHOLDER',
          });
+         // If ngcc tries to write out the typings files again, this will throw an exception.
          mainNgcc(
              {basePath: '/node_modules', propertiesToConsider: ['esm5'], compileAllFormats: false});
          expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({


### PR DESCRIPTION
…times

With the new API, where you can choose to only process the first
matching format, it is possible to process an entry-point multiple
times, if you pass in a different format each time.

Previously, ngcc would always try to process the typings files for
the entry-point along with processing the first format of the current
execution of ngcc. But this meant that it would be trying to process
the typings a second time.

Now we only process the typings if they have not already been
processed as part of processing another format in another
even if it was in a different execution of ngcc.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
