### PR TITLE
feat(core): Add `TestBed.typedGet`

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -11,6 +11,7 @@
 // this statement only.
 // clang-format off
 import {
+  AbstractType,
   Component,
   Directive,
   InjectFlags,
@@ -169,15 +170,21 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3 as any as TestBedStatic;
   }
 
-  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  static typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return TestBedRender3.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  static get(token: any, notFoundValue?: any): any;
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
-    return _getTestBedRender3().get(token, notFoundValue);
+    return _getTestBedRender3().get(token, notFoundValue, flags);
   }
 
   static createComponent<T>(component: Type<T>): ComponentFixture<T> {
@@ -263,11 +270,17 @@ export class TestBedRender3 implements Injector, TestBed {
 
   compileComponents(): Promise<any> { return this.compiler.compileComponents(); }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return this.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  get(token: any, notFoundValue?: any): any;
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     if (token === TestBedRender3) {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
+import {AbstractType, ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {ComponentFixture} from './component_fixture';
@@ -56,9 +56,12 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
   get(token: any, notFoundValue?: any): any;
 
@@ -243,12 +246,17 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine as any as TestBedStatic;
   }
 
-  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  static typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return TestBedViewEngine.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
-   * @suppress {duplicate}
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  static get(token: any, notFoundValue?: any): any;
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
@@ -481,11 +489,17 @@ export class TestBedViewEngine implements Injector, TestBed {
     }
   }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return this.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  get(token: any, notFoundValue?: any): any;
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     this._initIfNeeded();

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
+import {AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -130,9 +130,12 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
   get(token: any, notFoundValue?: any): any;
 

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -70,7 +70,6 @@ export interface TestBed {
         deps: any[];
     }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     /** @deprecated */ get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
@@ -78,12 +77,12 @@ export interface TestBed {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void;
     overrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
+    overrideProvider(token: any, provider: {
         useFactory?: Function;
         useValue?: any;
         deps?: any[];
-    }): void;
-    overrideProvider(token: any, provider: {
-        useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
         useFactory: Function;
@@ -92,6 +91,7 @@ export interface TestBed {
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
     resetTestingModule(): void;
+    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare const TestBed: TestBedStatic;
@@ -106,19 +106,18 @@ export interface TestBedStatic {
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     deprecatedOverrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
-    }): TestBedStatic;
-    deprecatedOverrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
     }): void;
+    deprecatedOverrideProvider(token: any, provider: {
+        useFactory?: Function;
+        useValue?: any;
+        deps?: any[];
+    }): TestBedStatic;
     /** @deprecated */ get(token: any, notFoundValue?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;
@@ -140,6 +139,7 @@ export interface TestBedStatic {
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBedStatic;
     resetTestEnvironment(): void;
     resetTestingModule(): TestBedStatic;
+    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare class TestComponentRenderer {


### PR DESCRIPTION
`TestBed.typedGet` is a non breaking change to make way for a typed
`TestBed.get` signature. This commit adds the function with a different
name and strong types.

A future commit for Angular 9.x will replace the current `TestBed.get`
signature with the one added here, and `TestBed.typedGet` will be then
marked as deprecated to be completly removed on Angular 10.x

`Injector.get` will match the same signature as `TestBed.typedGet` on
Angular 9.x, both being breaking changes added at the same time.

Issue #26491
Fixes #29905

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TestBed.get` returns `any`

Issue Number: #26491


## What is the new behavior?

`TestBed.typedGet<T>` returns `T`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is pre-work for a future breaking change where `TestBed.get` will no longer return `any`