### PR TITLE
build: fix api guardian error form npm

### DIFF
--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -87,7 +87,8 @@ jasmine_node_test(
 )
 # END-INTERNAL
 
-exports_files(
-    ["bin/ts-api-guardian"],
+filegroup(
+    name = "bin",
+    srcs = glob(["lib/*.js"]) + ["bin/ts-api-guardian"],
     visibility = ["//visibility:public"],
 )

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -36,7 +36,7 @@ def ts_api_guardian_test(
         # Locally we need to add the TS build target
         # But it will replaced to @npm//ts-api-guardian when publishing
         "@angular//tools/ts-api-guardian:lib",
-        "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        "@angular//tools/ts-api-guardian:bin",
     ]
 
     args = [


### PR DESCRIPTION
built-in, relative, absolute, nested node_modules - Error: Cannot find module '../lib/cli'

This is because the transpiled lib files need to be added to the data.
