### PR TITLE
fix(compiler): namespaced custom events

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -698,7 +698,7 @@ export class ParsedEvent {
   // Regular events have a target
   // Animation events have a phase
   constructor(
-      public name: string, public targetOrPhase: string, public type: ParsedEventType,
+      public name: string, public targetOrPhase: string|null, public type: ParsedEventType,
       public handler: AST, public sourceSpan: ParseSourceSpan,
       public handlerSpan: ParseSourceSpan) {}
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -792,7 +792,7 @@ function createHostListeners(
   return eventBindings.map(binding => {
     let bindingName = binding.name && sanitizeIdentifier(binding.name);
     const bindingFnName = binding.type === ParsedEventType.Animation ?
-        prepareSyntheticListenerFunctionName(bindingName, binding.targetOrPhase) :
+        prepareSyntheticListenerFunctionName(bindingName, binding.targetOrPhase !) :
         bindingName;
     const handlerName =
         meta.name && bindingName ? `${meta.name}_${bindingFnName}_HostBindingHandler` : null;

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -350,8 +350,15 @@ export class BindingParser {
   private _parseRegularEvent(
       name: string, expression: string, sourceSpan: ParseSourceSpan, handlerSpan: ParseSourceSpan,
       targetMatchableAttrs: string[][], targetEvents: ParsedEvent[]) {
-    // long format: 'target: eventName'
-    const [target, eventName] = splitAtColon(name, [null !, name]);
+    let target: string|null = null;
+    let eventName: string;
+
+    if (name.startsWith('^')) {
+      eventName = name.substring(1);
+    } else {
+      // long format: 'target: eventName'
+      [target, eventName] = splitAtColon(name, [null !, name]);
+    }
     const ast = this._parseAction(expression, handlerSpan);
     targetMatchableAttrs.push([name !, ast.source !]);
     targetEvents.push(

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -851,6 +851,13 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
           ]);
         });
 
+        it('should parse verbatim event names', () => {
+          expect(humanizeTplAst(parse('<div (^window:event)="v">', []))).toEqual([
+            [ElementAst, 'div'],
+            [BoundEventAst, 'window:event', null, 'v'],
+          ]);
+        });
+
         it('should report an error on empty expression', () => {
           expect(() => parse('<div (event)="">', []))
               .toThrowError(/Empty expressions are not allowed/);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #28491


## What is the new behavior?
New syntax for event namespaces - 
`<my-component (^namespace:event-name)="onEvent()></my-component>`
listens for event `namespace:event-name` instead of event `event-name` on target `namespace`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
