### PR TITLE
fix(core): consistently use ng:/// for sourcemap URLs

### DIFF
--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -71,7 +71,7 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
           throw new Error(`Unreachable state.`);
         }
         def = getCompilerFacade().compileInjectable(
-            angularCoreDiEnv, `ng://${type.name}/ngInjectableDef.js`, compilerMeta);
+            angularCoreDiEnv, `ng:///${type.name}/ngInjectableDef.js`, compilerMeta);
       }
       return def;
     },

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -123,7 +123,7 @@ export function compileDirective(type: Type<any>, directive: Directive): void {
     get: () => {
       if (ngDirectiveDef === null) {
         const name = type && type.name;
-        const sourceMapUrl = `ng://${name}/ngDirectiveDef.js`;
+        const sourceMapUrl = `ng:///${name}/ngDirectiveDef.js`;
         const compiler = getCompilerFacade();
         const facade = directiveMetadata(type as ComponentType<any>, directive);
         facade.typeSourceSpan = compiler.createParseSourceSpan('Directive', name, sourceMapUrl);

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -107,7 +107,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
     get: () => {
       if (ngModuleDef === null) {
         ngModuleDef = getCompilerFacade().compileNgModule(
-            angularCoreEnv, `ng://${moduleType.name}/ngModuleDef.js`, {
+            angularCoreEnv, `ng:///${moduleType.name}/ngModuleDef.js`, {
               type: moduleType,
               bootstrap: flatten(ngModule.bootstrap || EMPTY_ARRAY, resolveForwardRef),
               declarations: declarations.map(resolveForwardRef),
@@ -142,7 +142,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
           ],
         };
         ngInjectorDef = getCompilerFacade().compileInjector(
-            angularCoreEnv, `ng://${moduleType.name}/ngInjectorDef.js`, meta);
+            angularCoreEnv, `ng:///${moduleType.name}/ngInjectorDef.js`, meta);
       }
       return ngInjectorDef;
     },

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -21,7 +21,7 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
       if (ngPipeDef === null) {
         const typeName = type.name;
         ngPipeDef =
-            getCompilerFacade().compilePipe(angularCoreEnv, `ng://${typeName}/ngPipeDef.js`, {
+            getCompilerFacade().compilePipe(angularCoreEnv, `ng:///${typeName}/ngPipeDef.js`, {
               type: type,
               typeArgumentCount: 0,
               name: typeName,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, in jit mode, `ngInjectableDef`, `ngDirectiveDef`, `ngPipeDef` and `ngModuleDef` use `ng://`,
which display them in the top domain in Chrome Dev Tools, whereas `ngComponentDef` uses `ng:///` which display components in a separate domain.

You can currently see:

```
AppModule
UserService
ng://
|_ AppComponent
   |_ template.html
|_ AppComponent.js
...
```


## What is the new behavior?

This commits replaces all `ng://` with `ng:///` to display every Angular entity in the `ng://` domain.

```
ng://
|_ AppModule
|_ UserService
|_ AppComponent
...
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Note that this was already the case in VE:

https://github.com/angular/angular/blob/19afb791b42d03482cedaebe5defd65df12c913d/packages/compiler/src/compile_metadata.ts#L707-L711

