### PR TITLE
refactor(core): static-query schematic should handle abstract classes

### DIFF
--- a/packages/core/schematics/migrations/static-queries/angular/analyze_query_usage.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/analyze_query_usage.ts
@@ -8,9 +8,11 @@
 
 import * as ts from 'typescript';
 import {hasPropertyNameText} from '../../../utils/typescript/property_name';
-import {DeclarationUsageVisitor} from './declaration_usage_visitor';
+
+import {DeclarationUsageVisitor, FunctionContext} from './declaration_usage_visitor';
 import {ClassMetadataMap} from './ng_query_visitor';
 import {NgQueryDefinition, QueryTiming, QueryType} from './query-definition';
+import {updateSuperClassAbstractMembersContext} from './super_class';
 
 /**
  * Object that maps a given type of query to a list of lifecycle hooks that
@@ -34,11 +36,15 @@ export function analyzeNgQueryUsage(
       QueryTiming.DYNAMIC;
 }
 
-/** Checks whether a given class or it's derived classes use the specified query statically. */
+/**
+ * Checks whether a given query is used statically within the given class, its super
+ * class or derived classes.
+ */
 function isQueryUsedStatically(
     classDecl: ts.ClassDeclaration, query: NgQueryDefinition, classMetadataMap: ClassMetadataMap,
-    typeChecker: ts.TypeChecker, knownInputNames: string[]): boolean {
-  const usageVisitor = new DeclarationUsageVisitor(query.property, typeChecker);
+    typeChecker: ts.TypeChecker, knownInputNames: string[],
+    functionCtx: FunctionContext = new Map(), visitInheritedClasses = true): boolean {
+  const usageVisitor = new DeclarationUsageVisitor(query.property, typeChecker, functionCtx);
   const classMetadata = classMetadataMap.get(classDecl);
 
   // In case there is metadata for the current class, we collect all resolved Angular input
@@ -48,24 +54,9 @@ function isQueryUsedStatically(
     knownInputNames.push(...classMetadata.ngInputNames);
   }
 
-  // List of TypeScript nodes which can contain usages of the given query in order to
-  // access it statically. e.g.
-  //  (1) queries used in the "ngOnInit" lifecycle hook are static.
-  //  (2) inputs with setters can access queries statically.
-  const possibleStaticQueryNodes: ts.Node[] =
-      classDecl.members
-          .filter(m => {
-            if (ts.isMethodDeclaration(m) && m.body && hasPropertyNameText(m.name) &&
-                STATIC_QUERY_LIFECYCLE_HOOKS[query.type].indexOf(m.name.text) !== -1) {
-              return true;
-            } else if (
-                knownInputNames && ts.isSetAccessor(m) && m.body && hasPropertyNameText(m.name) &&
-                knownInputNames.indexOf(m.name.text) !== -1) {
-              return true;
-            }
-            return false;
-          })
-          .map((member: ts.SetAccessorDeclaration | ts.MethodDeclaration) => member.body !);
+  // Array of TypeScript nodes which can contain usages of the given query in
+  // order to access it statically.
+  const possibleStaticQueryNodes = filterQueryClassMemberNodes(classDecl, query, knownInputNames);
 
   // In case nodes that can possibly access a query statically have been found, check
   // if the query declaration is synchronously used within any of these nodes.
@@ -74,13 +65,66 @@ function isQueryUsedStatically(
     return true;
   }
 
-  // In case there are classes that derive from the current class, visit each
-  // derived class as inherited queries could be used statically.
-  if (classMetadata) {
-    return classMetadata.derivedClasses.some(
-        derivedClass => isQueryUsedStatically(
-            derivedClass, query, classMetadataMap, typeChecker, knownInputNames));
+  if (!classMetadata) {
+    return false;
+  }
+
+  // In case derived classes should also be analyzed, we determine the classes that derive
+  // from the current class and check if these have input setters or lifecycle hooks that
+  // use the query statically.
+  if (visitInheritedClasses) {
+    if (classMetadata.derivedClasses.some(
+            derivedClass => isQueryUsedStatically(
+                derivedClass, query, classMetadataMap, typeChecker, knownInputNames))) {
+      return true;
+    }
+  }
+
+  // In case the current class has a super class, we determine declared abstract function-like
+  // declarations in the super-class that are implemented in the current class. The super class
+  // will then be analyzed with the abstract declarations mapped to the implemented TypeScript
+  // nodes. This allows us to handle queries which are used in super classes through derived
+  // abstract method declarations.
+  if (classMetadata.superClass) {
+    const superClassDecl = classMetadata.superClass;
+
+    // Update the function context to map abstract declaration nodes to their implementation
+    // node in the base class. This ensures that the declaration usage visitor can analyze
+    // abstract class member declarations.
+    updateSuperClassAbstractMembersContext(classDecl, functionCtx, classMetadataMap);
+
+    if (isQueryUsedStatically(
+            superClassDecl, query, classMetadataMap, typeChecker, [], functionCtx, false)) {
+      return true;
+    }
   }
 
   return false;
+}
+
+
+/**
+ * Filters all class members from the class declaration that can access the
+ * given query statically (e.g. ngOnInit lifecycle hook or @Input setters)
+ */
+function filterQueryClassMemberNodes(
+    classDecl: ts.ClassDeclaration, query: NgQueryDefinition,
+    knownInputNames: string[]): ts.Block[] {
+  // Returns an array of TypeScript nodes which can contain usages of the given query
+  // in order to access it statically. e.g.
+  //  (1) queries used in the "ngOnInit" lifecycle hook are static.
+  //  (2) inputs with setters can access queries statically.
+  return classDecl.members
+      .filter(m => {
+        if (ts.isMethodDeclaration(m) && m.body && hasPropertyNameText(m.name) &&
+            STATIC_QUERY_LIFECYCLE_HOOKS[query.type].indexOf(m.name.text) !== -1) {
+          return true;
+        } else if (
+            knownInputNames && ts.isSetAccessor(m) && m.body && hasPropertyNameText(m.name) &&
+            knownInputNames.indexOf(m.name.text) !== -1) {
+          return true;
+        }
+        return false;
+      })
+      .map((member: ts.SetAccessorDeclaration | ts.MethodDeclaration) => member.body !);
 }

--- a/packages/core/schematics/migrations/static-queries/angular/super_class.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/super_class.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {isFunctionLikeDeclaration} from '../../../utils/typescript/functions';
+import {hasModifier} from '../../../utils/typescript/nodes';
+import {getPropertyNameText} from '../../../utils/typescript/property_name';
+
+import {FunctionContext} from './declaration_usage_visitor';
+import {ClassMetadataMap} from './ng_query_visitor';
+
+
+/**
+ * Updates the specified function context to map abstract super-class class members
+ * to their implementation TypeScript nodes. This allows us to run the declaration visitor
+ * for the super class with the context of the "baseClass" (e.g. with implemented abstract
+ * class members)
+ */
+export function updateSuperClassAbstractMembersContext(
+    baseClass: ts.ClassDeclaration, context: FunctionContext, classMetadataMap: ClassMetadataMap) {
+  getSuperClassDeclarations(baseClass, classMetadataMap).forEach(superClassDecl => {
+    superClassDecl.members.forEach(superClassMember => {
+      if (!superClassMember.name || !hasModifier(superClassMember, ts.SyntaxKind.AbstractKeyword)) {
+        return;
+      }
+
+      // Find the matching implementation of the abstract declaration from the super class.
+      const baseClassImpl = baseClass.members.find(
+          baseClassMethod => !!baseClassMethod.name &&
+              getPropertyNameText(baseClassMethod.name) ===
+                  getPropertyNameText(superClassMember.name !));
+
+      if (!baseClassImpl || !isFunctionLikeDeclaration(baseClassImpl) || !baseClassImpl.body) {
+        return;
+      }
+
+      if (!context.has(superClassMember)) {
+        context.set(superClassMember, baseClassImpl);
+      }
+    });
+  });
+}
+
+/** Gets all super-class TypeScript declarations for the given class. */
+function getSuperClassDeclarations(
+    classDecl: ts.ClassDeclaration, classMetadataMap: ClassMetadataMap) {
+  const declarations: ts.ClassDeclaration[] = [];
+
+  let current = classMetadataMap.get(classDecl);
+  while (current && current.superClass) {
+    declarations.push(current.superClass);
+    current = classMetadataMap.get(current.superClass);
+  }
+
+  return declarations;
+}

--- a/packages/core/schematics/utils/typescript/nodes.ts
+++ b/packages/core/schematics/utils/typescript/nodes.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+/** Checks whether the given TypeScript node has the specified modifier set. */
+export function hasModifier(node: ts.Node, modifierKind: ts.SyntaxKind) {
+  return !!node.modifiers && node.modifiers.some(m => m.kind === modifierKind);
+}


### PR DESCRIPTION
Queries can not only be accessed within derived classes, but also in
the super class through abstract methods. e.g.

```ts
abstract class BaseClass {

  abstract getEmbeddedForm(): NgForm {}

  ngOnInit() {
     this.getEmbeddedForm().doSomething();
  }
}

class Subclass extends BaseClass {
  @ViewChild(NgForm) form: NgForm;

  getEmbeddedForm() { return this.form; }

}
```

Same applies for abstract properties which are implemented in the base class
through accessors. This case is also now handled by the schematic.

Resolves FW-1213

**NOTE**: Blocked on #29663