### PR TITLE
feat(router): add an option to delegate/never reuse a route

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -448,6 +448,13 @@ export interface Route {
    */
   loadChildren?: LoadChildren;
   /**
+   * Determines if a route should be reused.
+   *
+   * - `delegate` : the default, delegates to a RouteReuseStrategy.
+   * - `never` : a route should never be reused.
+   */
+  reuse?: 'delegate'|'never';
+  /**
    * Defines when guards and resolvers will be run. One of
    * - `paramsOrQueryParamsChange` : Run when query parameters change.
    * - `always` : Run on every execution.

--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -22,8 +22,11 @@ export function createRouterState(
 function createNode(
     routeReuseStrategy: RouteReuseStrategy, curr: TreeNode<ActivatedRouteSnapshot>,
     prevState?: TreeNode<ActivatedRoute>): TreeNode<ActivatedRoute> {
+  const shouldNeverReuseRoute =
+      curr.value.routeConfig && curr.value.routeConfig !.reuse === 'never';
   // reuse an activated route that is currently displayed on the screen
-  if (prevState && routeReuseStrategy.shouldReuseRoute(curr.value, prevState.value.snapshot)) {
+  if (!shouldNeverReuseRoute && prevState &&
+      routeReuseStrategy.shouldReuseRoute(curr.value, prevState.value.snapshot)) {
     const value = prevState.value;
     value._futureSnapshot = curr.value;
     const children = createOrReuseChildren(routeReuseStrategy, curr, prevState);
@@ -65,7 +68,10 @@ function createOrReuseChildren(
     prevState: TreeNode<ActivatedRoute>) {
   return curr.children.map(child => {
     for (const p of prevState.children) {
-      if (routeReuseStrategy.shouldReuseRoute(p.value.snapshot, child.value)) {
+      const shouldNeverReuseRoute =
+          p.value.snapshot.routeConfig && p.value.snapshot.routeConfig.reuse === 'never';
+      if (!shouldNeverReuseRoute &&
+          routeReuseStrategy.shouldReuseRoute(p.value.snapshot, child.value)) {
         return createNode(routeReuseStrategy, child, p);
       }
     }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4644,6 +4644,82 @@ describe('Integration', () => {
          expect(teamCmp.route.firstChild.snapshot.params).toEqual({p: '2'});
        })));
 
+    describe('reuse', () => {
+      it('should never reuse routes',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([
+             {
+               path: 'a',
+               component: WrapperCmp,
+               reuse: 'never',
+               children: [
+                 {path: 'b', component: SimpleCmp},
+                 {path: 'c', component: SimpleCmp},
+               ]
+             },
+           ]);
+
+           router.navigateByUrl('/a/b');
+           advance(fixture);
+           const wrapperCmp = fixture.debugElement.children[1].componentInstance;
+           const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
+           expect(location.path()).toEqual('/a/b');
+           expect(wrapperCmp).toBeDefined();
+           expect(simpleCmp).toBeDefined();
+
+           router.navigateByUrl('/a/c');
+           advance(fixture);
+           expect(location.path()).toEqual('/a/c');
+           expect(fixture.debugElement.children[1].children[1].componentInstance)
+               .toBeAnInstanceOf(SimpleCmp);
+
+           router.navigateByUrl('/a/b');
+           advance(fixture);
+           const wrapperCmp2 = fixture.debugElement.children[1].componentInstance;
+           expect(location.path()).toEqual('/a/b');
+           expect(wrapperCmp2).not.toBe(wrapperCmp);
+         })));
+
+      it('should delegate route reusing to a RouteReuseStrategy',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([
+             {
+               path: 'a',
+               component: WrapperCmp,
+               reuse: 'delegate',
+               children: [
+                 {path: 'b', component: SimpleCmp},
+                 {path: 'c', component: SimpleCmp},
+               ]
+             },
+           ]);
+
+           router.navigateByUrl('/a/b');
+           advance(fixture);
+           const wrapperCmp = fixture.debugElement.children[1].componentInstance;
+           const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
+           expect(location.path()).toEqual('/a/b');
+           expect(wrapperCmp).toBeDefined();
+           expect(simpleCmp).toBeDefined();
+
+           router.navigateByUrl('/a/c');
+           advance(fixture);
+           expect(location.path()).toEqual('/a/c');
+           expect(fixture.debugElement.children[1].children[1].componentInstance)
+               .toBeAnInstanceOf(SimpleCmp);
+
+           router.navigateByUrl('/a/b');
+           advance(fixture);
+           const wrapperCmp2 = fixture.debugElement.children[1].componentInstance;
+           expect(location.path()).toEqual('/a/b');
+           expect(wrapperCmp2).toBe(wrapperCmp);
+         })));
+    });
+
     it('should support shorter lifecycles',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = createRoot(router, RootCmp);

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -297,6 +297,7 @@ export interface Route {
     pathMatch?: string;
     redirectTo?: string;
     resolve?: ResolveData;
+    reuse?: 'delegate' | 'never';
     runGuardsAndResolvers?: RunGuardsAndResolvers;
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
It is pretty simple to set one property to route config to disable route reuse strategy instead of configuring RouteReuseStrategy.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

