### PR TITLE
feat(compiler): support skipping leading trivia in the lexer

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -53,6 +53,8 @@ const NG_PROJECT_AS_ATTR_NAME = 'ngProjectAs';
 const GLOBAL_TARGET_RESOLVERS = new Map<string, o.ExternalReference>(
     [['window', R3.resolveWindow], ['document', R3.resolveDocument], ['body', R3.resolveBody]]);
 
+const LEADING_TRIVIA_CHARS = [' ', '\n', '\r', '\t'];
+
 //  if (rf & flags) { .. }
 export function renderFlagCheckIfStmt(
     flags: core.RenderFlags, statements: o.Statement[]): o.IfStmt {
@@ -1733,8 +1735,9 @@ export function parseTemplate(
   const {interpolationConfig, preserveWhitespaces} = options;
   const bindingParser = makeBindingParser(interpolationConfig);
   const htmlParser = new HtmlParser();
-  const parseResult =
-      htmlParser.parse(template, templateUrl, {...options, tokenizeExpansionForms: true});
+  const parseResult = htmlParser.parse(
+      template, templateUrl,
+      {...options, tokenizeExpansionForms: true, leadingTriviaChars: LEADING_TRIVIA_CHARS});
 
   if (parseResult.errors && parseResult.errors.length > 0) {
     return {errors: parseResult.errors, nodes: [], styleUrls: [], styles: []};

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -52,6 +52,18 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.EOF, '2:5'],
         ]);
       });
+
+      it('should skip over leading trivia for source-span start', () => {
+        expect(tokenizeAndHumanizeLineColumn(
+                   '<t>\n \t a</t>', {leadingTriviaChars: ['\n', ' ', '\t']}))
+            .toEqual([
+              [lex.TokenType.TAG_OPEN_START, '0:0'],
+              [lex.TokenType.TAG_OPEN_END, '0:2'],
+              [lex.TokenType.TEXT, '1:3'],
+              [lex.TokenType.TAG_CLOSE, '1:4'],
+              [lex.TokenType.EOF, '1:8'],
+            ]);
+      });
     });
 
     describe('content ranges', () => {


### PR DESCRIPTION
Leading trivia, such as whitespace or comments, is
confusing for developers looking at source-mapped
templates, since they expect the source-map segment
to start after the trivia.

This commit add skipping this trivia to the Angular lexer.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
