### PR TITLE
fix(ivy): queries not being inherited from undecorated classes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/base_def.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/base_def.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3BaseRefMetaData, compileBaseDefFromMetadata} from '@angular/compiler';
+import {ConstantPool, R3BaseRefMetaData, compileBaseDefFromMetadata} from '@angular/compiler';
+import {R3QueryMetadata} from '@angular/compiler/src/compiler';
 
 import {PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, ClassMember, Decorator, ReflectionHost} from '../../reflection';
+import {ClassDeclaration, ClassMember, Decorator, ReflectionHost, filterToMembersWithDecorator} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
+import {queriesFromFields} from './directive';
 import {isAngularDecorator} from './util';
 
 function containsNgTopLevelDecorator(decorators: Decorator[] | null, isCore: boolean): boolean {
@@ -41,8 +43,30 @@ export class BaseDefDecoratorHandler implements
     }
 
     let result: R3BaseRefDecoratorDetection|undefined = undefined;
+    const classMembers = this.reflector.getMembersOfClass(node);
+    const coreModule = this.isCore ? undefined : '@angular/core';
+    const viewChildFromFields = queriesFromFields(
+        filterToMembersWithDecorator(classMembers, 'ViewChild', coreModule), this.reflector,
+        this.evaluator);
+    const viewChildrenFromFields = queriesFromFields(
+        filterToMembersWithDecorator(classMembers, 'ViewChildren', coreModule), this.reflector,
+        this.evaluator);
+    const contentChildFromFields = queriesFromFields(
+        filterToMembersWithDecorator(classMembers, 'ContentChild', coreModule), this.reflector,
+        this.evaluator);
+    const contentChildrenFromFields = queriesFromFields(
+        filterToMembersWithDecorator(classMembers, 'ContentChildren', coreModule), this.reflector,
+        this.evaluator);
 
-    this.reflector.getMembersOfClass(node).forEach(property => {
+    if (viewChildFromFields.length || viewChildrenFromFields.length) {
+      result = result || {};
+      result.viewQueries = [...viewChildFromFields, ...viewChildrenFromFields];
+    }
+    if (contentChildFromFields.length || contentChildrenFromFields.length) {
+      result = result || {};
+      result.queries = [...contentChildFromFields, ...contentChildrenFromFields];
+    }
+    classMembers.forEach(property => {
       const {decorators} = property;
       if (decorators) {
         for (const decorator of decorators) {
@@ -110,11 +134,20 @@ export class BaseDefDecoratorHandler implements
       });
     }
 
+    if (metadata.viewQueries) {
+      analysis.viewQueries = metadata.viewQueries;
+    }
+
+    if (metadata.queries) {
+      analysis.queries = metadata.queries;
+    }
+
     return {analysis};
   }
 
-  compile(node: ClassDeclaration, analysis: R3BaseRefMetaData): CompileResult[]|CompileResult {
-    const {expression, type} = compileBaseDefFromMetadata(analysis);
+  compile(node: ClassDeclaration, analysis: R3BaseRefMetaData, pool: ConstantPool):
+      CompileResult[]|CompileResult {
+    const {expression, type} = compileBaseDefFromMetadata(analysis, pool);
 
     return {
       name: 'ngBaseDef',
@@ -127,4 +160,6 @@ export class BaseDefDecoratorHandler implements
 export interface R3BaseRefDecoratorDetection {
   inputs?: Array<{property: ClassMember, decorator: Decorator}>;
   outputs?: Array<{property: ClassMember, decorator: Decorator}>;
+  viewQueries?: R3QueryMetadata[];
+  queries?: R3QueryMetadata[];
 }

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -3033,6 +3033,92 @@ describe('compiler compliance', () => {
       expectEmit(result.source, expectedOutput, 'Invalid base definition');
     });
 
+    it('should add ngBaseDef if view queries are present', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule, ViewChild} from '@angular/core';
+            export class BaseClass {
+              @ViewChild('something') something: any;
+            }
+
+            @Component({
+              selector: 'my-component',
+              template: ''
+            })
+            export class MyComponent extends BaseClass {
+            }
+
+            @NgModule({
+              declarations: [MyComponent]
+            })
+            export class MyModule {}
+          `
+        }
+      };
+      const expectedOutput = `
+      const $e0_attrs$ = ["something"];
+      // ...
+      BaseClass.ngBaseDef = i0.ɵɵdefineBase({
+        viewQuery: function (rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵɵviewQuery($e0_attrs$, true, null);
+          }
+          if (rf & 2) {
+            var $tmp$;
+            ($r3$.ɵɵqueryRefresh(($tmp$ = $r3$.ɵɵloadViewQuery())) && (ctx.something = $tmp$.first));
+          }
+        }
+      });
+      // ...
+      `;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, expectedOutput, 'Invalid base definition');
+    });
+
+    it('should add ngBaseDef if content queries are present', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule, ContentChild} from '@angular/core';
+            export class BaseClass {
+              @ContentChild('something') something: any;
+            }
+
+            @Component({
+              selector: 'my-component',
+              template: ''
+            })
+            export class MyComponent extends BaseClass {
+            }
+
+            @NgModule({
+              declarations: [MyComponent]
+            })
+            export class MyModule {}
+          `
+        }
+      };
+      const expectedOutput = `
+      const $e0_attrs$ = ["something"];
+      // ...
+      BaseClass.ngBaseDef = i0.ɵɵdefineBase({
+        contentQueries: function (rf, ctx, dirIndex) {
+          if (rf & 1) {
+            $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, true, null);
+          }
+          if (rf & 2) {
+            var $tmp$;
+            ($r3$.ɵɵqueryRefresh(($tmp$ = $r3$.ɵɵloadContentQuery())) && (ctx.something = $tmp$.first));
+          }
+        }
+      });
+      // ...
+      `;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, expectedOutput, 'Invalid base definition');
+    });
+
     it('should NOT add ngBaseDef if @Component is present', () => {
       const files = {
         app: {

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -37,6 +37,8 @@ export interface CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3DirectiveMetadataFacade): any;
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
+  compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
+      any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
@@ -144,6 +146,13 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   viewProviders: Provider[]|null;
   interpolation?: [string, string];
   changeDetection?: ChangeDetectionStrategy;
+}
+
+export interface R3BaseMetadataFacade {
+  inputs?: {[key: string]: string | [string, string]};
+  outputs?: {[key: string]: string};
+  queries?: R3QueryMetadataFacade[];
+  viewQueries?: R3QueryMetadataFacade[];
 }
 
 export type ViewEncapsulation = number;

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -154,7 +154,13 @@ export class CompilerFacadeImpl implements CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3BaseMetadataFacade):
       any {
     const constantPool = new ConstantPool();
-    const res = compileBaseDefFromMetadata(facade, constantPool);
+    const meta = {
+      ...facade,
+      viewQueries: facade.viewQueries ? facade.viewQueries.map(convertToR3QueryMetadata) :
+                                        facade.viewQueries,
+      queries: facade.queries ? facade.queries.map(convertToR3QueryMetadata) : facade.queries
+    };
+    const res = compileBaseDefFromMetadata(meta, constantPool);
     return this.jitExpression(
         res.expression, angularCoreEnv, sourceMapUrl, constantPool.statements);
   }

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, R3ComponentMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
+import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, R3BaseMetadataFacade, R3ComponentMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
 import {ConstantPool} from './constant_pool';
 import {HostBinding, HostListener, Input, Output, Type} from './core';
 import {compileInjectable} from './injectable_compiler_2';
@@ -21,7 +21,7 @@ import {R3InjectorMetadata, R3NgModuleMetadata, compileInjector, compileNgModule
 import {compilePipeFromMetadata} from './render3/r3_pipe_compiler';
 import {R3Reference} from './render3/util';
 import {R3DirectiveMetadata, R3QueryMetadata} from './render3/view/api';
-import {ParsedHostBindings, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
+import {ParsedHostBindings, compileBaseDefFromMetadata, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
@@ -149,6 +149,14 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const preStatements = [...constantPool.statements, ...res.statements];
     return this.jitExpression(
         res.expression, angularCoreEnv, `ng:///${facade.name}.js`, preStatements);
+  }
+
+  compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3BaseMetadataFacade):
+      any {
+    const constantPool = new ConstantPool();
+    const res = compileBaseDefFromMetadata(facade, constantPool);
+    return this.jitExpression(
+        res.expression, angularCoreEnv, sourceMapUrl, constantPool.statements);
   }
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan {

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -37,6 +37,8 @@ export interface CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3DirectiveMetadataFacade): any;
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
+  compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
+      any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
@@ -144,6 +146,13 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   viewProviders: Provider[]|null;
   interpolation?: [string, string];
   changeDetection?: ChangeDetectionStrategy;
+}
+
+export interface R3BaseMetadataFacade {
+  inputs?: {[key: string]: string | [string, string]};
+  outputs?: {[key: string]: string};
+  queries?: R3QueryMetadataFacade[];
+  viewQueries?: R3QueryMetadataFacade[];
 }
 
 export type ViewEncapsulation = number;

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -9,12 +9,10 @@
 import {ChangeDetectionStrategy} from '../change_detection/constants';
 import {Provider} from '../di';
 import {Type} from '../interface/type';
-import {NG_BASE_DEF} from '../render3/fields';
 import {compileComponent as render3CompileComponent, compileDirective as render3CompileDirective} from '../render3/jit/directive';
 import {compilePipe as render3CompilePipe} from '../render3/jit/pipe';
 import {TypeDecorator, makeDecorator, makePropDecorator} from '../util/decorators';
 import {noop} from '../util/noop';
-import {fillProperties} from '../util/property';
 
 import {ViewEncapsulation} from './view';
 
@@ -695,47 +693,12 @@ export interface Input {
   bindingPropertyName?: string;
 }
 
-const initializeBaseDef = (target: any): void => {
-  const constructor = target.constructor;
-  const inheritedBaseDef = constructor.ngBaseDef;
-
-  const baseDef = constructor.ngBaseDef = {
-    inputs: {},
-    outputs: {},
-    declaredInputs: {},
-  };
-
-  if (inheritedBaseDef) {
-    fillProperties(baseDef.inputs, inheritedBaseDef.inputs);
-    fillProperties(baseDef.outputs, inheritedBaseDef.outputs);
-    fillProperties(baseDef.declaredInputs, inheritedBaseDef.declaredInputs);
-  }
-};
-
-/**
- * Does the work of creating the `ngBaseDef` property for the `Input` and `Output` decorators.
- * @param key "inputs" or "outputs"
- */
-const updateBaseDefFromIOProp = (getProp: (baseDef: {inputs?: any, outputs?: any}) => any) =>
-    (target: any, name: string, ...args: any[]) => {
-      const constructor = target.constructor;
-
-      if (!constructor.hasOwnProperty(NG_BASE_DEF)) {
-        initializeBaseDef(target);
-      }
-
-      const baseDef = constructor.ngBaseDef;
-      const defProp = getProp(baseDef);
-      defProp[name] = args[0] || name;
-    };
-
 /**
  * @Annotation
  * @publicApi
  */
-export const Input: InputDecorator = makePropDecorator(
-    'Input', (bindingPropertyName?: string) => ({bindingPropertyName}), undefined,
-    updateBaseDefFromIOProp(baseDef => baseDef.inputs || {}));
+export const Input: InputDecorator =
+    makePropDecorator('Input', (bindingPropertyName?: string) => ({bindingPropertyName}));
 
 /**
  * Type of the Output decorator / constructor function.
@@ -777,9 +740,8 @@ export interface Output {
  * @Annotation
  * @publicApi
  */
-export const Output: OutputDecorator = makePropDecorator(
-    'Output', (bindingPropertyName?: string) => ({bindingPropertyName}), undefined,
-    updateBaseDefFromIOProp(baseDef => baseDef.outputs || {}));
+export const Output: OutputDecorator =
+    makePropDecorator('Output', (bindingPropertyName?: string) => ({bindingPropertyName}));
 
 
 

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -18,7 +18,7 @@ import {noSideEffects} from '../util/closure';
 import {stringify} from '../util/stringify';
 
 import {EMPTY_ARRAY, EMPTY_OBJ} from './empty';
-import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
+import {NG_BASE_DEF, NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
 import {ComponentDef, ComponentDefFeature, ComponentTemplate, ComponentType, ContentQueriesFunction, DirectiveDef, DirectiveDefFeature, DirectiveType, DirectiveTypesOrFactory, FactoryFn, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory, ViewQueriesFunction, ɵɵBaseDef} from './interfaces/definition';
 // while SelectorFlags is unused here, it's required so that types don't get resolved lazily
 // see: https://github.com/Microsoft/web-build-tools/issues/1050
@@ -560,12 +560,25 @@ export function ɵɵdefineBase<T>(baseDefinition: {
    * of properties.
    */
   outputs?: {[P in keyof T]?: string};
+
+  /**
+   * Function to create instances of content queries associated with a given directive.
+   */
+  contentQueries?: ContentQueriesFunction<T>| null;
+
+  /**
+   * Additional set of instructions specific to view query processing. This could be seen as a
+   * set of instructions to be inserted into the template function.
+   */
+  viewQuery?: ViewQueriesFunction<T>| null;
 }): ɵɵBaseDef<T> {
   const declaredInputs: {[P in keyof T]: string} = {} as any;
   return {
     inputs: invertObject<T>(baseDefinition.inputs as any, declaredInputs),
     declaredInputs: declaredInputs,
     outputs: invertObject<T>(baseDefinition.outputs as any),
+    viewQuery: baseDefinition.viewQuery || null,
+    contentQueries: baseDefinition.contentQueries || null,
   };
 }
 
@@ -740,6 +753,10 @@ export function getDirectiveDef<T>(type: any): DirectiveDef<T>|null {
 
 export function getPipeDef<T>(type: any): PipeDef<T>|null {
   return (type as any)[NG_PIPE_DEF] || null;
+}
+
+export function getBaseDef<T>(type: any): ɵɵBaseDef<T>|null {
+  return (type as any)[NG_BASE_DEF] || null;
 }
 
 export function getNgModuleDef<T>(type: any, throwNotFound: true): NgModuleDef<T>;

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -96,7 +96,7 @@ export type ɵɵDirectiveDefWithMeta<
  * Runtime information for classes that are inherited by components or directives
  * that aren't defined as components or directives.
  *
- * This is an internal data structure used by the render to determine what inputs
+ * This is an internal data structure used by the renderer to determine what inputs
  * and outputs should be inherited.
  *
  * See: {@link defineBase}
@@ -123,6 +123,18 @@ export interface ɵɵBaseDef<T> {
    * (as in `@Output('alias') propertyName: any;`).
    */
   readonly outputs: {[P in keyof T]: string};
+
+  /**
+   * Function to create and refresh content queries associated with a given directive.
+   */
+  contentQueries: ContentQueriesFunction<T>|null;
+
+  /**
+   * Query-related instructions for a directive. Note that while directives don't have a
+   * view and as such view queries won't necessarily do anything, there might be
+   * components that extend the directive.
+   */
+  viewQuery: ViewQueriesFunction<T>|null;
 }
 
 /**
@@ -160,18 +172,6 @@ export interface DirectiveDef<T> extends ɵɵBaseDef<T> {
    * Factory function used to create a new directive instance.
    */
   factory: FactoryFn<T>;
-
-  /**
-   * Function to create and refresh content queries associated with a given directive.
-   */
-  contentQueries: ContentQueriesFunction<T>|null;
-
-  /**
-   * Query-related instructions for a directive. Note that while directives don't have a
-   * view and as such view queries won't necessarily do anything, there might be
-   * components that extend the directive.
-   */
-  viewQuery: ViewQueriesFunction<T>|null;
 
   /**
    * Refreshes host bindings on the associated directive.

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -173,6 +173,40 @@ describe('query logic', () => {
           .toBe(true);
     });
 
+    it('should support view queries inherited from undecorated superclasses', () => {
+      class MyComp {
+        @ViewChild('foo') foo: any;
+      }
+
+      @Component({selector: 'sub-comp', template: '<div #foo></div>'})
+      class SubComp extends MyComp {
+      }
+
+      TestBed.configureTestingModule({declarations: [SubComp]});
+
+      const fixture = TestBed.createComponent(SubComp);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.foo).toBeAnInstanceOf(ElementRef);
+    });
+
+    it('should support view queries inherited from undecorated grand superclasses', () => {
+      class MySuperComp {
+        @ViewChild('foo') foo: any;
+      }
+
+      class MyComp extends MySuperComp {}
+
+      @Component({selector: 'sub-comp', template: '<div #foo></div>'})
+      class SubComp extends MyComp {
+      }
+
+      TestBed.configureTestingModule({declarations: [SubComp]});
+
+      const fixture = TestBed.createComponent(SubComp);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.foo).toBeAnInstanceOf(ElementRef);
+    });
+
   });
 
   describe('content queries', () => {
@@ -397,6 +431,50 @@ describe('query logic', () => {
 
       expect(firstComponent.setEvents).toEqual(['textDir set', 'foo set']);
       expect(secondComponent.setEvents).toEqual(['textDir set', 'foo set']);
+    });
+
+    it('should support content queries inherited from undecorated superclasses', () => {
+      class MyComp {
+        @ContentChild('foo') foo: any;
+      }
+
+      @Component({selector: 'sub-comp', template: '<ng-content></ng-content>'})
+      class SubComp extends MyComp {
+      }
+
+      @Component({template: '<sub-comp><div #foo></div></sub-comp>'})
+      class App {
+        @ViewChild(SubComp) subComp !: SubComp;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, SubComp]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(ElementRef);
+    });
+
+    it('should support content queries inherited from undecorated grand superclasses', () => {
+      class MySuperComp {
+        @ContentChild('foo') foo: any;
+      }
+
+      class MyComp extends MySuperComp {}
+
+      @Component({selector: 'sub-comp', template: '<ng-content></ng-content>'})
+      class SubComp extends MyComp {
+      }
+
+      @Component({template: '<sub-comp><div #foo></div></sub-comp>'})
+      class App {
+        @ViewChild(SubComp) subComp !: SubComp;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, SubComp]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(ElementRef);
     });
 
   });

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -173,7 +173,7 @@ describe('query logic', () => {
           .toBe(true);
     });
 
-    it('should support view queries inherited from undecorated superclasses', () => {
+    it('should support ViewChild query inherited from undecorated superclasses', () => {
       class MyComp {
         @ViewChild('foo') foo: any;
       }
@@ -189,7 +189,7 @@ describe('query logic', () => {
       expect(fixture.componentInstance.foo).toBeAnInstanceOf(ElementRef);
     });
 
-    it('should support view queries inherited from undecorated grand superclasses', () => {
+    it('should support ViewChild query inherited from undecorated grand superclasses', () => {
       class MySuperComp {
         @ViewChild('foo') foo: any;
       }
@@ -205,6 +205,62 @@ describe('query logic', () => {
       const fixture = TestBed.createComponent(SubComp);
       fixture.detectChanges();
       expect(fixture.componentInstance.foo).toBeAnInstanceOf(ElementRef);
+    });
+
+    it('should support ViewChildren query inherited from undecorated superclasses', () => {
+      @Directive({selector: '[some-dir]'})
+      class SomeDir {
+      }
+
+      class MyComp {
+        @ViewChildren(SomeDir) foo !: QueryList<SomeDir>;
+      }
+
+      @Component({
+        selector: 'sub-comp',
+        template: `
+          <div some-dir></div>
+          <div some-dir></div>
+        `
+      })
+      class SubComp extends MyComp {
+      }
+
+      TestBed.configureTestingModule({declarations: [SubComp, SomeDir]});
+
+      const fixture = TestBed.createComponent(SubComp);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.foo).toBeAnInstanceOf(QueryList);
+      expect(fixture.componentInstance.foo.length).toBe(2);
+    });
+
+    it('should support ViewChildren query inherited from undecorated grand superclasses', () => {
+      @Directive({selector: '[some-dir]'})
+      class SomeDir {
+      }
+
+      class MySuperComp {
+        @ViewChildren(SomeDir) foo !: QueryList<SomeDir>;
+      }
+
+      class MyComp extends MySuperComp {}
+
+      @Component({
+        selector: 'sub-comp',
+        template: `
+          <div some-dir></div>
+          <div some-dir></div>
+        `
+      })
+      class SubComp extends MyComp {
+      }
+
+      TestBed.configureTestingModule({declarations: [SubComp, SomeDir]});
+
+      const fixture = TestBed.createComponent(SubComp);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.foo).toBeAnInstanceOf(QueryList);
+      expect(fixture.componentInstance.foo.length).toBe(2);
     });
 
   });
@@ -433,7 +489,7 @@ describe('query logic', () => {
       expect(secondComponent.setEvents).toEqual(['textDir set', 'foo set']);
     });
 
-    it('should support content queries inherited from undecorated superclasses', () => {
+    it('should support ContentChild query inherited from undecorated superclasses', () => {
       class MyComp {
         @ContentChild('foo') foo: any;
       }
@@ -454,7 +510,7 @@ describe('query logic', () => {
       expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(ElementRef);
     });
 
-    it('should support content queries inherited from undecorated grand superclasses', () => {
+    it('should support ContentChild query inherited from undecorated grand superclasses', () => {
       class MySuperComp {
         @ContentChild('foo') foo: any;
       }
@@ -475,6 +531,74 @@ describe('query logic', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(ElementRef);
+    });
+
+    it('should support ContentChildren query inherited from undecorated superclasses', () => {
+      @Directive({selector: '[some-dir]'})
+      class SomeDir {
+      }
+
+      class MyComp {
+        @ContentChildren(SomeDir) foo !: QueryList<SomeDir>;
+      }
+
+      @Component({selector: 'sub-comp', template: '<ng-content></ng-content>'})
+      class SubComp extends MyComp {
+      }
+
+      @Component({
+        template: `
+        <sub-comp>
+          <div some-dir></div>
+          <div some-dir></div>
+        </sub-comp>
+      `
+      })
+      class App {
+        @ViewChild(SubComp) subComp !: SubComp;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, SubComp, SomeDir]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(QueryList);
+      expect(fixture.componentInstance.subComp.foo.length).toBe(2);
+    });
+
+    it('should support ContentChildren query inherited from undecorated grand superclasses', () => {
+      @Directive({selector: '[some-dir]'})
+      class SomeDir {
+      }
+
+      class MySuperComp {
+        @ContentChildren(SomeDir) foo !: QueryList<SomeDir>;
+      }
+
+      class MyComp extends MySuperComp {}
+
+      @Component({selector: 'sub-comp', template: '<ng-content></ng-content>'})
+      class SubComp extends MyComp {
+      }
+
+      @Component({
+        template: `
+        <sub-comp>
+          <div some-dir></div>
+          <div some-dir></div>
+        </sub-comp>
+      `
+      })
+      class App {
+        @ViewChild(SubComp) subComp !: SubComp;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, SubComp, SomeDir]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.subComp.foo).toBeAnInstanceOf(QueryList);
+      expect(fixture.componentInstance.subComp.foo.length).toBe(2);
     });
 
   });

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -283,32 +283,6 @@ ivyEnabled && describe('render3 jit', () => {
     expect(InputDirAny.ngDirectiveDef.declaredInputs).toEqual({publicName: 'privateName'});
   });
 
-  it('should add ngBaseDef to types with @Input properties', () => {
-    class C {
-      @Input('alias1')
-      prop1 = 'test';
-
-      @Input('alias2')
-      prop2 = 'test';
-    }
-
-    expect((C as any).ngBaseDef).toBeDefined();
-    expect((C as any).ngBaseDef.inputs).toEqual({prop1: 'alias1', prop2: 'alias2'});
-  });
-
-  it('should add ngBaseDef to types with @Output properties', () => {
-    class C {
-      @Output('alias1')
-      prop1 = 'test';
-
-      @Output('alias2')
-      prop2 = 'test';
-    }
-
-    expect((C as any).ngBaseDef).toBeDefined();
-    expect((C as any).ngBaseDef.outputs).toEqual({prop1: 'alias1', prop2: 'alias2'});
-  });
-
   it('should compile ContentChildren query with string predicate on a directive', () => {
     @Directive({selector: '[test]'})
     class TestDirective {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -662,6 +662,7 @@ export interface OutputDecorator {
 export declare function ɵɵallocHostVars(count: number): void;
 
 export interface ɵɵBaseDef<T> {
+    contentQueries: ContentQueriesFunction<T> | null;
     /** @deprecated */ readonly declaredInputs: {
         [P in keyof T]: string;
     };
@@ -671,6 +672,7 @@ export interface ɵɵBaseDef<T> {
     readonly outputs: {
         [P in keyof T]: string;
     };
+    viewQuery: ViewQueriesFunction<T> | null;
 }
 
 export declare function ɵɵbind<T>(value: T): T | NO_CHANGE;
@@ -702,6 +704,8 @@ export declare function ɵɵdefineBase<T>(baseDefinition: {
     outputs?: {
         [P in keyof T]?: string;
     };
+    contentQueries?: ContentQueriesFunction<T> | null;
+    viewQuery?: ViewQueriesFunction<T> | null;
 }): ɵɵBaseDef<T>;
 
 export declare function ɵɵdefineComponent<T>(componentDefinition: {


### PR DESCRIPTION
Fixes view and content queries not being inherited in Ivy, if the base class hasn't been annotated with an Angular decorator (e.g. `Component` or `Directive`).

Also reworks the way the `ngBaseDef` is created so that it is added at the same point as the queries, rather than inside of the `Input` and `Output` decorators.

This PR partially resolves FW-1275. Support for host bindings will be added in a follow-up, because this PR is somewhat large as it is.
