### PR TITLE
fix(ivy): ngcc - do not copy declaration files into bundle clone

### DIFF
--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -43,10 +43,12 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
   protected copyBundle(
       bundle: EntryPointBundle, entryPointPath: AbsoluteFsPath, newDir: AbsoluteFsPath) {
     bundle.src.program.getSourceFiles().forEach(sourceFile => {
-      const relativePath = relative(entryPointPath, sourceFile.fileName);
-      const newFilePath = join(newDir, relativePath);
-      mkdir('-p', dirname(newFilePath));
-      cp(sourceFile.fileName, newFilePath);
+      if (!sourceFile.isDeclarationFile) {
+        const relativePath = relative(entryPointPath, sourceFile.fileName);
+        const newFilePath = join(newDir, relativePath);
+        mkdir('-p', dirname(newFilePath));
+        cp(sourceFile.fileName, newFilePath);
+      }
     });
   }
 


### PR DESCRIPTION
Previously, all of a program's files would be copied into the __ivy_ngcc__
folder where ngcc then writes its modifications into. The set of source files
in a program however is much larger than the source files contained within
the entry-point of interest, so many more files were copied than necessary.
Even worse, it may occur that an unrelated file in the program would collide
with an already existing source file, resulting in incorrectly overwriting
a file with unrelated content. This behavior has actually been observed
with @angular/animations and @angular/platform-browser/animations, where
the former package would overwrite declaration files of the latter package.

This commit fixes the issue by only copying relevant source files when cloning
a bundle's content into __ivy_ngcc__.

Fixes #29960