### PR TITLE
feat(core): add undecorated-base-class migration schematic

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -14,5 +14,6 @@ npm_package(
         "//packages/core/schematics/migrations/move-document",
         "//packages/core/schematics/migrations/static-queries",
         "//packages/core/schematics/migrations/template-var-assignment",
+        "//packages/core/schematics/migrations/undecorated-base-class",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -14,6 +14,11 @@
       "version": "8-beta",
       "description": "Warns developers if values are assigned to template variables",
       "factory": "./migrations/template-var-assignment/index"
+    },
+    "migration-v8-undecorated-base-class": {
+      "version": "8-beta",
+      "description": "Decorates undecorated base classes of directives and components that use DI with an appropriate decorator",
+      "factory": "./migrations/undecorated-base-class/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/undecorated-base-class/BUILD.bazel
+++ b/packages/core/schematics/migrations/undecorated-base-class/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/undecorated-base-class/google3:__pkg__",
         "//packages/core/schematics/test:__pkg__",
     ],
     deps = [

--- a/packages/core/schematics/migrations/undecorated-base-class/BUILD.bazel
+++ b/packages/core/schematics/migrations/undecorated-base-class/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "undecorated-base-class",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/undecorated-base-class/directive_visitor.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/directive_visitor.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {NgDecorator, getAngularDecorators} from '../../utils/ng_decorators';
+import {getPropertyNameText} from '../../utils/typescript/property_name';
+
+export interface ResolvedNgModule {
+  name: string;
+  node: ts.ClassDeclaration;
+  decorator: NgDecorator;
+  declarationsNode: ts.ArrayLiteralExpression;
+}
+
+export type DirectiveModuleMap = Map<ts.ClassDeclaration, ResolvedNgModule[]>;
+
+/**
+ * Visitor that walks through specified TypeScript nodes and collects all found
+ * NgModule definitions and directives/components.
+ */
+export class NgDirectiveVisitor {
+  directiveModules: DirectiveModuleMap = new Map();
+  resolvedDirectives: ts.ClassDeclaration[] = [];
+
+  constructor(public typeChecker: ts.TypeChecker) {}
+
+  visitNode(node: ts.Node) {
+    if (ts.isClassDeclaration(node)) {
+      this.visitClassDeclaration(node);
+    }
+
+    ts.forEachChild(node, n => this.visitNode(n));
+  }
+
+  private visitClassDeclaration(node: ts.ClassDeclaration) {
+    if (!node.decorators || !node.decorators.length) {
+      return;
+    }
+
+    const ngDecorators = getAngularDecorators(this.typeChecker, node.decorators);
+    const directiveDecorator =
+        ngDecorators.find(({name}) => name === 'Directive' || name === 'Component');
+    const ngModuleDecorator = ngDecorators.find(({name}) => name === 'NgModule');
+
+    if (ngModuleDecorator) {
+      this._visitNgModuleClass(node, ngModuleDecorator);
+    } else if (directiveDecorator) {
+      this.resolvedDirectives.push(node);
+    }
+  }
+
+  private _visitNgModuleClass(node: ts.ClassDeclaration, decorator: NgDecorator) {
+    const decoratorCall = decorator.node.expression;
+
+    if (!ts.isObjectLiteralExpression(decoratorCall.arguments[0])) {
+      return;
+    }
+
+    const metadata = decoratorCall.arguments[0] as ts.ObjectLiteralExpression;
+    const declarations = metadata.properties.filter(ts.isPropertyAssignment)
+                             .find(p => getPropertyNameText(p.name) === 'declarations');
+
+    // In case there is no "declarations" property in the NgModule metadata,
+    // just skip this module as there are no declared directives/components.
+    if (!declarations || !ts.isArrayLiteralExpression(declarations.initializer)) {
+      return;
+    }
+
+    const name = node.name ? node.name.text : 'default';
+    const declarationsNode = declarations.initializer;
+    const module: ResolvedNgModule = {name, node, decorator, declarationsNode};
+
+    declarationsNode.elements.forEach(el => {
+      const decl = this._getDeclarationSymbolOfNode(el);
+
+      if (!decl || !decl.valueDeclaration || !ts.isClassDeclaration(decl.valueDeclaration)) {
+        return;
+      }
+
+      const resolvedModules = this.directiveModules.get(decl.valueDeclaration) || [];
+      resolvedModules.push(module);
+      this.directiveModules.set(decl.valueDeclaration, resolvedModules);
+    });
+  }
+
+  /**
+   * Gets the declaration symbol of a given TypeScript node. Resolves aliased
+   * symbols to the symbol containing the value declaration.
+   */
+  private _getDeclarationSymbolOfNode(node: ts.Node): ts.Symbol|null {
+    let symbol = this.typeChecker.getSymbolAtLocation(node);
+
+    if (!symbol) {
+      return null;
+    }
+
+    // Resolve the symbol to it's original declaration symbol.
+    while (symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = this.typeChecker.getAliasedSymbol(symbol);
+    }
+
+    return symbol;
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/find_base_classes.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/find_base_classes.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+import {getBaseTypeIdentifiers} from '../../utils/typescript/class_declaration';
+
+/** Gets all base class declarations of the specified class declaration. */
+export function findBaseClassDeclarations(node: ts.ClassDeclaration, typeChecker: ts.TypeChecker) {
+  const result: ts.ClassDeclaration[] = [];
+  let currentClass = node;
+
+  while (currentClass) {
+    const baseTypes = getBaseTypeIdentifiers(currentClass);
+    if (!baseTypes || baseTypes.length !== 1) {
+      break;
+    }
+    const symbol = typeChecker.getTypeAtLocation(baseTypes[0]).getSymbol();
+
+    if (!symbol || !ts.isClassDeclaration(symbol.valueDeclaration)) {
+      break;
+    }
+    result.push(symbol.valueDeclaration);
+    currentClass = symbol.valueDeclaration;
+  }
+  return result;
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/undecorated-base-class/google3/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "google3",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = ["//packages/core/schematics/test:__pkg__"],
+    deps = [
+        "//packages/core/schematics/migrations/undecorated-base-class",
+        "//packages/core/schematics/utils",
+        "@npm//tslint",
+    ],
+)

--- a/packages/core/schematics/migrations/undecorated-base-class/google3/noUndecoratedBaseClassRule.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/google3/noUndecoratedBaseClassRule.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuleFailure, Rules} from 'tslint';
+import * as ts from 'typescript';
+
+import {NgDirectiveVisitor} from '../directive_visitor';
+import {UndecoratedBaseClassTransform} from '../transform';
+
+import {TslintUpdateRecorder} from './tslint_update_recorder';
+
+let lastSourceFile: ts.SourceFile|null = null;
+let prevSelectorIdx = 1;
+let selectorIdx = 1;
+
+/**
+ * Google3 tslint rule for the undecorated base class schematic. Rule
+ * can be used as fixer to make undecorated base classes work with Ivy.
+ */
+export class Rule extends Rules.TypedRule {
+  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    // In case the previous source file is equal to the current one, we need to restore
+    // the previous selector index. This is necessary because TSLint runs the rule multiple
+    // times for a source-file and we need to keep the selector indices similar.
+    if (sourceFile === lastSourceFile) {
+      selectorIdx = prevSelectorIdx;
+    } else {
+      lastSourceFile = sourceFile;
+      prevSelectorIdx = selectorIdx;
+    }
+
+    const ruleName = this.ruleName;
+    const typeChecker = program.getTypeChecker();
+    const sourceFiles = program.getSourceFiles().filter(
+        s => !s.isDeclarationFile && !program.isSourceFileFromExternalLibrary(s));
+    const directiveVisitor = new NgDirectiveVisitor(typeChecker);
+    const failures: RuleFailure[] = [];
+
+    // Analyze source files by detecting all directive and components.
+    sourceFiles.forEach(sourceFile => directiveVisitor.visitNode(sourceFile));
+
+    const {resolvedDirectives, directiveModules} = directiveVisitor;
+    const transformer = new UndecoratedBaseClassTransform(
+        typeChecker, directiveModules, getUpdateRecorder, () => selectorIdx++);
+    const updateRecorders = new Map<ts.SourceFile, TslintUpdateRecorder>();
+
+    resolvedDirectives.forEach(classDecl => {
+      // For the TSLint rule we only want to check directives within the
+      // current source file.
+      if (classDecl.getSourceFile() !== sourceFile) {
+        return;
+      }
+
+      transformer.migrateDirective(classDecl).forEach(({message, node}) => {
+        failures.push(new RuleFailure(node.getSourceFile(), node.getStart(), 0, message, ruleName));
+      });
+    });
+
+    // Record the changes collected in the import manager and NgModule manager.
+    transformer.recordChanges();
+
+    // Walk through each update recorder and commit the update. We need to add the
+    // replacements in batches per source file as there can be only one recorder
+    // per source file in order to not incorrectly shift offsets.
+    updateRecorders.forEach((recorder) => { failures.push(...recorder.failures); });
+
+    return failures;
+
+    /** Gets the update recorder for the specified source file. */
+    function getUpdateRecorder(sourceFile: ts.SourceFile): TslintUpdateRecorder {
+      if (updateRecorders.has(sourceFile)) {
+        return updateRecorders.get(sourceFile) !;
+      }
+      const recorder = new TslintUpdateRecorder(ruleName, sourceFile);
+      updateRecorders.set(sourceFile, recorder);
+      return recorder;
+    }
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/import_manager.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/import_manager.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {UpdateRecorder} from '@angular-devkit/schematics';
 import {dirname, resolve} from 'path';
 import * as ts from 'typescript';
+import {UpdateRecorder} from './update_recorder';
 
 /**
  * Import manager that can be used to add TypeScript imports to given source
@@ -157,7 +157,7 @@ export class ImportManager {
     }
 
     this.getUpdateRecorder(sourceFile)
-        .insertRight(
+        .addNewImport(
             importStartIndex,
             `\n${this.printer.printNode(ts.EmitHint.Unspecified, newImport, sourceFile)}`);
 
@@ -183,9 +183,8 @@ export class ImportManager {
           namedBindings.elements.concat(expressions.map(
               ({propertyName, importName}) => ts.createImportSpecifier(propertyName, importName))));
 
-      recorder.remove(namedBindings.getStart(), namedBindings.getWidth());
-      recorder.insertRight(
-          namedBindings.getStart(),
+      recorder.updateExistingImport(
+          namedBindings,
           this.printer.printNode(ts.EmitHint.Unspecified, newNamedBindings, sourceFile));
     });
   }

--- a/packages/core/schematics/migrations/undecorated-base-class/import_manager.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/import_manager.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {UpdateRecorder} from '@angular-devkit/schematics';
+import {dirname, resolve} from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Import manager that can be used to add TypeScript imports to given source
+ * files. The manager ensures that multiple transformations are applied properly
+ * without shifted offsets and that similar existing import declarations are re-used.
+ */
+export class ImportManager {
+  /** Map of import declarations that need to be updated to include the given symbols. */
+  private updatedImports =
+      new Map<ts.ImportDeclaration, {propertyName?: ts.Identifier, importName: ts.Identifier}[]>();
+  /** Map of source-files and their previously used identifier names. */
+  private usedIdentifierNames = new Map<ts.SourceFile, string[]>();
+  /**
+   * Array of previously resolved symbol imports. Cache can be re-used to return
+   * the same identifier without checking the source-file again.
+   */
+  private importCache: {
+    sourceFile: ts.SourceFile,
+    symbolName: string|null,
+    moduleName: string,
+    identifier: ts.Identifier
+  }[] = [];
+
+  constructor(
+      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder,
+      private printer: ts.Printer) {}
+
+  /**
+   * Adds an import to the given source-file and returns the TypeScript
+   * identifier that can be used to access the newly imported symbol.
+   */
+  addImportToSourceFile(
+      sourceFile: ts.SourceFile, symbolName: string|null, moduleName: string,
+      typeImport = false): ts.Expression {
+    const sourceDir = dirname(sourceFile.fileName);
+    let importStartIndex = 0;
+    let existingImport: ts.ImportDeclaration|null = null;
+
+    // In case the given import has been already generated previously, we just return
+    // the previous generated identifier in order to avoid duplicate generated imports.
+    const cachedImport = this.importCache.find(
+        c => c.sourceFile === sourceFile && c.symbolName === symbolName &&
+            c.moduleName === moduleName);
+    if (cachedImport) {
+      return cachedImport.identifier;
+    }
+
+    // Walk through all source-file top-level statements and search for import declarations
+    // that already match the specified "moduleName" and can be updated to import the
+    // given symbol. If no matching import can be found, the last import in the source-file
+    // will be used as starting point for imports that will be generated.
+    for (let i = sourceFile.statements.length - 1; i >= 0; i--) {
+      const statement = sourceFile.statements[i];
+
+      if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier) ||
+          !statement.importClause) {
+        continue;
+      }
+
+      if (!importStartIndex) {
+        importStartIndex = statement.getEnd();
+      }
+
+      const moduleSpecifier = statement.moduleSpecifier.text;
+
+      if (moduleSpecifier.startsWith('.') &&
+              resolve(sourceDir, moduleSpecifier) !== resolve(sourceDir, moduleName) ||
+          moduleSpecifier !== moduleName) {
+        continue;
+      }
+
+      if (statement.importClause.namedBindings) {
+        const namedBindings = statement.importClause.namedBindings;
+
+        // In case a "Type" symbol is imported, we can't use namespace imports
+        // because these only export symbols available at runtime (no types)
+        if (ts.isNamespaceImport(namedBindings) && !typeImport) {
+          return ts.createPropertyAccess(
+              ts.createIdentifier(namedBindings.name.text),
+              ts.createIdentifier(symbolName || 'default'));
+        } else if (ts.isNamedImports(namedBindings) && symbolName) {
+          const existingElement = namedBindings.elements.find(
+              e =>
+                  e.propertyName ? e.propertyName.text === symbolName : e.name.text === symbolName);
+
+          if (existingElement) {
+            return ts.createIdentifier(existingElement.name.text);
+          }
+
+          // In case the symbol could not be found in an existing import, we
+          // keep track of the import declaration as it can be updated to include
+          // the specified symbol name without having to create a new import.
+          existingImport = statement;
+        }
+      } else if (statement.importClause.name && !symbolName) {
+        return ts.createIdentifier(statement.importClause.name.text);
+      }
+    }
+
+    if (existingImport) {
+      const propertyIdentifier = ts.createIdentifier(symbolName !);
+      const generatedUniqueIdentifier = this._getUniqueIdentifier(sourceFile, symbolName !);
+      const needsGeneratedUniqueName = generatedUniqueIdentifier.text !== symbolName;
+      const importName = needsGeneratedUniqueName ? generatedUniqueIdentifier : propertyIdentifier;
+
+      // Since it can happen that multiple classes need to be imported within the
+      // specified source file and we want to add the identifiers to the existing
+      // import declaration, we need to keep track of the updated import declarations.
+      // We can't directly update the import declaration for each identifier as this
+      // would throw of the recorder offsets. We need to keep track of the new identifiers
+      // for the import and perform the import transformation only once.
+      this.updatedImports.set(
+          existingImport, (this.updatedImports.get(existingImport) || []).concat({
+            propertyName: needsGeneratedUniqueName ? propertyIdentifier : undefined,
+            importName: importName,
+          }));
+
+      // Keep track of all updated imports so that we don't generate duplicate
+      // similar imports as these can't be statically analyzed in the source-file yet.
+      this.importCache.push({sourceFile, moduleName, symbolName, identifier: importName});
+
+      return importName;
+    }
+
+    let identifier: ts.Identifier|null = null;
+    let newImport: ts.ImportDeclaration|null = null;
+
+    if (symbolName) {
+      const propertyIdentifier = ts.createIdentifier(symbolName);
+      const generatedUniqueIdentifier = this._getUniqueIdentifier(sourceFile, symbolName);
+      const needsGeneratedUniqueName = generatedUniqueIdentifier.text !== symbolName;
+      identifier = needsGeneratedUniqueName ? generatedUniqueIdentifier : propertyIdentifier;
+
+      newImport = ts.createImportDeclaration(
+          undefined, undefined,
+          ts.createImportClause(
+              undefined,
+              ts.createNamedImports([ts.createImportSpecifier(
+                  needsGeneratedUniqueName ? propertyIdentifier : undefined, identifier)])),
+          ts.createStringLiteral(moduleName));
+    } else {
+      identifier = this._getUniqueIdentifier(sourceFile, 'defaultExport');
+      newImport = ts.createImportDeclaration(
+          undefined, undefined, ts.createImportClause(identifier, undefined),
+          ts.createStringLiteral(moduleName));
+    }
+
+    this.getUpdateRecorder(sourceFile)
+        .insertRight(
+            importStartIndex,
+            `\n${this.printer.printNode(ts.EmitHint.Unspecified, newImport, sourceFile)}`);
+
+    // Keep track of all generated imports so that we don't generate duplicate
+    // similar imports as these can't be statically analyzed in the source-file yet.
+    this.importCache.push({sourceFile, symbolName, moduleName, identifier});
+
+    return identifier;
+  }
+
+  /**
+   * Stores the collected import changes within the appropriate update recorders. The
+   * updated imports can only be updated once because previous updates shift the
+   * source-file offsets.
+   */
+  recordChanges() {
+    this.updatedImports.forEach((expressions, importDecl) => {
+      const sourceFile = importDecl.getSourceFile();
+      const recorder = this.getUpdateRecorder(sourceFile);
+      const namedBindings = importDecl.importClause !.namedBindings as ts.NamedImports;
+      const newNamedBindings = ts.updateNamedImports(
+          namedBindings,
+          namedBindings.elements.concat(expressions.map(
+              ({propertyName, importName}) => ts.createImportSpecifier(propertyName, importName))));
+
+      recorder.remove(namedBindings.getStart(), namedBindings.getWidth());
+      recorder.insertRight(
+          namedBindings.getStart(),
+          this.printer.printNode(ts.EmitHint.Unspecified, newNamedBindings, sourceFile));
+    });
+  }
+
+  /** Gets an unique identifier with a base name for the given source file. */
+  private _getUniqueIdentifier(sourceFile: ts.SourceFile, baseName: string): ts.Identifier {
+    if (this.isUniqueIdentifierName(sourceFile, baseName)) {
+      this.usedIdentifierNames.set(
+          sourceFile, (this.usedIdentifierNames.get(sourceFile) || []).concat(baseName));
+      return ts.createIdentifier(baseName);
+    }
+
+    let name = null;
+    let counter = 1;
+    do {
+      name = `${baseName}_${counter++}`;
+    } while (!this.isUniqueIdentifierName(sourceFile, name));
+
+    this.usedIdentifierNames.set(
+        sourceFile, (this.usedIdentifierNames.get(sourceFile) || []).concat(name !));
+    return ts.createIdentifier(name !);
+  }
+
+  /** Checks whether the specified identifier name is used within the given source file. */
+  private isUniqueIdentifierName(sourceFile: ts.SourceFile, name: string) {
+    if (this.usedIdentifierNames.has(sourceFile) &&
+        this.usedIdentifierNames.get(sourceFile) !.indexOf(name) !== -1) {
+      return false;
+    }
+
+    const nodeQueue: ts.Node[] = [sourceFile];
+
+    while (nodeQueue.length) {
+      const node = nodeQueue.shift() !;
+
+      if (ts.isIdentifier(node) && node.text === name) {
+        return false;
+      }
+
+      nodeQueue.push(...node.getChildren());
+    }
+    return true;
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/index.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/index.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicContext, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {dirname, relative} from 'path';
+import * as ts from 'typescript';
+
+import {getAngularDecorators} from '../../utils/ng_decorators';
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {hasExplicitConstructor} from '../../utils/typescript/class_declaration';
+import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
+
+import {NgDirectiveVisitor} from './directive_visitor';
+import {findBaseClassDeclarations} from './find_base_classes';
+import {ImportManager} from './import_manager';
+import {NgModuleDeclarationsManager} from './module_declarations';
+
+
+/** Entry point for the V8 undecorated-base-class schematic. */
+export default function(): Rule {
+  return (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const failures: string[] = [];
+
+    ctx.logger.info('------ Undecorated base class migration ------');
+
+    if (!buildPaths.length && !testPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot decorate any base classes which use ' +
+          'dependency injection but are not decorated.');
+    }
+
+    for (const tsconfigPath of [...buildPaths, ...testPaths]) {
+      failures.push(...runUndecoratedBaseClassMigration(tree, tsconfigPath, basePath));
+    }
+
+    if (failures.length) {
+      ctx.logger.info('Could not migrate all base classes automatically. Please');
+      ctx.logger.info('manually fix the following failures:');
+      failures.forEach(message => ctx.logger.warn(`⮑   ${message}`));
+    } else {
+      ctx.logger.info('Successfully migrated all undecorated base classes.');
+    }
+
+    ctx.logger.info('----------------------------------------------');
+  };
+}
+
+function runUndecoratedBaseClassMigration(
+    tree: Tree, tsconfigPath: string, basePath: string): string[] {
+  const parsed = parseTsconfigFile(tsconfigPath, dirname(tsconfigPath));
+  const host = ts.createCompilerHost(parsed.options, true);
+  const failures: string[] = [];
+
+  // We need to overwrite the host "readFile" method, as we want the TypeScript
+  // program to be based on the file contents in the virtual file tree.
+  host.readFile = fileName => {
+    const buffer = tree.read(relative(basePath, fileName));
+    return buffer ? buffer.toString() : undefined;
+  };
+
+  const program = ts.createProgram(parsed.fileNames, parsed.options, host);
+  const typeChecker = program.getTypeChecker();
+  const printer = ts.createPrinter();
+  const directiveVisitor = new NgDirectiveVisitor(typeChecker);
+  const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
+
+  // Analyze source files by detecting all directive and components.
+  rootSourceFiles.forEach(sourceFile => directiveVisitor.visitNode(sourceFile));
+
+  const {resolvedDirectives, directiveModules} = directiveVisitor;
+  const updateRecorders = new Map<ts.SourceFile, UpdateRecorder>();
+  const updatedBaseClasses = new Set<ts.ClassDeclaration>();
+  const importManager = new ImportManager(getUpdateRecorder, printer);
+  const ngModuleManager =
+      new NgModuleDeclarationsManager(importManager, getUpdateRecorder, typeChecker, printer);
+  let selectorIdx = 1;
+
+  resolvedDirectives.forEach(classDecl => {
+    // In case the directive has an explicit constructor, we don't need to do
+    // anything because the class is already decorated with "@Directive" or "@Component"
+    if (hasExplicitConstructor(classDecl)) {
+      return;
+    }
+
+    const orderedBaseClasses = findBaseClassDeclarations(classDecl, typeChecker);
+    const ngModules = directiveModules.get(classDecl) || [];
+
+    for (let baseClass of orderedBaseClasses) {
+      // The list of base classes is ordered and we only need to find the first
+      // base class with an explicit constructor class member.
+      if (hasExplicitConstructor(baseClass)) {
+        // In case the first base class with an explicit constructor is already
+        // decorated with the "@Directive" decorator, we don't need to do anything.
+        if (baseClass.decorators &&
+            getAngularDecorators(typeChecker, baseClass.decorators)
+                .some(d => d.name === 'Directive' || d.name === 'Component')) {
+          break;
+        }
+
+        const baseClassFile = baseClass.getSourceFile();
+        const relativePath = relative(basePath, baseClassFile.fileName);
+
+        // In case the base class has already been decorated with other directives,
+        // we don't want to add the @Directive decorator multiple times but still
+        // add the base class to various NgModule declarations.
+        if (!updatedBaseClasses.has(baseClass)) {
+          const recorder = getUpdateRecorder(baseClassFile);
+          const directiveExpr =
+              importManager.addImportToSourceFile(baseClassFile, 'Directive', '@angular/core');
+
+          const newDecorator = ts.createDecorator(ts.createCall(
+              directiveExpr, undefined,
+              [ts.createObjectLiteral(
+                  [ts.createPropertyAssignment(
+                      'selector', ts.createStringLiteral(`_base_class_${selectorIdx++}`))],
+                  false)]));
+
+          const newDecoratorText =
+              printer.printNode(ts.EmitHint.Unspecified, newDecorator, baseClassFile);
+          recorder.insertLeft(baseClass.getStart(), `${newDecoratorText}\n`);
+          updatedBaseClasses.add(baseClass);
+        }
+
+        // In case the directive is used in any NgModule, we want to add the new
+        // dummy directive to the module declarations so that NGC does not complain
+        // about a missing module for the newly annotated directive base class.
+        ngModules.forEach(module => {
+          const failure = ngModuleManager.addDeclarationToNgModule(module, baseClass);
+          if (failure) {
+            const {line, character} =
+                ts.getLineAndCharacterOfPosition(baseClassFile, baseClass.getStart());
+            failures.push(`${relativePath}@${line + 1}:${character + 1}: ${failure}`);
+          }
+        });
+        break;
+      }
+    }
+  });
+
+  // Record the changes collected in the import manager and NgModule manager. The
+  // changes need to be recorded before committing the changes to the host tree.
+  importManager.recordChanges();
+  ngModuleManager.recordChanges();
+
+  // Walk through each update recorder and commit the update. We need to commit the
+  // updates in batches per source file as there can be only one recorder per source
+  // file in order to not incorrectly shift offsets.
+  updateRecorders.forEach(recorder => tree.commitUpdate(recorder));
+
+  return failures;
+
+  /** Gets the update recorder for the specified source file. */
+  function getUpdateRecorder(sourceFile: ts.SourceFile): UpdateRecorder {
+    if (updateRecorders.has(sourceFile)) {
+      return updateRecorders.get(sourceFile) !;
+    }
+    const recorder = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+    updateRecorders.set(sourceFile, recorder);
+    return recorder;
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/module_declarations.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/module_declarations.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {normalize} from '@angular-devkit/core';
+import {UpdateRecorder} from '@angular-devkit/schematics';
+import {dirname, relative} from 'path';
+import * as ts from 'typescript';
+
+import {hasModifier} from '../../utils/typescript/nodes';
+
+import {ResolvedNgModule} from './directive_visitor';
+import {ImportManager} from './import_manager';
+
+/**
+ * NgModule declarations manager that can be used to add declarations to specified
+ * resolved NgModule declarations. The manager ensures that multiple declarations
+ * are properly added without shifted offsets. Additionally abstract classes that
+ * need to be added to the "declarations" are explicitly casted to "Type<any>" to
+ * avoid compilation issues.
+*/
+export class NgModuleDeclarationsManager {
+  private updatedModules =
+      new Map<ResolvedNgModule, {expression: ts.Expression, target: ts.ClassDeclaration}[]>();
+
+  constructor(
+      private importManager: ImportManager,
+      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder,
+      private typeChecker: ts.TypeChecker, private printer: ts.Printer) {}
+
+  /** Adds the given class declaration to the specified NgModule definition. */
+  addDeclarationToNgModule(module: ResolvedNgModule, node: ts.ClassDeclaration): null|string {
+    if (this.updatedModules.has(module) &&
+        this.updatedModules.get(module) !.some(e => e.target === node)) {
+      return null;
+    }
+
+    const moduleSourceFile = module.node.getSourceFile();
+    const classFilePath = node.getSourceFile().fileName;
+
+    let expression: ts.Expression|null = null;
+
+    if (moduleSourceFile.fileName !== classFilePath) {
+      const exportName = this._findExportNameOfClass(node);
+
+      if (!exportName) {
+        return `Base class is not exported and cannot be added to ` +
+            `NgModule (${moduleSourceFile.fileName}#${module.name})`;
+      }
+
+      const symbolName = exportName === ts.InternalSymbolName.Default ? null : exportName;
+      const relativeImportPath = this._normalizeRelativePath(relative(
+          dirname(moduleSourceFile.fileName),
+          node.getSourceFile().fileName.replace(/(\.d)?\.ts$/, '')));
+      expression = this.importManager.addImportToSourceFile(
+          moduleSourceFile, symbolName, relativeImportPath);
+    } else if (node.name) {
+      // In case the specified target class declaration is defined along with the
+      // given NgModule in the same source file, we don't need to add any import
+      // and the class can be accessed directly
+      expression = ts.createIdentifier(node.name.text);
+    } else {
+      // In case the specified target class is defined in the same source file, but does
+      // not have a class name (e.g. `export default class {}`, we can't reference it
+      // in the NgModule and just need to skip updating the module.
+      return `Base class cannot be added to NgModule as the class has no name. ` +
+          `(${moduleSourceFile.fileName}#${module.name})`;
+    }
+
+    // In case the specified target class is marked as "abstract", we need to cast the
+    // identifier that is added to the module declarations to "Type<any>" in order to
+    // avoid compilation failures.
+    if (hasModifier(node, ts.SyntaxKind.AbstractKeyword)) {
+      const typeIdentifier = <ts.Identifier>this.importManager.addImportToSourceFile(
+          moduleSourceFile, 'Type', '@angular/core', true);
+      expression = ts.createAsExpression(
+          expression, ts.createTypeReferenceNode(
+                          typeIdentifier, [ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)]));
+    }
+
+    this.updatedModules.set(module, (this.updatedModules.get(module) || []).concat({
+      expression,
+      target: node,
+    }));
+    return null;
+  }
+
+  /**
+   * Stores the collected NgModule updates within the corresponding update recorders.
+   * Instead of updating the "NgModule" definitions once per "addDeclarationToNgModule"
+   * call, we record the transformation for the new declarations elements once. This
+   * is necessary because otherwise the source-file offsets are shifted and the
+   * transformed "NgModule" is not guaranteed contain all collected new declarations.
+   */
+  recordChanges() {
+    this.updatedModules.forEach((elements, module) => {
+      const moduleSourceFile = module.node.getSourceFile();
+      const recorder = this.getUpdateRecorder(moduleSourceFile);
+      const moduleDeclarations = module.declarationsNode;
+      const updatedDeclarations = ts.updateArrayLiteral(
+          moduleDeclarations, moduleDeclarations.elements.concat(elements.map(e => e.expression)));
+
+      recorder.remove(moduleDeclarations.getStart(), moduleDeclarations.getWidth());
+      recorder.insertRight(
+          moduleDeclarations.getStart(),
+          this.printer.printNode(ts.EmitHint.Unspecified, updatedDeclarations, moduleSourceFile));
+    });
+  }
+
+  /** Finds the export name of the specified class declaration. */
+  private _findExportNameOfClass(node: ts.ClassDeclaration): string|null {
+    const sourceFile = node.getSourceFile();
+    const fileSymbol = this.typeChecker.getSymbolAtLocation(sourceFile);
+
+    if (!fileSymbol) {
+      return null;
+    }
+
+    for (let exportSymbol of this.typeChecker.getExportsOfModule(fileSymbol)) {
+      if (this._getDeclarationOfSymbol(exportSymbol) === node) {
+        return exportSymbol.name;
+      }
+    }
+    return null;
+  }
+
+  /** Gets the value declaration of the specified symbol. */
+  private _getDeclarationOfSymbol(symbol: ts.Symbol): ts.Node|undefined {
+    while (symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = this.typeChecker.getAliasedSymbol(symbol);
+    }
+
+    return symbol.valueDeclaration;
+  }
+
+  /**
+   * Normalizes the given relative path so that it can be used within a TypeScript
+   * import declaration.
+   */
+  private _normalizeRelativePath(filePath: string): string {
+    const normalizedPath = normalize(filePath);
+    if (!normalizedPath.startsWith('../')) {
+      return `./${normalizedPath}`;
+    }
+    return normalizedPath;
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/module_declarations.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/module_declarations.ts
@@ -6,15 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {normalize} from '@angular-devkit/core';
-import {UpdateRecorder} from '@angular-devkit/schematics';
-import {dirname, relative} from 'path';
+import {dirname, normalize, relative} from 'path';
 import * as ts from 'typescript';
 
 import {hasModifier} from '../../utils/typescript/nodes';
 
 import {ResolvedNgModule} from './directive_visitor';
 import {ImportManager} from './import_manager';
+import {UpdateRecorder} from './update_recorder';
 
 /**
  * NgModule declarations manager that can be used to add declarations to specified
@@ -104,9 +103,8 @@ export class NgModuleDeclarationsManager {
       const updatedDeclarations = ts.updateArrayLiteral(
           moduleDeclarations, moduleDeclarations.elements.concat(elements.map(e => e.expression)));
 
-      recorder.remove(moduleDeclarations.getStart(), moduleDeclarations.getWidth());
-      recorder.insertRight(
-          moduleDeclarations.getStart(),
+      recorder.updateModuleDeclarations(
+          moduleDeclarations,
           this.printer.printNode(ts.EmitHint.Unspecified, updatedDeclarations, moduleSourceFile));
     });
   }
@@ -142,7 +140,7 @@ export class NgModuleDeclarationsManager {
    * import declaration.
    */
   private _normalizeRelativePath(filePath: string): string {
-    const normalizedPath = normalize(filePath);
+    const normalizedPath = normalize(filePath).replace(/\\/g, '/');
     if (!normalizedPath.startsWith('../')) {
       return `./${normalizedPath}`;
     }

--- a/packages/core/schematics/migrations/undecorated-base-class/transform.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/transform.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {getAngularDecorators} from '../../utils/ng_decorators';
+import {hasExplicitConstructor} from '../../utils/typescript/class_declaration';
+
+import {DirectiveModuleMap} from './directive_visitor';
+import {findBaseClassDeclarations} from './find_base_classes';
+import {ImportManager} from './import_manager';
+import {NgModuleDeclarationsManager} from './module_declarations';
+import {UpdateRecorder} from './update_recorder';
+
+export interface TransformFailure {
+  node: ts.Node;
+  message: string;
+}
+
+export class UndecoratedBaseClassTransform {
+  private defaultSelectorIdx = 1;
+  private printer = ts.createPrinter();
+  private importManager = new ImportManager(this.getUpdateRecorder, this.printer);
+  private ngModuleManager = new NgModuleDeclarationsManager(
+      this.importManager, this.getUpdateRecorder, this.typeChecker, this.printer);
+  private updatedBaseClasses = new Set<ts.ClassDeclaration>();
+
+  constructor(
+      private typeChecker: ts.TypeChecker, private directiveModules: DirectiveModuleMap,
+      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder,
+      private getNextSelectorIndex: () => number = () => this.defaultSelectorIdx++) {}
+
+  recordChanges() {
+    this.importManager.recordChanges();
+    this.ngModuleManager.recordChanges();
+  }
+
+  migrateDirective(directiveClass: ts.ClassDeclaration): TransformFailure[] {
+    // In case the directive has an explicit constructor, we don't need to do
+    // anything because the class is already decorated with "@Directive" or "@Component"
+    if (hasExplicitConstructor(directiveClass)) {
+      return [];
+    }
+
+    const failures: TransformFailure[] = [];
+    const orderedBaseClasses = findBaseClassDeclarations(directiveClass, this.typeChecker);
+    const ngModules = this.directiveModules.get(directiveClass) || [];
+
+    for (let baseClass of orderedBaseClasses) {
+      // The list of base classes is ordered and we only need to find the first
+      // base class with an explicit constructor class member.
+      if (hasExplicitConstructor(baseClass)) {
+        // In case the first base class with an explicit constructor is already
+        // decorated with the "@Directive" decorator, we don't need to do anything.
+        if (baseClass.decorators &&
+            getAngularDecorators(this.typeChecker, baseClass.decorators)
+                .some(d => d.name === 'Directive' || d.name === 'Component')) {
+          break;
+        }
+
+        const baseClassFile = baseClass.getSourceFile();
+
+        // In case the base class has already been decorated with other directives,
+        // we don't want to add the @Directive decorator multiple times but still
+        // add the base class to various NgModule declarations.
+        if (!this.updatedBaseClasses.has(baseClass)) {
+          const recorder = this.getUpdateRecorder(baseClassFile);
+          const directiveExpr =
+              this.importManager.addImportToSourceFile(baseClassFile, 'Directive', '@angular/core');
+
+          const newDecorator = ts.createDecorator(ts.createCall(
+              directiveExpr, undefined,
+              [ts.createObjectLiteral(
+                  [ts.createPropertyAssignment(
+                      'selector',
+                      ts.createStringLiteral(`_base_class_${this.getNextSelectorIndex()}`))],
+                  false)]));
+
+          const newDecoratorText =
+              this.printer.printNode(ts.EmitHint.Unspecified, newDecorator, baseClassFile);
+          recorder.addBaseClassDecorator(baseClass, `${newDecoratorText}\n`);
+          this.updatedBaseClasses.add(baseClass);
+        }
+
+        // In case the directive is used in any NgModule, we want to add the new
+        // dummy directive to the module declarations so that NGC does not complain
+        // about a missing module for the newly annotated directive base class.
+        ngModules.forEach(module => {
+          const failure = this.ngModuleManager.addDeclarationToNgModule(module, baseClass);
+          if (failure) {
+            failures.push({node: baseClass, message: failure});
+          }
+        });
+        break;
+      }
+    }
+    return failures;
+  }
+}

--- a/packages/core/schematics/migrations/undecorated-base-class/update_recorder.ts
+++ b/packages/core/schematics/migrations/undecorated-base-class/update_recorder.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Update recorder interface that is passed to the import and declarations
+ * manager. This makes it possible to re-use logic for both TSLint rules and
+ * CLI devkit schematic updates.
+ */
+export interface UpdateRecorder {
+  addNewImport(start: number, importText: string): void;
+  updateExistingImport(namedBindings: ts.NamedImports, newNamedBindings: string): void;
+  updateModuleDeclarations(node: ts.ArrayLiteralExpression, newDeclarations: string): void;
+  addBaseClassDecorator(node: ts.ClassDeclaration, decoratorText: string): void;
+  commitUpdate(): void;
+
+  /*
+  insertLeft(index: number, content: string): void;
+  insertRight(index: number, content: string): void;
+  remove(index: number, length: number): void;*/
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//packages/core/schematics/migrations/template-var-assignment",
         "//packages/core/schematics/migrations/template-var-assignment/google3",
         "//packages/core/schematics/migrations/undecorated-base-class",
+        "//packages/core/schematics/migrations/undecorated-base-class/google3",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/schematics",
         "@npm//@types/shelljs",

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "//packages/core/schematics/migrations/static-queries/google3",
         "//packages/core/schematics/migrations/template-var-assignment",
         "//packages/core/schematics/migrations/template-var-assignment/google3",
+        "//packages/core/schematics/migrations/undecorated-base-class",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/schematics",
         "@npm//@types/shelljs",

--- a/packages/core/schematics/test/google3/no_undecorated_base_class_rule_spec.ts
+++ b/packages/core/schematics/test/google3/no_undecorated_base_class_rule_spec.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {readFileSync, writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import * as shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+describe('Google3 noUndecoratedBaseClass TSLint rule', () => {
+  const rulesDirectory = dirname(require.resolve(
+      '../../migrations/undecorated-base-class/google3/noUndecoratedBaseClassRule'));
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(process.env['TEST_TMPDIR'] !, 'google3-test');
+    shx.mkdir('-p', tmpDir);
+
+    writeFile('tsconfig.json', JSON.stringify({compilerOptions: {module: 'es2015'}}));
+  });
+
+  afterEach(() => shx.rm('-r', tmpDir));
+
+  /** Runs TSLint with the no-undecorated-base-class TSLint rule.*/
+  function runTSLint(fix = true) {
+    const program = Linter.createProgram(join(tmpDir, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile(
+        {rules: {'no-undecorated-base-class': true}, linterOptions: {typeCheck: true}});
+
+    program.getRootFileNames().forEach(fileName => {
+      linter.lint(fileName, program.getSourceFile(fileName) !.getFullText(), config);
+    });
+
+    return linter;
+  }
+
+  /** Writes a file to the current temporary directory. */
+  function writeFile(fileName: string, content: string) {
+    writeFileSync(join(tmpDir, fileName), content);
+  }
+
+  function getFile(fileName: string) { return readFileSync(join(tmpDir, fileName), 'utf8'); }
+
+  it('should properly apply replacements for base class and referenced modules', () => {
+    writeFile('index.ts', `
+      import {Component, NgZone} from '@angular/core';
+      
+      export class Base {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({template: '<span></span>'})
+      export class MyComp extends Base {}
+    `);
+
+    writeFile('my-module.ts', `
+      import {NgModule} from '@angular/core';
+      import {MyComp} from './index';
+      
+      @NgModule({
+        declarations: [MyComp],
+      })
+      export class MyModule {}
+    `);
+
+    runTSLint();
+
+    expect(getFile('index.ts')).toContain(`{ Component, NgZone, Directive } from '@angular/core';`);
+    expect(getFile('index.ts')).toMatch(/@Directive\(.*\)\nexport class Base {/);
+    expect(getFile('my-module.ts')).toContain(`{ MyComp, Base } from './index';`);
+    expect(getFile('my-module.ts')).toContain(`declarations: [MyComp, Base],`);
+  });
+
+  it('should apply replacements properly for multiple base classes', () => {
+    writeFile('index.ts', `
+      import {Component, NgZone} from '@angular/core';
+      
+      export class Base {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({template: '<span></span>'})
+      export class MyComp extends Base {}
+    `);
+
+    writeFile('second.ts', `
+      import {Component, NgZone} from '@angular/core';
+      
+      export class Base {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({template: '<span></span>'})
+      export class MySecondComp extends Base {}
+    `);
+
+    writeFile('my-module.ts', `
+      import {NgModule} from '@angular/core';
+      import {MyComp} from './index';
+      import {MySecondComp} from './second';
+      
+      @NgModule({
+        declarations: [MyComp, MySecondComp],
+      })
+      export class MyModule {}
+      
+      @NgModule({
+        declarations: [MySecondComp],
+      })
+      export class MySecondModule {}
+    `);
+
+    runTSLint();
+
+    expect(getFile('index.ts'))
+        .toMatch(/@Directive\({ selector: "_base_class_\d" }\)\nexport class Base {/);
+    expect(getFile('second.ts'))
+        .toMatch(/@Directive\({ selector: "_base_class_\d" }\)\nexport class Base {/);
+    expect(getFile('my-module.ts')).toContain('declarations: [MyComp, MySecondComp, Base, Base_1]');
+    expect(getFile('my-module.ts')).toContain('declarations: [MySecondComp, Base_1]');
+    expect(getFile('my-module.ts')).toContain(`{ MyComp, Base } from './index';`);
+    expect(getFile('my-module.ts')).toContain(`{ MySecondComp, Base as Base_1 } from './second';`);
+  });
+
+  it('should create proper rule failures which explain needed changes', () => {
+    writeFile('index.ts', `
+      import {Component, NgZone} from '@angular/core';
+      
+      export class Base {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({template: '<span></span>'})
+      export class MyComp extends Base {}
+    `);
+
+    writeFile('my-module.ts', `
+      import {NgModule} from '@angular/core';
+      import {MyComp} from './index';
+      
+      @NgModule({
+        declarations: [MyComp],
+      })
+      export class MyModule {}
+    `);
+
+    const linter = runTSLint(false);
+    const failures = linter.getResult().failures;
+
+    expect(failures.length).toBe(4);
+    expect(failures[0].getFailure()).toMatch(/Base class needs to be decorated/);
+    expect(failures[1].getFailure()).toMatch(/Import needs to be updated.*NgZone, Directive }/);
+    expect(failures[2].getFailure()).toMatch(/Import needs to be updated.*MyComp, Base }/);
+    expect(failures[3].getFailure()).toMatch(/Module needs to have.*MyComp, Base]/);
+  });
+});

--- a/packages/core/schematics/test/undecorated_base_class_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_base_class_migration_spec.ts
@@ -1,0 +1,482 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+describe('undecorated base class migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+      }
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() { runner.runSchematic('migration-v8-undecorated-base-class', {}, tree); }
+
+  it('should add base class to NgModule definition in the same file', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({})
+      export class MyComponent extends BaseClass {}
+    
+      @NgModule({declarations: [MyComponent]})
+      export class MyModule {}
+    `);
+
+    runMigration();
+
+    expect(tree.readContent(`/index.ts`)).toContain(`{ Component, NgModule, NgZone, Directive }`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`@NgModule({declarations: [MyComponent, BaseClass]})`);
+  });
+
+  it('should add @Directive() decorator to extended base class', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      export class BaseClass2 {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({})
+      export class MyComponent extends BaseClass {}
+    
+      @Component({})
+      export class MyComponent2 extends BaseClass2 {}
+    
+      @NgModule({declarations: [MyComponent, MyComponent2]})
+      export class MyModule {}
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/index.ts'))
+        .toMatch(/@Directive\({ selector: "_base_class_1" }\)\nexport class BaseClass {/);
+    expect(tree.readContent('/index.ts'))
+        .toMatch(/@Directive\({ selector: "_base_class_2" }\)\nexport class BaseClass2 {/);
+  });
+
+  it('should not decorate base class if directive/component defines a constructor', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({})
+      export class MyComponent extends BaseClass {
+        constructor(zone: NgZone) {
+          super(zone);
+        }
+      }
+    
+      @NgModule({declarations: [MyComponent]})
+      export class MyModule {}
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [MyComponent]})`);
+    expect(tree.readContent('/index.ts')).not.toContain(`@Directive`);
+  });
+
+  it('should only decorate first class of inheritance chain', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      
+      export class SuperBaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      export class BaseClass extends SuperBaseClass {}
+      
+      @Component({})
+      export class MyComponent extends BaseClass {}
+    
+      @NgModule({declarations: [MyComponent]})
+      export class MyModule {}
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/index.ts'))
+        .toMatch(/@Directive\({ selector: "_base_class_1" }\)\nexport class SuperBaseClass {/);
+    expect(tree.readContent('/index.ts'))
+        .toMatch(/}\s+export class BaseClass extends SuperBaseClass {/);
+  });
+
+  it('should properly update import if @Directive can be accessed through existing namespace import',
+     () => {
+       writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+    
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+       writeFile('/base.ts', `
+      import * as core from '@angular/core';
+      
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+       runMigration();
+
+       expect(tree.readContent('/base.ts'))
+           .toMatch(/@core.Directive\(.+\)\nexport class BaseClass/);
+       expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A, BaseClass]})`);
+     });
+
+  it('should properly create import to unnamed base class', () => {
+    writeFile('/index.ts', `
+      import {NgModule} from '@angular/core';
+      import {A} from './comp';
+
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+      import baseClass from './base';
+      
+      @Component({})
+      export class A extends baseClass {}
+    `);
+
+    writeFile('/base.ts', `        
+      export default class {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts')).toMatch(/@Directive\(.+\)\nexport default class/);
+    expect(tree.readContent('/index.ts')).toContain('import defaultExport from "./base";');
+    expect(tree.readContent('/index.ts'))
+        .toContain(`@NgModule({declarations: [A, defaultExport]})`);
+  });
+
+  it('should properly create import to class that is exported with alias', () => {
+    writeFile('/index.ts', `
+      import {NgModule} from '@angular/core';
+      import {A} from './comp';
+
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+    `);
+
+    writeFile('/base.ts', `        
+      class InternalBaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      export {InternalBaseClass as BaseClass} 
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts')).toMatch(/@Directive\(.+\)\nclass InternalBaseClass/);
+    expect(tree.readContent('/index.ts')).toContain('import { BaseClass } from "./base";');
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A, BaseClass]})`);
+  });
+
+  it('should print a warning for base classes which are not exported', () => {
+    writeFile('/index.ts', `
+      import {NgModule} from '@angular/core';
+      import {A} from './comp';
+
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+      
+      // not exported
+      class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({})
+      export class A extends BaseClass {}
+    `);
+
+    const warnOutput: string[] = [];
+    runner.logger.subscribe(e => e.level === 'warn' && warnOutput.push(e.message));
+
+    runMigration();
+
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0])
+        .toContain(
+            'comp.ts@5:7: Base class is not exported and cannot be added to NgModule (index.ts#MyModule)');
+    expect(tree.readContent('/comp.ts')).toMatch(/@Directive\(.+\)\nclass BaseClass/);
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A]})`);
+  });
+
+  it('should properly update existing import with aliased specifier if identifier is already used',
+     () => {
+       writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      import {Directive} from './third_party_directive';
+      
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+      
+      @Component({})
+      export class MyComponent extends BaseClass {}
+    
+      @NgModule({declarations: [MyComponent]})
+      export class MyModule {}
+    `);
+
+       runMigration();
+
+       expect(tree.readContent(`/index.ts`))
+           .toContain(`{ Component, NgModule, NgZone, Directive as Directive_1 }`);
+       expect(tree.readContent('/index.ts'))
+           .toContain(`@NgModule({declarations: [MyComponent, BaseClass]})`);
+       expect(tree.readContent('/index.ts')).toMatch(/@Directive_1\(.+\)\nexport class BaseClass/);
+     });
+
+  it('should properly create new import with aliased specifier if identifier is already used',
+     () => {
+       writeFile('/index.ts', `
+      import {Component, NgModule, NgZone} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+    
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+       writeFile('/base.ts', `
+      import {Directive} from './external';
+    
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+       runMigration();
+
+       expect(tree.readContent('/base.ts')).toMatch(/@Directive_1\(.+\)\nexport class BaseClass/);
+       expect(tree.readContent(`/base.ts`))
+           .toContain(`{ Directive as Directive_1 } from "@angular/core";`);
+       expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A, BaseClass]})`);
+     });
+
+  it('should use existing aliased import of @Directive instead of creating new import', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+     
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    writeFile('/base.ts', `
+      import {Directive as AliasedDir} from '@angular/core';
+   
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts')).toMatch(/@AliasedDir\(.+\)\nexport class BaseClass {/);
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A, BaseClass]})`);
+  });
+
+  it('should cast abstract base classes to Type<any> when added to NgModule declarations', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+     
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    writeFile('/base.ts', `
+      export abstract class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts'))
+        .toMatch(/@Directive\(.+\)\nexport abstract class BaseClass {/);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`{ Component, NgModule, Type } from '@angular/core';`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`@NgModule({declarations: [A, (BaseClass as Type<any>)]})`);
+  });
+
+  it('should not decorate base class if already decorated with @Component', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+      
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    const baseFileContent = `
+      import {Component} from '@angular/core';
+      
+      @Component({
+        selector: 'my-sel'
+        template: 'hello',
+      })
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `;
+
+    writeFile('/base.ts', baseFileContent);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts')).toBe(baseFileContent);
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A]})`);
+  });
+
+
+  it('should not decorate base class if already decorated with @Directive', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+      
+      @NgModule({declarations: [A]})
+      export class MyModule {}
+    `);
+
+    const baseFileContent = `
+      import {Directive} from '@angular/core';
+      
+      @Directive({selector: 'my-sel'})
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `;
+
+    writeFile('/base.ts', baseFileContent);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts')).toBe(baseFileContent);
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A]})`);
+  });
+
+  it('should not decorate base class multiple times if base class is inherited multiple times', () => {
+    writeFile('/index.ts', `
+      import {Component, NgModule} from '@angular/core';
+      import {BaseClass} from './base';
+      
+      @Component({})
+      export class A extends BaseClass {}
+      
+      @Component({})
+      export class B extends BaseClass {}
+     
+      @NgModule({declarations: [A, B]})
+      export class MyModule {}
+    `);
+
+    writeFile('/base.ts', `
+      export class BaseClass {
+        constructor(zone: NgZone) {}
+      }
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/base.ts'))
+        .toMatch(
+            /^\s+import { Directive } from "@angular\/core";\s+@Directive\(.+\)\nexport class BaseClass {/);
+    expect(tree.readContent('/index.ts')).toContain(`{Component, NgModule} from '@angular/core';`);
+    expect(tree.readContent('/index.ts')).toContain(`@NgModule({declarations: [A, B, BaseClass]})`);
+  });
+});

--- a/packages/core/schematics/utils/typescript/class_declaration.ts
+++ b/packages/core/schematics/utils/typescript/class_declaration.ts
@@ -30,3 +30,8 @@ export function findParentClassDeclaration(node: ts.Node): ts.ClassDeclaration|n
   }
   return node;
 }
+
+/** Checks whether the given class declaration has an explicit constructor or not. */
+export function hasExplicitConstructor(node: ts.ClassDeclaration): boolean {
+  return node.members.some(ts.isConstructorDeclaration);
+}


### PR DESCRIPTION
Introduces a new upgrade schematic that automatically decorates
`@Directive` / `@Component` base classes that use dependency injection
with the `@Directive` decorator. The new dummy directives are also
added to the corresponding "NgModule" declarations in order to not
cause any compilation warnings.

Adding the `@Directive` decorator ensures that "ngtsc" can properly
create the needed Ivy fields so that dependency injection works
as expected once Ivy is enabled in the application.

References FW-1238