### PR TITLE
fix(core): resolve ts compile issues due to lenient tsconfig

### DIFF
--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true,
     "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "lib": ["es2015"],
     "types": [],
     "baseUrl": ".",

--- a/packages/core/schematics/utils/typescript/visit_nodes.ts
+++ b/packages/core/schematics/utils/typescript/visit_nodes.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-export interface TypeScriptVisitor { visitNode(node: ts.Node); }
+export interface TypeScriptVisitor { visitNode(node: ts.Node): void; }
 
 export function visitAllNodes(node: ts.Node, visitors: TypeScriptVisitor[]) {
   visitors.forEach(v => v.visitNode(node));


### PR DESCRIPTION
The code failed presubmit in google3 because the original ts config was not as strict
as the one used elsewhere in angular/angular and google3.
