### PR TITLE
test(ivy): pin deps on hello world size tests

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1497,
-        "main": 167065,
+        "main": 164945,
         "polyfills": 43626
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 30932,
+        "main": 14487,
         "polyfills": 43567
       }
     }

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -28,7 +28,7 @@
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.800.0-beta.11",
+    "@angular-devkit/build-angular": "0.800.0-beta.15",
     "@angular/cli": "file:../../node_modules/@angular/cli",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/language-service": "file:../../dist/packages-dist/language-service",

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -28,7 +28,7 @@
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.800.0-beta.11",
+    "@angular-devkit/build-angular": "0.800.0-beta.15",
     "@angular/cli": "file:../../node_modules/@angular/cli",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/language-service": "file:../../dist/packages-dist/language-service",

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -28,7 +28,7 @@
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.800.0-beta.11",
+    "@angular-devkit/build-angular": "0.800.0-beta.15",
     "@angular/cli": "file:../../node_modules/@angular/cli",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/language-service": "file:../../dist/packages-dist/language-service",


### PR DESCRIPTION
We recently had an unexpected size regression in the hello world
tests because the CLI devkit released an RC that regressed us and
the dependencies were not pinned. This change ensures that we only
update dependencies like devkit deliberately, so we do not have
mysterious breakages caused by other packages.
