### PR TITLE
build(docs-infra): upgrade RxJS to 6.5.1

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -92,7 +92,7 @@
     "@webcomponents/custom-elements": "^1.2.0",
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.4.1",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "zone.js": "^0.9.0"
   },
   "devDependencies": {

--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^7.0.0",
     "angular-in-memory-web-api": "^0.8.0",
     "core-js": "^2.5.4",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "web-animations-js": "^2.3.1",
     "zone.js": "~0.9.0"
   },

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "^7.0.0",
     "angular-in-memory-web-api": "^0.8.0",
     "core-js": "^2.5.4",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "web-animations-js": "^2.3.1",
     "zone.js": "~0.9.0"
   },

--- a/aio/tools/examples/shared/boilerplate/service-worker/package.json
+++ b/aio/tools/examples/shared/boilerplate/service-worker/package.json
@@ -23,7 +23,7 @@
     "@angular/service-worker": "^7.0.0",
     "angular-in-memory-web-api": "^0.8.0",
     "core-js": "^2.5.4",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "web-animations-js": "^2.3.1",
     "zone.js": "~0.9.0"
   },

--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -30,7 +30,7 @@
     "@nguniversal/module-map-ngfactory-loader": "^7.0.0",
     "angular-in-memory-web-api": "^0.8.0",
     "core-js": "^2.5.4",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "web-animations-js": "^2.3.1",
     "zone.js": "~0.9.0"
   },

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -36,7 +36,7 @@
     "angular-in-memory-web-api": "github:brandonroberts/in-memory-web-api-bazel#50a34d8",
     "core-js": "^2.5.4",
     "express": "^4.14.1",
-    "rxjs": "^6.3.0",
+    "rxjs": "^6.5.1",
     "systemjs": "0.19.39",
     "web-animations-js": "^2.3.1",
     "zone.js": "~0.9.0"

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -6702,7 +6702,7 @@ rx@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-rxjs@6.3.3, rxjs@^6.3.0:
+rxjs@6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   dependencies:
@@ -6711,6 +6711,13 @@ rxjs@6.3.3, rxjs@^6.3.0:
 rxjs@^6.1.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
   dependencies:
     tslib "^1.9.0"
 

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -8821,10 +8821,17 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@6.4.0, rxjs@^6.3.0, rxjs@^6.4.0:
+rxjs@6.4.0, rxjs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
☝️
Upgrade RxJS to 6.5.1 on angular.io and docs examples.
Related to #30043.