### PR TITLE
refactor(upgrade): rename `module` constant to avoid webpack bug

### DIFF
--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -296,7 +296,9 @@ export function getAngularJSGlobal(): any {
 export const bootstrap: typeof angular.bootstrap = (e, modules, config?) =>
     angular.bootstrap(e, modules, config);
 
-export const module: typeof angular.module = (prefix, dependencies?) =>
+// Do not declare as `module` to avoid webpack bug
+// (see https://github.com/angular/angular/issues/30050).
+export const module_: typeof angular.module = (prefix, dependencies?) =>
     angular.module(prefix, dependencies);
 
 export const element: typeof angular.element = (e => angular.element(e)) as typeof angular.element;

--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, CompilerOptions, Injector, NgModule, NgModuleRef, NgZone, StaticProvider, Testability, Type, resolveForwardRef} from '@angular/core';
+import {Compiler, CompilerOptions, Injector, NgModule, NgModuleRef, NgZone, StaticProvider, Testability, Type, isDevMode, resolveForwardRef} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import * as angular from '../../common/src/angular1';
@@ -598,8 +598,20 @@ export class UpgradeAdapter {
                   })
                   .then(() => this.ng2BootstrapDeferred.resolve(ng1Injector), onError)
                   .then(() => {
-                    let subscription =
-                        this.ngZone.onMicrotaskEmpty.subscribe({next: () => rootScope.$digest()});
+                    let subscription = this.ngZone.onMicrotaskEmpty.subscribe({
+                      next: () => {
+                        if (rootScope.$$phase) {
+                          if (isDevMode()) {
+                            console.warn(
+                                'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.');
+                          }
+
+                          return rootScope.$evalAsync(() => {});
+                        }
+
+                        return rootScope.$digest();
+                      }
+                    });
                     rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                   });
             })

--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -501,7 +501,7 @@ export class UpgradeAdapter {
     let rootScopePrototype: any;
     let rootScope: angular.IRootScopeService;
     const upgradeAdapter = this;
-    const ng1Module = this.ng1Module = angular.module(this.idPrefix, modules);
+    const ng1Module = this.ng1Module = angular.module_(this.idPrefix, modules);
     const platformRef = platformBrowserDynamic();
 
     this.ngZone = new NgZone({enableLongStackTrace: Zone.hasOwnProperty('longStackTraceZoneSpec')});

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -171,7 +171,46 @@ withEachNg1Version(() => {
          }));
     });
 
-    describe('scope/component change-detection', () => {
+    describe('change-detection', () => {
+      it('should not break if a $digest is already in progress', async(() => {
+           @Component({selector: 'my-app', template: ''})
+           class AppComponent {
+           }
+
+           @NgModule({declarations: [AppComponent], imports: [BrowserModule]})
+           class Ng2Module {
+           }
+
+           const ng1Module = angular.module('ng1', []);
+           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+           const element = html('<my-app></my-app>');
+
+           adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+             const $rootScope: any = ref.ng1RootScope;
+             const ngZone: NgZone = ref.ng2ModuleRef.injector.get<NgZone>(NgZone);
+             const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
+
+             // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
+             ngZone.onMicrotaskEmpty.emit(null);
+             expect(digestSpy).toHaveBeenCalledTimes(1);
+
+             digestSpy.calls.reset();
+
+             // Step 2: Cause the issue.
+             $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
+
+             // With the fix, `$digest` will only be run once (for `$apply()`).
+             // Without the fix, `$digest()` would have been run an extra time (`onMicrotaskEmpty`).
+             expect(digestSpy).toHaveBeenCalledTimes(1);
+
+             digestSpy.calls.reset();
+
+             // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
+             ngZone.onMicrotaskEmpty.emit(null);
+             expect(digestSpy).toHaveBeenCalledTimes(1);
+           });
+         }));
+
       it('should interleave scope and component expressions', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const ng1Module = angular.module_('ng1', []);
@@ -216,7 +255,6 @@ withEachNg1Version(() => {
              ref.dispose();
            });
          }));
-
 
       fixmeIvy(
           'FW-712: Rendering is being run on next "animation frame" rather than "Zone.microTaskEmpty" trigger')

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -181,7 +181,7 @@ withEachNg1Version(() => {
            class Ng2Module {
            }
 
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const element = html('<my-app></my-app>');
 
@@ -326,7 +326,7 @@ withEachNg1Version(() => {
       //      }
 
       //      const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-      //      const ng1Module = angular.module('ng1', []).directive(
+      //      const ng1Module = angular.module_('ng1', []).directive(
       //          'myApp', adapter.downgradeNg2Component(AppComponent));
 
       //      const element = html('<my-app></my-app>');

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -34,7 +34,7 @@ withEachNg1Version(() => {
 
       fixmeIvy('FW-714: ng1 projected content is not being rendered')
           .it('should instantiate ng2 in ng1 template and project content', async(() => {
-                const ng1Module = angular.module('ng1', []);
+                const ng1Module = angular.module_('ng1', []);
 
                 @Component({
                   selector: 'ng2',
@@ -60,7 +60,7 @@ withEachNg1Version(() => {
 
       it('should instantiate ng1 in ng2 template and project content', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            @Component({
              selector: 'ng2',
@@ -94,7 +94,7 @@ withEachNg1Version(() => {
            spyOn(platformRef, 'bootstrapModule').and.callThrough();
            spyOn(platformRef, 'bootstrapModuleFactory').and.callThrough();
 
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            @Component({selector: 'ng2', template: `{{ 'NG2' }}(<ng-content></ng-content>)`})
            class Ng2 {
            }
@@ -128,7 +128,7 @@ withEachNg1Version(() => {
       let adapter: UpgradeAdapter;
 
       beforeEach(() => {
-        angular.module('ng1', []);
+        angular.module_('ng1', []);
 
         @Component({
           selector: 'ng2',
@@ -174,7 +174,7 @@ withEachNg1Version(() => {
     describe('scope/component change-detection', () => {
       it('should interleave scope and component expressions', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const log: string[] = [];
            const l = (value: string) => {
              log.push(value);
@@ -265,7 +265,7 @@ withEachNg1Version(() => {
                 }
 
                 const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-                const ng1Module = angular.module('ng1', []).directive(
+                const ng1Module = angular.module_('ng1', []).directive(
                     'myApp', adapter.downgradeNg2Component(AppComponent));
 
                 const element = html('<my-app></my-app>');
@@ -319,7 +319,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.directive('ng2', adapter.downgradeNg2Component(WorksComponent));
 
            const element = html('<ng2></ng2>');
@@ -331,7 +331,7 @@ withEachNg1Version(() => {
       fixmeIvy('FW-715: ngOnChanges being called a second time unexpectedly')
           .it('should bind properties, events', async(() => {
                 const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-                const ng1Module = angular.module('ng1', []).value(
+                const ng1Module = angular.module_('ng1', []).value(
                     $EXCEPTION_HANDLER, (err: any) => { throw err; });
 
                 ng1Module.run(($rootScope: any) => {
@@ -456,7 +456,7 @@ withEachNg1Version(() => {
           .it('should support two-way binding and event listener', async(() => {
                 const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
                 const listenerSpy = jasmine.createSpy('$rootScope.listener');
-                const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+                const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
                   $rootScope['value'] = 'world';
                   $rootScope['listener'] = listenerSpy;
                 });
@@ -538,7 +538,7 @@ withEachNg1Version(() => {
                 class Ng2Module {
                 }
 
-                const ng1Module = angular.module('ng1', []).directive(
+                const ng1Module = angular.module_('ng1', []).directive(
                     'ng2', adapter.downgradeNg2Component(Ng2Component));
 
                 const element = html(`
@@ -564,7 +564,7 @@ withEachNg1Version(() => {
 
       it('should bind to ng-model', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            ng1Module.run(($rootScope: any /** TODO #9100 */) => { $rootScope.modelA = 'A'; });
 
@@ -622,7 +622,7 @@ withEachNg1Version(() => {
 
       it('should properly run cleanup when ng1 directive is destroyed', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const onDestroyed: EventEmitter<string> = new EventEmitter<string>();
 
            ng1Module.directive('ng1', () => {
@@ -678,7 +678,7 @@ withEachNg1Version(() => {
            }
 
            const ng1Module =
-               angular.module('ng1', [])
+               angular.module_('ng1', [])
                    .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
                    .directive('ng2Inner', adapter.downgradeNg2Component(Ng2InnerComponent))
                    .directive('ng2Outer', adapter.downgradeNg2Component(Ng2OuterComponent));
@@ -698,7 +698,7 @@ withEachNg1Version(() => {
 
       it('should fallback to the root ng2.injector when compiled outside the dom', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            ng1Module.directive('ng1', [
              '$compile',
@@ -734,7 +734,7 @@ withEachNg1Version(() => {
 
       fixmeIvy('FW-714: ng1 projected content is not being rendered')
           .it('should support multi-slot projection', async(() => {
-                const ng1Module = angular.module('ng1', []);
+                const ng1Module = angular.module_('ng1', []);
 
                 @Component({
                   selector: 'ng2',
@@ -777,7 +777,7 @@ withEachNg1Version(() => {
 
                 const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
                 const ng1Module =
-                    angular.module('ng1', [])
+                    angular.module_('ng1', [])
                         .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
                         .run(($rootScope: angular.IRootScopeService) => {
                           $rootScope['items'] = [
@@ -801,7 +801,7 @@ withEachNg1Version(() => {
 
       it('should allow attribute selectors for components in ng2', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
-           const ng1Module = angular.module('myExample', []);
+           const ng1Module = angular.module_('myExample', []);
 
            @Component({selector: '[works]', template: 'works!'})
            class WorksComponent {
@@ -852,7 +852,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -916,7 +916,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -980,7 +980,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -1041,7 +1041,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -1074,7 +1074,7 @@ withEachNg1Version(() => {
 
       it('should bind properties, events', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1132,7 +1132,7 @@ withEachNg1Version(() => {
 
       it('should bind optional properties', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1177,7 +1177,7 @@ withEachNg1Version(() => {
       it('should bind properties, events in controller when bindToController is not used',
          async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1221,7 +1221,7 @@ withEachNg1Version(() => {
 
       it('should bind properties, events in link function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1265,7 +1265,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl fetched from $httpBackend', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.value(
                '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
                  cbFn(200, `${method}:${url}`);
@@ -1294,7 +1294,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl as a function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.value(
                '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
                  cbFn(200, `${method}:${url}`);
@@ -1323,7 +1323,7 @@ withEachNg1Version(() => {
 
       it('should support empty template', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => { return {template: ''}; };
            ng1Module.directive('ng1', ng1);
@@ -1349,7 +1349,7 @@ withEachNg1Version(() => {
 
       it('should support template as a function', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => { return {template() { return ''; }}; };
            ng1Module.directive('ng1', ng1);
@@ -1375,7 +1375,7 @@ withEachNg1Version(() => {
 
       it('should support templateUrl fetched from $templateCache', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            ng1Module.run(($templateCache: any) => $templateCache.put('url.html', 'WORKS'));
 
            const ng1 = () => { return {templateUrl: 'url.html'}; };
@@ -1402,7 +1402,7 @@ withEachNg1Version(() => {
 
       it('should support controller with controllerAs', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1446,7 +1446,7 @@ withEachNg1Version(() => {
 
       it('should support bindToController', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1480,7 +1480,7 @@ withEachNg1Version(() => {
 
       it('should support bindToController with bindings', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = () => {
              return {
@@ -1514,7 +1514,7 @@ withEachNg1Version(() => {
 
       it('should support single require in linking fn', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = ($rootScope: any) => {
              return {
@@ -1555,7 +1555,7 @@ withEachNg1Version(() => {
 
       it('should support array require in linking fn', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const parent = () => { return {controller: class {parent = 'PARENT';}}; };
            const ng1 = () => {
@@ -1607,7 +1607,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1651,7 +1651,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1700,7 +1700,7 @@ withEachNg1Version(() => {
                constructor(cd: ChangeDetectorRef) { changeDetector = cd; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1754,7 +1754,7 @@ withEachNg1Version(() => {
                constructor(cd: ChangeDetectorRef) { changeDetector = cd; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1807,7 +1807,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1851,7 +1851,7 @@ withEachNg1Version(() => {
              class Ng2Component {
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -1904,7 +1904,7 @@ withEachNg1Version(() => {
                constructor() { ng2Instance = this; }
              }
 
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {valA: '<'},
@@ -2007,7 +2007,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -2096,7 +2096,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .directive('ng1A', () => ({
                                       template: '',
                                       scope: {},
@@ -2171,7 +2171,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .component('ng1', {
                    controller: function($scope: angular.IScope) {
                      $scope.$on('$destroy', scopeDestroyListener);
@@ -2217,7 +2217,7 @@ withEachNg1Version(() => {
              // on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module('ng1', ['ngAnimateMock'])
+             angular.module_('ng1', ['ngAnimateMock'])
                  .component('ng1', {
                    controller: class {
                      constructor(private $element: angular.IAugmentedJQuery) {} $onInit() {
@@ -2285,7 +2285,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             angular.module('ng1Module', [])
+             angular.module_('ng1Module', [])
                  .component('ng1', ng1Component)
                  .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2351,7 +2351,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             angular.module('ng1Module', [])
+             angular.module_('ng1Module', [])
                  .component('ng1', ng1Component)
                  .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2405,7 +2405,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2443,7 +2443,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2483,7 +2483,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2523,7 +2523,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1A', () => ng1DirectiveA)
                                    .directive('ng1B', () => ng1DirectiveB)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2562,7 +2562,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2615,7 +2615,7 @@ withEachNg1Version(() => {
 
                   // Define `ng1Module`
                   const ng1Module =
-                      angular.module('ng1Module', [])
+                      angular.module_('ng1Module', [])
                           .component('ng1', ng1Component)
                           .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
@@ -2680,7 +2680,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2739,7 +2739,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2813,7 +2813,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2879,7 +2879,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -2929,7 +2929,7 @@ withEachNg1Version(() => {
 
              // Define `ng1Module`
              const ng1Module =
-                 angular.module('ng1Module', [])
+                 angular.module_('ng1Module', [])
                      .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                      .component('ng1', ng1Component)
                      .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
@@ -2985,7 +2985,7 @@ withEachNg1Version(() => {
 
                   // Define `ng1Module`
                   const ng1Module =
-                      angular.module('ng1Module', [])
+                      angular.module_('ng1Module', [])
                           .component('ng1', ng1Component)
                           .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
@@ -3024,7 +3024,7 @@ withEachNg1Version(() => {
 
       it('should bind input properties (<) of components', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = {
              bindings: {personProfile: '<'},
@@ -3056,7 +3056,7 @@ withEachNg1Version(() => {
 
       it('should support ng2 > ng1 > ng2', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
 
            const ng1 = {
              template: 'ng1(<ng2b></ng2b>)',
@@ -3099,7 +3099,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module('myExample', []);
+           const module = angular.module_('myExample', []);
            module.factory('someToken', adapter.downgradeNg2Provider(SomeToken));
            adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
              expect(ref.ng1Injector.get('someToken')).toBe('correct_value');
@@ -3113,7 +3113,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module('myExample', []);
+           const module = angular.module_('myExample', []);
            module.value('testValue', 'secreteToken');
            adapter.upgradeNg1Provider('testValue');
            adapter.upgradeNg1Provider('testValue', {asToken: 'testToken'});
@@ -3128,7 +3128,7 @@ withEachNg1Version(() => {
 
       fixmeIvy('FW-714: ng1 projected content is not being rendered')
           .it('should respect hierarchical dependency injection for ng2', async(() => {
-                const ng1Module = angular.module('ng1', []);
+                const ng1Module = angular.module_('ng1', []);
 
                 @Component(
                     {selector: 'ng2-parent', template: `ng2-parent(<ng-content></ng-content>)`})
@@ -3162,7 +3162,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module('ng1', []);
+           angular.module_('ng1', []);
            let bootstrapResumed: boolean = false;
 
            const element = html('<div></div>');
@@ -3185,7 +3185,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            let a1Injector: angular.IInjectorService|undefined;
            ng1Module.run([
              '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
@@ -3208,7 +3208,7 @@ withEachNg1Version(() => {
            }
 
            const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module('ng1', []);
+           angular.module_('ng1', []);
            const element = html('<div></div>');
            adapter.bootstrap(element, ['ng1']).ready((ref) => {
              const ng2Testability: Testability = ref.ng2Injector.get(Testability);
@@ -3232,7 +3232,7 @@ withEachNg1Version(() => {
       fixmeIvy('FW-714: ng1 projected content is not being rendered')
           .it('should verify UpgradeAdapter example', async(() => {
                 const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-                const module = angular.module('myExample', []);
+                const module = angular.module_('myExample', []);
 
                 const ng1 = () => {
                   return {
@@ -3276,7 +3276,7 @@ withEachNg1Version(() => {
       let $rootScope: angular.IRootScopeService;
 
       beforeEach(() => {
-        const ng1Module = angular.module('ng1', []);
+        const ng1Module = angular.module_('ng1', []);
 
         @Component({
           selector: 'ng2',

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -143,7 +143,7 @@ export function downgradeModule<T>(
   let injector: Injector;
 
   // Create an ng1 module to bootstrap.
-  angular.module(lazyModuleName, [])
+  angular.module_(lazyModuleName, [])
       .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Lite)
       .factory(INJECTOR_KEY, [lazyInjectorKey, identity])
       .factory(

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModule, NgZone, Testability} from '@angular/core';
+import {Injector, NgModule, NgZone, Testability, isDevMode} from '@angular/core';
 
 import * as angular from '../../src/common/src/angular1';
 import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../../src/common/src/constants';
@@ -255,8 +255,18 @@ export class UpgradeModule {
                 // stabilizing
                 setTimeout(() => {
                   const $rootScope = $injector.get('$rootScope');
-                  const subscription =
-                      this.ngZone.onMicrotaskEmpty.subscribe(() => $rootScope.$digest());
+                  const subscription = this.ngZone.onMicrotaskEmpty.subscribe(() => {
+                    if ($rootScope.$$phase) {
+                      if (isDevMode()) {
+                        console.warn(
+                            'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.');
+                      }
+
+                      return $rootScope.$evalAsync();
+                    }
+
+                    return $rootScope.$digest();
+                  });
                   $rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                 }, 0);
               }

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -171,7 +171,7 @@ export class UpgradeModule {
     // Create an ng1 module to bootstrap
     const initModule =
         angular
-            .module(INIT_MODULE_NAME, [])
+            .module_(INIT_MODULE_NAME, [])
 
             .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
 
@@ -262,7 +262,7 @@ export class UpgradeModule {
               }
             ]);
 
-    const upgradeModule = angular.module(UPGRADE_MODULE_NAME, [INIT_MODULE_NAME].concat(modules));
+    const upgradeModule = angular.module_(UPGRADE_MODULE_NAME, [INIT_MODULE_NAME].concat(modules));
 
     // Make sure resumeBootstrap() only exists if the current bootstrap is deferred
     const windowAngular = (window as any)['angular'];

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -19,9 +19,64 @@ import {html, withEachNg1Version} from '../../../src/common/test/helpers/common_
 import {bootstrap} from './static_test_helpers';
 
 withEachNg1Version(() => {
-  describe('scope/component change-detection', () => {
+  describe('change-detection', () => {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
+
+    it('should not break if a $digest is already in progress', async(() => {
+         const element = html('<my-app></my-app>');
+
+         @Component({selector: 'my-app', template: ''})
+         class AppComponent {
+         }
+
+         @NgModule({
+           declarations: [AppComponent],
+           entryComponents: [AppComponent],
+           imports: [BrowserModule, UpgradeModule]
+         })
+         class Ng2Module {
+           ngDoBootstrap() {}
+         }
+
+         const ng1Module = angular.module('ng1', []).directive(
+             'myApp', downgradeComponent({component: AppComponent}));
+
+         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+           const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
+           const ngZone: NgZone = upgrade.ngZone;
+
+           // Wrap in a setTimeout to ensure all boostrap operations have completed.
+           setTimeout(
+               // Run inside the Angular zone, so that operations such as emitting
+               // `onMicrotaskEmpty` do not trigger entering/existing the zone (and thus another
+               // `$digest`). This also closer simulates what would happen in a real app.
+               () => ngZone.run(() => {
+                 const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
+
+                 // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
+                 ngZone.onMicrotaskEmpty.emit(null);
+                 expect(digestSpy).toHaveBeenCalledTimes(1);
+
+                 digestSpy.calls.reset();
+
+                 // Step 2: Cause the issue.
+                 $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
+
+                 // With the fix, `$digest` will only be run once (for `$apply()`).
+                 // Without the fix, `$digest()` would have been run an extra time
+                 // (`onMicrotaskEmpty`).
+                 expect(digestSpy).toHaveBeenCalledTimes(1);
+
+                 digestSpy.calls.reset();
+
+                 // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
+                 ngZone.onMicrotaskEmpty.emit(null);
+                 expect(digestSpy).toHaveBeenCalledTimes(1);
+               }),
+               0);
+         });
+       }));
 
     it('should interleave scope and component expressions', async(() => {
          const log: string[] = [];

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -61,7 +61,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .directive('ng1a', () => ({template: '{{ l(\'ng1a\') }}'}))
                                .directive('ng1b', () => ({template: '{{ l(\'ng1b\') }}'}))
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
@@ -125,7 +125,7 @@ withEachNg1Version(() => {
                 ngDoBootstrap() {}
               }
 
-              const ng1Module = angular.module('ng1', []).directive(
+              const ng1Module = angular.module_('ng1', []).directive(
                   'myApp', downgradeComponent({component: AppComponent}));
 
               bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -39,7 +39,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'myApp', downgradeComponent({component: AppComponent}));
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
@@ -200,7 +200,7 @@ withEachNg1Version(() => {
     //      }
 
     //      const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-    //      const ng1Module = angular.module('ng1', []).directive(
+    //      const ng1Module = angular.module_('ng1', []).directive(
     //          'myApp', adapter.downgradeNg2Component(AppComponent));
 
     //      const element = html('<my-app></my-app>');

--- a/packages/upgrade/static/test/integration/content_projection_spec.ts
+++ b/packages/upgrade/static/test/integration/content_projection_spec.ts
@@ -45,7 +45,7 @@ withEachNg1Version(() => {
 
               // the ng1 app module that will consume the downgraded component
               const ng1Module = angular
-                                    .module('ng1', [])
+                                    .module_('ng1', [])
                                     // create an ng1 facade of the ng2 component
                                     .directive('ng2', downgradeComponent({component: Ng2Component}))
                                     .run(($rootScope: angular.IRootScopeService) => {
@@ -79,7 +79,7 @@ withEachNg1Version(() => {
               }
 
               const ng1Module =
-                  angular.module('ng1', [])
+                  angular.module_('ng1', [])
                       .directive('ng2', downgradeComponent({component: Ng2Component}))
                       .run(($rootScope: angular.IRootScopeService) => {
                         $rootScope['items'] = [
@@ -128,7 +128,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1', () => ({
                                      transclude: true,
                                      template: '{{ prop }}(<ng-transclude></ng-transclude>)'
@@ -167,7 +167,7 @@ withEachNg1Version(() => {
                 ngDoBootstrap() {}
               }
 
-              const ng1Module = angular.module('ng1', []).directive(
+              const ng1Module = angular.module_('ng1', []).directive(
                   'ng2', downgradeComponent({component: Ng2Component}));
 
               // The ng-if on one of the projected children is here to make sure

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -25,7 +25,7 @@ withEachNg1Version(() => {
 
     fixmeIvy('FW-715: ngOnChanges being called a second time unexpectedly')
         .it('should bind properties, events', async(() => {
-              const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+              const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
                 $rootScope['name'] = 'world';
                 $rootScope['dataA'] = 'A';
                 $rootScope['dataB'] = 'B';
@@ -150,7 +150,7 @@ withEachNg1Version(() => {
             }));
 
     it('should bind properties to onpush components', async(() => {
-         const ng1Module = angular.module('ng1', []).run(
+         const ng1Module = angular.module_('ng1', []).run(
              ($rootScope: angular.IScope) => { $rootScope['dataB'] = 'B'; });
 
          @Component({
@@ -193,7 +193,7 @@ withEachNg1Version(() => {
     fixmeIvy('FW-715: ngOnChanges being called a second time unexpectedly')
         .it('should support two-way binding and event listener', async(() => {
               const listenerSpy = jasmine.createSpy('$rootScope.listener');
-              const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+              const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
                 $rootScope['value'] = 'world';
                 $rootScope['listener'] = listenerSpy;
               });
@@ -263,7 +263,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
                                  $rootScope.value1 = 0;
@@ -327,7 +327,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng2', downgradeComponent({component: Ng2Component, propagateDigest: false}))
                  .run(($rootScope: angular.IRootScopeService) => {
@@ -389,7 +389,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng2A', downgradeComponent({component: Ng2Component, propagateDigest: true}))
                  .directive(
@@ -444,7 +444,7 @@ withEachNg1Version(() => {
                 ngDoBootstrap() {}
               }
 
-              const ng1Module = angular.module('ng1', []).directive(
+              const ng1Module = angular.module_('ng1', []).directive(
                   'ng2', downgradeComponent({component: Ng2Component}));
 
               const element = html(`
@@ -467,7 +467,7 @@ withEachNg1Version(() => {
             }));
 
     it('should bind to ng-model', async(() => {
-         const ng1Module = angular.module('ng1', []).run(
+         const ng1Module = angular.module_('ng1', []).run(
              ($rootScope: angular.IScope) => { $rootScope['modelA'] = 'A'; });
 
          let ng2Instance: Ng2;
@@ -539,7 +539,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng1',
                      () => { return {template: '<div ng-if="!destroyIt"><ng2></ng2></div>'}; })
@@ -592,7 +592,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
                  .directive('ng2Inner', downgradeComponent({component: Ng2InnerComponent}))
                  .directive('ng2Outer', downgradeComponent({component: Ng2OuterComponent}));
@@ -627,7 +627,7 @@ withEachNg1Version(() => {
          }
 
          const ng1Module =
-             angular.module('ng1', [])
+             angular.module_('ng1', [])
                  .directive(
                      'ng1',
                      [
@@ -672,7 +672,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'worksComponent', downgradeComponent({component: WorksComponent}));
 
          const element = html('<works-component></works-component>');
@@ -700,7 +700,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'rootComponent', downgradeComponent({component: RootComponent}));
 
          const element = html('<root-component></root-component>');
@@ -731,7 +731,7 @@ withEachNg1Version(() => {
               }
 
               const ng1Module =
-                  angular.module('ng1', [])
+                  angular.module_('ng1', [])
                       .directive('parent', downgradeComponent({component: ParentComponent}))
                       .directive('child', downgradeComponent({component: ChildComponent}));
 
@@ -773,7 +773,7 @@ withEachNg1Version(() => {
               class LazyLoadedModule {
               }
 
-              const ng1Module = angular.module('ng1', []).directive(
+              const ng1Module = angular.module_('ng1', []).directive(
                   'ng2', downgradeComponent({component: Ng2Component}));
 
               const element = html('<ng2></ng2>');
@@ -808,7 +808,7 @@ withEachNg1Version(() => {
          }
 
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'ng2', downgradeComponent({component: Ng2Component, downgradedModule: 'foo'}));
 
          const element = html('<ng2></ng2>');

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -63,7 +63,7 @@ withEachNg1Version(() => {
 
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module('ng1', [downModA, downModB])
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
                                  .directive('ng2A', downgradeComponent({
                                               component: Ng2ComponentA,
                                               downgradedModule: downModA, propagateDigest,
@@ -131,7 +131,7 @@ withEachNg1Version(() => {
            const downModA = doDowngradeModule(Ng2ModuleA);
            const downModB = doDowngradeModule(Ng2ModuleB);
            const ng1Module =
-               angular.module('ng1', [downModA, downModB])
+               angular.module_('ng1', [downModA, downModB])
                    .directive('ng1A', () => ({template: 'ng1A(<ng2-b ng-if="showB"></ng2-b>)'}))
                    .directive('ng2A', downgradeComponent({
                                 component: Ng2ComponentA,
@@ -205,7 +205,7 @@ withEachNg1Version(() => {
 
                 const downModA = doDowngradeModule(Ng2ModuleA);
                 const downModB = doDowngradeModule(Ng2ModuleB);
-                const ng1Module = angular.module('ng1', [downModA, downModB])
+                const ng1Module = angular.module_('ng1', [downModA, downModB])
                                       .directive('ng2A', downgradeComponent({
                                                    component: Ng2ComponentA,
                                                    downgradedModule: downModA, propagateDigest,
@@ -299,7 +299,7 @@ withEachNg1Version(() => {
 
                 const downModA = doDowngradeModule(Ng2ModuleA);
                 const downModB = doDowngradeModule(Ng2ModuleB);
-                const ng1Module = angular.module('ng1', [downModA, downModB])
+                const ng1Module = angular.module_('ng1', [downModA, downModB])
                                       .directive('ng2A', downgradeComponent({
                                                    component: Ng2ComponentA,
                                                    downgradedModule: downModA, propagateDigest,
@@ -391,7 +391,7 @@ withEachNg1Version(() => {
 
                 const downMod = downgradeModule(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [downMod])
+                    angular.module_('ng1', [downMod])
                         .directive(
                             'ng2A', downgradeComponent({component: Ng2ComponentA, propagateDigest}))
                         .directive(
@@ -501,7 +501,7 @@ withEachNg1Version(() => {
 
                 const downModA = doDowngradeModule(Ng2ModuleA);
                 const downModB = doDowngradeModule(Ng2ModuleB);
-                const ng1Module = angular.module('ng1', [downModA, downModB])
+                const ng1Module = angular.module_('ng1', [downModA, downModB])
                                       .directive('ng2A', downgradeComponent({
                                                    component: Ng2ComponentA,
                                                    downgradedModule: downModA, propagateDigest,
@@ -568,7 +568,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2AComponent, propagateDigest}))
                    .run(($rootScope: angular.IRootScopeService) => $rootScope.value = 0);
@@ -631,7 +631,7 @@ withEachNg1Version(() => {
                     platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
                 const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [lazyModuleName])
+                    angular.module_('ng1', [lazyModuleName])
                         .directive(
                             'ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                         .value('ng1Value', 'foo');
@@ -676,7 +676,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -711,7 +711,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -752,7 +752,7 @@ withEachNg1Version(() => {
                     platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
                 const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [lazyModuleName])
+                    angular.module_('ng1', [lazyModuleName])
                         .directive(
                             'ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                         .run(($rootScope: angular.IRootScopeService) => {
@@ -822,7 +822,7 @@ withEachNg1Version(() => {
                     platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
                 const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [lazyModuleName])
+                    angular.module_('ng1', [lazyModuleName])
                         .directive(
                             'test', downgradeComponent({component: TestComponent, propagateDigest}))
                         .directive(
@@ -871,7 +871,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -924,7 +924,7 @@ withEachNg1Version(() => {
                     platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
                 const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [lazyModuleName])
+                    angular.module_('ng1', [lazyModuleName])
                         .directive(
                             'test', downgradeComponent({component: TestComponent, propagateDigest}))
                         .directive(
@@ -996,7 +996,7 @@ withEachNg1Version(() => {
                     platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
                 const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
                 const ng1Module =
-                    angular.module('ng1', [lazyModuleName])
+                    angular.module_('ng1', [lazyModuleName])
                         .directive(
                             'ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                         .run(($rootScope: angular.IRootScopeService) => {
@@ -1140,7 +1140,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1197,7 +1197,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1252,7 +1252,7 @@ withEachNg1Version(() => {
                platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
            const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
            const ng1Module =
-               angular.module('ng1', [lazyModuleName])
+               angular.module_('ng1', [lazyModuleName])
                    .directive(
                        'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
@@ -1317,7 +1317,7 @@ withEachNg1Version(() => {
         afterEach(() => setTempInjectorRef(null !));
 
         it('should throw if no downgraded module is included', async(() => {
-             const ng1Module = angular.module('ng1', [])
+             const ng1Module = angular.module_('ng1', [])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,
@@ -1349,7 +1349,7 @@ withEachNg1Version(() => {
            }));
 
         it('should throw if the corresponding downgraded module is not included', async(() => {
-             const ng1Module = angular.module('ng1', [downModA])
+             const ng1Module = angular.module_('ng1', [downModA])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,
@@ -1375,7 +1375,7 @@ withEachNg1Version(() => {
 
         it('should throw if `downgradedModule` is not specified and there are multiple downgraded modules',
            async(() => {
-             const ng1Module = angular.module('ng1', [downModA, downModB])
+             const ng1Module = angular.module_('ng1', [downModA, downModB])
                                    .value($EXCEPTION_HANDLER, errorSpy)
                                    .directive('ng2A', downgradeComponent({
                                                 component: Ng2CompA,

--- a/packages/upgrade/static/test/integration/examples_spec.ts
+++ b/packages/upgrade/static/test/integration/examples_spec.ts
@@ -66,7 +66,7 @@ withEachNg1Version(() => {
               // This module represents the AngularJS pieces of the application
               const ng1Module =
                   angular
-                      .module('myExample', [])
+                      .module_('myExample', [])
                       // This is an AngularJS component that will be upgraded
                       .directive(
                           'ng1',

--- a/packages/upgrade/static/test/integration/injection_spec.ts
+++ b/packages/upgrade/static/test/integration/injection_spec.ts
@@ -40,8 +40,8 @@ withEachNg1Version(() => {
          }
 
          // create the ng1 module that will import an ng2 service
-         const ng1Module =
-             angular.module('ng1Module', []).factory('ng2Service', downgradeInjectable(Ng2Service));
+         const ng1Module = angular.module_('ng1Module', [])
+                               .factory('ng2Service', downgradeInjectable(Ng2Service));
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then((upgrade) => {
@@ -71,7 +71,8 @@ withEachNg1Version(() => {
          }
 
          // create the ng1 module that will import an ng2 service
-         const ng1Module = angular.module('ng1Module', []).value('ng1Service', 'ng1 service value');
+         const ng1Module =
+             angular.module_('ng1Module', []).value('ng1Service', 'ng1 service value');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then((upgrade) => {
@@ -84,7 +85,7 @@ withEachNg1Version(() => {
        async(() => {
          let runBlockTriggered = false;
 
-         const ng1Module = angular.module('ng1Module', []).run([
+         const ng1Module = angular.module_('ng1Module', []).run([
            INJECTOR_KEY,
            function(injector: Injector) {
              runBlockTriggered = true;
@@ -124,7 +125,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1Module', []);
+         const ng1Module = angular.module_('ng1Module', []);
 
          bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
              .then(upgrade => expect(wrappedBootstrapCalled).toBe(true))

--- a/packages/upgrade/static/test/integration/testability_spec.ts
+++ b/packages/upgrade/static/test/integration/testability_spec.ts
@@ -31,7 +31,7 @@ withEachNg1Version(() => {
     it('should handle deferred bootstrap', fakeAsync(() => {
          let applicationRunning = false;
          let stayedInTheZone: boolean = undefined !;
-         const ng1Module = angular.module('ng1', []).run(() => {
+         const ng1Module = angular.module_('ng1', []).run(() => {
            applicationRunning = true;
            stayedInTheZone = NgZone.isInAngularZone();
          });
@@ -50,7 +50,7 @@ withEachNg1Version(() => {
        }));
 
     it('should propagate return value of resumeBootstrap', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          let a1Injector: angular.IInjectorService|undefined;
          ng1Module.run([
            '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
@@ -69,7 +69,7 @@ withEachNg1Version(() => {
        }));
 
     it('should wait for ng2 testability', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          const element = html('<div></div>');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
@@ -95,7 +95,7 @@ withEachNg1Version(() => {
        }));
 
     it('should not wait for $interval', fakeAsync(() => {
-         const ng1Module = angular.module('ng1', []);
+         const ng1Module = angular.module_('ng1', []);
          const element = html('<div></div>');
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -45,7 +45,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -85,7 +85,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -132,7 +132,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -173,7 +173,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -217,7 +217,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -268,7 +268,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                    .run(
@@ -313,7 +313,7 @@ withEachNg1Version(() => {
 
             // Define `ng1Module`
             const ng1Module =
-                angular.module('ng1Module', [])
+                angular.module_('ng1Module', [])
                     .component('ng1', ng1Component)
                     .directive('ng2', downgradeComponent({component: Ng2Component}))
                     .value(
@@ -364,7 +364,7 @@ withEachNg1Version(() => {
 
             // Define `ng1Module`
             const ng1Module =
-                angular.module('ng1Module', [])
+                angular.module_('ng1Module', [])
                     .component('ng1', ng1Component)
                     .directive('ng2', downgradeComponent({component: Ng2Component}))
                     .value(
@@ -434,7 +434,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1A', ng1ComponentA)
                                  .component('ng1B', ng1ComponentB)
                                  .component('ng1C', ng1ComponentC)
@@ -506,7 +506,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -583,7 +583,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -664,7 +664,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -737,7 +737,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -834,7 +834,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -917,7 +917,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1007,7 +1007,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1075,7 +1075,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .component('ng1A', ng1ComponentA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2X', downgradeComponent({component: Ng2ComponentX}));
@@ -1124,7 +1124,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1171,7 +1171,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1219,7 +1219,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1267,7 +1267,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1314,7 +1314,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1', [])
+           const ng1Module = angular.module_('ng1', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1379,7 +1379,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1452,7 +1452,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1506,7 +1506,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1554,7 +1554,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .controller('Ng1Controller', class { text = 'GREAT'; })
                                  .directive('ng1', () => ng1Directive)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1608,7 +1608,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1664,7 +1664,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .directive('ng1', () => ng1Directive)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -1716,7 +1716,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -1783,7 +1783,7 @@ withEachNg1Version(() => {
              // Define `ng1Module`
              const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
              const ng1Module =
-                 angular.module('ng1Module', [])
+                 angular.module_('ng1Module', [])
                      .component('ng1A', ng1ComponentA)
                      .component('ng1B', ng1ComponentB)
                      .component('ng1C', ng1ComponentC)
@@ -1854,7 +1854,7 @@ withEachNg1Version(() => {
 
              // Define `ng1Module`
              const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}))
                                    .value($EXCEPTION_HANDLER, mockExceptionHandler);
@@ -1929,7 +1929,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .component('ng1C', ng1ComponentC)
@@ -1995,7 +1995,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2052,7 +2052,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2110,7 +2110,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const ng1Module = angular.module('ng1Module', [])
+             const ng1Module = angular.module_('ng1Module', [])
                                    .component('ng1A', ng1ComponentA)
                                    .component('ng1B', ng1ComponentB)
                                    .component('ng1C', ng1ComponentC)
@@ -2175,7 +2175,7 @@ withEachNg1Version(() => {
 
                 // Define `ng1Module`
                 const ng1Module =
-                    angular.module('ng1Module', [])
+                    angular.module_('ng1Module', [])
                         .component('ng1', ng1Component)
                         .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -2236,7 +2236,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2302,7 +2302,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2377,7 +2377,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2450,7 +2450,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2509,7 +2509,7 @@ withEachNg1Version(() => {
 
            // Define `ng1Module`
            const ng1Module =
-               angular.module('ng1Module', [])
+               angular.module_('ng1Module', [])
                    .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2574,7 +2574,7 @@ withEachNg1Version(() => {
 
                 // Define `ng1Module`
                 const ng1Module =
-                    angular.module('ng1Module', [])
+                    angular.module_('ng1Module', [])
                         .component('ng1', ng1Component)
                         .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -2670,7 +2670,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}))
@@ -2823,7 +2823,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -2953,7 +2953,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3023,7 +3023,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3090,7 +3090,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3160,7 +3160,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3222,7 +3222,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3304,7 +3304,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3383,7 +3383,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3484,7 +3484,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .directive('ng1A', () => ng1DirectiveA)
                                  .directive('ng1B', () => ng1DirectiveB)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
@@ -3562,7 +3562,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -3619,7 +3619,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3683,7 +3683,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3750,7 +3750,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3819,7 +3819,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
@@ -3873,7 +3873,7 @@ withEachNg1Version(() => {
            }
 
            // Define `ng1Module`
-           const ng1Module = angular.module('ng1Module', [])
+           const ng1Module = angular.module_('ng1Module', [])
                                  .component('ng1', ng1Component)
                                  .directive('ng2', downgradeComponent({component: Ng2Component}));
 
@@ -3937,7 +3937,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1X', ng1Component)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
                                .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
@@ -4045,7 +4045,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1X', ng1Component)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
                                .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
@@ -4190,7 +4190,7 @@ withEachNg1Version(() => {
          }
 
          // Define `ng1Module`
-         const ng1Module = angular.module('ng1', [])
+         const ng1Module = angular.module_('ng1', [])
                                .component('ng1A', ng1ComponentA)
                                .component('ng1B', ng1ComponentB)
                                .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))


### PR DESCRIPTION
Backport of #30058 to 7.2.x.

##
**UPDATE:** This now, also, includes the changes from #29794 and #30126.