### PR TITLE
refactor(upgrade): rename `module` constant to avoid webpack bug

### DIFF
--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -296,7 +296,9 @@ export function getAngularJSGlobal(): any {
 export const bootstrap: typeof angular.bootstrap = (e, modules, config?) =>
     angular.bootstrap(e, modules, config);
 
-export const module: typeof angular.module = (prefix, dependencies?) =>
+// Do not declare as `module` to avoid webpack bug
+// (see https://github.com/angular/angular/issues/30050).
+export const module_: typeof angular.module = (prefix, dependencies?) =>
     angular.module(prefix, dependencies);
 
 export const element: typeof angular.element = (e => angular.element(e)) as typeof angular.element;

--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -9,7 +9,7 @@
 import {Compiler, CompilerOptions, Injector, NgModule, NgModuleRef, NgZone, StaticProvider, Testability, Type, resolveForwardRef} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
-import {IAngularBootstrapConfig, IAugmentedJQuery, IInjectorService, IModule, IProvideService, IRootScopeService, ITestabilityService, bootstrap, element as angularElement, module as angularModule} from '../../common/src/angular1';
+import {IAngularBootstrapConfig, IAugmentedJQuery, IInjectorService, IModule, IProvideService, IRootScopeService, ITestabilityService, bootstrap, element as angularElement, module_ as angularModule} from '../../common/src/angular1';
 import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, LAZY_MODULE_REF, NG_ZONE_KEY, UPGRADE_APP_TYPE_KEY} from '../../common/src/constants';
 import {downgradeComponent} from '../../common/src/downgrade_component';
 import {downgradeInjectable} from '../../common/src/downgrade_injectable';

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -32,7 +32,7 @@ withEachNg1Version(() => {
       it('should have AngularJS loaded', () => expect(angular.version.major).toBe(1));
 
       it('should instantiate ng2 in ng1 template and project content', async(() => {
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            @Component({
              selector: 'ng2',
@@ -58,7 +58,7 @@ withEachNg1Version(() => {
 
       it('should instantiate ng1 in ng2 template and project content', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            @Component({
              selector: 'ng2',
@@ -92,7 +92,7 @@ withEachNg1Version(() => {
            spyOn(platformRef, 'bootstrapModule').and.callThrough();
            spyOn(platformRef, 'bootstrapModuleFactory').and.callThrough();
 
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            @Component({selector: 'ng2', template: `{{ 'NG2' }}(<ng-content></ng-content>)`})
            class Ng2 {
            }
@@ -126,7 +126,7 @@ withEachNg1Version(() => {
       let adapter: UpgradeAdapter;
 
       beforeEach(() => {
-        angular.module('ng1', []);
+        angular.module_('ng1', []);
 
         @Component({
           selector: 'ng2',
@@ -172,7 +172,7 @@ withEachNg1Version(() => {
     describe('scope/component change-detection', () => {
       it('should interleave scope and component expressions', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const log: string[] = [];
            const l = (value: string) => {
              log.push(value);
@@ -254,7 +254,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []).directive(
+           const ng1Module = angular.module_('ng1', []).directive(
                'myApp', adapter.downgradeNg2Component(AppComponent));
 
            const element = html('<my-app></my-app>');
@@ -308,7 +308,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.directive('ng2', adapter.downgradeNg2Component(WorksComponent));
 
            const element = html('<ng2></ng2>');
@@ -320,7 +320,7 @@ withEachNg1Version(() => {
       it('should bind properties, events', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const ng1Module =
-               angular.module('ng1', []).value($EXCEPTION_HANDLER, (err: any) => { throw err; });
+               angular.module_('ng1', []).value($EXCEPTION_HANDLER, (err: any) => { throw err; });
 
            ng1Module.run(($rootScope: any) => {
              $rootScope.name = 'world';
@@ -442,7 +442,7 @@ withEachNg1Version(() => {
       it('should support two-way binding and event listener', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const listenerSpy = jasmine.createSpy('$rootScope.listener');
-           const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+           const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
              $rootScope['value'] = 'world';
              $rootScope['listener'] = listenerSpy;
            });
@@ -523,7 +523,7 @@ withEachNg1Version(() => {
            class Ng2Module {
            }
 
-           const ng1Module = angular.module('ng1', []).directive(
+           const ng1Module = angular.module_('ng1', []).directive(
                'ng2', adapter.downgradeNg2Component(Ng2Component));
 
            const element = html(`
@@ -549,7 +549,7 @@ withEachNg1Version(() => {
 
       it('should bind to ng-model', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            ng1Module.run(($rootScope: any /** TODO #9100 */) => { $rootScope.modelA = 'A'; });
 
@@ -607,7 +607,7 @@ withEachNg1Version(() => {
 
       it('should properly run cleanup when ng1 directive is destroyed', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const onDestroyed: EventEmitter<string> = new EventEmitter<string>();
 
            ng1Module.directive('ng1', () => {
@@ -663,7 +663,7 @@ withEachNg1Version(() => {
            }
 
            const ng1Module =
-               angular.module('ng1', [])
+               angular.module_('ng1', [])
                    .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
                    .directive('ng2Inner', adapter.downgradeNg2Component(Ng2InnerComponent))
                    .directive('ng2Outer', adapter.downgradeNg2Component(Ng2OuterComponent));
@@ -683,7 +683,7 @@ withEachNg1Version(() => {
 
       it('should fallback to the root ng2.injector when compiled outside the dom', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            ng1Module.directive('ng1', [
              '$compile',
@@ -718,7 +718,7 @@ withEachNg1Version(() => {
          }));
 
       it('should support multi-slot projection', async(() => {
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            @Component({
              selector: 'ng2',
@@ -758,7 +758,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
                                  .run(($rootScope: angular.IRootScopeService) => {
                                    $rootScope['items'] = [
@@ -782,7 +782,7 @@ withEachNg1Version(() => {
 
       it('should allow attribute selectors for components in ng2', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
-           const ng1Module = angular.module('myExample', []);
+           const ng1Module = angular.module_('myExample', []);
 
            @Component({selector: '[works]', template: 'works!'})
            class WorksComponent {
@@ -833,7 +833,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -897,7 +897,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -961,7 +961,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -1022,7 +1022,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -1055,7 +1055,7 @@ withEachNg1Version(() => {
 
       it('should bind properties, events', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1113,7 +1113,7 @@ withEachNg1Version(() => {
 
       it('should bind optional properties', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1158,7 +1158,7 @@ withEachNg1Version(() => {
       it('should bind properties, events in controller when bindToController is not used',
          async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1202,7 +1202,7 @@ withEachNg1Version(() => {
 
       it('should bind properties, events in link function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1246,7 +1246,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl fetched from $httpBackend', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.value(
                '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
                  cbFn(200, `${method}:${url}`);
@@ -1275,7 +1275,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl as a function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.value(
                '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
                  cbFn(200, `${method}:${url}`);
@@ -1304,7 +1304,7 @@ withEachNg1Version(() => {
 
       it('should support empty template', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => { return {template: ''}; };
            ng1Module.directive('ng1', ng1);
@@ -1330,7 +1330,7 @@ withEachNg1Version(() => {
 
       it('should support template as a function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => { return {template() { return ''; }}; };
            ng1Module.directive('ng1', ng1);
@@ -1356,7 +1356,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl fetched from $templateCache', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.run(($templateCache: any) => $templateCache.put('url.html', 'WORKS'));
 
            const ng1 = () => { return {templateUrl: 'url.html'}; };
@@ -1383,7 +1383,7 @@ withEachNg1Version(() => {
 
       it('should support controller with controllerAs', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1427,7 +1427,7 @@ withEachNg1Version(() => {
 
       it('should support bindToController', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1461,7 +1461,7 @@ withEachNg1Version(() => {
 
       it('should support bindToController with bindings', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1495,7 +1495,7 @@ withEachNg1Version(() => {
 
       it('should support single require in linking fn', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = ($rootScope: any) => {
              return {
@@ -1536,7 +1536,7 @@ withEachNg1Version(() => {
 
       it('should support array require in linking fn', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const parent = () => { return {controller: class {parent = 'PARENT';}}; };
            const ng1 = () => {
@@ -1588,7 +1588,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1632,7 +1632,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1681,7 +1681,7 @@ withEachNg1Version(() => {
                constructor(cd: ChangeDetectorRef) { changeDetector = cd; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1735,7 +1735,7 @@ withEachNg1Version(() => {
                constructor(cd: ChangeDetectorRef) { changeDetector = cd; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1788,7 +1788,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1832,7 +1832,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1885,7 +1885,7 @@ withEachNg1Version(() => {
                constructor() { ng2Instance = this; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {valA: '<'},
@@ -1988,7 +1988,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -2077,7 +2077,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -2152,7 +2152,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .component('ng1', {
                    controller: function($scope: angular.IScope) {
                      $scope.$on('$destroy', scopeDestroyListener);
@@ -2198,7 +2198,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .component('ng1', {
                    controller: class {
                      constructor(private $element: angular.IAugmentedJQuery) {} $onInit() {
@@ -2266,7 +2266,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             angular.module('ng1Module', [])
+             angular.module_('ng1Module', [])
                  .component('ng1', ng1Component)
                  .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2332,7 +2332,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             angular.module('ng1Module', [])
+             angular.module_('ng1Module', [])
                  .component('ng1', ng1Component)
                  .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2386,7 +2386,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2424,7 +2424,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2464,7 +2464,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2504,7 +2504,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2543,7 +2543,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2594,7 +2594,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2658,7 +2658,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2717,7 +2717,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2791,7 +2791,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2857,7 +2857,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2907,7 +2907,7 @@ withEachNg1Version(() => {
 
              // Define `ng1Module`
              const ng1Module =
-                 angular.module('ng1Module', [])
+                 angular.module_('ng1Module', [])
                      .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                      .component('ng1', ng1Component)
                      .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2961,7 +2961,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2997,7 +2997,7 @@ withEachNg1Version(() => {
 
       it('should bind input properties (<) of components', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = {
              bindings: {personProfile: '<'},
@@ -3029,7 +3029,7 @@ withEachNg1Version(() => {
 
       it('should support ng2 > ng1 > ng2', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = {
              template: 'ng1(<ng2b></ng2b>)',
@@ -3072,7 +3072,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module('myExample', []);
+           const module = angular.module_('myExample', []);
            module.factory('someToken', adapter.downgradeNg2Provider(SomeToken));
            adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
              expect(ref.ng1Injector.get('someToken')).toBe('correct_value');
@@ -3086,7 +3086,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module('myExample', []);
+           const module = angular.module_('myExample', []);
            module.value('testValue', 'secreteToken');
            adapter.upgradeNg1Provider('testValue');
            adapter.upgradeNg1Provider('testValue', {asToken: 'testToken'});
@@ -3100,7 +3100,7 @@ withEachNg1Version(() => {
          }));
 
       it('should respect hierarchical dependency injection for ng2', async(() => {
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            @Component({selector: 'ng2-parent', template: `ng2-parent(<ng-content></ng-content>)`})
            class Ng2Parent {
@@ -3133,7 +3133,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module('ng1', []);
+           angular.module_('ng1', []);
            let bootstrapResumed: boolean = false;
 
            const element = html('<div></div>');
@@ -3156,7 +3156,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            let a1Injector: angular.IInjectorService|undefined;
            ng1Module.run([
              '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
@@ -3179,7 +3179,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module('ng1', []);
+           angular.module_('ng1', []);
            const element = html('<div></div>');
            adapter.bootstrap(element, ['ng1']).ready((ref) => {
              const ng2Testability: Testability = ref.ng2Injector.get(Testability);
@@ -3202,7 +3202,7 @@ withEachNg1Version(() => {
     describe('examples', () => {
       it('should verify UpgradeAdapter example', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const module = angular.module('myExample', []);
+           const module = angular.module_('myExample', []);
 
            const ng1 = () => {
              return {
@@ -3246,7 +3246,7 @@ withEachNg1Version(() => {
       let $rootScope: angular.IRootScopeService;
 
       beforeEach(() => {
-        const ng1Module = angular.module('ng1', []);
+        const ng1Module = angular.module_('ng1', []);
 
         @Component({
           selector: 'ng2',

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -9,7 +9,7 @@
 import {Injector, NgModuleFactory, NgModuleRef, StaticProvider} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 
-import {IInjectorService, IProvideService, module as angularModule} from '../../src/common/src/angular1';
+import {IInjectorService, IProvideService, module_ as angularModule} from '../../src/common/src/angular1';
 import {$INJECTOR, $PROVIDE, DOWNGRADED_MODULE_COUNT_KEY, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../../src/common/src/constants';
 import {LazyModuleRef, UpgradeAppType, getDowngradedModuleCount, isFunction} from '../../src/common/src/util';
 

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -8,7 +8,7 @@
 
 import {Injector, NgModule, NgZone, Testability} from '@angular/core';
 
-import {IInjectorService, IIntervalService, IProvideService, ITestabilityService, bootstrap, element as angularElement, module as angularModule} from '../../src/common/src/angular1';
+import {IInjectorService, IIntervalService, IProvideService, ITestabilityService, bootstrap, element as angularElement, module_ as angularModule} from '../../src/common/src/angular1';
 import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../../src/common/src/constants';
 import {LazyModuleRef, UpgradeAppType, controllerKey} from '../../src/common/src/util';
 

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -60,7 +60,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .directive('ng1a', () => ({template: '{{ l(\'ng1a\') }}'}))
                                .directive('ng1b', () => ({template: '{{ l(\'ng1b\') }}'}))
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
@@ -118,7 +118,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'myApp', downgradeComponent({component: AppComponent}));
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {

--- a/packages/upgrade/static/test/integration/content_projection_spec.ts
+++ b/packages/upgrade/static/test/integration/content_projection_spec.ts
@@ -43,7 +43,7 @@ withEachNg1Version(() => {
 
          // the ng1 app module that will consume the downgraded component
          const ng1Module = angular
-                               .module('ng1', [])
+                               .module_('ng1', [])
                                // create an ng1 facade of the ng2 component
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
@@ -74,7 +74,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
                                  $rootScope['items'] = [
@@ -123,7 +123,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1', () => ({
                                      transclude: true,
                                      template: '{{ prop }}(<ng-transclude></ng-transclude>)'
@@ -161,7 +161,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'ng2', downgradeComponent({component: Ng2Component}));
 
          // The ng-if on one of the projected children is here to make sure

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -23,7 +23,7 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should bind properties, events', async(() => {
-         const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
            $rootScope['name'] = 'world';
            $rootScope['dataA'] = 'A';
            $rootScope['dataB'] = 'B';
@@ -147,7 +147,7 @@ withEachNg1Version(() => {
        }));
 
     it('should bind properties to onpush components', async(() => {
-         const ng1Module = angular.module('ng1', []).run(
+         const ng1Module = angular.module_('ng1', []).run(
              ($rootScope: angular.IScope) => { $rootScope['dataB'] = 'B'; });
 
          @Component({
@@ -189,7 +189,7 @@ withEachNg1Version(() => {
 
     it('should support two-way binding and event listener', async(() => {
          const listenerSpy = jasmine.createSpy('$rootScope.listener');
-         const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
            $rootScope['value'] = 'world';
            $rootScope['listener'] = listenerSpy;
          });
@@ -259,7 +259,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
                                  $rootScope.value1 = 0;
@@ -323,7 +323,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng2', downgradeComponent({component: Ng2Component, propagateDigest: false}))
                  .run(($rootScope: angular.IRootScopeService) => {
@@ -385,7 +385,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng2A', downgradeComponent({component: Ng2Component, propagateDigest: true}))
                  .directive(
@@ -439,7 +439,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'ng2', downgradeComponent({component: Ng2Component}));
 
          const element = html(`
@@ -462,7 +462,7 @@ withEachNg1Version(() => {
        }));
 
     it('should bind to ng-model', async(() => {
-         const ng1Module = angular.module('ng1', []).run(
+         const ng1Module = angular.module_('ng1', []).run(
              ($rootScope: angular.IScope) => { $rootScope['modelA'] = 'A'; });
 
          let ng2Instance: Ng2;
@@ -534,7 +534,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng1',
                      () => { return {template: '<div ng-if="!destroyIt"><ng2></ng2></div>'}; })
@@ -587,7 +587,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
                  .directive('ng2Inner', downgradeComponent({component: Ng2InnerComponent}))
                  .directive('ng2Outer', downgradeComponent({component: Ng2OuterComponent}));
@@ -622,7 +622,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng1',
                      [
@@ -667,7 +667,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'worksComponent', downgradeComponent({component: WorksComponent}));
 
          const element = html('<works-component></works-component>');
@@ -695,7 +695,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'rootComponent', downgradeComponent({component: RootComponent}));
 
          const element = html('<root-component></root-component>');
@@ -725,7 +725,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('parent', downgradeComponent({component: ParentComponent}))
                  .directive('child', downgradeComponent({component: ChildComponent}));
 
@@ -765,7 +765,7 @@ withEachNg1Version(() => {
          class LazyLoadedModule {
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'ng2', downgradeComponent({component: Ng2Component}));
 
          const element = html('<ng2></ng2>');
@@ -800,7 +800,7 @@ withEachNg1Version(() => {
          }
 
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'ng2', downgradeComponent({component: Ng2Component, downgradedModule: 'foo'}));
 
          const element = html('<ng2></ng2>');

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -62,7 +62,7 @@ withEachNg1Version(() => {
 
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module('ng1', [downModA, downModB])
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
                                  .directive('ng2A', downgradeComponent({
                                               component: Ng2ComponentA,
                                               downgradedModule: downModA, propagateDigest,
@@ -130,7 +130,7 @@ withEachNg1Version(() => {
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
            const ng1Module =
-               angular.module('ng1', [downModA, downModB])
+               angular.module_('ng1', [downModA, downModB])
                    .directive('ng1A', () => ({template: 'ng1A(<ng2-b ng-if="showB"></ng2-b>)'}))
                    .directive('ng2A', downgradeComponent({
                                 component: Ng2ComponentA,
@@ -203,7 +203,7 @@ withEachNg1Version(() => {
 
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module('ng1', [downModA, downModB])
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
                                  .directive('ng2A', downgradeComponent({
                                               component: Ng2ComponentA,
                                               downgradedModule: downModA, propagateDigest,
@@ -296,7 +296,7 @@ withEachNg1Version(() => {
 
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module('ng1', [downModA, downModB])
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
                                  .directive('ng2A', downgradeComponent({
                                               component: Ng2ComponentA,
                                               downgradedModule: downModA, propagateDigest,
@@ -386,7 +386,7 @@ withEachNg1Version(() => {
 
            const downMod = downgradeModule(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [downMod])
+               angular.module_('ng1', [downMod])
                    .directive(
                        'ng2A', downgradeComponent({component: Ng2ComponentA, propagateDigest}))
                    .directive(
@@ -494,7 +494,7 @@ withEachNg1Version(() => {
 
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module('ng1', [downModA, downModB])
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
                                  .directive('ng2A', downgradeComponent({
                                               component: Ng2ComponentA,
                                               downgradedModule: downModA, propagateDigest,
@@ -560,7 +560,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2AComponent, propagateDigest}))
                    .run(($rootScope: angular.IRootScopeService) => $rootScope.value = 0);
@@ -623,7 +623,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                    .value('ng1Value', 'foo');
 
@@ -667,7 +667,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -702,7 +702,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -742,7 +742,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                    .run(($rootScope: angular.IRootScopeService) => {
                      $rootScope.attrVal = 'bar';
@@ -809,7 +809,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'test', downgradeComponent({component: TestComponent, propagateDigest}))
                    .directive(
@@ -858,7 +858,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -908,7 +908,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'test', downgradeComponent({component: TestComponent, propagateDigest}))
                    .directive(
@@ -978,7 +978,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                    .run(($rootScope: angular.IRootScopeService) => {
                      rootScope = $rootScope;
@@ -1121,7 +1121,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1178,7 +1178,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1233,7 +1233,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1298,7 +1298,7 @@ withEachNg1Version(() => {
         afterEach(() => setTempInjectorRef(null !));
 
         it('should throw if no downgraded module is included', async(() => {
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,
@@ -1330,7 +1330,7 @@ withEachNg1Version(() => {
            }));
 
         it('should throw if the corresponding downgraded module is not included', async(() => {
-             const ng1Module = angular.module('ng1', [downModA])
+             const ng1Module = angular.module_('ng1', [downModA])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,
@@ -1356,7 +1356,7 @@ withEachNg1Version(() => {
 
         it('should throw if `downgradedModule` is not specified and there are multiple downgraded modules',
            async(() => {
-             const ng1Module = angular.module('ng1', [downModA, downModB])
+             const ng1Module = angular.module_('ng1', [downModA, downModB])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,

--- a/packages/upgrade/static/test/integration/examples_spec.ts
+++ b/packages/upgrade/static/test/integration/examples_spec.ts
@@ -64,7 +64,7 @@ withEachNg1Version(() => {
          // This module represents the AngularJS pieces of the application
          const ng1Module =
              angular
-                 .module('myExample', [])
+                 .module_('myExample', [])
                  // This is an AngularJS component that will be upgraded
                  .directive(
                      'ng1',

--- a/packages/upgrade/static/test/integration/injection_spec.ts
+++ b/packages/upgrade/static/test/integration/injection_spec.ts
@@ -40,8 +40,8 @@ withEachNg1Version(() => {
          }
 
          // create the ng1 module that will import an ng2 service
-         const ng1Module =
-             angular.module('ng1Module', []).factory('ng2Service', downgradeInjectable(Ng2Service));
+         const ng1Module = angular.module_('ng1Module', [])
+                               .factory('ng2Service', downgradeInjectable(Ng2Service));
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then((upgrade) => {
@@ -71,7 +71,8 @@ withEachNg1Version(() => {
          }
 
          // create the ng1 module that will import an ng2 service
-         const ng1Module = angular.module('ng1Module', []).value('ng1Service', 'ng1 service value');
+         const ng1Module =
+             angular.module_('ng1Module', []).value('ng1Service', 'ng1 service value');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then((upgrade) => {
@@ -84,7 +85,7 @@ withEachNg1Version(() => {
        async(() => {
          let runBlockTriggered = false;
 
-         const ng1Module = angular.module('ng1Module', []).run([
+         const ng1Module = angular.module_('ng1Module', []).run([
            INJECTOR_KEY,
            function(injector: Injector) {
              runBlockTriggered = true;
@@ -124,7 +125,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1Module', []);
+         const ng1Module = angular.module_('ng1Module', []);
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then(upgrade => expect(wrappedBootstrapCalled).toBe(true))

--- a/packages/upgrade/static/test/integration/testability_spec.ts
+++ b/packages/upgrade/static/test/integration/testability_spec.ts
@@ -31,7 +31,7 @@ withEachNg1Version(() => {
     it('should handle deferred bootstrap', fakeAsync(() => {
          let applicationRunning = false;
          let stayedInTheZone: boolean = undefined !;
-         const ng1Module = angular.module('ng1', []).run(() => {
+         const ng1Module = angular.module_('ng1', []).run(() => {
            applicationRunning = true;
            stayedInTheZone = NgZone.isInAngularZone();
          });
@@ -50,7 +50,7 @@ withEachNg1Version(() => {
        }));
 
     it('should propagate return value of resumeBootstrap', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          let a1Injector: angular.IInjectorService|undefined;
          ng1Module.run([
            '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
@@ -69,7 +69,7 @@ withEachNg1Version(() => {
        }));
 
     it('should wait for ng2 testability', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          const element = html('<div></div>');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
@@ -95,7 +95,7 @@ withEachNg1Version(() => {
        }));
 
     it('should not wait for $interval', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          const element = html('<div></div>');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -44,7 +44,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -84,7 +84,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -131,7 +131,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -172,7 +172,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -216,7 +216,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -267,7 +267,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -312,7 +312,7 @@ withEachNg1Version(() => {
 
             // Define `ng1Module`
             const ng1Module =
-                angular.module('ng1Module', [])
+                angular.module_('ng1Module', [])
                     .component('ng1', ng1Component)
                     .directive('ng2', downgradeComponent({component: Ng2Component}))
                     .value(
@@ -363,7 +363,7 @@ withEachNg1Version(() => {
 
             // Define `ng1Module`
             const ng1Module =
-                angular.module('ng1Module', [])
+                angular.module_('ng1Module', [])
                     .component('ng1', ng1Component)
                     .directive('ng2', downgradeComponent({component: Ng2Component}))
                     .value(
@@ -433,7 +433,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1A', ng1ComponentA)
                                  .component('ng1B', ng1ComponentB)
                                  .component('ng1C', ng1ComponentC)
@@ -505,7 +505,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -582,7 +582,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -663,7 +663,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -736,7 +736,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -833,7 +833,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -916,7 +916,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1006,7 +1006,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1074,7 +1074,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .component('ng1A', ng1ComponentA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2X', downgradeComponent({component: Ng2ComponentX}));
@@ -1123,7 +1123,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1170,7 +1170,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1218,7 +1218,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1266,7 +1266,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1313,7 +1313,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1378,7 +1378,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1451,7 +1451,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1505,7 +1505,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1553,7 +1553,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .controller('Ng1Controller', class { text = 'GREAT'; })
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1607,7 +1607,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1663,7 +1663,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1715,7 +1715,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1782,7 +1782,7 @@ withEachNg1Version(() => {
              // Define `ng1Module`
              const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
              const ng1Module =
-                 angular.module('ng1Module', [])
+                 angular.module_('ng1Module', [])
                      .component('ng1A', ng1ComponentA)
                      .component('ng1B', ng1ComponentB)
                      .component('ng1C', ng1ComponentC)
@@ -1853,7 +1853,7 @@ withEachNg1Version(() => {
 
              // Define `ng1Module`
              const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                                    .value($EXCEPTION_HANDLER, mockExceptionHandler);
@@ -1928,7 +1928,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .component('ng1C', ng1ComponentC)
@@ -1994,7 +1994,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2051,7 +2051,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2109,7 +2109,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .component('ng1C', ng1ComponentC)
@@ -2170,7 +2170,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -2231,7 +2231,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2297,7 +2297,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2372,7 +2372,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2445,7 +2445,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2504,7 +2504,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2567,7 +2567,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2660,7 +2660,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}))
@@ -2813,7 +2813,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2943,7 +2943,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3013,7 +3013,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3080,7 +3080,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3150,7 +3150,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3212,7 +3212,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3294,7 +3294,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3373,7 +3373,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3474,7 +3474,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3552,7 +3552,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -3609,7 +3609,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3673,7 +3673,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3740,7 +3740,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3809,7 +3809,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3863,7 +3863,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -3927,7 +3927,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1X', ng1Component)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
                                .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
@@ -4035,7 +4035,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1X', ng1Component)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
                                .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
@@ -4180,7 +4180,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1A', ng1ComponentA)
                                .component('ng1B', ng1ComponentB)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))


### PR DESCRIPTION
When targeting ES2015 (as is the default in cli@8), `const` is not downleveled to `var` and thus declaring `const module` throws an error due to webpack wrapping the code in a function call with a `module` argument (even when compiling for the `web` environment).

Related: webpack/webpack#7369

Fixes #30050.