### PR TITLE
build(docs-infra): upgrade cli command docs sources to 664990cad

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && yarn ivy-ngcc --properties module es2015",
     "build-with-ivy": "node scripts/build-with-ivy",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b00300ebd",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 664990cad",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b00300ebd...664990cad):

**Modified**
- help/build.json
- help/generate.json
- help/new.json
- help/serve.json
- help/test.json

##