### PR TITLE
docs: increase color contrast on elements in tutorial

### DIFF
--- a/aio/content/examples/toh-pt0/src/styles.1.css
+++ b/aio/content/examples/toh-pt0/src/styles.1.css
@@ -13,7 +13,7 @@ body {
   margin: 2em;
 }
 body, input[type="text"], button {
-  color: #888;
+  color: #333;
   font-family: Cambria, Georgia;
 }
 /* everywhere else */

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
@@ -37,7 +37,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color:#405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.css
@@ -37,7 +37,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color:#405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.css
@@ -37,7 +37,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color:#405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt4/src/app/messages/messages.component.css
+++ b/aio/content/examples/toh-pt4/src/app/messages/messages.component.css
@@ -30,6 +30,6 @@ button:disabled {
   cursor: auto;
 }
 button.clear {
-  color: #888;
+  color: #333;
   margin-bottom: 12px;
 }

--- a/aio/content/examples/toh-pt5/src/app/app.component.css
+++ b/aio/content/examples/toh-pt5/src/app/app.component.css
@@ -1,7 +1,6 @@
 /* AppComponent's private CSS styles */
 h1 {
   font-size: 1.2em;
-  color: #999;
   margin-bottom: 0;
 }
 h2 {
@@ -18,7 +17,7 @@ nav a {
   border-radius: 4px;
 }
 nav a:visited, a:link {
-  color: #607d8b;
+  color: #334953;
 }
 nav a:hover {
   color: #039be5;

--- a/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.css
@@ -34,7 +34,7 @@ h4 {
   color: #eee;
   max-height: 120px;
   min-width: 120px;
-  background-color: #607d8b;
+  background-color: #3f525c;
   border-radius: 2px;
 }
 .module:hover {

--- a/aio/content/examples/toh-pt5/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt5/src/app/heroes/heroes.component.css
@@ -22,7 +22,7 @@
 }
 
 .heroes a {
-  color: #888;
+  color: #333;
   text-decoration: none;
   position: relative;
   display: block;
@@ -38,7 +38,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color:#405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt5/src/app/messages/messages.component.css
+++ b/aio/content/examples/toh-pt5/src/app/messages/messages.component.css
@@ -30,6 +30,6 @@ button:disabled {
   cursor: auto;
 }
 button.clear {
-  color: #888;
+  color: #333;
   margin-bottom: 12px;
 }

--- a/aio/content/examples/toh-pt6/src/app/app.component.css
+++ b/aio/content/examples/toh-pt6/src/app/app.component.css
@@ -1,7 +1,6 @@
 /* AppComponent's private CSS styles */
 h1 {
   font-size: 1.2em;
-  color: #999;
   margin-bottom: 0;
 }
 h2 {
@@ -18,7 +17,7 @@ nav a {
   border-radius: 4px;
 }
 nav a:visited, a:link {
-  color: #607D8B;
+  color: #334953;
 }
 nav a:hover {
   color: #039be5;

--- a/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.css
@@ -34,7 +34,7 @@ h4 {
   color: #eee;
   max-height: 120px;
   min-width: 120px;
-  background-color: #607D8B;
+  background-color: #3f525c;
   border-radius: 2px;
 }
 .module:hover {

--- a/aio/content/examples/toh-pt6/src/app/hero-search/hero-search.component.html
+++ b/aio/content/examples/toh-pt6/src/app/hero-search/hero-search.component.html
@@ -1,5 +1,5 @@
 <div id="search-component">
-  <h4>Hero Search</h4>
+  <h4><label for="search-box">Hero Search</label></h4>
 
   <!-- #docregion input -->
   <input #searchBox id="search-box" (input)="search(searchBox.value)" />

--- a/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.css
@@ -22,7 +22,7 @@
 }
 
 .heroes a {
-  color: #888;
+  color: #333;
   text-decoration: none;
   position: relative;
   display: block;
@@ -38,7 +38,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color:#405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt6/src/app/messages/messages.component.css
+++ b/aio/content/examples/toh-pt6/src/app/messages/messages.component.css
@@ -30,6 +30,6 @@ button:disabled {
   cursor: auto;
 }
 button.clear {
-  color: #888;
+  color: #333;
   margin-bottom: 12px;
 }

--- a/aio/tools/examples/shared/boilerplate/common/src/styles.css
+++ b/aio/tools/examples/shared/boilerplate/common/src/styles.css
@@ -13,7 +13,7 @@ body {
   margin: 2em;
 }
 body, input[text], button {
-  color: #888;
+  color: #333;
   font-family: Cambria, Georgia;
 }
 a {


### PR DESCRIPTION
This increases the color contrast of elements in the tutorial (parts 1-6)
in order to meet WCAG 2.0 AA standards.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
~- [ ] Tests for the changes have been added (for bug fixes / features)~
~- [ ] Docs have been added / updated (for bug fixes / features)~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The color contrast for some elements throughout the tutorial parts 1-6 do not meet WCAG 2.0 AA standards. 

Before:
![Screen Shot 2019-04-05 at 2 45 36 PM](https://user-images.githubusercontent.com/347079/55649722-bdffda00-57b1-11e9-8679-943a7c83f604.png)


Issue Number: N/A


## What is the new behavior?
The color contrast has been increased to meet WCAG 2.0 AA standards. 

After:
![Screen Shot 2019-04-05 at 2 45 05 PM](https://user-images.githubusercontent.com/347079/55649742-c9530580-57b1-11e9-91f2-398c07c48f7a.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
