### PR TITLE
fix(core): use shakeable global definitions

### DIFF
--- a/integration/terser/.gitignore
+++ b/integration/terser/.gitignore
@@ -1,0 +1,1 @@
+core.min.js

--- a/integration/terser/package.json
+++ b/integration/terser/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "terser",
+  "version": "0.0.0",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/core": "file:../../dist/packages-dist/core",
+    "@angular/compiler": "file:../../dist/packages-dist/compiler",
+    "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
+    "rxjs": "file:../../node_modules/rxjs",
+    "terser": "3.17.0",
+    "zone.js": "file:../../node_modules/zone.js"
+  }
+}

--- a/integration/terser/test.js
+++ b/integration/terser/test.js
@@ -1,0 +1,25 @@
+const readFileSync = require('fs').readFileSync;
+const writeFileSync = require('fs').writeFileSync;
+const resolve = require('path').resolve;
+const Terser = require('terser');
+const GLOBAL_DEFS_FOR_TERSER = require('@angular/compiler-cli').GLOBAL_DEFS_FOR_TERSER;
+
+const outputPath = resolve(__dirname, './core.min.js');
+const pathToCoreFesm5 = resolve(__dirname, './node_modules/@angular/core/fesm5/core.js');
+const coreFesm5Content = readFileSync(pathToCoreFesm5, 'utf8');
+// Ensure that Terser global_defs exported by compiler-cli work.
+const terserOpts = {
+  compress: {
+    module: true,
+    global_defs: GLOBAL_DEFS_FOR_TERSER
+  }
+};
+const result = Terser.minify(coreFesm5Content, terserOpts);
+writeFileSync(outputPath, result.code);
+
+for (const def of Object.keys(GLOBAL_DEFS_FOR_TERSER)) {
+  if (result.code.includes(def)) {
+    throw `'${def}' should have been removed from core bundle, but was still there.\n` +
+      `See output at ${outputPath}.`;
+  }
+}

--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -17,6 +17,7 @@ export * from './src/transformers/api';
 export * from './src/transformers/entry_points';
 
 export * from './src/perform_compile';
+export * from './src/tooling';
 
 // TODO(tbosch): remove this once cli 1.5 is fully released,
 // and usages in G3 are changed to `CompilerOptions`.

--- a/packages/compiler-cli/src/tooling.ts
+++ b/packages/compiler-cli/src/tooling.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @module
+ * @description
+ * Tooling support helpers.
+ */
+
+/**
+ * Known values for global variables in `@angular/core` that Terser should set using
+ * https://github.com/terser-js/terser#conditional-compilation
+ */
+export const GLOBAL_DEFS_FOR_TERSER = {
+  ngDevMode: false,
+  ngI18nClosureMode: false,
+};

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -83,8 +83,7 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
  * set `ngDevMode == false` we should be helping the developer by providing
  * as much early warning and errors as possible.
  *
- * NOTE: changes to the `ngDevMode` name must be synced with the CLI and
- * possibly other third party tooling. Check with them before altering it.
+ * NOTE: changes to the `ngDevMode` name must be synced with `compiler-cli/src/tooling.ts`.
  */
 if (typeof ngDevMode === 'undefined' || ngDevMode) {
   ngDevModeResetPerfCounters();

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -82,7 +82,10 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
  * The idea is that unless we are doing production build where we explicitly
  * set `ngDevMode == false` we should be helping the developer by providing
  * as much early warning and errors as possible.
+ *
+ * NOTE: changes to the `ngDevMode` name must be synced with the CLI and
+ * possibly other third party tooling. Check with them before altering it.
  */
-if (typeof global['ngDevMode'] === 'undefined' || global['ngDevMode']) {
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
   ngDevModeResetPerfCounters();
 }

--- a/packages/core/src/util/ng_i18n_closure_mode.ts
+++ b/packages/core/src/util/ng_i18n_closure_mode.ts
@@ -13,8 +13,7 @@ declare global {
 }
 
 /**
- * NOTE: changes to the `ngI18nClosureMode` name must be synced with the CLI and
- * possibly other third party tooling. Check with them before altering it.
+ * NOTE: changes to the `ngI18nClosureMode` name must be synced with `compiler-cli/src/tooling.ts`.
  */
 if (typeof ngI18nClosureMode === 'undefined') {
   // Make sure to refer to ngI18nClosureMode as ['ngI18nClosureMode'] for closure.

--- a/packages/core/src/util/ng_i18n_closure_mode.ts
+++ b/packages/core/src/util/ng_i18n_closure_mode.ts
@@ -12,7 +12,11 @@ declare global {
   const ngI18nClosureMode: boolean;
 }
 
-if (typeof global['ngI18nClosureMode'] === 'undefined') {
+/**
+ * NOTE: changes to the `ngI18nClosureMode` name must be synced with the CLI and
+ * possibly other third party tooling. Check with them before altering it.
+ */
+if (typeof ngI18nClosureMode === 'undefined') {
   // Make sure to refer to ngI18nClosureMode as ['ngI18nClosureMode'] for closure.
   global['ngI18nClosureMode'] =
       // TODO(FW-1250): validate that this actually, you know, works.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The `ngDevMode` and `ngI18nClosureMode` are special in that they should be set to `false` on production builds in order to shake out code associated with it.

Angular CLI does this in https://github.com/angular/angular-cli/blob/5fc1f2499cbe57f9a95e4b0dfced130eb3a8046d/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts#L279-L282.

But in https://github.com/angular/angular/pull/28689 the toplevel usage was changed from `ngDevMode` to `global['ngDevMode']` (and the same for `ngI18nClosureMode`). This indirection prevents the static analysis in Terser from effecting the replacement.

## What is the new behavior?

The variables that should be defined globally are synced between Angular core and CLI.



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
