### PR TITLE
fix(bazel): Make sure only single copy of `@angular/bazel` is installed

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -55,13 +55,19 @@ function addDevDependenciesToPackageJson(options: Schema) {
     };
 
     const recorder = host.beginUpdate(packageJson);
-    const depsToInstall = Object.keys(devDependencies).filter((name) => {
-      return !findPropertyInAstObject(devDeps, name);
-    });
-    for (const packageName of depsToInstall) {
+    for (const packageName of Object.keys(devDependencies)) {
+      const existingDep = findPropertyInAstObject(deps, packageName);
+      if (existingDep) {
+        const content = packageJsonContent.toString();
+        removeKeyValueInAstObject(recorder, content, deps, packageName);
+      }
       const version = devDependencies[packageName];
       const indent = 4;
-      insertPropertyInAstObjectInOrder(recorder, devDeps, packageName, version, indent);
+      if (findPropertyInAstObject(devDeps, packageName)) {
+        replacePropertyInAstObject(recorder, devDeps, packageName, version, indent);
+      } else {
+        insertPropertyInAstObjectInOrder(recorder, devDeps, packageName, version, indent);
+      }
     }
     host.commitUpdate(recorder);
     return host;

--- a/packages/bazel/src/schematics/ng-add/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-add/index_spec.ts
@@ -100,7 +100,7 @@ describe('ng-add schematic', () => {
     expect(devDeps).toContain('@bazel/karma');
   });
 
-  it('should not add an existing dev dependency', () => {
+  it('should replace an existing dev dependency', () => {
     expect(host.files).toContain('/package.json');
     const packageJson = JSON.parse(host.readContent('/package.json'));
     packageJson.devDependencies['@angular/bazel'] = '4.2.42';
@@ -110,7 +110,20 @@ describe('ng-add schematic', () => {
     // It is possible that a dep gets added twice if the package already exists.
     expect(content.match(/@angular\/bazel/g) !.length).toEqual(1);
     const json = JSON.parse(content);
-    expect(json.devDependencies['@angular/bazel']).toBe('4.2.42');
+    expect(json.devDependencies['@angular/bazel']).toBe('1.2.3');
+  });
+
+  it('should remove an existing dependency', () => {
+    expect(host.files).toContain('/package.json');
+    const packageJson = JSON.parse(host.readContent('/package.json'));
+    packageJson.dependencies['@angular/bazel'] = '4.2.42';
+    expect(Object.keys(packageJson.dependencies)).toContain('@angular/bazel');
+    host.overwrite('/package.json', JSON.stringify(packageJson));
+    host = schematicRunner.runSchematic('ng-add', defaultOptions, host);
+    const content = host.readContent('/package.json');
+    const json = JSON.parse(content);
+    expect(Object.keys(json.dependencies)).not.toContain('@angular/bazel');
+    expect(json.devDependencies['@angular/bazel']).toBe('1.2.3');
   });
 
   it('should not create Bazel workspace file', () => {

--- a/packages/bazel/src/schematics/utility/json-utils.ts
+++ b/packages/bazel/src/schematics/utility/json-utils.ts
@@ -40,7 +40,7 @@ export function removeKeyValueInAstObject(
       const start = prop.start.offset;
       const end = prop.end.offset;
       let length = end - start;
-      const match = content.slice(end).match(/[,\s]+/);
+      const match = content.slice(end).match(/^[,\s]+/);
       if (match) {
         length += match.pop() !.length;
       }


### PR DESCRIPTION
When `ng add` is invoked independently of `ng new`, a node installation
of `@angular/bazel` is performed by the CLI before invoking the
schematic. This step appends `@angular/bazel` to the `dependencies`
section of `package.json`. The schematics then appends the same package
to `devDependencies`.

This leads to the warning:

```
warning package.json: "dependencies" has dependency "@angular/bazel" with
range "^8.0.0-beta.13" that collides with a dependency in "devDependencies"
of the same name with version "~8.0.0-beta.12"
```

This could have been avoided if `ng add` provides a `--no-save` feature, but it is not exposed.

PR Closes https://github.com/angular/angular/issues/30052 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
