### PR TITLE
fix(router): do not add hash when fragment is empty

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -288,8 +288,9 @@ export class DefaultUrlSerializer implements UrlSerializer {
   serialize(tree: UrlTree): string {
     const segment = `/${serializeSegment(tree.root, true)}`;
     const query = serializeQueryParams(tree.queryParams);
-    const fragment =
-        typeof tree.fragment === `string` ? `#${encodeUriFragment(tree.fragment !)}` : '';
+    const fragment = typeof tree.fragment === `string` && tree.fragment ?
+        `#${encodeUriFragment(tree.fragment !)}` :
+        '';
 
     return `${segment}${query}${fragment}`;
   }


### PR DESCRIPTION
Even when fragment attribute was empty, hash was added to URL.

Fix #29683

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When fragment of routerLink is empty the anchor save # in href.


## What is the new behavior?
Does not add # character to URL when the fragment is empty.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Fixes #29683 
