### PR TITLE
fix(ivy): let ngtsc unwrap expressions when resolving `forwardRef`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -197,6 +197,7 @@ export function unwrapExpression(node: ts.Expression): ts.Expression {
 }
 
 function expandForwardRef(arg: ts.Expression): ts.Expression|null {
+  arg = unwrapExpression(arg);
   if (!ts.isArrowFunction(arg) && !ts.isFunctionExpression(arg)) {
     return null;
   }
@@ -228,6 +229,7 @@ function expandForwardRef(arg: ts.Expression): ts.Expression|null {
  * expression otherwise
  */
 export function unwrapForwardRef(node: ts.Expression, reflector: ReflectionHost): ts.Expression {
+  node = unwrapExpression(node);
   if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression) ||
       node.arguments.length !== 1) {
     return node;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1570,6 +1570,8 @@ describe('ngtsc behavioral tests', () => {
           @ContentChild(forwardRef(() => TemplateRef)) child: any;
 
           @ContentChild(forwardRef(function() { return ViewContainerRef; })) child2: any;
+
+          @ContentChild((forwardRef((function() { return 'parens'; }) as any))) childInParens: any;
         }
     `);
 
@@ -1579,6 +1581,9 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toMatch(contentQueryRegExp('TemplateRef', true));
     // match `i0.ɵɵcontentQuery(dirIndex, ViewContainerRef, true, null)`
     expect(jsContents).toMatch(contentQueryRegExp('ViewContainerRef', true));
+    // match `i0.ɵɵcontentQuery(dirIndex, _c0, true, null)`
+    expect(jsContents).toContain('_c0 = ["parens"];');
+    expect(jsContents).toMatch(contentQueryRegExp('_c0', true));
   });
 
   it('should compile expressions that write keys', () => {


### PR DESCRIPTION
Previously, ngtsc would fail to resolve `forwardRef` calls if they
contained additional parenthesis or casts. This commit changes the
behavior to first unwrap the AST nodes to see past such insignificant
nodes, resolving the issue.

Fixes #29639
