### PR TITLE
docs: fix typos in getting-started

### DIFF
--- a/aio/content/getting-started/data.md
+++ b/aio/content/getting-started/data.md
@@ -118,7 +118,7 @@ When the "Buy" button is clicked, you'll use the cart service to add the current
 
 ## Create the cart page
 
-At this point, user can put items in the cart by clicking "Buy", but they can't yet see their cart. 
+At this point, users can put items in the cart by clicking "Buy", but they can't yet see their cart. 
 
 We'll create the cart page in two steps: 
 
@@ -127,7 +127,7 @@ We'll create the cart page in two steps:
 
 ### Set up the component
 
- To create the cart page, you being by following the same steps you did to create the product details component and to set up routing for the new component.
+ To create the cart page, you begin by following the same steps you did to create the product details component and to set up routing for the new component.
 
 1. Generate a cart component, named `cart`. 
 

--- a/aio/content/getting-started/routing.md
+++ b/aio/content/getting-started/routing.md
@@ -48,7 +48,7 @@ The app is already set up to use the Angular router and to use routing to naviga
     To do: I see a comment line with ellipses between the closing of h3 and div. It's an interesting way to show that we've clipped out some code. Should we use this elsewhere? 
     -->
 
-      The RouterLink directive give the router control over the anchor element. In this case, the route (URL) contains one fixed segment (`/products`) and the final segment is variable, inserting the id property of the current product. For example, the URL for a product with an `id` of 1 will be similar to `https://getting-started-myfork.stackblitz.io.products/1`. 
+      The RouterLink directive gives the router control over the anchor element. In this case, the route (URL) contains one fixed segment (`/products`) and the final segment is variable, inserting the id property of the current product. For example, the URL for a product with an `id` of 1 will be similar to `https://getting-started-myfork.stackblitz.io.products/1`. 
 
 1. Test the router by clicking a product name. The app displays the product details component, which currently always says "product-details works!" (We'll fix this in the next section.)
 


### PR DESCRIPTION
PR #27684 introduced a new getting-started guide and a few typos slipped through the review.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
