### PR TITLE
fix(router): setTimeout to greater then 0 ...

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -803,7 +803,7 @@ export class Router {
         // exists, restore the state.
         const state = change.state && change.state.navigationId ? change.state : null;
         setTimeout(
-            () => { this.scheduleNavigation(rawUrlTree, source, state, {replaceUrl: true}); }, 0);
+            () => { this.scheduleNavigation(rawUrlTree, source, state, {replaceUrl: true}); }, 1);
       });
     }
   }


### PR DESCRIPTION
to trigger in Firefox in a hybrid app (AngularJs and Angular) routing immediately, not every second route. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29113


## What is the new behavior?
Firefox is routing fine again, no more gaps between two routing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
