### PR TITLE
 fix(router): change undefined route snapshot fragment to null

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -115,8 +115,7 @@ import {UrlTree} from '../url_tree';
 export class RouterLink {
   // TODO(issue/24571): remove '!'.
   @Input() queryParams !: {[k: string]: any};
-  // TODO(issue/24571): remove '!'.
-  @Input() fragment !: string;
+  @Input() fragment: string|null = null;
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling !: QueryParamsHandling;
   // TODO(issue/24571): remove '!'.
@@ -197,8 +196,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @HostBinding('attr.target') @Input() target !: string;
   // TODO(issue/24571): remove '!'.
   @Input() queryParams !: {[k: string]: any};
-  // TODO(issue/24571): remove '!'.
-  @Input() fragment !: string;
+  @Input() fragment: string|null = null;
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling !: QueryParamsHandling;
   // TODO(issue/24571): remove '!'.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -93,7 +93,7 @@ export interface NavigationExtras {
    * this.router.navigate(['/results'], { fragment: 'top' });
    * ```
    */
-  fragment?: string;
+  fragment?: string|null;
 
   /**
    * DEPRECATED: Use `queryParamsHandling` instead to preserve

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1443,22 +1443,6 @@ describe('Integration', () => {
        expect(cmp.path.length).toEqual(2);
      })));
 
-  // https://github.com/angular/angular/issues/29391
-  it('should have a null fragment if fragment is not set',
-     fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
-
-      router.resetConfig([{path: 'simple', component: RouteCmp}]);
-
-      router.navigateByUrl('/simple');
-      advance(fixture);
-
-      const cmp = fixture.debugElement.children[1].componentInstance;
-
-      expect(cmp.route.snapshot.fragment).toBe(null);
-    })));
-
-
 
   describe('data', () => {
     class ResolveSix implements Resolve<number> {
@@ -1994,6 +1978,31 @@ describe('Integration', () => {
          const native = fixture.nativeElement.querySelector('area');
          expect(native.getAttribute('href')).toEqual('/home');
        }));
+
+    // https://github.com/angular/angular/issues/29391
+    it('should have a null fragment if fragment is not set', fakeAsync(() => {
+        @Component({
+          selector: 'someRoot',
+          template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
+        })
+        class RootCmpWithLink {
+        }
+
+        TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+        const router: Router = TestBed.get(Router);
+
+        const fixture = createRoot(router, RootCmpWithLink);
+
+        router.resetConfig([{path: 'home', component: RouteCmp}]);
+
+        const anchor = fixture.nativeElement.querySelector('a');
+        anchor.click();
+        advance(fixture);
+
+        const cmp = fixture.debugElement.children[1].componentInstance;
+
+        expect(cmp.route.snapshot.fragment).toBe(null);
+      }));
   });
 
   describe('redirects', () => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1443,6 +1443,21 @@ describe('Integration', () => {
        expect(cmp.path.length).toEqual(2);
      })));
 
+  // https://github.com/angular/angular/issues/29391
+  it('should have a null fragment if fragment is not set',
+     fakeAsync(inject([Router], (router: Router) => {
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'simple', component: RouteCmp}]);
+
+      router.navigateByUrl('/simple');
+      advance(fixture);
+
+      const cmp = fixture.debugElement.children[1].componentInstance;
+
+      expect(cmp.route.snapshot.fragment).toBe(null);
+    })));
+
 
 
   describe('data', () => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1981,28 +1981,28 @@ describe('Integration', () => {
 
     // https://github.com/angular/angular/issues/29391
     it('should have a null fragment if fragment is not set', fakeAsync(() => {
-        @Component({
-          selector: 'someRoot',
-          template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
-        })
-        class RootCmpWithLink {
-        }
+         @Component({
+           selector: 'someRoot',
+           template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
 
-        TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-        const router: Router = TestBed.get(Router);
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
 
-        const fixture = createRoot(router, RootCmpWithLink);
+         const fixture = createRoot(router, RootCmpWithLink);
 
-        router.resetConfig([{path: 'home', component: RouteCmp}]);
+         router.resetConfig([{path: 'home', component: RouteCmp}]);
 
-        const anchor = fixture.nativeElement.querySelector('a');
-        anchor.click();
-        advance(fixture);
+         const anchor = fixture.nativeElement.querySelector('a');
+         anchor.click();
+         advance(fixture);
 
-        const cmp = fixture.debugElement.children[1].componentInstance;
+         const cmp = fixture.debugElement.children[1].componentInstance;
 
-        expect(cmp.route.snapshot.fragment).toBe(null);
-      }));
+         expect(cmp.route.snapshot.fragment).toBe(null);
+       }));
   });
 
   describe('redirects', () => {

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -187,7 +187,7 @@ export declare class NavigationError extends RouterEvent {
 }
 
 export interface NavigationExtras {
-    fragment?: string;
+    fragment?: string | null;
     preserveFragment?: boolean;
     /** @deprecated */ preserveQueryParams?: boolean;
     queryParams?: Params | null;
@@ -364,7 +364,7 @@ export declare class RouterEvent {
 }
 
 export declare class RouterLink {
-    fragment: string;
+    fragment: string | null;
     preserveFragment: boolean;
     /** @deprecated */ preserveQueryParams: boolean;
     queryParams: {
@@ -397,7 +397,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 }
 
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
-    fragment: string;
+    fragment: string | null;
     href: string;
     preserveFragment: boolean;
     preserveQueryParams: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29391


## What is the new behavior?

If fragment is not set, it is always null.  Not sometimes null and sometimes undefined.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
