### PR TITLE
docs: temporary disable aio_monitoring job due to a version skew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,17 +689,19 @@ workflows:
           cron: "0 * * * *"
           filters: *publish_branches_filter
 
-  aio_monitoring:
-    jobs:
-      - aio_monitoring
-    triggers:
-      - schedule:
-          # Runs AIO monitoring job at 00:00AM every day.
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+# This job is currently disabled due to a version skew problem.
+# More info is available here: https://github.com/angular/angular/issues/30101
+#  aio_monitoring:
+#    jobs:
+#      - aio_monitoring
+#    triggers:
+#      - schedule:
+#          # Runs AIO monitoring job at 00:00AM every day.
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
 
 # TODO:
 # - don't build the g3 branch


### PR DESCRIPTION
Redirects that were updated in 24c61cb63e1b3cb0ad3c031ab5eaa418cbec4bed break the aio_monitoring CircleCI job, since we run the tests against the production angular.io site (that doesn't have the latest redirects config yet).

This change temporary disables the aio_monitoring job to avoid failures for other PRs. The problem will be resolved and the job will be enabled in followup PRs.


## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No