### PR TITLE
fix(common): suggest keyvalue pipe in error thrown when trying to use NgFor with an object

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -202,8 +202,13 @@ export class NgForOf<T> implements DoCheck {
         try {
           this._differ = this._differs.find(value).create(this.ngForTrackBy);
         } catch {
-          throw new Error(
-              `Cannot find a differ supporting object '${value}' of type '${getTypeName(value)}'. NgFor only supports binding to Iterables such as Arrays.`);
+          let errorMessage = `Cannot find a differ supporting object '${value}' of type ` +
+            `'${getTypeName(value)}'. NgFor only supports binding to Iterables such as Arrays`;
+          if (typeof value === 'object' && value !== null) {
+            errorMessage = `${errorMessage}. Use the keyvalue pipe to iterate over an object's ` +
+              `properties`;
+	        }
+          throw new Error(errorMessage);
         }
       }
     }

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -119,6 +119,15 @@ let thisArg: any;
                  /Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables such as Arrays/);
        }));
 
+    it('should throw on object ref and suggest using keyvalue pipe', async(() => {
+          fixture = createTestComponent();
+
+          getComponent().items = <any>{};
+          expect(() => fixture.detectChanges())
+              .toThrowError(
+                /Cannot find a differ supporting object '\[object Object\]' of type 'object'\. NgFor only supports binding to Iterables such as Arrays\. Use the keyvalue pipe to iterate over an object's properties/);
+       }));
+
     it('should throw on ref changing to string', async(() => {
          fixture = createTestComponent();
 


### PR DESCRIPTION
The error messaging in NgFor will now point developers toward the keyvalue pipe when they try to iterate over an object. This is valuable to developers who may not know about the new feature (introduced in 6.1).

fixes #28240

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When a developer tries to pass an object to NgFor, the error message does not mention the keyvalue pipe, which would allow iterating over an object's properties. 

Issue Number: 28240

## What is the new behavior?

The error handler returns the same message as before for invalid values passed into NgFor. 

If the invalid value is an object and not null, the handler will return the same error message, but with "Use the keyvalue pipe to iterate over an object's properties" appended.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information