### PR TITLE
ci(docs-infra): re-enable `aio_monitoring` CircleCI jobs and change time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,25 +712,23 @@ workflows:
           cron: "0 * * * *"
           filters: *publish_branches_filter
 
-# This job is currently disabled due to a version skew problem.
-# More info is available here: https://github.com/angular/angular/issues/30101
-#  aio_monitoring:
-#    jobs:
-#      - setup
-#      - aio_monitoring_stable:
-#          requires:
-#            - setup
-#      - aio_monitoring_next:
-#          requires:
-#            - setup
-#    triggers:
-#      - schedule:
-#          # Runs AIO monitoring jobs at 00:00AM every day.
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - master
+  aio_monitoring:
+    jobs:
+      - setup
+      - aio_monitoring_stable:
+          requires:
+            - setup
+      - aio_monitoring_next:
+          requires:
+            - setup
+    triggers:
+      - schedule:
+          # Runs AIO monitoring jobs at 10:00AM every day.
+          cron: "0 10 * * *"
+          filters:
+            branches:
+              only:
+                - master
 
 # TODO:
 # - don't build the g3 branch


### PR DESCRIPTION
The `aio_monitoring_next` CircleCI job was disabled due to a failure in [302254](https://circleci.com/gh/angular/angular/302254). It turned out the failure was caused because the job happened to run after a change had been merged into master and right before it was deployed to https://next.angular.io/ causing the tests not to match the deployed version.

This commit re-enables the job and moves it to a different time, when it is less likely that PRs will be being merged (and thus reducing the risk of a similar timming issue).

Fixes #30101
