### PR TITLE
refactor(core): run migration schematics for v8 beta and rc releases

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -1,12 +1,12 @@
 {
   "schematics": {
     "migration-v8-static-queries": {
-      "version": "8",
+      "version": "8-beta",
       "description": "Migrates ViewChild and ContentChild to explicit query timing",
       "factory": "./migrations/static-queries/index"
     },
     "migration-v8-template-local-variables": {
-      "version": "8",
+      "version": "8-beta",
       "description": "Warns developers if values are assigned to template variables",
       "factory": "./migrations/template-var-assignment/index"
     }


### PR DESCRIPTION
Currently the `static-query` and `template-var-assignment` schematic only runs
for `8.0.0` which does not include any betas or release candidates. We want to
run the schematic in the beta's and RC in order to get early feedback about the
schematics. Enabling it promptly with V8 stable release can result in accidental
breakages that we would like to fix/identify before.