### PR TITLE
fix(ivy): set ng-reflect properties for unbound directive inputs

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -10,24 +10,23 @@ import {assertDataInRange, assertEqual} from '../../util/assert';
 import {assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
-import {PropertyAliases, TAttributes, TNodeFlags, TNodeType} from '../interfaces/node';
-import {RComment, RElement, isProceduralRenderer} from '../interfaces/renderer';
+import {TAttributes, TNodeFlags, TNodeType} from '../interfaces/node';
+import {RElement, isProceduralRenderer} from '../interfaces/renderer';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {StylingContext} from '../interfaces/styling';
-import {BINDING_INDEX, LView, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
+import {BINDING_INDEX, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
 import {applyOnCreateInstructions} from '../node_util';
 import {decreaseElementDepthCount, getElementDepthCount, getIsParent, getLView, getPreviousOrParentTNode, getSelectedIndex, increaseElementDepthCount, setIsParent, setPreviousOrParentTNode} from '../state';
 import {getInitialClassNameValue, getInitialStyleStringValue, initializeStaticContext, patchContextWithStaticAttrs, renderInitialClasses, renderInitialStyles} from '../styling/class_and_style_bindings';
-import {getStylingContextFromLView, hasClassInput, hasStyleInput, isAnimationProp} from '../styling/util';
+import {getStylingContextFromLView, hasClassInput, hasStyleInput} from '../styling/util';
 import {NO_CHANGE} from '../tokens';
 import {attrsStylingIndexOf, setUpAttributes} from '../util/attrs_utils';
 import {renderStringify} from '../util/misc_utils';
 import {getNativeByIndex, getNativeByTNode, getTNode} from '../util/view_utils';
-import {createDirectivesAndLocals, createNodeAtIndex, elementCreate, executeContentQueries, initializeTNodeInputs, setInputsForProperty, setNgReflectProperties, setNodeStylingTemplate} from './shared';
+import {createDirectivesAndLocals, createNodeAtIndex, elementCreate, executeContentQueries, initializeTNodeInputs, setInputsForProperty, setNodeStylingTemplate} from './shared';
 import {getActiveDirectiveStylingIndex} from './styling';
-
 
 
 /**
@@ -108,10 +107,6 @@ export function ɵɵelementStart(
     if (inputData && inputData.hasOwnProperty('style')) {
       tNode.flags |= TNodeFlags.hasStyleInput;
     }
-    if (ngDevMode && attrs && inputData &&
-        (tNode.type === TNodeType.Element || tNode.type === TNodeType.Container)) {
-      setUnboundNgReflectProperties(attrs !, lView, native, tNode.type, inputData);
-    }
   }
 
   // we render the styling again below in case any directives have set any `style` and/or
@@ -127,28 +122,6 @@ export function ɵɵelementStart(
     lView[QUERIES] = currentQueries.clone();
   }
   executeContentQueries(tView, tNode, lView);
-}
-
-function setUnboundNgReflectProperties(
-    attrs: TAttributes, lView: LView, element: RElement | RComment, type: TNodeType,
-    inputs: PropertyAliases) {
-  let i = 0;
-  while (i < attrs.length) {
-    const value = attrs[i];
-    // If the value is a number, it's a bound property and we can ignore it because its value
-    // will be set in `elementPropertyInternal`.
-    if (typeof value !== 'number') {
-      const attrName = value as string;
-      const attrVal = attrs[++i];
-      // We check for an alias value because it means that it's an input.
-      // This way we don't reflect regular attributes.
-      const aliasValue = inputs[attrName];
-      if (aliasValue && !isAnimationProp(attrName)) {
-        setNgReflectProperties(lView, element, type, aliasValue, attrVal);
-      }
-    }
-    i++;
-  }
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -842,9 +842,18 @@ export function elementPropertyInternal<T>(
     if (isComponent(tNode)) markDirtyIfOnPush(lView, index + HEADER_OFFSET);
     if (ngDevMode) {
       if (tNode.type === TNodeType.Element || tNode.type === TNodeType.Container) {
-        // dataValue is an array containing: [directive instance index, publicName, privateName]
-        // we want to set the reflected property with the privateName: dataValue[2]
-        setNgReflectProperties(lView, element, tNode.type, dataValue[2] as string, value);
+        /**
+         * dataValue is an array containing runtime input or output names for the directives:
+         * i+0: directive instance index
+         * i+1: publicName
+         * i+2: privateName
+         *
+         * e.g. [0, 'change', 'change-minified']
+         * we want to set the reflected property with the privateName: dataValue[i+2]
+         */
+        for (let i = 0; i < dataValue.length; i += 3) {
+          setNgReflectProperty(lView, element, tNode.type, dataValue[i + 2] as string, value);
+        }
       }
     }
   } else if (tNode.type === TNodeType.Element) {
@@ -886,7 +895,7 @@ function markDirtyIfOnPush(lView: LView, viewIndex: number): void {
   }
 }
 
-export function setNgReflectProperties(
+export function setNgReflectProperty(
     lView: LView, element: RElement | RComment, type: TNodeType, attrName: string, value: any) {
   const renderer = lView[RENDERER];
   attrName = normalizeDebugBindingName(attrName);
@@ -1330,7 +1339,7 @@ function setInputsFromAttrs<T>(
       if (ngDevMode) {
         const lView = getLView();
         const nativeElement = getNativeByTNode(tNode, lView) as RElement;
-        setNgReflectProperties(lView, nativeElement, tNode.type, privateName, value);
+        setNgReflectProperty(lView, nativeElement, tNode.type, privateName, value);
       }
     }
   }

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -781,7 +781,7 @@ export function createTNode(
 /**
  * Consolidates all inputs or outputs of all directives on this logical node.
  *
- * @param tNodeFlags node flags
+ * @param tNode
  * @param direction whether to consider inputs or outputs
  * @returns PropertyAliases|null aggregate of all properties if any, `null` otherwise
  */
@@ -884,7 +884,7 @@ function markDirtyIfOnPush(lView: LView, viewIndex: number): void {
   }
 }
 
-function setNgReflectProperties(
+export function setNgReflectProperties(
     lView: LView, element: RElement | RComment, type: TNodeType, inputs: PropertyAliasValue,
     value: any) {
   for (let i = 0; i < inputs.length; i += 3) {
@@ -1772,7 +1772,7 @@ export function handleError(lView: LView, error: any): void {
  * Set the inputs of directives at the current node to corresponding value.
  *
  * @param lView the `LView` which contains the directives.
- * @param inputAliases mapping between the public "input" name and privately-known,
+ * @param inputs mapping between the public "input" name and privately-known,
  * possibly minified, property names to write to.
  * @param value Value to set.
  */

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -67,7 +67,7 @@ export function setUpAttributes(native: RElement, attrs: TAttributes): number {
           (renderer as ProceduralRenderer3).setAttribute(native, attrName, attrVal, namespaceURI) :
           native.setAttributeNS(namespaceURI, attrName, attrVal);
     } else {
-      /// attrName is string;
+      // attrName is string;
       const attrName = value as string;
       const attrVal = attrs[++i];
       // Standard attributes

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1700,6 +1700,20 @@ function declareTests(config?: {useJit: boolean}) {
             .toContain('ng-reflect-dir-prop="hello"');
       });
 
+      it('should reflect property values on unbound inputs', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
+        const template = '<div>' +
+            '<div my-dir elprop="hello" title="Reflect test"></div>' +
+            '</div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
+
+        const html = getDOM().getInnerHTML(fixture.nativeElement);
+        expect(html).toContain('ng-reflect-dir-prop="hello"');
+        expect(html).not.toContain('ng-reflect-title');
+      });
+
       it(`should work with prop names containing '$'`, () => {
         TestBed.configureTestingModule({declarations: [ParentCmp, SomeCmpWithInput]});
         const fixture = TestBed.createComponent(ParentCmp);

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1748,6 +1748,21 @@ function declareTests(config?: {useJit: boolean}) {
         expect(html).toContain('"ng-reflect-ng-if": "true"');
       });
 
+      it('should reflect property values of multiple directive bound to the same input name',
+         () => {
+           TestBed.configureTestingModule({declarations: [MyComp, MyDir, MyDir2]});
+           TestBed.overrideComponent(
+               MyComp, {set: {template: `<div my-dir my-dir2 [elprop]="ctxProp"></div>`}});
+           const fixture = TestBed.createComponent(MyComp);
+
+           fixture.componentInstance.ctxProp = 'hello';
+           fixture.detectChanges();
+
+           const html = getDOM().getInnerHTML(fixture.nativeElement);
+           expect(html).toContain('ng-reflect-dir-prop="hello"');
+           expect(html).toContain('ng-reflect-dir-prop2="hello"');
+         });
+
       it('should indicate when toString() throws', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
         const template = '<div my-dir [elprop]="toStringThrow"></div>';
@@ -2043,6 +2058,12 @@ class DynamicViewport {
 class MyDir {
   dirProp: string;
   constructor() { this.dirProp = ''; }
+}
+
+@Directive({selector: '[my-dir2]', inputs: ['dirProp2: elprop'], exportAs: 'mydir2'})
+class MyDir2 {
+  dirProp2: string;
+  constructor() { this.dirProp2 = ''; }
 }
 
 @Directive({selector: '[title]', inputs: ['title']})

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1687,25 +1687,21 @@ function declareTests(config?: {useJit: boolean}) {
     describe('logging property updates', () => {
       it('should reflect property values as attributes', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-        const template = '<div>' +
-            '<div my-dir [elprop]="ctxProp"></div>' +
-            '</div>';
-        TestBed.overrideComponent(MyComp, {set: {template}});
+        TestBed.overrideComponent(
+            MyComp, {set: {template: `<div my-dir [elprop]="ctxProp"></div>`}});
         const fixture = TestBed.createComponent(MyComp);
 
         fixture.componentInstance.ctxProp = 'hello';
         fixture.detectChanges();
 
-        expect(getDOM().getInnerHTML(fixture.nativeElement))
-            .toContain('ng-reflect-dir-prop="hello"');
+        const html = getDOM().getInnerHTML(fixture.nativeElement);
+        expect(html).toContain('ng-reflect-dir-prop="hello"');
       });
 
       it('should reflect property values on unbound inputs', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-        const template = '<div>' +
-            '<div my-dir elprop="hello" title="Reflect test"></div>' +
-            '</div>';
-        TestBed.overrideComponent(MyComp, {set: {template}});
+        TestBed.overrideComponent(
+            MyComp, {set: {template: `<div my-dir elprop="hello" title="Reflect test"></div>`}});
         const fixture = TestBed.createComponent(MyComp);
         fixture.detectChanges();
 
@@ -1719,21 +1715,37 @@ function declareTests(config?: {useJit: boolean}) {
         const fixture = TestBed.createComponent(ParentCmp);
         fixture.detectChanges();
 
-        expect(getDOM().getInnerHTML(fixture.nativeElement)).toContain('ng-reflect-test_="hello"');
+        const html = getDOM().getInnerHTML(fixture.nativeElement);
+        expect(html).toContain('ng-reflect-test_="hello"');
       });
 
       it('should reflect property values on template comments', () => {
         const fixture =
             TestBed.configureTestingModule({declarations: [MyComp]})
                 .overrideComponent(
-                    MyComp, {set: {template: '<ng-template [ngIf]="ctxBoolProp"></ng-template>'}})
+                    MyComp, {set: {template: `<ng-template [ngIf]="ctxBoolProp"></ng-template>`}})
                 .createComponent(MyComp);
 
         fixture.componentInstance.ctxBoolProp = true;
         fixture.detectChanges();
 
-        expect(getDOM().getInnerHTML(fixture.nativeElement))
-            .toContain('"ng\-reflect\-ng\-if"\: "true"');
+        const html = getDOM().getInnerHTML(fixture.nativeElement);
+        expect(html).toContain('"ng-reflect-ng-if": "true"');
+      });
+
+      it('should reflect property values on ng-containers', () => {
+        const fixture =
+            TestBed.configureTestingModule({declarations: [MyComp]})
+                .overrideComponent(
+                    MyComp,
+                    {set: {template: `<ng-container *ngIf="ctxBoolProp">content</ng-container>`}})
+                .createComponent(MyComp);
+
+        fixture.componentInstance.ctxBoolProp = true;
+        fixture.detectChanges();
+
+        const html = getDOM().getInnerHTML(fixture.nativeElement);
+        expect(html).toContain('"ng-reflect-ng-if": "true"');
       });
 
       it('should indicate when toString() throws', () => {


### PR DESCRIPTION
We only set ng-reflect properties on directive input bindings.
This PR ensures that we also add ng-reflect properties on unbound inputs for backwards compatibility.

FW-1266 #resolve
