### PR TITLE
fix(ivy): host bindings and listeners not being inherited from undecorated classes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -194,7 +194,7 @@ export function extractDirectiveMetadata(
     throw new Error(`Directive ${clazz.name.text} has no selector, please add it!`);
   }
 
-  const host = extractHostBindings(directive, decoratedElements, evaluator, coreModule);
+  const host = extractHostBindings(decoratedElements, evaluator, coreModule, directive);
 
   const providers: Expression|null =
       directive.has('providers') ? new WrappedNodeExpr(directive.get('providers') !) : null;
@@ -460,11 +460,11 @@ type StringMap<T> = {
   [key: string]: T;
 };
 
-function extractHostBindings(
-    metadata: Map<string, ts.Expression>, members: ClassMember[], evaluator: PartialEvaluator,
-    coreModule: string | undefined): ParsedHostBindings {
+export function extractHostBindings(
+    members: ClassMember[], evaluator: PartialEvaluator, coreModule: string | undefined,
+    metadata?: Map<string, ts.Expression>): ParsedHostBindings {
   let hostMetadata: StringMap<string|Expression> = {};
-  if (metadata.has('host')) {
+  if (metadata && metadata.has('host')) {
     const expr = metadata.get('host') !;
     const hostMetaMap = evaluator.evaluate(expr);
     if (!(hostMetaMap instanceof Map)) {
@@ -501,7 +501,7 @@ function extractHostBindings(
     throw new FatalDiagnosticError(
         // TODO: provide more granular diagnostic and output specific host expression that triggered
         // an error instead of the whole host object
-        ErrorCode.HOST_BINDING_PARSE_ERROR, metadata.get('host') !,
+        ErrorCode.HOST_BINDING_PARSE_ERROR, metadata !.get('host') !,
         errors.map((error: ParseError) => error.msg).join('\n'));
   }
 

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -3220,6 +3220,89 @@ describe('compiler compliance', () => {
       expectEmit(result.source, expectedOutput, 'Invalid base definition');
     });
 
+    it('should add ngBaseDef if a host binding is present', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule, HostBinding} from '@angular/core';
+            export class BaseClass {
+              @HostBinding('attr.tabindex')
+              tabindex = -1;
+            }
+
+            @Component({
+              selector: 'my-component',
+              template: ''
+            })
+            export class MyComponent extends BaseClass {
+            }
+
+            @NgModule({
+              declarations: [MyComponent]
+            })
+            export class MyModule {}
+          `
+        }
+      };
+      const expectedOutput = `
+      // ...
+      BaseClass.ngBaseDef = $r3$.ɵɵdefineBase({
+        hostBindings: function (rf, ctx, elIndex) {
+          if (rf & 1) {
+            $r3$.ɵɵallocHostVars(1);
+          }
+          if (rf & 2) {
+            $r3$.ɵɵelementAttribute(elIndex, "tabindex", $r3$.ɵɵbind(ctx.tabindex));
+          }
+        }
+      });
+      // ...
+      `;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, expectedOutput, 'Invalid base definition');
+    });
+
+    it('should add ngBaseDef if a host listener is present', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule, HostListener} from '@angular/core';
+            export class BaseClass {
+              @HostListener('mousedown', ['$event'])
+              handleMousedown(event: any) {}
+            }
+
+            @Component({
+              selector: 'my-component',
+              template: ''
+            })
+            export class MyComponent extends BaseClass {
+            }
+
+            @NgModule({
+              declarations: [MyComponent]
+            })
+            export class MyModule {}
+          `
+        }
+      };
+      const expectedOutput = `
+      // ...
+      BaseClass.ngBaseDef = $r3$.ɵɵdefineBase({
+        hostBindings: function (rf, ctx, elIndex) {
+          if (rf & 1) {
+            $r3$.ɵɵlistener("mousedown", function ($event) {
+              return ctx.handleMousedown($event);
+            });
+          }
+        }
+      });
+      // ...
+      `;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, expectedOutput, 'Invalid base definition');
+    });
+
     it('should NOT add ngBaseDef if @Component is present', () => {
       const files = {
         app: {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1723,7 +1723,7 @@ describe('ngtsc behavioral tests', () => {
         .toContain('Cannot have a pipe in an action expression');
   });
 
-  it('should throw in case pipes are used in host listeners', () => {
+  it('should throw in case pipes are used in host bindings', () => {
     env.tsconfig();
     env.write(`test.ts`, `
         import {Component} from '@angular/core';

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -149,6 +149,8 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
 }
 
 export interface R3BaseMetadataFacade {
+  name: string;
+  propMetadata: {[key: string]: any[]};
   inputs?: {[key: string]: string | [string, string]};
   outputs?: {[key: string]: string};
   queries?: R3QueryMetadataFacade[];

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -62,24 +62,7 @@ export interface R3DirectiveMetadata {
    * Mappings indicating how the directive interacts with its host element (host bindings,
    * listeners, etc).
    */
-  host: {
-    /**
-     * A mapping of attribute binding keys to `o.Expression`s.
-     */
-    attributes: {[key: string]: o.Expression};
-
-    /**
-     * A mapping of event binding keys to unparsed expressions.
-     */
-    listeners: {[key: string]: string};
-
-    /**
-     * A mapping of property binding keys to unparsed expressions.
-     */
-    properties: {[key: string]: string};
-
-    specialAttributes: {styleAttr?: string; classAttr?: string;}
-  };
+  host: R3HostMetadata;
 
   /**
    * Information about usage of specific lifecycle events which require special treatment in the
@@ -264,4 +247,27 @@ export interface R3ComponentDef {
   expression: o.Expression;
   type: o.Type;
   statements: o.Statement[];
+}
+
+/**
+ * Mappings indicating how the class interacts with its
+ * host element (host bindings, listeners, etc).
+ */
+export interface R3HostMetadata {
+  /**
+   * A mapping of attribute binding keys to `o.Expression`s.
+   */
+  attributes: {[key: string]: o.Expression};
+
+  /**
+   * A mapping of event binding keys to unparsed expressions.
+   */
+  listeners: {[key: string]: string};
+
+  /**
+   * A mapping of property binding keys to unparsed expressions.
+   */
+  properties: {[key: string]: string};
+
+  specialAttributes: {styleAttr?: string; classAttr?: string;};
 }

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -149,6 +149,8 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
 }
 
 export interface R3BaseMetadataFacade {
+  name: string;
+  propMetadata: {[key: string]: any[]};
   inputs?: {[key: string]: string | [string, string]};
   outputs?: {[key: string]: string};
   queries?: R3QueryMetadataFacade[];

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -571,6 +571,11 @@ export function ɵɵdefineBase<T>(baseDefinition: {
    * set of instructions to be inserted into the template function.
    */
   viewQuery?: ViewQueriesFunction<T>| null;
+
+  /**
+   * Function executed by the parent template to allow children to apply host bindings.
+   */
+  hostBindings?: HostBindingsFunction<T>;
 }): ɵɵBaseDef<T> {
   const declaredInputs: {[P in keyof T]: string} = {} as any;
   return {
@@ -579,6 +584,7 @@ export function ɵɵdefineBase<T>(baseDefinition: {
     outputs: invertObject<T>(baseDefinition.outputs as any),
     viewQuery: baseDefinition.viewQuery || null,
     contentQueries: baseDefinition.contentQueries || null,
+    hostBindings: baseDefinition.hostBindings || null
   };
 }
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -135,6 +135,11 @@ export interface ɵɵBaseDef<T> {
    * components that extend the directive.
    */
   viewQuery: ViewQueriesFunction<T>|null;
+
+  /**
+   * Refreshes host bindings on the associated directive.
+   */
+  hostBindings: HostBindingsFunction<T>|null;
 }
 
 /**
@@ -172,11 +177,6 @@ export interface DirectiveDef<T> extends ɵɵBaseDef<T> {
    * Factory function used to create a new directive instance.
    */
   factory: FactoryFn<T>;
-
-  /**
-   * Refreshes host bindings on the associated directive.
-   */
-  hostBindings: HostBindingsFunction<T>|null;
 
   /* The following are lifecycle hooks for this component */
   onChanges: (() => void)|null;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -666,6 +666,7 @@ export interface ɵɵBaseDef<T> {
     /** @deprecated */ readonly declaredInputs: {
         [P in keyof T]: string;
     };
+    hostBindings: HostBindingsFunction<T> | null;
     readonly inputs: {
         [P in keyof T]: string;
     };
@@ -706,6 +707,7 @@ export declare function ɵɵdefineBase<T>(baseDefinition: {
     };
     contentQueries?: ContentQueriesFunction<T> | null;
     viewQuery?: ViewQueriesFunction<T> | null;
+    hostBindings?: HostBindingsFunction<T>;
 }): ɵɵBaseDef<T>;
 
 export declare function ɵɵdefineComponent<T>(componentDefinition: {


### PR DESCRIPTION
Fixes `HostBinding` and `HostListener` declarations not being inherited from base classes that don't have an Angular decorator.

This PR resolves FW-1275.
