### PR TITLE
 add redirect links from deprecated http APIs page to deprecation summary

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -53,6 +53,10 @@
       {"type": 301, "source": "/**/api/common/SelectControlValueAccessor-*", "destination": "/api/forms/SelectControlValueAccessor"},
       {"type": 301, "source": "/**/api/common/NgModel", "destination": "/api/forms/NgModel"},
 
+      // APIs under `http` package is deprecated and new APIs are available under `common/http` package
+      {"type": 301, "source": "/api/http/:rest*", "destination": "/guide/deprecation#http"},
+      {"type": 301, "source": "/api/http", "destination": "/guide/deprecation#http"},
+
       // Animations moves, renames and removals
       {"type": 301, "source": "/api/animate/:rest*", "destination": "/api/animations/:rest*"},
       // AnimationStateDeclarationMetadata was removed

--- a/aio/ngsw-config.json
+++ b/aio/ngsw-config.json
@@ -87,6 +87,8 @@
     "!/api/common/Control*",
     "!/api/common/MaxLengthValidator*",
     "!/api/common/NgModel*",
+    "!/api/http/**",
+    "!/api/http",
     "!/api/platform-browser/AnimationDriver*",
     "!/api/testing/**",
     "!/docs/?*",

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -22,19 +22,11 @@
 /api/core/testing/index/TestBed-class.html	/api/core/testing/TestBed
 /api/core/testing/inject-function	/api/core/testing/inject
 /api/core/testing/inject-function.html	/api/core/testing/inject
-<<<<<<< HEAD
-/api/http/Headers-class	/api/http/Headers
-/api/http/Headers-class.html	/api/http/Headers
-/api/http/HTTP_PROVIDERS-let	/api/http/HttpModule
-/api/http/testing/index/MockBackend-class	/api/http/testing/MockBackend
-/api/http/testing/index/MockBackend-class.html	/api/http/testing/MockBackend
-=======
 /api/http/Headers-class	/guide/deprecation#http
 /api/http/Headers-class.html	/guide/deprecation#http
 /api/http/HTTP_PROVIDERS-let	/guide/deprecation#http
 /api/http/testing/index/MockBackend-class	/guide/deprecation#http
 /api/http/testing/index/MockBackend-class.html	/guide/deprecation#http
->>>>>>> 030a3662c5... docs: add redirect link to deprecation summary page
 /api/platform-browser-dynamic/testing/index/platformBrowserDynamicTesting-let.html	/api/platform-browser-dynamic/testing/platformBrowserDynamicTesting
 /api/platform-browser/AnimationDriver	/api/animations/browser/AnimationDriver
 /api/router/Route-class	/api/router/Route
@@ -173,15 +165,9 @@
 /docs/ts/latest/api/core/testing/index/fakeAsync-function.html	/api/core/testing/fakeAsync
 /docs/ts/latest/api/core/testing/index/TestComponentRenderer-class.html	/api/core/testing/TestComponentRenderer
 /docs/ts/latest/api/core/testing/index/tick-function.html	/api/core/testing/tick
-<<<<<<< HEAD
-/docs/ts/latest/api/http/Connection-class.html	/api/http/Connection
-/docs/ts/latest/api/http/testing/index/MockBackend-class.html	/api/http/testing/MockBackend
-/docs/ts/latest/api/http/testing/index/MockConnection-class.html	/api/http/testing/MockConnection
-=======
 /docs/ts/latest/api/http/Connection-class.html	/guide/deprecation#http
 /docs/ts/latest/api/http/testing/index/MockBackend-class.html	/guide/deprecation#http
 /docs/ts/latest/api/http/testing/index/MockConnection-class.html	/guide/deprecation#http
->>>>>>> 030a3662c5... docs: add redirect link to deprecation summary page
 /docs/ts/latest/api/platform-browser-dynamic/index/workerAppDynamicPlatform-let.html	/api/platform-browser-dynamic/workerAppDynamicPlatform
 /docs/ts/latest/api/testing/fakeAsync-function.html	/api/core/testing/fakeAsync
 /docs/ts/latest/cookbook/ts-to-js.html	https://github.com/angular/angular/blob/master/aio/content/guide/change-log.md#es6--described-in-typescript-to-javascript-2016-11-14

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -22,11 +22,19 @@
 /api/core/testing/index/TestBed-class.html	/api/core/testing/TestBed
 /api/core/testing/inject-function	/api/core/testing/inject
 /api/core/testing/inject-function.html	/api/core/testing/inject
+<<<<<<< HEAD
 /api/http/Headers-class	/api/http/Headers
 /api/http/Headers-class.html	/api/http/Headers
 /api/http/HTTP_PROVIDERS-let	/api/http/HttpModule
 /api/http/testing/index/MockBackend-class	/api/http/testing/MockBackend
 /api/http/testing/index/MockBackend-class.html	/api/http/testing/MockBackend
+=======
+/api/http/Headers-class	/guide/deprecation#http
+/api/http/Headers-class.html	/guide/deprecation#http
+/api/http/HTTP_PROVIDERS-let	/guide/deprecation#http
+/api/http/testing/index/MockBackend-class	/guide/deprecation#http
+/api/http/testing/index/MockBackend-class.html	/guide/deprecation#http
+>>>>>>> 030a3662c5... docs: add redirect link to deprecation summary page
 /api/platform-browser-dynamic/testing/index/platformBrowserDynamicTesting-let.html	/api/platform-browser-dynamic/testing/platformBrowserDynamicTesting
 /api/platform-browser/AnimationDriver	/api/animations/browser/AnimationDriver
 /api/router/Route-class	/api/router/Route
@@ -95,15 +103,15 @@
 /docs/js/latest/api/forms/index/FormBuilder-class.html	/api/forms/FormBuilder
 /docs/js/latest/api/forms/index/NG_VALIDATORS-let	/api/forms/NG_VALIDATORS
 /docs/js/latest/api/forms/index/Validator-interface.html	/api/forms/Validator
-/docs/js/latest/api/http/ConnectionBackend-class	/api/http/ConnectionBackend
-/docs/js/latest/api/http/index/Http-class.html	/api/http/Http
-/docs/js/latest/api/http/index/Jsonp-class.html	/api/http/Jsonp
-/docs/js/latest/api/http/index/ResponseOptions-class.html	/api/http/ResponseOptions
-/docs/js/latest/api/http/index/URLSearchParams-class	/api/http/URLSearchParams
-/docs/js/latest/api/http/index/XHRConnection-class	/api/http/XHRConnection
-/docs/js/latest/api/http/index/XHRConnection-class.html	/api/http/XHRConnection
-/docs/js/latest/api/http/testing/index/MockConnection-class.html	/api/http/testing/MockConnection
-/docs/js/latest/api/http/testing/MockBackend-class	/api/http/testing/MockBackend
+/docs/js/latest/api/http/ConnectionBackend-class	/guide/deprecation#http
+/docs/js/latest/api/http/index/Http-class.html	/guide/deprecation#http
+/docs/js/latest/api/http/index/Jsonp-class.html	/guide/deprecation#http
+/docs/js/latest/api/http/index/ResponseOptions-class.html	/guide/deprecation#http
+/docs/js/latest/api/http/index/URLSearchParams-class	/guide/deprecation#http
+/docs/js/latest/api/http/index/XHRConnection-class	/guide/deprecation#http
+/docs/js/latest/api/http/index/XHRConnection-class.html	/guide/deprecation#http
+/docs/js/latest/api/http/testing/index/MockConnection-class.html	/guide/deprecation#http
+/docs/js/latest/api/http/testing/MockBackend-class	/guide/deprecation#http
 /docs/js/latest/api/platform-browser-dynamic/index/platformBrowserDynamic-let.html	/api/platform-browser-dynamic/platformBrowserDynamic
 /docs/js/latest/api/platform-browser-dynamic/testing/index/BrowserDynamicTestingModule-class.html	/api/platform-browser-dynamic/testing/BrowserDynamicTestingModule
 /docs/js/latest/api/platform-browser/animations/index/BrowserAnimationsModule-class	/api/platform-browser/animations/BrowserAnimationsModule
@@ -165,9 +173,15 @@
 /docs/ts/latest/api/core/testing/index/fakeAsync-function.html	/api/core/testing/fakeAsync
 /docs/ts/latest/api/core/testing/index/TestComponentRenderer-class.html	/api/core/testing/TestComponentRenderer
 /docs/ts/latest/api/core/testing/index/tick-function.html	/api/core/testing/tick
+<<<<<<< HEAD
 /docs/ts/latest/api/http/Connection-class.html	/api/http/Connection
 /docs/ts/latest/api/http/testing/index/MockBackend-class.html	/api/http/testing/MockBackend
 /docs/ts/latest/api/http/testing/index/MockConnection-class.html	/api/http/testing/MockConnection
+=======
+/docs/ts/latest/api/http/Connection-class.html	/guide/deprecation#http
+/docs/ts/latest/api/http/testing/index/MockBackend-class.html	/guide/deprecation#http
+/docs/ts/latest/api/http/testing/index/MockConnection-class.html	/guide/deprecation#http
+>>>>>>> 030a3662c5... docs: add redirect link to deprecation summary page
 /docs/ts/latest/api/platform-browser-dynamic/index/workerAppDynamicPlatform-let.html	/api/platform-browser-dynamic/workerAppDynamicPlatform
 /docs/ts/latest/api/testing/fakeAsync-function.html	/api/core/testing/fakeAsync
 /docs/ts/latest/cookbook/ts-to-js.html	https://github.com/angular/angular/blob/master/aio/content/guide/change-log.md#es6--described-in-typescript-to-javascript-2016-11-14


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
added redirect links from deprecated http APIs page to redirect to release notes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
