### PR TITLE
feat(ivy): let ngtsc evaluate the spread operator in function calls

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -427,20 +427,20 @@ export class StaticInterpreter {
 
     const args = this.evaluateFunctionArguments(node, context);
     const newScope: Scope = new Map<ts.ParameterDeclaration, ResolvedValue>();
+    const calleeContext = {...context, scope: newScope};
     fn.parameters.forEach((param, index) => {
       let arg = args[index];
       if (param.node.dotDotDotToken !== undefined) {
         arg = args.slice(index);
       }
       if (arg === undefined && param.initializer !== null) {
-        arg = this.visitExpression(param.initializer, context);
+        arg = this.visitExpression(param.initializer, calleeContext);
       }
       newScope.set(param.node, arg);
     });
 
-    return ret.expression !== undefined ?
-        this.visitExpression(ret.expression, {...context, scope: newScope}) :
-        undefined;
+    return ret.expression !== undefined ? this.visitExpression(ret.expression, calleeContext) :
+                                          undefined;
   }
 
   private visitConditionalExpression(node: ts.ConditionalExpression, context: Context):

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -75,6 +75,12 @@ describe('ngtsc metadata', () => {
     expect(evaluate(`function foo(bar) { return bar; }`, 'foo("test")')).toEqual('test');
   });
 
+  it('function call default value works', () => {
+    expect(evaluate(`function foo(bar = 1) { return bar; }`, 'foo()')).toEqual(1);
+    expect(evaluate(`function foo(bar = 1) { return bar; }`, 'foo(2)')).toEqual(2);
+    expect(evaluate(`function foo(a, c = a) { return c; }; const a = 1;`, 'foo(2)')).toEqual(2);
+  });
+
   it('function call spread works', () => {
     expect(evaluate(`function foo(a, ...b) { return [a, b]; }`, 'foo(1, ...[2, 3])')).toEqual([
       1, [2, 3]

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -75,6 +75,12 @@ describe('ngtsc metadata', () => {
     expect(evaluate(`function foo(bar) { return bar; }`, 'foo("test")')).toEqual('test');
   });
 
+  it('function call spread works', () => {
+    expect(evaluate(`function foo(a, ...b) { return [a, b]; }`, 'foo(1, ...[2, 3])')).toEqual([
+      1, [2, 3]
+    ]);
+  });
+
   it('conditionals work', () => {
     expect(evaluate(`const x = false; const y = x ? 'true' : 'false';`, 'y')).toEqual('false');
   });
@@ -136,6 +142,7 @@ describe('ngtsc metadata', () => {
     expect(evaluate(`const a = [1, 2], b = 3, c = [4, 5];`, 'a[\'concat\'](b, c)')).toEqual([
       1, 2, 3, 4, 5
     ]);
+    expect(evaluate(`const a = [1, 2], b = [3, 4]`, 'a[\'concat\'](...b)')).toEqual([1, 2, 3, 4]);
   });
 
   it('negation works', () => {


### PR DESCRIPTION
**feat(ivy): let ngtsc evaluate the spread operator in function calls**
Previously, ngtsc's static evaluator did not take spread operators into
account when evaluating function calls, nor did it handle rest arguments
correctly. This commit adds support for static evaluation of these
language features.

**fix(ivy): let ngtsc evaluate default parameters in the callee context**
Previously, during the evaluation of a function call where no argument
was provided for a parameter that has a default value, the default value
would be taken from the context of the caller, instead of the callee.

This commit fixes the behavior by resolving the default value of a
parameter in the context of the callee.

---

Blocked on #29887