### PR TITLE
test(language-service): Load language service from tsconfig

### DIFF
--- a/integration/language_service_plugin/project/tsconfig.json
+++ b/integration/language_service_plugin/project/tsconfig.json
@@ -8,6 +8,9 @@
     "experimentalDecorators": true,
     "lib": [ "es2015", "dom" ],
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "plugins": [
+      {"name": "@angular/language-service"}
+    ]
   }
 }

--- a/integration/language_service_plugin/test.ts
+++ b/integration/language_service_plugin/test.ts
@@ -13,7 +13,6 @@ describe('Angular Language Service', () => {
   beforeEach(() => {
     jasmine.addMatchers(goldenMatcher);
     server = fork(SERVER_PATH, [
-      '--globalPlugins', '@angular/language-service',
       '--logVerbosity', 'verbose',
       '--logFile', join(PWD, 'tsserver.log'),
     ], {


### PR DESCRIPTION
This PR changes the integration test to load language service the way it would be loaded in the editor.
If the language service is specified in tsconfig, it'd only be loaded for Angular projects.
Specifying it as `globalPlugins` loads it unconditionally whenever tsserver is brought up.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
