### PR TITLE
ci: fix CODEOWNERS for ngcc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -399,10 +399,10 @@
 
 
 # ================================================
-#  packages/compiler-cli/src/ngcc/
+#  packages/compiler-cli/ngcc/
 # ================================================
 
-/packages/compiler-cli/src/ngcc/**                              @angular/fw-ngcc @angular/framework-global-approvers
+/packages/compiler-cli/ngcc/**                                  @angular/fw-ngcc @angular/framework-global-approvers
 
 
 


### PR DESCRIPTION
With a770aa231, ngcc was moved to a different directory (`compiler/src/ngcc/` --> `compiler/ngcc/`), but the `CODEOWNERS` file was not updated to reflect that.
