### PR TITLE
fix(bazel): Exclude common/upgrade* in metadata.tsconfig.json

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -9,7 +9,7 @@ function installLocalPackages() {
   readonly pwd=$(pwd)
   readonly packages=(
     animations common compiler core forms platform-browser
-    platform-browser-dynamic router bazel compiler-cli language-service upgrade
+    platform-browser-dynamic router bazel compiler-cli language-service
   )
   local local_packages=()
   for package in "${packages[@]}"; do

--- a/integration/bazel/angular-metadata.tsconfig.json
+++ b/integration/bazel/angular-metadata.tsconfig.json
@@ -23,6 +23,7 @@
     "node_modules/@angular/core/schematics/**",
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/**/testing/**",
+    "node_modules/@angular/common/upgrade*",
     "node_modules/@angular/router/upgrade*"
   ]
 }

--- a/integration/bazel/src/package.json
+++ b/integration/bazel/src/package.json
@@ -10,7 +10,6 @@
     "@angular/platform-browser": "packages-dist:platform-browser",
     "@angular/platform-browser-dynamic": "packages-dist:platform-browser-dynamic",
     "@angular/router": "packages-dist:router",
-    "@angular/upgrade": "packages-dist:upgrade",
     "reflect-metadata": "0.1.12",
     "rxjs": "6.4.0",
     "tslib": "1.9.3",

--- a/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
+++ b/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
@@ -20,6 +20,7 @@
     "node_modules/@angular/core/schematics/**",
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/**/testing/**",
+    "node_modules/@angular/common/upgrade*",
     "node_modules/@angular/router/upgrade*"
   ]
 }


### PR DESCRIPTION
It has a dependency on @angular/upgrade which is not part of the
dependencies in package.json, so postinstall would fail.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
