### PR TITLE
ci: add `aio/content/examples/*` to `docs-infra` group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -726,6 +726,7 @@ testing/**                                                      @angular/fw-test
 
 /aio/*                                                          @angular/docs-infra @angular/framework-global-approvers
 /aio/aio-builds-setup/**                                        @angular/docs-infra @angular/framework-global-approvers
+/aio/content/examples/*                                         @angular/docs-infra @angular/framework-global-approvers
 /aio/scripts/**                                                 @angular/docs-infra @angular/framework-global-approvers
 /aio/src/**                                                     @angular/docs-infra @angular/framework-global-approvers
 /aio/tests/**                                                   @angular/docs-infra @angular/framework-global-approvers


### PR DESCRIPTION
This directory contains some top-level files (`.gitignore`, `tsconfig.json`, `tslint.json`) that are related to the examples infrastructure (building, linting, etc.).

They had previously no owner; now they are owned by the `docs-infra` group.
