### PR TITLE
fix: ensure strict mode when evaluating in JIT

### DIFF
--- a/packages/compiler/src/output/output_jit.ts
+++ b/packages/compiler/src/output/output_jit.ts
@@ -31,6 +31,13 @@ export class JitEvaluator {
       createSourceMaps: boolean): {[key: string]: any} {
     const converter = new JitEmitterVisitor(reflector);
     const ctx = EmitterVisitorContext.createRoot();
+    // Ensure generated code is in strict mode
+    if (statements.length > 0 && !isUseStrictStatement(statements[0])) {
+      statements = [
+        o.literal('use strict').toStmt(),
+        ...statements,
+      ];
+    }
     converter.visitAllStatements(statements, ctx);
     converter.createReturnStmt(ctx);
     return this.evaluateCode(sourceUrl, ctx, converter.getArgs(), createSourceMaps);
@@ -49,7 +56,7 @@ export class JitEvaluator {
   evaluateCode(
       sourceUrl: string, ctx: EmitterVisitorContext, vars: {[key: string]: any},
       createSourceMap: boolean): any {
-    let fnBody = `"use strict";${ctx.toSource()}\n//# sourceURL=${sourceUrl}`;
+    let fnBody = `${ctx.toSource()}\n//# sourceURL=${sourceUrl}`;
     const fnArgNames: string[] = [];
     const fnArgValues: any[] = [];
     for (const argName in vars) {
@@ -149,4 +156,9 @@ export class JitEmitterVisitor extends AbstractJsEmitterVisitor {
     }
     ctx.print(ast, this._evalArgNames[id]);
   }
+}
+
+
+function isUseStrictStatement(statement: o.Statement): boolean {
+  return statement.isEquivalent(o.literal('use strict').toStmt());
 }

--- a/packages/compiler/src/output/output_jit.ts
+++ b/packages/compiler/src/output/output_jit.ts
@@ -49,7 +49,7 @@ export class JitEvaluator {
   evaluateCode(
       sourceUrl: string, ctx: EmitterVisitorContext, vars: {[key: string]: any},
       createSourceMap: boolean): any {
-    let fnBody = `${ctx.toSource()}\n//# sourceURL=${sourceUrl}`;
+    let fnBody = `"use strict";${ctx.toSource()}\n//# sourceURL=${sourceUrl}`;
     const fnArgNames: string[] = [];
     const fnArgValues: any[] = [];
     for (const argName in vars) {

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -8,7 +8,8 @@
 
 import {EmitterVisitorContext} from '@angular/compiler/src/output/abstract_emitter';
 import * as o from '@angular/compiler/src/output/output_ast';
-import {JitEmitterVisitor} from '@angular/compiler/src/output/output_jit';
+import {JitEmitterVisitor, JitEvaluator} from '@angular/compiler/src/output/output_jit';
+import {R3JitReflector} from '@angular/compiler/src/render3/r3_jit';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
 
 const anotherModuleUrl = 'somePackage/someOtherPath';
@@ -31,6 +32,20 @@ const anotherModuleUrl = 'somePackage/someOtherPath';
         const args = converter.getArgs();
         expect(Object.keys(args).length).toBe(20);
       });
+    });
+
+    it('should use strict mode', () => {
+      const evaluator = new JitEvaluator();
+      expect(() => {
+        evaluator.evaluateStatements(
+            'http://angular.io/something.ts',
+            [
+              // Set an undeclared variable
+              // foo = "bar";
+              o.variable('foo').equals(o.literal('bar')).toStmt(),
+            ],
+            new R3JitReflector({}), false);
+      }).toThrowError();
     });
   });
 }

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -47,5 +47,17 @@ const anotherModuleUrl = 'somePackage/someOtherPath';
             new R3JitReflector({}), false);
       }).toThrowError();
     });
+
+    it('should not add more than one strict mode statement if there is already one present', () => {
+      const converter = new JitEmitterVisitor(new JitReflector());
+      const ctx = EmitterVisitorContext.createRoot();
+      converter.visitAllStatements(
+          [
+            o.literal('use strict').toStmt(),
+          ],
+          ctx);
+      const matches = ctx.toSource().match(/'use strict';/g) !;
+      expect(matches.length).toBe(1);
+    });
   });
 }


### PR DESCRIPTION
To help prevent regressions that could be caused by poor compiler behavior, this fix ensures that all code executed by the JIT evaluator is in strict mode.