### PR TITLE
build: publish ts-api-guardian rule in the npm package

### DIFF
--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -1,11 +1,10 @@
+# BEGIN-DEV-ONLY
 load(
     "@build_bazel_rules_nodejs//:defs.bzl",
     "jasmine_node_test",
     "npm_package",
 )
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
-
-exports_files(["bin/ts-api-guardian"])
 
 ts_library(
     name = "lib",
@@ -35,10 +34,17 @@ genrule(
 npm_package(
     name = "ts-api-guardian",
     srcs = [
+        "BUILD.bazel",
         "README.md",
         "bin/ts-api-guardian",
+        "index.bzl",
         "package.json",
     ],
+    replacements = {
+        "(#|\/\/)\\s+BEGIN-DEV-ONLY[\\w\W]+?(#|\/\/)\\s+END-DEV-ONLY": "",
+        "@angular//tools/ts-api-guardian": "@npm_ts_api_guardian//",
+        "angular/tools/ts-api-guardian/": "npm_ts_api_guardian/",
+    },
     deps = [
         ":lib",
         ":license",
@@ -78,4 +84,11 @@ jasmine_node_test(
         ":package.json",
     ],
     tags = ["local"],
+)
+# END-DEV-ONLY
+
+filegroup(
+    name = "bin",
+    srcs = glob(["lib/*.js"]) + ["bin/ts-api-guardian"],
+    visibility = ["//visibility:public"],
 )

--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -1,4 +1,4 @@
-# BEGIN-DEV-ONLY
+# BEGIN-INTERNAL
 load(
     "@build_bazel_rules_nodejs//:defs.bzl",
     "jasmine_node_test",
@@ -41,7 +41,6 @@ npm_package(
         "package.json",
     ],
     replacements = {
-        "(#|\/\/)\\s+BEGIN-DEV-ONLY[\\w\W]+?(#|\/\/)\\s+END-DEV-ONLY": "",
         "@angular//tools/ts-api-guardian": "@npm_ts_api_guardian//",
         "angular/tools/ts-api-guardian/": "npm_ts_api_guardian/",
     },
@@ -85,7 +84,7 @@ jasmine_node_test(
     ],
     tags = ["local"],
 )
-# END-DEV-ONLY
+# END-INTERNAL
 
 filegroup(
     name = "bin",

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -33,8 +33,11 @@ def ts_api_guardian_test(
     """Runs ts_api_guardian
     """
     data += [
+        # BEGIN-DEV-ONLY
+        # Locally we need to add the TS build target
         "@angular//tools/ts-api-guardian:lib",
-        "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        # END-DEV-ONLY
+        "@angular//tools/ts-api-guardian:bin",
     ]
 
     args = [

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -33,10 +33,10 @@ def ts_api_guardian_test(
     """Runs ts_api_guardian
     """
     data += [
-        # BEGIN-DEV-ONLY
+        # BEGIN-INTERNAL
         # Locally we need to add the TS build target
         "@angular//tools/ts-api-guardian:lib",
-        # END-DEV-ONLY
+        # END-INTERNAL
         "@angular//tools/ts-api-guardian:bin",
     ]
 

--- a/tools/ts-api-guardian/package.json
+++ b/tools/ts-api-guardian/package.json
@@ -4,6 +4,12 @@
   "description": "Guards the API of TypeScript libraries!",
   "main": "lib/main.js",
   "typings": "lib/main.d.ts",
+  "bazelWorkspaces": {
+    "npm_ts_api_guardian": {
+      "version": "0.4.1",
+      "rootPath": "."
+    }
+  },
   "bin": {
     "ts-api-guardian": "./bin/ts-api-guardian"
   },


### PR DESCRIPTION
With this change downstream users will no longer need to build ts-api-guardian from source as now the bazel rule is available in the npm package.

This can be used by installing ts-api-guardian as a devDependency and changing the load syntax from:
```
load("@angular//tools/ts-api-guardian:index.bzl", "ts_api_guardian_test")
```

to:
```
load("@npm_ts_api_guardian//:index.bzl", "ts_api_guardian_test")
```

**Note**: downstream users should also clean their `WORKSPACE` and remove the dependencies of angular workspace.
