### PR TITLE
fix(ivy): ngcc - prefer JavaScript source files when resolving module…

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -12,7 +12,7 @@ import {FileSystem} from '../file_system/file_system';
 import {PathMappings} from '../utils';
 import {BundleProgram, makeBundleProgram} from './bundle_program';
 import {EntryPointFormat, EntryPointJsonProperty} from './entry_point';
-import {NgccCompilerHost} from './ngcc_compiler_host';
+import {NgccCompilerHost, NgccSourcesCompilerHost} from './ngcc_compiler_host';
 
 /**
  * A bundle of files and paths (and TS programs) that correspond to a particular
@@ -48,56 +48,19 @@ export function makeEntryPointBundle(
     noLib: true,
     rootDir: entryPointPath, ...pathMappings
   };
-  const host = new NgccCompilerHost(fs, options);
+  const srcHost = new NgccSourcesCompilerHost(fs, options, entryPointPath);
+  const dtsHost = new NgccCompilerHost(fs, options);
   const rootDirs = [AbsoluteFsPath.from(entryPointPath)];
 
   // Create the bundle programs, as necessary.
   const src = makeBundleProgram(
       fs, isCore, AbsoluteFsPath.resolve(entryPointPath, formatPath), 'r3_symbols.js', options,
-      host);
+      srcHost);
   const dts = transformDts ? makeBundleProgram(
                                  fs, isCore, AbsoluteFsPath.resolve(entryPointPath, typingsPath),
-                                 'r3_symbols.d.ts', options, host) :
+                                 'r3_symbols.d.ts', options, dtsHost) :
                              null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
 
   return {format, formatProperty, rootDirs, isCore, isFlatCore, src, dts};
-}
-
-/**
- * Create a compiler host that resolves a module import as a JavaScript source file if available,
- * instead of the .d.ts typings file that would have been resolved by TypeScript. This is necessary
- * for packages that have their typings in the same directory as the sources, which would otherwise
- * let TypeScript prefer the .d.ts file instead of the JavaScript source file.
- * @param entryPointPath The path of the directly where the entry-point resides in.
- * @param options The compiler options to create the host from.
- */
-function createCompilerHostThatPrefersJs(
-    entryPointPath: string, options: ts.CompilerOptions): ts.CompilerHost {
-  const host = ts.createCompilerHost(options);
-  const cache = ts.createModuleResolutionCache(
-      host.getCurrentDirectory(), file => host.getCanonicalFileName(file));
-  host.resolveModuleNames = (moduleNames, containingFile, reusedNames, redirectedReference) => {
-    return moduleNames.map(moduleName => {
-      const {resolvedModule} = ts.resolveModuleName(
-          moduleName, containingFile, options, host, cache, redirectedReference);
-
-      // If the module request originated from a relative import in a JavaScript source file,
-      // TypeScript may have resolved the module to its .d.ts declaration file if the .js source
-      // file was in the same directory. This is undesirable, as we need to have the actual
-      // JavaScript being present in the program. This logic recognizes this scenario and rewires
-      // the resolved .d.ts declaration file to its .js counterpart, if it exists.
-      if (resolvedModule !== undefined && resolvedModule.extension === ts.Extension.Dts &&
-          containingFile.endsWith('js') &&
-          (moduleName.startsWith('./') || moduleName.startsWith('../')) &&
-          resolvedModule.resolvedFileName.startsWith(entryPointPath)) {
-        const jsFile = resolvedModule.resolvedFileName.replace(/\.d\.ts$/, '.js');
-        if (host.fileExists(jsFile)) {
-          return {...resolvedModule, resolvedFileName: jsFile, extension: ts.Extension.Js};
-        }
-      }
-      return resolvedModule;
-    });
-  };
-  return host;
 }

--- a/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
+++ b/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
@@ -14,7 +14,7 @@ import {FileSystem} from '../file_system/file_system';
 export class NgccCompilerHost implements ts.CompilerHost {
   private _caseSensitive = this.fs.exists(AbsoluteFsPath.fromUnchecked(__filename.toUpperCase()));
 
-  constructor(private fs: FileSystem, private options: ts.CompilerOptions) {}
+  constructor(protected fs: FileSystem, protected options: ts.CompilerOptions) {}
 
   getSourceFile(fileName: string, languageVersion: ts.ScriptTarget): ts.SourceFile|undefined {
     const text = this.readFile(fileName);
@@ -62,5 +62,45 @@ export class NgccCompilerHost implements ts.CompilerHost {
       return undefined;
     }
     return this.fs.readFile(AbsoluteFsPath.fromUnchecked(fileName));
+  }
+}
+
+/**
+ * Represents a compiler host that resolves a module import as a JavaScript source file if
+ * available, instead of the .d.ts typings file that would have been resolved by TypeScript. This
+ * is necessary for packages that have their typings in the same directory as the sources, which
+ * would otherwise let TypeScript prefer the .d.ts file instead of the JavaScript source file.
+ */
+export class NgccSourcesCompilerHost extends NgccCompilerHost {
+  readonly cache = ts.createModuleResolutionCache(
+      this.getCurrentDirectory(), file => this.getCanonicalFileName(file));
+
+  constructor(fs: FileSystem, options: ts.CompilerOptions, protected entryPointPath: string) {
+    super(fs, options);
+  }
+
+  resolveModuleNames(
+      moduleNames: string[], containingFile: string, reusedNames?: string[],
+      redirectedReference?: ts.ResolvedProjectReference): Array<ts.ResolvedModule|undefined> {
+    return moduleNames.map(moduleName => {
+      const {resolvedModule} = ts.resolveModuleName(
+          moduleName, containingFile, this.options, this, this.cache, redirectedReference);
+
+      // If the module request originated from a relative import in a JavaScript source file,
+      // TypeScript may have resolved the module to its .d.ts declaration file if the .js source
+      // file was in the same directory. This is undesirable, as we need to have the actual
+      // JavaScript being present in the program. This logic recognizes this scenario and rewires
+      // the resolved .d.ts declaration file to its .js counterpart, if it exists.
+      if (resolvedModule !== undefined && resolvedModule.extension === ts.Extension.Dts &&
+          containingFile.endsWith('js') &&
+          (moduleName.startsWith('./') || moduleName.startsWith('../')) &&
+          resolvedModule.resolvedFileName.startsWith(this.entryPointPath)) {
+        const jsFile = resolvedModule.resolvedFileName.replace(/\.d\.ts$/, '.js');
+        if (this.fileExists(jsFile)) {
+          return {...resolvedModule, resolvedFileName: jsFile, extension: ts.Extension.Js};
+        }
+      }
+      return resolvedModule;
+    });
   }
 }

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
+import {MockFileSystem} from '../helpers/mock_file_system';
+
+function createMockFileSystem() {
+  return new MockFileSystem({
+    '/node_modules/test': {
+      'package.json':
+          '{"module": "./index.js", "es2015": "./es2015/index.js", "typings": "./index.d.ts"}',
+      'index.d.ts': 'export * from "./public_api";',
+      'index.js': 'export * from "./public_api";',
+      'index.metadata.json': '...',
+      'public_api.d.ts': `
+        export * from "test/secondary";
+        export * from "./nested";
+        export declare class TestClass {};
+      `,
+      'public_api.js': `
+        export * from "test/secondary";
+        export * from "./nested";
+        export const TestClass = function() {};
+       `,
+      'root.d.ts': `
+        import * from 'other';
+        export declare class RootClass {};
+      `,
+      'root.js': `
+        import * from 'other';
+        export const RootClass = function() {};
+      `,
+      'nested': {
+        'index.d.ts': 'export * from "../root";',
+        'index.js': 'export * from "../root";',
+      },
+      'es2015': {
+        'index.js': 'export * from "./public_api";',
+        'public_api.js': 'export class TestClass {};',
+        'root.js': `
+          import * from 'other';
+          export class RootClass {};
+        `,
+        'nested': {
+          'index.js': 'export * from "../root";',
+        },
+      },
+      'secondary': {
+        'package.json':
+            '{"module": "./index.js", "es2015": "./es2015/index.js", "typings": "./index.d.ts"}',
+        'index.d.ts': 'export * from "./public_api";',
+        'index.js': 'export * from "./public_api";',
+        'index.metadata.json': '...',
+        'public_api.d.ts': 'export declare class SecondaryClass {};',
+        'public_api.js': 'export class SecondaryClass {};',
+        'es2015': {
+          'index.js': 'export * from "./public_api";',
+          'public_api.js': 'export class SecondaryClass {};',
+        },
+      },
+    },
+    '/node_modules/other': {
+      'package.json':
+          '{"module": "./index.js", "es2015": "./es2015/index.js", "typings": "./index.d.ts"}',
+      'index.d.ts': 'export * from "./public_api";',
+      'index.js': 'export * from "./public_api";',
+      'index.metadata.json': '...',
+      'public_api.d.ts': 'export declare class OtherClass {};',
+      'public_api.js': 'export class OtherClass {};',
+      'es2015': {
+        'index.js': 'export * from "./public_api";',
+        'public_api.js': 'export class OtherClass {};',
+      },
+    },
+  });
+}
+
+describe('entry point bundle', () => {
+  // https://github.com/angular/angular/issues/29939
+  it('should resolve JavaScript sources instead of declaration files if they are adjacent', () => {
+    const fs = createMockFileSystem();
+    const esm5bundle = makeEntryPointBundle(
+        fs, '/node_modules/test', './index.js', './index.d.ts', false, 'esm5', 'esm5', true) !;
+
+    expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
+        .toEqual(jasmine.arrayWithExactContents([
+          // Modules from the entry-point itself should be source files
+          '/node_modules/test/index.js',
+          '/node_modules/test/public_api.js',
+          '/node_modules/test/nested/index.js',
+          '/node_modules/test/root.js',
+
+          // Modules from a secondary entry-point should be declaration files
+          '/node_modules/test/secondary/public_api.d.ts',
+          '/node_modules/test/secondary/index.d.ts',
+
+          // Modules resolved from "other" should be declaration files
+          '/node_modules/other/public_api.d.ts',
+          '/node_modules/other/index.d.ts',
+        ]));
+
+    expect(esm5bundle.dts !.program.getSourceFiles().map(sf => sf.fileName))
+        .toEqual(jasmine.arrayWithExactContents([
+          // All modules in the dts program should be declaration files
+          '/node_modules/test/index.d.ts',
+          '/node_modules/test/public_api.d.ts',
+          '/node_modules/test/nested/index.d.ts',
+          '/node_modules/test/root.d.ts',
+          '/node_modules/test/secondary/public_api.d.ts',
+          '/node_modules/test/secondary/index.d.ts',
+          '/node_modules/other/public_api.d.ts',
+          '/node_modules/other/index.d.ts',
+        ]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -11,7 +11,7 @@ import {ExternalReference} from '@angular/compiler/src/compiler';
 import * as ts from 'typescript';
 
 import {LogicalFileSystem, LogicalProjectPath} from '../../path';
-import {getSourceFile, isDeclaration, nodeNameForError} from '../../util/src/typescript';
+import {getSourceFile, isDeclaration, nodeNameForError, resolveModuleName} from '../../util/src/typescript';
 
 import {findExportedNameOfNode} from './find_export';
 import {ImportMode, Reference} from './references';
@@ -162,12 +162,12 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
   private enumerateExportsOfModule(specifier: string, fromFile: string):
       Map<ts.Declaration, string>|null {
     // First, resolve the module specifier to its entry point, and get the ts.Symbol for it.
-    const resolved = ts.resolveModuleName(specifier, fromFile, this.options, this.host);
-    if (resolved.resolvedModule === undefined) {
+    const resolvedModule = resolveModuleName(specifier, fromFile, this.options, this.host);
+    if (resolvedModule === undefined) {
       return null;
     }
 
-    const entryPointFile = this.program.getSourceFile(resolved.resolvedModule.resolvedFileName);
+    const entryPointFile = this.program.getSourceFile(resolvedModule.resolvedFileName);
     if (entryPointFile === undefined) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/imports/src/resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/resolver.ts
@@ -8,6 +8,7 @@
 
 import * as ts from 'typescript';
 
+import {resolveModuleName} from '../../util/src/typescript';
 import {Reference} from './references';
 
 export interface ReferenceResolver {
@@ -28,8 +29,7 @@ export class ModuleResolver {
 
   resolveModuleName(module: string, containingFile: ts.SourceFile): ts.SourceFile|null {
     const resolved =
-        ts.resolveModuleName(module, containingFile.fileName, this.compilerOptions, this.host)
-            .resolvedModule;
+        resolveModuleName(module, containingFile.fileName, this.compilerOptions, this.host);
     if (resolved === undefined) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -33,7 +33,7 @@ import {IvyCompilation, declarationTransformFactory, ivyTransformFactory} from '
 import {aliasTransformFactory} from './transform/src/alias';
 import {TypeCheckContext, TypeCheckingConfig, typeCheckFilePath} from './typecheck';
 import {normalizeSeparators} from './util/src/path';
-import {getRootDirs, isDtsPath} from './util/src/typescript';
+import {getRootDirs, isDtsPath, resolveModuleName} from './util/src/typescript';
 
 export class NgtscProgram implements api.Program {
   private tsProgram: ts.Program;
@@ -253,10 +253,10 @@ export class NgtscProgram implements api.Program {
       // of the root files.
       const containingFile = this.tsProgram.getRootFileNames()[0];
       const [entryPath, moduleName] = entryRoute.split('#');
-      const resolved = ts.resolveModuleName(entryPath, containingFile, this.options, this.host);
+      const resolvedModule = resolveModuleName(entryPath, containingFile, this.options, this.host);
 
-      if (resolved.resolvedModule) {
-        entryRoute = entryPointKeyFor(resolved.resolvedModule.resolvedFileName, moduleName);
+      if (resolvedModule) {
+        entryRoute = entryPointKeyFor(resolvedModule.resolvedFileName, moduleName);
       }
     }
 

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -91,3 +91,20 @@ export function nodeDebugInfo(node: ts.Node): string {
   const {line, character} = ts.getLineAndCharacterOfPosition(sf, node.pos);
   return `[${sf.fileName}: ${ts.SyntaxKind[node.kind]} @ ${line}:${character}]`;
 }
+
+/**
+ * Resolve the specified `moduleName` using the given `compilerOptions` and `compilerHost`.
+ *
+ * This helper will attempt to use the `CompilerHost.resolveModuleNames()` method if available.
+ * Otherwise it will fallback on the `ts.ResolveModuleName()` function.
+ */
+export function resolveModuleName(
+    moduleName: string, containingFile: string, compilerOptions: ts.CompilerOptions,
+    compilerHost: ts.CompilerHost): ts.ResolvedModule|undefined {
+  if (compilerHost.resolveModuleNames) {
+    return compilerHost.resolveModuleNames([moduleName], containingFile)[0];
+  } else {
+    return ts.resolveModuleName(moduleName, containingFile, compilerOptions, compilerHost)
+        .resolvedModule;
+  }
+}


### PR DESCRIPTION
… imports

Packages that do not follow APF may have the declaration files in the same
directory as one source format, typically ES5. This is problematic for ngcc,
as it needs to create a TypeScript program with all JavaScript sources of
an entry-point, whereas TypeScript's module resolution mechanism would have
resolved an internal module import to the external facing .d.ts declaration
file, instead of the JavaScript source file. This behavior results in the
program to be analysed being incomplete.

This commit introduces a custom compiler host that recognizes the above
scenario and rewires the resolution of a .d.ts declaration file to its
JavaScript counterpart, if applicable.

Fixes #29939