### PR TITLE
build: unable to accept new symbol-extractor golden on windows

### DIFF
--- a/tools/symbol-extractor/cli.ts
+++ b/tools/symbol-extractor/cli.ts
@@ -43,7 +43,7 @@ function main(argv: [string, string, string] | [string, string]): boolean {
       const defineFlag = (compile !== 'legacy') ? `--define=compile=${compile} ` : '';
       console.error(`TEST FAILED!`);
       console.error(`  To update the golden file run: `);
-      console.error(`    yarn bazel run ${defineFlag}${process.env['BAZEL_TARGET']}.accept`);
+      console.error(`    yarn bazel run ${defineFlag}${process.env['TEST_TARGET']}.accept`);
     }
   }
   return passed;

--- a/tools/symbol-extractor/index.bzl
+++ b/tools/symbol-extractor/index.bzl
@@ -3,12 +3,11 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-"""This test verifies that a set of top level symbols from a javascript file match a gold file.
-"""
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
 
-# This does a deep import under //internal because of not wanting the wrapper macro
-# because it introduces an extra target_bin target.
-load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary", "nodejs_test")
+"""
+  This test verifies that a set of top level symbols from a javascript file match a gold file.
+"""
 
 def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
     """This test verifies that a set of top level symbols from a javascript file match a gold file.
@@ -17,7 +16,6 @@ def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
         src,
         golden,
         Label("//tools/symbol-extractor:lib"),
-        Label("@bazel_tools//tools/bash/runfiles"),
         Label("@npm//typescript"),
     ]
     entry_point = "angular/tools/symbol-extractor/cli.js"


### PR DESCRIPTION
Currently when working on Windows, it's not possibly to accept a new
golden for a `symbol-extractor` Bazel test. This is because the generated
executable output from the `nodejs_binary` rule (without a macro) misses
a Windows executable wrapper that sets up the proper environment
variables for the runfiles. Causing the following failure on Windows:

```
 >>>> FAIL: RUNFILES environment variable is not set. <<<<
```