### PR TITLE
docs(docs-infra): fix typo in the aio/tools/examples/README

### DIFF
--- a/aio/tools/examples/README.md
+++ b/aio/tools/examples/README.md
@@ -29,7 +29,7 @@ Currently you will find the next boilerplates:
 
 
 * CLI - For CLI based examples. This is the default one, to be used in the majority of the examples.
-* systemjs - Currently in deprecation, only used in a a few examples.
+* systemjs - Currently in deprecation, only used in a few examples.
 * i18n - Based on the CLI one, features a few scripts for i18n.
 * universal - Based on the cli with a extra server for universal.
 


### PR DESCRIPTION
Remove an 'a' that was accidentally repeated twice in the aio/tools/examples/README.md file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are currently two 'a' words in a row (e.g 'in a a few') in the aio/tools/examples/README.md file.

Issue Number: N/A


## What is the new behavior?
One 'a' is removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information