### PR TITLE
build: update rxjs peerDeps to ^6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "selenium-webdriver": "3.5.0",
     "shelljs": "^0.8.1",
     "source-map": "^0.6.1",

--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@angular/core": "^2.0.0-rc.7",
     "reflect-metadata": "^0.1.2",
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "jpm": "1.1.4",
     "firefox-profile": "0.4.0",
     "selenium-webdriver": "^2.53.3"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
   },
   "locales": "locales",
   "peerDependencies": {
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "@angular/core": "0.0.0-PLACEHOLDER"
   },
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "zone.js": "~0.9.0"
   },
   "repository": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.5.1"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,7 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.1",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,7 +31,7 @@
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.5.1"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9401,6 +9401,13 @@ rxjs@6.4.0, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
Since `rxjs@6.5.1` is hot off the presses this evening with some bug fixes and features. We can update this again... 