### PR TITLE
fix(bazel): restore ng build --prod

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -140,7 +140,12 @@ function updateAngularJsonToUseBazelBuilder(options: Schema): Rule {
           options: {
             targetLabel: '//src:prodapp',
             bazelCommand: 'build',
-          }
+          },
+          configurations: {
+            production: {
+              targetLabel: '//src:prodapp',
+            },
+          },
         },
         indent);
     replacePropertyInAstObject(


### PR DESCRIPTION
`ng build` by default builds the prodapp because there is not
a dev build in Bazel. This PR restores the `--prod` to do the
same to prevent achitect from showing missing config error.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
