### PR TITLE
test: fix ts api guardian and public guard tests on windows

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -22,3 +22,4 @@ steps:
     # Run tests
     - yarn bazel test //tools/ts-api-guardian:all
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
+    - yarn bazel test //tools/public_api_guard/...

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,8 @@
 *.js eol=lf
 *.ts eol=lf
 
+# API guardian patch must always use LF for tests to work
+*.patch eol=lf
+
 # Must keep Windows line ending to be parsed correctly
 scripts/windows/packages.txt eol=crlf

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -46,7 +46,8 @@ def ts_api_guardian_test(
     ]
 
     for i in strip_export_pattern:
-        args += ["--stripExportPattern", i]
+        # The below replacement is needed because under Windows '^' needs to be escaped twice
+        args += ["--stripExportPattern", i.replace("^", "^^^^")]
 
     for i in allow_module_identifiers:
         args += ["--allowModuleIdentifiers", i]

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -298,7 +298,7 @@ class ResolvedDeclarationEmitter {
         const jsdocComment = this.processJsDocTags(node, tagOptions);
         if (jsdocComment) {
           // Add the annotation after the leading whitespace
-          output = output.replace(/^(\n\s*)/, `$1${jsdocComment} `);
+          output = output.replace(/^(\r?\n\s*)/, `$1${jsdocComment} `);
         }
       }
 

--- a/tools/ts-api-guardian/test/cli_e2e_test.ts
+++ b/tools/ts-api-guardian/test/cli_e2e_test.ts
@@ -124,7 +124,11 @@ function execute(args: string[]): {stdout: string, stderr: string, status: numbe
   // We need to determine the directory that includes the `ts-api-guardian` npm_package that
   // will be used to spawn the CLI binary. This is a workaround because technically we shouldn't
   // spawn a child process that doesn't have the custom NodeJS module resolution for Bazel.
-  const nodePath = path.join(path.dirname(require.resolve('../lib/cli.js')), '../');
+  const nodePath = [
+    path.join(require.resolve('npm/node_modules/chalk/package.json'), '../../'),
+    path.join(require.resolve('../lib/cli.js'), '../../'),
+  ].join(process.platform === 'win32' ? ';' : ':');
+
   const output = child_process.spawnSync(process.execPath, [BINARY_PATH, ...args], {
     env: {
       'NODE_PATH': nodePath,


### PR DESCRIPTION
This change addresses several issues with ts-api-guardian and public api guards related tests in Windows

The fixes contain 3 main changes:
1) In `stripExportPattern` - replace `^` with `^^^^`  in RegExp due to a double escaping requirment under Windows. Note that under Linux this the extra character has no effect because it's still a valid RegExp in Js.

2. Force `*.patch` files to always be with a LF line sequence instead of CRLF in windows

3. When adding JSDoc comments consider the presence of a carriage return in a line new feed

Partially addresses #29785

