### PR TITLE
build: use fine grain dependencies for ts-api-guardian

### DIFF
--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "@npm//@types/diff",
         "@npm//@types/minimist",
         "@npm//@types/node",
+        "@npm//chalk",
         "@npm//diff",
         "@npm//minimist",
         "@npm//typescript",
@@ -41,7 +42,8 @@ npm_package(
         "package.json",
     ],
     replacements = {
-        "@angular//tools/ts-api-guardian": "@npm_ts_api_guardian//",
+        "@angular//tools/ts-api-guardian:bin": "@npm_ts_api_guardian//:bin",
+        "@angular//tools/ts-api-guardian:lib": "@npm//ts-api-guardian",
         "angular/tools/ts-api-guardian/": "npm_ts_api_guardian/",
     },
     deps = [
@@ -78,7 +80,6 @@ jasmine_node_test(
         "test/fixtures/*.patch",
     ]) + [
         ":ts-api-guardian",
-        "@npm//chalk",
         # TODO: remove this once the boostrap.js workaround has been removed.
         ":package.json",
     ],
@@ -86,8 +87,7 @@ jasmine_node_test(
 )
 # END-INTERNAL
 
-filegroup(
-    name = "bin",
-    srcs = glob(["lib/*.js"]) + ["bin/ts-api-guardian"],
+exports_files(
+    ["bin/ts-api-guardian"],
     visibility = ["//visibility:public"],
 )

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -33,11 +33,10 @@ def ts_api_guardian_test(
     """Runs ts_api_guardian
     """
     data += [
-        # BEGIN-INTERNAL
         # Locally we need to add the TS build target
+        # But it will replaced to @npm//ts-api-guardian when publishing
         "@angular//tools/ts-api-guardian:lib",
-        # END-INTERNAL
-        "@angular//tools/ts-api-guardian:bin",
+        "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
     ]
 
     args = [
@@ -58,7 +57,6 @@ def ts_api_guardian_test(
     nodejs_test(
         name = name,
         data = data,
-        node_modules = "@npm//:node_modules",
         entry_point = "angular/tools/ts-api-guardian/bin/ts-api-guardian",
         templated_args = args + ["--verify", golden, actual],
         **kwargs
@@ -68,7 +66,6 @@ def ts_api_guardian_test(
         name = name + ".accept",
         testonly = True,
         data = data,
-        node_modules = "@npm//:node_modules",
         entry_point = "angular/tools/ts-api-guardian/bin/ts-api-guardian",
         templated_args = args + ["--out", golden, actual],
         **kwargs


### PR DESCRIPTION
build: use fine grain dependencies for ts-api-guardian

At the moment `ts_api_guardian_test` rule depends on the entire node_modules tree, this is causing an input file tree of over 71473 in the material repo which is failing RBE

With this change we add only the required dependencies to as data attribute instead of the `@npm//:node_modules` introduced in this commit https://github.com/angular/angular/commit/ce2713f5b19679caa53453dd1c59bc56cc8d1b40

With this change we should also reduce the `Too many open files in system` error that sometimes crops up