### PR TITLE
fix(bazel): make name param in ng add optional

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -11,7 +11,7 @@
 import {JsonAstObject, parseJsonAst} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree, apply, applyTemplates, chain, mergeWith, url} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
-import {getWorkspacePath} from '@schematics/angular/utility/config';
+import {getWorkspace, getWorkspacePath} from '@schematics/angular/utility/config';
 import {findPropertyInAstObject, insertPropertyInAstObjectInOrder} from '@schematics/angular/utility/json-utils';
 import {validateProjectName} from '@schematics/angular/utility/validation';
 
@@ -112,7 +112,7 @@ function updateGitignore() {
  */
 function updateAngularJsonToUseBazelBuilder(options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
-    const {name} = options;
+    const name = options.name !;
     const workspacePath = getWorkspacePath(host);
     if (!workspacePath) {
       throw new Error('Could not find angular.json');
@@ -368,6 +368,10 @@ function installNodeModules(options: Schema): Rule {
 
 export default function(options: Schema): Rule {
   return (host: Tree) => {
+    options.name = options.name || getWorkspace(host).defaultProject;
+    if (!options.name) {
+      throw new Error('Please specify a project using "--name project-name"');
+    }
     validateProjectName(options.name);
 
     return chain([

--- a/packages/bazel/src/schematics/ng-add/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-add/index_spec.ts
@@ -55,6 +55,7 @@ describe('ng-add schematic', () => {
           },
         },
       },
+      defaultProject: 'demo',
     }));
     schematicRunner =
         new SchematicTestRunner('@angular/bazel', require.resolve('../collection.json'));
@@ -187,6 +188,15 @@ describe('ng-add schematic', () => {
     expect(demo.architect['extract-i18n'].builder)
         .toBe('@angular-devkit/build-angular:extract-i18n');
     expect(lint.builder).toBe('@angular-devkit/build-angular:tslint');
+  });
+
+  it('should get defaultProject if name is not provided', () => {
+    const options = {};
+    host = schematicRunner.runSchematic('ng-add', options, host);
+    const content = host.readContent('/angular.json');
+    const json = JSON.parse(content);
+    const builder = json.projects.demo.architect.build.builder;
+    expect(builder).toBe('@angular/bazel:build');
   });
 
   it('should create a backup for original tsconfig.json', () => {

--- a/packages/bazel/src/schematics/ng-add/schema.d.ts
+++ b/packages/bazel/src/schematics/ng-add/schema.d.ts
@@ -9,7 +9,7 @@ export interface Schema {
   /**
    * The name of the project.
    */
-  name: string;
+  name?: string;
   /**
    * When true, does not install dependency packages.
    */

--- a/packages/bazel/src/schematics/ng-add/schema.json
+++ b/packages/bazel/src/schematics/ng-add/schema.json
@@ -20,6 +20,5 @@
     }
   },
   "required": [
-    "name"
   ]
 }


### PR DESCRIPTION
`ng add` should infer project name from `defaultProject` if none is provided.

PR closes https://github.com/angular/angular/issues/29572

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
