### PR TITLE
perf(ivy): make sure host-styling instructions are efficiently queued

### DIFF
--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -322,7 +322,7 @@ export interface StylingContext extends
    * `hostStylingApply`), the queue is flushed and the values are rendered onto
    * the host element.
    */
-  [StylingIndex.HostInstructionsQueue]: HostInstructionsQueue|null;
+  [StylingIndex.FinalDirectiveIndexThatFlushes]: number;
 
   /**
    * Location of animation context (which contains the active players) for this element styling
@@ -377,18 +377,18 @@ export interface StylingContext extends
  * only allows for styling to be applied once that directive is encountered (which will happen
  * as the last update for that element).
  */
-export interface HostInstructionsQueue extends Array<number|Function|any[]> { [0]: number; }
+export interface HostInstructionsQueue extends Array<null|number|Function|any[]> { [0]: number; }
 
 /**
  * Used as a reference for any values contained within `HostInstructionsQueue`.
  */
 export const enum HostInstructionsQueueIndex {
-  LastRegisteredDirectiveIndexPosition = 0,
+  ValuesLengthPosition = 0,
   ValuesStartPosition = 1,
-  DirectiveIndexOffset = 0,
+  PriorityOffset = 0,
   InstructionFnOffset = 1,
-  ParamsOffset = 2,
-  Size = 3,
+  ParamsStartOffset = 2,
+  Size = 7  // 5 args + function + priority
 }
 
 /**
@@ -712,20 +712,22 @@ export const enum MapBasedOffsetValuesIndex {
  */
 export const enum StylingFlags {
   // Implies no configurations
-  None = 0b00000,
+  None = 0b000000,
   // Whether or not the entry or context itself is dirty
-  Dirty = 0b00001,
+  Dirty = 0b000001,
   // Whether or not this is a class-based assignment
-  Class = 0b00010,
+  Class = 0b000010,
   // Whether or not a sanitizer was applied to this property
-  Sanitize = 0b00100,
+  Sanitize = 0b000100,
   // Whether or not any player builders within need to produce new players
-  PlayerBuildersDirty = 0b01000,
+  Deferred = 0b001000,
+  // Whether or not any player builders within need to produce new players
+  PlayerBuildersDirty = 0b010000,
   // The max amount of bits used to represent these configuration values
-  BindingAllocationLocked = 0b10000,
-  BitCountSize = 5,
-  // There are only five bits here
-  BitMask = 0b11111
+  BindingAllocationLocked = 0b100000,
+  BitCountSize = 6,
+  // There are only six bits here
+  BitMask = 0b111111
 }
 
 /** Used as numeric pointer values to determine what cells to update in the `StylingContext` */
@@ -749,7 +751,7 @@ export const enum StylingIndex {
   CachedMultiStyles = 7,
   // Multi and single entries are stored in `StylingContext` as: Flag; PropertyName;  PropertyValue
   // Position of where the initial styles are stored in the styling context
-  HostInstructionsQueue = 8,
+  FinalDirectiveIndexThatFlushes = 8,
   PlayerContext = 9,
   // Location of single (prop) value entries are stored within the context
   SingleStylesStartPosition = 10,

--- a/packages/core/src/render3/styling/host_instructions_queue.ts
+++ b/packages/core/src/render3/styling/host_instructions_queue.ts
@@ -5,8 +5,10 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
-import {HostInstructionsQueue, HostInstructionsQueueIndex, StylingContext, StylingIndex} from '../interfaces/styling';
-import {DEFAULT_TEMPLATE_DIRECTIVE_INDEX} from '../styling/shared';
+import {HostInstructionsQueueIndex, StylingContext, StylingIndex} from '../interfaces/styling';
+import {getDirectiveInheritanceInstructionsQueue, getHostInstructionsQueue, setHostInstructionsQueue} from '../state';
+
+import {DEFAULT_TEMPLATE_DIRECTIVE_INDEX} from './shared';
 
 /*
  * This file contains the logic to defer all hostBindings-related styling code to run
@@ -23,51 +25,48 @@ import {DEFAULT_TEMPLATE_DIRECTIVE_INDEX} from '../styling/shared';
  */
 
 export function registerHostDirective(context: StylingContext, directiveIndex: number) {
-  let buffer = context[StylingIndex.HostInstructionsQueue];
-  if (!buffer) {
-    buffer = context[StylingIndex.HostInstructionsQueue] = [DEFAULT_TEMPLATE_DIRECTIVE_INDEX];
-  }
-  buffer[HostInstructionsQueueIndex.LastRegisteredDirectiveIndexPosition] = directiveIndex;
+  context[StylingIndex.FinalDirectiveIndexThatFlushes] = directiveIndex;
 }
 
 /**
  * Queues a styling instruction to be run just before `renderStyling()` is executed.
  */
-export function enqueueHostInstruction<T extends Function>(
-    context: StylingContext, priority: number, instructionFn: T, instructionFnArgs: ParamsOf<T>) {
-  const buffer: HostInstructionsQueue = context[StylingIndex.HostInstructionsQueue] !;
-  const index = findNextInsertionIndex(buffer, priority);
-  buffer.splice(index, 0, priority, instructionFn, instructionFnArgs);
-}
+export function enqueueHostInstruction(
+    priority: number, instructionFn: Function, arg1: any, arg2: any, arg3: any, arg4: any,
+    arg5: any) {
+  const queue = getHostInstructionsQueue();
+  let i = queue[HostInstructionsQueueIndex.ValuesLengthPosition];
 
-/**
- * Figures out where exactly to to insert the next host instruction queue entry.
- */
-function findNextInsertionIndex(buffer: HostInstructionsQueue, priority: number): number {
-  for (let i = HostInstructionsQueueIndex.ValuesStartPosition; i < buffer.length;
-       i += HostInstructionsQueueIndex.Size) {
-    const p = buffer[i + HostInstructionsQueueIndex.DirectiveIndexOffset] as number;
-    if (p > priority) {
-      return i;
-    }
+  // the goal is to reuse the array instead of recreating a new array between each
+  // host element.
+  if (i < queue.length) {
+    queue[i++] = priority;
+    queue[i++] = instructionFn;
+    queue[i++] = arg1;
+    queue[i++] = arg2;
+    queue[i++] = arg3;
+    queue[i++] = arg4;
+    queue[i++] = arg5;
+  } else {
+    queue.push(priority, instructionFn, arg1, arg2, arg3, arg4, arg5);
   }
-  return buffer.length;
+  queue[HostInstructionsQueueIndex.ValuesLengthPosition] += HostInstructionsQueueIndex.Size;
 }
 
 /**
  * Iterates through the host instructions queue (if present within the provided
  * context) and executes each queued instruction entry.
  */
-export function flushQueue(context: StylingContext): void {
-  const buffer = context[StylingIndex.HostInstructionsQueue];
-  if (buffer) {
-    for (let i = HostInstructionsQueueIndex.ValuesStartPosition; i < buffer.length;
-         i += HostInstructionsQueueIndex.Size) {
-      const fn = buffer[i + HostInstructionsQueueIndex.InstructionFnOffset] as Function;
-      const args = buffer[i + HostInstructionsQueueIndex.ParamsOffset] as any[];
-      fn.apply(this, args);
-    }
-    buffer.length = HostInstructionsQueueIndex.ValuesStartPosition;
+export function flushQueue(): void {
+  const queue = getHostInstructionsQueue();
+  const length = queue[HostInstructionsQueueIndex.ValuesLengthPosition] as number;
+  queue[HostInstructionsQueueIndex.ValuesLengthPosition] =
+      HostInstructionsQueueIndex.ValuesStartPosition;
+  let i = HostInstructionsQueueIndex.ValuesStartPosition;
+  while (i < length) {
+    const fn = queue[i + HostInstructionsQueueIndex.InstructionFnOffset] as Function;
+    i += HostInstructionsQueueIndex.ParamsStartOffset;
+    fn(queue[i++], queue[i++], queue[i++], queue[i++], queue[i++]);
   }
 }
 
@@ -81,15 +80,66 @@ export function flushQueue(context: StylingContext): void {
  * the styling context) attempts to render its styling.
  */
 export function allowFlush(context: StylingContext, directiveIndex: number): boolean {
-  const buffer = context[StylingIndex.HostInstructionsQueue];
-  if (buffer) {
-    return buffer[HostInstructionsQueueIndex.LastRegisteredDirectiveIndexPosition] ===
-        directiveIndex;
-  }
-  return true;
+  const index = context[StylingIndex.FinalDirectiveIndexThatFlushes];
+
+  // if the template level value is set then this means that there are no host
+  // level bindings to flush at all
+  return index === DEFAULT_TEMPLATE_DIRECTIVE_INDEX || index === directiveIndex;
 }
 
 /**
- * Infers the parameters of a given function into a typed array.
+ * The total amount of entries per host instruction.
  */
-export type ParamsOf<T> = T extends(...args: infer T) => any ? T : never;
+const QUEUE_TUPLE_LENGTH = 7;
+
+/**
+ * Called when a directive inheritance chain has starts.
+ *
+ * When an inheritance chain starts (where parent and sub-classed
+ * directives execute their host binding functions) all style and
+ * class bindings are applied to the active host instructions queue.
+ *
+ * Style and class binding code expects the sub-classed directives to
+ * apply their styling bindings first and then the parent bindings. For
+ * this to work a special "inheritance-only" host instructions queue is
+ * assigned which is then later flushed inside of `directiveInheritanceEnd`.
+ */
+export function directiveInheritanceStart() {
+  setHostInstructionsQueue(getDirectiveInheritanceInstructionsQueue());
+}
+
+/**
+ * Called when a directive inheritance chain has ended.
+ *
+ * Due to the nature of how sub-classed directives are evaluated during
+ * change detection, style and class bindings are evaluated at the wrong
+ * moment and their values are not applied in the correct order. For this
+ * to work properly, all style/class bindings applied during an inheritance
+ * chain are reverse-inserted into the host instructions queue when the
+ * inheritance chain exits.
+ */
+export function directiveInheritanceEnd() {
+  // this will restore the non-inheritance host instructions queue
+  setHostInstructionsQueue(null);
+
+  const queue = getDirectiveInheritanceInstructionsQueue();
+  const length = queue[HostInstructionsQueueIndex.ValuesLengthPosition];
+
+  // the loop will iterate one tuple at a time in reverse. This is because the
+  // sub-classed directive bindings are applied from parent to child. Therefore
+  // to apply them in the order of child-first then the loop will iterate in the
+  // opposite order.
+  for (let i = length - QUEUE_TUPLE_LENGTH; i >= 0; i -= QUEUE_TUPLE_LENGTH) {
+    let j = i;
+
+    // it's safe to call this function again because the host instructions queue
+    // is now writing to the default queue (this was reset at the start of this
+    // function).
+    enqueueHostInstruction(
+        queue[j++] as number, queue[j++] as Function, queue[j++], queue[j++], queue[j++],
+        queue[j++], queue[j++]);
+  }
+
+  queue[HostInstructionsQueueIndex.ValuesLengthPosition] =
+      HostInstructionsQueueIndex.ValuesStartPosition;
+}

--- a/packages/core/src/render3/styling/util.ts
+++ b/packages/core/src/render3/styling/util.ts
@@ -28,16 +28,16 @@ export function createEmptyStylingContext(
     initialStyles?: InitialStylingValues | null,
     initialClasses?: InitialStylingValues | null): StylingContext {
   const context: StylingContext = [
-    wrappedElement || null,          // Element
-    0,                               // MasterFlags
-    [] as any,                       // DirectiveRefs (this gets filled below)
-    initialStyles || [null, null],   // InitialStyles
-    initialClasses || [null, null],  // InitialClasses
-    [0, 0],                          // SinglePropOffsets
-    [0],                             // CachedMultiClassValue
-    [0],                             // CachedMultiStyleValue
-    null,                            // HostBuffer
-    null,                            // PlayerContext
+    wrappedElement || null,            // Element
+    0,                                 // MasterFlags
+    [] as any,                         // DirectiveRefs (this gets filled below)
+    initialStyles || [null, null],     // InitialStyles
+    initialClasses || [null, null],    // InitialClasses
+    [0, 0],                            // SinglePropOffsets
+    [0],                               // CachedMultiClassValue
+    [0],                               // CachedMultiStyleValue
+    DEFAULT_TEMPLATE_DIRECTIVE_INDEX,  // HostBuffer
+    null,                              // PlayerContext
   ];
 
   // whenever a context is created there is always a `null` directive

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -690,6 +690,9 @@
     "name": "getHighestElementOrICUContainer"
   },
   {
+    "name": "getHostInstructionsQueue"
+  },
+  {
     "name": "getHostNative"
   },
   {
@@ -873,6 +876,9 @@
     "name": "hasValueChanged"
   },
   {
+    "name": "hostInstructionsQueue"
+  },
+  {
     "name": "hyphenate"
   },
   {
@@ -996,6 +1002,9 @@
     "name": "isRootView"
   },
   {
+    "name": "isSingleValueCacheHit"
+  },
+  {
     "name": "isStylingContext"
   },
   {
@@ -1024,6 +1033,9 @@
   },
   {
     "name": "makeParamDecorator"
+  },
+  {
+    "name": "markAsDeferred"
   },
   {
     "name": "markDirty"

--- a/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
+++ b/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
@@ -101,12 +101,12 @@ describe('style and class based bindings', () => {
     store = store || new MockStylingStore(element as HTMLElement, BindingType.Style);
     const handler = new CorePlayerHandler();
     return function(
-        context: StylingContext, targetDirective?: any, firstRender?: boolean,
+        context: StylingContext, targetDirectiveIndex: number = 0, firstRender?: boolean,
         renderer?: Renderer3): {[key: string]: any} {
       const lView = createMockViewData(handler, context);
       _renderStyling(
           context, (renderer || {}) as Renderer3, getRootContextInternal(lView), !!firstRender,
-          null, store, targetDirective);
+          null, store, targetDirectiveIndex);
       return store !.getValues();
     };
   }
@@ -219,7 +219,7 @@ describe('style and class based bindings', () => {
           [0, 0, 0, 0],
           [0, 0, 10, null, 0],
           [0, 0, 10, null, 0],
-          null,
+          0,
           null,
         ]);
       });
@@ -236,7 +236,7 @@ describe('style and class based bindings', () => {
           [0, 0, 0, 0],
           [0, 0, 10, null, 0],
           [0, 0, 10, null, 0],
-          null,
+          0,
           null,
         ]);
       });
@@ -502,7 +502,7 @@ describe('style and class based bindings', () => {
              [1, 1, 1, 1, 10, 14],
              [1, 0, 22, null, 1],
              [1, 0, 18, null, 1],
-             null,
+             0,
              null,
 
              // #10
@@ -541,7 +541,7 @@ describe('style and class based bindings', () => {
              [2, 2, 1, 1, 10, 18, 2, 1, 10, 14, 22],
              [2, 0, 34, null, 1, 0, 38, null, 1],
              [2, 0, 26, null, 1, 0, 30, null, 1],
-             null,
+             0,
              null,
 
              // #10
@@ -604,7 +604,7 @@ describe('style and class based bindings', () => {
              [3, 3, 1, 1, 10, 22, 2, 1, 10, 14, 26, 3, 3, 18, 10, 14, 30, 26, 22],
              [3, 0, 46, null, 1, 0, 50, null, 1, 0, 54, null, 1],
              [3, 0, 34, null, 1, 0, 38, null, 1, 0, 42, null, 1],
-             null,
+             0,
              null,
 
              // #10
@@ -704,7 +704,7 @@ describe('style and class based bindings', () => {
           height: '100px',
         });
         updateStyles(stylingContext, {height: '200px'});
-        expect(getStyles(stylingContext, null, true)).toEqual({height: '200px'});
+        expect(getStyles(stylingContext, undefined, true)).toEqual({height: '200px'});
       });
 
       it('should evaluate the delta between style changes when rendering occurs', () => {
@@ -1209,7 +1209,7 @@ describe('style and class based bindings', () => {
           [1, 0, 1, 0, 10],
           [0, 0, 22, null, 0],
           [1, 0, 14, cachedStyleValue, 1],
-          null,
+          0,
           null,
 
           // #10
@@ -1242,7 +1242,7 @@ describe('style and class based bindings', () => {
           [1, 0, 1, 0, 10],
           [0, 0, 22, null, 0],
           [1, 0, 14, cachedStyleValue, 1],
-          null,
+          0,
           null,
 
           // #10
@@ -1899,7 +1899,7 @@ describe('style and class based bindings', () => {
         [0, 2, 0, 2, 10, 14],
         [2, 0, 18, null, 2],
         [0, 0, 18, null, 0],
-        null,
+        0,
         null,
 
         // #10
@@ -1981,7 +1981,7 @@ describe('style and class based bindings', () => {
            [2, 2, 2, 2, 10, 14, 18, 22],
            [2, 0, 34, null, 2],
            [2, 0, 26, null, 2],
-           null,
+           0,
            null,
 
            // #10
@@ -2046,7 +2046,7 @@ describe('style and class based bindings', () => {
            [2, 2, 2, 2, 10, 14, 18, 22],
            [2, 0, 38, 'tall round', 2],
            [2, 0, 26, cachedStyleMap, 2],
-           null,
+           0,
            null,
 
            // #10
@@ -2129,7 +2129,7 @@ describe('style and class based bindings', () => {
            [2, 2, 2, 2, 10, 14, 18, 22],
            [2, 0, 38, cachedClassMap, 2],
            [1, 0, 26, cachedStyleMap, 1],
-           null,
+           0,
            null,
 
            // #10
@@ -2226,7 +2226,7 @@ describe('style and class based bindings', () => {
            [0, 0, 0, 0],               //
            [1, 0, 14, classesMap, 1],  //
            [1, 0, 10, stylesMap, 1],   //
-           null,                       //
+           0,                          //
            null,                       //
 
            // #10
@@ -2253,7 +2253,7 @@ describe('style and class based bindings', () => {
            [0, 0, 0, 0],               //
            [1, 0, 14, classesMap, 1],  //
            [1, 0, 10, stylesMap, 1],   //
-           null,                       //
+           0,                          //
            null,                       //
 
            // #10
@@ -2283,7 +2283,7 @@ describe('style and class based bindings', () => {
         [0, 0, 0, 0],
         [3, 0, 10, 'apple orange banana', 3],
         [0, 0, 10, null, 0],
-        null,
+        0,
         null,
 
         // #10
@@ -2650,7 +2650,7 @@ describe('style and class based bindings', () => {
            [1, 1, 1, 1, 10, 14],            //
            [1, 0, 22, null, 1],             //
            [1, 0, 18, null, 1],             //
-           null,                            //
+           0,                               //
            null,                            //
 
            // #10
@@ -2714,7 +2714,7 @@ describe('style and class based bindings', () => {
            [1, 1, 1, 1, 10, 14],                      //
            [1, 0, 26, classMapWithPlayerFactory, 1],  //
            [1, 0, 18, styleMapWithPlayerFactory, 1],  //
-           null,                                      //
+           0,                                         //
            playerContext,
 
            // #10
@@ -2776,7 +2776,7 @@ describe('style and class based bindings', () => {
            [1, 1, 1, 1, 10, 14],            //
            [1, 0, 26, cachedClassMap, 1],   //
            [1, 0, 18, cachedStyleMap, 1],   //
-           null,                            //
+           0,                               //
            playerContext,
 
            // #10


### PR DESCRIPTION
This PR optimizes Angular's styling mechanisms to avoid unnecessary
array construction and garbage collection by holding onto a queue of
operations and then reusing it for other elements.