### PR TITLE
build(bazel): pin versions of nodejs rules in @angular/bazel peer deps and @bazel/schematics

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
-    "@bazel/typescript": "^0.27.10",
+    "@bazel/typescript": "0.27.10",
     "typescript": ">=3.3.3333 <3.4"
   },
   "repository": {

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -49,8 +49,8 @@ function addDevDependenciesToPackageJson(options: Schema) {
       '@angular/bazel': angularCoreVersion,
       '@bazel/bazel': '^0.24.0',
       '@bazel/ibazel': '^0.9.0',
-      '@bazel/karma': '^0.27.10',
-      '@bazel/typescript': '^0.27.10',
+      '@bazel/karma': '0.27.10',
+      '@bazel/typescript': '0.27.10',
     };
 
     const recorder = host.beginUpdate(packageJson);


### PR DESCRIPTION
Since @angular/bazel depends on the internal non-public API of @bazel/typescript and @build_bazel_rules_nodejs we pin the versions of nodejs rules deps in /integration/bazel and in the bazel schematics here to avoid failures like https://circleci.com/gh/angular/angular/278479 after making rules_nodejs releases.

In the future we should consume only the public API of nodejs rules or add a integration test that would catch the above failure in the rules_nodejs repo.