### PR TITLE
feat(ivy): generate ɵɵproperty in host bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -213,7 +213,7 @@ describe('compiler compliance: bindings', () => {
               $r3$.ɵɵallocHostVars(1);
             }
             if (rf & 2) {
-              $r3$.ɵɵelementProperty(elIndex, "id", $r3$.ɵɵbind(ctx.dirId), null, true);
+              $r3$.ɵɵproperty("id", ctx.dirId, null, true);
             }
           }
         });
@@ -260,7 +260,7 @@ describe('compiler compliance: bindings', () => {
               $r3$.ɵɵallocHostVars(3);
             }
             if (rf & 2) {
-              $r3$.ɵɵelementProperty(elIndex, "id", $r3$.ɵɵbind($r3$.ɵɵpureFunction1(1, $ff$, ctx.id)), null, true);
+              $r3$.ɵɵproperty("id", $r3$.ɵɵpureFunction1(1, $ff$, ctx.id), null, true);
             }
           },
           consts: 0,

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -1285,8 +1285,8 @@ describe('compiler compliance: styling', () => {
           $r3$.ɵɵelementHostStyling(null, null, $r3$.ɵɵdefaultStyleSanitizer);
         }
         if (rf & 2) {
-          $r3$.ɵɵelementProperty(elIndex, "id", $r3$.ɵɵbind(ctx.id), null, true);
-          $r3$.ɵɵelementProperty(elIndex, "title", $r3$.ɵɵbind(ctx.title), null, true);
+          $r3$.ɵɵproperty("id", ctx.id, null, true);
+          $r3$.ɵɵproperty("title", ctx.title, null, true);
           $r3$.ɵɵelementHostStylingMap(ctx.myClass, ctx.myStyle);
           $r3$.ɵɵelementHostStylingApply();
         }
@@ -1331,8 +1331,8 @@ describe('compiler compliance: styling', () => {
           $r3$.ɵɵelementHostStyling($_c0$, $_c1$);
         }
         if (rf & 2) {
-          $r3$.ɵɵelementProperty(elIndex, "id", $r3$.ɵɵbind(ctx.id), null, true);
-          $r3$.ɵɵelementProperty(elIndex, "title", $r3$.ɵɵbind(ctx.title), null, true);
+          $r3$.ɵɵproperty("id", ctx.id, null, true);
+          $r3$.ɵɵproperty("title", ctx.title, null, true);
           $r3$.ɵɵelementHostStyleProp(0, ctx.myWidth);
           $r3$.ɵɵelementHostClassProp(0, ctx.myFooClass);
           $r3$.ɵɵelementHostStylingApply();

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1762,7 +1762,7 @@ describe('ngtsc behavioral tests', () => {
         }
         if (rf & 2) {
           i0.\u0275\u0275elementAttribute(elIndex, "hello", i0.\u0275\u0275bind(ctx.foo));
-          i0.\u0275\u0275elementProperty(elIndex, "prop", i0.\u0275\u0275bind(ctx.bar), null, true);
+          i0.\u0275\u0275property("prop", ctx.bar, null, true);
           i0.\u0275\u0275elementHostClassProp(0, ctx.someClass);
           i0.\u0275\u0275elementHostStylingApply();
         }
@@ -3266,12 +3266,12 @@ describe('ngtsc behavioral tests', () => {
             i0.\u0275\u0275allocHostVars(6);
           }
           if (rf & 2) {
-            i0.\u0275\u0275elementProperty(elIndex, "href", i0.\u0275\u0275bind(ctx.propHref), i0.\u0275\u0275sanitizeUrlOrResourceUrl, true);
-            i0.\u0275\u0275elementProperty(elIndex, "src", i0.\u0275\u0275bind(ctx.propSrc), i0.\u0275\u0275sanitizeUrlOrResourceUrl, true);
-            i0.\u0275\u0275elementProperty(elIndex, "action", i0.\u0275\u0275bind(ctx.propAction), i0.\u0275\u0275sanitizeUrl, true);
-            i0.\u0275\u0275elementProperty(elIndex, "profile", i0.\u0275\u0275bind(ctx.propProfile), i0.\u0275\u0275sanitizeResourceUrl, true);
-            i0.\u0275\u0275elementProperty(elIndex, "innerHTML", i0.\u0275\u0275bind(ctx.propInnerHTML), i0.\u0275\u0275sanitizeHtml, true);
-            i0.\u0275\u0275elementProperty(elIndex, "title", i0.\u0275\u0275bind(ctx.propSafeTitle), null, true);
+            i0.\u0275\u0275property("href", ctx.propHref, i0.\u0275\u0275sanitizeUrlOrResourceUrl, true);
+            i0.\u0275\u0275property("src", ctx.propSrc, i0.\u0275\u0275sanitizeUrlOrResourceUrl, true);
+            i0.\u0275\u0275property("action", ctx.propAction, i0.\u0275\u0275sanitizeUrl, true);
+            i0.\u0275\u0275property("profile", ctx.propProfile, i0.\u0275\u0275sanitizeResourceUrl, true);
+            i0.\u0275\u0275property("innerHTML", ctx.propInnerHTML, i0.\u0275\u0275sanitizeHtml, true);
+            i0.\u0275\u0275property("title", ctx.propSafeTitle, null, true);
           }
         }
       `;
@@ -3306,9 +3306,9 @@ describe('ngtsc behavioral tests', () => {
             i0.\u0275\u0275allocHostVars(6);
           }
           if (rf & 2) {
-            i0.\u0275\u0275elementProperty(elIndex, "src", i0.\u0275\u0275bind(ctx.srcProp), null, true);
-            i0.\u0275\u0275elementProperty(elIndex, "href", i0.\u0275\u0275bind(ctx.hrefProp), null, true);
-            i0.\u0275\u0275elementProperty(elIndex, "title", i0.\u0275\u0275bind(ctx.titleProp), null, true);
+            i0.\u0275\u0275property("src", ctx.srcProp, null, true);
+            i0.\u0275\u0275property("href", ctx.hrefProp, null, true);
+            i0.\u0275\u0275property("title", ctx.titleProp, null, true);
             i0.\u0275\u0275elementAttribute(elIndex, "src", i0.\u0275\u0275bind(ctx.srcAttr));
             i0.\u0275\u0275elementAttribute(elIndex, "href", i0.\u0275\u0275bind(ctx.hrefAttr));
             i0.\u0275\u0275elementAttribute(elIndex, "title", i0.\u0275\u0275bind(ctx.titleAttr));

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -652,9 +652,17 @@ function createHostBindingsFunction(
         }
       }
 
-      const instructionParams: o.Expression[] = [
-        elVarExp, o.literal(bindingName), o.importExpr(R3.bind).callFn([bindingExpr.currValExpr])
-      ];
+      const isPropertyInstruction = instruction === R3.property;
+      const instructionParams: o.Expression[] = isPropertyInstruction ?
+          [
+            o.literal(bindingName),
+            bindingExpr.currValExpr,
+          ] :
+          [
+            elVarExp,
+            o.literal(bindingName),
+            o.importExpr(R3.bind).callFn([bindingExpr.currValExpr]),
+          ];
       if (sanitizerFn) {
         instructionParams.push(sanitizerFn);
       }
@@ -762,7 +770,7 @@ function getBindingNameAndInstruction(binding: ParsedProperty):
       // compatibility instruction available for this purpose.
       instruction = R3.componentHostSyntheticProperty;
     } else {
-      instruction = R3.elementProperty;
+      instruction = R3.property;
     }
   }
 


### PR DESCRIPTION
- Updates host bindings code generation to generate `ɵɵselect` and `ɵɵproperty` instructions
- Updates relevant tests

## PR Checklist
- [x] Tests for the changes have been updated/added


## PR Type
- [x] Feature