### PR TITLE
feat(router): add `NavigationFinally` RouterEvent

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -106,11 +106,35 @@ export class NavigationStart extends RouterEvent {
 /**
  * @description
  *
+ * Represents an event triggered when navigation is over. `NavigationEnd`,
+ * `NavigationCancel`, and `NavigationError`all extend the abstract `NavigationFinally` class.
+ *
+ * Example:
+ *
+ * ```
+ * class MyService {
+ *   constructor(public router: Router) {
+ *     router.events.pipe(
+ *       filter(e => e instanceof NavigationFinally)
+ *     ).subscribe(e => {
+ *       // do stuff...
+ *     });
+ *   }
+ * }
+ * ```
+ *
+ * @publicApi
+ */
+export abstract class NavigationFinally extends RouterEvent {}
+
+/**
+ * @description
+ *
  * Represents an event triggered when a navigation ends successfully.
  *
  * @publicApi
  */
-export class NavigationEnd extends RouterEvent {
+export class NavigationEnd extends NavigationFinally {
   constructor(
       /** @docsNotRequired */
       id: number,
@@ -134,7 +158,7 @@ export class NavigationEnd extends RouterEvent {
  *
  * @publicApi
  */
-export class NavigationCancel extends RouterEvent {
+export class NavigationCancel extends NavigationFinally {
   constructor(
       /** @docsNotRequired */
       id: number,
@@ -156,7 +180,7 @@ export class NavigationCancel extends RouterEvent {
  *
  * @publicApi
  */
-export class NavigationError extends RouterEvent {
+export class NavigationError extends NavigationFinally {
   constructor(
       /** @docsNotRequired */
       id: number,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,7 +11,7 @@ export {Data, LoadChildren, LoadChildrenCallback, ResolveData, Route, Routes, Ru
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet} from './directives/router_outlet';
-export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
+export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationFinally, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router} from './router';

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -159,7 +159,7 @@ export declare type Navigation = {
     previousNavigation: Navigation | null;
 };
 
-export declare class NavigationCancel extends RouterEvent {
+export declare class NavigationCancel extends NavigationFinally {
     reason: string;
     constructor(
     id: number,
@@ -168,7 +168,7 @@ export declare class NavigationCancel extends RouterEvent {
     toString(): string;
 }
 
-export declare class NavigationEnd extends RouterEvent {
+export declare class NavigationEnd extends NavigationFinally {
     urlAfterRedirects: string;
     constructor(
     id: number,
@@ -177,7 +177,7 @@ export declare class NavigationEnd extends RouterEvent {
     toString(): string;
 }
 
-export declare class NavigationError extends RouterEvent {
+export declare class NavigationError extends NavigationFinally {
     error: any;
     constructor(
     id: number,
@@ -199,6 +199,8 @@ export interface NavigationExtras {
         [k: string]: any;
     };
 }
+
+export declare abstract class NavigationFinally extends RouterEvent {}
 
 export declare class NavigationStart extends RouterEvent {
     navigationTrigger?: 'imperative' | 'popstate' | 'hashchange';


### PR DESCRIPTION
As suggested in #28885, this nonbreaking change adds a new `NavigationFinally` RouterEvent class
which `NavigationEnd`, `NavigationError`, and `NavigationCancel` extend. This addition allows for easier filtering on navigation-is-over router events.

For example, currently you must do this if you wish to subscribe to navigation-is-over router events:

```typescript
 class MyService {
   constructor(public router: Router) {
      router.events.pipe(
        filter(e => e instanceof NavigationEnd || e instanceof NavigationCancel || e instanceof NavigationError)
      ).subscribe(e => {
        // do stuff...
      });
   }
 }
```

After this change you can do this:

```typescript
 class MyService {
   constructor(public router: Router) {
      router.events.pipe(
        filter(e => e instanceof NavigationFinally)
      ).subscribe(e => {
        // do stuff...
      });
   }
 }
```

### Notes
1. **Currently, this PR does not add any tests.** It's unclear to me if any tests are needed as there are no existing tests which check that different RouterEvent subclasses actually extend `RouterEvent`. 
2. I decided to make `NavigationFinally` an abstract class because that is what it is, but I notice that the `RouterEvent` class is not marked as `abstract`, even though (as far as I am aware) it is an abstract class--so perhaps `NavigationFinally` should also not be abstract.

The name was suggested by @jasonaden.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added **(see "notes" above)**
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28885

## What is the new behavior?
After this change, `NavigationEnd`, `NavigationCancel`, and `NavigationError` all extend from an abstract `NavigationFinally` class, which itself extends `RouterEvent`.

## Does this PR introduce a breaking change?

- [x] No