### PR TITLE
feat(ivy): ngDevMode has state getter methods

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -164,7 +164,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     const renderer = rendererFactory.createRenderer(hostRNode, this.componentDef);
 
     if (rootSelectorOrNode && hostRNode) {
-      ngDevMode && ngDevMode.rendererSetAttribute++;
+      ngDevMode && ngDevMode.perfCounters.rendererSetAttribute++;
       isProceduralRenderer(renderer) ?
           renderer.setAttribute(hostRNode, 'ng-version', VERSION.full) :
           hostRNode.setAttribute('ng-version', VERSION.full);

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -478,7 +478,7 @@ function i18nStartFirstPass(
 }
 
 function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode | null): TNode {
-  ngDevMode && ngDevMode.rendererMoveNode++;
+  ngDevMode && ngDevMode.perfCounters.rendererMoveNode++;
   const nextNode = tNode.next;
   const viewData = getLView();
   if (!previousTNode) {
@@ -697,7 +697,7 @@ function readCreateOpCodes(
     if (typeof opCode == 'string') {
       const textRNode = createTextNode(opCode, renderer);
       const textNodeIndex = createOpCodes[++i] as number;
-      ngDevMode && ngDevMode.rendererCreateTextNode++;
+      ngDevMode && ngDevMode.perfCounters.rendererCreateTextNode++;
       previousTNode = currentTNode;
       currentTNode = createDynamicNodeAtIndex(textNodeIndex, TNodeType.Element, textRNode, null);
       visitedNodes.push(textNodeIndex);
@@ -756,7 +756,7 @@ function readCreateOpCodes(
                            typeof commentValue, 'string',
                            `Expected "${commentValue}" to be a comment node value`);
           const commentRNode = renderer.createComment(commentValue);
-          ngDevMode && ngDevMode.rendererCreateComment++;
+          ngDevMode && ngDevMode.perfCounters.rendererCreateComment++;
           previousTNode = currentTNode;
           currentTNode = createDynamicNodeAtIndex(
               commentNodeIndex, TNodeType.IcuContainer, commentRNode, null);
@@ -773,7 +773,7 @@ function readCreateOpCodes(
                            typeof tagNameValue, 'string',
                            `Expected "${tagNameValue}" to be an element node tag name`);
           const elementRNode = renderer.createElement(tagNameValue);
-          ngDevMode && ngDevMode.rendererCreateElement++;
+          ngDevMode && ngDevMode.perfCounters.rendererCreateElement++;
           previousTNode = currentTNode;
           currentTNode = createDynamicNodeAtIndex(
               elementNodeIndex, TNodeType.Element, elementRNode, tagNameValue);
@@ -894,7 +894,7 @@ function removeNode(index: number, viewData: LView) {
     }
   }
 
-  ngDevMode && ngDevMode.rendererRemoveNode++;
+  ngDevMode && ngDevMode.perfCounters.rendererRemoveNode++;
 }
 
 /**

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -167,7 +167,7 @@ function containerInternal(
 
   const adjustedIndex = index + HEADER_OFFSET;
   const comment = lView[RENDERER].createComment(ngDevMode ? 'container' : '');
-  ngDevMode && ngDevMode.rendererCreateComment++;
+  ngDevMode && ngDevMode.perfCounters.rendererCreateComment++;
   const tNode = createNodeAtIndex(index, TNodeType.Container, comment, tagName, attrs);
   const lContainer = lView[adjustedIndex] =
       createLContainer(lView[adjustedIndex], lView, comment, tNode);

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -52,7 +52,7 @@ export function ɵɵelementStart(
                    lView[BINDING_INDEX], tView.bindingStartIndex,
                    'elements should be created before any bindings ');
 
-  ngDevMode && ngDevMode.rendererCreateElement++;
+  ngDevMode && ngDevMode.perfCounters.rendererCreateElement++;
 
   const native = elementCreate(name);
   const renderer = lView[RENDERER];
@@ -211,11 +211,11 @@ export function ɵɵelementAttribute(
     const renderer = lView[RENDERER];
     const element = getNativeByIndex(index, lView) as RElement;
     if (value == null) {
-      ngDevMode && ngDevMode.rendererRemoveAttribute++;
+      ngDevMode && ngDevMode.perfCounters.rendererRemoveAttribute++;
       isProceduralRenderer(renderer) ? renderer.removeAttribute(element, name, namespace) :
                                        element.removeAttribute(name);
     } else {
-      ngDevMode && ngDevMode.rendererSetAttribute++;
+      ngDevMode && ngDevMode.perfCounters.rendererSetAttribute++;
       const tNode = getTNode(index, lView);
       const strValue =
           sanitizer == null ? renderStringify(value) : sanitizer(value, tNode.tagName || '', name);

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -41,7 +41,7 @@ export function ɵɵelementContainerStart(
                    lView[BINDING_INDEX], tView.bindingStartIndex,
                    'element containers should be created before any bindings');
 
-  ngDevMode && ngDevMode.rendererCreateComment++;
+  ngDevMode && ngDevMode.perfCounters.rendererCreateComment++;
   const native = renderer.createComment(ngDevMode ? tagName : '');
 
   ngDevMode && assertDataInRange(lView, index - 1);

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -158,7 +158,7 @@ function listenerInternal(
         // - or element reference (in all other cases)
         listenerFn = wrapListener(tNode, lView, listenerFn, false /** preventDefault */);
         const cleanupFn = renderer.listen(resolved.name || target, eventName, listenerFn);
-        ngDevMode && ngDevMode.rendererAddEventListener++;
+        ngDevMode && ngDevMode.perfCounters.rendererAddEventListener++;
 
         lCleanup.push(listenerFn, cleanupFn);
         tCleanup && tCleanup.push(eventName, idxOrTargetGetter, lCleanupIndex, lCleanupIndex + 1);
@@ -167,7 +167,7 @@ function listenerInternal(
     } else {
       listenerFn = wrapListener(tNode, lView, listenerFn, true /** preventDefault */);
       target.addEventListener(eventName, listenerFn, useCapture);
-      ngDevMode && ngDevMode.rendererAddEventListener++;
+      ngDevMode && ngDevMode.perfCounters.rendererAddEventListener++;
 
       lCleanup.push(listenerFn);
       tCleanup && tCleanup.push(eventName, idxOrTargetGetter, lCleanupIndex, useCapture);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -552,7 +552,7 @@ export function createDirectivesAndLocals(
   if (!getBindingsEnabled()) return;
   const previousOrParentTNode = getPreviousOrParentTNode();
   if (tView.firstTemplatePass) {
-    ngDevMode && ngDevMode.firstTemplatePass++;
+    ngDevMode && ngDevMode.perfCounters.firstTemplatePass++;
     resolveDirectives(
         tView, lView, findDirectiveMatches(tView, lView, previousOrParentTNode),
         previousOrParentTNode, localRefs || null);
@@ -627,7 +627,7 @@ export function createTView(
     viewIndex: number, templateFn: ComponentTemplate<any>| null, consts: number, vars: number,
     directives: DirectiveDefListOrFactory | null, pipes: PipeDefListOrFactory | null,
     viewQuery: ViewQueriesFunction<any>| null, schemas: SchemaMetadata[] | null): TView {
-  ngDevMode && ngDevMode.tView++;
+  ngDevMode && ngDevMode.perfCounters.tView++;
   const bindingStartIndex = HEADER_OFFSET + consts;
   // This length does not yet contain host bindings from child directives because at this point,
   // we don't know which directives are active on this template. As soon as a directive is matched
@@ -754,7 +754,7 @@ export type TsickleIssue1009 = any;
 export function createTNode(
     tParent: TElementNode | TContainerNode | null, type: TNodeType, adjustedIndex: number,
     tagName: string | null, attrs: TAttributes | null): TNode {
-  ngDevMode && ngDevMode.tNode++;
+  ngDevMode && ngDevMode.perfCounters.tNode++;
   return {
     type: type,
     index: adjustedIndex,
@@ -866,7 +866,7 @@ export function elementPropertyInternal<T>(
     if (ngDevMode) {
       validateAgainstEventProperties(propName);
       validateAgainstUnknownProperties(lView, element, propName, tNode);
-      ngDevMode.rendererSetProperty++;
+      ngDevMode.perfCounters.rendererSetProperty++;
     }
 
     savePropertyDebugData(tNode, lView, propName, lView[TVIEW].data, nativeOnly);

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -29,7 +29,7 @@ export function ɵɵtext(index: number, value?: any): void {
   ngDevMode && assertEqual(
                    lView[BINDING_INDEX], lView[TVIEW].bindingStartIndex,
                    'text nodes should be created before any bindings');
-  ngDevMode && ngDevMode.rendererCreateTextNode++;
+  ngDevMode && ngDevMode.perfCounters.rendererCreateTextNode++;
   const textNative = createTextNode(value, lView[RENDERER]);
   const tNode = createNodeAtIndex(index, TNodeType.Element, textNative, null, null);
 
@@ -53,7 +53,7 @@ export function ɵɵtextBinding<T>(index: number, value: T | NO_CHANGE): void {
     ngDevMode && assertDataInRange(lView, index + HEADER_OFFSET);
     const element = getNativeByIndex(index, lView) as any as RText;
     ngDevMode && assertDefined(element, 'native element should exist');
-    ngDevMode && ngDevMode.rendererSetText++;
+    ngDevMode && ngDevMode.perfCounters.rendererSetText++;
     const renderer = lView[RENDERER];
     isProceduralRenderer(renderer) ? renderer.setValue(element, renderStringify(value)) :
                                      element.textContent = renderStringify(value);

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -228,7 +228,7 @@ function executeNodeAction(
   } else if (action === WalkTNodeTreeAction.Detach) {
     nativeRemoveNode(renderer, node, isComponent(tNode));
   } else if (action === WalkTNodeTreeAction.Destroy) {
-    ngDevMode && ngDevMode.rendererDestroyNode++;
+    ngDevMode && ngDevMode.perfCounters.rendererDestroyNode++;
     (renderer as ProceduralRenderer3).destroyNode !(node);
   }
 }
@@ -474,7 +474,7 @@ function cleanUpView(view: LView | LContainer): void {
     const hostTNode = view[T_HOST];
     // For component views only, the local renderer is destroyed as clean up time.
     if (hostTNode && hostTNode.type === TNodeType.Element && isProceduralRenderer(view[RENDERER])) {
-      ngDevMode && ngDevMode.rendererDestroy++;
+      ngDevMode && ngDevMode.perfCounters.rendererDestroy++;
       (view[RENDERER] as ProceduralRenderer3).destroy();
     }
     // For embedded views still attached to a container: remove query result from this view.

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -18,6 +18,19 @@ import {resetPreOrderHookFlags} from './util/view_utils';
 
 
 
+/** For dev mode, add the state getter methods to `ngDevMode.state` to make them easier to get to */
+if (ngDevMode) {
+  ngDevMode.state = {
+      getElementDepthCount,     getCurrentDirectiveDef,
+      getBindingsEnabled,       getLView,
+      getActiveDirectiveId,     getActiveDirectiveSuperClassDepth,
+      getPreviousOrParentTNode, getIsParent,
+      getContextLView,          getCheckNoChangesMode,
+      getBindingRoot,           getCurrentQueryIndex,
+      getSelectedIndex,         getNamespace,
+  };
+}
+
 /**
  * Store the element depth count. This is used to identify the root elements of the template
  * so that we can than attach `LView` to only those elements.

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -548,7 +548,8 @@ function updateStylingMap(
     context: StylingContext, input: {[key: string]: any} | string |
         BoundPlayerFactory<null|string|{[key: string]: any}>| null,
     entryIsClassBased: boolean, directiveIndex: number = 0): void {
-  ngDevMode && (entryIsClassBased ? ngDevMode.classMap++ : ngDevMode.styleMap++);
+  ngDevMode &&
+      (entryIsClassBased ? ngDevMode.perfCounters.classMap++ : ngDevMode.perfCounters.styleMap++);
   ngDevMode && assertValidDirectiveIndex(context, directiveIndex);
 
   // early exit (this is what's done to avoid using ctx.bind() to cache the value)
@@ -609,7 +610,8 @@ function updateStylingMap(
     setContextPlayersDirty(context, true);
   }
 
-  ngDevMode && (entryIsClassBased ? ngDevMode.classMapCacheMiss++ : ngDevMode.styleMapCacheMiss++);
+  ngDevMode && (entryIsClassBased ? ngDevMode.perfCounters.classMapCacheMiss++ :
+                                    ngDevMode.perfCounters.styleMapCacheMiss++);
 }
 
 /**
@@ -914,7 +916,7 @@ function updateSingleStylingValue(
   const currDirective = getDirectiveIndexFromEntry(context, singleIndex);
   const value: string|boolean|null = (input instanceof BoundPlayerFactory) ? input.value : input;
 
-  ngDevMode && ngDevMode.stylingProp++;
+  ngDevMode && ngDevMode.perfCounters.stylingProp++;
 
   if (hasValueChanged(currFlag, currValue, value) &&
       (forceOverride || allowValueChange(currValue, value, currDirective, directiveIndex))) {
@@ -971,7 +973,7 @@ function updateSingleStylingValue(
       setContextPlayersDirty(context, true);
     }
 
-    ngDevMode && ngDevMode.stylingPropCacheMiss++;
+    ngDevMode && ngDevMode.perfCounters.stylingPropCacheMiss++;
   }
 }
 
@@ -1000,7 +1002,7 @@ export function renderStyling(
     isFirstRender: boolean, classesStore?: BindingStore | null, stylesStore?: BindingStore | null,
     directiveIndex: number = 0): number {
   let totalPlayersQueued = 0;
-  ngDevMode && ngDevMode.stylingApply++;
+  ngDevMode && ngDevMode.perfCounters.stylingApply++;
 
   // this prevents multiple attempts to render style/class values on
   // the same element...
@@ -1015,7 +1017,7 @@ export function renderStyling(
     flushHostInstructionsQueue(context);
 
     if (isContextDirty(context)) {
-      ngDevMode && ngDevMode.stylingApplyCacheMiss++;
+      ngDevMode && ngDevMode.perfCounters.stylingApplyCacheMiss++;
 
       // this is here to prevent things like <ng-container [style] [class]>...</ng-container>
       // or if there are any host style or class bindings present in a directive set on
@@ -1152,12 +1154,12 @@ export function setStyle(
   } else if (value) {
     value = value.toString();  // opacity, z-index and flexbox all have number values which may not
     // assign as numbers
-    ngDevMode && ngDevMode.rendererSetStyle++;
+    ngDevMode && ngDevMode.perfCounters.rendererSetStyle++;
     isProceduralRenderer(renderer) ?
         renderer.setStyle(native, prop, value, RendererStyleFlags3.DashCase) :
         native.style.setProperty(prop, value);
   } else {
-    ngDevMode && ngDevMode.rendererRemoveStyle++;
+    ngDevMode && ngDevMode.perfCounters.rendererRemoveStyle++;
     isProceduralRenderer(renderer) ?
         renderer.removeStyle(native, prop, RendererStyleFlags3.DashCase) :
         native.style.removeProperty(prop);
@@ -1191,11 +1193,11 @@ function setClass(
     // DOMTokenList will throw if we try to add or remove an empty string.
   } else if (className !== '') {
     if (add) {
-      ngDevMode && ngDevMode.rendererAddClass++;
+      ngDevMode && ngDevMode.perfCounters.rendererAddClass++;
       isProceduralRenderer(renderer) ? renderer.addClass(native, className) :
                                        native['classList'].add(className);
     } else {
-      ngDevMode && ngDevMode.rendererRemoveClass++;
+      ngDevMode && ngDevMode.perfCounters.rendererRemoveClass++;
       isProceduralRenderer(renderer) ? renderer.removeClass(native, className) :
                                        native['classList'].remove(className);
     }

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -62,7 +62,7 @@ export function setUpAttributes(native: RElement, attrs: TAttributes): number {
       const namespaceURI = attrs[i++] as string;
       const attrName = attrs[i++] as string;
       const attrVal = attrs[i++] as string;
-      ngDevMode && ngDevMode.rendererSetAttribute++;
+      ngDevMode && ngDevMode.perfCounters.rendererSetAttribute++;
       isProc ?
           (renderer as ProceduralRenderer3).setAttribute(native, attrName, attrVal, namespaceURI) :
           native.setAttributeNS(namespaceURI, attrName, attrVal);
@@ -71,7 +71,7 @@ export function setUpAttributes(native: RElement, attrs: TAttributes): number {
       const attrName = value as string;
       const attrVal = attrs[++i];
       // Standard attributes
-      ngDevMode && ngDevMode.rendererSetAttribute++;
+      ngDevMode && ngDevMode.perfCounters.rendererSetAttribute++;
       if (isAnimationProp(attrName)) {
         if (isProc) {
           (renderer as ProceduralRenderer3).setProperty(native, attrName, attrVal);

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -314,7 +314,7 @@ export function createContainerRef(
     lContainer[ACTIVE_INDEX] = -1;
   } else {
     const commentNode = hostView[RENDERER].createComment(ngDevMode ? 'container' : '');
-    ngDevMode && ngDevMode.rendererCreateComment++;
+    ngDevMode && ngDevMode.perfCounters.rendererCreateComment++;
 
     // A container can be created on the root (topmost / bootstrapped) component and in this case we
     // can't use LTree to insert container's marker node (both parent of a comment node and the

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -9,7 +9,13 @@
 import {global} from './global';
 
 declare global {
-  const ngDevMode: null|NgDevModePerfCounters;
+  const ngDevMode: null|NgDevMode;
+
+  interface NgDevMode {
+    perfCounters: NgDevModePerfCounters;
+    state: any;
+  }
+
   interface NgDevModePerfCounters {
     firstTemplatePass: number;
     tNode: number;
@@ -44,8 +50,9 @@ declare global {
   }
 }
 
-export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
-  const newCounters: NgDevModePerfCounters = {
+
+export function ngDevModeResetPerfCounters() {
+  const perfCounters: NgDevModePerfCounters = {
     firstTemplatePass: 0,
     tNode: 0,
     tView: 0,
@@ -78,9 +85,13 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     stylingApplyCacheMiss: 0,
   };
 
+  global['ngDevMode'] = global['ngDevMode'] || {
+    perfCounters: null,
+    state: 'state module not loaded yet',
+  };
+
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.
-  global['ngDevMode'] = newCounters;
-  return newCounters;
+  global['ngDevMode'].perfCounters = perfCounters;
 }
 
 /**

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -12,7 +12,7 @@ import {By} from '@angular/platform-browser';
 import {onlyInIvy} from '@angular/private/testing';
 
 function getNoOfNativeListeners(): number {
-  return ngDevMode ? ngDevMode.rendererAddEventListener : 0;
+  return ngDevMode && ngDevMode.perfCounters ? ngDevMode.perfCounters.rendererAddEventListener : 0;
 }
 
 describe('event listeners', () => {


### PR DESCRIPTION
- Moves all perf counters under `ngDevMode.perfCounters`
- Adds all global state getter methods to `ngDevMode.state`. For example: `ngDevMode.state.getLView()` or `ngDevMode.state.getSelectedIndex()`.

This should be useful when debugging issues with global state.
