### PR TITLE
 feat(ivy): support `@Injectable` with explicit deps in ngtsc

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -196,15 +196,12 @@ function extractInjectableMetadata(
       };
     } else {
       const userDeps = reflectDeps(meta, reflector);
-      if (userDeps !== undefined) {
-        // If `deps` was explicitly specified, consider those as constructor dependencies.
-        ctorDeps = userDeps;
-      } else if (strictCtorDeps) {
+      if (strictCtorDeps && userDeps === undefined) {
         // Since neither `use*` nor `deps` was provided, validate the deps according to
         // strictCtorDeps.
         validateConstructorDependencies(clazz, rawCtorDeps);
       }
-      return {name, type, typeArgumentCount, providedIn, ctorDeps};
+      return {name, type, typeArgumentCount, providedIn, ctorDeps, userDeps};
     }
   } else {
     throw new FatalDiagnosticError(

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -164,10 +164,9 @@ describe('ngtsc behavioral tests', () => {
     expect(dtsContents).toContain('static ngInjectableDef: i0.\u0275\u0275InjectableDef<Service>;');
   });
 
-  it('should compile Injectables with invalid constructor with explicit deps without errors',
-     () => {
-       env.tsconfig();
-       env.write('test.ts', `
+  it('should compile Injectables with invalid constructor with deps without errors', () => {
+    env.tsconfig();
+    env.write('test.ts', `
         import {Injectable} from '@angular/core';
         
         export const TOKEN = 'TOKEN';
@@ -178,15 +177,16 @@ describe('ngtsc behavioral tests', () => {
         }
     `);
 
-       env.driveMain();
+    env.driveMain();
 
-       const jsContents = env.getContents('test.js');
-       expect(jsContents)
-           .toContain('Service.ngInjectableDef = i0.defineInjectable({ token: Service,');
-       expect(jsContents)
-           .toContain(
-               'function Service_Factory(t) { return new (t || Service)(i0.inject(TOKEN)); }');
-     });
+    const jsContents = env.getContents('test.js');
+    expect(jsContents).toContain('Service.ngInjectableDef = i0.defineInjectable({ token: Service,');
+    expect(jsContents).toContain('factory: function Service_Factory(t) { var r = null; if (t) {');
+    expect(jsContents)
+        .toContain('throw new Error("Service has a constructor which is not compatible');
+    expect(jsContents).toContain('(r = new Service(i0.inject(TOKEN)));');
+    expect(jsContents).toContain('return r; }, providedIn: \'root\' });');
+  });
 
   it('should compile @Injectable with an @Optional dependency', () => {
     env.tsconfig();

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -164,6 +164,30 @@ describe('ngtsc behavioral tests', () => {
     expect(dtsContents).toContain('static ngInjectableDef: i0.\u0275\u0275InjectableDef<Service>;');
   });
 
+  it('should compile Injectables with invalid constructor with explicit deps without errors',
+     () => {
+       env.tsconfig();
+       env.write('test.ts', `
+        import {Injectable} from '@angular/core';
+        
+        export const TOKEN = 'TOKEN';
+
+        @Injectable({ providedIn: 'root', deps: [TOKEN] })
+        export class Service {
+          constructor(private notInjectable: string) {}
+        }
+    `);
+
+       env.driveMain();
+
+       const jsContents = env.getContents('test.js');
+       expect(jsContents)
+           .toContain('Service.ngInjectableDef = i0.defineInjectable({ token: Service,');
+       expect(jsContents)
+           .toContain(
+               'function Service_Factory(t) { return new (t || Service)(i0.inject(TOKEN)); }');
+     });
+
   it('should compile @Injectable with an @Optional dependency', () => {
     env.tsconfig();
     env.write('test.ts', `
@@ -1126,7 +1150,7 @@ describe('ngtsc behavioral tests', () => {
            env.write('test.ts', `
             import {Injectable} from '@angular/core';
 
-            @Injectable()
+            @Injectable({providedIn: 'root'})
             export class Test {
               constructor(private notInjectable: string) {}
             }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -180,11 +180,12 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('Service.ngInjectableDef = i0.defineInjectable({ token: Service,');
+    expect(jsContents)
+        .toContain('Service.ngInjectableDef = i0.\u0275\u0275defineInjectable({ token: Service,');
     expect(jsContents).toContain('factory: function Service_Factory(t) { var r = null; if (t) {');
     expect(jsContents)
         .toContain('throw new Error("Service has a constructor which is not compatible');
-    expect(jsContents).toContain('(r = new Service(i0.inject(TOKEN)));');
+    expect(jsContents).toContain('(r = new Service(i0.\u0275\u0275inject(TOKEN)));');
     expect(jsContents).toContain('return r; }, providedIn: \'root\' });');
   });
 

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -94,7 +94,16 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
       expression: o.importExpr(Identifiers.inject).callFn([meta.useExisting]),
     });
   } else {
-    result = compileFactoryFunction(factoryMeta);
+    if (meta.userDeps !== undefined) {
+      result = compileFactoryFunction({
+        ...factoryMeta,
+        delegate: meta.type,
+        delegateDeps: meta.userDeps,
+        delegateType: R3FactoryDelegateType.Class,
+      });
+    } else {
+      result = compileFactoryFunction(factoryMeta);
+    }
   }
 
   const token = meta.type;

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -122,7 +122,7 @@ export interface StaticClassProvider extends StaticClassSansProvider {
  * ### Example
  *
  * ```
- * @Injectable(SomeModule, {deps: []})
+ * @Injectable({providedIn: SomeModule, deps: []})
  * class MyService {}
  * ```
  *


### PR DESCRIPTION
**feat(ivy): support `@Injectable` with explicit deps in ngtsc**
Previously, any explicit `deps` provided for `@Injectable` would not be
taken into account when compiling the factory function, instead the
reflected constructor dependencies would be used instead.

This commit updates ngtsc to take such explicit deps into account and use
them instead of the constructor dependencies. As a result, if the
constructor contains parameter types not valid for DI purposes, the user-
specified deps will still allow the service to be created.

Closes FW-648