### PR TITLE
ci(docs-infra): temporarily lower the min required PWA score for localhost tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,10 @@ jobs:
       - run: yarn --cwd aio lint
         # Run PWA-score tests
         # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+        # Temporarily lowering the min required PWA score to avoid flakes on CI.
+        # TODO(gkalpak): Re-enable once https://github.com/angular/angular/issues/29910 is resolved.
+      # - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+      - run: yarn --cwd aio test-pwa-score-localhost 70
         # Check the bundle sizes.
         # (Run before unit and e2e tests, which destroy the `dist/` directory.)
       - run: yarn --cwd aio payload-size
@@ -284,7 +287,10 @@ jobs:
       - run: yarn --cwd aio build-local --progress=false
         # Run PWA-score tests
         # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+        # Temporarily lowering the min required PWA score to avoid flakes on CI.
+        # TODO(gkalpak): Re-enable once https://github.com/angular/angular/issues/29910 is resolved.
+      # - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+      - run: yarn --cwd aio test-pwa-score-localhost 70
         # Run unit tests
       - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests


### PR DESCRIPTION
The PWA score tests have been occasionally failing on CI recently (possibly due to CI VM/network issues).

This commit temporarily disables them, until we investigate the root-cause and/or put a work-around in place.

The PWA score tests are still run against the deployed versions (which don't suffer as much) or PRs with public previews (as part of the `test_aio_preview` job) and on upstream builds (as part of the `deploy_aio` job).

Related to #29910.

[1]: https://github.com/angular/angular/blob/3a836c362/.circleci/config.yml#L390
