### PR TITLE
fix(core): Fix Type<T> for strictFunctionTypes

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -431,7 +431,7 @@ export function providerToFactory(
             `Invalid provider for the NgModule '${stringify(ngModuleType)}'` + ngModuleDetail);
       }
       if (hasDeps(provider)) {
-        factory = () => new (classRef)(...injectArgs(provider.deps));
+        factory = () => new (classRef)(...injectArgs(provider.deps) as never[]);
       } else {
         return injectableDefOrInjectorDefFactory(classRef);
       }

--- a/packages/core/src/di/util.ts
+++ b/packages/core/src/di/util.ts
@@ -24,7 +24,7 @@ export function convertInjectableProviderToFactory(
     const reflectionCapabilities = new ReflectionCapabilities();
     const deps = reflectionCapabilities.parameters(type);
     // TODO - convert to flags.
-    return () => new type(...injectArgs(deps as any[]));
+    return () => new type(...injectArgs(deps as any[]) as never[]);
   }
 
   if (USE_VALUE in provider) {
@@ -43,13 +43,13 @@ export function convertInjectableProviderToFactory(
       const reflectionCapabilities = new ReflectionCapabilities();
       deps = reflectionCapabilities.parameters(type);
     }
-    return () => new classProvider.useClass(...injectArgs(deps));
+    return () => new classProvider.useClass(...injectArgs(deps) as never[]);
   } else {
     let deps = (provider as ConstructorSansProvider).deps;
     if (!deps) {
       const reflectionCapabilities = new ReflectionCapabilities();
       deps = reflectionCapabilities.parameters(type);
     }
-    return () => new type(...injectArgs(deps !));
+    return () => new type(...injectArgs(deps !) as never[]);
   }
 }

--- a/packages/core/src/interface/type.ts
+++ b/packages/core/src/interface/type.ts
@@ -32,7 +32,7 @@ export function isType(v: any): v is Type<any> {
  */
 export interface AbstractType<T> extends Function { prototype: T; }
 
-export interface Type<T> extends Function { new (...args: any[]): T; }
+export interface Type<T> extends Function { new (...args: never[]): T; }
 
 export type Mutable<T extends{[x: string]: any}, K extends string> = {
   [P in K]: T[P];

--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -33,7 +33,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
 
   isReflectionEnabled(): boolean { return true; }
 
-  factory<T>(t: Type<T>): (args: any[]) => T { return (...args: any[]) => new t(...args); }
+  factory<T>(t: Type<T>): (args: any[]) => T { return (...args: never[]) => new t(...args); }
 
   /** @internal */
   _zipTypesAndAnnotations(paramTypes: any[], paramAnnotations: any[]): any[][] {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, Component as _Component, ComponentFactoryResolver, ComponentRef, ɵɵdefineInjector, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, QueryList, RendererFactory2, TemplateRef, ViewContainerRef, ViewRef, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef,} from '../../src/core';
+import {ChangeDetectorRef, Component as _Component, ComponentFactoryResolver, ComponentRef, ɵɵdefineInjector, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, QueryList, RendererFactory2, TemplateRef, Type, ViewContainerRef, ViewRef, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef,} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
 import {ViewEncapsulation} from '../../src/metadata';
 import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefinePipe, injectComponentFactoryResolver, ɵɵlistener, ɵɵloadViewQuery, ɵɵNgOnChangesFeature, ɵɵqueryRefresh, ɵɵviewQuery,} from '../../src/render3/index';
@@ -1237,8 +1237,8 @@ describe('ViewContainerRef', () => {
 
         expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
             .toEqual('header');
-        expect(
-            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+        expect(directiveInstance !.vcref.injector.get(ElementRef as Type<ElementRef<HTMLElement>>)
+                   .nativeElement.tagName.toLowerCase())
             .toEqual('header');
         expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
       });
@@ -1256,8 +1256,8 @@ describe('ViewContainerRef', () => {
 
         expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
             .toEqual('header-cmp');
-        expect(
-            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+        expect(directiveInstance !.vcref.injector.get(ElementRef as Type<ElementRef<HTMLElement>>)
+                   .nativeElement.tagName.toLowerCase())
             .toEqual('header-cmp');
         expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
       });
@@ -1270,7 +1270,8 @@ describe('ViewContainerRef', () => {
 
         new TemplateFixture(createTemplate, () => {}, 2, 0, [DirectiveWithVCRef]);
         expect(directiveInstance !.vcref.element.nativeElement.textContent).toEqual('container');
-        expect(directiveInstance !.vcref.injector.get(ElementRef).nativeElement.textContent)
+        expect(directiveInstance !.vcref.injector.get(ElementRef as Type<ElementRef<HTMLElement>>)
+                   .nativeElement.textContent)
             .toEqual('container');
         expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
       });


### PR DESCRIPTION
See - https://github.com/Microsoft/TypeScript/issues/24428
tl;dr - When using `--strict` mode, `any` isn't a subtype of `string`
and thus the function doesn't match types.

Fixes #29905

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current definition for `Type<T>` uses `any[]` for the `new` function, however this doesn't work well with `strictFunctionTypes` because for example `new(foo:string)` isn't assignable because `any` isn't a subtype of string.

See - https://github.com/Microsoft/TypeScript/issues/24428

Issue Number: #29905


## What is the new behavior?

`Type<T>` now uses `never[]` which means we can't instantiate with `new` whatever we cast to `Type<T>` but now it should be assignable because `never` is a subtype of `string`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
