### PR TITLE
ci: correctly detect status 400 as failure in `get-commit-range`

### DIFF
--- a/.circleci/get-commit-range.js
+++ b/.circleci/get-commit-range.js
@@ -141,7 +141,7 @@ function getJson(url) {
     const opts = {headers: {Accept: 'application/json'}};
     const onResponse = res => {
       const statusCode = res.statusCode || -1;
-      const isSuccess = (200 <= statusCode) && (statusCode <= 400);
+      const isSuccess = (200 <= statusCode) && (statusCode < 400);
       let responseText = '';
 
       res.


### PR DESCRIPTION
☝️ 