### PR TITLE
ci(docs-infra): fix and re-enable the `aio_monitoring` CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,19 +689,17 @@ workflows:
           cron: "0 * * * *"
           filters: *publish_branches_filter
 
-# This job is currently disabled due to a version skew problem.
-# More info is available here: https://github.com/angular/angular/issues/30101
-#  aio_monitoring:
-#    jobs:
-#      - aio_monitoring
-#    triggers:
-#      - schedule:
-#          # Runs AIO monitoring job at 00:00AM every day.
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - master
+  aio_monitoring:
+    jobs:
+      - aio_monitoring
+    triggers:
+      - schedule:
+          # Runs AIO monitoring job at 00:00AM every day.
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
 
 # TODO:
 # - don't build the g3 branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
       - *attach_workspace
       - *init_environment
         # Deploy angular.io to production (if necessary)
-      - run: setPublicVar CI_STABLE_BRANCH "$(npm info @angular/core dist-tags.latest | sed -r 's/^\s*([0-9]+\.[0-9]+)\.[0-9]+.*$/\1.x/')"
+      - run: setPublicVar_CI_STABLE_BRANCH
       - run: yarn --cwd aio deploy-production
 
   test_aio_local:
@@ -495,6 +495,12 @@ jobs:
     steps:
       - *attach_workspace
       - *init_environment
+      - run: setPublicVar_CI_STABLE_BRANCH
+      - run:
+          name: Check out `aio/` from the stable branch
+          command: |
+            git fetch origin $CI_STABLE_BRANCH
+            git checkout --force origin/$CI_STABLE_BRANCH -- aio/
       - run:
           name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,9 +493,7 @@ jobs:
       # which does not load the browser through the Bazel webtesting rules.
       - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - *attach_workspace
       - *init_environment
       - run:
           name: Run tests against the deployed apps
@@ -691,7 +689,10 @@ workflows:
 
   aio_monitoring:
     jobs:
-      - aio_monitoring
+      - setup
+      - aio_monitoring:
+          requires:
+            - setup
     triggers:
       - schedule:
           # Runs AIO monitoring job at 00:00AM every day.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
           command: 'openssl aes-256-cbc -d -in .circleci/github_token -k "${KEY}" -out ~/.git_credentials'
       - run: ./scripts/ci/publish-build-artifacts.sh
 
-  aio_monitoring:
+  aio_monitoring_stable:
     <<: *job_defaults
     docker:
       # This job needs Chrome to be globally installed because the tests run with Protractor
@@ -496,8 +496,27 @@ jobs:
       - *attach_workspace
       - *init_environment
       - run:
-          name: Run tests against the deployed apps
-          command: ./aio/scripts/test-production.sh $CI_AIO_MIN_PWA_SCORE
+          name: Run tests against the deployed app
+          command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE
+      - run:
+          name: Notify caretaker about failure
+          # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
+          # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+          command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $SLACK_CARETAKER_WEBHOOK_URL'
+          when: on_fail
+
+  aio_monitoring_next:
+    <<: *job_defaults
+    docker:
+      # This job needs Chrome to be globally installed because the tests run with Protractor
+      # which does not load the browser through the Bazel webtesting rules.
+      - image: *browsers_docker_image
+    steps:
+      - *attach_workspace
+      - *init_environment
+      - run:
+          name: Run tests against the deployed app
+          command: ./aio/scripts/test-production.sh https://next.angular.io/ $CI_AIO_MIN_PWA_SCORE
       - run:
           name: Notify caretaker about failure
           # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
@@ -690,12 +709,15 @@ workflows:
   aio_monitoring:
     jobs:
       - setup
-      - aio_monitoring:
+      - aio_monitoring_stable:
+          requires:
+            - setup
+      - aio_monitoring_next:
           requires:
             - setup
     triggers:
       - schedule:
-          # Runs AIO monitoring job at 00:00AM every day.
+          # Runs AIO monitoring jobs at 00:00AM every day.
           cron: "0 0 * * *"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,7 @@ jobs:
       - *attach_workspace
       - *init_environment
       - run:
-          name: Run tests against the deployed app
+          name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE
       - run:
           name: Notify caretaker about failure
@@ -515,7 +515,7 @@ jobs:
       - *attach_workspace
       - *init_environment
       - run:
-          name: Run tests against the deployed app
+          name: Run tests against https://next.angular.io/
           command: ./aio/scripts/test-production.sh https://next.angular.io/ $CI_AIO_MIN_PWA_SCORE
       - run:
           name: Notify caretaker about failure

--- a/.circleci/env-helpers.inc.sh
+++ b/.circleci/env-helpers.inc.sh
@@ -36,3 +36,38 @@ function setSecretVar() {
   # Restore original shell options.
   eval "$originalShellOptions";
 }
+
+
+# Create a function to set an environment variable, when called.
+#
+# Use this function for creating setter for public environment variables that require expensive or
+# time-consuming computaions and may not be needed. When needed, you can call this function to set
+# the environment variable (which will be available through `$BASH_ENV` from that point onwards).
+#
+# Arguments:
+# - `<name>`: The name of the environment variable. The generated setter function will be
+#   `setPublicVar_<name>`.
+# - `<code>`: The code to run to compute the value for the variable. Since this code should be
+#   executed lazily, it must be properly escaped. For example:
+#   ```sh
+#   # DO NOT do this:
+#   createPublicVarSetter MY_VAR "$(whoami)";  # `whoami` will be evaluated eagerly
+#
+#   # DO this isntead:
+#   createPublicVarSetter MY_VAR "\$(whoami)";  # `whoami` will NOT be evaluated eagerly
+#   ```
+#
+# Usage: `createPublicVarSetter <name> <code>`
+#
+# Example:
+# ```sh
+# createPublicVarSetter MY_VAR 'echo "FOO"';
+# echo $MY_VAR;  # Not defined
+#
+# setPublicVar_MY_VAR;
+# source $BASH_ENV;
+# echo $MY_VAR;  # FOO
+# ```
+function createPublicVarSetter() {
+  echo "setPublicVar_$1() { setPublicVar $1 \"$2\"; }" >> $BASH_ENV;
+}

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -35,6 +35,13 @@ setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";
 
 
 ####################################################################################################
+# Define "lazy" PUBLIC environment variables for CircleCI.
+# (I.e. functions to set an environment variable when called.)
+####################################################################################################
+createPublicVarSetter CI_STABLE_BRANCH "\$(npm info @angular/core dist-tags.latest | sed -r 's/^\\s*([0-9]+\\.[0-9]+)\\.[0-9]+.*$/\\1.x/')";
+
+
+####################################################################################################
 # Define SECRET environment variables for CircleCI.
 ####################################################################################################
 setSecretVar CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN "$AIO_DEPLOY_TOKEN";

--- a/aio/scripts/test-production.sh
+++ b/aio/scripts/test-production.sh
@@ -6,11 +6,8 @@ set +x -eu -o pipefail
   readonly aioDir="$(realpath $thisDir/..)"
 
   readonly protractorConf="$aioDir/tests/deployment/e2e/protractor.conf.js"
-  readonly minPwaScore="$1"
-  readonly urls=(
-    "https://angular.io/"
-    "https://next.angular.io/"
-  )
+  readonly targetUrl="$1"
+  readonly minPwaScore="$2"
 
   cd "$aioDir"
 
@@ -19,16 +16,14 @@ set +x -eu -o pipefail
   yarn install --frozen-lockfile --non-interactive
   yarn update-webdriver
 
-  # Run checks for all URLs.
-  for url in "${urls[@]}"; do
-    echo -e "\nChecking '$url'...\n-----"
+  # Run checks for target URL.
+  echo -e "\nChecking '$targetUrl'...\n-----"
 
-    # Run basic e2e and deployment config tests.
-    yarn protractor "$protractorConf" --baseUrl "$url"
+  # Run basic e2e and deployment config tests.
+  yarn protractor "$protractorConf" --baseUrl "$targetUrl"
 
-    # Run PWA-score tests.
-    yarn test-pwa-score "$url" "$minPwaScore"
-  done
+  # Run PWA-score tests.
+  yarn test-pwa-score "$targetUrl" "$minPwaScore"
 
   echo -e "\nAll checks passed!"
 )


### PR DESCRIPTION
The job was started failing and was disabled in #30102 (see #30101 for details).
This PR fixes and re-enabled the job (see individual commits for details).

Fixes #30101.