### PR TITLE
docs: typo fix, change "insure" to "ensure"

### DIFF
--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -123,7 +123,7 @@ For example, `main` should point at a JavaScript file, not a TypeScript file.
 ## Use TypeScript path mapping for peer dependencies
 
 Angular libraries should list all `@angular/*` dependencies as peer dependencies.
-This insures that when modules ask for Angular, they all get the exact same module.
+This ensures that when modules ask for Angular, they all get the exact same module.
 If a library lists `@angular/core` in `dependencies` instead of `peerDependencies`, it might get a different Angular module instead, which would cause your application to break.
 
 While developing a library, you must install all peer dependencies through `devDependencies` to ensure that the library compiles properly.


### PR DESCRIPTION
Fix minor typo in the docs about creating libraries