### PR TITLE
feat(forms): change addControl & removeControl to accept options

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1275,48 +1275,63 @@ export class FormGroup extends AbstractControl {
   }
 
   /**
+   * Unregisters a control with the group's list of controls.
+   *
+   * This method does not update the value or validity of the control.
+   * Use {@link FormGroup#removeControl removeControl} instead.
+   *
+   * @param name The control name to unregister from the collection
+   */
+  unregisterControl(name: string): AbstractControl|null {
+    if (!this.controls[name]) return null;
+    const control = this.controls[name];
+    control._registerOnCollectionChange(() => {});
+    delete (this.controls[name]);
+    return control;
+  }
+
+  /**
    * Add a control to this group.
    *
    * This method also updates the value and validity of the control.
    *
    * @param name The control name to add to the collection
    * @param control Provides the control for the given name
-   * @param options Configuration options that determine how the control propagates changes
-   * and emits events after the control is added.
-   *
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is added.
+   * * `onlySelf`: When true, only update this control. When false or not supplied,
+   * update all direct ancestors. Default is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
-   * `valueChanges`
-   * observables emit events with the latest status and value when the control is added.
-   * When false, no events are emitted.
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * added. When false, no events are emitted.
    */
-  addControl(name: string, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+  addControl(
+      name: string, control: AbstractControl,
+      opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     this.registerControl(name, control);
 
-    if (options.emitEvent === false) return;
-
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
     this._onCollectionChange();
   }
 
   /**
    * Remove a control from this group.
    *
-   * @param name The control name to remove from the collection
-   * @param options Configuration options that determine how the control propagates changes
-   * and emits events after the control is removed.
+   * This method also updates the value and validity of the control.
    *
+   * @param name The control name to remove from the collection
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is removed.
+   * * `onlySelf`: When true, only update this control. When false or not supplied,
+   * update all direct ancestors. Default is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
-   * `valueChanges`
-   * observables emit events with the latest status and value when the control is removed.
-   * When false, no events are emitted.
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * removed. When false, no events are emitted.
    */
-  removeControl(name: string, options: {emitEvent?: boolean} = {}): void {
-    if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
-    delete (this.controls[name]);
+  removeControl(name: string, opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    this.unregisterControl(name);
 
-    if (options.emitEvent === false) return;
-
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
     this._onCollectionChange();
   }
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1703,11 +1703,16 @@ export class FormArray extends AbstractControl {
    * Insert a new `AbstractControl` at the end of the array.
    *
    * @param control Form control to be inserted
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is inserted.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * inserted. When false, no events are emitted.
    */
-  push(control: AbstractControl): void {
+  push(control: AbstractControl, opts: {emitEvent?: boolean} = {}): void {
     this.controls.push(control);
     this._registerControl(control);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
     this._onCollectionChange();
   }
 
@@ -1716,23 +1721,33 @@ export class FormArray extends AbstractControl {
    *
    * @param index Index in the array to insert the control
    * @param control Form control to be inserted
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is inserted.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * inserted. When false, no events are emitted.
    */
-  insert(index: number, control: AbstractControl): void {
+  insert(index: number, control: AbstractControl, opts: {emitEvent?: boolean} = {}): void {
     this.controls.splice(index, 0, control);
 
     this._registerControl(control);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
   }
 
   /**
    * Remove the control at the given `index` in the array.
    *
    * @param index Index in the array to remove the control
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is removed.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * removed. When false, no events are emitted.
    */
-  removeAt(index: number): void {
+  removeAt(index: number, opts: {emitEvent?: boolean} = {}): void {
     if (this.controls[index]) this.controls[index]._registerOnCollectionChange(() => {});
     this.controls.splice(index, 1);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
   }
 
   /**
@@ -1740,8 +1755,13 @@ export class FormArray extends AbstractControl {
    *
    * @param index Index in the array to replace the control
    * @param control The `AbstractControl` control to replace the existing control
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is replaced.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * replaced. When false, no events are emitted.
    */
-  setControl(index: number, control: AbstractControl): void {
+  setControl(index: number, control: AbstractControl, opts: {emitEvent?: boolean} = {}): void {
     if (this.controls[index]) this.controls[index]._registerOnCollectionChange(() => {});
     this.controls.splice(index, 1);
 
@@ -1750,7 +1770,7 @@ export class FormArray extends AbstractControl {
       this._registerControl(control);
     }
 
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
     this._onCollectionChange();
   }
 
@@ -1916,6 +1936,12 @@ export class FormArray extends AbstractControl {
   /**
    * Remove all controls in the `FormArray`.
    *
+   * @param opts Configuration options determine how the control propagates changes and emits
+   * events after the control is cleared.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the control is
+   * cleared. When false, no events are emitted.
+   *
    * @usageNotes
    * ### Remove all elements from a FormArray
    *
@@ -1943,11 +1969,11 @@ export class FormArray extends AbstractControl {
    * }
    * ```
    */
-  clear(): void {
+  clear(opts: {emitEvent?: boolean} = {}): void {
     if (this.controls.length < 1) return;
     this._forEachChild((control: AbstractControl) => control._registerOnCollectionChange(() => {}));
     this.controls.splice(0);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(opts);
   }
 
   /** @internal */

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1281,9 +1281,19 @@ export class FormGroup extends AbstractControl {
    *
    * @param name The control name to add to the collection
    * @param control Provides the control for the given name
+   * @param options Configuration options that determine how the control propagates changes
+   * and emits events after the control is added.
+   *
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is added.
+   * When false, no events are emitted.
    */
-  addControl(name: string, control: AbstractControl): void {
+  addControl(name: string, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
     this.registerControl(name, control);
+
+    if (options.emitEvent === false) return;
+
     this.updateValueAndValidity();
     this._onCollectionChange();
   }
@@ -1292,10 +1302,20 @@ export class FormGroup extends AbstractControl {
    * Remove a control from this group.
    *
    * @param name The control name to remove from the collection
+   * @param options Configuration options that determine how the control propagates changes
+   * and emits events after the control is removed.
+   *
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is removed.
+   * When false, no events are emitted.
    */
-  removeControl(name: string): void {
+  removeControl(name: string, options: {emitEvent?: boolean} = {}): void {
     if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
     delete (this.controls[name]);
+
+    if (options.emitEvent === false) return;
+
     this.updateValueAndValidity();
     this._onCollectionChange();
   }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1287,9 +1287,7 @@ export class FormGroup extends AbstractControl {
    * `valueChanges` observables emit events with the latest status and value when the control is
    * added. When false, no events are emitted.
    */
-  addControl(
-      name: string, control: AbstractControl,
-      opts: {emitEvent?: boolean} = {}): void {
+  addControl(name: string, control: AbstractControl, opts: {emitEvent?: boolean} = {}): void {
     this.registerControl(name, control);
 
     this.updateValueAndValidity(opts);

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1275,22 +1275,6 @@ export class FormGroup extends AbstractControl {
   }
 
   /**
-   * Unregisters a control with the group's list of controls.
-   *
-   * This method does not update the value or validity of the control.
-   * Use {@link FormGroup#removeControl removeControl} instead.
-   *
-   * @param name The control name to unregister from the collection
-   */
-  unregisterControl(name: string): AbstractControl|null {
-    if (!this.controls[name]) return null;
-    const control = this.controls[name];
-    control._registerOnCollectionChange(() => {});
-    delete (this.controls[name]);
-    return control;
-  }
-
-  /**
    * Add a control to this group.
    *
    * This method also updates the value and validity of the control.
@@ -1299,15 +1283,13 @@ export class FormGroup extends AbstractControl {
    * @param control Provides the control for the given name
    * @param opts Configuration options determine how the control propagates changes and emits
    * events after the control is added.
-   * * `onlySelf`: When true, only update this control. When false or not supplied,
-   * update all direct ancestors. Default is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * added. When false, no events are emitted.
    */
   addControl(
       name: string, control: AbstractControl,
-      opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+      opts: {emitEvent?: boolean} = {}): void {
     this.registerControl(name, control);
 
     this.updateValueAndValidity(opts);
@@ -1322,14 +1304,15 @@ export class FormGroup extends AbstractControl {
    * @param name The control name to remove from the collection
    * @param opts Configuration options determine how the control propagates changes and emits
    * events after the control is removed.
-   * * `onlySelf`: When true, only update this control. When false or not supplied,
-   * update all direct ancestors. Default is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * removed. When false, no events are emitted.
    */
-  removeControl(name: string, opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
-    this.unregisterControl(name);
+  removeControl(name: string, opts: {emitEvent?: boolean} = {}): void {
+    if (this.controls[name]) {
+      this.controls[name]._registerOnCollectionChange(() => {});
+      delete (this.controls[name]);
+    }
 
     this.updateValueAndValidity(opts);
     this._onCollectionChange();

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -83,69 +83,69 @@ import {of } from 'rxjs';
       });
 
       it('should not emit event when pushing if emitEvent is false', fakeAsync(() => {
-        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
-        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-        a.push(c1, {emitEvent: false});
-        tick();
+           a.push(c1, {emitEvent: false});
+           tick();
 
-        expect(a.length).toEqual(1);
-        expect(a.controls).toEqual([c1]);
-      }));
+           expect(a.length).toEqual(1);
+           expect(a.controls).toEqual([c1]);
+         }));
 
       it('should not emit event when removing if emitEvent is false', fakeAsync(() => {
-        a.push(c1);
-        a.push(c2);
-        a.push(c3);
+           a.push(c1);
+           a.push(c2);
+           a.push(c3);
 
-        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
-        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-        a.removeAt(1, {emitEvent: false});
-        tick();
+           a.removeAt(1, {emitEvent: false});
+           tick();
 
-        expect(a.controls).toEqual([c1, c3]);
-      }));
+           expect(a.controls).toEqual([c1, c3]);
+         }));
 
       it('should not emit event when clearing if emitEvent is false', fakeAsync(() => {
-        a.push(c1);
-        a.push(c2);
-        a.push(c3);
+           a.push(c1);
+           a.push(c2);
+           a.push(c3);
 
-        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
-        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-        a.clear({emitEvent: false});
-        tick();
+           a.clear({emitEvent: false});
+           tick();
 
-        expect(a.controls).toEqual([]);
-      }));
+           expect(a.controls).toEqual([]);
+         }));
 
       it('should not emit event when inserting if emitEvent is false', fakeAsync(() => {
-        a.push(c1);
-        a.push(c3);
+           a.push(c1);
+           a.push(c3);
 
-        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
-        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-        a.insert(1, c2, {emitEvent: false});
-        tick();
+           a.insert(1, c2, {emitEvent: false});
+           tick();
 
-        expect(a.controls).toEqual([c1, c2, c3]);
-      }));
+           expect(a.controls).toEqual([c1, c2, c3]);
+         }));
 
       it('should not emit event when replacing if emitEvent is false', fakeAsync(() => {
-        a.push(c1);
-        a.push(c3);
+           a.push(c1);
+           a.push(c3);
 
-        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
-        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-        a.setControl(1, c2, {emitEvent: false});
-        tick();
+           a.setControl(1, c2, {emitEvent: false});
+           tick();
 
-        expect(a.controls).toEqual([c1, c2]);
-      }));
+           expect(a.controls).toEqual([c1, c2]);
+         }));
     });
 
     describe('value', () => {

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -121,7 +121,7 @@ import {of } from 'rxjs';
         expect(a.controls).toEqual([]);
       }));
 
-      it('should not emit event when inserting if emitEvent is false', () => {
+      it('should not emit event when inserting if emitEvent is false', fakeAsync(() => {
         a.push(c1);
         a.push(c3);
 
@@ -132,9 +132,9 @@ import {of } from 'rxjs';
         tick();
 
         expect(a.controls).toEqual([c1, c2, c3]);
-      });
+      }));
 
-      it('should not emit event when replacing if emitEvent is false', () => {
+      it('should not emit event when replacing if emitEvent is false', fakeAsync(() => {
         a.push(c1);
         a.push(c3);
 
@@ -145,7 +145,7 @@ import {of } from 'rxjs';
         tick();
 
         expect(a.controls).toEqual([c1, c2]);
-      });
+      }));
     });
 
     describe('value', () => {

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -81,6 +81,71 @@ import {of } from 'rxjs';
 
         expect(a.controls).toEqual([c1, c2, c3]);
       });
+
+      it('should not emit event when pushing if emitEvent is false', fakeAsync(() => {
+        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+        a.push(c1, {emitEvent: false});
+        tick();
+
+        expect(a.length).toEqual(1);
+        expect(a.controls).toEqual([c1]);
+      }));
+
+      it('should not emit event when removing if emitEvent is false', fakeAsync(() => {
+        a.push(c1);
+        a.push(c2);
+        a.push(c3);
+
+        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+        a.removeAt(1, {emitEvent: false});
+        tick();
+
+        expect(a.controls).toEqual([c1, c3]);
+      }));
+
+      it('should not emit event when clearing if emitEvent is false', fakeAsync(() => {
+        a.push(c1);
+        a.push(c2);
+        a.push(c3);
+
+        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+        a.clear({emitEvent: false});
+        tick();
+
+        expect(a.controls).toEqual([]);
+      }));
+
+      it('should not emit event when inserting if emitEvent is false', () => {
+        a.push(c1);
+        a.push(c3);
+
+        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+        a.insert(1, c2, {emitEvent: false});
+        tick();
+
+        expect(a.controls).toEqual([c1, c2, c3]);
+      });
+
+      it('should not emit event when replacing if emitEvent is false', () => {
+        a.push(c1);
+        a.push(c3);
+
+        a.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+        a.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+        a.setControl(1, c2, {emitEvent: false});
+        tick();
+
+        expect(a.controls).toEqual([c1, c2]);
+      });
     });
 
     describe('value', () => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -171,29 +171,6 @@ import {of } from 'rxjs';
         expect(g.valid).toBe(true);
       });
 
-      it('should not update value and validity when control is registered', () => {
-        const g = new FormGroup({'one': new FormControl('1')});
-        expect(g.value).toEqual({'one': '1'});
-        expect(g.valid).toBe(true);
-
-        g.registerControl('two', new FormControl('2', Validators.minLength(10)));
-
-        expect(g.value).toEqual({'one': '1'});
-        expect(g.valid).toBe(true);
-      });
-
-      it('should not update value and validity when control is unregistered', () => {
-        const g = new FormGroup(
-            {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
-        expect(g.value).toEqual({'one': '1', 'two': '2'});
-        expect(g.valid).toBe(false);
-
-        g.unregisterControl('two');
-
-        expect(g.value).toEqual({'one': '1', 'two': '2'});
-        expect(g.valid).toBe(false);
-      });
-
       it('should not emit events when control is added and emitEvent is false', fakeAsync(() => {
            const g = new FormGroup({'one': new FormControl('1')});
            expect(g.value).toEqual({'one': '1'});

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -171,19 +171,45 @@ import {of } from 'rxjs';
         expect(g.valid).toBe(true);
       });
 
-      it('should not update value and validity when control is added with emitEvent false', () => {
+      it('should not update value and validity when control is registered', () => {
         const g = new FormGroup({'one': new FormControl('1')});
         expect(g.value).toEqual({'one': '1'});
         expect(g.valid).toBe(true);
 
-        g.addControl('two', new FormControl('2', Validators.minLength(10)), {emitEvent: false});
+        g.registerControl('two', new FormControl('2', Validators.minLength(10)));
 
         expect(g.value).toEqual({'one': '1'});
         expect(g.valid).toBe(true);
       });
 
-      it('should not update value and validity when control is removed with emitEvent false',
-         () => {
+      it('should not update value and validity when control is unregistered', () => {
+        const g = new FormGroup(
+            {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
+        expect(g.value).toEqual({'one': '1', 'two': '2'});
+        expect(g.valid).toBe(false);
+
+        g.unregisterControl('two');
+
+        expect(g.value).toEqual({'one': '1', 'two': '2'});
+        expect(g.valid).toBe(false);
+      });
+
+      it('should not emit events when control is added and emitEvent is false', fakeAsync(() => {
+           const g = new FormGroup({'one': new FormControl('1')});
+           expect(g.value).toEqual({'one': '1'});
+           expect(g.valid).toBe(true);
+
+           g.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           g.statusChanges.subscribe((value) => { throw 'Should not happen'; });
+
+           g.addControl('two', new FormControl('2', Validators.minLength(10)), {emitEvent: false});
+           tick();
+
+           expect(g.value).toEqual({'one': '1', 'two': '2'});
+           expect(g.valid).toBe(false);
+         }));
+
+      it('should not emit events when control is removed and emitEvent is false', fakeAsync(() => {
            const g = new FormGroup({
              'one': new FormControl('1'),
              'two': new FormControl('2', Validators.minLength(10))
@@ -191,11 +217,15 @@ import {of } from 'rxjs';
            expect(g.value).toEqual({'one': '1', 'two': '2'});
            expect(g.valid).toBe(false);
 
-           g.removeControl('two', {emitEvent: false});
+           g.valueChanges.subscribe((value) => { throw 'Should not happen'; });
+           g.statusChanges.subscribe((value) => { throw 'Should not happen'; });
 
-           expect(g.value).toEqual({'one': '1', 'two': '2'});
-           expect(g.valid).toBe(false);
-         });
+           g.removeControl('two', {emitEvent: false});
+           tick();
+
+           expect(g.value).toEqual({'one': '1'});
+           expect(g.valid).toBe(true);
+         }));
     });
 
     describe('dirty', () => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -182,17 +182,20 @@ import {of } from 'rxjs';
         expect(g.valid).toBe(true);
       });
 
-      it('should not update value and validity when control is removed with emitEvent false', () => {
-        const g = new FormGroup(
-            {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
-        expect(g.value).toEqual({'one': '1', 'two': '2'});
-        expect(g.valid).toBe(false);
+      it('should not update value and validity when control is removed with emitEvent false',
+         () => {
+           const g = new FormGroup({
+             'one': new FormControl('1'),
+             'two': new FormControl('2', Validators.minLength(10))
+           });
+           expect(g.value).toEqual({'one': '1', 'two': '2'});
+           expect(g.valid).toBe(false);
 
-        g.removeControl('two', {emitEvent: false});
+           g.removeControl('two', {emitEvent: false});
 
-        expect(g.value).toEqual({'one': '1', 'two': '2'});
-        expect(g.valid).toBe(false);
-      });
+           expect(g.value).toEqual({'one': '1', 'two': '2'});
+           expect(g.valid).toBe(false);
+         });
     });
 
     describe('dirty', () => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -170,6 +170,29 @@ import {of } from 'rxjs';
         expect(g.value).toEqual({'one': '1'});
         expect(g.valid).toBe(true);
       });
+
+      it('should not update value and validity when control is added with emitEvent false', () => {
+        const g = new FormGroup({'one': new FormControl('1')});
+        expect(g.value).toEqual({'one': '1'});
+        expect(g.valid).toBe(true);
+
+        g.addControl('two', new FormControl('2', Validators.minLength(10)), {emitEvent: false});
+
+        expect(g.value).toEqual({'one': '1'});
+        expect(g.valid).toBe(true);
+      });
+
+      it('should not update value and validity when control is removed with emitEvent false', () => {
+        const g = new FormGroup(
+            {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
+        expect(g.value).toEqual({'one': '1', 'two': '2'});
+        expect(g.valid).toBe(false);
+
+        g.removeControl('two', {emitEvent: false});
+
+        expect(g.value).toEqual({'one': '1', 'two': '2'});
+        expect(g.valid).toBe(false);
+      });
     });
 
     describe('dirty', () => {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -273,7 +273,6 @@ export declare class FormGroup extends AbstractControl {
         [key: string]: AbstractControl;
     }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     addControl(name: string, control: AbstractControl, opts?: {
-        onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     contains(controlName: string): boolean;
@@ -286,7 +285,6 @@ export declare class FormGroup extends AbstractControl {
     }): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
     removeControl(name: string, opts?: {
-        onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     reset(value?: any, options?: {
@@ -300,7 +298,6 @@ export declare class FormGroup extends AbstractControl {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    unregisterControl(name: string): AbstractControl | null;
 }
 
 export declare class FormGroupDirective extends ControlContainer implements Form, OnChanges {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -272,7 +272,9 @@ export declare class FormGroup extends AbstractControl {
     constructor(controls: {
         [key: string]: AbstractControl;
     }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    addControl(name: string, control: AbstractControl): void;
+    addControl(name: string, control: AbstractControl, options?: {
+        emitEvent?: boolean;
+    }): void;
     contains(controlName: string): boolean;
     getRawValue(): any;
     patchValue(value: {
@@ -282,7 +284,9 @@ export declare class FormGroup extends AbstractControl {
         emitEvent?: boolean;
     }): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
-    removeControl(name: string): void;
+    removeControl(name: string, options?: {
+        emitEvent?: boolean;
+    }): void;
     reset(value?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -171,28 +171,28 @@ export declare class FormArray extends AbstractControl {
     constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     at(index: number): AbstractControl;
     clear(opts?: {
-        emitEvent?: boolean
+        emitEvent?: boolean;
     }): void;
     getRawValue(): any[];
     insert(index: number, control: AbstractControl, opts?: {
-        emitEvent?: boolean
+        emitEvent?: boolean;
     }): void;
     patchValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     push(control: AbstractControl, opts?: {
-        emitEvent?: boolean
+        emitEvent?: boolean;
     }): void;
     removeAt(index: number, opts?: {
-        emitEvent?: boolean
+        emitEvent?: boolean;
     }): void;
     reset(value?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     setControl(index: number, control: AbstractControl, opts?: {
-        emitEvent?: boolean
+        emitEvent?: boolean;
     }): void;
     setValue(value: any[], options?: {
         onlySelf?: boolean;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -170,20 +170,30 @@ export declare class FormArray extends AbstractControl {
     readonly length: number;
     constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     at(index: number): AbstractControl;
-    clear(opts?: {emitEvent?: boolean}): void;
+    clear(opts?: {
+        emitEvent?: boolean
+    }): void;
     getRawValue(): any[];
-    insert(index: number, control: AbstractControl, opts?: {emitEvent?: boolean}): void;
+    insert(index: number, control: AbstractControl, opts?: {
+        emitEvent?: boolean
+    }): void;
     patchValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    push(control: AbstractControl, opts?: {emitEvent?: boolean}): void;
-    removeAt(index: number, opts?: {emitEvent?: boolean}): void;
+    push(control: AbstractControl, opts?: {
+        emitEvent?: boolean
+    }): void;
+    removeAt(index: number, opts?: {
+        emitEvent?: boolean
+    }): void;
     reset(value?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    setControl(index: number, control: AbstractControl, opts?: {emitEvent?: boolean}): void;
+    setControl(index: number, control: AbstractControl, opts?: {
+        emitEvent?: boolean
+    }): void;
     setValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -272,7 +272,8 @@ export declare class FormGroup extends AbstractControl {
     constructor(controls: {
         [key: string]: AbstractControl;
     }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    addControl(name: string, control: AbstractControl, options?: {
+    addControl(name: string, control: AbstractControl, opts?: {
+        onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     contains(controlName: string): boolean;
@@ -284,7 +285,8 @@ export declare class FormGroup extends AbstractControl {
         emitEvent?: boolean;
     }): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
-    removeControl(name: string, options?: {
+    removeControl(name: string, opts?: {
+        onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     reset(value?: any, options?: {
@@ -298,6 +300,7 @@ export declare class FormGroup extends AbstractControl {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
+    unregisterControl(name: string): AbstractControl | null;
 }
 
 export declare class FormGroupDirective extends ControlContainer implements Form, OnChanges {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -170,20 +170,20 @@ export declare class FormArray extends AbstractControl {
     readonly length: number;
     constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     at(index: number): AbstractControl;
-    clear(): void;
+    clear(opts?: {emitEvent?: boolean}): void;
     getRawValue(): any[];
-    insert(index: number, control: AbstractControl): void;
+    insert(index: number, control: AbstractControl, opts?: {emitEvent?: boolean}): void;
     patchValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    push(control: AbstractControl): void;
-    removeAt(index: number): void;
+    push(control: AbstractControl, opts?: {emitEvent?: boolean}): void;
+    removeAt(index: number, opts?: {emitEvent?: boolean}): void;
     reset(value?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    setControl(index: number, control: AbstractControl): void;
+    setControl(index: number, control: AbstractControl, opts?: {emitEvent?: boolean}): void;
     setValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;


### PR DESCRIPTION
This commit adds an optional argument to the methods addControl
and removeControl in the FormGroup class. This argument can be
used to prevent an event from being emitted.

PR Close #29662

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29662 


## What is the new behavior?
An argument can now be specified to prevent an event from being emitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
