### PR TITLE
test: fix ngc-wrapped bazel tests in windows

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -202,7 +202,7 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
     throw new Error(`Couldn't find bazel bin in the rootDirs: ${compilerOpts.rootDirs}`);
   }
 
-  const writtenExpectedOuts = [...expectedOuts];
+  const writtenExpectedOuts = expectedOuts.map(p => p.replace(/\\/g, '/'));
 
   const originalWriteFile = tsHost.writeFile.bind(tsHost);
   tsHost.writeFile =

--- a/packages/bazel/test/ngc-wrapped/tsconfig_template.ts
+++ b/packages/bazel/test/ngc-wrapped/tsconfig_template.ts
@@ -7,7 +7,6 @@
  */
 
 import * as path from 'path';
-import * as ts from 'typescript';
 
 const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 
@@ -32,7 +31,6 @@ export function createTsConfig(options: TsConfigOptions) {
   const result = options.defaultTsConfig;
 
   return {
-    'extends': '../angular/packages/bazel/test/ngc-wrapped/empty/tsconfig',
     'compilerOptions': {
       ...result.compilerOptions,
       'outDir': options.outDir,
@@ -71,7 +69,8 @@ export function createTsConfig(options: TsConfigOptions) {
       'tsickleExternsPath': '',
       // we don't copy the node_modules into our tmp dir, so we should look in
       // the original workspace directory for it
-      'nodeModulesPrefix': '../npm/node_modules',
+      'nodeModulesPrefix':
+          path.join(require.resolve('npm/node_modules/typescript/package.json'), '../../'),
     },
     'files': options.files,
     'angularCompilerOptions': {


### PR DESCRIPTION

Fixes the below target in windows
```
//packages/bazel/test/ngc-wrapped:ngc_test
```

Partially addresses #29785

