### PR TITLE
fix(bazel): transitive npm deps in ng_module

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,8 @@ Try running `yarn bazel` instead.
 #   - 0.15.3 Includes a fix for the `jasmine_node_test` rule ignoring target tags
 #   - 0.16.8 Supports npm installed bazel workspaces
 #   - 0.26.0 Fix for data files in yarn_install and npm_install
-check_rules_nodejs_version("0.26.0")
+#   - 0.27.12 Adds NodeModuleSources provider for transtive npm deps support
+check_rules_nodejs_version("0.27.12")
 
 # Setup the Node.js toolchain
 node_repositories(

--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -16,6 +16,7 @@ load(
 load(
     "@build_bazel_rules_nodejs//internal/common:node_module_info.bzl",
     _NodeModuleInfo = "NodeModuleInfo",
+    _NodeModuleSources = "NodeModuleSources",
     _collect_node_modules_aspect = "collect_node_modules_aspect",
 )
 load(
@@ -24,6 +25,7 @@ load(
 )
 
 NodeModuleInfo = _NodeModuleInfo
+NodeModuleSources = _NodeModuleSources
 collect_node_modules_aspect = _collect_node_modules_aspect
 
 tsc_wrapped_tsconfig = _tsc_wrapped_tsconfig

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -14,6 +14,7 @@ load(
     "DEFAULT_NG_XI18N",
     "DEPS_ASPECTS",
     "NodeModuleInfo",
+    "NodeModuleSources",
     "TsConfigInfo",
     "collect_node_modules_aspect",
     "compile_ts",
@@ -498,10 +499,11 @@ def _compile_action(ctx, inputs, outputs, dts_bundles_out, messages_out, tsconfi
             file_inputs += ctx.attr.tsconfig[TsConfigInfo].deps
 
     # Also include files from npm fine grained deps as action_inputs.
-    # These deps are identified by the NodeModuleInfo provider.
+    # These deps are identified by the NodeModuleSources provider.
     for d in ctx.attr.deps:
-        if NodeModuleInfo in d:
-            file_inputs.extend(_filter_ts_inputs(d.files))
+        if NodeModuleSources in d:
+            # Note: we can't avoid calling .to_list() on sources
+            file_inputs.extend(_filter_ts_inputs(d[NodeModuleSources].sources.to_list()))
 
     # Collect the inputs and summary files from our deps
     action_inputs = depset(


### PR DESCRIPTION
BREAKING CHANGE: `ng_module` now depends on a minimum of build_bazel_rules_nodejs 0.27.12.

---

Equivalent change to ng_module that was made to ts_library in https://github.com/bazelbuild/rules_nodejs/pull/675.

This fixes the issue reported by @mattem and reproducible here https://github.com/mattem/ng_transitive_deps_eg

If a transitive npm dep such as `@npm//moment-timezone` is missing which is not used directly by any files compiled in an `ng_module` but is used transitively by a dep like `//service`,

```
ng_module(
    name = "component",
    srcs = glob(["*.ts"]),
    deps = [
        "//service",
        "@npm//@angular/core",
        "@npm//@angular/common",
        # "@npm//moment-timezone",
    ],
    visibility = ["//:__subpackages__"],
    tsconfig = "//:tsconfig",
)
```

this can lead to the `isSkipSelf ` error which is not helpful at all:

```
ERROR: /Users/greg/google/gregmagolan/ng_transitive_deps_eg/component/BUILD:3:1: Compiling Angular templates (ngc) //component:component failed (Exit 1) ngc-wrapped__bin failed: error executing command bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin '--node_options=--expose-gc' '--node_options=--stack-trace-limit=100' '--node_options=--max-old-space-size=2048' ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
: TypeError: Cannot read property 'isSkipSelf' of null
    at ProviderElementContext._getDependency (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:20171:22)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:20116:64
    at Array.map (<anonymous>)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:20116:30
    at Array.map (<anonymous>)
    at ProviderElementContext._getOrCreateLocalProvider (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:20094:67)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:19992:27
    at Array.forEach (<anonymous>)
    at new ProviderElementContext (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:19989:53)
    at TemplateParseVisitor.visitElement (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:21476:35)
    at Element.visit (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:10673:80)
    at visit (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:10689:41)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:10691:29
    at Array.forEach (<anonymous>)
    at visitAll$1 (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:10690:15)
    at TemplateParser.tryParseHtml (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:21329:26)
    at TemplateParser.tryParse (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:21310:25)
    at TemplateParser.parse (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:21288:31)
    at AotCompiler._parseTemplate (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24803:47)
    at AotCompiler._createTypeCheckBlock (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24550:27)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24518:31
    at Array.forEach (<anonymous>)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24512:53
    at Array.forEach (<anonymous>)
    at AotCompiler._createNgFactoryStub (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24491:28)
    at AotCompiler.emitTypeCheckStub (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler/bundles/compiler.umd.js:24459:22)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/transformers/program.js:655:54
    at Array.forEach (<anonymous>)
    at AngularCompilerProgram._updateProgramWithTypeCheckStubs (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/transformers/program.js:649:41)
    at AngularCompilerProgram.initSync (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/transformers/program.js:582:22)
    at AngularCompilerProgram.get [as tsProgram] (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/transformers/program.js:514:26)
    at AngularCompilerProgram.getTsProgram (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/transformers/program.js:147:83)
    at gatherDiagnosticsForInputsOnly (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:408:37)
    at gatherDiagnostics (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:340:46)
    at Object.performCompilation (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/compiler-cli/src/perform_compile.js:213:72)
    at compile (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:342:57)
    at runOneBuild (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:116:33)
    at main (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:39:20)
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:432:28
    at /private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:10:17
    at Object.<anonymous> (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/sandbox/darwin-sandbox/2/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin.runfiles/npm/node_modules/@angular/bazel/src/ngc-wrapped/index.js:16:3)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Object.<anonymous> (/private/var/tmp/_bazel_greg/d2c57935f6122ffd071eacd6aaf609f9/execroot/sandbox/bazel-out/host/bin/external/npm/node_modules/@angular/bazel/ngc-wrapped__bin_bin_loader.js:489:24)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3)

INFO: Elapsed time: 76.755s, Critical Path: 25.71s
INFO: 1 process: 1 darwin-sandbox.
FAILED: Build did NOT complete successfully
```