### PR TITLE
docs: add cross-platform support to the schematics for libraries guide

### DIFF
--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -78,7 +78,7 @@ To tell the library how to build the schematics, add a `tsconfig.schematics.json
 
   * The `outDir` maps to the library's output folder. By default, this is  the `dist/my-lib` folder at the root of your workspace.
 
-1. To make sure your schematics source files get compiled into the library bundle, add the following scripts to the `package.json` file in your library project's root folder (`projects/my-lib`).
+1. To make sure your schematics source files get compiled into the library bundle, add the following scripts to the `package.json` file in your library project's root folder (`projects/my-lib`). For Windows users, replace the `cp` command with `copy` or use a cross-platform solution like [ncp](https://www.npmjs.com/package/ncp).
 
 <code-example header="projects/my-lib/package.json (Build Scripts)" path="schematics-for-libraries/projects/my-lib/package.json">
 </code-example>


### PR DESCRIPTION
Add Windows friendly commands for copying schematics into the library.

Fixes #29952

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The [schematics for libraries guide](https://angular.io/guide/schematics-for-libraries) uses the `cp` command to copy schematics into the library's output directory (in the `package.json` file). The `cp` command is not a valid command in Windows cmd.exe and will throw an error it the scripts are executed.
Issue Number: 29952


## What is the new behavior?
Additional documentation explains that Windows users should use the `copy` command or look into a cross-platform solution such as [ncp](https://www.npmjs.com/package/ncp).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information