### PR TITLE
fix(ivy): explicitly compile ngModuleDef for RootScopeModule in R3TestBed

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -505,14 +505,10 @@ export class R3TestBedCompiler {
   }
 
   private compileTestModule(): void {
-    const rootProviderOverrides = this.rootProviderOverrides;
-
-    @NgModule({
-      providers: [...rootProviderOverrides],
-      jit: true,
-    })
-    class RootScopeModule {
-    }
+    class RootScopeModule {}
+    compileNgModuleDefs(RootScopeModule as NgModuleType<any>, {
+      providers: [...this.rootProviderOverrides],
+    });
 
     const ngZone = new NgZone({enableLongStackTrace: true});
     const providers: Provider[] = [


### PR DESCRIPTION
This commit unifies the way auxiliary RootScopeModule and DynamicTestModule are compiled in R3TestBed by calling `compileNgModuleDefs` explicitly for RootScopeModule. This change also resolves the problem where TestBed's code was used from the @angular/core NPM package: due to the "jit" flag, the @NgModule decorator on the RootScopeModule was transformed to RootScopeModule.decorators = [...], but actual ngModuleDef was never defined.

This PR resolves FW-1280.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No