### PR TITLE
perf(ivy): do not use spread operations in styling

### DIFF
--- a/packages/core/src/render3/styling/host_instructions_queue.ts
+++ b/packages/core/src/render3/styling/host_instructions_queue.ts
@@ -65,7 +65,7 @@ export function flushQueue(context: StylingContext): void {
          i += HostInstructionsQueueIndex.Size) {
       const fn = buffer[i + HostInstructionsQueueIndex.InstructionFnOffset] as Function;
       const args = buffer[i + HostInstructionsQueueIndex.ParamsOffset] as any[];
-      fn(...args);
+      fn.apply(this, args);
     }
     buffer.length = HostInstructionsQueueIndex.ValuesStartPosition;
   }


### PR DESCRIPTION
While investigating styling performance regressions, it was discovered
that a single `fn(...args)` operation was causing a performance hit
because the generated es5 `__spread` operation uses `[].concat` and
reads from the `arguments` values (which are not very efficient). This
patch changes that around to use `fn.apply` instead.