### PR TITLE
fix(common): add `@Injectable()` to common pipes

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise} from '@angular/core';
+import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise} from '@angular/core';
 import {Observable, SubscriptionLike} from 'rxjs';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -67,6 +67,7 @@ const _observableStrategy = new ObservableStrategy();
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'async', pure: false})
 export class AsyncPipe implements OnDestroy, PipeTransform {
   private _latestValue: any = null;

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Pipe, PipeTransform} from '@angular/core';
+import {Injectable, Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -24,6 +24,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @ngModule CommonModule
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'lowercase'})
 export class LowerCasePipe implements PipeTransform {
   /**
@@ -67,6 +68,7 @@ const unicodeWordMatch =
  * @ngModule CommonModule
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'titlecase'})
 export class TitleCasePipe implements PipeTransform {
   /**
@@ -91,6 +93,7 @@ export class TitleCasePipe implements PipeTransform {
  * @ngModule CommonModule
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'uppercase'})
 export class UpperCasePipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Inject, Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatDate} from '../i18n/format_date';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -150,6 +150,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @publicApi
  */
 // clang-format on
+@Injectable()
 @Pipe({name: 'date', pure: true})
 export class DatePipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private locale: string) {}

--- a/packages/common/src/pipes/i18n_plural_pipe.ts
+++ b/packages/common/src/pipes/i18n_plural_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {NgLocalization, getPluralCategory} from '../i18n/localization';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -26,6 +26,7 @@ const _INTERPOLATION_REGEXP: RegExp = /#/g;
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'i18nPlural', pure: true})
 export class I18nPluralPipe implements PipeTransform {
   constructor(private _localization: NgLocalization) {}

--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Pipe, PipeTransform} from '@angular/core';
+import {Injectable, Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -26,6 +26,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'i18nSelect', pure: true})
 export class I18nSelectPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/json_pipe.ts
+++ b/packages/common/src/pipes/json_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Pipe, PipeTransform} from '@angular/core';
+import {Injectable, Pipe, PipeTransform} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -23,6 +23,7 @@ import {Pipe, PipeTransform} from '@angular/core';
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'json', pure: false})
 export class JsonPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform} from '@angular/core';
+import {Injectable, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform} from '@angular/core';
 
 function makeKeyValuePair<K, V>(key: K, value: V): KeyValue<K, V> {
   return {key: key, value: value};
@@ -43,6 +43,7 @@ export interface KeyValue<K, V> {
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'keyvalue', pure: false})
 export class KeyValuePipe implements PipeTransform {
   constructor(private readonly differs: KeyValueDiffers) {}

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Inject, Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatCurrency, formatNumber, formatPercent} from '../i18n/format_number';
 import {getCurrencySymbol} from '../i18n/locale_data_api';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
@@ -46,6 +46,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'number'})
 export class DecimalPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -99,6 +100,7 @@ export class DecimalPipe implements PipeTransform {
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'percent'})
 export class PercentPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -153,6 +155,7 @@ export class PercentPipe implements PipeTransform {
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'currency'})
 export class CurrencyPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}

--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Pipe, PipeTransform} from '@angular/core';
+import {Injectable, Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -44,6 +44,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
+@Injectable()
 @Pipe({name: 'slice', pure: false})
 export class SlicePipe implements PipeTransform {
   /**


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Feature

## What is the current behavior?
Common pipes don't have the `@Injectable` decorator.

Issue Number: [FW-1242](https://angular-team.atlassian.net/browse/FW-1242)

## What is the new behavior?
Common pipes have the `@Injectable` decorator which makes them injectable for ivy.

## Does this PR introduce a breaking change?
- [x] No