### PR TITLE
test(upgrade): rename `angular.module()` to `angular.module_()`

### DIFF
--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -179,7 +179,7 @@ withEachNg1Version(() => {
            class Ng2Module {
            }
 
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module = angular.module_('ng1', []);
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const element = html('<my-app></my-app>');
 
@@ -315,7 +315,7 @@ withEachNg1Version(() => {
       //      }
 
       //      const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-      //      const ng1Module = angular.module('ng1', []).directive(
+      //      const ng1Module = angular.module_('ng1', []).directive(
       //          'myApp', adapter.downgradeNg2Component(AppComponent));
 
       //      const element = html('<my-app></my-app>');

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -38,7 +38,7 @@ withEachNg1Version(() => {
            ngDoBootstrap() {}
          }
 
-         const ng1Module = angular.module('ng1', []).directive(
+         const ng1Module = angular.module_('ng1', []).directive(
              'myApp', downgradeComponent({component: AppComponent}));
 
          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
@@ -193,7 +193,7 @@ withEachNg1Version(() => {
     //      }
 
     //      const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-    //      const ng1Module = angular.module('ng1', []).directive(
+    //      const ng1Module = angular.module_('ng1', []).directive(
     //          'myApp', adapter.downgradeNg2Component(AppComponent));
 
     //      const element = html('<my-app></my-app>');


### PR DESCRIPTION
With #30058, the ngUpgrade internal `angular.module()` method was renamed to `angular.module_()` (to avoid a webpack bug).

Merging #29794 afterwards resulted in some broken tests, because it still used the old `angular.module()` method name. (The PR had been tested on CI against a revision that did not contain the rename.)

This commit fixes the broken tests by renaming the remaining occurrences of `angular.module()`.

##
I have also incorporated the changes in #30107 for 7.2.x.