### PR TITLE
Listeners coalesce runtime perf more info on tnode

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -755,6 +755,8 @@ export function createTNode(
     index: adjustedIndex,
     injectorIndex: tParent ? tParent.injectorIndex : -1,
     directiveStart: -1,
+    cleanupStart: -1,
+    cleanupEnd: -1,
     directiveEnd: -1,
     propertyMetadataStartIndex: -1,
     propertyMetadataEndIndex: -1,

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -232,6 +232,17 @@ export interface TNode {
   injectorIndex: number;
 
   /**
+   * Marks a starting index in the TView.cleanup structure where entries for a given node are
+   * stored.
+   */
+  cleanupStart: number;
+
+  /**
+   * Marks an ending index in the TView.cleanup structure where entries for a given node are stored.
+   */
+  cleanupEnd: number;
+
+  /**
    * Stores starting index of the directives.
    */
   directiveStart: number;

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -131,6 +131,13 @@ export function getNativeByTNode(tNode: TNode, hostView: LView): RNode {
   return unwrapRNode(hostView[tNode.index]);
 }
 
+/**
+ * A helper function that returns `true` if a given `TNode` has any matching directives.
+ */
+export function hasDirectives(tNode: TNode): boolean {
+  return tNode.directiveEnd > tNode.directiveStart;
+}
+
 export function getTNode(index: number, view: LView): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
   ngDevMode && assertLessThan(index, view[TVIEW].data.length, 'wrong index for TNode');

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -849,6 +849,9 @@
     "name": "hasClassInput"
   },
   {
+    "name": "hasDirectives"
+  },
+  {
     "name": "hasParentInjector"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1263,6 +1263,9 @@
     "name": "storeCleanupFn"
   },
   {
+    "name": "storeListenerTCleanup"
+  },
+  {
     "name": "stringify"
   },
   {


### PR DESCRIPTION
** Only review the second commit ** (the first commit is part of #29859).

The second commit is a runtime perf-optimisation that limits the scope of search in `TNode.cleanup` when looking up existing listeners to coalesce. While it certainly improves things from CPU cycles point of view, sadly it does so at the expense of memory usage (and one could argue that CPU as well if we take GC into account). 

At this point I feel like adding 2 numbers to each and every `TNode` is too much to pay for CPU cycles optimisations here, but I would like to confirm with solid numbers from perf profiling. As such my recommendation would be to:
- merge #29859 for now;
- hold off this PR until we go to the benchpress-phase of perf testing and got more numbers.

Still, opening this WIP PR so we can discuss.