### PR TITLE
perf(ivy): attempt to coalesce listeners only in presence of directives

### DIFF
--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -131,6 +131,13 @@ export function getNativeByTNode(tNode: TNode, hostView: LView): RNode {
   return unwrapRNode(hostView[tNode.index]);
 }
 
+/**
+ * A helper function that returns `true` if a given `TNode` has any matching directives.
+ */
+export function hasDirectives(tNode: TNode): boolean {
+  return tNode.directiveEnd > tNode.directiveStart;
+}
+
 export function getTNode(index: number, view: LView): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
   ngDevMode && assertLessThan(index, view[TVIEW].data.length, 'wrong index for TNode');

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -849,6 +849,9 @@
     "name": "hasClassInput"
   },
   {
+    "name": "hasDirectives"
+  },
+  {
     "name": "hasParentInjector"
   },
   {


### PR DESCRIPTION
Slight perf improvement in the process of searching for existing listeners to coalesce: we don't have to search for existing listeners is there are no directives matching on a given node as we can't register multiple event handlers for the same event in a template (this would mean having duplicate attributes).