### PR TITLE
fix(ivy): ngcc - do not copy external files when writing bundles

### DIFF
--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -32,46 +32,44 @@ const NGCC_DIRECTORY = '__ivy_ngcc__';
 export class NewEntryPointFileWriter extends InPlaceFileWriter {
   writeBundle(entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileInfo[]) {
     // The new folder is at the root of the overall package
-    const relativeEntryPointPath = relative(entryPoint.package, entryPoint.path);
-    const relativeNewDir = join(NGCC_DIRECTORY, relativeEntryPointPath);
-    const newDir = AbsoluteFsPath.fromUnchecked(join(entryPoint.package, relativeNewDir));
-    this.copyBundle(bundle, entryPoint.package, entryPoint.path, newDir);
-    transformedFiles.forEach(file => this.writeFile(file, entryPoint.path, newDir));
-    this.updatePackageJson(entryPoint, bundle.formatProperty, newDir);
+    const ngccFolder = AbsoluteFsPath.fromUnchecked(join(entryPoint.package, NGCC_DIRECTORY));
+    this.copyBundle(bundle, entryPoint.package, ngccFolder);
+    transformedFiles.forEach(file => this.writeFile(file, entryPoint.package, ngccFolder));
+    this.updatePackageJson(entryPoint, bundle.formatProperty, ngccFolder);
   }
 
   protected copyBundle(
-      bundle: EntryPointBundle, packagePath: AbsoluteFsPath, entryPointPath: AbsoluteFsPath,
-      newDir: AbsoluteFsPath) {
+      bundle: EntryPointBundle, packagePath: AbsoluteFsPath, ngccFolder: AbsoluteFsPath) {
     bundle.src.program.getSourceFiles().forEach(sourceFile => {
-      const isOutsidePackage = relative(packagePath, sourceFile.fileName).startsWith('..');
+      const relativePath = relative(packagePath, sourceFile.fileName);
+      const isOutsidePackage = relativePath.startsWith('..');
       if (!sourceFile.isDeclarationFile && !isOutsidePackage) {
-        const relativePath = relative(entryPointPath, sourceFile.fileName);
-        const newFilePath = join(newDir, relativePath);
+        const newFilePath = join(ngccFolder, relativePath);
         mkdir('-p', dirname(newFilePath));
         cp(sourceFile.fileName, newFilePath);
       }
     });
   }
 
-  protected writeFile(file: FileInfo, entryPointPath: AbsoluteFsPath, newDir: AbsoluteFsPath):
+  protected writeFile(file: FileInfo, packagePath: AbsoluteFsPath, ngccFolder: AbsoluteFsPath):
       void {
     if (isDtsPath(file.path.replace(/\.map$/, ''))) {
       // This is either `.d.ts` or `.d.ts.map` file
       super.writeFileAndBackup(file);
     } else {
-      const relativePath = relative(entryPointPath, file.path);
-      const newFilePath = join(newDir, relativePath);
+      const relativePath = relative(packagePath, file.path);
+      const newFilePath = join(ngccFolder, relativePath);
       mkdir('-p', dirname(newFilePath));
       writeFileSync(newFilePath, file.contents, 'utf8');
     }
   }
 
   protected updatePackageJson(
-      entryPoint: EntryPoint, formatProperty: EntryPointJsonProperty, newDir: AbsoluteFsPath) {
-    const bundlePath = entryPoint.packageJson[formatProperty] !;
-    const newBundlePath = relative(entryPoint.path, join(newDir, bundlePath));
-    (entryPoint.packageJson as any)[formatProperty + '_ivy_ngcc'] = newBundlePath;
+      entryPoint: EntryPoint, formatProperty: EntryPointJsonProperty, ngccFolder: AbsoluteFsPath) {
+    const formatPath = join(entryPoint.path, entryPoint.packageJson[formatProperty] !);
+    const newFormatPath = join(ngccFolder, relative(entryPoint.package, formatPath));
+    const newFormatProperty = formatProperty + '_ivy_ngcc';
+    (entryPoint.packageJson as any)[newFormatProperty] = relative(entryPoint.path, newFormatPath);
     writeFileSync(join(entryPoint.path, 'package.json'), JSON.stringify(entryPoint.packageJson));
   }
 }

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -35,15 +35,17 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
     const relativeEntryPointPath = relative(entryPoint.package, entryPoint.path);
     const relativeNewDir = join(NGCC_DIRECTORY, relativeEntryPointPath);
     const newDir = AbsoluteFsPath.fromUnchecked(join(entryPoint.package, relativeNewDir));
-    this.copyBundle(bundle, entryPoint.path, newDir);
+    this.copyBundle(bundle, entryPoint.package, entryPoint.path, newDir);
     transformedFiles.forEach(file => this.writeFile(file, entryPoint.path, newDir));
     this.updatePackageJson(entryPoint, bundle.formatProperty, newDir);
   }
 
   protected copyBundle(
-      bundle: EntryPointBundle, entryPointPath: AbsoluteFsPath, newDir: AbsoluteFsPath) {
+      bundle: EntryPointBundle, packagePath: AbsoluteFsPath, entryPointPath: AbsoluteFsPath,
+      newDir: AbsoluteFsPath) {
     bundle.src.program.getSourceFiles().forEach(sourceFile => {
-      if (!sourceFile.isDeclarationFile) {
+      const isOutsidePackage = relative(packagePath, sourceFile.fileName).startsWith('..');
+      if (!sourceFile.isDeclarationFile && !isOutsidePackage) {
         const relativePath = relative(entryPointPath, sourceFile.fileName);
         const newFilePath = join(newDir, relativePath);
         mkdir('-p', dirname(newFilePath));


### PR DESCRIPTION
Only the JS files that are actually part of the entry-point
should be copied to the new entry-point folder in the
`NewEntryPointFileWriter`.

Previously some typings and external JS files were
being copied which was messing up the node_modules
structure.

Fixes https://github.com/angular/angular-cli/issues/14193
