### PR TITLE
fix(router): fix a problem with router not responding to back button

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -555,6 +555,7 @@ export class Router {
                      * way the next navigation will be coming from the current URL in the browser.
                      */
                     this.rawUrlTree = t.rawUrl;
+                    this.browserUrlTree = t.urlAfterRedirects;
                     t.resolve(null);
                     return EMPTY;
                   }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -661,6 +661,33 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/login');
        })));
 
+    it('should set browserUrlTree with urlUpdateStrategy="eagar" and false `shouldProcessUrl`',
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = TestBed.createComponent(RootCmp);
+          advance(fixture);
+
+          router.urlUpdateStrategy = 'eager';
+
+          router.resetConfig([
+            {path: 'team/:id', component: SimpleCmp},
+            {path: 'login', component: AbsoluteSimpleLinkCmp}
+          ]);
+
+          router.navigateByUrl('/team/22');
+          advance(fixture, 1);
+
+          expect((router as any).browserUrlTree.toString()).toBe('/team/22')
+
+          // Force to not process URL changes
+          router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
+
+          router.navigateByUrl('/login');
+          advance(fixture, 1);
+
+          // Because we now can't process any URL, we will end up back at the root.
+          expect((router as any).browserUrlTree.toString()).toBe('/');
+        })));
+
     it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -662,31 +662,31 @@ describe('Integration', () => {
        })));
 
     it('should set browserUrlTree with urlUpdateStrategy="eagar" and false `shouldProcessUrl`',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = TestBed.createComponent(RootCmp);
-          advance(fixture);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = TestBed.createComponent(RootCmp);
+         advance(fixture);
 
-          router.urlUpdateStrategy = 'eager';
+         router.urlUpdateStrategy = 'eager';
 
-          router.resetConfig([
-            {path: 'team/:id', component: SimpleCmp},
-            {path: 'login', component: AbsoluteSimpleLinkCmp}
-          ]);
+         router.resetConfig([
+           {path: 'team/:id', component: SimpleCmp},
+           {path: 'login', component: AbsoluteSimpleLinkCmp}
+         ]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture, 1);
+         router.navigateByUrl('/team/22');
+         advance(fixture, 1);
 
-          expect((router as any).browserUrlTree.toString()).toBe('/team/22')
+         expect((router as any).browserUrlTree.toString()).toBe('/team/22');
 
-          // Force to not process URL changes
-          router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
+         // Force to not process URL changes
+         router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
 
-          router.navigateByUrl('/login');
-          advance(fixture, 1);
+         router.navigateByUrl('/login');
+         advance(fixture, 1);
 
-          // Because we now can't process any URL, we will end up back at the root.
-          expect((router as any).browserUrlTree.toString()).toBe('/');
-        })));
+         // Because we now can't process any URL, we will end up back at the root.
+         expect((router as any).browserUrlTree.toString()).toBe('/');
+       })));
 
     it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {


### PR DESCRIPTION
There was a problem with a combination of the `eager` URL update, browser `back` button, and hybrid applications. Details provided in internal ticket http://b/123667227.

This fix handles the problem by setting `router.browserUrlTree` when all conditions have failed, meaning the browser doesn't do anything with the navigation other than update internal data structures. Without this change, the problem was an old value was stored in `router.broserUrlTree` causing some new navigations to be compared to an old value and breaking future navigations.
