### PR TITLE
docs: use correct values from `code-example` in i18n

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -369,7 +369,7 @@ except that you choose among alternative translations based on a string value in
 and you define those string values.
 
 The following format message in the component template binds to the component's `gender` property,
-which outputs one of the following string values: "m", "f" or "o".
+which outputs one of the following string values: "male", "female" or "other".
 The message maps those values to the appropriate translations:
 
 <code-example path="i18n/src/app/app.component.html" region="i18n-select" header="src/app/app.component.html" linenums="false">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Wrong string values are mentioned for `gender` from i18n example app (`m`, `f`, `o`). But in the example app the values `male`, `female` and `other` are used. This can be confusing.

Issue Number: N/A


## What is the new behavior?
Correct string values are mentioned for `gender` from i18n example app (`male`, `female` and `other`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
