### PR TITLE
build: update rxjs version requirements to 6.4.0

### DIFF
--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@angular/core": "^2.0.0-rc.7",
     "reflect-metadata": "^0.1.2",
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.4.0",
     "jpm": "1.1.4",
     "firefox-profile": "0.4.0",
     "selenium-webdriver": "^2.53.3"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
   },
   "locales": "locales",
   "peerDependencies": {
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.4.0",
     "@angular/core": "0.0.0-PLACEHOLDER"
   },
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.4.0",
     "zone.js": "~0.9.0"
   },
   "repository": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.4.0"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.4.0",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.4.0",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,7 +31,7 @@
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.4.0"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"


### PR DESCRIPTION
Simply moves the needle a bit for RxJS version requirements in angular packages.