### PR TITLE
test: fix Bazel compiler tests in windows

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -20,5 +20,5 @@ steps:
     # Add Bazel CI config
     - copy .codefresh\bazel.rc %ProgramData%\bazel.bazelrc
     # Run tests
-    - yarn bazel test //tools/ts-api-guardian:all
+    - yarn bazel test //tools/ts-api-guardian:all //packages/compiler/test
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -577,7 +577,7 @@ function readBazelWrittenFilesFrom(
     const entries = fs.readdirSync(dir);
     for (const name of entries) {
       const fullName = path.join(dir, name);
-      const destName = path.join(dest, name);
+      const destName = path.posix.join(dest, name);
       const stat = fs.statSync(fullName);
       if (!skip(name, fullName)) {
         if (stat.isDirectory()) {
@@ -590,11 +590,11 @@ function readBazelWrittenFilesFrom(
     }
   }
   try {
-    processDirectory(bazelPackageRoot, path.join('/node_modules/@angular', packageName));
+    processDirectory(bazelPackageRoot, path.posix.join('node_modules/@angular', packageName));
     // todo: check why we always need an index.d.ts
     if (fs.existsSync(path.join(bazelPackageRoot, `${packageName}.d.ts`))) {
       const content = fs.readFileSync(path.join(bazelPackageRoot, `${packageName}.d.ts`), 'utf8');
-      map.set(path.join('/node_modules/@angular', packageName, 'index.d.ts'), content);
+      map.set(path.posix.join('node_modules/@angular', packageName, 'index.d.ts'), content);
     }
   } catch (e) {
     console.error(
@@ -632,25 +632,29 @@ export function setup(options: {
       if (options.compileAngular) {
         // If this fails please add //packages/core:npm_package as a test data dependency.
         readBazelWrittenFilesFrom(
-            path.join(sources, 'angular/packages/core/npm_package'), 'core', angularFiles,
-            skipDirs);
+            path.join(require.resolve('angular/packages/core/npm_package/package.json'), '../'),
+            'core', angularFiles, skipDirs);
       }
       if (options.compileFakeCore) {
         readBazelWrittenFilesFrom(
-            path.join(sources, 'angular/packages/compiler-cli/test/ngtsc/fake_core/npm_package'),
+            path.join(
+                require.resolve(
+                    'angular/packages/compiler-cli/test/ngtsc/fake_core/npm_package/package.json'),
+                '../'),
             'core', angularFiles, skipDirs);
       }
       if (options.compileAnimations) {
         // If this fails please add //packages/animations:npm_package as a test data dependency.
         readBazelWrittenFilesFrom(
-            path.join(sources, 'angular/packages/animations/npm_package'), 'animations',
-            angularFiles, skipDirs);
+            path.join(
+                require.resolve('angular/packages/animations/npm_package/package.json'), '../'),
+            'animations', angularFiles, skipDirs);
       }
       if (options.compileCommon) {
         // If this fails please add //packages/common:npm_package as a test data dependency.
         readBazelWrittenFilesFrom(
-            path.join(sources, 'angular/packages/common/npm_package'), 'common', angularFiles,
-            skipDirs);
+            path.join(require.resolve('angular/packages/common/npm_package/package.json'), '../'),
+            'common', angularFiles, skipDirs);
       }
       return;
     }


### PR DESCRIPTION
This fixes the below test target in Windows

```
//packages/compiler/test:test
```

Partially addresses #29785
