### PR TITLE
refactor(core): Fix "explicit-query-timing" failure span.

### DIFF
--- a/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
@@ -60,7 +60,7 @@ export class Rule extends Rules.TypedRule {
           `marked as "{static: ${(timing === QueryTiming.STATIC).toString()}}".`;
 
       failures.push(new RuleFailure(
-          sourceFile, queryExpr.getStart(), queryExpr.getWidth(), failureMessage, this.ruleName,
+          sourceFile, queryExpr.getStart(), queryExpr.getEnd(), failureMessage, this.ruleName,
           fix));
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`RuleFailure.startPosition` is bigger than `RuleFailure.endPosition` because the width is passed. In google3, this causes Critique to highlight the wrong lines.
Issue Number: b/130153967

## What is the new behavior?
Failure end position is set correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
