### PR TITLE
Breaking typed testbed get

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -670,7 +670,7 @@ describe('AppComponent', () => {
       });
 
       it('should not be loaded/registered until necessary', () => {
-        const loader: TestElementsLoader = fixture.debugElement.injector.get(ElementsLoader);
+        const loader = fixture.debugElement.injector.get(ElementsLoader) as unknown as TestElementsLoader;
         expect(loader.loadCustomElement).not.toHaveBeenCalled();
 
         setHasFloatingToc(true);
@@ -775,14 +775,14 @@ describe('AppComponent', () => {
 
       describe('showing search results', () => {
         it('should not display search results when query is empty', () => {
-          const searchService: MockSearchService = TestBed.get(SearchService);
+          const searchService = TestBed.get(SearchService) as unknown as MockSearchService;
           searchService.searchResults.next({ query: '', results: [] });
           fixture.detectChanges();
           expect(component.showSearchResults).toBe(false);
         });
 
         it('should hide the results when a search result is selected', () => {
-          const searchService: MockSearchService = TestBed.get(SearchService);
+          const searchService = TestBed.get(SearchService) as unknown as MockSearchService;
 
           const results = [
             { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '', deprecated: false }

--- a/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
+++ b/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
@@ -26,7 +26,7 @@ describe('AnnouncementBarComponent', () => {
     });
 
     httpMock = injector.get(HttpTestingController);
-    mockLogger = injector.get(Logger);
+    mockLogger = injector.get(Logger) as unknown as MockLogger;
     fixture = TestBed.createComponent(AnnouncementBarComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/aio/src/app/custom-elements/code/code.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code.component.spec.ts
@@ -254,7 +254,7 @@ describe('CodeComponent', () => {
     it('should display an error when copy fails', () => {
       const snackBar: MatSnackBar = TestBed.get(MatSnackBar);
       const copierService: CopierService = TestBed.get(CopierService);
-      const logger: TestLogger = TestBed.get(Logger);
+      const logger = TestBed.get(Logger) as unknown as TestLogger;
       spyOn(snackBar, 'open');
       spyOn(copierService, 'copyText').and.returnValue(false);
       getButton().click();

--- a/aio/src/app/custom-elements/contributor/contributor-list.component.spec.ts
+++ b/aio/src/app/custom-elements/contributor/contributor-list.component.spec.ts
@@ -24,8 +24,8 @@ describe('ContributorListComponent', () => {
       {provide: LocationService, useClass: TestLocationService }
     ]);
 
-    locationService = injector.get(LocationService);
-    contributorService = injector.get(ContributorService);
+    locationService = injector.get(LocationService) as unknown as TestLocationService;
+    contributorService = injector.get(ContributorService) as unknown as TestContributorService;
     contributorGroups = contributorService.testContributors;
   });
 

--- a/aio/src/app/custom-elements/lazy-custom-element.component.spec.ts
+++ b/aio/src/app/custom-elements/lazy-custom-element.component.spec.ts
@@ -23,7 +23,7 @@ describe('LazyCustomElementComponent', () => {
       ],
     });
 
-    mockLogger = injector.get(Logger);
+    mockLogger = injector.get(Logger) as unknown as MockLogger;
     fixture = TestBed.createComponent(LazyCustomElementComponent);
   });
 

--- a/aio/src/app/custom-elements/toc/toc.component.spec.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.spec.ts
@@ -48,7 +48,7 @@ describe('TocComponent', () => {
       fixture = TestBed.createComponent(HostEmbeddedTocComponent);
       tocComponentDe = fixture.debugElement.children[0];
       tocComponent = tocComponentDe.componentInstance;
-      tocService = TestBed.get(TocService);
+      tocService = TestBed.get(TocService) as unknown as TestTocService;
     });
 
     it('should create tocComponent', () => {
@@ -134,7 +134,7 @@ describe('TocComponent', () => {
       beforeEach(() => {
         fixture.detectChanges();
         page = setPage();
-        scrollToTopSpy = TestBed.get(ScrollService).scrollToTop;
+        scrollToTopSpy = (TestBed.get(ScrollService) as unknown as TestScrollService).scrollToTop;
       });
 
       it('should have more than 4 displayed items', () => {
@@ -248,7 +248,7 @@ describe('TocComponent', () => {
 
       tocComponentDe = fixture.debugElement.children[0];
       tocComponent = tocComponentDe.componentInstance;
-      tocService = TestBed.get(TocService);
+      tocService = TestBed.get(TocService) as unknown as TestTocService;
 
       fixture.detectChanges();
       page = setPage();

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -32,9 +32,9 @@ describe('DocumentService', () => {
     const injector = createInjector(initialUrl);
     httpMock = injector.get(HttpTestingController) as HttpTestingController;
     return {
-      locationService: injector.get(LocationService) as MockLocationService,
+      locationService: injector.get(LocationService) as unknown as MockLocationService,
       docService: injector.get(DocumentService) as DocumentService,
-      logger: injector.get(Logger) as MockLogger
+      logger: injector.get(Logger) as unknown as MockLogger
     };
   }
 

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -128,8 +128,8 @@ describe('DocViewerComponent', () => {
     };
 
     beforeEach(() => {
-      titleService = TestBed.get(Title);
-      tocService = TestBed.get(TocService);
+      titleService = TestBed.get(Title) as unknown as MockTitle;
+      tocService = TestBed.get(TocService) as unknown as MockTocService;
 
       targetEl = document.createElement('div');
       document.body.appendChild(targetEl);  // Required for `innerText` to work as expected.
@@ -299,7 +299,7 @@ describe('DocViewerComponent', () => {
       docViewer.render({contents, id}).toPromise();
 
     beforeEach(() => {
-      const elementsLoader = TestBed.get(ElementsLoader) as MockElementsLoader;
+      const elementsLoader = TestBed.get(ElementsLoader) as unknown as MockElementsLoader;
       loadElementsSpy = elementsLoader.loadContainedCustomElements.and.returnValue(of(undefined));
       prepareTitleAndTocSpy = spyOn(docViewer, 'prepareTitleAndToc');
       swapViewsSpy = spyOn(docViewer, 'swapViews').and.returnValue(of(undefined));
@@ -454,7 +454,9 @@ describe('DocViewerComponent', () => {
     describe('(on error) should clean up, log the error and recover', () => {
       let logger: MockLogger;
 
-      beforeEach(() => logger = TestBed.get(Logger));
+      beforeEach(() => {
+        logger = TestBed.get(Logger) as unknown as MockLogger;
+      });
 
       it('when `prepareTitleAndTocSpy()` fails', async () => {
         const error = Error('Typical `prepareTitleAndToc()` error');

--- a/aio/src/app/layout/notification/notification.component.spec.ts
+++ b/aio/src/app/layout/notification/notification.component.spec.ts
@@ -92,7 +92,7 @@ describe('NotificationComponent', () => {
   it('should update localStorage key when dismiss is called', () => {
     configTestingModule();
     createComponent();
-    const setItemSpy: jasmine.Spy = TestBed.get(WindowToken).localStorage.setItem;
+    const setItemSpy: jasmine.Spy = (TestBed.get(WindowToken) as MockWindow).localStorage.setItem;
     component.dismiss();
     expect(setItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018', 'hide');
   });
@@ -105,7 +105,7 @@ describe('NotificationComponent', () => {
 
   it('should not show the notification if the there is a "hide" flag in localStorage', () => {
     configTestingModule();
-    const getItemSpy: jasmine.Spy = TestBed.get(WindowToken).localStorage.getItem;
+    const getItemSpy: jasmine.Spy = (TestBed.get(WindowToken) as MockWindow).localStorage.getItem;
     getItemSpy.and.returnValue('hide');
     createComponent();
     expect(getItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018');

--- a/aio/src/app/shared/deployment.service.spec.ts
+++ b/aio/src/app/shared/deployment.service.spec.ts
@@ -15,7 +15,7 @@ describe('Deployment service', () => {
     it('should get the mode from the `mode` query parameter if available', () => {
       const injector = getInjector();
 
-      const locationService: MockLocationService = injector.get(LocationService);
+      const locationService = injector.get(LocationService) as unknown as MockLocationService;
       locationService.search.and.returnValue({ mode: 'bar' });
 
       const deployment = injector.get(Deployment);

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -23,9 +23,9 @@ describe('LocationService', () => {
         { provide: SwUpdatesService, useClass: MockSwUpdatesService }
     ]);
 
-    location  = injector.get(LocationStrategy);
+    location  = injector.get(LocationStrategy) as MockLocationStrategy;
     service  = injector.get(LocationService);
-    swUpdates  = injector.get(SwUpdatesService);
+    swUpdates  = injector.get(SwUpdatesService) as unknown as MockSwUpdatesService;
   });
 
   describe('currentUrl', () => {
@@ -355,7 +355,7 @@ describe('LocationService', () => {
     let platformLocation: MockPlatformLocation;
 
     beforeEach(() => {
-      platformLocation = injector.get(PlatformLocation);
+      platformLocation = injector.get(PlatformLocation) as unknown as MockPlatformLocation;
     });
 
     it('should call replaceState on PlatformLocation', () => {
@@ -552,7 +552,7 @@ describe('LocationService', () => {
     let gaLocationChanged: jasmine.Spy;
 
     beforeEach(() => {
-      const gaService = injector.get(GaService);
+      const gaService = injector.get(GaService) as unknown as TestGaService;
       gaLocationChanged = gaService.locationChanged;
       // execute currentPath observable so that gaLocationChanged is called
       service.currentPath.subscribe();

--- a/aio/src/app/shared/reporting-error-handler.spec.ts
+++ b/aio/src/app/shared/reporting-error-handler.spec.ts
@@ -18,11 +18,11 @@ describe('ReportingErrorHandler service', () => {
       { provide: ErrorHandler, useClass: ReportingErrorHandler },
       { provide: WindowToken, useFactory: () => ({ onerror: onerrorSpy }) }
     ]);
-    handler = injector.get(ErrorHandler);
+    handler = injector.get(ErrorHandler) as ReportingErrorHandler;
   });
 
   it('should be registered on the AppModule', () => {
-    handler = TestBed.configureTestingModule({ imports: [AppModule] }).get(ErrorHandler);
+    handler = TestBed.configureTestingModule({ imports: [AppModule] }).get(ErrorHandler) as ReportingErrorHandler;
     expect(handler).toEqual(jasmine.any(ReportingErrorHandler));
   });
 

--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -43,10 +43,10 @@ describe('ScrollService', () => {
         { provide: ViewportScroller, useValue: viewportScrollerStub },
         { provide: LocationStrategy, useClass: MockLocationStrategy }
     ]);
-    platformLocation = injector.get(PlatformLocation);
-    document = injector.get(DOCUMENT);
+    platformLocation = injector.get(PlatformLocation) as MockPlatformLocation;
+    document = injector.get(DOCUMENT) as unknown as MockDocument;
     scrollService = injector.get(ScrollService);
-    location = injector.get(Location);
+    location = injector.get(Location) as SpyLocation;
 
     spyOn(window, 'scrollBy');
   });

--- a/aio/src/app/shared/toc.service.spec.ts
+++ b/aio/src/app/shared/toc.service.spec.ts
@@ -27,7 +27,7 @@ describe('TocService', () => {
       { provide: ScrollSpyService, useClass: MockScrollSpyService },
       TocService,
     ]);
-    scrollSpyService = injector.get(ScrollSpyService);
+    scrollSpyService = injector.get(ScrollSpyService) as unknown as MockScrollSpyService;
     tocService = injector.get(TocService);
     tocService.tocList.subscribe(tocList => lastTocList = tocList);
   });
@@ -327,7 +327,7 @@ describe('TocService', () => {
     });
 
     it('should have bypassed HTML sanitizing of heading\'s innerHTML ', () => {
-      const domSanitizer: TestDomSanitizer = injector.get(DomSanitizer);
+      const domSanitizer = injector.get(DomSanitizer) as unknown as TestDomSanitizer;
       expect(domSanitizer.bypassSecurityTrustHtml)
         .toHaveBeenCalledWith('Setup to develop <i>locally</i>.');
     });

--- a/aio/src/app/sw-updates/sw-updates.service.spec.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.spec.ts
@@ -28,9 +28,9 @@ describe('SwUpdatesService', () => {
       SwUpdatesService
     ]);
 
-    appRef = injector.get(ApplicationRef);
+    appRef = injector.get(ApplicationRef) as unknown as MockApplicationRef;
     service = injector.get(SwUpdatesService);
-    swu = injector.get(SwUpdate);
+    swu = injector.get(SwUpdate) as unknown as MockSwUpdate;
     checkInterval = (service as any).checkInterval;
   };
   const tearDown = () => service.ngOnDestroy();

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -164,7 +164,7 @@ describe('ngInjectableDef Bazel Integration', () => {
     TestBed.configureTestingModule({
       providers: [{provide: 'foo', useValue: 'bar'}],
     });
-    expect(TestBed.get(INJECTOR).get('foo')).toEqual('bar');
+    expect(TestBed.get(INJECTOR).get('foo' as any)).toEqual('bar');
   });
 
   it('Component injector understands requests for INJECTABLE', () => {
@@ -181,6 +181,6 @@ describe('ngInjectableDef Bazel Integration', () => {
     });
 
     const fixture = TestBed.createComponent(TestCmp);
-    expect(fixture.componentRef.injector.get(INJECTOR).get('foo')).toEqual('bar');
+    expect(fixture.componentRef.injector.get(INJECTOR).get('foo' as any)).toEqual('bar');
   });
 });

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -113,8 +113,8 @@ export function createPlatform(injector: Injector): PlatformRef {
         'There can be only one platform. Destroy the previous one to create a new one.');
   }
   _platform = injector.get(PlatformRef);
-  const inits = injector.get(PLATFORM_INITIALIZER, null);
-  if (inits) inits.forEach((init: any) => init());
+  const inits = injector.get(PLATFORM_INITIALIZER, []);
+  inits.forEach((init: any) => init());
   return _platform;
 }
 
@@ -257,7 +257,7 @@ export class PlatformRef {
       const ngZoneInjector = Injector.create(
           {providers: providers, parent: this.injector, name: moduleFactory.moduleType.name});
       const moduleRef = <InternalNgModuleRef<M>>moduleFactory.create(ngZoneInjector);
-      const exceptionHandler: ErrorHandler = moduleRef.injector.get(ErrorHandler, null);
+      const exceptionHandler = moduleRef.injector.get(ErrorHandler, null);
       if (!exceptionHandler) {
         throw new Error('No ErrorHandler. Is platform module (BrowserModule) included?');
       }
@@ -593,7 +593,8 @@ export class ApplicationRef {
     this.componentTypes.push(componentFactory.componentType);
 
     // Create a factory associated with the current module if it's not bound to some other
-    const ngModule = isBoundToModule(componentFactory) ? null : this._injector.get(NgModuleRef);
+    const ngModule =
+        isBoundToModule(componentFactory) ? undefined : this._injector.get(NgModuleRef);
     const selectorOrNode = rootSelectorOrNode || componentFactory.selector;
     const compRef = componentFactory.create(Injector.NULL, [], selectorOrNode, ngModule);
 

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {getClosureSafeProperty} from '../util/property';
 import {stringify} from '../util/stringify';
 import {resolveForwardRef} from './forward_ref';
@@ -35,7 +35,9 @@ export const INJECTOR = new InjectionToken<Injector>(
     );
 
 export class NullInjector implements Injector {
-  get(token: any, notFoundValue: any = _THROW_IF_NOT_FOUND): any {
+  get<T>(token: unknown, notFoundValue: null): null;
+  get<T>(token: unknown, notFoundValue?: T): T;
+  get<T>(token: unknown, notFoundValue: T = _THROW_IF_NOT_FOUND as T): T|null {
     if (notFoundValue === _THROW_IF_NOT_FOUND) {
       // Intentionally left behind: With dev tools open the debugger will stop here. There is no
       // reason why correctly written application should cause this exception.
@@ -74,12 +76,11 @@ export abstract class Injector {
    * @returns The instance from the injector if defined, otherwise the `notFoundValue`.
    * @throws When the `notFoundValue` is `undefined` or `Injector.THROW_IF_NOT_FOUND`.
    */
-  abstract get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-  /**
-   * @deprecated from v4.0.0 use Type<T> or InjectionToken<T>
-   * @suppress {duplicate}
-   */
-  abstract get(token: any, notFoundValue?: any): any;
+  abstract get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  abstract get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 
   /**
    * @deprecated from v5 use the new signature Injector.create(options)
@@ -161,9 +162,14 @@ export class StaticInjector implements Injector {
     recursivelyProcessProviders(records, providers);
   }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-  get(token: any, notFoundValue?: any): any;
-  get(token: any, notFoundValue?: any, flags: InjectFlags = InjectFlags.Default): any {
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T|null,
+      flags: InjectFlags = InjectFlags.Default): T|null {
     const record = this._records.get(token);
     try {
       return tryResolveToken(token, record, this._records, this.parent, notFoundValue, flags);

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {stringify} from '../util/stringify';
 
 import {InjectionToken} from './injection_token';
@@ -118,7 +118,8 @@ export const inject = ɵɵinject;
  * `InjectableDef`.
  */
 export function injectRootLimpMode<T>(
-    token: Type<T>| InjectionToken<T>, notFoundValue: T | undefined, flags: InjectFlags): T|null {
+    token: Type<T>| InjectionToken<T>| AbstractType<T>, notFoundValue: T | undefined,
+    flags: InjectFlags): T|null {
   const injectableDef: ɵɵInjectableDef<T>|null = getInjectableDef(token);
   if (injectableDef && injectableDef.providedIn == 'root') {
     return injectableDef.value === undefined ? injectableDef.value = injectableDef.factory() :

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AbstractType, Type} from '../interface/type';
+
+import {InjectionToken} from './injection_token';
 import {Injector, THROW_IF_NOT_FOUND} from './injector';
+import {InjectFlags} from './interface/injector';
 import {Provider} from './interface/provider';
 import {Self, SkipSelf} from './metadata';
 import {cyclicDependencyError, instantiationError, noProviderError, outOfBoundsError} from './reflective_errors';
 import {ReflectiveKey} from './reflective_key';
 import {ReflectiveDependency, ResolvedReflectiveFactory, ResolvedReflectiveProvider, resolveReflectiveProviders} from './reflective_provider';
+
 
 
 // Threshold for the dynamic version
@@ -265,7 +270,11 @@ export abstract class ReflectiveInjector implements Injector {
    */
   abstract instantiateResolved(provider: ResolvedReflectiveProvider): any;
 
-  abstract get(token: any, notFoundValue?: any): any;
+  abstract get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  abstract get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export class ReflectiveInjector_ implements ReflectiveInjector {
@@ -296,7 +305,11 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
     }
   }
 
-  get(token: any, notFoundValue: any = THROW_IF_NOT_FOUND): any {
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null): T|null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T): T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = THROW_IF_NOT_FOUND as T): T|null {
     return this._getByKey(ReflectiveKey.get(token), null, notFoundValue);
   }
 
@@ -437,7 +450,7 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
       inj = inj_.parent;
     }
     if (inj !== null) {
-      return inj.get(key.token, notFoundValue);
+      return inj.get(key.token as any, notFoundValue);
     } else {
       return this._throwOrNull(key, notFoundValue);
     }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -140,7 +140,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
         ngModule ? createChainedInjector(injector, ngModule.injector) : injector;
 
     const rendererFactory =
-        rootViewInjector.get(RendererFactory2, domRendererFactory3) as RendererFactory3;
+        rootViewInjector.get(RendererFactory2, domRendererFactory3 as RendererFactory2);
     const sanitizer = rootViewInjector.get(Sanitizer, null);
 
     const hostRNode = isInternalRootView ?

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -8,6 +8,7 @@
 
 import {ChangeDetectorRef as ViewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {Injector} from '../di/injector';
+import {Type} from '../interface/type';
 import {ComponentFactory as viewEngine_ComponentFactory, ComponentRef as viewEngine_ComponentRef} from '../linker/component_factory';
 import {ElementRef as ViewEngine_ElementRef} from '../linker/element_ref';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
@@ -226,7 +227,8 @@ export function createContainerRef(
           ngModuleRef?: viewEngine_NgModuleRef<any>|undefined): viewEngine_ComponentRef<C> {
         const contextInjector = injector || this.parentInjector;
         if (!ngModuleRef && (componentFactory as any).ngModule == null && contextInjector) {
-          ngModuleRef = contextInjector.get(viewEngine_NgModuleRef, null);
+          ngModuleRef = contextInjector.get(
+              viewEngine_NgModuleRef as Type<viewEngine_NgModuleRef<any>|null>, null);
         }
 
         const componentRef =

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -8,9 +8,8 @@
 
 import {ApplicationRef} from '../application_ref';
 import {ChangeDetectorRef} from '../change_detection/change_detection';
-import {Injector} from '../di/injector';
-import {InjectFlags} from '../di/interface/injector';
-import {Type} from '../interface/type';
+import {InjectFlags, InjectionToken, Injector} from '../di';
+import {AbstractType, Type} from '../interface/type';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryBoundToModule, ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {ElementRef} from '../linker/element_ref';
@@ -334,7 +333,11 @@ export function createInjector(view: ViewData, elDef: NodeDef): Injector {
 
 class Injector_ implements Injector {
   constructor(private view: ViewData, private elDef: NodeDef|null) {}
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null): T|null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T): T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T): T|null {
     const allowPrivateServices =
         this.elDef ? (this.elDef.flags & NodeFlags.ComponentView) !== 0 : false;
     return Services.resolveDep(
@@ -496,8 +499,15 @@ class NgModuleRef_ implements NgModuleData, InternalNgModuleRef<any> {
     initNgModule(this);
   }
 
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      injectFlags: InjectFlags = InjectFlags.Default): any {
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T,
+      injectFlags: InjectFlags = InjectFlags.Default): T|null {
     let flags = DepFlags.None;
     if (injectFlags & InjectFlags.SkipSelf) {
       flags |= DepFlags.SkipSelf;

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -1444,7 +1444,7 @@ const DEFAULT_COMPONENT_ID = '1';
         fixture.detectChanges();
         engine.flush();
 
-        const player = engine.players.pop();
+        const player = engine.players.pop() !;
         player.finish();
 
         expect(getDOM().hasStyle(cmp.element.nativeElement, 'background-color', 'green'))
@@ -2510,7 +2510,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
            expect(cmp.event).toBeFalsy();
 
-           const player = engine.players.pop();
+           const player = engine.players.pop() !;
            player.finish();
            flushMicrotasks();
 

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -8,6 +8,7 @@
 import {AUTO_STYLE, AnimationPlayer, animate, animateChild, group, query, sequence, stagger, state, style, transition, trigger, ɵAnimationGroupPlayer as AnimationGroupPlayer} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine} from '@angular/animations/browser';
 import {matchesElement} from '@angular/animations/browser/src/render/shared';
+import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/transition_animation_engine';
 import {ENTER_CLASSNAME, LEAVE_CLASSNAME} from '@angular/animations/browser/src/util';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {CommonModule} from '@angular/common';
@@ -2733,7 +2734,7 @@ import {HostListener} from '../../src/metadata/directives';
         expect(players.length).toEqual(2);
         expect(engine.players.length).toEqual(1);
 
-        expect(engine.players[0].getRealPlayer()).toBe(players[1]);
+        expect((engine.players[0] as TransitionAnimationPlayer).getRealPlayer()).toBe(players[1]);
       });
 
       it('should fire and synchronize the start/done callbacks on sub triggers even if they are not allowed to animate within the animation',
@@ -2972,7 +2973,8 @@ import {HostListener} from '../../src/metadata/directives';
            engine.flush();
 
            expect(engine.players.length).toEqual(1);  // child player, parent cover, parent player
-           const groupPlayer = engine.players[0].getRealPlayer() as AnimationGroupPlayer;
+           const groupPlayer = (engine.players[0] as TransitionAnimationPlayer)
+                                   .getRealPlayer() as AnimationGroupPlayer;
            const childPlayer = groupPlayer.players.find(player => {
              if (player instanceof MockAnimationPlayer) {
                return matchesElement(player.element, '.child');

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -7,6 +7,7 @@
  */
 import {animate, animateChild, group, query, sequence, style, transition, trigger, ɵAnimationGroupPlayer as AnimationGroupPlayer} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine} from '@angular/animations/browser';
+import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/transition_animation_engine';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {Component, HostBinding} from '@angular/core';
 import {TestBed, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
@@ -129,7 +130,7 @@ import {RouterTestingModule} from '@angular/router/testing';
          fixture.detectChanges();
          engine.flush();
 
-         const player = engine.players[0] !;
+         const player = engine.players[0] !as TransitionAnimationPlayer;
          const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
@@ -236,7 +237,7 @@ import {RouterTestingModule} from '@angular/router/testing';
          fixture.detectChanges();
          engine.flush();
 
-         const player = engine.players[0] !;
+         const player = engine.players[0] !as TransitionAnimationPlayer;
          const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
@@ -340,7 +341,7 @@ import {RouterTestingModule} from '@angular/router/testing';
          fixture.detectChanges();
          engine.flush();
 
-         const player = engine.players[0] !;
+         const player = engine.players[0] !as TransitionAnimationPlayer;
          const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
@@ -433,14 +434,14 @@ import {RouterTestingModule} from '@angular/router/testing';
          fixture.detectChanges();
          engine.flush();
 
-         const players = engine.players;
+         const players = engine.players as TransitionAnimationPlayer[];
          expect(players.length).toEqual(1);
          const [p1] = players;
 
-         const innerPlayers = p1.getRealPlayer().players;
+         const innerPlayers = (p1.getRealPlayer() as AnimationGroupPlayer).players;
          expect(innerPlayers.length).toEqual(2);
 
-         const [ip1, ip2] = innerPlayers;
+         const [ip1, ip2] = innerPlayers as MockAnimationPlayer[];
          expect(ip1.element.innerText).toEqual('page1');
          expect(ip2.element.innerText).toEqual('page2');
        }));

--- a/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
@@ -303,7 +303,7 @@ import {TestBed} from '../../testing';
 
          expect(foo.style.getPropertyValue('max-height')).toEqual('0px');
 
-         const player = engine.players.pop();
+         const player = engine.players.pop() !;
          player.finish();
 
          expect(foo.style.getPropertyValue('max-height')).toBeFalsy();
@@ -357,7 +357,7 @@ import {TestBed} from '../../testing';
          expect(elm.style.getPropertyValue('display')).toEqual('inline');
          expect(elm.style.getPropertyValue('position')).toEqual('absolute');
 
-         const player = engine.players.pop();
+         const player = engine.players.pop() !;
          player.finish();
          player.destroy();
 

--- a/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
@@ -62,7 +62,8 @@ import {ivyEnabled} from '@angular/private/testing';
       fixture.detectChanges();
 
       expect(engine.players.length).toEqual(1);
-      let webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+      let webPlayer =
+          (engine.players[0] as TransitionAnimationPlayer).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '0px', offset: 0}, {height: '100px', offset: 1}
@@ -76,7 +77,8 @@ import {ivyEnabled} from '@angular/private/testing';
         engine.flush();
 
         expect(engine.players.length).toEqual(1);
-        webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+        webPlayer = (engine.players[0] as TransitionAnimationPlayer)
+                        .getRealPlayer() as ɵWebAnimationsPlayer;
 
         expect(webPlayer.keyframes).toEqual([
           {height: '100px', offset: 0}, {height: '0px', offset: 1}
@@ -116,7 +118,8 @@ import {ivyEnabled} from '@angular/private/testing';
       engine.flush();
 
       expect(engine.players.length).toEqual(1);
-      let webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+      let webPlayer =
+          (engine.players[0] as TransitionAnimationPlayer).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '100px', offset: 0}, {height: '120px', offset: 1}
@@ -154,7 +157,7 @@ import {ivyEnabled} from '@angular/private/testing';
       engine.flush();
 
       expect(engine.players.length).toEqual(1);
-      let player = engine.players[0];
+      let player = engine.players[0] as TransitionAnimationPlayer;
       let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
@@ -172,7 +175,7 @@ import {ivyEnabled} from '@angular/private/testing';
       engine.flush();
 
       expect(engine.players.length).toEqual(1);
-      player = engine.players[0];
+      player = engine.players[0] as TransitionAnimationPlayer;
       webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
@@ -223,7 +226,7 @@ import {ivyEnabled} from '@angular/private/testing';
       cmp.exp = true;
       fixture.detectChanges();
 
-      let player = engine.players[0] !;
+      let player = engine.players[0] !as TransitionAnimationPlayer;
       let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
       expect(webPlayer.keyframes).toEqual([
         {height: '0px', offset: 0},
@@ -234,7 +237,7 @@ import {ivyEnabled} from '@angular/private/testing';
       cmp.exp = false;
       fixture.detectChanges();
 
-      player = engine.players[0] !;
+      player = engine.players[0] !as TransitionAnimationPlayer;
       webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
       expect(webPlayer.keyframes).toEqual([
         {height: '300px', offset: 0},
@@ -372,14 +375,14 @@ import {ivyEnabled} from '@angular/private/testing';
       cmp.exp = 'a';
       fixture.detectChanges();
 
-      let player = engine.players[0] !;
+      let player = engine.players[0] !as TransitionAnimationPlayer;
       let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
       webPlayer.setPosition(0.5);
 
       cmp.exp = 'b';
       fixture.detectChanges();
 
-      player = engine.players[0] !;
+      player = engine.players[0] !as TransitionAnimationPlayer;
       webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
       expect(approximate(parseFloat(webPlayer.keyframes[0]['width'] as string), 150))
           .toBeLessThan(0.05);
@@ -428,7 +431,7 @@ import {ivyEnabled} from '@angular/private/testing';
          cmp.items = [0, 1, 2, 3, 4];
          fixture.detectChanges();
 
-         let player = engine.players[0] !;
+         let player = engine.players[0] !as TransitionAnimationPlayer;
          let groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
          let players = groupPlayer.players;
          expect(players.length).toEqual(5);
@@ -442,7 +445,7 @@ import {ivyEnabled} from '@angular/private/testing';
          cmp.items = [];
          fixture.detectChanges();
 
-         player = engine.players[0];
+         player = engine.players[0] as TransitionAnimationPlayer;
          groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
          players = groupPlayer.players;
 
@@ -504,7 +507,7 @@ import {ivyEnabled} from '@angular/private/testing';
          expect(elm.style.getPropertyValue('display')).toEqual('inline');
          expect(elm.style.getPropertyValue('position')).toEqual('absolute');
 
-         const player = engine.players.pop();
+         const player = engine.players.pop() !;
          player.finish();
          player.destroy();
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -343,9 +343,8 @@ class SomeComponent {
              initializerDone = true;
            }, 1);
 
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null);
-           const moduleFactory = compilerFactory.createCompiler().compileModuleSync(
+           const compilerFactory = defaultPlatform.injector.get(CompilerFactory, null);
+           const moduleFactory = compilerFactory !.createCompiler().compileModuleSync(
                createModule([{provide: APP_INITIALIZER, useValue: () => promise, multi: true}]));
            defaultPlatform.bootstrapModuleFactory(moduleFactory).then(_ => {
              expect(initializerDone).toBe(true);
@@ -353,9 +352,8 @@ class SomeComponent {
          }));
 
       it('should rethrow sync errors even if the exceptionHandler is not rethrowing', async(() => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null);
-           const moduleFactory = compilerFactory.createCompiler().compileModuleSync(createModule(
+           const compilerFactory = defaultPlatform.injector.get(CompilerFactory, null);
+           const moduleFactory = compilerFactory !.createCompiler().compileModuleSync(createModule(
                [{provide: APP_INITIALIZER, useValue: () => { throw 'Test'; }, multi: true}]));
            expect(() => defaultPlatform.bootstrapModuleFactory(moduleFactory)).toThrow('Test');
            // Error rethrown will be seen by the exception handler since it's after
@@ -365,9 +363,8 @@ class SomeComponent {
 
       it('should rethrow promise errors even if the exceptionHandler is not rethrowing',
          async(() => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null);
-           const moduleFactory = compilerFactory.createCompiler().compileModuleSync(createModule(
+           const compilerFactory = defaultPlatform.injector.get(CompilerFactory, null);
+           const moduleFactory = compilerFactory !.createCompiler().compileModuleSync(createModule(
                [{provide: APP_INITIALIZER, useValue: () => Promise.reject('Test'), multi: true}]));
            defaultPlatform.bootstrapModuleFactory(moduleFactory)
                .then(() => expect(false).toBe(true), (e) => {

--- a/packages/core/test/di/injector_spec.ts
+++ b/packages/core/test/di/injector_spec.ts
@@ -13,16 +13,16 @@ import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
 {
   describe('Injector.NULL', () => {
     it('should throw if no arg is given', () => {
-      expect(() => Injector.NULL.get('someToken'))
+      expect(() => Injector.NULL.get('someToken' as any))
           .toThrowError('NullInjectorError: No provider for someToken!');
     });
 
     it('should throw if THROW_IF_NOT_FOUND is given', () => {
-      expect(() => Injector.NULL.get('someToken', Injector.THROW_IF_NOT_FOUND))
+      expect(() => Injector.NULL.get('someToken' as any, Injector.THROW_IF_NOT_FOUND))
           .toThrowError('NullInjectorError: No provider for someToken!');
     });
 
     it('should return the default value',
-       () => { expect(Injector.NULL.get('someToken', 'notFound')).toEqual('notFound'); });
+       () => { expect(Injector.NULL.get('someToken' as any, 'notFound')).toEqual('notFound'); });
   });
 }

--- a/packages/core/test/di/reflective_injector_spec.ts
+++ b/packages/core/test/di/reflective_injector_spec.ts
@@ -35,7 +35,7 @@ class Car {
 
 @Injectable()
 class CarWithOptionalEngine {
-  constructor(@Optional() public engine: Engine) {}
+  constructor(@Optional() public engine?: Engine) {}
 }
 
 @Injectable()
@@ -191,7 +191,7 @@ function factoryFn(a: any){}
         {provide: Car, useClass: CarWithOptionalEngine, multi: true}
       ]);
 
-      const cars = injector.get(Car);
+      const cars: Car[] = injector.get(Car) as any;
       expect(cars.length).toEqual(2);
       expect(cars[0]).toBeAnInstanceOf(SportsCar);
       expect(cars[1]).toBeAnInstanceOf(CarWithOptionalEngine);
@@ -201,7 +201,7 @@ function factoryFn(a: any){}
       const injector =
           createInjector([Engine, SportsCar, {provide: Car, useExisting: SportsCar, multi: true}]);
 
-      const cars = injector.get(Car);
+      const cars: Car[] = injector.get(Car) as any;
       expect(cars.length).toEqual(1);
       expect(cars[0]).toBe(injector.get(SportsCar));
     });
@@ -209,7 +209,7 @@ function factoryFn(a: any){}
     it('should throw when the aliased provider does not exist', () => {
       const injector = createInjector([{provide: 'car', useExisting: SportsCar}]);
       const e = `No provider for ${stringify(SportsCar)}! (car -> ${stringify(SportsCar)})`;
-      expect(() => injector.get('car')).toThrowError(e);
+      expect(() => injector.get('car' as any)).toThrowError(e);
     });
 
     it('should handle forwardRef in useExisting', () => {
@@ -217,7 +217,7 @@ function factoryFn(a: any){}
         {provide: 'originalEngine', useClass: forwardRef(() => Engine)},
         {provide: 'aliasedEngine', useExisting: <any>forwardRef(() => 'originalEngine')}
       ]);
-      expect(injector.get('aliasedEngine')).toBeAnInstanceOf(Engine);
+      expect(injector.get('aliasedEngine' as any)).toBeAnInstanceOf(Engine);
     });
 
     it('should support overriding factory dependencies', () => {
@@ -233,7 +233,7 @@ function factoryFn(a: any){}
       const injector = createInjector([CarWithOptionalEngine]);
 
       const car = injector.get(CarWithOptionalEngine);
-      expect(car.engine).toEqual(null);
+      expect(car.engine as any).toEqual(null);
     });
 
     it('should flatten passed-in providers', () => {
@@ -253,7 +253,7 @@ function factoryFn(a: any){}
     it('should use non-type tokens', () => {
       const injector = createInjector([{provide: 'token', useValue: 'value'}]);
 
-      expect(injector.get('token')).toEqual('value');
+      expect(injector.get('token' as any)).toEqual('value');
     });
 
     it('should throw when given invalid providers', () => {
@@ -271,7 +271,7 @@ function factoryFn(a: any){}
 
     it('should throw when no provider defined', () => {
       const injector = createInjector([]);
-      expect(() => injector.get('NonExisting')).toThrowError('No provider for NonExisting!');
+      expect(() => injector.get('NonExisting' as any)).toThrowError('No provider for NonExisting!');
     });
 
     it('should show the full path when no provider', () => {
@@ -322,7 +322,7 @@ function factoryFn(a: any){}
 
     it('should support null values', () => {
       const injector = createInjector([{provide: 'null', useValue: null}]);
-      expect(injector.get('null')).toBe(null);
+      expect(injector.get('null' as any) as any).toBe(null);
     });
 
   });

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -187,7 +187,7 @@ function factoryFn(a: any){}
       const injector = Injector.create([{provide: 'car', useExisting: SportsCar}]);
       const e =
           `StaticInjectorError[car -> ${stringify(SportsCar)}]: \n  NullInjectorError: No provider for ${stringify(SportsCar)}!`;
-      expect(() => injector.get('car')).toThrowError(e);
+      expect(() => injector.get('car' as any)).toThrowError(e);
     });
 
     it('should handle forwardRef in useExisting', () => {
@@ -198,7 +198,7 @@ function factoryFn(a: any){}
           deps: []
         }
       ]);
-      expect(injector.get('aliasedEngine')).toBeAnInstanceOf(Engine);
+      expect(injector.get('aliasedEngine' as any)).toBeAnInstanceOf(Engine);
     });
 
     it('should support overriding factory dependencies', () => {
@@ -238,7 +238,7 @@ function factoryFn(a: any){}
     it('should use non-type tokens', () => {
       const injector = Injector.create([{provide: 'token', useValue: 'value'}]);
 
-      expect(injector.get('token')).toEqual('value');
+      expect(injector.get('token' as any)).toEqual('value');
     });
 
     it('should throw when given invalid providers', () => {
@@ -277,7 +277,7 @@ function factoryFn(a: any){}
 
     it('should throw when no provider defined', () => {
       const injector = Injector.create([]);
-      expect(() => injector.get('NonExisting'))
+      expect(() => injector.get('NonExisting' as any))
           .toThrowError(
               'StaticInjectorError[NonExisting]: \n  NullInjectorError: No provider for NonExisting!');
     });
@@ -340,8 +340,8 @@ function factoryFn(a: any){}
         {provide: 'null', useValue: null},
         {provide: 'undefined', useValue: undefined},
       ]);
-      expect(injector.get('null')).toBe(null);
-      expect(injector.get('undefined')).toBe(undefined);
+      expect(injector.get('null' as any) as any).toBe(null);
+      expect(injector.get('undefined' as any) as any).toBe(undefined);
     });
 
   });
@@ -466,7 +466,7 @@ function factoryFn(a: any){}
         {provide: 'token', useFactory: (e: any) => e, deps: [[new Inject(Engine)]]}
       ]);
 
-      expect(injector.get('token')).toBeAnInstanceOf(Engine);
+      expect(injector.get('token' as any)).toBeAnInstanceOf(Engine);
     });
   });
 

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1156,7 +1156,8 @@ function declareTests(config?: {useJit: boolean}) {
             const compFixture =
                 TestBed.configureTestingModule({imports: [RootModule]}).createComponent(RootComp);
             const compiler = <Compiler>TestBed.get(Compiler);
-            const myModule = compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef));
+            const myModule =
+                compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef).injector);
             const myCompFactory = (<ComponentFactoryResolver>TestBed.get(ComponentFactoryResolver))
                                       .resolveComponentFactory(MyComp);
 
@@ -1199,7 +1200,7 @@ function declareTests(config?: {useJit: boolean}) {
                                        .createComponent(RootComp);
                const compiler = <Compiler>TestBed.get(Compiler);
                const myModule =
-                   compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef));
+                   compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef).injector);
                const myCompFactory =
                    myModule.componentFactoryResolver.resolveComponentFactory(MyComp);
 

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -771,7 +771,7 @@ function declareTests(config?: {useJit: boolean}) {
         if (ivyEnabled) {
           errorMsg = `R3InjectorError(SomeModule)[car -> SportsCar]: \n  ` + errorMsg;
         }
-        expect(() => injector.get('car')).toThrowError(errorMsg);
+        expect(() => injector.get('car' as any)).toThrowError(errorMsg);
       });
 
       it('should handle forwardRef in useExisting', () => {
@@ -779,7 +779,7 @@ function declareTests(config?: {useJit: boolean}) {
           {provide: 'originalEngine', useClass: forwardRef(() => Engine)},
           {provide: 'aliasedEngine', useExisting: <any>forwardRef(() => 'originalEngine')}
         ]);
-        expect(injector.get('aliasedEngine')).toBeAnInstanceOf(Engine);
+        expect(injector.get('aliasedEngine' as any)).toBeAnInstanceOf(Engine);
       });
 
       it('should support overriding factory dependencies', () => {
@@ -815,7 +815,7 @@ function declareTests(config?: {useJit: boolean}) {
       it('should use non-type tokens', () => {
         const injector = createInjector([{provide: 'token', useValue: 'value'}]);
 
-        expect(injector.get('token')).toEqual('value');
+        expect(injector.get('token' as any)).toEqual('value');
       });
 
       it('should throw when given invalid providers', () => {
@@ -848,8 +848,8 @@ function declareTests(config?: {useJit: boolean}) {
           }
         }]);
 
-        expect(injector.get('token')).toBeUndefined();
-        expect(injector.get('token')).toBeUndefined();
+        expect(injector.get('token' as any)).toBeUndefined();
+        expect(injector.get('token' as any)).toBeUndefined();
         expect(factoryCounter).toBe(1);
       });
 
@@ -861,7 +861,7 @@ function declareTests(config?: {useJit: boolean}) {
               {provide: 'lazy', useFactory: () => 'lazyValue'},
               {
                 provide: 'eager',
-                useFactory: (i: Injector) => `eagerValue: ${i.get('lazy')}`,
+                useFactory: (i: Injector) => `eagerValue: ${i.get('lazy' as any)}`,
                 deps: [Injector]
               },
             ]
@@ -871,7 +871,7 @@ function declareTests(config?: {useJit: boolean}) {
             constructor(@Inject('eager') eager: any) {}
           }
 
-          expect(createModule(MyModule).injector.get('eager')).toBe('eagerValue: lazyValue');
+          expect(createModule(MyModule).injector.get('eager' as any)).toBe('eagerValue: lazyValue');
         });
 
         it('should inject providers that were declared after it', () => {
@@ -879,7 +879,7 @@ function declareTests(config?: {useJit: boolean}) {
             providers: [
               {
                 provide: 'eager',
-                useFactory: (i: Injector) => `eagerValue: ${i.get('lazy')}`,
+                useFactory: (i: Injector) => `eagerValue: ${i.get('lazy' as any)}`,
                 deps: [Injector]
               },
               {provide: 'lazy', useFactory: () => 'lazyValue'},
@@ -890,7 +890,7 @@ function declareTests(config?: {useJit: boolean}) {
             constructor(@Inject('eager') eager: any) {}
           }
 
-          expect(createModule(MyModule).injector.get('eager')).toBe('eagerValue: lazyValue');
+          expect(createModule(MyModule).injector.get('eager' as any)).toBe('eagerValue: lazyValue');
         });
       });
 
@@ -902,7 +902,7 @@ function declareTests(config?: {useJit: boolean}) {
               {provide: 'eager1', useFactory: () => 'v1'},
               {
                 provide: 'eager2',
-                useFactory: (i: Injector) => `v2: ${i.get('eager1')}`,
+                useFactory: (i: Injector) => `v2: ${i.get('eager1' as any)}`,
                 deps: [Injector]
               },
             ]
@@ -912,7 +912,7 @@ function declareTests(config?: {useJit: boolean}) {
             constructor(@Inject('eager1') eager1: any, @Inject('eager2') eager2: any) {}
           }
 
-          expect(createModule(MyModule).injector.get('eager2')).toBe('v2: v1');
+          expect(createModule(MyModule).injector.get('eager2' as any)).toBe('v2: v1');
         });
 
         it('should inject providers that were declared after it', () => {
@@ -920,7 +920,7 @@ function declareTests(config?: {useJit: boolean}) {
             providers: [
               {
                 provide: 'eager1',
-                useFactory: (i: Injector) => `v1: ${i.get('eager2')}`,
+                useFactory: (i: Injector) => `v1: ${i.get('eager2' as any)}`,
                 deps: [Injector]
               },
               {provide: 'eager2', useFactory: () => 'v2'},
@@ -931,7 +931,7 @@ function declareTests(config?: {useJit: boolean}) {
             constructor(@Inject('eager1') eager1: any, @Inject('eager2') eager2: any) {}
           }
 
-          expect(createModule(MyModule).injector.get('eager1')).toBe('v1: v2');
+          expect(createModule(MyModule).injector.get('eager1' as any)).toBe('v1: v2');
         });
 
         it('eager providers should get initialized only once', () => {
@@ -970,7 +970,7 @@ function declareTests(config?: {useJit: boolean}) {
         if (ivyEnabled) {
           errorMsg = `R3InjectorError(SomeModule)[NonExisting]: \n  ` + errorMsg;
         }
-        expect(() => injector.get('NonExisting')).toThrowError(errorMsg);
+        expect(() => injector.get('NonExisting' as any)).toThrowError(errorMsg);
       });
 
       it('should throw when trying to instantiate a cyclic dependency', () => {
@@ -980,7 +980,7 @@ function declareTests(config?: {useJit: boolean}) {
 
       it('should support null values', () => {
         const injector = createInjector([{provide: 'null', useValue: null}]);
-        expect(injector.get('null')).toBe(null);
+        expect(injector.get('null' as any) as any).toBe(null);
       });
 
 
@@ -1139,7 +1139,7 @@ function declareTests(config?: {useJit: boolean}) {
 
           expect(injector.get(SomeModule)).toBeAnInstanceOf(SomeModule);
           expect(injector.get(ImportedModule)).toBeAnInstanceOf(ImportedModule);
-          expect(injector.get('token1')).toBe('imported');
+          expect(injector.get('token1' as any)).toBe('imported');
         });
 
 
@@ -1160,7 +1160,7 @@ function declareTests(config?: {useJit: boolean}) {
 
           expect(injector.get(SomeModule)).toBeAnInstanceOf(SomeModule);
           expect(injector.get(ImportedModule)).toBeAnInstanceOf(ImportedModule);
-          expect(injector.get('token1')).toBe('imported');
+          expect(injector.get('token1' as any)).toBe('imported');
         });
 
         it('should overwrite the providers of imported modules', () => {
@@ -1174,7 +1174,7 @@ function declareTests(config?: {useJit: boolean}) {
           }
 
           const injector = createModule(SomeModule).injector;
-          expect(injector.get('token1')).toBe('direct');
+          expect(injector.get('token1' as any)).toBe('direct');
         });
 
 
@@ -1193,7 +1193,7 @@ function declareTests(config?: {useJit: boolean}) {
           }
 
           const injector = createModule(SomeModule).injector;
-          expect(injector.get('token1')).toBe('direct');
+          expect(injector.get('token1' as any)).toBe('direct');
         });
 
         it('should overwrite the providers of imported modules on the second import level', () => {
@@ -1213,7 +1213,7 @@ function declareTests(config?: {useJit: boolean}) {
           }
 
           const injector = createModule(SomeModule).injector;
-          expect(injector.get('token1')).toBe('direct');
+          expect(injector.get('token1' as any)).toBe('direct');
         });
 
         it('should add the providers of exported modules', () => {
@@ -1229,7 +1229,7 @@ function declareTests(config?: {useJit: boolean}) {
 
           expect(injector.get(SomeModule)).toBeAnInstanceOf(SomeModule);
           expect(injector.get(ExportedValue)).toBeAnInstanceOf(ExportedValue);
-          expect(injector.get('token1')).toBe('exported');
+          expect(injector.get('token1' as any)).toBe('exported');
         });
 
         it('should overwrite the providers of exported modules', () => {
@@ -1243,7 +1243,7 @@ function declareTests(config?: {useJit: boolean}) {
           }
 
           const injector = createModule(SomeModule).injector;
-          expect(injector.get('token1')).toBe('direct');
+          expect(injector.get('token1' as any)).toBe('direct');
         });
 
         it('should overwrite the providers of imported modules by following imported modules',
@@ -1261,7 +1261,7 @@ function declareTests(config?: {useJit: boolean}) {
              }
 
              const injector = createModule(SomeModule).injector;
-             expect(injector.get('token1')).toBe('imported2');
+             expect(injector.get('token1' as any)).toBe('imported2');
            });
 
         it('should overwrite the providers of exported modules by following exported modules',
@@ -1279,7 +1279,7 @@ function declareTests(config?: {useJit: boolean}) {
              }
 
              const injector = createModule(SomeModule).injector;
-             expect(injector.get('token1')).toBe('exported2');
+             expect(injector.get('token1' as any)).toBe('exported2');
            });
 
         it('should overwrite the providers of imported modules by exported modules', () => {
@@ -1296,7 +1296,7 @@ function declareTests(config?: {useJit: boolean}) {
           }
 
           const injector = createModule(SomeModule).injector;
-          expect(injector.get('token1')).toBe('exported');
+          expect(injector.get('token1' as any)).toBe('exported');
         });
 
         it('should not overwrite the providers if a module was already used on the same level',
@@ -1314,7 +1314,7 @@ function declareTests(config?: {useJit: boolean}) {
              }
 
              const injector = createModule(SomeModule).injector;
-             expect(injector.get('token1')).toBe('imported2');
+             expect(injector.get('token1' as any)).toBe('imported2');
            });
 
         it('should not overwrite the providers if a module was already used on a child level',
@@ -1336,7 +1336,7 @@ function declareTests(config?: {useJit: boolean}) {
              }
 
              const injector = createModule(SomeModule).injector;
-             expect(injector.get('token1')).toBe('imported2');
+             expect(injector.get('token1' as any)).toBe('imported2');
            });
 
         it('should throw when given invalid providers in an imported ModuleWithProviders', () => {

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -163,7 +163,7 @@ function declareTests(config?: {useJit: boolean}) {
         const tokenValue = 1;
         const injector = createInjector([{provide: token, useValue: tokenValue}]);
 
-        expect(injector.get(token)).toEqual(tokenValue);
+        expect(injector.get(token as any)).toEqual(tokenValue);
       });
 
       it('should support providers with an anonymous function as token', () => {
@@ -192,7 +192,7 @@ function declareTests(config?: {useJit: boolean}) {
         }
         const data = [new TestClass(1), new TestClass(2)];
         const injector = createInjector([{provide: 'someToken', useValue: data}]);
-        expect(injector.get('someToken')).toEqual(data);
+        expect(injector.get('someToken' as any)).toEqual(data);
       });
 
       describe('ANALYZE_FOR_ENTRY_COMPONENTS providers', () => {

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -241,14 +241,14 @@ describe('View injector', () => {
         {provide: 'instance', useValue: new TestValue('a')},
         {provide: 'nested', useValue: [{'a': [1]}, new TestValue('b')]},
       ]);
-      expect(el.injector.get('numLiteral')).toBe(0);
-      expect(el.injector.get('boolLiteral')).toBe(true);
-      expect(el.injector.get('strLiteral')).toBe('a');
-      expect(el.injector.get('null')).toBe(null);
-      expect(el.injector.get('array')).toEqual([1]);
-      expect(el.injector.get('map')).toEqual({'a': 1});
-      expect(el.injector.get('instance')).toEqual(new TestValue('a'));
-      expect(el.injector.get('nested')).toEqual([{'a': [1]}, new TestValue('b')]);
+      expect(el.injector.get('numLiteral' as any)).toBe(0);
+      expect(el.injector.get('boolLiteral' as any)).toBe(true);
+      expect(el.injector.get('strLiteral' as any)).toBe('a');
+      expect(el.injector.get('null' as any) as any).toBe(null);
+      expect(el.injector.get('array' as any)).toEqual([1]);
+      expect(el.injector.get('map' as any)).toEqual({'a': 1});
+      expect(el.injector.get('instance' as any)).toEqual(new TestValue('a'));
+      expect(el.injector.get('nested' as any)).toEqual([{'a': [1]}, new TestValue('b')]);
     });
 
     it('should instantiate providers that have dependencies with SkipSelf', () => {
@@ -267,7 +267,7 @@ describe('View injector', () => {
         }
       });
       const el = createComponent('<div simpleDirective><span someOtherDirective></span></div>');
-      expect(el.children[0].children[0].injector.get('injectable2'))
+      expect(el.children[0].children[0].injector.get('injectable2' as any))
           .toEqual('injectable1-injectable2');
     });
 
@@ -282,7 +282,7 @@ describe('View injector', () => {
       ];
       TestBed.overrideDirective(SimpleDirective, {add: {providers}});
       const el = createComponent('<div simpleDirective></div>');
-      expect(el.children[0].injector.get('injectable2')).toEqual('injectable1-injectable2');
+      expect(el.children[0].injector.get('injectable2' as any)).toEqual('injectable1-injectable2');
     });
 
     it('should instantiate viewProviders that have dependencies', () => {
@@ -296,7 +296,7 @@ describe('View injector', () => {
       ];
       TestBed.overrideComponent(SimpleComponent, {set: {viewProviders}});
       const el = createComponent('<div simpleComponent></div>');
-      expect(el.children[0].injector.get('injectable2')).toEqual('injectable1-injectable2');
+      expect(el.children[0].injector.get('injectable2' as any)).toEqual('injectable1-injectable2');
     });
 
     it('should instantiate components that depend on viewProviders providers', () => {
@@ -315,7 +315,9 @@ describe('View injector', () => {
       ];
       TestBed.overrideDirective(SimpleDirective, {set: {providers}});
       const el = createComponent('<div simpleDirective></div>');
-      expect(el.children[0].injector.get('injectable1')).toEqual(['injectable11', 'injectable12']);
+      expect(el.children[0].injector.get('injectable1' as any)).toEqual([
+        'injectable11', 'injectable12'
+      ]);
     });
 
     it('should instantiate providers lazily', () => {
@@ -329,7 +331,7 @@ describe('View injector', () => {
 
       expect(created).toBe(false);
 
-      el.children[0].injector.get('service');
+      el.children[0].injector.get('service' as any);
 
       expect(created).toBe(true);
     });
@@ -345,8 +347,8 @@ describe('View injector', () => {
                                    }
                                  }]);
 
-      expect(el.injector.get('token')).toBeUndefined();
-      expect(el.injector.get('token')).toBeUndefined();
+      expect(el.injector.get('token' as any)).toBeUndefined();
+      expect(el.injector.get('token' as any)).toBeUndefined();
       expect(factoryCounter).toBe(1);
     });
 
@@ -359,7 +361,7 @@ describe('View injector', () => {
             {provide: 'lazy', useFactory: () => 'lazyValue'},
             {
               provide: 'eager',
-              useFactory: (i: Injector) => `eagerValue: ${i.get('lazy')}`,
+              useFactory: (i: Injector) => `eagerValue: ${i.get('lazy' as any)}`,
               deps: [Injector]
             },
           ]
@@ -371,7 +373,7 @@ describe('View injector', () => {
 
         const ctx =
             TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-        expect(ctx.debugElement.injector.get('eager')).toBe('eagerValue: lazyValue');
+        expect(ctx.debugElement.injector.get('eager' as any)).toBe('eagerValue: lazyValue');
       });
 
       it('should inject providers that were declared after it', () => {
@@ -380,7 +382,7 @@ describe('View injector', () => {
           providers: [
             {
               provide: 'eager',
-              useFactory: (i: Injector) => `eagerValue: ${i.get('lazy')}`,
+              useFactory: (i: Injector) => `eagerValue: ${i.get('lazy' as any)}`,
               deps: [Injector]
             },
             {provide: 'lazy', useFactory: () => 'lazyValue'},
@@ -393,7 +395,7 @@ describe('View injector', () => {
 
         const ctx =
             TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-        expect(ctx.debugElement.injector.get('eager')).toBe('eagerValue: lazyValue');
+        expect(ctx.debugElement.injector.get('eager' as any)).toBe('eagerValue: lazyValue');
       });
     });
 
@@ -405,7 +407,7 @@ describe('View injector', () => {
             {provide: 'eager1', useFactory: () => 'v1'},
             {
               provide: 'eager2',
-              useFactory: (i: Injector) => `v2: ${i.get('eager1')}`,
+              useFactory: (i: Injector) => `v2: ${i.get('eager1' as any)}`,
               deps: [Injector]
             },
           ]
@@ -417,7 +419,7 @@ describe('View injector', () => {
 
         const ctx =
             TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-        expect(ctx.debugElement.injector.get('eager2')).toBe('v2: v1');
+        expect(ctx.debugElement.injector.get('eager2' as any)).toBe('v2: v1');
       });
 
       it('should inject providers that were declared after it', () => {
@@ -426,7 +428,7 @@ describe('View injector', () => {
           providers: [
             {
               provide: 'eager1',
-              useFactory: (i: Injector) => `v1: ${i.get('eager2')}`,
+              useFactory: (i: Injector) => `v1: ${i.get('eager2' as any)}`,
               deps: [Injector]
             },
             {provide: 'eager2', useFactory: () => 'v2'},
@@ -439,7 +441,7 @@ describe('View injector', () => {
 
         const ctx =
             TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-        expect(ctx.debugElement.injector.get('eager1')).toBe('v1: v2');
+        expect(ctx.debugElement.injector.get('eager1' as any)).toBe('v1: v2');
       });
     });
 
@@ -448,7 +450,7 @@ describe('View injector', () => {
          @Component({providers: [{provide: 'a', useFactory: () => 'aValue'}], template: ''})
          class SomeComponent {
            public a: string;
-           constructor(injector: Injector) { this.a = injector.get('a'); }
+           constructor(injector: Injector) { this.a = injector.get('a' as any); }
          }
 
          const comp = TestBed.configureTestingModule({declarations: [SomeComponent]})
@@ -498,7 +500,7 @@ describe('View injector', () => {
 
       expect(created).toBe(false);
 
-      el.children[0].injector.get('service');
+      el.children[0].injector.get('service' as any);
 
       expect(created).toBe(true);
     });
@@ -757,7 +759,8 @@ describe('View injector', () => {
                                  })
                                  .createComponent(MyComp);
 
-         expect(compFixture.componentInstance.vc.parentInjector.get('someToken')).toBe('someValue');
+         expect(compFixture.componentInstance.vc.parentInjector.get('someToken' as any))
+             .toBe('someValue');
        });
   });
 
@@ -917,7 +920,7 @@ describe('View injector', () => {
                               .get(ComponentFactoryResolver)
                               .resolveComponentFactory(TestComp);
       const component = compFactory.create(testInjector);
-      expect(component.instance.vcr.parentInjector.get('someToken')).toBe('someNewValue');
+      expect(component.instance.vcr.parentInjector.get('someToken' as any)).toBe('someNewValue');
     });
 
     it('should inject TemplateRef', () => {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -23,6 +23,7 @@ import {NgForOf} from '../../test/render3/common_with_def';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, createComponent, getDirectiveOnNode, TemplateFixture,} from './render_util';
+import {Injector} from '@angular/core';
 
 const Component: typeof _Component = function(...args: any[]): any {
   // In test we use @Component for documentation only so it's safe to mock out the implementation.
@@ -1110,7 +1111,8 @@ describe('ViewContainerRef', () => {
 
              // The injector should retrieve the change detector ref for DynamicComp. As such,
              // the doCheck hook for DynamicComp should NOT run upon ref.detectChanges().
-             const changeDetector = ref.injector.get(ChangeDetectorRef);
+             const changeDetector =
+                 ref.injector.get(ChangeDetectorRef) as EmbeddedViewRef<DynamicComp>;
              changeDetector.detectChanges();
              expect(dynamicComp.doCheckCount).toEqual(1);
              expect(changeDetector.context).toEqual(dynamicComp);
@@ -1966,15 +1968,15 @@ describe('ViewContainerRef', () => {
        () => {
          const fixture = new ComponentFixture(AppCmpt, {
            injector: {
-             get: (token: any) => {
+             get: (token: unknown) => {
                if (token === 'foo') return 'bar';
              }
-           }
+           } as Injector
          });
          expect(fixture.outerHtml).toBe('<div host="mark"></div>');
 
          const parentInjector = fixture.component.getVCRefParentInjector();
-         expect(parentInjector.get('foo')).toEqual('bar');
+         expect(parentInjector.get('foo' as any)).toEqual('bar');
        });
 
     it('should check bindings for components dynamically created by root component', () => {

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleRef} from '@angular/core';
+import {NgModuleRef, Type} from '@angular/core';
 import {InjectFlags, inject} from '@angular/core/src/di';
 import {INJECTOR, Injector} from '@angular/core/src/di/injector';
 import {ɵɵInjectableDef, ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, NgZone, RendererFactory2, getDebugNode} from '@angular/core';
+import {ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, NgZone, RendererFactory2, Type, getDebugNode} from '@angular/core';
+
 
 
 /**

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -11,6 +11,7 @@
 // this statement only.
 // clang-format off
 import {
+  AbstractType,
   Component,
   Directive,
   InjectFlags,
@@ -169,15 +170,21 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3 as any as TestBedStatic;
   }
 
-  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  static typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return TestBedRender3.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  static get(token: any, notFoundValue?: any): any;
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
-    return _getTestBedRender3().get(token, notFoundValue);
+    return _getTestBedRender3().get(token, notFoundValue, flags);
   }
 
   static createComponent<T>(component: Type<T>): ComponentFixture<T> {
@@ -263,11 +270,17 @@ export class TestBedRender3 implements Injector, TestBed {
 
   compileComponents(): Promise<any> { return this.compiler.compileComponents(); }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return this.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  get(token: any, notFoundValue?: any): any;
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     if (token === TestBedRender3) {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -170,6 +170,7 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3 as any as TestBedStatic;
   }
 
+  /** @deprecated from v9.0.0 use get<T>() */
   static typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>,
       notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
@@ -177,13 +178,15 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3.get(token, notFoundValue, flags);
   }
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  static get(
-      token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      flags: InjectFlags = InjectFlags.Default): any {
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T|null {
     return _getTestBedRender3().get(token, notFoundValue, flags);
   }
 
@@ -270,6 +273,7 @@ export class TestBedRender3 implements Injector, TestBed {
 
   compileComponents(): Promise<any> { return this.compiler.compileComponents(); }
 
+  /** @deprecated from v9.0.0 use get<T>() */
   typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>,
       notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
@@ -277,14 +281,17 @@ export class TestBedRender3 implements Injector, TestBed {
     return this.get(token, notFoundValue, flags);
   }
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      flags: InjectFlags = InjectFlags.Default): any {
-    if (token === TestBedRender3) {
-      return this;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T|null {
+    if (token as unknown === TestBedRender3) {
+      return this as any;
     }
     const result = this.testModuleRef.injector.get(token, UNDEFINED, flags);
     return result === UNDEFINED ? this.compiler.injector.get(token, notFoundValue, flags) : result;
@@ -370,7 +377,7 @@ export class TestBedRender3 implements Injector, TestBed {
     const noNgZone = this.get(ComponentFixtureNoNgZone as any, false);
     // TODO: Don't cast as `any`, proper type is boolean[]
     const autoDetect: boolean = this.get(ComponentFixtureAutoDetect as any, false);
-    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone as Type<NgZone|null>, null);
+    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
     const initComponent = () => {
       const componentRef =

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -56,14 +56,15 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
+  /** @deprecated from v9.0.0 use get<T>() */
   typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  get(token: any, notFoundValue?: any): any;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
 
   execute(tokens: any[], fn: Function, context?: any): any;
 
@@ -246,6 +247,7 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine as any as TestBedStatic;
   }
 
+  /** @deprecated from v9.0.0 use get<T>() */
   static typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>,
       notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
@@ -253,13 +255,15 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine.get(token, notFoundValue, flags);
   }
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  static get(
-      token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      flags: InjectFlags = InjectFlags.Default): any {
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  static get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T|null {
     return _getTestBedViewEngine().get(token, notFoundValue, flags);
   }
 
@@ -489,6 +493,7 @@ export class TestBedViewEngine implements Injector, TestBed {
     }
   }
 
+  /** @deprecated from v9.0.0 use get<T>() */
   typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>,
       notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
@@ -496,15 +501,18 @@ export class TestBedViewEngine implements Injector, TestBed {
     return this.get(token, notFoundValue, flags);
   }
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      flags: InjectFlags = InjectFlags.Default): any {
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T|null = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T|null {
     this._initIfNeeded();
     if (token === TestBed) {
-      return this;
+      return this as any;
     }
     // Tests can inject things from the ng module and from the compiler,
     // but the ng module can't inject things from the compiler and vice versa.
@@ -635,7 +643,7 @@ export class TestBedViewEngine implements Injector, TestBed {
     const noNgZone = this.get(ComponentFixtureNoNgZone as any, false);
     // TODO: Don't cast as `any`, proper type is boolean[]
     const autoDetect: boolean = this.get(ComponentFixtureAutoDetect as any, false);
-    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone as Type<NgZone|null>, null);
+    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone, null);
     const testComponentRenderer: TestComponentRenderer = this.get(TestComponentRenderer);
     const rootElId = `root${_nextRootElementId++}`;
     testComponentRenderer.insertRootElement(rootElId);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
+import {AbstractType, ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {ComponentFixture} from './component_fixture';
@@ -56,9 +56,12 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
   get(token: any, notFoundValue?: any): any;
 
@@ -243,12 +246,17 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine as any as TestBedStatic;
   }
 
-  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  static typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return TestBedViewEngine.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
-   * @suppress {duplicate}
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  static get(token: any, notFoundValue?: any): any;
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
@@ -481,11 +489,17 @@ export class TestBedViewEngine implements Injector, TestBed {
     }
   }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>,
+      notFoundValue: T = Injector.THROW_IF_NOT_FOUND as T,
+      flags: InjectFlags = InjectFlags.Default): T {
+    return this.get(token, notFoundValue, flags);
+  }
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
-  get(token: any, notFoundValue?: any): any;
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     this._initIfNeeded();

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
+import {AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -130,9 +130,12 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  typedGet<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
+   * as a breaking change.
    */
   get(token: any, notFoundValue?: any): any;
 

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -130,14 +130,15 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
+  /** @deprecated from v9.0.0 use get<T>() */
   typedGet<T>(
       token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 
-  /**
-   * @deprecated from v8.0.0 use typedGet<T>(). Note that `typedGet` will be renamed back to `get`
-   * as a breaking change.
-   */
-  get(token: any, notFoundValue?: any): any;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;
 }

--- a/packages/examples/core/di/ts/injector_spec.ts
+++ b/packages/examples/core/di/ts/injector_spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectFlags, InjectionToken, Injector, Type, inject, ɵsetCurrentInjector as setCurrentInjector} from '@angular/core';
+import {AbstractType, InjectFlags, InjectionToken, Injector, Type, inject, ɵsetCurrentInjector as setCurrentInjector} from '@angular/core';
 
 class MockRootScopeInjector implements Injector {
   constructor(readonly parent: Injector) {}
 
   get<T>(
-      token: Type<T>|InjectionToken<T>, defaultValue?: any,
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, defaultValue?: T,
       flags: InjectFlags = InjectFlags.Default): T {
     if ((token as any).ngInjectableDef && (token as any).ngInjectableDef.providedIn === 'root') {
       const old = setCurrentInjector(this);
@@ -32,9 +32,9 @@ class MockRootScopeInjector implements Injector {
       // #docregion Injector
       const injector: Injector =
           Injector.create({providers: [{provide: 'validToken', useValue: 'Value'}]});
-      expect(injector.get('validToken')).toEqual('Value');
-      expect(() => injector.get('invalidToken')).toThrowError();
-      expect(injector.get('invalidToken', 'notFound')).toEqual('notFound');
+      expect(injector.get('validToken' as any)).toEqual('Value');
+      expect(() => injector.get('invalidToken' as any)).toThrowError();
+      expect(injector.get('invalidToken' as any, 'notFound')).toEqual('notFound');
       // #enddocregion
     });
 

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -416,7 +416,7 @@ class CompWithUrlTemplate {
               ]
             });
             TestBed.overrideProvider('a', {useValue: 'mockValue'});
-            expect(TestBed.get('a')).toBe('mockValue');
+            expect(TestBed.get('a' as any)).toBe('mockValue');
           });
 
           it('should support useFactory', () => {
@@ -428,7 +428,7 @@ class CompWithUrlTemplate {
             });
             TestBed.overrideProvider(
                 'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
-            expect(TestBed.get('a')).toBe('mockA: depValue');
+            expect(TestBed.get('a' as any)).toBe('mockA: depValue');
           });
 
           it('should support @Optional without matches', () => {
@@ -439,7 +439,7 @@ class CompWithUrlTemplate {
             });
             TestBed.overrideProvider(
                 'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            expect(TestBed.get('a')).toBe('mockA: null');
+            expect(TestBed.get('a' as any)).toBe('mockA: null');
           });
 
           it('should support Optional with matches', () => {
@@ -451,7 +451,7 @@ class CompWithUrlTemplate {
             });
             TestBed.overrideProvider(
                 'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            expect(TestBed.get('a')).toBe('mockA: depValue');
+            expect(TestBed.get('a' as any)).toBe('mockA: depValue');
           });
 
           it('should support SkipSelf', () => {
@@ -471,7 +471,8 @@ class CompWithUrlTemplate {
 
             const compiler = TestBed.get(Compiler) as Compiler;
             const modFactory = compiler.compileModuleSync(MyModule);
-            expect(modFactory.create(getTestBed()).injector.get('a')).toBe('mockA: parentDepValue');
+            expect(modFactory.create(getTestBed()).injector.get('a' as any))
+                .toBe('mockA: parentDepValue');
           });
 
           it('should keep imported NgModules eager', () => {
@@ -490,7 +491,7 @@ class CompWithUrlTemplate {
             });
             TestBed.overrideProvider('a', {useValue: 'mockValue'});
 
-            expect(TestBed.get('a')).toBe('mockValue');
+            expect(TestBed.get('a' as any)).toBe('mockValue');
             expect(someModule).toBeAnInstanceOf(SomeModule);
           });
 
@@ -511,7 +512,7 @@ class CompWithUrlTemplate {
                 });
                 TestBed.deprecatedOverrideProvider('a', {useValue: 'mockValue'});
 
-                expect(TestBed.get('a')).toBe('mockValue');
+                expect(TestBed.get('a' as any)).toBe('mockValue');
                 expect(someModule).toBeUndefined();
               });
 
@@ -532,7 +533,7 @@ class CompWithUrlTemplate {
               TestBed.overrideProvider(
                   'b', {useFactory: (a: string) => `mockB: ${a}`, deps: ['a']});
 
-              expect(TestBed.get('b')).toBe('mockB: aValue');
+              expect(TestBed.get('b' as any)).toBe('mockB: aValue');
             });
 
             it('should inject providers that were declared afterwards', () => {
@@ -540,7 +541,7 @@ class CompWithUrlTemplate {
               TestBed.overrideProvider(
                   'a', {useFactory: (b: string) => `mockA: ${b}`, deps: ['b']});
 
-              expect(TestBed.get('a')).toBe('mockA: bValue');
+              expect(TestBed.get('a' as any)).toBe('mockA: bValue');
             });
           });
         });
@@ -560,7 +561,7 @@ class CompWithUrlTemplate {
             const ctx =
                 TestBed.configureTestingModule({declarations: [MComp]}).createComponent(MComp);
 
-            expect(ctx.debugElement.injector.get('a')).toBe('mockValue');
+            expect(ctx.debugElement.injector.get('a' as any)).toBe('mockValue');
           });
 
           it('should support useFactory', () => {
@@ -579,7 +580,7 @@ class CompWithUrlTemplate {
             const ctx =
                 TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-            expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
+            expect(ctx.debugElement.injector.get('a' as any)).toBe('mockA: depValue');
           });
 
           it('should support @Optional without matches', () => {
@@ -597,7 +598,7 @@ class CompWithUrlTemplate {
             const ctx =
                 TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-            expect(ctx.debugElement.injector.get('a')).toBe('mockA: null');
+            expect(ctx.debugElement.injector.get('a' as any)).toBe('mockA: null');
           });
 
           it('should support Optional with matches', () => {
@@ -616,7 +617,7 @@ class CompWithUrlTemplate {
             const ctx =
                 TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-            expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
+            expect(ctx.debugElement.injector.get('a' as any)).toBe('mockA: depValue');
           });
 
           it('should support SkipSelf', () => {
@@ -643,7 +644,8 @@ class CompWithUrlTemplate {
                 'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
             const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir]})
                             .createComponent(MyComp);
-            expect(ctx.debugElement.children[0].injector.get('a')).toBe('mockA: parentDepValue');
+            expect(ctx.debugElement.children[0].injector.get('a' as any))
+                .toBe('mockA: parentDepValue');
           });
 
           it('should support multiple providers in a template', () => {
@@ -674,8 +676,8 @@ class CompWithUrlTemplate {
             TestBed.overrideProvider('a', {useValue: 'mockA'});
             const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]})
                             .createComponent(MyComp);
-            expect(ctx.debugElement.children[0].injector.get('a')).toBe('mockA');
-            expect(ctx.debugElement.children[1].injector.get('a')).toBe('mockA');
+            expect(ctx.debugElement.children[0].injector.get('a' as any)).toBe('mockA');
+            expect(ctx.debugElement.children[1].injector.get('a' as any)).toBe('mockA');
           });
 
           describe('injecting eager providers into an eager overwritten provider', () => {
@@ -697,7 +699,7 @@ class CompWithUrlTemplate {
               const ctx =
                   TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-              expect(ctx.debugElement.injector.get('b')).toBe('mockB: aValue');
+              expect(ctx.debugElement.injector.get('b' as any)).toBe('mockB: aValue');
             });
 
             it('should inject providers that were declared after it', () => {
@@ -706,7 +708,7 @@ class CompWithUrlTemplate {
               const ctx =
                   TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-              expect(ctx.debugElement.injector.get('a')).toBe('mockA: bValue');
+              expect(ctx.debugElement.injector.get('a' as any)).toBe('mockA: bValue');
             });
           });
         });
@@ -715,7 +717,7 @@ class CompWithUrlTemplate {
           TestBed.overrideProvider('a', {useValue: 'mockValue'});
           TestBed.resetTestingModule();
           TestBed.configureTestingModule({providers: [{provide: 'a', useValue: 'aValue'}]});
-          expect(TestBed.get('a')).toBe('aValue');
+          expect(TestBed.get('a' as any)).toBe('aValue');
         });
       });
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -80,7 +80,8 @@ export class ServerModule {
 }
 
 function _document(injector: Injector) {
-  let config: PlatformConfig|null = injector.get(INITIAL_CONFIG, null);
+  let config: PlatformConfig|null =
+      injector.get(INITIAL_CONFIG as InjectionToken<PlatformConfig|null>, null);
   if (config && config.document) {
     return parseDocument(config.document, config.url);
   } else {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, NgModuleFactory, NgModuleRef, PlatformRef, StaticProvider, Type, ɵisPromise} from '@angular/core';
+import {ApplicationRef, InjectionToken, NgModuleFactory, NgModuleRef, PlatformRef, StaticProvider, Type, ɵisPromise} from '@angular/core';
 import {ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -33,7 +33,7 @@ function _getPlatform(
 function _render<T>(
     platform: PlatformRef, moduleRefPromise: Promise<NgModuleRef<T>>): Promise<string> {
   return moduleRefPromise.then((moduleRef) => {
-    const transitionId = moduleRef.injector.get(ɵTRANSITION_ID, null);
+    const transitionId = moduleRef.injector.get(ɵTRANSITION_ID as InjectionToken<{}|null>, null);
     if (!transitionId) {
       throw new Error(
           `renderModule[Factory]() requires the use of BrowserModule.withServerTransition() to ensure
@@ -48,19 +48,17 @@ the server-rendered app can be properly bootstrapped into a client app.`);
           const asyncPromises: Promise<any>[] = [];
 
           // Run any BEFORE_APP_SERIALIZED callbacks just before rendering to string.
-          const callbacks = moduleRef.injector.get(BEFORE_APP_SERIALIZED, null);
-          if (callbacks) {
-            for (const callback of callbacks) {
-              try {
-                const callbackResult = callback();
-                if (ɵisPromise(callbackResult)) {
-                  asyncPromises.push(callbackResult);
-                }
-
-              } catch (e) {
-                // Ignore exceptions.
-                console.warn('Ignoring BEFORE_APP_SERIALIZED Exception: ', e);
+          const callbacks = moduleRef.injector.get(BEFORE_APP_SERIALIZED, []);
+          for (const callback of callbacks) {
+            try {
+              const callbackResult = callback();
+              if (ɵisPromise(callbackResult)) {
+                asyncPromises.push(callbackResult);
               }
+
+            } catch (e) {
+              // Ignore exceptions.
+              console.warn('Ignoring BEFORE_APP_SERIALIZED Exception: ', e);
             }
           }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -10,7 +10,7 @@ import {AnimationBuilder, animate, state, style, transition, trigger} from '@ang
 import {DOCUMENT, PlatformLocation, isPlatformServer} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationRef, CompilerFactory, Component, HostListener, Inject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, PlatformRef, ViewEncapsulation, destroyPlatform, getPlatform} from '@angular/core';
+import {ApplicationRef, CompilerFactory, Component, HostListener, Inject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, PlatformRef, Type, ViewEncapsulation, destroyPlatform, getPlatform} from '@angular/core';
 import {async, inject} from '@angular/core/testing';
 import {BrowserModule, Title, TransferState, makeStateKey} from '@angular/platform-browser';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -193,7 +193,7 @@ class SVGServerModule {
                 'transform': 'translate3d(0, 0, 0)',  // not natively supported by Domino
               })),
         transition('void => *', [animate('0ms')]),
-      ], )]
+      ])]
 })
 class MyAnimationApp {
   state = 'active';
@@ -612,10 +612,9 @@ class HiddenModule {
 
       it('using renderModuleFactory should work',
          async(inject([PlatformRef], (defaultPlatform: PlatformRef) => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null);
+           const compilerFactory = defaultPlatform.injector.get(CompilerFactory, null);
            const moduleFactory =
-               compilerFactory.createCompiler().compileModuleSync(AsyncServerModule);
+               compilerFactory !.createCompiler().compileModuleSync(AsyncServerModule);
            renderModuleFactory(moduleFactory, {document: doc}).then(output => {
              expect(output).toBe(expectedOutput);
              called = true;
@@ -820,10 +819,9 @@ class HiddenModule {
 
       it('adds transfer script tag when using renderModuleFactory',
          async(inject([PlatformRef], (defaultPlatform: PlatformRef) => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null);
+           const compilerFactory = defaultPlatform.injector.get(CompilerFactory, null);
            const moduleFactory =
-               compilerFactory.createCompiler().compileModuleSync(TransferStoreModule);
+               compilerFactory !.createCompiler().compileModuleSync(TransferStoreModule);
            renderModuleFactory(moduleFactory, {document: '<app></app>'}).then(output => {
              expect(output).toBe(defaultExpectedOutput);
              called = true;

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -183,8 +183,7 @@ class MyComp2 {
 
 function createWebWorkerBrokerFactory(
     messageBuses: PairedMessageBuses, wwSerializer: Serializer, uiSerializer: Serializer,
-    domRendererFactory: DomRendererFactory2,
-    uiRenderStore: RenderStore): ClientMessageBrokerFactory {
+    rendererFactory2: RendererFactory2, uiRenderStore: RenderStore): ClientMessageBrokerFactory {
   const uiMessageBus = messageBuses.ui;
   const wwMessageBus = messageBuses.worker;
 
@@ -194,18 +193,18 @@ function createWebWorkerBrokerFactory(
   // set up the ui side
   const uiBrokerFactory = new (ServiceMessageBrokerFactory as any)(uiMessageBus, uiSerializer);
   const renderer = new MessageBasedRenderer2(
-      uiBrokerFactory, uiMessageBus, uiSerializer, uiRenderStore, domRendererFactory);
+      uiBrokerFactory, uiMessageBus, uiSerializer, uiRenderStore, rendererFactory2);
   renderer.start();
 
   return wwBrokerFactory;
 }
 
 function createWebWorkerRendererFactory2(
-    workerSerializer: Serializer, uiSerializer: Serializer, domRendererFactory: DomRendererFactory2,
+    workerSerializer: Serializer, uiSerializer: Serializer, rendererFactory2: RendererFactory2,
     uiRenderStore: RenderStore, workerRenderStore: RenderStore): RendererFactory2 {
   const messageBuses = createPairedMessageBuses();
   const brokerFactory = createWebWorkerBrokerFactory(
-      messageBuses, workerSerializer, uiSerializer, domRendererFactory, uiRenderStore);
+      messageBuses, workerSerializer, uiSerializer, rendererFactory2, uiRenderStore);
 
   const rendererFactory =
       new RenderFactory(brokerFactory, messageBuses.worker, workerSerializer, workerRenderStore);

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewContainerRef} from '@angular/core';
+import {AbstractType, Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, InjectionToken, Injector, OnDestroy, OnInit, Output, Type, ViewContainerRef} from '@angular/core';
 
 import {Data} from '../config';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
+
 
 /**
  * @description
@@ -146,13 +147,15 @@ class OutletInjector implements Injector {
       private route: ActivatedRoute, private childContexts: ChildrenOutletContexts,
       private parent: Injector) {}
 
-  get(token: any, notFoundValue?: any): any {
-    if (token === ActivatedRoute) {
-      return this.route;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null): T|null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T): T;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T|null): T|null {
+    if (token as unknown === ActivatedRoute) {
+      return this.route as any;
     }
 
-    if (token === ChildrenOutletContexts) {
-      return this.childContexts;
+    if (token as unknown === ChildrenOutletContexts) {
+      return this.childContexts as any;
     }
 
     return this.parent.get(token, notFoundValue);

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
-import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, Type, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -406,7 +406,7 @@ describe('Integration', () => {
 
        TestBed.configureTestingModule({imports: [TestModule]});
 
-       const router: Router = TestBed.get(Router);
+       const router = TestBed.get(Router);
        const fixture = createRoot(router, RootCmp);
 
        router.resetConfig([{
@@ -476,7 +476,7 @@ describe('Integration', () => {
        }
        TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
 
-       const router: Router = TestBed.get(Router);
+       const router = TestBed.get(Router);
 
        const fixture = createRoot(router, RootCmpWithLink);
 
@@ -1120,8 +1120,8 @@ describe('Integration', () => {
   // Errors should behave the same for both deferred and eager URL update strategies
   ['deferred', 'eager'].forEach((strat: any) => {
     it('should dispatch NavigationError after the url has been reset back', fakeAsync(() => {
-         const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
+         const router = TestBed.get(Router);
+         const location = TestBed.get(Location);
          const fixture = createRoot(router, RootCmp);
 
          router.resetConfig(
@@ -1147,8 +1147,8 @@ describe('Integration', () => {
        }));
 
     it('should reset the url with the right state when navigation errors', fakeAsync(() => {
-         const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
+         const router = TestBed.get(Router);
+         const location = TestBed.get(Location);
          const fixture = createRoot(router, RootCmp);
 
          router.resetConfig([
@@ -1214,8 +1214,8 @@ describe('Integration', () => {
        TestBed.configureTestingModule(
            {providers: [{provide: 'returnsFalse', useValue: () => false}]});
 
-       const router: Router = TestBed.get(Router);
-       const location: SpyLocation = TestBed.get(Location);
+       const router = TestBed.get(Router);
+       const location = TestBed.get(Location);
 
        const fixture = createRoot(router, RootCmp);
 
@@ -1236,7 +1236,7 @@ describe('Integration', () => {
          }
        });
 
-       location.simulateHashChange('/throwing');
+       (location as SpyLocation).simulateHashChange('/throwing');
        advance(fixture);
 
        expect(routerUrlBeforeEmittingError).toEqual('/simple');
@@ -1401,7 +1401,7 @@ describe('Integration', () => {
 
        TestBed.configureTestingModule({declarations: [Container]});
 
-       const router: Router = TestBed.get(Router);
+       const router = TestBed.get(Router);
 
        const fixture = createRoot(router, Container);
        const cmp = fixture.componentInstance;
@@ -1703,7 +1703,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
 
          const fixture = createRoot(router, RootCmpWithLink);
 
@@ -1726,7 +1726,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({declarations: [CmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
 
          let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
          router.resetConfig([{path: 'home', component: SimpleCmp}]);
@@ -1746,7 +1746,7 @@ describe('Integration', () => {
          class RootCmpWithLink {
          }
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
          const fixture = createRoot(router, RootCmpWithLink);
 
          router.resetConfig([{path: 'home', component: SimpleCmp}]);
@@ -1776,7 +1776,7 @@ describe('Integration', () => {
          class RootCmpWithLink {
          }
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
          const fixture = createRoot(router, RootCmpWithLink);
 
          router.resetConfig([{path: 'home', component: SimpleCmp}]);
@@ -1798,7 +1798,7 @@ describe('Integration', () => {
          class RootCmpWithLink {
          }
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
          const fixture = createRoot(router, RootCmpWithLink);
 
          router.resetConfig([{path: 'home', component: SimpleCmp}]);
@@ -1970,7 +1970,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({declarations: [RootCmpWithArea]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
 
          const fixture = createRoot(router, RootCmpWithArea);
 
@@ -2642,7 +2642,8 @@ describe('Integration', () => {
 
         it('should allow a predicate function to determine when to run guards and resolvers',
            fakeAsync(inject([Router], (router: Router) => {
-             const fixture = configureRouter(router, (from, to) => to.paramMap.get('p') === '2');
+             const fixture =
+                 configureRouter(router, (from, to) => to.paramMap.get('p' as any) === '2');
 
              const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
              const recordedData: any[] = [];
@@ -3131,7 +3132,7 @@ describe('Integration', () => {
           TestBed.configureTestingModule({
             providers: [{
               provide: 'alwaysFalse',
-              useValue: (a: any, b: any) => a.paramMap.get('id') === '22',
+              useValue: (a: any, b: any) => a.paramMap.get('id' as any) === '22',
             }]
           });
         });
@@ -3598,7 +3599,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
 
          const f = TestBed.createComponent(RootCmpWithLink);
          advance(f);
@@ -3683,7 +3684,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({declarations: [ComponentWithRouterLink]});
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
 
          router.resetConfig([
            {
@@ -3815,25 +3816,25 @@ describe('Integration', () => {
              const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
              const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
 
-             expect(pInj.get('moduleName')).toEqual('parent');
-             expect(pInj.get('fromParent')).toEqual('from parent');
+             expect(pInj.get('moduleName' as any)).toEqual('parent');
+             expect(pInj.get('fromParent' as any)).toEqual('from parent');
              expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
-             expect(pInj.get('fromChild', null)).toEqual(null);
-             expect(pInj.get(Child, null)).toEqual(null);
+             expect(pInj.get('fromChild' as any, null)).toEqual(null);
+             expect(pInj.get(Child as Type<Child>, null)).toEqual(null);
 
-             expect(cInj.get('moduleName')).toEqual('child');
-             expect(cInj.get('fromParent')).toEqual('from parent');
-             expect(cInj.get('fromChild')).toEqual('from child');
+             expect(cInj.get('moduleName' as any)).toEqual('child');
+             expect(cInj.get('fromParent' as any)).toEqual('from parent');
+             expect(cInj.get('fromChild' as any)).toEqual('from child');
              expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
              expect(cInj.get(Child)).toBeAnInstanceOf(Child);
              // The child module can not shadow the parent component
-             expect(cInj.get('shadow')).toEqual('from parent component');
+             expect(cInj.get('shadow' as any)).toEqual('from parent component');
 
              const pmInj = pInj.get(NgModuleRef).injector;
              const cmInj = cInj.get(NgModuleRef).injector;
 
-             expect(pmInj.get('moduleName')).toEqual('parent');
-             expect(cmInj.get('moduleName')).toEqual('child');
+             expect(pmInj.get('moduleName' as any)).toEqual('parent');
+             expect(cmInj.get('moduleName' as any)).toEqual('child');
 
              expect(pmInj.get(Parent, '-')).toEqual('-');
              expect(cmInj.get(Parent, '-')).toEqual('-');
@@ -4708,7 +4709,7 @@ describe('Integration', () => {
 
          TestBed.configureTestingModule({imports: [TestModule]});
 
-         const router: Router = TestBed.get(Router);
+         const router = TestBed.get(Router);
          router.routeReuseStrategy = new AttachDetachReuseStrategy();
 
          const fixture = createRoot(router, RootCmpWithCondOutlet);
@@ -4808,7 +4809,7 @@ class AbsoluteLinkCmp {
 class DummyLinkCmp {
   private exact: boolean;
   constructor(route: ActivatedRoute) {
-    this.exact = route.snapshot.paramMap.get('exact') === 'true';
+    this.exact = route.snapshot.paramMap.get('exact' as any) === 'true';
   }
 }
 
@@ -4913,7 +4914,7 @@ class QueryParamsAndFragmentCmp {
   fragment: Observable<string>;
 
   constructor(route: ActivatedRoute) {
-    this.name = route.queryParamMap.pipe(map((p: ParamMap) => p.get('name')));
+    this.name = route.queryParamMap.pipe(map((p: ParamMap) => p.get('name' as any)));
     this.fragment = route.fragment;
   }
 }

--- a/packages/upgrade/src/common/src/upgrade_helper.ts
+++ b/packages/upgrade/src/common/src/upgrade_helper.ts
@@ -43,7 +43,7 @@ export class UpgradeHelper {
   constructor(
       private injector: Injector, private name: string, elementRef: ElementRef,
       directive?: IDirective) {
-    this.$injector = injector.get($INJECTOR);
+    this.$injector = injector.get($INJECTOR as any);
     this.$compile = this.$injector.get($COMPILE);
     this.$controller = this.$injector.get($CONTROLLER);
 

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -3092,9 +3092,9 @@ withEachNg1Version(() => {
            adapter.upgradeNg1Provider('testValue', {asToken: 'testToken'});
            adapter.upgradeNg1Provider('testValue', {asToken: String});
            adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
-             expect(ref.ng2Injector.get('testValue')).toBe('secreteToken');
+             expect(ref.ng2Injector.get('testValue' as any)).toBe('secreteToken');
              expect(ref.ng2Injector.get(String)).toBe('secreteToken');
-             expect(ref.ng2Injector.get('testToken')).toBe('secreteToken');
+             expect(ref.ng2Injector.get('testToken' as any)).toBe('secreteToken');
              ref.dispose();
            });
          }));

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -166,7 +166,7 @@ export function downgradeModule<T>(
               const result: LazyModuleRef = {
                 promise: bootstrapFn(angular1Providers).then(ref => {
                   injector = result.injector = new NgAdapterInjector(ref.injector);
-                  injector.get($INJECTOR);
+                  injector.get($INJECTOR as any);
 
                   return injector;
                 })

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -116,7 +116,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
     // We ask for the AngularJS scope from the Angular injector, since
     // we will put the new component scope onto the new injector for each component
-    const $parentScope = injector.get($SCOPE);
+    const $parentScope = injector.get($SCOPE as any) as IScope;
     // QUESTION 1: Should we create an isolated scope if the scope is only true?
     // QUESTION 2: Should we make the scope accessible through `$element.scope()/isolateScope()`?
     this.$componentScope = $parentScope.$new(!!this.directive.scope);

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -245,7 +245,7 @@ export class UpgradeModule {
 
                 // Initialize the ng1 $injector provider
                 setTempInjectorRef($injector);
-                this.injector.get($INJECTOR);
+                this.injector.get($INJECTOR as any);
 
                 // Put the injector on the DOM, so that it can be "required"
                 angularElement(element).data !(controllerKey(INJECTOR_KEY), this.injector);

--- a/packages/upgrade/static/src/util.ts
+++ b/packages/upgrade/static/src/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '@angular/core';
+import {AbstractType, InjectFlags, InjectionToken, Injector, Type, ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '@angular/core';
 
 
 export class NgAdapterInjector implements Injector {
@@ -16,11 +16,18 @@ export class NgAdapterInjector implements Injector {
   // `NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR`. In such a case we should not walk up to the module
   // injector.
   // AngularJS only supports a single tree and should always check the module injector.
-  get(token: any, notFoundValue?: any): any {
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  get<T>(token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags):
+      T;
+  get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T|null,
+      flags?: InjectFlags): T|null {
     if (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
       return notFoundValue;
     }
 
-    return this.modInjector.get(token, notFoundValue);
+    return this.modInjector.get(token, notFoundValue, flags);
   }
 }

--- a/packages/upgrade/static/test/integration/injection_spec.ts
+++ b/packages/upgrade/static/test/integration/injection_spec.ts
@@ -88,7 +88,7 @@ withEachNg1Version(() => {
            INJECTOR_KEY,
            function(injector: Injector) {
              runBlockTriggered = true;
-             expect(injector.get($INJECTOR)).toBeDefined();
+             expect(injector.get($INJECTOR as any)).toBeDefined();
            }
          ]);
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -439,8 +439,8 @@ export declare class InjectionToken<T> {
 }
 
 export declare abstract class Injector {
-    abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-    /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
+    abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+    abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: Object;
     static ngInjectableDef: never;
@@ -1099,7 +1099,8 @@ export declare class QueryList<T> {
 export declare abstract class ReflectiveInjector implements Injector {
     abstract readonly parent: Injector | null;
     abstract createChildFromResolved(providers: ResolvedReflectiveProvider[]): ReflectiveInjector;
-    abstract get(token: any, notFoundValue?: any): any;
+    abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+    abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     abstract instantiateResolved(provider: ResolvedReflectiveProvider): any;
     abstract resolveAndCreateChild(providers: Provider[]): ReflectiveInjector;
     abstract resolveAndInstantiate(provider: Provider): any;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -70,7 +70,6 @@ export interface TestBed {
         deps: any[];
     }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     /** @deprecated */ get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
@@ -78,12 +77,12 @@ export interface TestBed {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void;
     overrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
+    overrideProvider(token: any, provider: {
         useFactory?: Function;
         useValue?: any;
         deps?: any[];
-    }): void;
-    overrideProvider(token: any, provider: {
-        useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
         useFactory: Function;
@@ -92,6 +91,7 @@ export interface TestBed {
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
     resetTestingModule(): void;
+    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare const TestBed: TestBedStatic;
@@ -106,19 +106,18 @@ export interface TestBedStatic {
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     deprecatedOverrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
-    }): TestBedStatic;
-    deprecatedOverrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
     }): void;
+    deprecatedOverrideProvider(token: any, provider: {
+        useFactory?: Function;
+        useValue?: any;
+        deps?: any[];
+    }): TestBedStatic;
     /** @deprecated */ get(token: any, notFoundValue?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;
@@ -140,6 +139,7 @@ export interface TestBedStatic {
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBedStatic;
     resetTestEnvironment(): void;
     resetTestingModule(): TestBedStatic;
+    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare class TestComponentRenderer {

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -70,7 +70,8 @@ export interface TestBed {
         deps: any[];
     }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
-    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+    get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;
@@ -91,7 +92,7 @@ export interface TestBed {
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
     resetTestingModule(): void;
-    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    /** @deprecated */ typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare const TestBed: TestBedStatic;
@@ -106,25 +107,27 @@ export interface TestBedStatic {
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     deprecatedOverrideProvider(token: any, provider: {
+        useFactory?: Function;
+        useValue?: any;
+        deps?: any[];
+    }): TestBedStatic;
+    deprecatedOverrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
     }): void;
-    deprecatedOverrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
-    }): TestBedStatic;
-    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): TestBedStatic;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useValue: any;
+        useFactory: Function;
+        deps: any[];
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
         useFactory?: Function;
@@ -132,14 +135,13 @@ export interface TestBedStatic {
         deps?: any[];
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
+        useValue: any;
     }): TestBedStatic;
     overrideTemplate(component: Type<any>, template: string): TestBedStatic;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBedStatic;
     resetTestEnvironment(): void;
     resetTestingModule(): TestBedStatic;
-    typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    /** @deprecated */ typedGet<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
 }
 
 export declare class TestComponentRenderer {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TestBed.get` returns `any`
`TestBed.typedGet` returns `T`
`Injector.get` for things not matching `Type<T>|InjectionToken<T>` return `any`

Issue Number: N/A


## What is the new behavior?

`TestBed.get` returns `T` (copy of `TestBed.typedGet`)
`TestBed.typedGet` is deprecated
`Injector.get` also matches `TestBed.get` signature (i.e. now accepts `AbstractType<T>`) and the deprecated signature has been deleted.

String providers are no longer supported by the signature and need to be casted to `any` or migrated to an InjectionToken


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is supposed to follow after PR #30036, and this should be merged for 9.x assuming the mentioned PR was merged on 8.x