### PR TITLE
feat(ivy): generate ɵɵproperty instructions

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 14287,
+        "main": 14455,
         "polyfills": 43567
       }
     }

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -317,7 +317,7 @@ describe('compiler compliance', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "id", $r3$.ɵɵbind(ctx.id));
+            $r3$.ɵɵproperty("id", ctx.id);
           }
         }
       `;
@@ -365,10 +365,10 @@ describe('compiler compliance', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "ternary", $r3$.ɵɵbind((ctx.cond ? $r3$.ɵɵpureFunction1(8, $c0$, ctx.a): $c1$)));
-            $r3$.ɵɵelementProperty(0, "pipe", $r3$.ɵɵbind($r3$.ɵɵpipeBind3(1, 4, ctx.value, 1, 2)));
-            $r3$.ɵɵelementProperty(0, "and", $r3$.ɵɵbind((ctx.cond && $r3$.ɵɵpureFunction1(10, $c0$, ctx.b))));
-            $r3$.ɵɵelementProperty(0, "or", $r3$.ɵɵbind((ctx.cond || $r3$.ɵɵpureFunction1(12, $c0$, ctx.c))));
+            $r3$.ɵɵproperty("ternary", (ctx.cond ? $r3$.ɵɵpureFunction1(8, $c0$, ctx.a): $c1$));
+            $r3$.ɵɵproperty("pipe", $r3$.ɵɵpipeBind3(1, 4, ctx.value, 1, 2));
+            $r3$.ɵɵproperty("and", (ctx.cond && $r3$.ɵɵpureFunction1(10, $c0$, ctx.b)));
+            $r3$.ɵɵproperty("or", (ctx.cond || $r3$.ɵɵpureFunction1(12, $c0$, ctx.c)));
           }
         }
       `;
@@ -880,7 +880,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(0);
-                $r3$.ɵɵelementProperty(0, "names", $r3$.ɵɵbind($r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.customName)));
+                $r3$.ɵɵproperty("names", $r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.customName));
               }
             },
            directives: [MyComp],
@@ -963,9 +963,8 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(0);
-                $r3$.ɵɵelementProperty(
-                    0, "names",
-                    $r3$.ɵɵbind($r3$.ɵɵpureFunctionV(1, $e0_ff$, [ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8])));
+                $r3$.ɵɵproperty("names",
+                    $r3$.ɵɵpureFunctionV(1, $e0_ff$, [ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8]));
               }
             },
             directives: [MyComp],
@@ -1028,7 +1027,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(0);
-                $r3$.ɵɵelementProperty(0, "config", $r3$.ɵɵbind($r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.name)));
+                $r3$.ɵɵproperty("config", $r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.name));
               }
             },
             directives: [ObjectComp],
@@ -1097,9 +1096,9 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(0);
-                $r3$.ɵɵelementProperty(
-                    0, "config",
-                    $r3$.ɵɵbind($r3$.ɵɵpureFunction2(5, $e0_ff_2$, ctx.name, $r3$.ɵɵpureFunction1(3, $e0_ff_1$, $r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.duration)))));
+                $r3$.ɵɵproperty(
+                    "config",
+                    $r3$.ɵɵpureFunction2(5, $e0_ff_2$, ctx.name, $r3$.ɵɵpureFunction1(3, $e0_ff_1$, $r3$.ɵɵpureFunction1(1, $e0_ff$, ctx.duration))));
               }
             },
             directives: [NestedComp],
@@ -1261,9 +1260,9 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵselect(0);
-              $r3$.ɵɵelementProperty(0, "ngIf", $r3$.ɵɵbind(ctx.visible));
+              $r3$.ɵɵproperty("ngIf", ctx.visible);
               $r3$.ɵɵselect(1);
-              $r3$.ɵɵelementProperty(1, "ngIf", $r3$.ɵɵbind(ctx.visible));
+              $r3$.ɵɵproperty("ngIf", ctx.visible);
             }
           }
         `;
@@ -2350,7 +2349,7 @@ describe('compiler compliance', () => {
         if (rf & 2) {
           const $app$ = $i0$.ɵɵnextContext();
           $r3$.ɵɵselect(3);
-          $i0$.ɵɵelementProperty(3, "ngIf", $i0$.ɵɵbind($app$.showing));
+          $i0$.ɵɵproperty("ngIf", $app$.showing);
         }
       }
 
@@ -2361,7 +2360,7 @@ describe('compiler compliance', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngForOf", $i0$.ɵɵbind(ctx.items));
+          $i0$.ɵɵproperty("ngForOf", ctx.items);
         }
       }`;
 
@@ -2442,9 +2441,9 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(0);
-                $r3$.ɵɵelementProperty(0, "name", $r3$.ɵɵbind(ctx.name1));
+                $r3$.ɵɵproperty("name", ctx.name1);
                 $r3$.ɵɵselect(1);
-                $r3$.ɵɵelementProperty(1, "name", $r3$.ɵɵbind(ctx.name2));
+                $r3$.ɵɵproperty("name", ctx.name2);
               }
             },
             directives: [LifecycleComp],
@@ -2576,7 +2575,7 @@ describe('compiler compliance', () => {
                   }
                   if (rf & 2) {
                     $r3$.ɵɵselect(1);
-                    $r3$.ɵɵelementProperty(1,"forOf",$r3$.ɵɵbind(ctx.items));
+                    $r3$.ɵɵproperty("forOf", ctx.items);
                   }
                 },
                 directives: function() { return [ForOfDirective]; },
@@ -2658,7 +2657,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(1);
-                $r3$.ɵɵelementProperty(1, "forOf", $r3$.ɵɵbind(ctx.items));
+                $r3$.ɵɵproperty("forOf", ctx.items);
               }
             },
             directives: function() { return [ForOfDirective]; },
@@ -2743,7 +2742,7 @@ describe('compiler compliance', () => {
               $r3$.ɵɵselect(2);
               $r3$.ɵɵtextBinding(2, $r3$.ɵɵinterpolation1("", IDENT.name, ""));
               $r3$.ɵɵselect(4);
-              $r3$.ɵɵelementProperty(4, "forOf", $r3$.ɵɵbind(IDENT.infos));
+              $r3$.ɵɵproperty("forOf", IDENT.infos);
             }
           }
 
@@ -2762,7 +2761,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵselect(1);
-                $r3$.ɵɵelementProperty(1, "forOf", $r3$.ɵɵbind(ctx.items));
+                $r3$.ɵɵproperty("forOf", ctx.items);
               }
             },
             directives: function () { return [ForOfDirective]; },

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -82,7 +82,7 @@ describe('compiler compliance: bindings', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "title", $i0$.ɵɵbind($ctx$.title));
+          $i0$.ɵɵproperty("title", $ctx$.title);
         }
       }`;
       const result = compile(files, angularFiles);
@@ -174,7 +174,7 @@ describe('compiler compliance: bindings', () => {
         }
         if (rf & 2) {
             $i0$.ɵɵselect(0);
-            $i0$.ɵɵelementProperty(0, "for", $i0$.ɵɵbind(ctx.forValue));
+            $i0$.ɵɵproperty("for", ctx.forValue);
         }
       }`;
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -140,7 +140,7 @@ describe('compiler compliance: directives', () => {
                         }
                         if (rf & 2) {
                             $r3$.ɵɵselect(0);
-                            $r3$.ɵɵelementProperty(0, "someDirective", $r3$.ɵɵbind(true));
+                            $r3$.ɵɵproperty("someDirective", true);
                         }
                     },
                     …
@@ -255,7 +255,7 @@ describe('compiler compliance: directives', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵselect(0);
-              $r3$.ɵɵelementProperty(0, "ngIf", $r3$.ɵɵbind(ctx.showing));
+              $r3$.ɵɵproperty("ngIf", ctx.showing);
             }
           },
           …
@@ -303,7 +303,7 @@ describe('compiler compliance: directives', () => {
                         }
                         if (rf & 2) {
                             $r3$.ɵɵselect(0);
-                            $r3$.ɵɵelementProperty(0, "someDirective", $r3$.ɵɵbind(true));
+                            $r3$.ɵɵproperty("someDirective", true);
                         }
                     },
                     …

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -580,7 +580,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "ngForOf", $r3$.ɵɵbind(ctx.items));
+            $r3$.ɵɵproperty("ngForOf", ctx.items);
           }
         }
       `;
@@ -767,7 +767,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "ngForOf", $r3$.ɵɵbind(ctx.items));
+            $r3$.ɵɵproperty("ngForOf", ctx.items);
           }
         }
       `;
@@ -1429,7 +1429,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
           }
         }
       `;
@@ -1491,9 +1491,9 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(1);
-            $r3$.ɵɵelementProperty(1, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
           }
         }
       `;
@@ -1558,7 +1558,7 @@ describe('i18n support in the view compiler', () => {
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
             $r3$.ɵɵselect(4);
-            $r3$.ɵɵelementProperty(4, "ngIf", $r3$.ɵɵbind($ctx_r0$.exists));
+            $r3$.ɵɵproperty("ngIf", $ctx_r0$.exists);
             $r3$.ɵɵi18nExp($r3$.ɵɵbind($ctx_r0$.valueA));
             $r3$.ɵɵi18nExp($r3$.ɵɵbind($r3$.ɵɵpipeBind1(3, 3, $ctx_r0$.valueB)));
             $r3$.ɵɵi18nApply(0);
@@ -1628,9 +1628,9 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵselect(3);
-            $r3$.ɵɵelementProperty(3, "ngIf", $r3$.ɵɵbind(!ctx.visible));
+            $r3$.ɵɵproperty("ngIf", !ctx.visible);
           }
         }
       `;
@@ -1686,7 +1686,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
           }
         }
       `;
@@ -2597,9 +2597,9 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nApply(1);
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵselect(3);
-            $r3$.ɵɵelementProperty(3, "ngIf", $r3$.ɵɵbind(ctx.available));
+            $r3$.ɵɵproperty("ngIf", ctx.available);
           }
         }
       `;
@@ -2935,7 +2935,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(3);
-            $r3$.ɵɵelementProperty(3, "ngIf", $r3$.ɵɵbind(ctx.visible));
+            $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nApply(1);
@@ -3075,7 +3075,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.ageVisible));
+            $r3$.ɵɵproperty("ngIf", ctx.ageVisible);
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nApply(1);
           }
@@ -3174,7 +3174,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(2);
-            $r3$.ɵɵelementProperty(2, "ngIf", $r3$.ɵɵbind(ctx.ageVisible));
+            $r3$.ɵɵproperty("ngIf", ctx.ageVisible);
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.weight));
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.height));

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -164,7 +164,7 @@ describe('compiler compliance: listen()', () => {
           }
           if (rf & 2) {
             $i0$.ɵɵselect(0);
-            $i0$.ɵɵelementProperty(0, "ngIf", $i0$.ɵɵbind(ctx.showing));
+            $i0$.ɵɵproperty("ngIf", ctx.showing);
           }
         }
         `;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
@@ -147,8 +147,8 @@ describe('r3_view_compiler', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "@attr", …);
-          $i0$.ɵɵelementProperty(0, "@binding", …);
+          $i0$.ɵɵproperty("@attr", …);
+          $i0$.ɵɵproperty("@binding", …);
         }
       }`;
       const result = compile(files, angularFiles);
@@ -179,7 +179,7 @@ describe('r3_view_compiler', () => {
           $i0$.ɵɵelementStart(0, "div");
           …
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "@mySelector", …);
+          $i0$.ɵɵproperty("@mySelector", …);
         }
       }`;
       const result = compile(files, angularFiles);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -227,11 +227,11 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵselect(0);
-              $r3$.ɵɵelementProperty(0, "@foo", $r3$.ɵɵbind(ctx.exp));
+              $r3$.ɵɵproperty("@foo", ctx.exp);
               $r3$.ɵɵselect(1);
-              $r3$.ɵɵelementProperty(1, "@bar", $r3$.ɵɵbind(undefined));
+              $r3$.ɵɵproperty("@bar", undefined);
               $r3$.ɵɵselect(2);
-              $r3$.ɵɵelementProperty(2, "@baz", $r3$.ɵɵbind(undefined));
+              $r3$.ɵɵproperty("@baz", undefined);
             }
           },
           encapsulation: 2
@@ -289,7 +289,7 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵelementEnd();
             } if (rf & 2) {
               $r3$.ɵɵselect(0);
-              $r3$.ɵɵelementProperty(0, "@myAnimation", $r3$.ɵɵbind(ctx.exp));
+              $r3$.ɵɵproperty("@myAnimation", ctx.exp);
             }
           },
           encapsulation: 2,

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -76,7 +76,7 @@ describe('compiler compliance: template', () => {
           const $outer1$ = $i0$.ɵɵnextContext().$implicit;
           const $myComp1$ = $i0$.ɵɵnextContext();
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "title", $i0$.ɵɵbind($myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component)));
+          $i0$.ɵɵproperty("title", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component));
           $r3$.ɵɵselect(1);
           $i0$.ɵɵtextBinding(1, $i0$.ɵɵinterpolation1(" ", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component), " "));
         }
@@ -91,7 +91,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $myComp2$ = $i0$.ɵɵnextContext(2);
           $r3$.ɵɵselect(1);
-          $i0$.ɵɵelementProperty(1, "ngForOf", $i0$.ɵɵbind($myComp2$.items));
+          $i0$.ɵɵproperty("ngForOf", $myComp2$.items);
         }
       }
 
@@ -104,7 +104,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $outer2$ = ctx.$implicit;
           $r3$.ɵɵselect(1);
-          $i0$.ɵɵelementProperty(1, "ngForOf", $i0$.ɵɵbind($outer2$.items));
+          $i0$.ɵɵproperty("ngForOf", $outer2$.items);
         }
       }
       // ...
@@ -114,7 +114,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngForOf", $i0$.ɵɵbind(ctx.items));
+          $i0$.ɵɵproperty("ngForOf", ctx.items);
         }
       }`;
 
@@ -171,7 +171,7 @@ describe('compiler compliance: template', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(0);
-            $r3$.ɵɵelementProperty(0, "ngForOf", $r3$.ɵɵbind(ctx._data));
+            $r3$.ɵɵproperty("ngForOf", ctx._data);
           }
         }
         `;
@@ -225,7 +225,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngForOf", $i0$.ɵɵbind(ctx.items));
+          $i0$.ɵɵproperty("ngForOf", ctx.items);
         }
       }`;
 
@@ -285,7 +285,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $app$ = $i0$.ɵɵnextContext();
           $r3$.ɵɵselect(1);
-          $i0$.ɵɵelementProperty(1, "ngIf", $i0$.ɵɵbind($app$.showing));
+          $i0$.ɵɵproperty("ngIf", $app$.showing);
         }
       }
 
@@ -296,7 +296,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngForOf", $i0$.ɵɵbind(ctx.items));
+          $i0$.ɵɵproperty("ngForOf", ctx.items);
         }
       }`;
 
@@ -356,7 +356,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $middle$ = ctx.$implicit;
           $r3$.ɵɵselect(1);
-          $i0$.ɵɵelementProperty(1, "ngForOf", $i0$.ɵɵbind($middle$.items));
+          $i0$.ɵɵproperty("ngForOf", $middle$.items);
         }
       }
 
@@ -369,7 +369,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $outer$ = ctx.$implicit;
           $r3$.ɵɵselect(1);
-          $i0$.ɵɵelementProperty(1, "ngForOf", $i0$.ɵɵbind($outer$.items));
+          $i0$.ɵɵproperty("ngForOf", $outer$.items);
         }
       }
       // ...
@@ -379,7 +379,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngForOf", $i0$.ɵɵbind(ctx.items));
+          $i0$.ɵɵproperty("ngForOf", ctx.items);
         }
       }`;
 
@@ -426,7 +426,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "boundAttr", $i0$.ɵɵbind(ctx.b));
+          $i0$.ɵɵproperty("boundAttr", ctx.b);
         }
       }`;
 
@@ -669,7 +669,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵɵpipe(1, "pipe");
         } if (rf & 2) {
           $i0$.ɵɵselect(0);
-          $i0$.ɵɵelementProperty(0, "ngIf", $i0$.ɵɵbind($i0$.ɵɵpipeBind1(1, 1, ctx.val)));
+          $i0$.ɵɵproperty("ngIf", $i0$.ɵɵpipeBind1(1, 1, ctx.val));
         }
       }`;
 

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -104,7 +104,7 @@ describe('template source-mapping', () => {
         });
         expect(mappings).toContain({
           source: '[attr]="name"',
-          generated: 'i0.ɵɵelementProperty(0, "attr", i0.ɵɵbind(ctx.name))',
+          generated: 'i0.ɵɵproperty("attr", ctx.name)',
           sourceUrl: '../test.ts'
         });
       });
@@ -118,7 +118,7 @@ describe('template source-mapping', () => {
         });
         expect(mappings).toContain({
           source: '[attr]="greeting + name"',
-          generated: 'i0.ɵɵelementProperty(0, "attr", i0.ɵɵbind((ctx.greeting + ctx.name)))',
+          generated: 'i0.ɵɵproperty("attr", (ctx.greeting + ctx.name))',
           sourceUrl: '../test.ts'
         });
       });
@@ -132,7 +132,7 @@ describe('template source-mapping', () => {
         });
         expect(mappings).toContain({
           source: 'bind-attr="name"',
-          generated: 'i0.ɵɵelementProperty(0, "attr", i0.ɵɵbind(ctx.name))',
+          generated: 'i0.ɵɵproperty("attr", ctx.name)',
           sourceUrl: '../test.ts'
         });
       });

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -123,6 +123,8 @@ export class Identifiers {
   static pipeBind4: o.ExternalReference = {name: 'ɵɵpipeBind4', moduleName: CORE};
   static pipeBindV: o.ExternalReference = {name: 'ɵɵpipeBindV', moduleName: CORE};
 
+  static property: o.ExternalReference = {name: 'ɵɵproperty', moduleName: CORE};
+
   static i18n: o.ExternalReference = {name: 'ɵɵi18n', moduleName: CORE};
   static i18nAttributes: o.ExternalReference = {name: 'ɵɵi18nAttributes', moduleName: CORE};
   static i18nExp: o.ExternalReference = {name: 'ɵɵi18nExp', moduleName: CORE};

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -39,6 +39,7 @@ import {I18N_ICU_MAPPING_PREFIX, TRANSLATION_PREFIX, assembleBoundTextPlaceholde
 import {Instruction, StylingBuilder} from './styling_builder';
 import {CONTEXT_NAME, IMPLICIT_REFERENCE, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, asLiteral, getAttrsForDirectiveMatching, invalid, trimTrailingNulls, unsupported} from './util';
 
+
 // Default selector used by `<ng-content>` if none specified
 const DEFAULT_NG_CONTENT_SELECTOR = '*';
 
@@ -51,20 +52,6 @@ const NG_PROJECT_AS_ATTR_NAME = 'ngProjectAs';
 // List of supported global targets for event listeners
 const GLOBAL_TARGET_RESOLVERS = new Map<string, o.ExternalReference>(
     [['window', R3.resolveWindow], ['document', R3.resolveDocument], ['body', R3.resolveBody]]);
-
-function mapBindingToInstruction(type: BindingType): o.ExternalReference|undefined {
-  switch (type) {
-    case BindingType.Property:
-    case BindingType.Animation:
-      return R3.elementProperty;
-    case BindingType.Class:
-      return R3.elementClassProp;
-    case BindingType.Attribute:
-      return R3.elementAttribute;
-    default:
-      return undefined;
-  }
-}
 
 //  if (rf & flags) { .. }
 export function renderFlagCheckIfStmt(
@@ -707,13 +694,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // the reason why `undefined` is used is because the renderer understands this as a
     // special value to symbolize that there is no RHS to this binding
     // TODO (matsko): revisit this once FW-959 is approached
-    const emptyValueBindInstruction = o.importExpr(R3.bind).callFn([o.literal(undefined)]);
+    const emptyValueBindInstruction = o.literal(undefined);
 
     // Generate element input bindings
     allOtherInputs.forEach((input: t.BoundAttribute) => {
-
-      const instruction = mapBindingToInstruction(input.type);
-      if (input.type === BindingType.Animation) {
+      const inputType = input.type;
+      if (inputType === BindingType.Animation) {
         const value = input.value.visit(this._valueConverter);
         // animation bindings can be presented in the following formats:
         // 1. [@binding]="fooExp"
@@ -727,10 +713,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         const hasValue = value instanceof LiteralPrimitive ? !!value.value : true;
         this.allocateBindingSlots(value);
         const bindingName = prepareSyntheticPropertyName(input.name);
-        this.updateInstruction(elementIndex, input.sourceSpan, R3.elementProperty, () => {
+
+        this.updateInstruction(elementIndex, input.sourceSpan, R3.property, () => {
           return [
-            o.literal(elementIndex), o.literal(bindingName),
-            (hasValue ? this.convertPropertyBinding(implicit, value) : emptyValueBindInstruction)
+            o.literal(bindingName),
+            (hasValue ? this.convertPropertyBinding(implicit, value, true) :
+                        emptyValueBindInstruction),
           ];
         });
       } else if (instruction) {
@@ -742,7 +730,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         if (value !== undefined) {
           const params: any[] = [];
           const [attrNamespace, attrName] = splitNsName(input.name);
-          const isAttributeBinding = input.type === BindingType.Attribute;
+          const isAttributeBinding = inputType === BindingType.Attribute;
           const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
           if (sanitizationRef) params.push(sanitizationRef);
           if (attrNamespace) {
@@ -757,15 +745,34 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             }
           }
           this.allocateBindingSlots(value);
-          this.updateInstruction(elementIndex, input.sourceSpan, instruction, () => {
-            return [
-              o.literal(elementIndex), o.literal(attrName),
-              this.convertPropertyBinding(implicit, value), ...params
-            ];
-          });
+
+          if (inputType === BindingType.Property && !(value instanceof Interpolation)) {
+            // Bound, un-interpolated properties
+            this.updateInstruction(elementIndex, input.sourceSpan, R3.property, () => {
+              return [
+                o.literal(attrName), this.convertPropertyBinding(implicit, value, true), ...params
+              ];
+            });
+          } else {
+            let instruction: any;
+
+            if (inputType === BindingType.Property) {
+              // Interpolated properties
+              instruction = R3.elementProperty;
+            } else if (inputType === BindingType.Class) {
+              instruction = R3.elementClassProp;
+            } else {
+              instruction = R3.elementAttribute;
+            }
+
+            this.updateInstruction(elementIndex, input.sourceSpan, instruction, () => {
+              return [
+                o.literal(elementIndex), o.literal(attrName),
+                this.convertPropertyBinding(implicit, value), ...params
+              ];
+            });
+          }
         }
-      } else {
-        this._unsupported(`binding type ${input.type}`);
       }
     });
 
@@ -856,7 +863,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       return trimTrailingNulls(parameters);
     });
 
-    // handle property bindings e.g. ɵɵelementProperty(1, 'ngForOf', ɵɵbind(ctx.items));
+    // handle property bindings e.g. ɵɵproperty('ngForOf', ctx.items), et al;
     const context = o.variable(CONTEXT_NAME);
     this.templatePropertyBindings(template, templateIndex, context, template.templateAttrs);
 
@@ -970,12 +977,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       if (input instanceof t.BoundAttribute) {
         const value = input.value.visit(this._valueConverter);
         this.allocateBindingSlots(value);
-        this.updateInstruction(templateIndex, template.sourceSpan, R3.elementProperty, () => {
-          return [
-            o.literal(templateIndex), o.literal(input.name),
-            this.convertPropertyBinding(context, value)
-          ];
-        });
+        this.updateInstruction(
+            templateIndex, template.sourceSpan, R3.property,
+            () => [o.literal(input.name), this.convertPropertyBinding(context, value, true)]);
       }
     });
   }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -89,6 +89,7 @@ export {
   ɵɵloadContentQuery,
   ɵɵelementEnd,
   ɵɵelementProperty,
+  ɵɵproperty,
   ɵɵcomponentHostSyntheticProperty,
   ɵɵcomponentHostSyntheticListener,
   ɵɵprojectionDef,

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -7,7 +7,9 @@
  */
 
 import {Type} from '../../interface/type';
+import {assertEqual} from '../../util/assert';
 import {getClosureSafeProperty} from '../../util/property';
+
 import {ClassProvider, ConstructorProvider, ExistingProvider, FactoryProvider, StaticClassProvider, ValueProvider} from './provider';
 
 

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -98,7 +98,8 @@ class MyApp {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'title', ɵɵbind(ctx.name));
+        ɵɵselect(0);
+        ɵɵproperty('title', ctx.name);
         ɵɵtextBinding(1, ɵɵinterpolation1('Hello ', ctx.name, '!'));
       }
       ...

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -18,7 +18,7 @@ import {BINDING_INDEX, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
 import {applyOnCreateInstructions} from '../node_util';
-import {decreaseElementDepthCount, getActiveDirectiveId, getElementDepthCount, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, increaseElementDepthCount, setIsParent, setPreviousOrParentTNode} from '../state';
+import {decreaseElementDepthCount, getActiveDirectiveId, getElementDepthCount, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedElementIndex, increaseElementDepthCount, setIsParent, setPreviousOrParentTNode} from '../state';
 import {getInitialClassNameValue, getInitialStyleStringValue, initializeStaticContext, patchContextWithStaticAttrs, renderInitialClasses, renderInitialStyles} from '../styling/class_and_style_bindings';
 import {getStylingContextFromLView, hasClassInput, hasStyleInput} from '../styling/util';
 import {NO_CHANGE} from '../tokens';
@@ -272,7 +272,7 @@ export function ɵɵelementAttribute(
  * @codeGenApi
  */
 export function ɵɵelementHostAttrs(attrs: TAttributes) {
-  const hostElementIndex = getSelectedIndex();
+  const hostElementIndex = getSelectedElementIndex();
   ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const lView = getLView();
   const tNode = getTNode(hostElementIndex, lView);

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {validateAgainstEventAttributes} from '../../sanitization/sanitization';
-import {assertDataInRange, assertEqual} from '../../util/assert';
+import {assertDataInRange, assertEqual, assertNotEqual} from '../../util/assert';
 import {assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
@@ -273,6 +273,7 @@ export function ɵɵelementAttribute(
  */
 export function ɵɵelementHostAttrs(attrs: TAttributes) {
   const hostElementIndex = getSelectedIndex();
+  ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const lView = getLView();
   const tNode = getTNode(hostElementIndex, lView);
 

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {assertNotEqual} from '../../util/assert';
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {BINDING_INDEX} from '../interfaces/view';
@@ -12,6 +13,7 @@ import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {TsickleIssue1009, elementPropertyInternal, loadComponentRenderer, storeBindingMetadata} from './shared';
+
 
 
 /**
@@ -38,6 +40,7 @@ export function ɵɵproperty<T>(
     propName: string, value: T, sanitizer?: SanitizerFn | null,
     nativeOnly?: boolean): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   const bindReconciledValue = ɵɵbind(value);
   elementPropertyInternal(index, propName, bindReconciledValue, sanitizer, nativeOnly);
   return ɵɵproperty;

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -9,7 +9,7 @@ import {assertNotEqual} from '../../util/assert';
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {BINDING_INDEX} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {getLView, getSelectedElementIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {TsickleIssue1009, elementPropertyInternal, loadComponentRenderer, storeBindingMetadata} from './shared';
@@ -39,7 +39,7 @@ import {TsickleIssue1009, elementPropertyInternal, loadComponentRenderer, storeB
 export function ɵɵproperty<T>(
     propName: string, value: T, sanitizer?: SanitizerFn | null,
     nativeOnly?: boolean): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   const bindReconciledValue = ɵɵbind(value);
   elementPropertyInternal(index, propName, bindReconciledValue, sanitizer, nativeOnly);

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {assertEqual, assertLessThan} from '../../util/assert';
+import {assertEqual, assertLessThan, assertNotEqual} from '../../util/assert';
 import {bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4} from '../bindings';
 import {BINDING_INDEX, TVIEW} from '../interfaces/view';
 import {getLView, getSelectedIndex} from '../state';
@@ -358,6 +358,7 @@ export function ɵɵpropertyInterpolate(propName: string, v0: any): TsickleIssue
 export function ɵɵpropertyInterpolate1(
     propName: string, prefix: string, v0: any, suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation1(prefix, v0, suffix));
   return ɵɵpropertyInterpolate1;
 }
@@ -394,6 +395,7 @@ export function ɵɵpropertyInterpolate2(
     propName: string, prefix: string, v0: any, i0: string, v1: any,
     suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation2(prefix, v0, i0, v1, suffix));
   return ɵɵpropertyInterpolate2;
 }
@@ -433,6 +435,7 @@ export function ɵɵpropertyInterpolate3(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation3(prefix, v0, i0, v1, i1, v2, suffix));
   return ɵɵpropertyInterpolate3;
 }
@@ -474,6 +477,7 @@ export function ɵɵpropertyInterpolate4(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName, ɵɵinterpolation4(prefix, v0, i0, v1, i1, v2, i2, v3, suffix));
   return ɵɵpropertyInterpolate4;
@@ -518,6 +522,7 @@ export function ɵɵpropertyInterpolate5(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName, ɵɵinterpolation5(prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix));
   return ɵɵpropertyInterpolate5;
@@ -564,6 +569,7 @@ export function ɵɵpropertyInterpolate6(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
       ɵɵinterpolation6(prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix));
@@ -614,6 +620,7 @@ export function ɵɵpropertyInterpolate7(
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any,
     suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
       ɵɵinterpolation7(prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix));
@@ -666,6 +673,7 @@ export function ɵɵpropertyInterpolate8(
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
       ɵɵinterpolation8(prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix));
@@ -702,6 +710,7 @@ export function ɵɵpropertyInterpolate8(
  */
 export function ɵɵpropertyInterpolateV(propName: string, values: any[]): TsickleIssue1009 {
   const index = getSelectedIndex();
+  ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
 
   elementPropertyInternal(index, propName, ɵɵinterpolationV(values));
   return ɵɵpropertyInterpolateV;

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -8,7 +8,7 @@
 import {assertEqual, assertLessThan, assertNotEqual} from '../../util/assert';
 import {bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4} from '../bindings';
 import {BINDING_INDEX, TVIEW} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {getLView, getSelectedElementIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {renderStringify} from '../util/misc_utils';
 
@@ -357,7 +357,7 @@ export function ɵɵpropertyInterpolate(propName: string, v0: any): TsickleIssue
  */
 export function ɵɵpropertyInterpolate1(
     propName: string, prefix: string, v0: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation1(prefix, v0, suffix));
   return ɵɵpropertyInterpolate1;
@@ -394,7 +394,7 @@ export function ɵɵpropertyInterpolate1(
 export function ɵɵpropertyInterpolate2(
     propName: string, prefix: string, v0: any, i0: string, v1: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation2(prefix, v0, i0, v1, suffix));
   return ɵɵpropertyInterpolate2;
@@ -434,7 +434,7 @@ export function ɵɵpropertyInterpolate2(
 export function ɵɵpropertyInterpolate3(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(index, propName, ɵɵinterpolation3(prefix, v0, i0, v1, i1, v2, suffix));
   return ɵɵpropertyInterpolate3;
@@ -476,7 +476,7 @@ export function ɵɵpropertyInterpolate3(
 export function ɵɵpropertyInterpolate4(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName, ɵɵinterpolation4(prefix, v0, i0, v1, i1, v2, i2, v3, suffix));
@@ -521,7 +521,7 @@ export function ɵɵpropertyInterpolate4(
 export function ɵɵpropertyInterpolate5(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName, ɵɵinterpolation5(prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix));
@@ -568,7 +568,7 @@ export function ɵɵpropertyInterpolate5(
 export function ɵɵpropertyInterpolate6(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
@@ -619,7 +619,7 @@ export function ɵɵpropertyInterpolate7(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
@@ -672,7 +672,7 @@ export function ɵɵpropertyInterpolate8(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
   elementPropertyInternal(
       index, propName,
@@ -709,7 +709,7 @@ export function ɵɵpropertyInterpolate8(
  * @returns itself, so that it may be chained.
  */
 export function ɵɵpropertyInterpolateV(propName: string, values: any[]): TsickleIssue1009 {
-  const index = getSelectedIndex();
+  const index = getSelectedElementIndex();
   ngDevMode && assertNotEqual(index, -1, 'index not selected prior to instruction');
 
   elementPropertyInternal(index, propName, ɵɵinterpolationV(values));

--- a/packages/core/src/render3/instructions/select.ts
+++ b/packages/core/src/render3/instructions/select.ts
@@ -36,7 +36,7 @@ export function ɵɵselect(index: number): void {
   ngDevMode &&
       assertLessThan(
           index, getLView().length - HEADER_OFFSET, 'Should be within range for the view data');
-  setSelectedIndex(index);
   const lView = getLView();
   executePreOrderHooks(lView, lView[TVIEW], getCheckNoChangesMode(), index);
+  setSelectedIndex(index);
 }

--- a/packages/core/src/render3/instructions/select.ts
+++ b/packages/core/src/render3/instructions/select.ts
@@ -8,7 +8,7 @@
 import {assertGreaterThan, assertLessThan} from '../../util/assert';
 import {executePreOrderHooks} from '../hooks';
 import {HEADER_OFFSET, TVIEW} from '../interfaces/view';
-import {getCheckNoChangesMode, getLView, setSelectedIndex} from '../state';
+import {getCheckNoChangesMode, getLView, setSelectedElementIndex} from '../state';
 
 /**
  * Selects an element for later binding instructions.
@@ -38,5 +38,5 @@ export function ɵɵselect(index: number): void {
           index, getLView().length - HEADER_OFFSET, 'Should be within range for the view data');
   const lView = getLView();
   executePreOrderHooks(lView, lView[TVIEW], getCheckNoChangesMode(), index);
-  setSelectedIndex(index);
+  setSelectedElementIndex(index, true);
 }

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -10,7 +10,7 @@ import {assertEqual, assertNotEqual} from '../../util/assert';
 import {TNode, TNodeType} from '../interfaces/node';
 import {PlayerFactory} from '../interfaces/player';
 import {FLAGS, HEADER_OFFSET, LView, LViewFlags, RENDERER, RootContextFlags} from '../interfaces/view';
-import {getActiveDirectiveId, getActiveDirectiveSuperClassDepth, getLView, getPreviousOrParentTNode, getSelectedIndex} from '../state';
+import {getActiveDirectiveId, getActiveDirectiveSuperClassDepth, getLView, getPreviousOrParentTNode, getSelectedElementIndex} from '../state';
 import {getInitialClassNameValue, renderStyling, updateClassProp as updateElementClassProp, updateContextWithBindings, updateStyleProp as updateElementStyleProp, updateStylingMap} from '../styling/class_and_style_bindings';
 import {ParamsOf, enqueueHostInstruction, registerHostDirective} from '../styling/host_instructions_queue';
 import {BoundPlayerFactory} from '../styling/player_factory';
@@ -206,7 +206,7 @@ export function ɵɵelementHostStyleProp(
     styleIndex: number, value: string | number | String | PlayerFactory | null,
     suffix?: string | null, forceOverride?: boolean): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
-  const hostElementIndex = getSelectedIndex();
+  const hostElementIndex = getSelectedElementIndex();
   ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
 
   const stylingContext = getStylingContext(hostElementIndex, getLView());
@@ -287,7 +287,7 @@ export function ɵɵelementClassProp(
 export function ɵɵelementHostClassProp(
     classIndex: number, value: boolean | PlayerFactory, forceOverride?: boolean): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
-  const hostElementIndex = getSelectedIndex();
+  const hostElementIndex = getSelectedElementIndex();
   ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const stylingContext = getStylingContext(hostElementIndex, getLView());
 
@@ -383,7 +383,7 @@ export function ɵɵelementHostStylingMap(
     classes: {[key: string]: any} | string | NO_CHANGE | null,
     styles?: {[styleName: string]: any} | NO_CHANGE | null): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
-  const hostElementIndex = getSelectedIndex();
+  const hostElementIndex = getSelectedElementIndex();
   ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const stylingContext = getStylingContext(hostElementIndex, getLView());
   const args: ParamsOf<typeof updateStylingMap> =
@@ -418,7 +418,7 @@ export function ɵɵelementStylingApply(index: number): void {
  * @codeGenApi
  */
 export function ɵɵelementHostStylingApply(): void {
-  const hostElementIndex = getSelectedIndex();
+  const hostElementIndex = getSelectedElementIndex();
   ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   elementStylingApplyInternal(getActiveDirectiveStylingIndex(), hostElementIndex);
 }

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
-import {assertEqual} from '../../util/assert';
+import {assertEqual, assertNotEqual} from '../../util/assert';
 import {TNode, TNodeType} from '../interfaces/node';
 import {PlayerFactory} from '../interfaces/player';
 import {FLAGS, HEADER_OFFSET, LView, LViewFlags, RENDERER, RootContextFlags} from '../interfaces/view';
@@ -207,6 +207,7 @@ export function ɵɵelementHostStyleProp(
     suffix?: string | null, forceOverride?: boolean): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
   const hostElementIndex = getSelectedIndex();
+  ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
 
   const stylingContext = getStylingContext(hostElementIndex, getLView());
   const valueToAdd = resolveStylePropValue(value, suffix);
@@ -287,6 +288,7 @@ export function ɵɵelementHostClassProp(
     classIndex: number, value: boolean | PlayerFactory, forceOverride?: boolean): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
   const hostElementIndex = getSelectedIndex();
+  ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const stylingContext = getStylingContext(hostElementIndex, getLView());
 
   const input = (value instanceof BoundPlayerFactory) ?
@@ -382,6 +384,7 @@ export function ɵɵelementHostStylingMap(
     styles?: {[styleName: string]: any} | NO_CHANGE | null): void {
   const directiveStylingIndex = getActiveDirectiveStylingIndex();
   const hostElementIndex = getSelectedIndex();
+  ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
   const stylingContext = getStylingContext(hostElementIndex, getLView());
   const args: ParamsOf<typeof updateStylingMap> =
       [stylingContext, classes, styles, directiveStylingIndex];
@@ -415,7 +418,9 @@ export function ɵɵelementStylingApply(index: number): void {
  * @codeGenApi
  */
 export function ɵɵelementHostStylingApply(): void {
-  elementStylingApplyInternal(getActiveDirectiveStylingIndex(), getSelectedIndex());
+  const hostElementIndex = getSelectedIndex();
+  ngDevMode && assertNotEqual(hostElementIndex, -1, 'index not selected prior to instruction');
+  elementStylingApplyInternal(getActiveDirectiveStylingIndex(), hostElementIndex);
 }
 
 export function elementStylingApplyInternal(directiveStylingIndex: number, index: number): void {

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -84,6 +84,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵɵpipeBind4': r3.ɵɵpipeBind4,
   'ɵɵpipeBindV': r3.ɵɵpipeBindV,
   'ɵɵprojectionDef': r3.ɵɵprojectionDef,
+  'ɵɵproperty': r3.ɵɵproperty,
   'ɵɵpipe': r3.ɵɵpipe,
   'ɵɵqueryRefresh': r3.ɵɵqueryRefresh,
   'ɵɵviewQuery': r3.ɵɵviewQuery,

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -484,7 +484,7 @@ function expandModuleWithProviders(value: Type<any>| ModuleWithProviders<{}>): T
 }
 
 function isModuleWithProviders(value: any): value is ModuleWithProviders<{}> {
-  return (value as{ngModule?: any}).ngModule !== undefined;
+  return value && (value as{ngModule?: any}).ngModule !== undefined;
 }
 
 function isNgModule<T>(value: Type<T>): value is Type<T>&{ngModuleDef: NgModuleDef<T>} {

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -470,9 +470,6 @@ let _selectedIndex = -1;
  * current `LView` to act on.
  */
 export function getSelectedIndex() {
-  ngDevMode &&
-      assertGreaterThan(
-          _selectedIndex, -1, 'select() should be called prior to retrieving the selected index');
   return _selectedIndex;
 }
 

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -276,6 +276,9 @@
     "name": "executePreOrderHooks"
   },
   {
+    "name": "executeTemplate"
+  },
+  {
     "name": "executeViewQueryFn"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -411,6 +411,9 @@
     "name": "getRootView"
   },
   {
+    "name": "getSelectedIndex"
+  },
+  {
     "name": "getStylingContextFromLView"
   },
   {
@@ -463,6 +466,9 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
+  },
+  {
+    "name": "invokeRootComponentHostBindings"
   },
   {
     "name": "isAnimationProp"
@@ -610,9 +616,6 @@
   },
   {
     "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -216,6 +216,9 @@
     "name": "executePreOrderHooks"
   },
   {
+    "name": "executeTemplate"
+  },
+  {
     "name": "executeViewQueryFn"
   },
   {
@@ -316,6 +319,9 @@
   },
   {
     "name": "getRootView"
+  },
+  {
+    "name": "getSelectedIndex"
   },
   {
     "name": "hasParentInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -348,6 +348,9 @@
     "name": "invokeHostBindingsInCreationMode"
   },
   {
+    "name": "invokeRootComponentHostBindings"
+  },
+  {
     "name": "isComponentDef"
   },
   {
@@ -439,9 +442,6 @@
   },
   {
     "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -591,6 +591,9 @@
     "name": "executePreOrderHooks"
   },
   {
+    "name": "executeTemplate"
+  },
+  {
     "name": "executeViewQueryFn"
   },
   {
@@ -817,6 +820,9 @@
   },
   {
     "name": "getRootView"
+  },
+  {
+    "name": "getSelectedIndex"
   },
   {
     "name": "getSinglePropIndexValue"
@@ -1341,9 +1347,6 @@
     "name": "ɵɵelementEnd"
   },
   {
-    "name": "ɵɵelementProperty"
-  },
-  {
     "name": "ɵɵelementStart"
   },
   {
@@ -1366,6 +1369,9 @@
   },
   {
     "name": "ɵɵnextContext"
+  },
+  {
+    "name": "ɵɵproperty"
   },
   {
     "name": "ɵɵreference"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -939,6 +939,9 @@
     "name": "invokeHostBindingsInCreationMode"
   },
   {
+    "name": "invokeRootComponentHostBindings"
+  },
+  {
     "name": "isAnimationProp"
   },
   {
@@ -1183,9 +1186,6 @@
   },
   {
     "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveHostElement"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -11,8 +11,8 @@ import {withBody} from '@angular/private/testing';
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, RendererType2} from '../../src/core';
 import {whenRendered} from '../../src/render3/component';
-import {LifecycleHooksFeature, getRenderedText, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵgetCurrentView, ɵɵtemplateRefExtractor} from '../../src/render3/index';
-import {detectChanges, markDirty, tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵlistener, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {LifecycleHooksFeature, getRenderedText, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵgetCurrentView, ɵɵproperty, ɵɵselect, ɵɵtemplateRefExtractor} from '../../src/render3/index';
+import {detectChanges, markDirty, tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵlistener, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
 import {FLAGS, LViewFlags} from '../../src/render3/interfaces/view';
@@ -144,7 +144,8 @@ describe('change detection', () => {
             ɵɵelement(0, 'my-comp');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'name', ɵɵbind(ctx.name));
+            ɵɵselect(0);
+            ɵɵproperty('name', ctx.name);
           }
         },
         directives: () => [MyComponent]
@@ -356,7 +357,8 @@ describe('change detection', () => {
               ɵɵelement(0, 'manual-comp');
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'name', ɵɵbind(ctx.name));
+              ɵɵselect(0);
+              ɵɵproperty('name', ctx.name);
             }
 
           },
@@ -770,7 +772,8 @@ describe('change detection', () => {
                   ɵɵelement(0, 'child-comp');
                 }
                 if (rf & RenderFlags.Update) {
-                  ɵɵelementProperty(0, 'inp', ɵɵbind(true));
+                  ɵɵselect(0);
+                  ɵɵproperty('inp', true);
                 }
               },
               directives: [ChildComp]
@@ -868,7 +871,8 @@ describe('change detection', () => {
             }
             if (rf & RenderFlags.Update) {
               const foo = ɵɵreference(1) as any;
-              ɵɵelementProperty(2, 'tmp', ɵɵbind(foo));
+              ɵɵselect(2);
+              ɵɵproperty('tmp', foo);
             }
           }, 3, 1, [StructuralComp]);
 
@@ -910,7 +914,8 @@ describe('change detection', () => {
             }
             if (rf & RenderFlags.Update) {
               const foo = ɵɵreference(1) as any;
-              ɵɵelementProperty(2, 'tmp', ɵɵbind(foo));
+              ɵɵselect(2);
+              ɵɵproperty('tmp', foo);
             }
           }, 3, 1, [StructuralComp]);
 
@@ -1084,7 +1089,8 @@ describe('change detection', () => {
             ɵɵelement(0, 'on-push-comp');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'value', ɵɵbind(ctx.value));
+            ɵɵselect(0);
+            ɵɵproperty('value', ctx.value);
           }
         }, 1, 1, [OnPushComp]);
 

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -8,8 +8,8 @@
 
 import {NgForOfContext} from '@angular/common';
 
-import {AttributeMarker, ɵɵdefineComponent, ɵɵelement, ɵɵgetCurrentView, ɵɵtemplateRefExtractor} from '../../src/render3/index';
-import {ɵɵbind, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵinterpolation3, ɵɵinterpolationV, ɵɵlistener, ɵɵload, ɵɵnextContext, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵelement, ɵɵgetCurrentView, ɵɵproperty, ɵɵselect, ɵɵtemplateRefExtractor} from '../../src/render3/index';
+import {ɵɵbind, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵinterpolation3, ɵɵinterpolationV, ɵɵlistener, ɵɵload, ɵɵnextContext, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵrestoreView} from '../../src/render3/state';
 
@@ -54,7 +54,8 @@ describe('@angular/common integration', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(1, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(1);
+              ɵɵproperty('ngForOf', ctx.items);
             }
           },
           directives: () => [NgForOf]
@@ -120,7 +121,8 @@ describe('@angular/common integration', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(1, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(1);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -184,7 +186,8 @@ describe('@angular/common integration', () => {
                   0, ngForTemplate, 1, 0, 'comp', [AttributeMarker.Template, 'ngFor', 'ngForOf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.rows));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.rows);
             }
           },
           directives: () => [NgForOf, Comp, Dir]
@@ -260,7 +263,8 @@ describe('@angular/common integration', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(3, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(3);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -318,7 +322,8 @@ describe('@angular/common integration', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(1, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(1);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -337,7 +342,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const row = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(row.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', row.data);
         }
       }
 
@@ -412,7 +418,8 @@ describe('@angular/common integration', () => {
                   0, divTemplate, 2, 1, 'div', [AttributeMarker.Template, 'ngFor', 'ngForOf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -428,7 +435,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const row = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(row.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', row.data);
         }
       }
 
@@ -507,7 +515,8 @@ describe('@angular/common integration', () => {
                   0, divTemplate, 2, 1, 'div', [AttributeMarker.Template, 'ngFor', 'ngForOf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -526,7 +535,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const row = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(row));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', row);
         }
       }
 
@@ -541,7 +551,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const cell = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(cell.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', cell.data);
         }
       }
 
@@ -682,7 +693,8 @@ describe('@angular/common integration', () => {
                   0, itemTemplate0, 2, 1, 'span', [AttributeMarker.Template, 'ngFor', 'ngForOf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.items);
             }
 
           },
@@ -701,7 +713,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item0 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item0.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item0.data);
         }
       }
 
@@ -716,7 +729,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item1 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item1.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item1.data);
         }
       }
 
@@ -731,7 +745,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item2 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item2.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item2.data);
         }
       }
 
@@ -746,7 +761,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item3 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item3.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item3.data);
         }
       }
 
@@ -761,7 +777,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item4 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item4.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item4.data);
         }
       }
 
@@ -776,7 +793,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item5 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item5.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item5.data);
         }
       }
 
@@ -791,7 +809,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item6 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item6.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item6.data);
         }
       }
 
@@ -806,7 +825,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const item7 = ctx.$implicit as any;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(item7.data));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', item7.data);
         }
       }
 
@@ -875,8 +895,10 @@ describe('@angular/common integration', () => {
               ɵɵtemplate(1, templateTwo, 2, 1, 'div', [AttributeMarker.Template, 'ngIf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
-              ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+              ɵɵselect(0);
+              ɵɵproperty('ngIf', ctx.showing);
+              ɵɵselect(1);
+              ɵɵproperty('ngIf', ctx.showing);
             }
 
           },
@@ -944,7 +966,8 @@ describe('@angular/common integration', () => {
               ɵɵtemplate(0, divTemplate, 2, 1, 'div', [AttributeMarker.Template, 'ngIf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
+              ɵɵselect(0);
+              ɵɵproperty('ngIf', ctx.showing);
             }
 
           },
@@ -960,7 +983,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const app = ɵɵnextContext();
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(app.outerShowing));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', app.outerShowing);
         }
       }
 
@@ -972,7 +996,8 @@ describe('@angular/common integration', () => {
         }
         if (rf & RenderFlags.Update) {
           const app = ɵɵnextContext(2);
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(app.innerShowing));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', app.innerShowing);
         }
       }
 
@@ -1026,7 +1051,8 @@ describe('@angular/common integration', () => {
             }
             if (rf & RenderFlags.Update) {
               const tplRef = ɵɵload(1);
-              ɵɵelementProperty(2, 'ngTemplateOutlet', ɵɵbind(myApp.showing ? tplRef : null));
+              ɵɵselect(2);
+              ɵɵproperty('ngTemplateOutlet', myApp.showing ? tplRef : null);
             }
           },
           directives: () => [NgTemplateOutlet]
@@ -1070,7 +1096,8 @@ describe('@angular/common integration', () => {
             }
             if (rf & RenderFlags.Update) {
               const tplRef = ɵɵreference(1);
-              ɵɵelementProperty(2, 'ngTemplateOutlet', ɵɵbind(myApp.showing ? tplRef : null));
+              ɵɵselect(2);
+              ɵɵproperty('ngTemplateOutlet', myApp.showing ? tplRef : null);
             }
           },
           directives: () => [NgTemplateOutlet]

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -8,8 +8,8 @@
 
 import {InjectionToken, ViewEncapsulation, ɵɵdefineInjectable, ɵɵdefineInjector} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
-import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵtemplate} from '../../src/render3/index';
-import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
+import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {ComponentDef, RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -138,7 +138,8 @@ describe('component', () => {
         ɵɵelement(4097, 'comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(4097, 'name', ɵɵbind(ctx.name));
+        ɵɵselect(4097);
+        ɵɵproperty('name', ctx.name);
       }
     }, 4098, 1, [Comp]);
 
@@ -189,7 +190,8 @@ it('should not invoke renderer destroy method for embedded views', () => {
               2, MyComponent_div_Template_2, 2, 0, 'div', [AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(ctx.visible));
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', ctx.visible);
         }
       }
     });
@@ -271,7 +273,8 @@ describe('component with a container', () => {
       ɵɵelement(0, 'wrapper');
     }
     if (rf & RenderFlags.Update) {
-      ɵɵelementProperty(0, 'items', ɵɵbind(ctx.items));
+      ɵɵselect(0);
+      ɵɵproperty('items', ctx.items);
     }
   }
 
@@ -462,7 +465,8 @@ describe('recursive components', () => {
                 ɵɵelement(0, 'tree-comp');
               }
               if (rf0 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'data', ɵɵbind(ctx.data.left));
+                ɵɵselect(0);
+                ɵɵproperty('data', ctx.data.left);
               }
               ɵɵembeddedViewEnd();
             }
@@ -476,7 +480,8 @@ describe('recursive components', () => {
                 ɵɵelement(0, 'tree-comp');
               }
               if (rf0 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'data', ɵɵbind(ctx.data.right));
+                ɵɵselect(0);
+                ɵɵproperty('data', ctx.data.right);
               }
               ɵɵembeddedViewEnd();
             }
@@ -523,8 +528,10 @@ describe('recursive components', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵtextBinding(0, ɵɵbind(ctx.data.value));
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.data.left));
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(ctx.data.right));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', ctx.data.left);
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', ctx.data.right);
         }
 
       },
@@ -539,7 +546,8 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵelementProperty(0, 'data', ɵɵbind(parent.data.left));
+      ɵɵselect(0);
+      ɵɵproperty('data', parent.data.left);
     }
   }
 
@@ -550,7 +558,8 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵelementProperty(0, 'data', ɵɵbind(parent.data.right));
+      ɵɵselect(0);
+      ɵɵproperty('data', parent.data.right);
     }
   }
 

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -9,8 +9,8 @@
 import {QueryList, TemplateRef, ViewContainerRef} from '@angular/core';
 import {SelectorFlags} from '@angular/core/src/render3/interfaces/projection';
 
-import {AttributeMarker, detectChanges, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵloadViewQuery, ɵɵqueryRefresh, ɵɵreference, ɵɵtemplateRefExtractor, ɵɵviewQuery} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵprojection, ɵɵprojectionDef, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, detectChanges, ɵɵbind, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelementProperty, ɵɵloadViewQuery, ɵɵproperty, ɵɵqueryRefresh, ɵɵreference, ɵɵselect, ɵɵtemplateRefExtractor, ɵɵviewQuery} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵprojection, ɵɵprojectionDef, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgForOf, NgIf} from './common_with_def';
@@ -22,7 +22,7 @@ describe('content projection', () => {
     /**
      * <div><ng-content></ng-content></div>
      */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -34,7 +34,7 @@ describe('content projection', () => {
     /**
      * <child>content</child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         { ɵɵtext(1, 'content'); }
@@ -48,7 +48,7 @@ describe('content projection', () => {
 
   it('should project content when <ng-content> is at a template root', () => {
     /** <ng-content></ng-content> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -56,7 +56,7 @@ describe('content projection', () => {
     }, 1);
 
     /** <child>content</child> */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         { ɵɵtext(1, 'content'); }
@@ -70,7 +70,7 @@ describe('content projection', () => {
 
   it('should project content with siblings', () => {
     /** <ng-content></ng-content> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -84,7 +84,7 @@ describe('content projection', () => {
      *  after
      * </child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -104,7 +104,7 @@ describe('content projection', () => {
 
   it('should re-project content when root.', () => {
     /** <div><ng-content></ng-content></div> */
-    const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
+    const GrandChild = createComponent('grand-child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -114,7 +114,7 @@ describe('content projection', () => {
     }, 2);
 
     /** <grand-child><ng-content></ng-content></grand-child> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'grand-child');
@@ -124,7 +124,7 @@ describe('content projection', () => {
     }, 2, 0, [GrandChild]);
 
     /** <child><b>Hello</b>World!</child> */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -145,7 +145,7 @@ describe('content projection', () => {
   it('should project components', () => {
 
     /** <div><ng-content></ng-content></div> */
-    const Child = createComponent('child', (rf: RenderFlags, ctx: any) => {
+    const Child = createComponent('child', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -154,7 +154,7 @@ describe('content projection', () => {
       }
     }, 2);
 
-    const ProjectedComp = createComponent('projected-comp', (rf: RenderFlags, ctx: any) => {
+    const ProjectedComp = createComponent('projected-comp', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵtext(0, 'content');
       }
@@ -165,7 +165,7 @@ describe('content projection', () => {
      *   <projected-comp></projected-comp>
      * </child>
      */
-    const Parent = createComponent('parent', (rf: RenderFlags, ctx: any) => {
+    const Parent = createComponent('parent', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         { ɵɵelement(1, 'projected-comp'); }
@@ -180,7 +180,7 @@ describe('content projection', () => {
 
   it('should project components that have their own projection', () => {
     /** <div><ng-content></ng-content></div> */
-    const Child = createComponent('child', (rf: RenderFlags, ctx: any) => {
+    const Child = createComponent('child', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -190,7 +190,7 @@ describe('content projection', () => {
     }, 2);
 
     /** <p><ng-content></ng-content></p> */
-    const ProjectedComp = createComponent('projected-comp', (rf: RenderFlags, ctx: any) => {
+    const ProjectedComp = createComponent('projected-comp', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'p');
@@ -207,7 +207,7 @@ describe('content projection', () => {
      *   </projected-comp>
      * </child>
      */
-    const Parent = createComponent('parent', (rf: RenderFlags, ctx: any) => {
+    const Parent = createComponent('parent', (rf: RenderFlags) => {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -233,7 +233,7 @@ describe('content projection', () => {
 
   it('should project containers', () => {
     /** <div><ng-content></ng-content></div> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -290,7 +290,7 @@ describe('content projection', () => {
 
   it('should project containers into root', () => {
     /** <ng-content></ng-content> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -339,7 +339,7 @@ describe('content projection', () => {
 
   it('should project containers with if-else.', () => {
     /** <div><ng-content></ng-content></div> */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -441,7 +441,7 @@ describe('content projection', () => {
      *   content
      * </child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -500,7 +500,7 @@ describe('content projection', () => {
     }, 2);
 
     /** <child></child> */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelement(0, 'child');
 
@@ -553,7 +553,7 @@ describe('content projection', () => {
        /**
         * <child>content</child>
         */
-       const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+       const Parent = createComponent('parent', function(rf: RenderFlags) {
          if (rf & RenderFlags.Create) {
            ɵɵelementStart(0, 'child');
            {
@@ -721,7 +721,7 @@ describe('content projection', () => {
 
     let parent: any;
     /** <parent><p>text</p></parent> */
-    const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
+    const App = createComponent('app', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'parent');
         {
@@ -783,7 +783,7 @@ describe('content projection', () => {
        /**
         * <child>content</child>
         */
-       const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+       const Parent = createComponent('parent', function(rf: RenderFlags) {
          if (rf & RenderFlags.Create) {
            ɵɵelementStart(0, 'child');
            {
@@ -818,12 +818,13 @@ describe('content projection', () => {
         ɵɵtext(2, '-After');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+        ɵɵselect(1);
+        ɵɵproperty('ngIf', ctx.showing);
       }
 
     }, 3, 1, [NgIf]);
 
-    function IfTemplate(rf1: RenderFlags, ctx: any) {
+    function IfTemplate(rf1: RenderFlags) {
       if (rf1 & RenderFlags.Create) {
         ɵɵprojection(0);
       }
@@ -836,7 +837,7 @@ describe('content projection', () => {
      *     Some text
      * </child>
      */
-    const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
+    const App = createComponent('app', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -882,12 +883,13 @@ describe('content projection', () => {
         ɵɵtext(2, '-After');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+        ɵɵselect(1);
+        ɵɵproperty('ngIf', ctx.showing);
       }
 
     }, 3, 1, [NgIf]);
 
-    function IfTemplate(rf: RenderFlags, ctx: any) {
+    function IfTemplate(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojection(0);
       }
@@ -900,7 +902,7 @@ describe('content projection', () => {
      *     Some text
      * </child>
      */
-    const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
+    const App = createComponent('app', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -948,7 +950,8 @@ describe('content projection', () => {
         ɵɵtext(3, '-After');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(2, 'ngIf', ɵɵbind(ctx.showing));
+        ɵɵselect(2);
+        ɵɵproperty('ngIf', ctx.showing);
       }
 
     }, 4, 1, [NgIf]);
@@ -966,7 +969,7 @@ describe('content projection', () => {
      *     <span>B</span>
      * </child>
      */
-    const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
+    const App = createComponent('app', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -1002,7 +1005,7 @@ describe('content projection', () => {
      () => {
        let triggerDir !: Trigger;
 
-       function NgTemplate(rf: RenderFlags, ctx: any) {
+       function NgTemplate(rf: RenderFlags) {
          if (rf & RenderFlags.Create) {
            ɵɵprojection(0);
          }
@@ -1015,7 +1018,7 @@ describe('content projection', () => {
         */
        const Comp = createComponent(
            'comp',
-           (rf: RenderFlags, ctx: any) => {
+           (rf: RenderFlags) => {
              if (rf & RenderFlags.Create) {
                ɵɵprojectionDef();
                ɵɵtemplate(1, NgTemplate, 1, 0, 'ng-template', null, null, ɵɵtemplateRefExtractor);
@@ -1056,7 +1059,7 @@ describe('content projection', () => {
         *    Some content
         * </comp>
         */
-       const App = createComponent('app', (rf: RenderFlags, ctx: any) => {
+       const App = createComponent('app', (rf: RenderFlags) => {
          if (rf & RenderFlags.Create) {
            ɵɵelement(0, 'button', [AttributeMarker.Bindings, 'trigger']);
            ɵɵelementStart(1, 'comp', null, ['comp', '']);
@@ -1065,7 +1068,8 @@ describe('content projection', () => {
          }
          if (rf & RenderFlags.Update) {
            const comp = ɵɵreference(2);
-           ɵɵelementProperty(0, 'trigger', ɵɵbind(comp));
+           ɵɵselect(0);
+           ɵɵproperty('trigger', comp);
          }
        }, 4, 1, [Comp, Trigger]);
 
@@ -1081,7 +1085,7 @@ describe('content projection', () => {
      * <div><ng-content></ng-content></div>
      * <span><ng-content></ng-content></span>
      */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'div');
@@ -1096,7 +1100,7 @@ describe('content projection', () => {
     /**
      * <child>content</child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         { ɵɵtext(1, 'content'); }
@@ -1153,7 +1157,7 @@ describe('content projection', () => {
     /**
      * <child>content</child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -1181,13 +1185,14 @@ describe('content projection', () => {
       ({{index}}): <ng-content></ng-content>
      </div>
      */
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         { ɵɵtemplate(0, ForTemplate, 3, 1, 'div', [AttributeMarker.Template, 'ngFor', 'ngForOf']); }
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'ngForOf', ɵɵbind(items));
+        ɵɵselect(0);
+        ɵɵproperty('ngForOf', items);
       }
     }, 1, 1, [NgForOf]);
 
@@ -1206,7 +1211,7 @@ describe('content projection', () => {
     /**
      * <child>content</child>
      */
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         { ɵɵtext(1, 'content'); }
@@ -1219,7 +1224,7 @@ describe('content projection', () => {
   });
 
   it('should project with multiple instances of a component with projection', () => {
-    const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags, ctx: any) {
+    const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵtext(0, 'Before');
@@ -1238,7 +1243,7 @@ describe('content projection', () => {
      *     <p>456</p>
      * </projection-comp>
      */
-    const AppComp = createComponent('app-comp', function(rf: RenderFlags, ctx: any) {
+    const AppComp = createComponent('app-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'projection-comp');
         {
@@ -1277,7 +1282,7 @@ describe('content projection', () => {
      * <ng-content></ng-content>
      * After
      */
-    const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags, ctx: any) {
+    const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵtext(0, 'Before');
@@ -1297,7 +1302,7 @@ describe('content projection', () => {
      *     <p>456</p>
      * </projection-comp>
      */
-    const ProjectionParent = createComponent('parent-comp', function(rf: RenderFlags, ctx: any) {
+    const ProjectionParent = createComponent('parent-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'projection-comp');
@@ -1332,7 +1337,7 @@ describe('content projection', () => {
      *    **DEF**
      * </parent-comp>
      */
-    const AppComp = createComponent('app-comp', function(rf: RenderFlags, ctx: any) {
+    const AppComp = createComponent('app-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'parent-comp');
         { ɵɵtext(1, '**ABC**'); }
@@ -1358,7 +1363,7 @@ describe('content projection', () => {
   it('should project ng-container at the content root', () => {
 
     `<ng-content></ng-content>`;
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -1372,7 +1377,7 @@ describe('content projection', () => {
         </ng-container>
       </ng-container>
     </child>`;
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -1395,7 +1400,7 @@ describe('content projection', () => {
   it('should re-project ng-container at the content root', () => {
 
     `<ng-content></ng-content>`;
-    const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
+    const GrandChild = createComponent('grand-child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -1405,7 +1410,7 @@ describe('content projection', () => {
     `<grand-child>
       <ng-content></ng-content>
     </grand-child>`;
-    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+    const Child = createComponent('child', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵelementStart(0, 'grand-child');
@@ -1421,7 +1426,7 @@ describe('content projection', () => {
         </ng-container>
       </ng-container>
     </child>`;
-    const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+    const Parent = createComponent('parent', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'child');
         {
@@ -1443,7 +1448,7 @@ describe('content projection', () => {
 
   it('should handle projected containers inside other containers', () => {
     // <div>Child content</div>
-    const NestedComp = createComponent('nested-comp', function(rf: RenderFlags, ctx: any) {
+    const NestedComp = createComponent('nested-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelementStart(0, 'div');
         ɵɵtext(1, 'Child content');
@@ -1452,7 +1457,7 @@ describe('content projection', () => {
     }, 2, 0, []);
 
     // <ng-content></ng-content>
-    const RootComp = createComponent('root-comp', function(rf: RenderFlags, ctx: any) {
+    const RootComp = createComponent('root-comp', function(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵprojectionDef();
         ɵɵprojection(0);
@@ -1464,7 +1469,7 @@ describe('content projection', () => {
     //     <nested-comp *ngIf="!last"></nested-comp>
     //   </ng-container>
     // </root-comp>
-    function MyApp_ng_container_1_child_comp_1_Template(rf: RenderFlags, ctx: any) {
+    function MyApp_ng_container_1_child_comp_1_Template(rf: RenderFlags) {
       if (rf & RenderFlags.Create) {
         ɵɵelement(0, 'nested-comp');
       }
@@ -1530,7 +1535,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content select="span[title=toFirst]"></ng-content></div>
        *  <div id="second"><ng-content select="span[title=toSecond]"></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['span', 'title', 'toFirst']], [['span', 'title', 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1548,7 +1553,7 @@ describe('content projection', () => {
        *  <span title="toSecond">2</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1574,7 +1579,7 @@ describe('content projection', () => {
       /**
        *  <ng-content select="[title]"></ng-content>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['', 'title', '']]]);
           { ɵɵprojection(0, 1); }
@@ -1586,7 +1591,7 @@ describe('content projection', () => {
        *  <span [title]="'Some title'">Has title</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1597,7 +1602,8 @@ describe('content projection', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(1, 'title', ɵɵbind('Some title'));
+          ɵɵselect(1);
+          ɵɵproperty('title', 'Some title');
         }
       }, 3, 1, [Child]);
 
@@ -1611,7 +1617,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content select="span.toFirst"></ng-content></div>
        *  <div id="second"><ng-content select="span.toSecond"></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([
             [['span', SelectorFlags.CLASS, 'toFirst']],
@@ -1632,7 +1638,7 @@ describe('content projection', () => {
        *  <span class="toSecond">2</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1658,7 +1664,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content select="span.toFirst"></ng-content></div>
        *  <div id="second"><ng-content select="span.toSecond"></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([
             [['span', SelectorFlags.CLASS, 'toFirst']],
@@ -1679,7 +1685,7 @@ describe('content projection', () => {
        *  <span class="toSecond noise">2</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1705,7 +1711,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content select="span"></ng-content></div>
        *  <div id="second"><ng-content select="span.toSecond"></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['span']], [['span', SelectorFlags.CLASS, 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1723,7 +1729,7 @@ describe('content projection', () => {
        *  <span class="toSecond">2</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1749,7 +1755,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content select="span.toFirst"></ng-content></div>
        *  <div id="second"><ng-content></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['span', SelectorFlags.CLASS, 'toFirst']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1767,7 +1773,7 @@ describe('content projection', () => {
        *  <span class="toSecond noise">2</span>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1794,7 +1800,7 @@ describe('content projection', () => {
        *  <div id="first"><ng-content></ng-content></div>
        *  <div id="second"><ng-content select="span.toSecond"></ng-content></div>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['span', SelectorFlags.CLASS, 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1813,7 +1819,7 @@ describe('content projection', () => {
        *  remaining
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1846,7 +1852,7 @@ describe('content projection', () => {
        *  <hr>
        *  <ng-content></ng-content>
        */
-      const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
+      const GrandChild = createComponent('grand-child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['span']]]);
           ɵɵprojection(0, 1);
@@ -1861,7 +1867,7 @@ describe('content projection', () => {
        *    <span>in child template</span>
        *  </grand-child>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef();
           ɵɵelementStart(0, 'grand-child');
@@ -1882,7 +1888,7 @@ describe('content projection', () => {
        *  </div>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1907,7 +1913,7 @@ describe('content projection', () => {
        * <hr>
        * <ng-content select="[card-content]"></ng-content>
        */
-      const Card = createComponent('card', function(rf: RenderFlags, ctx: any) {
+      const Card = createComponent('card', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['', 'card-title', '']], [['', 'card-content', '']]]);
           ɵɵprojection(0, 1);
@@ -1922,7 +1928,7 @@ describe('content projection', () => {
        *  <ng-content card-content></ng-content>
        * </card>
        */
-      const CardWithTitle = createComponent('card-with-title', function(rf: RenderFlags, ctx: any) {
+      const CardWithTitle = createComponent('card-with-title', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef();
           ɵɵelementStart(0, 'card');
@@ -1941,7 +1947,7 @@ describe('content projection', () => {
        *  content
        * </card-with-title>
        */
-      const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
+      const App = createComponent('app', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'card-with-title');
           { ɵɵtext(1, 'content'); }
@@ -1960,7 +1966,7 @@ describe('content projection', () => {
       /**
        *  <ng-content select="div"></ng-content>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['div']]]);
           ɵɵprojection(0, 1);
@@ -1973,7 +1979,7 @@ describe('content projection', () => {
        *  <div>should project</div>
        * </child>
        */
-      const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
+      const Parent = createComponent('parent', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'child');
           {
@@ -1999,7 +2005,7 @@ describe('content projection', () => {
        *  <ng-content select="div"></ng-content>
        * </span>
        */
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
+      const Child = createComponent('child', function(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([[['div']]]);
           ɵɵelementStart(0, 'span');
@@ -2008,7 +2014,7 @@ describe('content projection', () => {
         }
       }, 2);
 
-      function IfTemplate(rf: RenderFlags, ctx: any) {
+      function IfTemplate(rf: RenderFlags) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'div');
           { ɵɵtext(1, 'content'); }
@@ -2028,7 +2034,8 @@ describe('content projection', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.value));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', ctx.value);
         }
       }, 2, 1, [Child, NgIf]);
 

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -13,7 +13,7 @@ import {ComponentType, RenderFlags} from '@angular/core/src/render3/interfaces/d
 import {createInjector} from '../../src/di/r3_injector';
 import {ɵɵdefineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHasToken, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
-import {ɵɵProvidersFeature, ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinjectAttribute, ɵɵinterpolation2, ɵɵload, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵtemplate, ɵɵtemplateRefExtractor, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
+import {ɵɵProvidersFeature, ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinjectAttribute, ɵɵinterpolation2, ɵɵload, ɵɵprojection, ɵɵprojectionDef, ɵɵproperty, ɵɵreference, ɵɵselect, ɵɵtemplate, ɵɵtemplateRefExtractor, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
 import {LContainer, NATIVE} from '../../src/render3/interfaces/container';
 import {TNODE} from '../../src/render3/interfaces/injector';
 import {AttributeMarker, TNodeType} from '../../src/render3/interfaces/node';
@@ -494,7 +494,8 @@ describe('di', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+            ɵɵselect(1);
+            ɵɵproperty('ngIf', ctx.showing);
           }
         }, 2, 1, [DirA, DirB, NgIf]);
 
@@ -621,7 +622,8 @@ describe('di', () => {
           }
           if (rf & RenderFlags.Update) {
             const foo = ɵɵreference(2) as any;
-            ɵɵelementProperty(4, 'tmp', ɵɵbind(foo));
+            ɵɵselect(4);
+            ɵɵproperty('tmp', foo);
           }
         }, 5, 1, [DirA, DirB, StructuralDir]);
 
@@ -1252,7 +1254,8 @@ describe('di', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+              ɵɵselect(1);
+              ɵɵproperty('ngIf', ctx.showing);
 
               // testing only
               dirB = getDirectiveOnNode(0);
@@ -1978,7 +1981,8 @@ describe('di', () => {
                     ['dir', '', 'dirSame', '', AttributeMarker.Template, 'ngIf']);
               }
               if (rf & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
+                ɵɵselect(0);
+                ɵɵproperty('ngIf', ctx.showing);
               }
             },
             directives: directives

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -8,8 +8,8 @@
 
 import {EventEmitter, TemplateRef, ViewContainerRef} from '@angular/core';
 
-import {AttributeMarker, RenderFlags, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject} from '../../src/render3/index';
-import {ɵɵbind, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵlistener, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, RenderFlags, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵlistener, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 
 import {NgIf} from './common_with_def';
 import {ComponentFixture, TemplateFixture, createComponent} from './render_util';
@@ -55,7 +55,10 @@ describe('directive', () => {
         ɵɵelement(0, 'span', ['class', 'fade', AttributeMarker.Bindings, 'test', 'other']);
       }
 
-      function updateTemplate() { ɵɵelementProperty(0, 'test', ɵɵbind(false)); }
+      function updateTemplate() {
+        ɵɵselect(0);
+        ɵɵproperty('test', false);
+      }
 
       const fixture = new TemplateFixture(createTemplate, updateTemplate, 1, 1, [Directive]);
 
@@ -108,9 +111,12 @@ describe('directive', () => {
          }
 
          function updateTemplate() {
-           ɵɵelementProperty(0, 'prop1', ɵɵbind(true));
-           ɵɵelementProperty(0, 'test', ɵɵbind(false));
-           ɵɵelementProperty(0, 'prop2', ɵɵbind(true));
+           ɵɵselect(0);
+           ɵɵproperty('prop1', true);
+           ɵɵselect(0);
+           ɵɵproperty('test', false);
+           ɵɵselect(0);
+           ɵɵproperty('prop2', true);
          }
 
          const fixture = new TemplateFixture(createTemplate, updateTemplate, 1, 3, [Directive]);
@@ -210,7 +216,8 @@ describe('directive', () => {
                   ['directiveA', '', AttributeMarker.Template, 'ngIf']);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.visible));
+              ɵɵselect(0);
+              ɵɵproperty('ngIf', ctx.visible);
             }
           },
           directives: [DirectiveA, NgIf]

--- a/packages/core/test/render3/discovery_utils_spec.ts
+++ b/packages/core/test/render3/discovery_utils_spec.ts
@@ -7,8 +7,8 @@
  */
 import {StaticInjector} from '../../src/di/injector';
 import {createInjector} from '../../src/di/r3_injector';
-import {AttributeMarker, RenderFlags, getHostElement, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵi18n, ɵɵi18nApply, ɵɵi18nExp} from '../../src/render3/index';
-import {markDirty, ɵɵbind, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵlistener, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, RenderFlags, getHostElement, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵi18n, ɵɵi18nApply, ɵɵi18nExp, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {markDirty, ɵɵbind, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵlistener, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {getComponent, getContext, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getRootComponents, getViewComponent, loadLContext} from '../../src/render3/util/discovery_utils';
 
 import {NgIf} from './common_with_def';
@@ -132,7 +132,8 @@ describe('discovery utils', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵtextBinding(1, ɵɵbind(ctx.text));
-          ɵɵelementProperty(8, 'ngIf', ɵɵbind(true));
+          ɵɵselect(8);
+          ɵɵproperty('ngIf', true);
           ɵɵi18nExp(ɵɵbind(ctx.text));
           ɵɵi18nApply(10);
         }

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementAttribute, ɵɵelementClassProp, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation2, ɵɵnextContext, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementAttribute, ɵɵelementClassProp, ɵɵelementEnd, ɵɵelementStart, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation2, ɵɵnextContext, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -44,7 +44,8 @@ describe('exports', () => {
         }
         if (rf & RenderFlags.Update) {
           const tmp = ɵɵreference(2) as any;
-          ɵɵelementProperty(0, 'title', ɵɵbind(tmp.value));
+          ɵɵselect(0);
+          ɵɵproperty('title', tmp.value);
         }
       }, 3, 1);
 
@@ -129,7 +130,8 @@ describe('exports', () => {
         }
         if (rf & RenderFlags.Update) {
           const tmp = ɵɵreference(2) as any;
-          ɵɵelementProperty(0, 'myDir', ɵɵbind(tmp));
+          ɵɵselect(0);
+          ɵɵproperty('myDir', tmp);
         }
       }, 3, 1, [MyComponent, MyDir]);
 
@@ -235,7 +237,8 @@ describe('exports', () => {
           ɵɵtemplate(2, outerTemplate, 5, 2, 'div', [AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(app.outer));
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', app.outer);
         }
       }, 3, 1, [NgIf]);
 
@@ -255,7 +258,8 @@ describe('exports', () => {
           const app = ɵɵnextContext();
           const outerInput = ɵɵreference(1) as any;
           ɵɵtextBinding(1, ɵɵbind(outerInput.value));
-          ɵɵelementProperty(4, 'ngIf', ɵɵbind(app.inner));
+          ɵɵselect(4);
+          ɵɵproperty('ngIf', app.inner);
         }
       }
 

--- a/packages/core/test/render3/host_binding_spec.ts
+++ b/packages/core/test/render3/host_binding_spec.ts
@@ -8,7 +8,7 @@
 
 import {ElementRef, QueryList, ViewContainerRef} from '@angular/core';
 
-import {AttributeMarker, ɵɵInheritDefinitionFeature, ɵɵNgOnChangesFeature, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵtemplate} from '../../src/render3/index';
+import {AttributeMarker, ɵɵInheritDefinitionFeature, ɵɵNgOnChangesFeature, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
 import {ɵɵallocHostVars, ɵɵbind, ɵɵdirectiveInject, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementHostAttrs, ɵɵelementHostStyleProp, ɵɵelementHostStyling, ɵɵelementHostStylingApply, ɵɵelementProperty, ɵɵelementStart, ɵɵelementStyleProp, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵlistener, ɵɵload, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵpureFunction1, ɵɵpureFunction2} from '../../src/render3/pure_function';
@@ -383,7 +383,8 @@ describe('host bindings', () => {
             ɵɵelement(0, 'init-hook-comp');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'inputValue', ɵɵbind(ctx.value));
+            ɵɵselect(0);
+            ɵɵproperty('inputValue', ctx.value);
           }
         },
         consts: 1,
@@ -440,7 +441,8 @@ describe('host bindings', () => {
             ɵɵelement(0, 'input', ['hostBindingDir', '']);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'disabled', ɵɵbind(ctx.isDisabled));
+            ɵɵselect(0);
+            ɵɵproperty('disabled', ctx.isDisabled);
           }
         },
         consts: 1,
@@ -509,7 +511,8 @@ describe('host bindings', () => {
         ɵɵtemplate(0, NgForTemplate, 2, 0, 'div', [AttributeMarker.Template, 'ngFor', 'ngForOf']);
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.rows));
+        ɵɵselect(0);
+        ɵɵproperty('ngForOf', ctx.rows);
       }
     }, 1, 1, [HostBindingDir, NgForOf]);
 
@@ -536,7 +539,8 @@ describe('host bindings', () => {
         ɵɵelement(1, 'host-binding-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'names', ɵɵbind(ɵɵpureFunction1(1, ff, ctx.name)));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction1(1, ff, ctx.name));
       }
     }, 2, 3, [HostBindingComp, NameComp]);
 
@@ -617,7 +621,8 @@ describe('host bindings', () => {
         ɵɵelement(1, 'host-binding-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'names', ɵɵbind(ɵɵpureFunction2(1, ff3, ctx.name, ctx.otherName)));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction2(1, ff3, ctx.name, ctx.otherName));
       }
     }, 2, 4, [HostBindingComp, NameComp]);
 

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -12,7 +12,7 @@ import {noop} from '../../../compiler/src/render3/view/util';
 import {Component as _Component} from '../../src/core';
 import {ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/definition';
 import {getTranslationForTemplate, ɵɵi18n, ɵɵi18nApply, ɵɵi18nAttributes, ɵɵi18nEnd, ɵɵi18nExp, ɵɵi18nPostprocess, ɵɵi18nStart} from '../../src/render3/i18n';
-import {ɵɵallocHostVars, ɵɵbind, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵnextContext, ɵɵprojection, ɵɵprojectionDef, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵallocHostVars, ɵɵbind, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵnextContext, ɵɵprojection, ɵɵprojectionDef, ɵɵproperty, ɵɵselect, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nUpdateOpCode, I18nUpdateOpCodes, IcuType, TI18n} from '../../src/render3/interfaces/i18n';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
@@ -699,7 +699,8 @@ describe('Runtime i18n', () => {
           ɵɵi18nEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(true));
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', true);
         }
       }
 
@@ -728,7 +729,8 @@ describe('Runtime i18n', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(2, 'ngIf', true);
+              ɵɵselect(2);
+              ɵɵproperty('ngIf', true);
             }
           }
         });
@@ -835,7 +837,8 @@ describe('Runtime i18n', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(2, 'ngIf', true);
+              ɵɵselect(2);
+              ɵɵproperty('ngIf', true);
             }
           }
         });
@@ -1477,7 +1480,8 @@ describe('Runtime i18n', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(1, 'ngForOf', ɵɵbind(ctx.items));
+              ɵɵselect(1);
+              ɵɵproperty('ngForOf', ctx.items);
             }
           },
           directives: () => [NgForOf]

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -10,7 +10,7 @@ import {NgForOfContext} from '@angular/common';
 import {ɵɵpropertyInterpolate, ɵɵpropertyInterpolate1, ɵɵpropertyInterpolate2, ɵɵpropertyInterpolate3, ɵɵpropertyInterpolate4, ɵɵpropertyInterpolate5, ɵɵpropertyInterpolate6, ɵɵpropertyInterpolate7, ɵɵpropertyInterpolate8, ɵɵpropertyInterpolateV} from '@angular/core/src/render3/instructions/all';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {RenderFlags, ɵɵbind, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵelementStyleProp, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵelementStylingMap, ɵɵinterpolation1, ɵɵproperty, ɵɵselect, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
+import {RenderFlags, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementStart, ɵɵelementStyleProp, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵelementStylingMap, ɵɵinterpolation1, ɵɵproperty, ɵɵselect, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl} from '../../src/sanitization/bypass';
 import {ɵɵdefaultStyleSanitizer, ɵɵsanitizeHtml, ɵɵsanitizeResourceUrl, ɵɵsanitizeScript, ɵɵsanitizeStyle, ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
@@ -49,10 +49,16 @@ describe('instructions', () => {
     it('should update bindings when value changes', () => {
       const t = new TemplateFixture(createAnchor, () => {}, 1, 1);
 
-      t.update(() => ɵɵelementProperty(0, 'title', ɵɵbind('Hello')));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'Hello');
+      });
       expect(t.html).toEqual('<a title="Hello"></a>');
 
-      t.update(() => ɵɵelementProperty(0, 'title', ɵɵbind('World')));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'World');
+      });
       expect(t.html).toEqual('<a title="World"></a>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
@@ -64,7 +70,10 @@ describe('instructions', () => {
     });
 
     it('should not update bindings when value does not change', () => {
-      const idempotentUpdate = () => ɵɵelementProperty(0, 'title', ɵɵbind('Hello'));
+      const idempotentUpdate = () => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'Hello');
+      };
       const t = new TemplateFixture(createAnchor, idempotentUpdate, 1, 1);
 
       t.update();
@@ -976,14 +985,18 @@ describe('instructions', () => {
 
   describe('elementProperty', () => {
     it('should use sanitizer function when available', () => {
-      const t = new TemplateFixture(createDiv, () => {}, 1);
+      const t = new TemplateFixture(createDiv, () => {}, 1, 1);
 
-      t.update(() => ɵɵelementProperty(0, 'title', 'javascript:true', ɵɵsanitizeUrl));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'javascript:true', ɵɵsanitizeUrl);
+      });
       expect(t.html).toEqual('<div title="unsafe:javascript:true"></div>');
 
-      t.update(
-          () => ɵɵelementProperty(
-              0, 'title', bypassSanitizationTrustUrl('javascript:false'), ɵɵsanitizeUrl));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', bypassSanitizationTrustUrl('javascript:false'), ɵɵsanitizeUrl);
+      });
       expect(t.html).toEqual('<div title="javascript:false"></div>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
@@ -994,10 +1007,13 @@ describe('instructions', () => {
     });
 
     it('should not stringify non string values', () => {
-      const t = new TemplateFixture(() => { ɵɵelement(0, 'input'); }, () => {}, 1);
+      const t = new TemplateFixture(() => { ɵɵelement(0, 'input'); }, () => {}, 1, 1);
 
       // Note: don't use 'hidden' here because IE10 does not support the hidden property
-      t.update(() => ɵɵelementProperty(0, 'required', false));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('required', false);
+      });
       // The required property would be true if `false` was stringified into `"false"`.
       expect((t.hostElement as HTMLElement).querySelector('input') !.required).toEqual(false);
       expect(ngDevMode).toHaveProperties({
@@ -1127,7 +1143,8 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const row_r2 = ctx0.$implicit;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(row_r2));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', row_r2);
         }
       }
 
@@ -1163,7 +1180,8 @@ describe('instructions', () => {
               ɵɵtemplate(0, ToDoAppComponent_NgForOf_Template_0, 2, 1, 'ul', _c0);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.rows));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.rows);
             }
           },
           directives: [NgForOf]
@@ -1280,66 +1298,84 @@ describe('instructions', () => {
 
     it('should work for script sanitization', () => {
       const s = new LocalMockSanitizer(value => `${value} //sanitized`);
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = 'fn();';
       const outputValue = 'fn(); //sanitized';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toEqual(outputValue);
     });
 
     it('should bypass script sanitization if marked by the service', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = s.bypassSecurityTrustScript('alert("bar")');
       const outputValue = 'alert("bar")';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should bypass ivy-level script sanitization if a custom sanitizer is used', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = bypassSanitizationTrustScript('alert("bar")');
       const outputValue = 'alert("bar")-ivy';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should work for html sanitization', () => {
       const s = new LocalMockSanitizer(value => `${value} <!--sanitized-->`);
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = '<header></header>';
       const outputValue = '<header></header> <!--sanitized-->';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toEqual(outputValue);
     });
 
     it('should bypass html sanitization if marked by the service', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = s.bypassSecurityTrustHtml('<div onclick="alert(123)"></div>');
       const outputValue = '<div onclick="alert(123)"></div>';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should bypass ivy-level script sanitization if a custom sanitizer is used', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = bypassSanitizationTrustHtml('<div onclick="alert(123)"></div>');
       const outputValue = '<div onclick="alert(123)"></div>-ivy';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -318,8 +318,10 @@ describe('instructions', () => {
         const t = new TemplateFixture(createDiv, () => {}, 1, 1);
         expect(() => { t.update(() => { ɵɵpropertyInterpolate('title', 123); }); }).toThrow();
         expect(() => {
-          ɵɵselect(0);
-          t.update(() => { ɵɵpropertyInterpolate('title', 123); });
+          t.update(() => {
+            ɵɵselect(0);
+            ɵɵpropertyInterpolate('title', 123);
+          });
         }).not.toThrow();
       });
     });
@@ -375,8 +377,10 @@ describe('instructions', () => {
           t.update(() => { ɵɵpropertyInterpolate1('title', 'start', 'whatever', 'end'); });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
-          t.update(() => { ɵɵpropertyInterpolate1('title', 'start', 'whatever', 'end'); });
+          t.update(() => {
+            ɵɵselect(0);
+            ɵɵpropertyInterpolate1('title', 'start', 'whatever', 'end');
+          });
         }).not.toThrow();
       });
     });
@@ -437,8 +441,10 @@ describe('instructions', () => {
           t.update(() => { ɵɵpropertyInterpolate2('title', '', '', '', '', ''); });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
-          t.update(() => { ɵɵpropertyInterpolate2('title', '', '', '', '', ''); });
+          t.update(() => {
+            ɵɵselect(0);
+            ɵɵpropertyInterpolate2('title', '', '', '', '', '');
+          });
         }).not.toThrow();
       });
     });
@@ -499,8 +505,10 @@ describe('instructions', () => {
           t.update(() => { ɵɵpropertyInterpolate3('title', '', '', '', '', '', '', ''); });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
-          t.update(() => { ɵɵpropertyInterpolate3('title', '', '', '', '', '', '', ''); });
+          t.update(() => {
+            ɵɵselect(0);
+            ɵɵpropertyInterpolate3('title', '', '', '', '', '', '', '');
+          });
         }).not.toThrow();
       });
     });
@@ -566,8 +574,10 @@ describe('instructions', () => {
           t.update(() => { ɵɵpropertyInterpolate4('title', '', '', '', '', '', '', '', '', ''); });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
-          t.update(() => { ɵɵpropertyInterpolate4('title', '', '', '', '', '', '', '', '', ''); });
+          t.update(() => {
+            ɵɵselect(0);
+            ɵɵpropertyInterpolate4('title', '', '', '', '', '', '', '', '', '');
+          });
         }).not.toThrow();
       });
     });
@@ -637,8 +647,8 @@ describe('instructions', () => {
           });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
           t.update(() => {
+            ɵɵselect(0);
             ɵɵpropertyInterpolate5('title', '', '', '', '', '', '', '', '', '', '', '');
           });
         }).not.toThrow();
@@ -713,8 +723,8 @@ describe('instructions', () => {
           });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
           t.update(() => {
+            ɵɵselect(0);
             ɵɵpropertyInterpolate6('title', '', '', '', '', '', '', '', '', '', '', '', '', '');
           });
         }).not.toThrow();
@@ -794,8 +804,8 @@ describe('instructions', () => {
           });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
           t.update(() => {
+            ɵɵselect(0);
             ɵɵpropertyInterpolate7(
                 'title', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '');
           });
@@ -876,8 +886,8 @@ describe('instructions', () => {
           });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
           t.update(() => {
+            ɵɵselect(0);
             ɵɵpropertyInterpolate8(
                 'title', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '');
           });
@@ -972,8 +982,8 @@ describe('instructions', () => {
           });
         }).toThrow();
         expect(() => {
-          ɵɵselect(0);
           t.update(() => {
+            ɵɵselect(0);
             ɵɵpropertyInterpolateV(
                 'title',
                 ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']);

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -10,7 +10,7 @@ import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {RendererType2} from '../../src/render/api';
 import {getLContext} from '../../src/render3/context_discovery';
-import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵtemplateRefExtractor} from '../../src/render3/index';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect, ɵɵtemplateRefExtractor} from '../../src/render3/index';
 import {ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementAttribute, ɵɵelementClassProp, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementHostAttrs, ɵɵelementHostClassProp, ɵɵelementHostStyleProp, ɵɵelementHostStyling, ɵɵelementHostStylingApply, ɵɵelementHostStylingMap, ɵɵelementProperty, ɵɵelementStart, ɵɵelementStyleProp, ɵɵelementStyling, ɵɵelementStylingApply, ɵɵelementStylingMap, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵinterpolation3, ɵɵinterpolation4, ɵɵinterpolation5, ɵɵinterpolation6, ɵɵinterpolation7, ɵɵinterpolation8, ɵɵinterpolationV, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {MONKEY_PATCH_KEY_NAME} from '../../src/render3/interfaces/context';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
@@ -568,7 +568,8 @@ describe('render3 integration test', () => {
           ɵɵelement(0, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'condition', ɵɵbind(ctx.condition));
+          ɵɵselect(0);
+          ɵɵproperty('condition', ctx.condition);
         }
       }, 1, 1, [MyComp]);
 
@@ -724,7 +725,8 @@ describe('render3 integration test', () => {
                      0, ngIfTemplate, 2, 0, 'ng-template', [AttributeMarker.Bindings, 'ngIf']);
                }
                if (rf & RenderFlags.Update) {
-                 ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.value));
+                 ɵɵselect(0);
+                 ɵɵproperty('ngIf', ctx.value);
                }
              }, 1, 1, [NgIf]);
 
@@ -993,7 +995,8 @@ describe('render3 integration test', () => {
         }
         if (rf & RenderFlags.Update) {
           const content = ɵɵreference(2) as any;
-          ɵɵelementProperty(0, 'contentTpl', ɵɵbind(content));
+          ɵɵselect(0);
+          ɵɵproperty('contentTpl', content);
         }
       }, 3, 1, [Directive]);
 
@@ -1197,8 +1200,9 @@ describe('render3 integration test', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'beforeTree', ɵɵbind(ctx.beforeTree));
-        ɵɵelementProperty(0, 'afterTree', ɵɵbind(ctx.afterTree));
+        ɵɵselect(0);
+        ɵɵproperty('beforeTree', ctx.beforeTree);
+        ɵɵproperty('afterTree', ctx.afterTree);
         ɵɵcontainerRefreshStart(1);
         {
           const rf0 = ɵɵembeddedViewStart(0, 3, 0);
@@ -1624,7 +1628,8 @@ describe('render3 integration test', () => {
             const foo = ɵɵreference(1) as any;
             ɵɵelementClassProp(2, 0, ctx.class);
             ɵɵelementStylingApply(2);
-            ɵɵelementProperty(2, 'tmp', ɵɵbind(foo));
+            ɵɵselect(2);
+            ɵɵproperty('tmp', foo);
           }
         }, 3, 1, [StructuralComp]);
 
@@ -2331,6 +2336,7 @@ describe('component animations', () => {
         selectors: [['child-comp-with-anim']],
         hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
           if (rf & RenderFlags.Update) {
+            ɵɵselect(0);
             ɵɵelementProperty(0, '@fooAnim', ctx.exp);
           }
         },
@@ -2473,7 +2479,8 @@ describe('element discovery', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(1, 'ngIf', true);
+            ɵɵselect(1);
+            ɵɵproperty('ngIf', true);
           }
         }
       });
@@ -3074,7 +3081,8 @@ describe('sanitization', () => {
             ɵɵelement(0, 'a');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'href', ɵɵbind(ctx.href), ɵɵsanitizeUrl);
+            ɵɵselect(0);
+            ɵɵproperty('href', ctx.href, ɵɵsanitizeUrl);
           }
         }
       });

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -806,7 +806,7 @@ describe('lifecycles', () => {
        * <parent [val]="1">
        *   <projected [val]="1">content</projected>
        * </parent>
-       * * <parent [val]="2">
+       * <parent [val]="2">
        *   <projected [val]="2">content</projected>
        * </parent>
        *

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {ComponentFactoryResolver, OnDestroy, SimpleChange, SimpleChanges, ViewContainerRef} from '../../src/core';
-import {AttributeMarker, ComponentTemplate, LifecycleHooksFeature, injectComponentFactoryResolver, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {markDirty, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, ComponentTemplate, LifecycleHooksFeature, injectComponentFactoryResolver, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
+import {markDirty, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -22,7 +22,8 @@ describe('lifecycles', () => {
         ɵɵelement(0, name);
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+        ɵɵselect(0);
+        ɵɵproperty('val', ctx.val);
       }
     };
   }
@@ -86,7 +87,8 @@ describe('lifecycles', () => {
              ɵɵelement(0, 'comp');
            }
            if (rf & RenderFlags.Update) {
-             ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+             ɵɵselect(0);
+             ɵɵproperty('val', ctx.val);
            }
          }, 1, 1, directives);
 
@@ -136,9 +138,10 @@ describe('lifecycles', () => {
           ɵɵelement(1, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 2, 0, directives);
 
@@ -199,7 +202,8 @@ describe('lifecycles', () => {
           ɵɵtemplate(0, IfTemplate, 1, 0, 'comp', [AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
+          ɵɵselect(0);
+          ɵɵproperty('ngIf', ctx.showing);
         }
       }, 1, 0, directives);
 
@@ -288,13 +292,14 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 1);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 2);
+          ɵɵproperty('val', 2);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 4, 0, directives);
 
@@ -347,9 +352,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 5);
+          ɵɵproperty('val', 5);
           ɵɵcontainerRefreshStart(1);
           {
             for (let j = 2; j < 5; j++) {
@@ -358,7 +364,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', j);
+                ɵɵselect(0);
+                ɵɵproperty('val', j);
               }
               ɵɵembeddedViewEnd();
             }
@@ -388,9 +395,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 5);
+          ɵɵproperty('val', 5);
           ɵɵcontainerRefreshStart(1);
           {
             for (let j = 2; j < 5; j++) {
@@ -399,7 +407,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'parent');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', j);
+                ɵɵselect(0);
+                ɵɵproperty('val', j);
               }
               ɵɵembeddedViewEnd();
             }
@@ -573,7 +582,8 @@ describe('lifecycles', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+        ɵɵselect(0);
+        ɵɵproperty('val', ctx.val);
       }
     }, 2, 1, [Comp]);
 
@@ -627,9 +637,10 @@ describe('lifecycles', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'val', 1);
+        ɵɵselect(0);
+        ɵɵproperty('val', 1);
         ɵɵselect(3);
-        ɵɵelementProperty(3, 'val', 4);
+        ɵɵproperty('val', 4);
         ɵɵcontainerRefreshStart(2);
         {
           for (let i = 2; i < 4; i++) {
@@ -640,7 +651,8 @@ describe('lifecycles', () => {
               ɵɵelementEnd();
             }
             if (rf1 & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'val', i);
+              ɵɵselect(0);
+              ɵɵproperty('val', i);
             }
             ɵɵembeddedViewEnd();
           }
@@ -751,14 +763,15 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 33);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 2);
+          ɵɵproperty('val', 44);
         }
       }, 4, 0, directives);
 
       const fixture = new ComponentFixture(App);
-      expect(events).toEqual(['parent1', 'parent2', 'comp1', 'comp2']);
+      expect(events).toEqual(['parent33', 'parent44', 'comp33', 'comp44']);
     });
 
     it('should be called in projected components before their hosts', () => {
@@ -820,13 +833,14 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 1);
+          ɵɵproperty('val', 1);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val', 2);
+          ɵɵproperty('val', 2);
           ɵɵselect(4);
-          ɵɵelementProperty(4, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 6, 0, directives);
 
@@ -853,9 +867,10 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val', 4);
+          ɵɵproperty('val', 4);
           ɵɵcontainerRefreshStart(2);
           {
             for (let i = 2; i < 4; i++) {
@@ -866,7 +881,8 @@ describe('lifecycles', () => {
                 ɵɵelementEnd();
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', i);
+                ɵɵselect(0);
+                ɵɵproperty('val', i);
               }
               ɵɵembeddedViewEnd();
             }
@@ -1101,9 +1117,10 @@ describe('lifecycles', () => {
           ɵɵelement(1, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 2, 0, defs);
 
@@ -1149,13 +1166,14 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 1);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 2);
+          ɵɵproperty('val', 2);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 4, 0, defs);
 
@@ -1176,9 +1194,10 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+          ɵɵselect(0);
+          ɵɵproperty('val', ctx.val);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', ɵɵbind(ctx.val));
+          ɵɵproperty('val', ctx.val);
         }
       }, 2, 2, [Comp, ProjectedComp]);
 
@@ -1192,9 +1211,10 @@ describe('lifecycles', () => {
           ɵɵelement(1, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 2);
+          ɵɵproperty('val', 2);
         }
       }, 2, 0, [ParentComp]);
 
@@ -1217,9 +1237,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 4);
+          ɵɵproperty('val', 4);
           ɵɵcontainerRefreshStart(1);
           {
             for (let i = 2; i < 4; i++) {
@@ -1228,7 +1249,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', i);
+                ɵɵselect(0);
+                ɵɵproperty('val', i);
               }
               ɵɵembeddedViewEnd();
             }
@@ -1257,9 +1279,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', 4);
+          ɵɵproperty('val', 4);
           ɵɵcontainerRefreshStart(1);
           {
             for (let i = 2; i < 4; i++) {
@@ -1268,7 +1291,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'parent');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', i);
+                ɵɵselect(0);
+                ɵɵproperty('val', i);
               }
               ɵɵembeddedViewEnd();
             }
@@ -1316,7 +1340,8 @@ describe('lifecycles', () => {
             ɵɵelement(0, 'comp');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'val', ɵɵbind(ctx.myVal));
+            ɵɵselect(0);
+            ɵɵproperty('val', ctx.myVal);
           }
         }, 1, 1, defs);
 
@@ -1343,9 +1368,10 @@ describe('lifecycles', () => {
             ɵɵelement(2, 'parent');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'val', 1);
+            ɵɵselect(0);
+            ɵɵproperty('val', 1);
             ɵɵselect(2);
-            ɵɵelementProperty(2, 'val', 4);
+            ɵɵproperty('val', 4);
             ɵɵcontainerRefreshStart(1);
             {
               for (let i = 2; i < 4; i++) {
@@ -1354,7 +1380,8 @@ describe('lifecycles', () => {
                   ɵɵelement(0, 'parent');
                 }
                 if (rf1 & RenderFlags.Update) {
-                  ɵɵelementProperty(0, 'val', i);
+                  ɵɵselect(0);
+                  ɵɵproperty('val', i);
                 }
                 ɵɵembeddedViewEnd();
               }
@@ -1505,9 +1532,10 @@ describe('lifecycles', () => {
                 ɵɵelement(1, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', ɵɵbind('1'));
+                ɵɵselect(0);
+                ɵɵproperty('val', '1');
                 ɵɵselect(1);
-                ɵɵelementProperty(1, 'val', ɵɵbind('2'));
+                ɵɵproperty('val', '2');
               }
               ɵɵembeddedViewEnd();
             }
@@ -1622,13 +1650,14 @@ describe('lifecycles', () => {
                 ɵɵelementEnd();
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', 1);
+                ɵɵselect(0);
+                ɵɵproperty('val', 1);
                 ɵɵselect(1);
-                ɵɵelementProperty(1, 'val', 1);
+                ɵɵproperty('val', 1);
                 ɵɵselect(2);
-                ɵɵelementProperty(2, 'val', 2);
+                ɵɵproperty('val', 2);
                 ɵɵselect(3);
-                ɵɵelementProperty(3, 'val', 2);
+                ɵɵproperty('val', 2);
               }
               ɵɵembeddedViewEnd();
             }
@@ -1671,9 +1700,10 @@ describe('lifecycles', () => {
                 ɵɵelement(2, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', ɵɵbind('1'));
+                ɵɵselect(0);
+                ɵɵproperty('val', '1');
                 ɵɵselect(2);
-                ɵɵelementProperty(2, 'val', ɵɵbind('3'));
+                ɵɵproperty('val', '3');
                 ɵɵcontainerRefreshStart(1);
                 {
                   if (ctx.condition2) {
@@ -1682,7 +1712,8 @@ describe('lifecycles', () => {
                       ɵɵelement(0, 'comp');
                     }
                     if (rf2 & RenderFlags.Update) {
-                      ɵɵelementProperty(0, 'val', ɵɵbind('2'));
+                      ɵɵselect(0);
+                      ɵɵproperty('val', '2');
                     }
                     ɵɵembeddedViewEnd();
                   }
@@ -1765,9 +1796,10 @@ describe('lifecycles', () => {
                 ɵɵelement(2, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val', ɵɵbind('1'));
+                ɵɵselect(0);
+                ɵɵproperty('val', '1');
                 ɵɵselect(2);
-                ɵɵelementProperty(2, 'val', ɵɵbind('5'));
+                ɵɵproperty('val', '5');
                 ɵɵcontainerRefreshStart(1);
                 {
                   for (let j = 2; j < ctx.len; j++) {
@@ -1776,7 +1808,8 @@ describe('lifecycles', () => {
                       ɵɵelement(0, 'comp');
                     }
                     if (rf2 & RenderFlags.Update) {
-                      ɵɵelementProperty(0, 'val', ɵɵbind(j));
+                      ɵɵselect(0);
+                      ɵɵproperty('val', j);
                     }
                     ɵɵembeddedViewEnd();
                   }
@@ -1995,8 +2028,8 @@ describe('lifecycles', () => {
         ɵɵelement(0, 'comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'val1', ɵɵbind(ctx.a));
-        ɵɵelementProperty(0, 'publicVal2', ɵɵbind(ctx.b));
+        ɵɵselect(0);
+        ɵɵproperty('val1', ctx.a)('publicVal2', ctx.b);
       }
     }, 1, 2, [Comp]);
 
@@ -2067,8 +2100,8 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(ctx.val1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(ctx.val2));
+          ɵɵselect(0);
+          ɵɵproperty('val1', ctx.val1)('publicVal2', ctx.val2);
         }
       }, 1, 2, defs);
 
@@ -2113,8 +2146,8 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(ctx.val1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(ctx.val2));
+          ɵɵselect(0);
+          ɵɵproperty('val1', ctx.val1)('publicVal2', ctx.val2);
         }
       }, 1, 2, defs);
 
@@ -2158,11 +2191,11 @@ describe('lifecycles', () => {
           ɵɵelement(1, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val1', ɵɵbind(2));
-          ɵɵelementProperty(1, 'publicVal2', ɵɵbind(2));
+          ɵɵselect(1);
+          ɵɵproperty('val1', 2)('publicVal2', 2);
         }
       }, 2, 4, defs);
 
@@ -2224,8 +2257,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-                ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+                ɵɵselect(0);
+                ɵɵproperty('val1', 1)('publicVal2', 1);
               }
               ɵɵembeddedViewEnd();
             }
@@ -2296,11 +2329,10 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val1', ɵɵbind(2));
-          ɵɵelementProperty(1, 'publicVal2', ɵɵbind(2));
+          ɵɵproperty('val1', 2)('publicVal2', 2);
         }
       }, 2, 4, defs);
 
@@ -2344,17 +2376,14 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val1', ɵɵbind(2));
-          ɵɵelementProperty(1, 'publicVal2', ɵɵbind(2));
+          ɵɵproperty('val1', 2)('publicVal2', 2);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val1', ɵɵbind(3));
-          ɵɵelementProperty(2, 'publicVal2', ɵɵbind(3));
+          ɵɵproperty('val1', 3)('publicVal2', 3);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val1', ɵɵbind(4));
-          ɵɵelementProperty(3, 'publicVal2', ɵɵbind(4));
+          ɵɵproperty('val1', 4)('publicVal2', 4);
         }
       }, 4, 8, defs);
 
@@ -2404,8 +2433,8 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'comp', ['dir', '']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
         }
       }, 1, 2, defs);
 
@@ -2445,8 +2474,8 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'div', ['dir', '']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
         }
       }, 1, 2, defs);
 
@@ -2481,11 +2510,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val1', ɵɵbind(5));
-          ɵɵelementProperty(2, 'publicVal2', ɵɵbind(5));
+          ɵɵproperty('val1', 5)('publicVal2', 5);
           ɵɵcontainerRefreshStart(1);
           {
             for (let j = 2; j < 5; j++) {
@@ -2494,8 +2522,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'comp');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val1', ɵɵbind(j));
-                ɵɵelementProperty(0, 'publicVal2', ɵɵbind(j));
+                ɵɵselect(0);
+                ɵɵproperty('val1', j)('publicVal2', j);
               }
               ɵɵembeddedViewEnd();
             }
@@ -2568,11 +2596,10 @@ describe('lifecycles', () => {
           ɵɵelement(2, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val1', ɵɵbind(1));
-          ɵɵelementProperty(0, 'publicVal2', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val1', 1)('publicVal2', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val1', ɵɵbind(5));
-          ɵɵelementProperty(2, 'publicVal2', ɵɵbind(5));
+          ɵɵproperty('val1', 5)('publicVal2', 5);
           ɵɵcontainerRefreshStart(1);
           {
             for (let j = 2; j < 5; j++) {
@@ -2581,8 +2608,8 @@ describe('lifecycles', () => {
                 ɵɵelement(0, 'parent');
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'val1', ɵɵbind(j));
-                ɵɵelementProperty(0, 'publicVal2', ɵɵbind(j));
+                ɵɵselect(0);
+                ɵɵproperty('val1', j)('publicVal2', j);
               }
               ɵɵembeddedViewEnd();
             }
@@ -2699,7 +2726,8 @@ describe('lifecycles', () => {
               ɵɵelement(0, 'div');
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'id', ɵɵbind(ctx.a));
+              ɵɵselect(0);
+              ɵɵproperty('id', ctx.a);
             }
           },
           selectors: [['my-comp']],
@@ -2720,7 +2748,8 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'my-comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'value', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('value', 1);
         }
       }, 1, 1, [MyComp]);
 
@@ -2774,6 +2803,8 @@ describe('lifecycles', () => {
     it('should call all hooks in correct order', () => {
       const Comp = createAllHooksComponent('comp', (rf: RenderFlags, ctx: any) => {});
 
+      let val = 0;
+
       /**
        * <comp [val]="1"></comp>
        * <comp [val]="2"></comp>
@@ -2789,24 +2820,25 @@ describe('lifecycles', () => {
         // This means when `fixture.update()` is called below, ngOnChanges should fire,
         // even though the *value* itself never changed.
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          ɵɵselect(0);
+          ɵɵproperty('val', val++);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 2);
+          ɵɵproperty('val', val++);
         }
-      }, 2, 0, [Comp]);
+      }, 2, 2, [Comp]);
 
       const fixture = new ComponentFixture(App);
       expect(events).toEqual([
-        'changes comp1', 'init comp1', 'check comp1', 'changes comp2', 'init comp2', 'check comp2',
-        'contentInit comp1', 'contentCheck comp1', 'contentInit comp2', 'contentCheck comp2',
-        'viewInit comp1', 'viewCheck comp1', 'viewInit comp2', 'viewCheck comp2'
+        'changes comp0', 'init comp0', 'check comp0', 'changes comp1', 'init comp1', 'check comp1',
+        'contentInit comp0', 'contentCheck comp0', 'contentInit comp1', 'contentCheck comp1',
+        'viewInit comp0', 'viewCheck comp0', 'viewInit comp1', 'viewCheck comp1'
       ]);
 
       events = [];
-      fixture.update();  // Changes are made due to lack of `bind()` call in template fn.
+      fixture.update();  // Changes are made due to incrementing `val` in bindings above.
       expect(events).toEqual([
-        'changes comp1', 'check comp1', 'changes comp2', 'check comp2', 'contentCheck comp1',
-        'contentCheck comp2', 'viewCheck comp1', 'viewCheck comp2'
+        'changes comp2', 'check comp2', 'changes comp3', 'check comp3', 'contentCheck comp2',
+        'contentCheck comp3', 'viewCheck comp2', 'viewCheck comp3'
       ]);
     });
 
@@ -2819,47 +2851,48 @@ describe('lifecycles', () => {
           ɵɵelement(0, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+          ɵɵselect(0);
+          ɵɵproperty('val', ctx.val);
         }
       }, 1, 1, [Comp]);
 
-      /**
-       * <parent [val]="1"></parent>
-       * <parent [val]="2"></parent>
-       */
+      let val = 0;
+
       const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           ɵɵelement(0, 'parent');
           ɵɵelement(1, 'parent');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', 1);
+          // NOTE: The incrementing `val++` below ensures ngOnChanges will be called.
+          ɵɵselect(0);
+          ɵɵproperty('val', val++);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', 2);
+          ɵɵproperty('val', val++);
         }
-      }, 2, 0, [Parent]);
+      }, 2, 2, [Parent]);
 
       const fixture = new ComponentFixture(App);
       expect(events).toEqual([
+        'changes parent0',      'init parent0',         'check parent0',
         'changes parent1',      'init parent1',         'check parent1',
-        'changes parent2',      'init parent2',         'check parent2',
-        'contentInit parent1',  'contentCheck parent1', 'contentInit parent2',
-        'contentCheck parent2', 'changes comp1',        'init comp1',
-        'check comp1',          'contentInit comp1',    'contentCheck comp1',
-        'viewInit comp1',       'viewCheck comp1',      'changes comp2',
-        'init comp2',           'check comp2',          'contentInit comp2',
-        'contentCheck comp2',   'viewInit comp2',       'viewCheck comp2',
-        'viewInit parent1',     'viewCheck parent1',    'viewInit parent2',
-        'viewCheck parent2'
+        'contentInit parent0',  'contentCheck parent0', 'contentInit parent1',
+        'contentCheck parent1', 'changes comp0',        'init comp0',
+        'check comp0',          'contentInit comp0',    'contentCheck comp0',
+        'viewInit comp0',       'viewCheck comp0',      'changes comp1',
+        'init comp1',           'check comp1',          'contentInit comp1',
+        'contentCheck comp1',   'viewInit comp1',       'viewCheck comp1',
+        'viewInit parent0',     'viewCheck parent0',    'viewInit parent1',
+        'viewCheck parent1'
       ]);
 
       events = [];
       fixture.update();
       expect(events).toEqual([
-        'changes parent1', 'check parent1', 'changes parent2', 'check parent2',
-        'contentCheck parent1', 'contentCheck parent2', 'check comp1', 'contentCheck comp1',
-        'viewCheck comp1', 'check comp2', 'contentCheck comp2', 'viewCheck comp2',
-        'viewCheck parent1', 'viewCheck parent2'
+        'changes parent2', 'check parent2', 'changes parent3', 'check parent3',
+        'contentCheck parent2', 'contentCheck parent3', 'changes comp2', 'check comp2',
+        'contentCheck comp2', 'viewCheck comp2', 'changes comp3', 'check comp3',
+        'contentCheck comp3', 'viewCheck comp3', 'viewCheck parent2', 'viewCheck parent3'
       ]);
 
     });
@@ -2879,7 +2912,7 @@ describe('lifecycles', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', ɵɵbind(ctx.val));
+          ɵɵproperty('val', ctx.val);
         }
       }, 2, 1, [View]);
 
@@ -2901,13 +2934,14 @@ describe('lifecycles', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'val', ɵɵbind(1));
+          ɵɵselect(0);
+          ɵɵproperty('val', 1);
           ɵɵselect(1);
-          ɵɵelementProperty(1, 'val', ɵɵbind(1));
+          ɵɵproperty('val', 1);
           ɵɵselect(2);
-          ɵɵelementProperty(2, 'val', ɵɵbind(2));
+          ɵɵproperty('val', 2);
           ɵɵselect(3);
-          ɵɵelementProperty(3, 'val', ɵɵbind(2));
+          ɵɵproperty('val', 2);
         }
       }, 4, 4, [Parent, Content]);
 
@@ -2983,7 +3017,8 @@ describe('lifecycles', () => {
           ɵɵtemplate(0, conditionTpl, 1, 1, 'ng-template', [AttributeMarker.Bindings, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'ngIf', ɵɵbind(cmpt.showing));
+          ɵɵselect(0);
+          ɵɵproperty('ngIf', ɵɵbind(cmpt.showing));
         }
       }
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,8 +8,8 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
+import {ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {containerEl, renderToHtml} from './render_util';
@@ -381,7 +381,8 @@ describe('outputs', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'change', ɵɵbind(ctx.change));
+        ɵɵselect(0);
+        ɵɵproperty('change', ctx.change);
       }
     }
 

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -11,7 +11,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {createInjector} from '../../src/di/r3_injector';
 import {ɵɵdefineDirective, ɵɵdefinePipe} from '../../src/render3/definition';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵload, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵload, ɵɵproperty, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵpipe, ɵɵpipeBind1, ɵɵpipeBind3, ɵɵpipeBind4, ɵɵpipeBindV} from '../../src/render3/pipe';
 
@@ -109,7 +109,8 @@ describe('pipe', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'elprop', ɵɵbind(ɵɵpipeBind1(1, 1, ctx)));
+        ɵɵselect(0);
+        ɵɵproperty('elprop', ɵɵpipeBind1(1, 1, ctx));
         directive = getDirectiveOnNode(0);
       }
     }
@@ -171,7 +172,8 @@ describe('pipe', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'id', ɵɵbind(ɵɵpipeBind1(1, 1, 'Megatron')));
+        ɵɵselect(0);
+        ɵɵproperty('id', ɵɵpipeBind1(1, 1, 'Megatron'));
       }
     }
 
@@ -256,8 +258,10 @@ describe('pipe', () => {
           ɵɵcontainer(4);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'id', ɵɵbind(ɵɵpipeBind1(1, 2, true)));
-          ɵɵelementProperty(2, 'id', ɵɵbind(ɵɵpipeBind1(3, 4, true)));
+          ɵɵselect(0);
+          ɵɵproperty('id', ɵɵpipeBind1(1, 2, true));
+          ɵɵselect(2);
+          ɵɵproperty('id', ɵɵpipeBind1(3, 4, true));
           pipeInstances.push(ɵɵload<CountingImpurePipe>(1), ɵɵload(3));
           ɵɵcontainerRefreshStart(4);
           {
@@ -270,7 +274,8 @@ describe('pipe', () => {
                   ɵɵelementEnd();
                 }
                 if (rf1 & RenderFlags.Update) {
-                  ɵɵelementProperty(0, 'id', ɵɵbind(ɵɵpipeBind1(1, 1, true)));
+                  ɵɵselect(0);
+                  ɵɵproperty('id', ɵɵpipeBind1(1, 1, true));
                   pipeInstances.push(ɵɵload<CountingImpurePipe>(1));
                 }
               }

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
+import {ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
 import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵlistener, ɵɵload, ɵɵreference, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
@@ -22,7 +22,8 @@ describe('elementProperty', () => {
         ɵɵelement(0, 'span');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id));
+        ɵɵselect(0);
+        ɵɵproperty('id', ctx.id);
       }
     }, 1, 1);
 
@@ -145,8 +146,8 @@ describe('elementProperty', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'disabled', ɵɵbind(ctx.isDisabled));
-          ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id));
+          ɵɵselect(0);
+          ɵɵproperty('disabled', ctx.isDisabled)('id', ctx.id);
         }
       }, 2, 2, deps);
 
@@ -176,8 +177,8 @@ describe('elementProperty', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'disabled', ɵɵbind(ctx.isDisabled));
-          ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id));
+          ɵɵselect(0);
+          ɵɵproperty('disabled', ctx.isDisabled)('id', ctx.id);
         }
       }, 2, 2, deps);
 
@@ -220,7 +221,8 @@ describe('elementProperty', () => {
           ɵɵelement(0, 'comp');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id));
+          ɵɵselect(0);
+          ɵɵproperty('id', ctx.id);
         }
       }, 1, 1, [Comp]);
 
@@ -246,7 +248,8 @@ describe('elementProperty', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'disabled', ɵɵbind(ctx.isDisabled));
+          ɵɵselect(0);
+          ɵɵproperty('disabled', ctx.isDisabled);
         }
       }, 2, 1, deps);
 
@@ -276,7 +279,8 @@ describe('elementProperty', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id));
+          ɵɵselect(0);
+          ɵɵproperty('id', ctx.id);
         }
       }, 2, 1, deps);
 
@@ -314,7 +318,8 @@ describe('elementProperty', () => {
           ɵɵcontainer(2);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id1));
+          ɵɵselect(0);
+          ɵɵproperty('id', ctx.id1);
           ɵɵcontainerRefreshStart(2);
           {
             if (ctx.condition) {
@@ -325,7 +330,8 @@ describe('elementProperty', () => {
                 ɵɵelementEnd();
               }
               if (rf0 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id2));
+                ɵɵselect(0);
+                ɵɵproperty('id', ctx.id2);
               }
               ɵɵembeddedViewEnd();
             } else {
@@ -336,7 +342,8 @@ describe('elementProperty', () => {
                 ɵɵelementEnd();
               }
               if (rf1 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'id', ɵɵbind(ctx.id3));
+                ɵɵselect(0);
+                ɵɵproperty('id', ctx.id3);
               }
               ɵɵembeddedViewEnd();
             }
@@ -422,7 +429,8 @@ describe('elementProperty', () => {
           ɵɵelement(0, 'div', ['role', 'button', 'myDir', '']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'role', ɵɵbind(ctx.role));
+          ɵɵselect(0);
+          ɵɵproperty('role', ctx.role);
         }
       }, 1, 1, deps);
 

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AttributeMarker, ɵɵdefineComponent, ɵɵtemplate} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵpureFunction1, ɵɵpureFunction2, ɵɵpureFunction3, ɵɵpureFunction4, ɵɵpureFunction5, ɵɵpureFunction6, ɵɵpureFunction7, ɵɵpureFunction8, ɵɵpureFunctionV} from '../../src/render3/pure_function';
 import {ComponentFixture, createComponent, getDirectiveOnNode, renderToHtml} from '../../test/render3/render_util';
@@ -42,7 +42,8 @@ describe('array literals', () => {
         ɵɵelement(0, 'my-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'names', ɵɵbind(ɵɵpureFunction1(1, e0_ff, ctx.customName)));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction1(1, e0_ff, ctx.customName));
       }
     }, 1, 3, directives);
 
@@ -79,7 +80,8 @@ describe('array literals', () => {
       }
       if (rf & RenderFlags.Update) {
         const comp = ɵɵnextContext();
-        ɵɵelementProperty(0, 'names', ɵɵbind(ɵɵpureFunction1(1, e0_ff, comp.customName)));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction1(1, e0_ff, comp.customName));
       }
     }
 
@@ -93,7 +95,8 @@ describe('array literals', () => {
             [AttributeMarker.Bindings, 'names', AttributeMarker.Template, 'ngIf']);
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
+        ɵɵselect(0);
+        ɵɵproperty('ngIf', ctx.showing);
       }
     }, 1, 1, [MyComp, NgIf]);
 
@@ -137,8 +140,9 @@ describe('array literals', () => {
         ɵɵelement(0, 'many-prop-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'names1', ɵɵbind(ɵɵpureFunction1(2, e0_ff, ctx.customName)));
-        ɵɵelementProperty(0, 'names2', ɵɵbind(ɵɵpureFunction1(4, e0_ff_1, ctx.customName2)));
+        ɵɵselect(0);
+        ɵɵproperty('names1', ɵɵpureFunction1(2, e0_ff, ctx.customName))(
+            'names2', ɵɵpureFunction1(4, e0_ff_1, ctx.customName2));
       }
     }, 1, 6, [ManyPropComp]);
 
@@ -183,8 +187,8 @@ describe('array literals', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(
-                0, 'names', ɵɵbind(ctx.someFn(ɵɵpureFunction1(1, e0_ff, ctx.customName))));
+            ɵɵselect(0);
+            ɵɵproperty('names', ctx.someFn(ɵɵpureFunction1(1, e0_ff, ctx.customName)));
           }
         },
         directives: directives
@@ -221,8 +225,8 @@ describe('array literals', () => {
         ɵɵelement(0, 'my-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(
-            0, 'names', ɵɵbind(ɵɵpureFunction2(1, e0_ff, ctx.customName, ctx.customName2)));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction2(1, e0_ff, ctx.customName, ctx.customName2));
       }
     }, 1, 4, directives);
 
@@ -299,18 +303,19 @@ describe('array literals', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'names', ɵɵbind(ɵɵpureFunction3(6, e0_ff, c[5], c[6], c[7])));
-        ɵɵelementProperty(1, 'names', ɵɵbind(ɵɵpureFunction4(10, e2_ff, c[4], c[5], c[6], c[7])));
-        ɵɵelementProperty(
-            2, 'names', ɵɵbind(ɵɵpureFunction5(15, e4_ff, c[3], c[4], c[5], c[6], c[7])));
-        ɵɵelementProperty(
-            3, 'names', ɵɵbind(ɵɵpureFunction6(21, e6_ff, c[2], c[3], c[4], c[5], c[6], c[7])));
-        ɵɵelementProperty(
-            4, 'names',
-            ɵɵbind(ɵɵpureFunction7(28, e8_ff, c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
-        ɵɵelementProperty(
-            5, 'names',
-            ɵɵbind(ɵɵpureFunction8(36, e10_ff, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
+        ɵɵselect(0);
+        ɵɵproperty('names', ɵɵpureFunction3(6, e0_ff, c[5], c[6], c[7]));
+        ɵɵselect(1);
+        ɵɵproperty('names', ɵɵpureFunction4(10, e2_ff, c[4], c[5], c[6], c[7]));
+        ɵɵselect(2);
+        ɵɵproperty('names', ɵɵpureFunction5(15, e4_ff, c[3], c[4], c[5], c[6], c[7]));
+        ɵɵselect(3);
+        ɵɵproperty('names', ɵɵpureFunction6(21, e6_ff, c[2], c[3], c[4], c[5], c[6], c[7]));
+        ɵɵselect(4);
+        ɵɵproperty('names', ɵɵpureFunction7(28, e8_ff, c[1], c[2], c[3], c[4], c[5], c[6], c[7]));
+        ɵɵselect(5);
+        ɵɵproperty(
+            'names', ɵɵpureFunction8(36, e10_ff, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]));
       }
     }
 
@@ -356,10 +361,11 @@ describe('array literals', () => {
         ɵɵelement(0, 'my-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(
-            0, 'names', ɵɵbind(ɵɵpureFunctionV(3, e0_ff, [
+        ɵɵselect(0);
+        ɵɵproperty(
+            'names', ɵɵpureFunctionV(3, e0_ff, [
               c[0], c[1], c[2], c[3], ɵɵpureFunction1(1, e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
-            ])));
+            ]));
       }
     }
 
@@ -409,7 +415,8 @@ describe('object literals', () => {
         ɵɵelement(0, 'object-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'config', ɵɵbind(ɵɵpureFunction1(1, e0_ff, ctx.name)));
+        ɵɵselect(0);
+        ɵɵproperty('config', ɵɵpureFunction1(1, e0_ff, ctx.name));
       }
     }, 1, 3, defs);
 
@@ -446,11 +453,11 @@ describe('object literals', () => {
         ɵɵelement(0, 'object-comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(
-            0, 'config',
-            ɵɵbind(ɵɵpureFunction2(
-                5, e0_ff, ctx.name,
-                ɵɵpureFunction1(3, e0_ff_1, ɵɵpureFunction1(1, e0_ff_2, ctx.duration)))));
+        ɵɵselect(0);
+        ɵɵproperty(
+            'config', ɵɵpureFunction2(
+                          5, e0_ff, ctx.name,
+                          ɵɵpureFunction1(3, e0_ff_1, ɵɵpureFunction1(1, e0_ff_2, ctx.duration))));
       }
     }, 1, 8, defs);
 
@@ -525,9 +532,10 @@ describe('object literals', () => {
               ɵɵelementEnd();
             }
             if (rf1 & RenderFlags.Update) {
-              ɵɵelementProperty(
-                  0, 'config', ɵɵbind(ɵɵpureFunction2(
-                                   1, e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
+              ɵɵselect(0);
+              ɵɵproperty(
+                  'config',
+                  ɵɵpureFunction2(1, e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration));
             }
             ɵɵembeddedViewEnd();
           }

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -10,8 +10,8 @@ import {NgForOfContext} from '@angular/common';
 import {ElementRef, QueryList, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {EventEmitter} from '../..';
-import {AttributeMarker, detectChanges, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵload, ɵɵreference, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, detectChanges, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵload, ɵɵreference, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, ɵɵcontentQuery, ɵɵloadContentQuery, ɵɵloadViewQuery, ɵɵqueryRefresh, ɵɵviewQuery} from '../../src/render3/query';
 import {getLView} from '../../src/render3/state';
@@ -1399,7 +1399,8 @@ describe('query', () => {
                     0, Cmpt_Template_1, 2, 0, 'ng-template', [AttributeMarker.Bindings, 'ngIf']);
               }
               if (rf & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.value));
+                ɵɵselect(0);
+                ɵɵproperty('ngIf', ctx.value);
               }
             },
             2, 1, [NgIf], [],
@@ -1434,7 +1435,8 @@ describe('query', () => {
             ɵɵelement(0, 'div', null, ['foo', '']);
           }
           if (rf1 & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'id', ɵɵbind(row.$implicit));
+            ɵɵselect(0);
+            ɵɵproperty('id', row.$implicit);
           }
         }
 
@@ -1461,7 +1463,8 @@ describe('query', () => {
                 ɵɵtemplate(0, Cmpt_Template_1, 2, 1, 'ng-template', ['ngForOf', '']);
               }
               if (rf & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.value));
+                ɵɵselect(0);
+                ɵɵproperty('ngForOf', ctx.value);
               }
             },
             viewQuery: function(rf: RenderFlags, ctx: Cmpt) {
@@ -1507,7 +1510,8 @@ describe('query', () => {
                ɵɵelement(0, 'div', null, ['foo', '']);
              }
              if (rf & RenderFlags.Update) {
-               ɵɵelementProperty(0, 'id', ɵɵbind('foo1_' + ctx.idx));
+               ɵɵselect(0);
+               ɵɵproperty('id', 'foo1_' + ctx.idx);
              }
            }
 
@@ -1516,7 +1520,8 @@ describe('query', () => {
                ɵɵelement(0, 'div', null, ['foo', '']);
              }
              if (rf & RenderFlags.Update) {
-               ɵɵelementProperty(0, 'id', ɵɵbind('foo2_' + ctx.idx));
+               ɵɵselect(0);
+               ɵɵproperty('id', 'foo2_' + ctx.idx);
              }
            }
 
@@ -1616,7 +1621,8 @@ describe('query', () => {
                ɵɵelement(0, 'div', null, ['foo', '']);
              }
              if (rf & RenderFlags.Update) {
-               ɵɵelementProperty(0, 'id', ɵɵbind('foo_' + ctx.container_idx + '_' + ctx.idx));
+               ɵɵselect(0);
+               ɵɵproperty('id', 'foo_' + ctx.container_idx + '_' + ctx.idx);
              }
            }
 
@@ -1720,7 +1726,8 @@ describe('query', () => {
               }
               if (rf & RenderFlags.Update) {
                 const tplRef = ɵɵreference(1);
-                ɵɵelementProperty(2, 'ngTemplateOutlet', ɵɵbind(myApp.show ? tplRef : null));
+                ɵɵselect(2);
+                ɵɵproperty('ngTemplateOutlet', myApp.show ? tplRef : null);
               }
             },
             directives: () => [NgTemplateOutlet],
@@ -2402,7 +2409,8 @@ describe('query', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.showing));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', ctx.showing);
         }
       }, 2, 1, [ShallowComp, NgIf]);
 

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -10,8 +10,8 @@ import {AnimationEvent} from '@angular/animations';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
-import {ɵɵdefineComponent} from '../../src/render3/index';
-import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
+import {ɵɵdefineComponent, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {tick, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -176,7 +176,8 @@ describe('animation renderer factory', () => {
           ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, '@myAnimation', ɵɵbind(ctx.exp));
+          ɵɵselect(0);
+          ɵɵproperty('@myAnimation', ctx.exp);
         }
       },
       factory: () => new SomeComponentWithAnimation,

--- a/packages/core/test/render3/template_ref_spec.ts
+++ b/packages/core/test/render3/template_ref_spec.ts
@@ -8,8 +8,8 @@
 
 import {TemplateRef} from '@angular/core';
 
-import {AttributeMarker, RenderFlags, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵbind, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementProperty, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, RenderFlags, ɵɵdefineDirective, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 
 import {NgIf} from './common_with_def';
 import {ComponentFixture, createComponent, getDirectiveOnNode} from './render_util';
@@ -111,7 +111,8 @@ describe('TemplateRef', () => {
           ɵɵtemplate(0, ngIfTemplate, 1, 0, 'ng-template', [AttributeMarker.Bindings, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'ngIf', ɵɵbind(ctx.showing));
+          ɵɵselect(0);
+          ɵɵproperty('ngIf', ctx.showing);
         }
       }
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -9,7 +9,7 @@
 import {ChangeDetectorRef, Component as _Component, ComponentFactoryResolver, ComponentRef, ɵɵdefineInjector, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, QueryList, RendererFactory2, TemplateRef, ViewContainerRef, ViewRef, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef,} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
 import {ViewEncapsulation} from '../../src/metadata';
-import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefinePipe, injectComponentFactoryResolver, ɵɵlistener, ɵɵloadViewQuery, ɵɵNgOnChangesFeature, ɵɵqueryRefresh, ɵɵviewQuery,} from '../../src/render3/index';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefinePipe, injectComponentFactoryResolver, ɵɵlistener, ɵɵloadViewQuery, ɵɵNgOnChangesFeature, ɵɵqueryRefresh, ɵɵviewQuery, ɵɵselect, ɵɵproperty,} from '../../src/render3/index';
 
 import {ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementHostAttrs, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵinterpolation3, ɵɵnextContext, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵtemplate, ɵɵtext, ɵɵtextBinding,} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
@@ -85,7 +85,8 @@ describe('ViewContainerRef', () => {
 
     function updateTemplate() {
       const tplRef = ɵɵreference(1);
-      ɵɵelementProperty(2, 'tplRef', ɵɵbind(tplRef));
+      ɵɵselect(2);
+      ɵɵproperty('tplRef', tplRef);
     }
 
     describe('createEmbeddedView (incl. insert)', () => {
@@ -184,8 +185,10 @@ describe('ViewContainerRef', () => {
 
         function update() {
           const tplRef = ɵɵreference(1);
-          ɵɵelementProperty(2, 'tplRef', ɵɵbind(tplRef));
-          ɵɵelementProperty(3, 'tplRef', ɵɵbind(tplRef));
+          ɵɵselect(2);
+          ɵɵproperty('tplRef', tplRef);
+          ɵɵselect(3);
+          ɵɵproperty('tplRef', tplRef);
         }
 
         const fixture = new TemplateFixture(createTemplate, update, 4, 2, [DirectiveWithVCRef]);
@@ -211,7 +214,8 @@ describe('ViewContainerRef', () => {
 
         function updateTemplate() {
           const tplRef = ɵɵreference(1);
-          ɵɵelementProperty(0, 'tplRef', ɵɵbind(tplRef));
+          ɵɵselect(0);
+          ɵɵproperty('tplRef', tplRef);
         }
 
         const fixture =
@@ -453,7 +457,8 @@ describe('ViewContainerRef', () => {
             ɵɵpipe(1, 'starPipe');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'name', ɵɵbind(ɵɵpipeBind1(1, 1, 'C')));
+            ɵɵselect(0);
+            ɵɵproperty('name', ɵɵpipeBind1(1, 1, 'C'));
           }
         }
 
@@ -486,9 +491,10 @@ describe('ViewContainerRef', () => {
               }
               if (rf & RenderFlags.Update) {
                 const tplRef = ɵɵreference(1);
-                ɵɵelementProperty(3, 'tplRef', ɵɵbind(tplRef));
-                ɵɵelementProperty(3, 'name', ɵɵbind(ɵɵpipeBind1(2, 3, 'A')));
-                ɵɵelementProperty(5, 'name', ɵɵbind(ɵɵpipeBind1(4, 5, 'B')));
+                ɵɵselect(3);
+                ɵɵproperty('tplRef', tplRef)('name', ɵɵpipeBind1(2, 3, 'A'));
+                ɵɵselect(5);
+                ɵɵproperty('name', ɵɵpipeBind1(4, 5, 'B'));
               }
             },
             directives: [Child, DirectiveWithVCRef],
@@ -550,7 +556,8 @@ describe('ViewContainerRef', () => {
                    ɵɵelementEnd();
                  }
                  if (rf & RenderFlags.Update) {
-                   ɵɵelementProperty(0, 'tplDir', ɵɵbind(ctx.tpl));
+                   ɵɵselect(0);
+                   ɵɵproperty('tplDir', ctx.tpl);
                    ɵɵtextBinding(1, ɵɵbind(ctx.name));
                  }
                },
@@ -576,7 +583,8 @@ describe('ViewContainerRef', () => {
 
              if (rf & RenderFlags.Update) {
                const tplRef = ɵɵreference(1);
-               ɵɵelementProperty(2, 'tpl', ɵɵbind(tplRef));
+               ɵɵselect(2);
+               ɵɵproperty('tpl', tplRef);
              }
 
            }, 3, 1, [Child]);
@@ -635,8 +643,8 @@ describe('ViewContainerRef', () => {
               }
 
               if (rf & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'ngForOf', ɵɵbind(loop.rows));
-                ɵɵelementProperty(0, 'ngForTemplate', ɵɵbind(loop.tpl));
+                ɵɵselect(0);
+                ɵɵproperty('ngForOf', loop.rows)('ngForTemplate', loop.tpl);
               }
             },
             inputs: {tpl: 'tpl', rows: 'rows'},
@@ -669,8 +677,8 @@ describe('ViewContainerRef', () => {
 
           if (rf & RenderFlags.Update) {
             const rowTemplateRef = ɵɵreference(1);
-            ɵɵelementProperty(2, 'tpl', ɵɵbind(rowTemplateRef));
-            ɵɵelementProperty(2, 'rows', ɵɵbind(parent.rows));
+            ɵɵselect(2);
+            ɵɵproperty('tpl', rowTemplateRef)('rows', parent.rows);
           }
 
         }, 3, 2, [LoopComp]);
@@ -686,8 +694,8 @@ describe('ViewContainerRef', () => {
           if (rf & RenderFlags.Update) {
             const row = ctx.$implicit as any;
             const cellTemplateRef = ɵɵreference(1);
-            ɵɵelementProperty(2, 'tpl', ɵɵbind(cellTemplateRef));
-            ɵɵelementProperty(2, 'rows', ɵɵbind(row.data));
+            ɵɵselect(2);
+            ɵɵproperty('tpl', cellTemplateRef)('rows', row.data);
           }
         }
 
@@ -1343,8 +1351,8 @@ describe('ViewContainerRef', () => {
             let tplRef: any;
             if (rf & RenderFlags.Update) {
               tplRef = ɵɵreference(1);
-              ɵɵelementProperty(3, 'tplRef', ɵɵbind(tplRef));
-              ɵɵelementProperty(3, 'name', ɵɵbind(cmp.name));
+              ɵɵselect(3);
+              ɵɵproperty('tplRef', tplRef)('name', cmp.name);
             }
           },
           directives: [Child, DirectiveWithVCRef]
@@ -1438,8 +1446,8 @@ describe('ViewContainerRef', () => {
             }
             if (rf & RenderFlags.Update) {
               const tplRef = ɵɵreference(1);
-              ɵɵelementProperty(4, 'tplRef', ɵɵbind(tplRef));
-              ɵɵelementProperty(4, 'name', ɵɵbind(cmp.name));
+              ɵɵselect(4);
+              ɵɵproperty('tplRef', tplRef)('name', cmp.name);
             }
           },
           directives: [ChildWithView, DirectiveWithVCRef]
@@ -1521,8 +1529,8 @@ describe('ViewContainerRef', () => {
                  }
                  if (rf & RenderFlags.Update) {
                    tplRef = ɵɵreference(1);
-                   ɵɵelementProperty(3, 'tplRef', ɵɵbind(tplRef));
-                   ɵɵelementProperty(3, 'name', ɵɵbind(cmp.name));
+                   ɵɵselect(3);
+                   ɵɵproperty('tplRef', tplRef)('name', cmp.name);
                  }
                },
                directives: [ChildWithSelector, DirectiveWithVCRef]
@@ -1575,8 +1583,8 @@ describe('ViewContainerRef', () => {
                  }
                  if (rf & RenderFlags.Update) {
                    tplRef = ɵɵreference(1);
-                   ɵɵelementProperty(3, 'tplRef', ɵɵbind(tplRef));
-                   ɵɵelementProperty(3, 'name', ɵɵbind(cmp.name));
+                   ɵɵselect(3);
+                   ɵɵproperty('tplRef', tplRef)('name', cmp.name);
                  }
                },
                directives: [ChildWithSelector, DirectiveWithVCRef]
@@ -1648,7 +1656,8 @@ describe('ViewContainerRef', () => {
           ɵɵelement(0, 'hooks');
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(0, 'name', ɵɵbind('C'));
+          ɵɵselect(0);
+          ɵɵproperty('name', 'C');
         }
       }
 
@@ -1678,9 +1687,10 @@ describe('ViewContainerRef', () => {
             }
             if (rf & RenderFlags.Update) {
               const tplRef = ɵɵreference(1);
-              ɵɵelementProperty(2, 'tplRef', ɵɵbind(tplRef));
-              ɵɵelementProperty(2, 'name', ɵɵbind('A'));
-              ɵɵelementProperty(3, 'name', ɵɵbind('B'));
+              ɵɵselect(2);
+              ɵɵproperty('tplRef', tplRef)('name', 'A');
+              ɵɵselect(3);
+              ɵɵproperty('name', 'B');
             }
           },
           directives: [ComponentWithHooks, DirectiveWithVCRef],
@@ -1772,8 +1782,10 @@ describe('ViewContainerRef', () => {
               ɵɵelement(1, 'hooks');
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'name', ɵɵbind('A'));
-              ɵɵelementProperty(1, 'name', ɵɵbind('B'));
+              ɵɵselect(0);
+              ɵɵproperty('name', 'A');
+              ɵɵselect(1);
+              ɵɵproperty('name', 'B');
             }
           },
           directives: [ComponentWithHooks, DirectiveWithVCRef],

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -931,6 +931,8 @@ export declare function ɵɵprojection(nodeIndex: number, selectorIndex?: number
 
 export declare function ɵɵprojectionDef(selectors?: CssSelectorList[]): void;
 
+export declare function ɵɵproperty<T>(propName: string, value: T, sanitizer?: SanitizerFn | null, nativeOnly?: boolean): TsickleIssue1009;
+
 export declare function ɵɵProvidersFeature<T>(providers: Provider[], viewProviders?: Provider[]): (definition: DirectiveDef<T>) => void;
 
 export declare function ɵɵpureFunction0<T>(slotOffset: number, pureFn: () => T, thisArg?: any): T;


### PR DESCRIPTION
## WIP - Not ready for review

Updates the compiler to generate `ɵɵproperty` instructions rather than `ɵɵelementProperty(..., ɵɵbind(...)` instructions.

- Updates the compiler
- Fixes an issue where `setSelectedIndex` was being called too soon in `ɵɵselect`.
- Adds `executeTemplate` function to centralize what needs to be done when a template was called (in this case we need to call `ɵɵnamespaceHTML()` and then `setSelectedIndex(-1)`.
- Updates logic around executing embedded view templates to ensure that the currently selected index is reset to its previous after the embedded template runs. This is because running `ɵɵproperty` can trigger the execution of an embedded veiw's template (in cases like setting the `ngIf` property), and the selected index needs to be set to `-1` before the embedded template is run, and back to the appropriate value before the next `ɵɵproperty` instruction is run in the parent template.
- Updates hand-written tests using `ɵɵelementProperty` to use `ɵɵproperty`.
- Updates several hand-written template tests, particularly in `lifecycle_spec.ts` because they were making assumptions about the behavior of `ɵɵelementProperty` when `ɵɵbind` wasn't supplied.
- Updates the `vars` argument of several tests where bindings were being used, but no `vars` count was being supplied.
- Consolidates `setActiveHostElement` to be just `setSelectedIndex`.
- Ensures that selected index is _only_ set to `-1` in cases where we are just about to execute a template function.
- Ensures that selected index is captured and persisted when changed, after but the `ɵɵselect` instruction.
- Adds documentation noting that `setSelectedIndex` should never be called with `-1` unless a template is about to be executed, and that the current selected index should be captured and reset with a `try/finally` in cases where it's altered.
- DOES NOT update `ɵɵelementProperty` use for host bindings.
- DOES NOT update `ɵɵpropertyInterpolateX` generate
- NOTE: hello world size up slightly. This is likely because we're now generating more instructions, this should be reduced when we introduce chaining to code generation, and possibly with some refactoring of the instructions themselves.

The last two above will be done in separate PRs. This one did _enough_, haha.