### PR TITLE
ci: don't sync most of /modules/** except for benchmarks

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -35,7 +35,8 @@ merge:
     # this list must be manually kept in sync with google3/third_party/javascript/angular2/copy.bara.sky
     include:
       - "LICENSE"
-      - "modules/**"
+      - "modules/benchmarks/**"
+      - "modules/system.d.ts"
       - "packages/**"
     # list of patterns to ignore for the files changed by the PR
     exclude:


### PR DESCRIPTION
we don't need these files in g3 and they just create sync noise.

CL to remove this from g3 is: cl/245342562
