### PR TITLE
perf(ivy): ngcc - exit early if the targeted package has been compiled

### DIFF
--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
     ),
     deps = [
         "//packages/compiler-cli/ngcc",
+        "//packages/compiler-cli/ngcc/test/helpers",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/path",
@@ -46,6 +47,7 @@ ts_library(
     ),
     deps = [
         "//packages/compiler-cli/ngcc",
+        "//packages/compiler-cli/ngcc/test/helpers",
         "//packages/compiler-cli/src/ngtsc/path",
         "//packages/compiler-cli/test:test_utils",
         "@npm//@types/mock-fs",

--- a/packages/compiler-cli/ngcc/test/helpers/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/helpers/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//packages/compiler-cli/ngcc:__subpackages__"])
+
+ts_library(
+    name = "helpers",
+    testonly = True,
+    srcs = glob([
+        "*.ts",
+    ]),
+    deps = [
+        "//packages/compiler-cli/ngcc",
+        "//packages/compiler-cli/src/ngtsc/path",
+        "//packages/compiler-cli/src/ngtsc/testing",
+    ],
+)

--- a/packages/compiler-cli/ngcc/test/helpers/mock_logger.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_logger.ts
@@ -9,9 +9,14 @@
 import {Logger} from '../../src/logging/logger';
 
 export class MockLogger implements Logger {
-  logs: string[][] = [];
-  debug(...args: string[]) { this.logs.push(args); }
-  info(...args: string[]) { this.logs.push(args); }
-  warn(...args: string[]) { this.logs.push(args); }
-  error(...args: string[]) { this.logs.push(args); }
+  logs: {[P in keyof Logger]: string[][]} = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  };
+  debug(...args: string[]) { this.logs.debug.push(args); }
+  info(...args: string[]) { this.logs.info.push(args); }
+  warn(...args: string[]) { this.logs.warn.push(args); }
+  error(...args: string[]) { this.logs.error.push(args); }
 }


### PR DESCRIPTION
**This is a quick fix for webpack but there are more optimisations to be achieved on the
first time run by replacing the TS module resolver for the initial walk of the tree.**

Previously we always walked the whole folder tree looking for
entry-points before we tested whether a target package had been
processed already. This could take >10secs!

This commit does a quick check of the target package before doing
the full walk which brings down the execution time for ngcc in this
case dramatically.

```
$ time ./node_modules/.bin/ivy-ngcc -t @angular/common/http/testing
Compiling @angular/core : fesm2015 as esm2015
Compiling @angular/core : fesm5 as esm5
Compiling @angular/core : esm2015 as esm2015
Compiling @angular/core : esm5 as esm5
Compiling @angular/common/http : fesm2015 as esm2015
Compiling @angular/common/http : fesm5 as esm5
Compiling @angular/common/http : esm2015 as esm2015
Compiling @angular/common/http : esm5 as esm5
Compiling @angular/common/http/testing : fesm2015 as esm2015
Compiling @angular/common/http/testing : fesm5 as esm5
Compiling @angular/common/http/testing : esm2015 as esm2015
Compiling @angular/common/http/testing : esm5 as esm5

real	0m19.766s
user	0m28.533s
sys	0m2.262s
```

```
$ time ./node_modules/.bin/ivy-ngcc -t @angular/common/http/testing
The target entry-point has already been processed

real	0m0.666s
user	0m0.605s
sys	0m0.113s
```