### PR TITLE
docs: cli overview - add in-page nav, change title to match left nav better

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -1,4 +1,4 @@
-<h1 class="no-toc">CLI Command Reference</h1>
+# CLI Overview and Command Reference
 
 The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold, and maintain Angular applications. You can use the tool directly in a command shell, or indirectly through an interactive UI such as [Angular Console](https://angularconsole.com).
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Changes CLI Overview (`cli/index.md`) so that:
* It generate the in-page navigation on the right. This makes it easier to find the command overview, which is a super handy summary. 
* The title better matches the nav entry on the left and unites the purpose of the page and section. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No in-page navigation.
Title is "CLI Command Reference" which matches the left nav section title but doesn't match the page's entry under that (Overview). 


Issue Number: N/A


## What is the new behavior?
See above. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
