### PR TITLE
fix(ivy): don't throw error when evaluating function with more than one statement

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -421,7 +421,7 @@ export class StaticInterpreter {
 
     const body = fn.body;
     if (body.length !== 1 || !ts.isReturnStatement(body[0])) {
-      throw new Error('Function body must have a single return statement only.');
+      return DynamicValue.fromUnknown(node);
     }
     const ret = body[0] as ts.ReturnStatement;
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -356,6 +356,17 @@ describe('ngtsc metadata', () => {
     expect(id.text).toEqual('Target');
   });
 
+  it('should resolve functions with more than one statement to an unknown value', () => {
+    const value = evaluate(`function foo(bar) { const b = bar; return b; }`, 'foo("test")');
+
+    if (!(value instanceof DynamicValue)) {
+      return fail(`Should have resolved to a DynamicValue`);
+    }
+
+    expect(value.isFromUnknown()).toBe(true);
+    expect((value.node as ts.CallExpression).expression.getText()).toBe('foo');
+  });
+
   describe('(visited file tracking)', () => {
     it('should track each time a source file is visited', () => {
       const visitedFilesSpy = jasmine.createSpy('visitedFilesCb');


### PR DESCRIPTION
Resolves functions with more than one statement to unknown dynamic values, rather than throwing an error.
