### PR TITLE
build: Remove cc_binary dependency on brotli

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
-
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:defaults.bzl", "karma_web_test")

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "angular-mocks-1.5": "npm:angular-mocks@1.5",
     "angular-mocks-1.6": "npm:angular-mocks@1.6",
     "base64-js": "1.2.1",
+    "brotli": "^1.3.2",
     "canonical-path": "1.0.0",
     "chokidar": "^2.1.1",
     "convert-source-map": "^1.5.1",

--- a/packages/bazel/package.bzl
+++ b/packages/bazel/package.bzl
@@ -24,13 +24,6 @@ def rules_angular_dev_dependencies():
     shorter.
     """
 
-    http_archive(
-        name = "org_brotli",
-        sha256 = "774b893a0700b0692a76e2e5b7e7610dbbe330ffbe3fe864b4b52ca718061d5a",
-        strip_prefix = "brotli-1.0.5",
-        url = "https://github.com/google/brotli/archive/v1.0.5.zip",
-    )
-
     # Needed for Remote Execution
     _maybe(
         http_archive,

--- a/packages/bazel/src/ng_rollup_bundle.bzl
+++ b/packages/bazel/src/ng_rollup_bundle.bzl
@@ -194,7 +194,7 @@ ng_rollup_bundle = rule(
         "_brotli": attr.label(
             executable = True,
             cfg = "host",
-            default = Label("@org_brotli//:brotli"),
+            default = Label("//tools/brotli-cli"),
         ),
         "_rollup": attr.label(
             executable = True,

--- a/tools/brotli-cli/BUILD.bazel
+++ b/tools/brotli-cli/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+
+nodejs_binary(
+    name = "brotli-cli",
+    data = [
+        "cli.js",
+        "@npm//brotli",
+    ],
+    entry_point = "angular/tools/brotli-cli/cli.js",
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/brotli-cli/cli.js
+++ b/tools/brotli-cli/cli.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const fs = require('fs');
+const compress = require('brotli/compress');
+
+function main(args) {
+  const output = args[0].substring('--output='.length);
+  const input = args[1];
+  const buffer = fs.readFileSync(input);
+  fs.writeFileSync(output, compress(buffer, {mode: 0, quality: 11}));
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,7 +1311,7 @@ base64-js@1.2.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
   integrity sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.1.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
@@ -1547,6 +1547,13 @@ braces@^2.3.0, braces@^2.3.1, braces@^2.3.2:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+brotli@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
+  integrity sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=
+  dependencies:
+    base64-js "^1.1.2"
 
 browserify-zlib@~0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Just use the JavaScript port instead. We don't care about speed since we compress once as a build step.
