### PR TITLE
refactor(core): static-query schematic should check templates

### DIFF
--- a/packages/core/schematics/migrations/static-queries/BUILD.bazel
+++ b/packages/core/schematics/migrations/static-queries/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
         "//packages/core/schematics/test:__pkg__",
     ],
     deps = [
+        "//packages/compiler",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/schematics",
         "@npm//@types/node",

--- a/packages/core/schematics/migrations/static-queries/angular/ng_query_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/ng_query_visitor.ts
@@ -7,10 +7,14 @@
  */
 
 import * as ts from 'typescript';
+
+import {ResolvedTemplate} from '../../../utils/ng_component_template';
 import {getAngularDecorators} from '../../../utils/ng_decorators';
 import {findParentClassDeclaration, getBaseTypeIdentifiers} from '../../../utils/typescript/class_declaration';
+
 import {getInputNamesOfClass} from './directive_inputs';
 import {NgQueryDefinition, QueryType} from './query-definition';
+
 
 /** Resolved metadata of a given class. */
 export interface ClassMetadata {
@@ -20,6 +24,8 @@ export interface ClassMetadata {
   superClass: ts.ClassDeclaration|null;
   /** List of property names that declare an Angular input within the given class. */
   ngInputNames: string[];
+  /** Component template that belongs to that class if present. */
+  template?: ResolvedTemplate;
 }
 
 /** Type that describes a map which can be used to get a class declaration's metadata. */
@@ -48,8 +54,6 @@ export class NgQueryResolveVisitor {
         this.visitClassDeclaration(node as ts.ClassDeclaration);
         break;
     }
-
-    ts.forEachChild(node, node => this.visitNode(node));
   }
 
   private visitPropertyDeclaration(node: ts.PropertyDeclaration) {

--- a/packages/core/schematics/migrations/static-queries/angular/query_read_html_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/query_read_html_visitor.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor} from '@angular/compiler';
+import {BoundAttribute, BoundEvent, BoundText, Element, Node, NullVisitor, Template, visitAll} from '@angular/compiler/src/render3/r3_ast';
+
+/**
+ * AST visitor that traverses the Render3 HTML AST in order to check if the given
+ * query property is accessed statically in the template.
+ */
+export class QueryReadHtmlVisitor extends NullVisitor {
+  private hasQueryTemplateReference = false;
+  private expressionAstVisitor = new ExpressionAstVisitor(this.queryPropertyName);
+
+  constructor(public queryPropertyName: string) { super(); }
+
+  /** Checks whether the given query is statically accessed within the specified HTML nodes. */
+  isQueryUsedStatically(htmlNodes: Node[]): boolean {
+    this.hasQueryTemplateReference = false;
+    this.expressionAstVisitor.hasQueryPropertyRead = false;
+
+    // Visit all AST nodes and check if the query property is used statically.
+    visitAll(this, htmlNodes);
+
+    return !this.hasQueryTemplateReference && this.expressionAstVisitor.hasQueryPropertyRead;
+  }
+
+  visitElement(element: Element): void {
+    // In case there is a template references variable that matches the query property
+    // name, we can finish this visitor as such a template variable can be used in the
+    // entire template and the query therefore can't be accessed from the template.
+    if (element.references.some(r => r.name === this.queryPropertyName)) {
+      this.hasQueryTemplateReference = true;
+      return;
+    }
+
+    visitAll(this, element.attributes);
+    visitAll(this, element.inputs);
+    visitAll(this, element.outputs);
+    visitAll(this, element.children);
+  }
+
+  visitTemplate(template: Template): void {
+    visitAll(this, template.attributes);
+    visitAll(this, template.inputs);
+    visitAll(this, template.outputs);
+
+    // We don't want to visit any children of the template as these never can't
+    // access a query statically. The templates can be rendered in the ngAfterViewInit"
+    // lifecycle hook at the earliest.
+  }
+
+  visitBoundAttribute(attribute: BoundAttribute) {
+    attribute.value.visit(this.expressionAstVisitor, attribute.sourceSpan);
+  }
+
+  visitBoundText(text: BoundText) { text.value.visit(this.expressionAstVisitor, text.sourceSpan); }
+
+  visitBoundEvent(node: BoundEvent) {
+    node.handler.visit(this.expressionAstVisitor, node.handlerSpan);
+  }
+}
+
+/**
+ * AST visitor that checks if the given expression contains property reads that
+ * refer to the specified query property name.
+ */
+class ExpressionAstVisitor extends RecursiveAstVisitor {
+  hasQueryPropertyRead = false;
+
+  constructor(private queryPropertyName: string) { super(); }
+
+  visitPropertyRead(node: PropertyRead, span: ParseSourceSpan): any {
+    // The receiver of the property read needs to be "implicit" as queries are accessed
+    // from the component instance and not from other objects.
+    if (node.receiver instanceof ImplicitReceiver && node.name === this.queryPropertyName) {
+      this.hasQueryPropertyRead = true;
+      return;
+    }
+
+    super.visitPropertyRead(node, span);
+  }
+}

--- a/packages/core/schematics/migrations/static-queries/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/static-queries/google3/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     visibility = ["//packages/core/schematics/test:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/static-queries",
+        "//packages/core/schematics/utils",
         "@npm//tslint",
     ],
 )

--- a/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
@@ -8,6 +8,9 @@
 
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
+
+import {NgComponentTemplateVisitor} from '../../../utils/ng_component_template';
+import {visitAllNodes} from '../../../utils/typescript/visit_nodes';
 import {analyzeNgQueryUsage} from '../angular/analyze_query_usage';
 import {NgQueryResolveVisitor} from '../angular/ng_query_visitor';
 import {QueryTiming} from '../angular/query-definition';
@@ -25,14 +28,29 @@ export class Rule extends Rules.TypedRule {
   applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
     const typeChecker = program.getTypeChecker();
     const queryVisitor = new NgQueryResolveVisitor(program.getTypeChecker());
+    const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
     const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
     const printer = ts.createPrinter();
     const failures: RuleFailure[] = [];
 
-    // Analyze source files by detecting queries and class relations.
-    rootSourceFiles.forEach(sourceFile => queryVisitor.visitNode(sourceFile));
+    // Analyze source files by detecting queries, class relations and component templates.
+    rootSourceFiles.forEach(sourceFile => {
+      // The visit utility function only traverses the source file once. We don't want to
+      // traverse through all source files multiple times for each visitor as this could be
+      // slow.
+      visitAllNodes(sourceFile, [queryVisitor, templateVisitor]);
+    });
 
     const {resolvedQueries, classMetadata} = queryVisitor;
+
+    // Add all resolved templates to the class metadata so that we can also
+    // check component templates for static query usage.
+    templateVisitor.resolvedTemplates.forEach(template => {
+      if (classMetadata.has(template.container)) {
+        classMetadata.get(template.container) !.template = template;
+      }
+    });
+
     const queries = resolvedQueries.get(sourceFile);
 
     // No queries detected for the given source file.

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -10,12 +10,15 @@ import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {dirname, relative} from 'path';
 import * as ts from 'typescript';
 
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
+import {visitAllNodes} from '../../utils/typescript/visit_nodes';
 
 import {analyzeNgQueryUsage} from './angular/analyze_query_usage';
 import {NgQueryResolveVisitor} from './angular/ng_query_visitor';
 import {getTransformedQueryCallExpr} from './transform';
+
 
 
 /** Entry point for the V8 static-query migration. */
@@ -58,13 +61,27 @@ function runStaticQueryMigration(tree: Tree, tsconfigPath: string, basePath: str
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const queryVisitor = new NgQueryResolveVisitor(typeChecker);
+  const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
   const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
   const printer = ts.createPrinter();
 
-  // Analyze source files by detecting queries and class relations.
-  rootSourceFiles.forEach(sourceFile => queryVisitor.visitNode(sourceFile));
+  // Analyze source files by detecting queries, class relations and component templates.
+  rootSourceFiles.forEach(sourceFile => {
+    // The visit utility function only traverses the source file once. We don't want to
+    // traverse through all source files multiple times for each visitor as this could be
+    // slow.
+    visitAllNodes(sourceFile, [queryVisitor, templateVisitor]);
+  });
 
   const {resolvedQueries, classMetadata} = queryVisitor;
+
+  // Add all resolved templates to the class metadata so that we can also
+  // check component templates for static query usage.
+  templateVisitor.resolvedTemplates.forEach(template => {
+    if (classMetadata.has(template.container)) {
+      classMetadata.get(template.container) !.template = template;
+    }
+  });
 
   // Walk through all source files that contain resolved queries and update
   // the source files if needed. Note that we need to update multiple queries

--- a/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
@@ -9,7 +9,7 @@
 import {PropertyWrite, parseTemplate} from '@angular/compiler';
 import {Variable, visitAll} from '@angular/compiler/src/render3/r3_ast';
 
-import {ResolvedTemplate} from './angular/ng_component_template';
+import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {PropertyAssignment, PropertyWriteHtmlVisitor} from './angular/property_write_html_visitor';
 
 export interface TemplateVariableAssignment {

--- a/packages/core/schematics/migrations/template-var-assignment/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/template-var-assignment/google3/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     visibility = ["//packages/core/schematics/test:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/template-var-assignment",
+        "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
         "@npm//tslint",
     ],

--- a/packages/core/schematics/migrations/template-var-assignment/google3/noTemplateVariableAssignmentRule.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/google3/noTemplateVariableAssignmentRule.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {createHtmlSourceFile} from '../../../utils/tslint/tslint_html_source_file';
 import {analyzeResolvedTemplate} from '../analyze_template';
-import {NgComponentTemplateVisitor} from '../angular/ng_component_template';
+import {NgComponentTemplateVisitor} from '../../../utils/ng_component_template';
 
 const FAILURE_MESSAGE = 'Found assignment to template variable. This does not work with Ivy and ' +
     'needs to be updated.';

--- a/packages/core/schematics/migrations/template-var-assignment/google3/noTemplateVariableAssignmentRule.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/google3/noTemplateVariableAssignmentRule.ts
@@ -9,9 +9,10 @@
 import {RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 
-import {createHtmlSourceFile} from '../../../utils/tslint/tslint_html_source_file';
-import {analyzeResolvedTemplate} from '../analyze_template';
 import {NgComponentTemplateVisitor} from '../../../utils/ng_component_template';
+import {createHtmlSourceFile} from '../../../utils/tslint/tslint_html_source_file';
+import {visitAllNodes} from '../../../utils/typescript/visit_nodes';
+import {analyzeResolvedTemplate} from '../analyze_template';
 
 const FAILURE_MESSAGE = 'Found assignment to template variable. This does not work with Ivy and ' +
     'needs to be updated.';
@@ -26,7 +27,7 @@ export class Rule extends Rules.TypedRule {
     const failures: RuleFailure[] = [];
 
     // Analyze the current source files by detecting all referenced HTML templates.
-    templateVisitor.visitNode(sourceFile);
+    visitAllNodes(sourceFile, [templateVisitor]);
 
     const {resolvedTemplates} = templateVisitor;
 

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -11,11 +11,12 @@ import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit
 import {dirname, relative} from 'path';
 import * as ts from 'typescript';
 
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
+import {visitAllNodes} from '../../utils/typescript/visit_nodes';
 
 import {analyzeResolvedTemplate} from './analyze_template';
-import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 
 type Logger = logging.LoggerApi;
 
@@ -63,7 +64,7 @@ function runTemplateVariableAssignmentCheck(
   const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
 
   // Analyze source files by detecting HTML templates.
-  rootSourceFiles.forEach(sourceFile => templateVisitor.visitNode(sourceFile));
+  rootSourceFiles.forEach(sourceFile => visitAllNodes(sourceFile, [templateVisitor]));
 
   const {resolvedTemplates} = templateVisitor;
   const collectedFailures: string[] = [];

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -15,7 +15,7 @@ import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
 
 import {analyzeResolvedTemplate} from './analyze_template';
-import {NgComponentTemplateVisitor} from './angular/ng_component_template';
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 
 type Logger = logging.LoggerApi;
 

--- a/packages/core/schematics/test/google3/explicit_query_timing_rule_spec.ts
+++ b/packages/core/schematics/test/google3/explicit_query_timing_rule_spec.ts
@@ -128,4 +128,24 @@ describe('Google3 explicitQueryTiming TSLint rule', () => {
     expect(failures.length).toBe(1);
     expect(failures[0].getFailure()).toMatch(/analysis of the query.*"{static: false}"/);
   });
+
+  it('should detect query usage in component template', () => {
+    writeFile('index.ts', `
+      import {Component, ViewChild} from '@angular/core';
+      
+      @Component({
+        template: \`
+          <span #test></span>
+          <my-comp [binding]="query"></my-comp>
+        \`
+      })
+      export class MyComp {
+        @ViewChild('test') query: any;
+      }
+    `);
+
+    runTSLint();
+
+    expectFileToContain('index.ts', `@ViewChild('test', { static: true }) query: any;`);
+  });
 });

--- a/packages/core/schematics/utils/BUILD.bazel
+++ b/packages/core/schematics/utils/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics:__subpackages__"],
     deps = [
+        "//packages/compiler",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
     ],

--- a/packages/core/schematics/utils/ng_component_template.ts
+++ b/packages/core/schematics/utils/ng_component_template.ts
@@ -10,10 +10,10 @@ import {existsSync, readFileSync} from 'fs';
 import {dirname, resolve} from 'path';
 import * as ts from 'typescript';
 
-import {computeLineStartsMap, getLineAndCharacterFromPosition} from '../../../utils/line_mappings';
-import {getAngularDecorators} from '../../../utils/ng_decorators';
-import {unwrapExpression} from '../../../utils/typescript/functions';
-import {getPropertyNameText} from '../../../utils/typescript/property_name';
+import {computeLineStartsMap, getLineAndCharacterFromPosition} from './line_mappings';
+import {getAngularDecorators} from './ng_decorators';
+import {unwrapExpression} from './typescript/functions';
+import {getPropertyNameText} from './typescript/property_name';
 
 export interface ResolvedTemplate {
   /** File content of the given template. */

--- a/packages/core/schematics/utils/parse_html.ts
+++ b/packages/core/schematics/utils/parse_html.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {parseTemplate} from '@angular/compiler';
+import {Node} from '@angular/compiler/src/render3/r3_ast';
+
+/**
+ * Parses the given HTML content using the Angular compiler. In case the parsing
+ * fails, null is being returned.
+ */
+export function parseHtmlGracefully(htmlContent: string, filePath: string): Node[]|null {
+  try {
+    return parseTemplate(htmlContent, filePath).nodes;
+  } catch {
+    // Do nothing if the template couldn't be parsed. We don't want to throw any
+    // exception if a template is syntactically not valid. e.g. template could be
+    // using preprocessor syntax.
+    return null;
+  }
+}

--- a/packages/core/schematics/utils/typescript/visit_nodes.ts
+++ b/packages/core/schematics/utils/typescript/visit_nodes.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+export interface TypeScriptVisitor { visitNode(node: ts.Node); }
+
+export function visitAllNodes(node: ts.Node, visitors: TypeScriptVisitor[]) {
+  visitors.forEach(v => v.visitNode(node));
+  ts.forEachChild(node, node => visitAllNodes(node, visitors));
+}


### PR DESCRIPTION
Queries can technically be also accessed within component templates
e.g.

```html
<my-comp [binding]="myQuery"></my-comp>
```

In that case the query with the property "myQuery" is accessed
statically and needs to be marked with `static: true`. There are
other edge cases that need to be handled as the template property
read doesn't necessarily resolve to the actual query property.

For example:

```html
<foo #myQuery></foo>
<my-comp [binding]="myQuery"></my-comp>
```

In this scenario the binding doesn't refer to the actual query
because the template reference variable takes precedence. The
query doesn't need to be marked with "static: true" this time.

This commit ensures that the `static-query` migration schematic
now handles this cases properly. Also template property reads
that access queries from within a `<ng-template>` are ignored
as these can't access the query before the view has been initialized.

**Note**: Blocked on #29688 

Resolves FW-1216