### PR TITLE
fix(ivy): don't reuse a ts.Program more than once in ngtsc

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -164,7 +164,10 @@ export class TypeCheckContext {
 
   calculateTemplateDiagnostics(
       originalProgram: ts.Program, originalHost: ts.CompilerHost,
-      originalOptions: ts.CompilerOptions): ts.Diagnostic[] {
+      originalOptions: ts.CompilerOptions): {
+    diagnostics: ts.Diagnostic[],
+    program: ts.Program,
+  } {
     const typeCheckSf = this.typeCheckFile.render();
     // First, build the map of original source files.
     const sfMap = new Map<string, ts.SourceFile>();
@@ -191,17 +194,23 @@ export class TypeCheckContext {
       diagnostics.push(...typeCheckProgram.getSemanticDiagnostics(sf));
     }
 
-    return diagnostics.filter((diag: ts.Diagnostic): boolean => {
-      if (diag.code === 6133 /* $var is declared but its value is never read. */) {
-        return false;
-      } else if (diag.code === 6199 /* All variables are unused. */) {
-        return false;
-      } else if (
-          diag.code === 2695 /* Left side of comma operator is unused and has no side effects. */) {
-        return false;
-      }
-      return true;
-    });
+    return {
+      diagnostics: diagnostics.filter(
+          (diag: ts.Diagnostic):
+              boolean => {
+                if (diag.code === 6133 /* $var is declared but its value is never read. */) {
+                  return false;
+                } else if (diag.code === 6199 /* All variables are unused. */) {
+                  return false;
+                } else if (
+                    diag.code ===
+                    2695 /* Left side of comma operator is unused and has no side effects. */) {
+                  return false;
+                }
+                return true;
+              }),
+      program: typeCheckProgram,
+    };
   }
 
   private addInlineTypeCheckBlock(

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -899,7 +899,7 @@ export function createProgram({rootNames, options, host, oldProgram}: {
   host: CompilerHost, oldProgram?: Program
 }): Program {
   if (options.enableIvy === true) {
-    return new NgtscProgram(rootNames, options, host, oldProgram);
+    return new NgtscProgram(rootNames, options, host, oldProgram as NgtscProgram);
   } else if (options.enableIvy === 'tsc') {
     return new TscPassThroughProgram(rootNames, options, host, oldProgram);
   }

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -44,4 +44,14 @@ describe('ngtsc incremental compilation', () => {
     expect(written).toContain('/test.js');
     expect(written).not.toContain('/service.js');
   });
+
+  it('should compile incrementally with template type-checking turned on', () => {
+    env.tsconfig({ivyTemplateTypeCheck: true});
+    env.write('main.ts', 'export class Foo {}');
+    env.driveMain();
+    env.invalidateCachedFile('main.ts');
+    env.driveMain();
+    // If program reuse were configured incorrectly (as was responsible for
+    // https://github.com/angular/angular/issues/30079), this would have crashed.
+  });
 });


### PR DESCRIPTION
ngtsc previously could attempt to reuse the main ts.Program twice. This
occurred when template type-checking was enabled and then an incremental
build was performed. This breaks a TypeScript invariant - ts.Programs can
only be reused once.

The creation of the template type-checking program reuses the main program,
rendering it moot. Then, on the next incremental build the main program
would be subject to reuse again, which would crash inside TypeScript.

This commit fixes the issue by reusing the template type-checking program
from the previous run on the next incremental build. Since under normal
circumstances the files in the type-checking program aren't changed, this
should be just as fast.

Testing strategy: a test is added in the incremental_spec which validates
that program reuse with type-checking turned on does not crash the compiler.

Fixes #30079

## Other information
