### PR TITLE
docs-infra: support API aliases in dgeni

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -75,7 +75,7 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
     readTypeScriptModules.ignoreExportsMatching = [/^[_ɵ]|^VERSION$/];
     readTypeScriptModules.hidePrivateMembers = true;
 
-    // NOTE: This list shold be in sync with tools/public_api_guard/BUILD.bazel
+    // NOTE: This list should be in sync with tools/public_api_guard/BUILD.bazel
     readTypeScriptModules.sourceFiles = [
       'animations/index.ts',
       'animations/browser/index.ts',

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -32,9 +32,11 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
   .processor(require('./processors/simplifyMemberAnchors'))
   .processor(require('./processors/computeStability'))
   .processor(require('./processors/removeInjectableConstructors'))
+  .processor(require('./processors/collectPackageContentDocs'))
   .processor(require('./processors/processPackages'))
   .processor(require('./processors/processNgModuleDocs'))
   .processor(require('./processors/fixupRealProjectRelativePath'))
+  .processor(require('./processors/processAliasDocs'))
 
 
   /**
@@ -72,7 +74,7 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
 
     // API files are typescript
     readTypeScriptModules.basePath = API_SOURCE_PATH;
-    readTypeScriptModules.ignoreExportsMatching = [/^[_ɵ]|^VERSION$/];
+    readTypeScriptModules.ignoreExportsMatching = [/^[_]|^VERSION$/];
     readTypeScriptModules.hidePrivateMembers = true;
 
     // NOTE: This list should be in sync with tools/public_api_guard/BUILD.bazel

--- a/aio/tools/transforms/angular-api-package/processors/addMetadataAliases.js
+++ b/aio/tools/transforms/angular-api-package/processors/addMetadataAliases.js
@@ -15,9 +15,13 @@ module.exports = function addMetadataAliasesProcessor() {
       docs.forEach(doc => {
         switch(doc.docType) {
         case 'directive':
-        case 'component':
-          doc.aliases = doc.aliases.concat(extractSelectors(doc[doc.docType + 'Options'].selector));
+        case 'component': {
+          const selector = doc[doc.docType + 'Options'].selector;
+          if (selector) {
+            doc.aliases = doc.aliases.concat(extractSelectors(selector));
+          }
           break;
+        }
         case 'pipe':
           if (doc.pipeOptions.name) {
             doc.aliases = doc.aliases.concat(stripQuotes(doc.pipeOptions.name));

--- a/aio/tools/transforms/angular-api-package/processors/addMetadataAliases.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/addMetadataAliases.spec.js
@@ -54,4 +54,15 @@ describe('addSelectorsAsAliases processor', () => {
     expect(docs[11].aliases).toEqual([docs[11].name]);
     expect(docs[12].aliases).toEqual([docs[12].name]);
   });
+
+  it('should ignore directives and components that have no selector', () => {
+    const processor = processorFactory();
+    const docs = [
+      { docType: 'directive', name: 'MyDirective', aliases: ['MyDirective'], directiveOptions: { } },
+      { docType: 'component', name: 'MyComponent', aliases: ['MyComponent'], componentOptions: { } },
+    ];
+    processor.$process(docs);
+    expect(docs[0].aliases).toEqual([docs[0].name]);
+    expect(docs[1].aliases).toEqual([docs[1].name]);
+  });
 });

--- a/aio/tools/transforms/angular-api-package/processors/collectPackageContentDocs.js
+++ b/aio/tools/transforms/angular-api-package/processors/collectPackageContentDocs.js
@@ -1,0 +1,19 @@
+const { dirname } = require('canonical-path');
+
+module.exports = function collectPackageContentDocsProcessor() {
+  return {
+    $runAfter: ['tags-extracted'],
+    $runBefore: ['computing-ids', 'processPackages'],
+    packageContentFiles: {},
+    $process(docs) {
+      return docs.filter(doc => {
+        if (doc.docType === 'package-content') {
+          this.packageContentFiles[dirname(doc.fileInfo.filePath)] = doc;
+          return false;
+        } else {
+          return true;
+        }
+      });
+    }
+  };
+};

--- a/aio/tools/transforms/angular-api-package/processors/collectPackageContentDocs.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/collectPackageContentDocs.spec.js
@@ -1,0 +1,49 @@
+const testPackage = require('../../helpers/test-package');
+const processorFactory = require('./collectPackageContentDocs');
+const Dgeni = require('dgeni');
+
+describe('collectPackageContentDocs processor', () => {
+
+  it('should be available on the injector', () => {
+    const dgeni = new Dgeni([testPackage('angular-api-package')]);
+    const injector = dgeni.configureInjector();
+    const processor = injector.get('collectPackageContentDocsProcessor');
+    expect(processor.$process).toBeDefined();
+    expect(processor.$runAfter).toEqual(['tags-extracted']);
+    expect(processor.$runBefore).toEqual(['computing-ids', 'processPackages']);
+  });
+
+  it('should collect any `package-content` docs in the `packageContentFiles` map', () => {
+    const docs = [
+      { fileInfo: { filePath: 'some/a' }, docType: 'a', id: 'a' },
+      { fileInfo: { filePath: 'some/x/PACKAGE.md' }, docType: 'package-content', id: 'x' },
+      { fileInfo: { filePath: 'some/b' }, docType: 'b', id: 'b' },
+      { fileInfo: { filePath: 'some/y/PACKAGE.md' }, docType: 'package-content', id: 'y' },
+      { fileInfo: { filePath: 'some/z/PACKAGE.md' }, docType: 'package-content', id: 'z' },
+    ];
+    const processor = processorFactory();
+    processor.$process(docs);
+
+    expect(processor.packageContentFiles).toEqual({
+      'some/x': { fileInfo: { filePath: 'some/x/PACKAGE.md' }, docType: 'package-content', id: 'x' },
+      'some/y': { fileInfo: { filePath: 'some/y/PACKAGE.md' }, docType: 'package-content', id: 'y' },
+      'some/z': { fileInfo: { filePath: 'some/z/PACKAGE.md' }, docType: 'package-content', id: 'z' },
+    });
+  });
+
+  it('should filter out any `package-content` docs from the collection', () => {
+    const docs = [
+      { fileInfo: { filePath: 'some/a' }, docType: 'a', id: 'a' },
+      { fileInfo: { filePath: 'some/x/PACKAGE.md' }, docType: 'package-content', id: 'x' },
+      { fileInfo: { filePath: 'some/b' }, docType: 'b', id: 'b' },
+      { fileInfo: { filePath: 'some/y/PACKAGE.md' }, docType: 'package-content', id: 'y' },
+      { fileInfo: { filePath: 'some/z/PACKAGE.md' }, docType: 'package-content', id: 'z' },
+    ];
+    const processor = processorFactory();
+    const newDocs = processor.$process(docs);
+    expect(newDocs).toEqual([
+      { fileInfo: { filePath: 'some/a' }, docType: 'a', id: 'a' },
+      { fileInfo: { filePath: 'some/b' }, docType: 'b', id: 'b' },
+    ]);
+  });
+});

--- a/aio/tools/transforms/angular-api-package/processors/processAliasDocs.js
+++ b/aio/tools/transforms/angular-api-package/processors/processAliasDocs.js
@@ -1,0 +1,40 @@
+/**
+ * Copies over the properties from a doc's alias if it is marked with `@alias`.
+ */
+module.exports = function processAliasDocs(getDocFromAlias, log, createDocMessage) {
+  return {
+    $runAfter: ['tags-extracted', 'ids-computed'],
+    $runBefore: ['filterPrivateDocs'],
+    propertiesToKeep: [
+      'name', 'id', 'aliases', 'fileInfo', 'startingLine', 'endingLine',
+      'path', 'originalModule', 'outputPath', 'privateExport', 'moduleDoc'
+    ],
+    $process(docs) {
+      docs.forEach(doc => {
+        if (doc.aliasDocId) {
+          const aliasDocs = getDocFromAlias(doc.aliasDocId, doc);
+          if (aliasDocs.length === 1) {
+            const aliasDoc = aliasDocs[0];
+            log.debug('processing alias', doc.id, doc.aliasDocId, aliasDoc.id);
+            // Clean out the unwanted properties from the doc
+            Object.keys(doc).forEach(key => {
+              if (!this.propertiesToKeep.includes(key)) {
+                delete doc[key];
+              }
+            });
+            // Copy over all the properties of the alias doc.
+            Object.keys(aliasDoc).forEach(key => {
+              if (!this.propertiesToKeep.includes(key)) {
+                doc[key] = aliasDoc[key];
+              }
+            });
+          } else if (aliasDocs.length === 0) {
+            throw new Error(createDocMessage(`There is no doc that matches "@alias ${doc.aliasDocId}"`, doc));
+          } else {
+            throw new Error(createDocMessage(`There is more than one doc that matches "@alias ${doc.aliasDocId}": ${aliasDocs.map(d => d.id).join(', ')}.`, doc));
+          }
+        }
+      });
+    }
+  };
+};

--- a/aio/tools/transforms/angular-api-package/processors/processAliasDocs.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/processAliasDocs.spec.js
@@ -1,0 +1,83 @@
+const testPackage = require('../../helpers/test-package');
+const processorFactory = require('./processAliasDocs');
+const Dgeni = require('dgeni');
+const mockLogFactory = require('dgeni/lib/mocks/log');
+const createDocMessageFactory = require('dgeni-packages/base/services/createDocMessage');
+
+describe('processAliasDocs processor', () => {
+
+  let getDocFromAlias, log, createDocMessage, processor;
+
+  beforeEach(() => {
+    getDocFromAlias = jasmine.createSpy('getDocFromAlias');
+    log = mockLogFactory(false);
+    createDocMessage = createDocMessageFactory();
+    processor = processorFactory(getDocFromAlias, log, createDocMessage);
+  });
+
+  it('should be available on the injector', () => {
+    const dgeni = new Dgeni([testPackage('angular-api-package')]);
+    const injector = dgeni.configureInjector();
+    const processor = injector.get('processAliasDocs');
+    expect(processor.$process).toBeDefined();
+  });
+
+  it('should run before the correct processor', () => {
+    expect(processor.$runBefore).toEqual(['filterPrivateDocs']);
+  });
+
+  it('should run after the correct processor', () => {
+    expect(processor.$runAfter).toEqual(['tags-extracted', 'ids-computed']);
+  });
+
+  it('should ignore docs that do not have an `@alias` tag', () => {
+    const docs = [{}];
+    getDocFromAlias.and.returnValue([{ prop1: 'prop-1', prop2: 'prop-2', prop3: 'prop-3' }]);
+    processor.$process(docs);
+    expect(docs).toEqual([{}]);
+  });
+
+  it('should copy over properties from a valid alias doc', () => {
+    const docs = [{ aliasDocId: 'alias-doc' }];
+    getDocFromAlias.and.returnValue([{ prop1: 'prop-1', prop2: 'prop-2', prop3: 'prop-3' }]);
+    processor.$process(docs);
+    expect(docs).toEqual([
+      { prop1: 'prop-1', prop2: 'prop-2', prop3: 'prop-3' }
+    ]);
+  });
+
+  it('should error if `@alias` does not match a doc', () => {
+    const docs = [{ aliasDocId: 'alias-doc' }];
+    getDocFromAlias.and.returnValue([]);
+    expect(() => processor.$process(docs)).toThrowError('There is no doc that matches "@alias alias-doc" - doc');
+  });
+
+  it('should error if `@alias` matches more than one doc', () => {
+    const docs = [{ aliasDocId: 'alias-doc' }];
+    getDocFromAlias.and.returnValue([{id: 'alias-1'}, {id: 'alias-2'}]);
+    expect(() => processor.$process(docs)).toThrowError('There is more than one doc that matches "@alias alias-doc": alias-1, alias-2. - doc');
+  });
+
+  it('should remove all but the specified properties from the original doc', () => {
+    processor.propertiesToKeep = ['x', 'y'];
+    const docs = [{ aliasDocId: 'alias-doc', x: 'original-x', z: 'original-z' }];
+    getDocFromAlias.and.returnValue([{}]);
+    processor.$process(docs);
+    expect(docs).toEqual([{ x: 'original-x' }]);
+  });
+
+  it('should copy over all but the specified properties from the aliased doc', () => {
+    processor.propertiesToKeep = ['x', 'y'];
+    const docs = [{ aliasDocId: 'alias-doc', x: 'original-x', z: 'original-z' }];
+    getDocFromAlias.and.returnValue([{ x: 'alias-x', y: 'alias-y', z: 'alias-z' }]);
+    processor.$process(docs);
+    expect(docs).toEqual([{ x: 'original-x', z: 'alias-z' }]);
+  });
+
+  it('should have default properties to keep', () => {
+    expect(processor.propertiesToKeep).toEqual([
+      'name', 'id', 'aliases', 'fileInfo', 'startingLine', 'endingLine',
+      'path', 'originalModule', 'outputPath', 'privateExport', 'moduleDoc'
+    ]);
+  });
+});

--- a/aio/tools/transforms/angular-api-package/processors/processPackages.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/processPackages.spec.js
@@ -9,36 +9,19 @@ describe('processPackages processor', () => {
     const injector = dgeni.configureInjector();
     const processor = injector.get('processPackages');
     expect(processor.$process).toBeDefined();
-    expect(processor.$runAfter).toEqual(['extractDecoratedClassesProcessor', 'computeStability']);
-    expect(processor.$runBefore).toEqual(['computing-ids', 'generateKeywordsProcessor']);
+    expect(processor.$runAfter).toEqual(['processAliasDocs', 'collectPackageContentDocsProcessor']);
+    expect(processor.$runBefore).toEqual(['rendering-docs', 'checkContentRules']);
   });
-
-  it('should filter out any `package-content` docs from the collection', () => {
-    const docs = [
-      { fileInfo: { filePath: 'some/a' }, docType: 'a', id: 'a' },
-      { fileInfo: { filePath: 'some/x' }, docType: 'package-content', id: 'x' },
-      { fileInfo: { filePath: 'some/b' }, docType: 'b', id: 'b' },
-      { fileInfo: { filePath: 'some/y' }, docType: 'package-content', id: 'y' },
-      { fileInfo: { filePath: 'some/z' }, docType: 'package-content', id: 'z' },
-    ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
-    expect(newDocs).toEqual([
-      { fileInfo: { filePath: 'some/a' }, docType: 'a', id: 'a' },
-      { fileInfo: { filePath: 'some/b' }, docType: 'b', id: 'b' },
-    ]);
-  });
-
 
   it('should change `module` docs to `package` docs', () => {
-    const processor = processorFactory();
+    const processor = processorFactory({ packageContentFiles: {} });
     const docs = [
       { fileInfo: { filePath: 'some/a' }, docType: 'module', id: 'a' },
       { fileInfo: { filePath: 'some/b' }, docType: 'module', id: 'b' },
       { docType: 'other', id: 'c' },
     ];
-    const newDocs = processor.$process(docs);
-    expect(newDocs).toEqual([
+    processor.$process(docs);
+    expect(docs).toEqual([
       jasmine.objectContaining({ docType: 'package', id: 'a' }),
       jasmine.objectContaining({ docType: 'package', id: 'b' }),
       jasmine.objectContaining({ docType: 'other', id: 'c' }),
@@ -54,21 +37,23 @@ describe('processPackages processor', () => {
         someProp: 'foo',
       },
       {
+        fileInfo: { filePath: 'some/package-2/index' },
+        docType: 'module',
+        id: 'package-2',
+      },
+    ];
+    const packageContentFiles = {
+      'some/package-1': {
         fileInfo: { filePath: 'some/package-1/PACKAGE.md' },
         docType: 'package-content',
         id: 'package-1/PACKAGE.md',
         shortDescription: 'some short description',
         description: 'some description',
         see: [ 'a', 'b' ],
-      },
-      {
-        fileInfo: { filePath: 'some/package-2/index' },
-        docType: 'module',
-        id: 'package-2',
-      },
-    ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
+      }
+    };
+    const processor = processorFactory({ packageContentFiles });
+    processor.$process(docs);
 
     const package1 = jasmine.objectContaining({
       fileInfo: { filePath: 'some/package-1/PACKAGE.md' },
@@ -90,7 +75,7 @@ describe('processPackages processor', () => {
       isPrimaryPackage: true,
     });
 
-    expect(newDocs).toEqual([package1, package2]);
+    expect(docs).toEqual([package1, package2]);
   });
 
   it('should compute primary and second package info', () => {
@@ -111,20 +96,20 @@ describe('processPackages processor', () => {
         id: 'package-1/sub-2',
       },
     ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
+    const processor = processorFactory({ packageContentFiles: {} });
+    processor.$process(docs);
 
-    expect(newDocs[0].isPrimaryPackage).toBe(true);
-    expect(newDocs[1].isPrimaryPackage).toBe(false);
-    expect(newDocs[2].isPrimaryPackage).toBe(false);
+    expect(docs[0].isPrimaryPackage).toBe(true);
+    expect(docs[1].isPrimaryPackage).toBe(false);
+    expect(docs[2].isPrimaryPackage).toBe(false);
 
-    expect(newDocs[0].packageInfo.primary).toBe(newDocs[0]);
-    expect(newDocs[1].packageInfo.primary).toBe(newDocs[0]);
-    expect(newDocs[2].packageInfo.primary).toBe(newDocs[0]);
+    expect(docs[0].packageInfo.primary).toBe(docs[0]);
+    expect(docs[1].packageInfo.primary).toBe(docs[0]);
+    expect(docs[2].packageInfo.primary).toBe(docs[0]);
 
-    expect(newDocs[0].packageInfo.secondary).toEqual([newDocs[1], newDocs[2]]);
-    expect(newDocs[1].packageInfo.secondary).toEqual([newDocs[1], newDocs[2]]);
-    expect(newDocs[2].packageInfo.secondary).toEqual([newDocs[1], newDocs[2]]);
+    expect(docs[0].packageInfo.secondary).toEqual([docs[1], docs[2]]);
+    expect(docs[1].packageInfo.secondary).toEqual([docs[1], docs[2]]);
+    expect(docs[2].packageInfo.secondary).toEqual([docs[1], docs[2]]);
   });
 
   it('should partition the exports of packages into groups, sorted by id', () => {
@@ -150,28 +135,28 @@ describe('processPackages processor', () => {
         ]
       },
     ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
+    const processor = processorFactory({ packageContentFiles: {} });
+    processor.$process(docs);
 
-    expect(newDocs[0].decorators).toEqual([
+    expect(docs[0].decorators).toEqual([
       { docType: 'decorator', id: 'decorator-1' },
     ]);
-    expect(newDocs[0].functions).toEqual([
+    expect(docs[0].functions).toEqual([
       { docType: 'function', id: 'function-1' },
     ]);
-    expect(newDocs[0].structures).toEqual([
+    expect(docs[0].structures).toEqual([
       { docType: 'enum', id: 'enum-1' },
       { docType: 'interface', id: 'interface-1' },
       { docType: 'interface', id: 'interface-2' },
     ]);
-    expect(newDocs[0].directives).toEqual([
+    expect(docs[0].directives).toEqual([
       { docType: 'directive', id: 'directive-1' },
       { docType: 'directive', id: 'directive-2' },
     ]);
-    expect(newDocs[0].pipes).toEqual([
+    expect(docs[0].pipes).toEqual([
       { docType: 'pipe', id: 'pipe-1' },
     ]);
-    expect(newDocs[0].types).toEqual([
+    expect(docs[0].types).toEqual([
       { docType: 'const', id: 'const-1' },
       { docType: 'const', id: 'const-2' },
       { docType: 'type-alias', id: 'type-alias-1' },
@@ -215,13 +200,13 @@ describe('processPackages processor', () => {
         ]
       },
     ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
+    const processor = processorFactory({ packageContentFiles: {} });
+    processor.$process(docs);
 
-    expect(newDocs[0].deprecated).toBeTruthy();
-    expect(newDocs[1].deprecated).toBeTruthy();
-    expect(newDocs[2].deprecated).toBeUndefined();
-    expect(newDocs[3].deprecated).toBeUndefined();
+    expect(docs[0].deprecated).toBeTruthy();
+    expect(docs[1].deprecated).toBeTruthy();
+    expect(docs[2].deprecated).toBeUndefined();
+    expect(docs[3].deprecated).toBeUndefined();
   });
 
   it('should compute the deprecated status of packages', () => {
@@ -275,12 +260,12 @@ describe('processPackages processor', () => {
         ]
       },
     ];
-    const processor = processorFactory();
-    const newDocs = processor.$process(docs);
-    expect(newDocs[0].packageDeprecated).toBe(true);
-    expect(newDocs[1].packageDeprecated).toBeUndefined();
-    expect(newDocs[2].packageDeprecated).toBe(false);
-    expect(newDocs[3].packageDeprecated).toBeUndefined();
-    expect(newDocs[4].packageDeprecated).toBe(false);
+    const processor = processorFactory({ packageContentFiles: {} });
+    processor.$process(docs);
+    expect(docs[0].packageDeprecated).toBe(true);
+    expect(docs[1].packageDeprecated).toBeUndefined();
+    expect(docs[2].packageDeprecated).toBe(false);
+    expect(docs[3].packageDeprecated).toBeUndefined();
+    expect(docs[4].packageDeprecated).toBe(false);
   });
 });

--- a/aio/tools/transforms/angular-api-package/tag-defs/alias.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/alias.js
@@ -1,0 +1,6 @@
+module.exports = function() {
+  return {
+    name: 'alias',
+    docProperty: 'aliasDocId'
+  };
+};

--- a/aio/tools/transforms/angular-base-package/processors/checkContentRules.js
+++ b/aio/tools/transforms/angular-base-package/processors/checkContentRules.js
@@ -37,6 +37,8 @@ module.exports = function checkContentRules(log, createDocMessage) {
       const logMessage = this.failOnContentErrors ? log.error.bind(log) : log.warn.bind(log);
       const errors = [];
       docs.forEach(doc => {
+        // Ignore private exports (and members of a private export).
+        if (doc.id && doc.id.indexOf('ɵ') !== -1) return;
         const docErrors = [];
         const rules = this.docTypeRules[doc.docType] || {};
         if (rules) {

--- a/aio/tools/transforms/angular-base-package/processors/checkContentRules.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/checkContentRules.spec.js
@@ -50,7 +50,7 @@ describe('checkContentRules processor', function() {
 
     const docs = [
       { docType: 'test1', description: 'test doc 1', name: 'test-1' },
-      { docType: 'test2', description: 'test doc 2', name: 'test-2' }
+      { docType: 'test2', description: 'test doc 2', name: 'test-2' },
     ];
     processor.$process(docs);
     expect(nameSpy1).toHaveBeenCalledTimes(1);
@@ -119,4 +119,17 @@ describe('checkContentRules processor', function() {
          - doc "test-1" (test1) `);
   });
 
+  it('should ignore docs whose id contains a barred-o', () => {
+    const nameSpy1 = jasmine.createSpy('name 1');
+    processor.docTypeRules = { 'doc-type': { name: [nameSpy1] } };
+    const docs = [
+      { docType: 'doc-type', id: 'package/class/property/param', name: 'name-1' },
+      { docType: 'doc-type', id: 'package/class/property/ɵparam', name: 'name-2' },
+      { docType: 'doc-type', id: 'package/class/ɵproperty/param', name: 'name-3' },
+      { docType: 'doc-type', id: 'package/ɵclass/property/param', name: 'name-4' },
+    ];
+    processor.$process(docs);
+    expect(nameSpy1).toHaveBeenCalledTimes(1);
+    expect(nameSpy1).toHaveBeenCalledWith(docs[0], 'name', 'name-1');
+  });
 });

--- a/aio/tools/transforms/authors-package/index.spec.js
+++ b/aio/tools/transforms/authors-package/index.spec.js
@@ -23,70 +23,62 @@ describe('authors-package (integration tests)', () => {
     });
   });
 
-  it('should generate marketing docs if the "fileChanged" is a marketing doc', (done) => {
-    generateDocs('aio/content/marketing/about.html', { silent: true }).then(() => {
+  it('should generate marketing docs if the "fileChanged" is a marketing doc', () => {
+    return generateDocs('aio/content/marketing/about.html', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'about.json'));
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, '../navigation.json'));
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, '../contributors.json'));
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, '../resources.json'));
-      done();
     });
   });
 
-  it('should generate tutorial docs if the "fileChanged" is a tutorial doc', (done) => {
-    generateDocs('aio/content/tutorial/toh-pt5.md', { silent: true }).then(() => {
+  it('should generate tutorial docs if the "fileChanged" is a tutorial doc', () => {
+    return generateDocs('aio/content/tutorial/toh-pt5.md', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial/toh-pt5.json'));
-      done();
     });
   });
 
-  it('should generate tutorial docs if the "fileChanged" is the tutorial index', (done) => {
-    generateDocs('aio/content/tutorial/index.md', { silent: true }).then(() => {
+  it('should generate tutorial docs if the "fileChanged" is the tutorial index', () => {
+    return generateDocs('aio/content/tutorial/index.md', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial.json'));
-      done();
     });
   });
 
-  it('should generate tutorial docs if the "fileChanged" is a tutorial example', (done) => {
-    generateDocs('aio/content/examples/toh-pt3/app/app.component.1.html', { silent: true }).then(() => {
+  it('should generate tutorial docs if the "fileChanged" is a tutorial example', () => {
+    return generateDocs('aio/content/examples/toh-pt3/app/app.component.1.html', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial/toh-pt3.json'));
-      done();
     });
   });
 
-  it('should generate guide doc if the "fileChanged" is a guide doc', (done) => {
-    generateDocs('aio/content/guide/architecture.md', { silent: true }).then(() => {
+  it('should generate guide doc if the "fileChanged" is a guide doc', () => {
+    return generateDocs('aio/content/guide/architecture.md', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'guide/architecture.json'));
-      done();
     });
   });
 
-  it('should generate guide doc if the "fileChanged" is a guide example', (done) => {
-    generateDocs('aio/content/examples/architecture/src/app/app.module.ts', { silent: true }).then(() => {
+  it('should generate guide doc if the "fileChanged" is a guide example', () => {
+    return generateDocs('aio/content/examples/architecture/src/app/app.module.ts', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'guide/architecture.json'));
-      done();
     });
   });
 
-  it('should generate API doc if the "fileChanged" is an API doc', (done) => {
-    generateDocs('packages/forms/src/form_builder.ts', { silent: true }).then(() => {
+  it('should generate API doc if the "fileChanged" is an API doc', () => {
+    return generateDocs('packages/forms/src/form_builder.ts', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'api/forms/FormBuilder.json'));
-      done();
     });
   }, 16000);
 
-  it('should generate API doc if the "fileChanged" is an API example', (done) => {
-    generateDocs('packages/examples/forms/ts/formBuilder/form_builder_example.ts', { silent: true }).then(() => {
+  it('should generate API doc if the "fileChanged" is an API example', () => {
+    return generateDocs('packages/examples/forms/ts/formBuilder/form_builder_example.ts', { silent: true }).then(() => {
       expect(fs.writeFile).toHaveBeenCalled();
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'api/forms/FormBuilder.json'));
-      done();
     });
   }, 16000);
 });

--- a/aio/tools/transforms/templates/api/lib/descendants.html
+++ b/aio/tools/transforms/templates/api/lib/descendants.html
@@ -12,7 +12,7 @@
 {% endmacro -%}
 
 {%- macro renderDescendants(doc, descendantType, title='', recursed=true, docTypeMatcher=descendantType) %}
-  {% set descendants = doc.descendants | filterByPropertyValue('docType', docTypeMatcher) %}
+  {% set descendants = doc.descendants | filterByPropertyValue('docType', docTypeMatcher) | filterByPropertyValue('privateExport', undefined) %}
   {% if descendants.length %}
   <div class="descendants {$ descendantType $}">
     {% if title %}<h2>{$ title $}</h2>{% endif %}

--- a/packages/common/public_api.ts
+++ b/packages/common/public_api.ts
@@ -14,4 +14,10 @@
 export * from './src/common';
 export {registerLocaleData as ɵregisterLocaleData} from './src/i18n/locale_data';
 
+import {ɵChangeDetectorStatus} from '@angular/core';
+
+/**
+ * @alias core/ɵChangeDetectorStatus
+ */
+export const ChangeDetectorStatus = ɵChangeDetectorStatus;
 // This file only reexports content of the `src` folder. Keep it that way.

--- a/packages/common/public_api.ts
+++ b/packages/common/public_api.ts
@@ -14,10 +14,4 @@
 export * from './src/common';
 export {registerLocaleData as ɵregisterLocaleData} from './src/i18n/locale_data';
 
-import {ɵChangeDetectorStatus} from '@angular/core';
-
-/**
- * @alias core/ɵChangeDetectorStatus
- */
-export const ChangeDetectorStatus = ɵChangeDetectorStatus;
 // This file only reexports content of the `src` folder. Keep it that way.


### PR DESCRIPTION
Note that I have hacked the public API of common as a test subject.
See https://pr29673-24e78ae.ngbuilds.io/api/common/ChangeDetectorStatus
and
https://pr29673-24e78ae.ngbuilds.io/api/common#structures

These will be removed once we are happy with the behaviour.