### PR TITLE
fix(animations): getAnimationStyle causes exceptions in older browsers

### DIFF
--- a/packages/animations/browser/src/render/css_keyframes/element_animation_style_handler.ts
+++ b/packages/animations/browser/src/render/css_keyframes/element_animation_style_handler.ts
@@ -140,8 +140,8 @@ function setAnimationStyle(element: any, name: string, value: string, index?: nu
   element.style[prop] = value;
 }
 
-function getAnimationStyle(element: any, name: string) {
-  return element.style[ANIMATION_PROP + name];
+export function getAnimationStyle(element: any, name: string) {
+  return element.style[ANIMATION_PROP + name] || '';
 }
 
 function countChars(value: string, char: string): number {

--- a/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ElementAnimationStyleHandler} from '../../../src/render/css_keyframes/element_animation_style_handler';
+import {ElementAnimationStyleHandler, getAnimationStyle} from '../../../src/render/css_keyframes/element_animation_style_handler';
 import {computeStyle} from '../../../src/util';
-
 import {assertStyle, createElement, makeAnimationEvent, supportsAnimationEventCreation} from './shared';
 
 const EMPTY_FN = () => {};
@@ -226,6 +225,24 @@ const EMPTY_FN = () => {};
       event = makeAnimationEvent('end', 'fooAnimation', 1234, timestampAfterDelay);
       element.dispatchEvent(event);
       expect(done).toBeTruthy();
+    });
+
+    // Issue: https://github.com/angular/angular/issues/24094
+    it('should not break getAnimationStyle in old browsers', () => {
+      // Old browsers like Chrome Android 34 returns null if element.style
+      // is not found, modern browsers returns empty string.
+      const fakeElement = {
+        style: {
+          'animationstyle1': 'value',
+          'animationstyle2': null,
+          'animationstyle3': '',
+          'animation': null
+        }
+      };
+      expect(getAnimationStyle(fakeElement, 'style1')).toBe('value');
+      expect(getAnimationStyle(fakeElement, 'style2')).toBe('');
+      expect(getAnimationStyle(fakeElement, 'style3')).toBe('');
+      expect(getAnimationStyle(fakeElement, '')).toBe('');
     });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24094


## What is the new behavior?
Animation doesn't break in old browsers now 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
