### PR TITLE
fix(bazel): use //:tsconfig.json as the default for ng_module (#29670)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
-    "tsconfig.json",
     "LICENSE",
     "protractor-perf.conf.js",
 ])
+
+alias(
+    name = "tsconfig.json",
+    actual = "//packages:tsconfig-build.json",
+)
 
 filegroup(
     name = "web_test_bootstrap_scripts",

--- a/packages/bazel/index.bzl
+++ b/packages/bazel/index.bzl
@@ -7,7 +7,7 @@
 Users should not load files under "/src"
 """
 
-load("//packages/bazel/src:ng_module.bzl", _ng_module = "ng_module")
+load("//packages/bazel/src:ng_module.bzl", _ng_module = "ng_module_macro")
 load("//packages/bazel/src/ng_package:ng_package.bzl", _ng_package = "ng_package")
 load(
     "//packages/bazel/src/protractor:protractor_web_test.bzl",

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -634,3 +634,21 @@ This rule extends the [ts_library] rule.
 
 [ts_library]: http://tsetse.info/api/build_defs.html#ts_library
 """
+
+def ng_module_macro(tsconfig = None, **kwargs):
+    """Wraps `ng_module` to set the default for the `tsconfig` attribute.
+
+    This must be a macro so that the string is converted to a label in the context of the
+    workspace that declares the `ng_module` target, rather than the workspace that defines
+    `ng_module`, or the workspace where the build is taking place.
+
+    This macro is re-exported as `ng_module` in the public API.
+
+    Args:
+      tsconfig: the label pointing to a tsconfig.json file
+      **kwargs: remaining args to pass to the ng_module rule
+    """
+    if not tsconfig:
+        tsconfig = "//:tsconfig.json"
+
+    ng_module(tsconfig = tsconfig, **kwargs)

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
@@ -18,6 +18,7 @@ ng_module(
     deps = [
         "//packages/core",
         "@npm//@types",
+        "@npm//tslib",
     ],
 )
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -7,7 +7,6 @@ load("@npm_bazel_typescript//:index.bzl", _ts_library = "ts_library")
 load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
 load("//packages/bazel/src:ng_rollup_bundle.bzl", _ng_rollup_bundle = "ng_rollup_bundle")
 
-_DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
 _INTERNAL_NG_MODULE_XI18N = "//packages/bazel/src/ngc-wrapped:xi18n"
@@ -82,11 +81,8 @@ def ts_library(tsconfig = None, testonly = False, deps = [], module_name = None,
         # Match the types[] in //packages:tsconfig-test.json
         deps.append("@npm//@types/jasmine")
         deps.append("@npm//@types/node")
-    if not tsconfig:
-        if testonly:
-            tsconfig = _DEFAULT_TSCONFIG_TEST
-        else:
-            tsconfig = _DEFAULT_TSCONFIG_BUILD
+    if not tsconfig and testonly:
+        tsconfig = _DEFAULT_TSCONFIG_TEST
 
     if not module_name:
         module_name = _default_module_name(testonly)
@@ -106,11 +102,9 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         # Match the types[] in //packages:tsconfig-test.json
         deps.append("@npm//@types/jasmine")
         deps.append("@npm//@types/node")
-    if not tsconfig:
-        if testonly:
-            tsconfig = _DEFAULT_TSCONFIG_TEST
-        else:
-            tsconfig = _DEFAULT_TSCONFIG_BUILD
+    if not tsconfig and testonly:
+        tsconfig = _DEFAULT_TSCONFIG_TEST
+
     if not module_name:
         module_name = _default_module_name(testonly)
     if not entry_point:


### PR DESCRIPTION
This matches the behavior of ts_library

cherry-pick of #29670
