### PR TITLE
fix(core): add missing migration to npm package

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -9,5 +9,8 @@ npm_package(
     name = "npm_package",
     srcs = ["migrations.json"],
     visibility = ["//packages/core:__pkg__"],
-    deps = ["//packages/core/schematics/migrations/static-queries"],
+    deps = [
+        "//packages/core/schematics/migrations/static-queries",
+        "//packages/core/schematics/migrations/template-var-assignment",
+    ],
 )


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
While running `ng update @angular/core --next`, the following error would be displayed:

```
Cannot find module '....\node_modules\@angular\core\schematics\migrations\template-var-assignment\index'
```

This happened because the Schematics migration was referenced, but not included.


## What is the new behavior?
This commit fixes that bug by including the migration in the Bazel npm package dependencies.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
