### PR TITLE
ci: remove integration test "uname -a" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,6 @@ jobs:
     steps:
       - *attach_workspace
       - *init_environment
-      - run: uname -r
       # Runs the integration tests in parallel across multiple CircleCI container instances. The
       # amount of container nodes for this job is controlled by the "parallelism" option.
       - run: ./integration/run_tests.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}


### PR DESCRIPTION
We recently added the "uname -a" command to the CircleCI
integration test in order to identify Linux kernels that
broke Chrome sandboxing.

Since this issue seems to be claimed as fixed by the CircleCI
support and we didn't see any sandboxing issues the last month,
we are removing the debugging command we added.

See: https://github.com/angular/angular/commit/80379697e2755fadb313512654291891f1851659