### PR TITLE
fix(ivy): support module.id as @NgModule's "id" field value

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -499,6 +499,25 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toContain('i0.\u0275registerNgModuleType("test", TestModule);');
   });
 
+  it('should emit a \u0275registerNgModuleType call when the module id is defined as `module.id`',
+     () => {
+       env.tsconfig();
+       env.write('index.d.ts', `
+         declare const module = {id: string};
+       `);
+       env.write('test.ts', `
+         import {NgModule} from '@angular/core';
+
+         @NgModule({id: module.id})
+         export class TestModule {}
+       `);
+
+       env.driveMain();
+
+       const jsContents = env.getContents('test.js');
+       expect(jsContents).toContain('i0.\u0275registerNgModuleType(module.id, TestModule);');
+     });
+
   it('should filter out directives and pipes from module exports in the injector def', () => {
     env.tsconfig();
     env.write('test.ts', `

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -496,7 +496,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('i0.\u0275registerNgModuleType("test", TestModule);');
+    expect(jsContents).toContain('i0.\u0275registerNgModuleType(\'test\', TestModule);');
   });
 
   it('should emit a \u0275registerNgModuleType call when the module id is defined as `module.id`',


### PR DESCRIPTION
Prior to this commit, the check that verifies correct "id" field type was too strict and didn't allow `module.id` as @NgModule's "id" field value. This change adds a special handling for `module.id` and uses it as @NgModule id as is. [Example of `module.id` provided by Webpack](https://webpack.js.org/api/module-variables/#moduleid-commonjs).

This PR resolves FW-1281.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No