### PR TITLE
refactor(ivy): Add space for insert before node in container

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -8,10 +8,11 @@
 
 import {Injector} from '../di';
 import {getViewComponent} from '../render3/global_utils_api';
-import {LContainer, NATIVE, VIEWS} from '../render3/interfaces/container';
+import {LContainer, NATIVE} from '../render3/interfaces/container';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/node';
 import {StylingIndex} from '../render3/interfaces/styling';
-import {LView, NEXT, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
+import {LView, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
+import {getContainerViewAt, getContainerViewCount} from '../render3/node_manipulation';
 import {getProp, getValue, isClassBasedValue} from '../render3/styling/class_and_style_bindings';
 import {getStylingContextFromLView} from '../render3/styling/util';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/util/discovery_utils';
@@ -20,6 +21,7 @@ import {findComponentView} from '../render3/util/view_traversal_utils';
 import {getComponentViewByIndex, getNativeByTNode, isComponent, isLContainer} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
+
 
 /**
  * @publicApi
@@ -502,8 +504,8 @@ function _queryNodeChildrenR3(
 function _queryNodeChildrenInContainerR3(
     lContainer: LContainer, predicate: Predicate<DebugNode>, matches: DebugNode[],
     elementsOnly: boolean, rootNativeNode: any) {
-  for (let i = 0; i < lContainer[VIEWS].length; i++) {
-    const childView = lContainer[VIEWS][i];
+  for (let i = 0; i < getContainerViewCount(lContainer); i++) {
+    const childView = getContainerViewAt(lContainer, i) !;
     _queryNodeChildrenR3(
         childView[TVIEW].node !, childView, predicate, matches, elementsOnly, rootNativeNode);
   }

--- a/packages/core/src/render3/debug.ts
+++ b/packages/core/src/render3/debug.ts
@@ -11,7 +11,7 @@ import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, TIcu} from './interfaces/i18n';
 import {TNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
-import {RComment, RElement} from './interfaces/renderer';
+import {RComment, RElement, RNode} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTENT_QUERIES, CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, INJECTOR, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, TVIEW, T_HOST} from './interfaces/view';
 import {getTNode, unwrapRNode} from './util/view_utils';
@@ -207,7 +207,14 @@ export class LContainerDebug {
 
   get activeIndex(): number { return this._raw_lContainer[ACTIVE_INDEX]; }
   get views(): LViewDebug[] {
-    return this._raw_lContainer[VIEWS].map(toDebug as(l: LView) => LViewDebug);
+    return this
+        ._raw_lContainer[VIEWS]
+        // All odd indices are actual LViews
+        .filter((_, i) => i % 2 === 1)
+        .map(toDebug as(l: LView) => LViewDebug);
+  }
+  get insertBeforeList(): (RNode|null)[] {
+    return this._raw_lContainer[VIEWS].filter((_, i) => i % 2 === 0) as(RNode | null)[];
   }
   get parent(): LViewDebug|LContainerDebug|null { return toDebug(this._raw_lContainer[PARENT]); }
   get queries(): LQueries|null { return this._raw_lContainer[QUERIES]; }

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -9,15 +9,17 @@ import {assertEqual} from '../../util/assert';
 import {assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {executePreOrderHooks, registerPostOrderHooks} from '../hooks';
-import {ACTIVE_INDEX, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX} from '../interfaces/container';
 import {ComponentTemplate} from '../interfaces/definition';
 import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType} from '../interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, LView, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
-import {appendChild, removeView} from '../node_manipulation';
+import {appendChild, getContainerViewCount, removeView} from '../node_manipulation';
 import {getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsParent, setPreviousOrParentTNode} from '../state';
 import {getNativeByTNode, loadInternal} from '../util/view_utils';
+
 import {addToViewTree, createDirectivesAndLocals, createLContainer, createNodeAtIndex, createTView} from './shared';
+
 
 /**
  * Creates an LContainer for inline views, e.g.
@@ -127,7 +129,7 @@ export function ɵɵcontainerRefreshEnd(): void {
   const nextIndex = lContainer[ACTIVE_INDEX];
 
   // remove extra views at the end of the container
-  while (nextIndex < lContainer[VIEWS].length) {
+  while (nextIndex < getContainerViewCount(lContainer)) {
     removeView(lContainer, nextIndex);
   }
 }

--- a/packages/core/src/render3/instructions/embedded_view.ts
+++ b/packages/core/src/render3/instructions/embedded_view.ts
@@ -8,15 +8,17 @@
 
 import {assertDefined, assertEqual} from '../../util/assert';
 import {assertLContainerOrUndefined} from '../assert';
-import {ACTIVE_INDEX, LContainer, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX, LContainer} from '../interfaces/container';
 import {RenderFlags} from '../interfaces/definition';
 import {TContainerNode, TNodeType} from '../interfaces/node';
 import {FLAGS, LView, LViewFlags, PARENT, QUERIES, TVIEW, TView, T_HOST} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
-import {insertView, removeView} from '../node_manipulation';
+import {getContainerViewAt, getContainerViewCount, insertView, removeView} from '../node_manipulation';
 import {enterView, getIsParent, getLView, getPreviousOrParentTNode, isCreationMode, leaveView, setIsParent, setPreviousOrParentTNode} from '../state';
 import {resetPreOrderHookFlags} from '../util/view_utils';
+
 import {assignTViewNodeToLView, createLView, createTView, refreshDescendantViews} from './shared';
+
 
 /**
  * Marks the start of an embedded view.
@@ -60,8 +62,9 @@ export function ɵɵembeddedViewStart(
   }
   if (lContainer) {
     if (isCreationMode(viewToRender)) {
+      // TODO(benlesh): Pass the proper insertBeforeNode here.
       // it is a new view, insert it into collection of views for a given container
-      insertView(viewToRender, lContainer, lContainer[ACTIVE_INDEX] !);
+      insertView(viewToRender, lContainer, lContainer[ACTIVE_INDEX] !, null);
     }
     lContainer[ACTIVE_INDEX] !++;
   }
@@ -107,11 +110,11 @@ function getOrCreateEmbeddedTView(
  * @returns index of a found view or -1 if not found
  */
 function scanForView(lContainer: LContainer, startIdx: number, viewBlockId: number): LView|null {
-  const views = lContainer[VIEWS];
-  for (let i = startIdx; i < views.length; i++) {
-    const viewAtPositionId = views[i][TVIEW].id;
+  for (let i = startIdx; i < getContainerViewCount(lContainer); i++) {
+    const view = getContainerViewAt(lContainer, i) !;
+    const viewAtPositionId = view[TVIEW].id;
     if (viewAtPositionId === viewBlockId) {
-      return views[i];
+      return view;
     } else if (viewAtPositionId < viewBlockId) {
       // found a view that should not be at this position - remove
       removeView(lContainer, i);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -19,7 +19,7 @@ import {attachLContainerDebug, attachLViewDebug} from '../debug';
 import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
 import {executeHooks, executePreOrderHooks, registerPreOrderHooks} from '../hooks';
-import {ACTIVE_INDEX, LContainer, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX, LContainer} from '../interfaces/container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {INJECTOR_BLOOM_PARENT_SIZE, NodeInjectorFactory} from '../interfaces/injector';
 import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
@@ -29,6 +29,7 @@ import {SanitizerFn} from '../interfaces/sanitization';
 import {StylingContext} from '../interfaces/styling';
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from '../node_assert';
+import {getContainerViewAt, getContainerViewCount} from '../node_manipulation';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
 import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, isCreationMode, leaveView, resetComponentState, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode, setSelectedIndex, ɵɵnamespaceHTML} from '../state';
 import {initializeStaticContext as initializeStaticStylingContext} from '../styling/class_and_style_bindings';
@@ -1449,8 +1450,8 @@ function refreshDynamicEmbeddedViews(lView: LView) {
     // header.
     if (current.length < HEADER_OFFSET && current[ACTIVE_INDEX] === -1) {
       const container = current as LContainer;
-      for (let i = 0; i < container[VIEWS].length; i++) {
-        const dynamicViewData = container[VIEWS][i];
+      for (let i = 0; i < getContainerViewCount(container); i++) {
+        const dynamicViewData = getContainerViewAt(container, i) !;
         // The directives and pipes are not needed here as an existing view is only being refreshed.
         ngDevMode && assertDefined(dynamicViewData[TVIEW], 'TView must be allocated');
         renderEmbeddedTemplate(dynamicViewData, dynamicViewData[TVIEW], dynamicViewData[CONTEXT] !);

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -8,7 +8,7 @@
 
 import {TNode} from './node';
 import {LQueries} from './query';
-import {RComment, RElement} from './renderer';
+import {RComment, RElement, RNode} from './renderer';
 import {StylingContext} from './styling';
 import {HOST, LView, NEXT, PARENT, QUERIES, T_HOST} from './view';
 
@@ -94,13 +94,20 @@ export interface LContainer extends Array<any> {
       RComment;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
 
   /**
-*A list of the container's currently active child views. Views will be inserted
-*here as they are added and spliced from here when they are removed. We need
-*to keep a record of current views so we know which views are already in the DOM
-*(and don't need to be re-added) and so we can remove views from the DOM when they
-*are no longer required.
-*/
-  [VIEWS]: LView[];
+   * A list of the container's currently active child views, and "insert before" RNodes.
+   *
+   * The structure of the list is as follows:
+   *
+   * - `index` (even): `RNode|null` -  The DOM node that can be used to insert DOM for a view
+   * inserted before the `LView` at `index + 1`. If the value is `null`, then the following `LView`
+   * is an empty.
+   * view, and you must use the next `RNode` found in the views list for insertion.
+   * - `index + 1` (odd): `LView` - A child view for the container.
+   *
+   * This list is used to identify views that are already inserted into DOM, so we know what we need
+   * to remove if the container's parent view is removed.
+   */
+  [VIEWS]: (RNode|null|LView)[];
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -327,6 +327,15 @@
     "name": "getContainerRenderParent"
   },
   {
+    "name": "getContainerViewAt"
+  },
+  {
+    "name": "getContainerViewCount"
+  },
+  {
+    "name": "getContainerViewIndex"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -252,6 +252,15 @@
     "name": "getContainerRenderParent"
   },
   {
+    "name": "getContainerViewAt"
+  },
+  {
+    "name": "getContainerViewCount"
+  },
+  {
+    "name": "getContainerViewIndex"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -672,6 +672,15 @@
     "name": "getContainerRenderParent"
   },
   {
+    "name": "getContainerViewAt"
+  },
+  {
+    "name": "getContainerViewCount"
+  },
+  {
+    "name": "getContainerViewIndex"
+  },
+  {
     "name": "getContextLView"
   },
   {


### PR DESCRIPTION
This is the first step in preparing to refactor how we are locating the insert before node for inserting views into containers. The design doc that outlines the totality of this change can be found here: https://hackmd.io/s/S1qsVYxw4
