### PR TITLE
fix(bazel): support running ng-add on minimal applications

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -154,15 +154,18 @@ function updateAngularJsonToUseBazelBuilder(options: Schema): Rule {
           },
         },
         indent);
-    replacePropertyInAstObject(
-        recorder, architect, 'test', {
-          builder: '@angular/bazel:build',
-          options: {'bazelCommand': 'test', 'targetLabel': '//src/...'},
-        },
-        indent);
+
+    if (findPropertyInAstObject(architect, 'test')) {
+      replacePropertyInAstObject(
+          recorder, architect, 'test', {
+            builder: '@angular/bazel:build',
+            options: {'bazelCommand': 'test', 'targetLabel': '//src/...'},
+          },
+          indent);
+    }
 
     const e2eArchitect = findE2eArchitect(workspaceJsonAst, name);
-    if (e2eArchitect) {
+    if (e2eArchitect && findPropertyInAstObject(e2eArchitect, 'e2e')) {
       replacePropertyInAstObject(
           recorder, e2eArchitect, 'e2e', {
             builder: '@angular/bazel:build',

--- a/packages/bazel/src/schematics/ng-add/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-add/index_spec.ts
@@ -246,4 +246,23 @@ describe('ng-add schematic', () => {
     const json = JSON.parse(content);
     expect(json.scripts.postinstall).toBe('ngc -p ./angular-metadata.tsconfig.json');
   });
+
+  it('should work when run on a minimal project (without test and e2e targets)', () => {
+    host.overwrite('angular.json', JSON.stringify({
+      projects: {
+        'demo': {
+          architect: {
+            build: {},
+            serve: {},
+            'extract-i18n': {
+              builder: '@angular-devkit/build-angular:extract-i18n',
+            },
+          },
+        },
+      },
+    }));
+
+    expect(() => schematicRunner.runSchematic('ng-add', defaultOptions, host)).not.toThrowError();
+  });
+
 });


### PR DESCRIPTION
Minimal applications don't have `test` and `e2e` targets but we are not currently checking if they exists.

Fixes #29680
