### PR TITLE
docs: fix grammatical errors in the guides and API documentation

### DIFF
--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -209,7 +209,7 @@ Learn more in the [Testing](guide/testing) guide.
 
 ## Services that need other services 
 
-Service can have their own dependencies. `HeroService` is very simple and doesn't have any dependencies of its own. Suppose, however, that you want it to report its activities through a logging service. You can apply the same *constructor injection* pattern,
+Services can have their own dependencies. `HeroService` is very simple and doesn't have any dependencies of its own. Suppose, however, that you want it to report its activities through a logging service. You can apply the same *constructor injection* pattern,
 adding a constructor that takes a `Logger` parameter.
 
 Here is the revised `HeroService` that injects `Logger`, side by side with the previous service for comparison.

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -750,7 +750,7 @@ with the injected `MessageService`.
   header="app/http-interceptors/logging-interceptor.ts)">
 </code-example>
 
-The RxJS `tap` operator captures whether the request succeed or failed.
+The RxJS `tap` operator captures whether the request succeeded or failed.
 The RxJS `finalize` operator is called when the response observable either errors or completes (which it must),
 and reports the outcome to the `MessageService`.
 

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -264,7 +264,7 @@ export type CanDeactivateFn<T> =
 /**
  * @description
  *
- * Interface that class can implement to be a data provider.
+ * Interface that classes can implement to be a data provider.
  *
  * ```
  * class Backend {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are grammatical errors in the DI and HttpClient guides as well as the Resolve API documentation.

Issue Number: N/A


## What is the new behavior?

The grammatical errors are fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
