### PR TITLE
build: add render3 entry-point to legacy test systemjs config

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -31,6 +31,7 @@ System.config({
     'rxjs': 'node_modules/rxjs',
   },
   packages: {
+    '@angular/core/src/render3': {main: 'index.js', defaultExtension: 'js'},
     '@angular/core/testing': {main: 'index.js', defaultExtension: 'js'},
     '@angular/core': {main: 'index.js', defaultExtension: 'js'},
     '@angular/animations/browser/testing': {main: 'index.js', defaultExtension: 'js'},


### PR DESCRIPTION
Until the legacy job has been migrated to Bazel w/ Saucelabs, we
need to add the `render3` entry-point to the test SystemJS configuration
so that developers don't get inconsistent behavior between Bazel tests
and the legacy tests. e.g. https://circleci.com/gh/angular/angular/270102