### PR TITLE
fix(ivy): include context name for template functions for `ng-content`

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -805,7 +805,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     const tagName = sanitizeIdentifier(template.tagName || '');
-    const contextName = `${tagName ? this.contextName + '_' + tagName : ''}_${templateIndex}`;
+    const contextName = `${this.contextName}${tagName ? '_' + tagName : ''}_${templateIndex}`;
     const templateName = `${contextName}_Template`;
 
     const parameters: o.Expression[] = [


### PR DESCRIPTION
Previously, a template's context name would only be included in an embedded
template function if the element that the template was declared on has a
tag name. This is generally true for elements, except for `ng-content`
that does not have a tag name. By omitting the context name the compiler
could introduce duplicate template function names, which would fail at runtime.

This commit fixes the behavior by always including the context name in the
template function's name, regardless of tag name.

Resolves FW-1272