### PR TITLE
fix(core): don't include a local `EventListener` in typings

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -22,7 +22,7 @@ export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';
 export * from './linker';
-export {DebugElement, DebugNode, asNativeElements, getDebugNode, Predicate} from './debug/debug_node';
+export {DebugElement, DebugEventListener, DebugNode, asNativeElements, getDebugNode, Predicate} from './debug/debug_node';
 export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './testability/testability';
 export * from './change_detection';
 export * from './platform_core_providers';

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -21,7 +21,7 @@ import {getComponentViewByIndex, getNativeByTNode, isComponent, isLContainer} fr
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
-export class EventListener {
+export class DebugEventListener {
   constructor(public name: string, public callback: Function) {}
 }
 
@@ -29,7 +29,7 @@ export class EventListener {
  * @publicApi
  */
 export interface DebugNode {
-  readonly listeners: EventListener[];
+  readonly listeners: DebugEventListener[];
   readonly parent: DebugElement|null;
   readonly nativeNode: any;
   readonly injector: Injector;
@@ -39,7 +39,7 @@ export interface DebugNode {
   readonly providerTokens: any[];
 }
 export class DebugNode__PRE_R3__ {
-  readonly listeners: EventListener[] = [];
+  readonly listeners: DebugEventListener[] = [];
   readonly parent: DebugElement|null = null;
   readonly nativeNode: any;
   private readonly _debugContext: DebugContext;
@@ -219,7 +219,7 @@ class DebugNode__POST_R3__ implements DebugNode {
   }
   get context(): any { return getContext(this.nativeNode as Element); }
 
-  get listeners(): EventListener[] {
+  get listeners(): DebugEventListener[] {
     return getListeners(this.nativeNode as Element).filter(isBrowserEvents);
   }
 

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -21,6 +21,9 @@ import {getComponentViewByIndex, getNativeByTNode, isComponent, isLContainer} fr
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
+/**
+ * @publicApi
+ */
 export class DebugEventListener {
   constructor(public name: string, public callback: Function) {}
 }

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DebugElement__PRE_R3__, DebugNode__PRE_R3__, EventListener, getDebugNode, indexDebugNode, removeDebugNodeFromIndex} from '../debug/debug_node';
+import {DebugElement__PRE_R3__, DebugEventListener, DebugNode__PRE_R3__, getDebugNode, indexDebugNode, removeDebugNodeFromIndex} from '../debug/debug_node';
 import {Injector} from '../di';
 import {InjectableType} from '../di/injectable';
 import {InjectableDef, getInjectableDef} from '../di/interface/defs';
@@ -827,7 +827,7 @@ export class DebugRenderer2 implements Renderer2 {
     if (typeof target !== 'string') {
       const debugEl = getDebugNode(target);
       if (debugEl) {
-        debugEl.listeners.push(new EventListener(eventName, callback));
+        debugEl.listeners.push(new DebugEventListener(eventName, callback));
       }
     }
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -224,6 +224,12 @@ export declare const DebugElement: {
     new (...args: any[]): DebugElement;
 };
 
+export declare class DebugEventListener {
+    callback: Function;
+    name: string;
+    constructor(name: string, callback: Function);
+}
+
 export interface DebugNode {
     readonly componentInstance: any;
     readonly context: any;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -228,7 +228,7 @@ export interface DebugNode {
     readonly componentInstance: any;
     readonly context: any;
     readonly injector: Injector;
-    readonly listeners: EventListener[];
+    readonly listeners: DebugEventListener[];
     readonly nativeNode: any;
     readonly parent: DebugElement | null;
     readonly providerTokens: any[];


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


With dts bundles, `core.d.ts` will include an `EventListener` class as it's used in https://github.com/angular/angular/blob/303eae918d997070a36b523ddc97e018f622c258/packages/core/src/debug/debug_node.ts#L32

This will conflict with the DOM EventListener, as anything in `core.d.ts` which is using the DOM EventListener will fallback in using the one defined in the same module and hence build will fail because their implementation is different.

With this change, we rename the local `EventListener` to `DebugEventListener`, the later one is non exported.

Fixes #29806


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
