### PR TITLE
fix(ivy): multi provider override support in TestBed

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -229,6 +229,27 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World !');
   });
 
+  it('allow to override multi provider', () => {
+    const MY_TOKEN = new InjectionToken('MyProvider');
+    class MyProvider {}
+
+    @Component({selector: 'my-comp', template: ``})
+    class MyComp {
+      constructor(@Inject(MY_TOKEN) public myProviders: MyProvider[]) {}
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [MyComp],
+      providers: [{provide: MY_TOKEN, useValue: {value: 'old provider'}, multi: true}]
+    });
+
+    const multiOverride = {useValue: [{value: 'new provider'}], multi: true};
+    TestBed.overrideProvider(MY_TOKEN, multiOverride as any);
+
+    const fixture = TestBed.createComponent(MyComp);
+    expect(fixture.componentInstance.myProviders).toEqual([{value: 'new provider'}]);
+  });
+
   it('should resolve components that are extended by other components', () => {
     // SimpleApp uses SimpleCmp in its template, which is extended by InheritedCmp
     const simpleApp = TestBed.createComponent(SimpleApp);


### PR DESCRIPTION
Overriding multi provider values (providers with `multi: true` flag) via TestBed require additional handling: all existing multi-provider values for the same token should be removed from the override list, so that they are not included into the final value of a given provider. This commit adds this logic to make sure we handle multi providers correctly.

This PR resolves FW-1251.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No