### PR TITLE
fix(ivy): creation mode not run on view detached from change detection

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1273,8 +1273,9 @@ export function componentRefresh(adjustedElementIndex: number): void {
   const hostView = getComponentViewByIndex(adjustedElementIndex, lView);
   ngDevMode && assertNodeType(lView[TVIEW].data[adjustedElementIndex] as TNode, TNodeType.Element);
 
-  // Only attached CheckAlways components or attached, dirty OnPush components should be checked
-  if (viewAttachedToChangeDetector(hostView) &&
+  // Only components in creation mode, attached CheckAlways
+  // components or attached, dirty OnPush components should be checked
+  if ((viewAttachedToChangeDetector(hostView) || isCreationMode(lView)) &&
       hostView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
     syncViewWithBlueprint(hostView);
     checkView(hostView, hostView[CONTEXT]);

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive} from '@angular/core';
+import {ChangeDetectorRef, Component, Directive} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -55,6 +55,30 @@ describe('projection', () => {
     fixture.componentInstance.items = [6, 7, 8, 9];
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('6|7|8|');
+  });
+
+  it('should project content if the change detector has been detached', () => {
+    @Component({selector: 'my-comp', template: '<ng-content></ng-content>'})
+    class MyComp {
+      constructor(changeDetectorRef: ChangeDetectorRef) { changeDetectorRef.detach(); }
+    }
+
+    @Component({
+      selector: 'my-app',
+      template: `
+        <my-comp>
+          <p>hello</p>
+        </my-comp>
+      `
+    })
+    class MyApp {
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp, MyApp]});
+    const fixture = TestBed.createComponent(MyApp);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement).toHaveText('hello');
   });
 
   describe('on inline templates (e.g.  *ngIf)', () => {


### PR DESCRIPTION
Fixes the creation mode block not being run on components which have been detached from change detection.

This PR resolves FW-1217.
Fixes #29645.