### PR TITLE
fix(aio): remove scroll position from sessionStorage when a ServiceWo…

### DIFF
--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -293,21 +293,35 @@ describe('LocationService', () => {
       expect(goExternalSpy).toHaveBeenCalledWith(externalUrl);
     });
 
+    it('should not remove the stored scroll position when navigating to external URLs', () => {
+      const removeStoredScrollPositionSpy = spyOn(scrollService, 'removeStoredScrollPosition');
+      const goExternalSpy = spyOn(service, 'goExternal');
+      const externalUrl = 'http://some/far/away/land';
+
+      // External URL - No ServiceWorker update
+      service.go(externalUrl);
+      expect(removeStoredScrollPositionSpy).not.toHaveBeenCalled();
+      expect(goExternalSpy).toHaveBeenCalledWith(externalUrl);
+
+      // External URL - ServiceWorker update
+      swUpdates.updateActivated.next('foo');
+      service.go(externalUrl);
+      expect(removeStoredScrollPositionSpy).not.toHaveBeenCalled();
+      expect(goExternalSpy).toHaveBeenCalledWith(externalUrl);
+    });
+
     it('should do a "full page navigation" if a ServiceWorker update has been activated', () => {
       const goExternalSpy = spyOn(service, 'goExternal');
-      const removeStoredScrollPositionSpy = spyOn(scrollService, 'removeStoredScrollPosition');
 
       // Internal URL - No ServiceWorker update
       service.go('some-internal-url');
       expect(goExternalSpy).not.toHaveBeenCalled();
-      expect(removeStoredScrollPositionSpy).not.toHaveBeenCalled();
       expect(location.path(true)).toEqual('some-internal-url');
 
       // Internal URL - ServiceWorker update
       swUpdates.updateActivated.next('foo');
       service.go('other-internal-url');
       expect(goExternalSpy).toHaveBeenCalledWith('other-internal-url');
-      expect(removeStoredScrollPositionSpy).toHaveBeenCalled();
       expect(location.path(true)).toEqual('some-internal-url');
     });
 

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -6,6 +6,7 @@ import { map, tap } from 'rxjs/operators';
 
 import { GaService } from 'app/shared/ga.service';
 import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
+import { ScrollService } from './scroll.service';
 
 @Injectable()
 export class LocationService {
@@ -25,6 +26,7 @@ export class LocationService {
   constructor(
     private gaService: GaService,
     private location: Location,
+    private scrollService: ScrollService,
     private platformLocation: PlatformLocation,
     swUpdates: SwUpdatesService) {
 
@@ -41,9 +43,13 @@ export class LocationService {
   go(url: string|null|undefined) {
     if (!url) { return; }
     url = this.stripSlashes(url);
-    if (/^http/.test(url) || this.swUpdateActivated) {
+    if (/^http/.test(url)) {
       // Has http protocol so leave the site
-      // (or do a "full page navigation" if a ServiceWorker update has been activated)
+      this.goExternal(url);
+    } else if (this.swUpdateActivated) {
+      // (Do a "full page navigation" if a ServiceWorker update has been activated)
+      // We need to remove stored Position in order to be sure to scroll to the Top position
+      this.scrollService.removeStoredScrollPosition();
       this.goExternal(url);
     } else {
       this.location.go(url);


### PR DESCRIPTION
…rker update has been activated


closes #29893

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When we nagivate on angular.io, we might have a unexpected scrolldrown on the new page when a ServiceWorker update has been activated.


Issue Number: #29893


## What is the new behavior?
when a ServiceWorker update has been activated, we remove the scroll Position from the sessionStorage before the nagivation

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No