### PR TITLE
fix(ivy): remove debug utilities from ivy production builds

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 157393,
+        "main": 149205,
         "polyfills": 43567
       }
     }

--- a/packages/platform-browser/src/dom/debug/ng_probe.ts
+++ b/packages/platform-browser/src/dom/debug/ng_probe.ts
@@ -37,9 +37,18 @@ function _ngProbeTokensToMap(tokens: core.NgProbeToken[]): {[name: string]: any}
 }
 
 /**
+ * In Ivy, we don't support NgProbe because we have our own set of testing utilities
+ * with more robust functionality.
+ *
+ * We shouldn't bring in NgProbe because it prevents DebugNode and friends from
+ * tree-shaking properly.
+ */
+export const ELEMENT_PROBE_PROVIDERS__POST_R3__ = [];
+
+/**
  * Providers which support debugging Angular applications (e.g. via `ng.probe`).
  */
-export const ELEMENT_PROBE_PROVIDERS: core.Provider[] = [
+export const ELEMENT_PROBE_PROVIDERS__PRE_R3__: core.Provider[] = [
   {
     provide: core.APP_INITIALIZER,
     useFactory: _createNgProbe,
@@ -49,3 +58,5 @@ export const ELEMENT_PROBE_PROVIDERS: core.Provider[] = [
     multi: true,
   },
 ];
+
+export const ELEMENT_PROBE_PROVIDERS = ELEMENT_PROBE_PROVIDERS__PRE_R3__;

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -18,3 +18,5 @@ export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl,
 
 export * from './private_export';
 export {VERSION} from './version';
+// This must be exported so it doesn't get tree-shaken away prematurely
+export {ELEMENT_PROBE_PROVIDERS__POST_R3__ as ɵELEMENT_PROBE_PROVIDERS__POST_R3__} from './dom/debug/ng_probe';


### PR DESCRIPTION
Prior to this commit, we were pulling DebugNode and DebugElement
into production builds because BrowserModule automatically pulled
in NgProbe and thus getDebugNode. In Ivy, this is not necessary
because Ivy has its own set of debug utilities. We should use these
existing tools instead of NgProbe.

This commit adds an Ivy switch so we do not pull in NgProbe utilities
when running with Ivy. This saves us ~8KB in prod builds.

Note: Master is red for unrelated size regressions :-(