### PR TITLE
build(docs-infra): do not include `announcements.json` in sitemap

### DIFF
--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.js
@@ -1,12 +1,12 @@
 module.exports = function createSitemap() {
   return {
-    blacklistedDocTypes: [
+    ignoredDocTypes: [
       'announcements-json',
       'contributors-json',
       'navigation-json',
       'resources-json',
     ],
-    blacklistedPaths: [
+    ignoredPaths: [
       'file-not-found',
       'overview-dump',
       'test',
@@ -23,8 +23,8 @@ module.exports = function createSitemap() {
           // Filter out docs that are not outputted
           .filter(doc => doc.outputPath)
           // Filter out unwanted docs
-          .filter(doc => this.blacklistedDocTypes.indexOf(doc.docType) === -1)
-          .filter(doc => this.blacklistedPaths.indexOf(doc.path) === -1)
+          .filter(doc => this.ignoredDocTypes.indexOf(doc.docType) === -1)
+          .filter(doc => this.ignoredPaths.indexOf(doc.path) === -1)
           // Capture the path of each doc
           .map(doc => doc.path)
           // Convert the homepage: `index` to `/`

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.js
@@ -1,14 +1,15 @@
 module.exports = function createSitemap() {
   return {
     blacklistedDocTypes: [
-      'navigation-json',
+      'announcements-json',
       'contributors-json',
+      'navigation-json',
       'resources-json',
     ],
     blacklistedPaths: [
-      'test',
       'file-not-found',
-      'overview-dump'
+      'overview-dump',
+      'test',
     ],
     $runAfter: ['paths-computed'],
     $runBefore: ['rendering-docs'],

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
@@ -53,7 +53,7 @@ describe('createSitemap processor', () => {
           { path: 'cde', outputPath: 'cde', docType: 'bad' },
           { path: 'fgh', outputPath: 'fgh', docType: 'good' },
         ];
-        processor.blacklistedDocTypes = ['bad'];
+        processor.ignoredDocTypes = ['bad'];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
@@ -64,7 +64,7 @@ describe('createSitemap processor', () => {
           { path: 'cde', outputPath: 'cde' },
           { path: 'fgh', outputPath: 'fgh' },
         ];
-        processor.blacklistedPaths = ['cde'];
+        processor.ignoredPaths = ['cde'];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });


### PR DESCRIPTION
The `announcements.json` file should not be included in the sitemap and including it causes an error in Google Search Console (because the generated URL does not exist).

(This is a follow-up to fbef94a8e.)
