### PR TITLE
ci(docs-infra): do not build with Ivy on 7.2.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,9 +544,9 @@ workflows:
       - test_aio_local:
           requires:
             - build-npm-packages
-      - test_aio_local_ivy:
-          requires:
-            - build-npm-packages
+      # - test_aio_local_ivy:
+      #     requires:
+      #       - build-npm-packages
       - test_aio_tools:
           requires:
             - build-npm-packages


### PR DESCRIPTION
The 7.2.x does not include the code necessary to build with Ivy. The `test_aio_local_ivy` job needs to be skipped on 7.2.x.

The job was accidentally enabled while rebasing 1cdffbdc2.
