### PR TITLE
test: fix ngc compiler tests under windows

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -20,7 +20,7 @@ steps:
     # Add Bazel CI config
     - copy .codefresh\bazel.rc %ProgramData%\bazel.bazelrc
     # Run tests
-    - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test //packages/compiler/test //packages/compiler-cli/test:ngc
+    - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test //packages/compiler/test //packages/compiler-cli/test:ngc //packages/compiler-cli/test/ngtsc:ngtsc
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
     - yarn bazel test //tools/public_api_guard/...
     - yarn bazel test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance

--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -20,7 +20,7 @@ steps:
     # Add Bazel CI config
     - copy .codefresh\bazel.rc %ProgramData%\bazel.bazelrc
     # Run tests
-    - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test
+    - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test //packages/compiler/test //packages/compiler-cli/test:ngc
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
     - yarn bazel test //tools/public_api_guard/...
     - yarn bazel test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -70,7 +70,7 @@ export function createPerformWatchHost(
       const watcher = chokidar.watch(options.basePath, {
         // ignore .dotfiles, .js and .map files.
         // can't ignore other files as we e.g. want to recompile if an `.html` file changes as well.
-        ignored: /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json)/,
+        ignored: /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json|node_modules)/,
         ignoreInitial: true,
         persistent: true,
       });

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -2028,11 +2028,13 @@ describe('ngc transformer command-line', () => {
       const exitCode =
           main(['-p', path.join(basePath, 'src/tsconfig.json')], message => messages.push(message));
       expect(exitCode).toBe(1, 'Compile was expected to fail');
+      const srcPathWithSep = `lib${path.sep}`;
       expect(messages[0])
-          .toEqual(`lib/test.component.ts(6,21): Error during template compile of 'TestComponent'
+          .toEqual(
+              `${srcPathWithSep}test.component.ts(6,21): Error during template compile of 'TestComponent'
   Tagged template expressions are not supported in metadata in 't1'
-    't1' references 't2' at lib/indirect1.ts(3,27)
-      't2' contains the error at lib/indirect2.ts(4,27).
+    't1' references 't2' at ${srcPathWithSep}indirect1.ts(3,27)
+      't2' contains the error at ${srcPathWithSep}indirect2.ts(4,27).
 `);
     });
   });

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -29,7 +29,7 @@ function setupFakeCore(support: TestSupport): void {
   const nodeModulesPath = path.join(support.basePath, 'node_modules');
   const angularCoreDirectory = path.join(nodeModulesPath, '@angular/core');
 
-  fs.symlinkSync(fakeNpmPackageDir, angularCoreDirectory, 'dir');
+  fs.symlinkSync(fakeNpmPackageDir, angularCoreDirectory, 'junction');
 }
 
 /**
@@ -121,7 +121,7 @@ export class NgtscTestEnvironment {
     if (this.multiCompileHostExt === null) {
       throw new Error(`Not tracking written files - call enableMultipleCompilations()`);
     }
-    const outDir = path.join(this.support.basePath, 'built');
+    const outDir = path.posix.join(this.support.basePath, 'built');
     const writtenFiles = new Set<string>();
     this.multiCompileHostExt.getFilesWrittenSinceLastFlush().forEach(rawFile => {
       if (rawFile.startsWith(outDir)) {

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -19,7 +19,7 @@ export function makeTempDir(): string {
   let dir: string;
   while (true) {
     const id = (Math.random() * 1000000).toFixed(0);
-    dir = path.join(tmpdir, `tmp.${id}`);
+    dir = path.posix.join(tmpdir, `tmp.${id}`);
     if (!fs.existsSync(dir)) break;
   }
   fs.mkdirSync(dir);


### PR DESCRIPTION
test: fix several Bazel compiler tests in windows

```
//packages/compiler-cli/test:ngc
//packages/compiler/test:test
//packages/compiler-cli/test/ngtsc:ngtsc
```

This also address `node_modules` to the ignored paths for ngc compiler as otherwise the `ready` is never fired

Partially addresses #29785