### PR TITLE
perf(ivy): store views directly on LContainer

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -8,10 +8,10 @@
 
 import {Injector} from '../di';
 import {getViewComponent} from '../render3/global_utils_api';
-import {LContainer, NATIVE, VIEWS} from '../render3/interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from '../render3/interfaces/container';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/node';
 import {StylingIndex} from '../render3/interfaces/styling';
-import {LView, NEXT, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
+import {LView, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
 import {getProp, getValue, isClassBasedValue} from '../render3/styling/class_and_style_bindings';
 import {getStylingContextFromLView} from '../render3/styling/util';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/util/discovery_utils';
@@ -502,8 +502,8 @@ function _queryNodeChildrenR3(
 function _queryNodeChildrenInContainerR3(
     lContainer: LContainer, predicate: Predicate<DebugNode>, matches: DebugNode[],
     elementsOnly: boolean, rootNativeNode: any) {
-  for (let i = 0; i < lContainer[VIEWS].length; i++) {
-    const childView = lContainer[VIEWS][i];
+  for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
+    const childView = lContainer[i];
     _queryNodeChildrenR3(
         childView[TVIEW].node !, childView, predicate, matches, elementsOnly, rootNativeNode);
   }

--- a/packages/core/src/render3/debug.ts
+++ b/packages/core/src/render3/debug.ts
@@ -7,7 +7,8 @@
  */
 
 import {assertDefined} from '../util/assert';
-import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
+
+import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/container';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, TIcu} from './interfaces/i18n';
 import {TNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
@@ -207,7 +208,8 @@ export class LContainerDebug {
 
   get activeIndex(): number { return this._raw_lContainer[ACTIVE_INDEX]; }
   get views(): LViewDebug[] {
-    return this._raw_lContainer[VIEWS].map(toDebug as(l: LView) => LViewDebug);
+    return this._raw_lContainer.slice(CONTAINER_HEADER_OFFSET)
+        .map(toDebug as(l: LView) => LViewDebug);
   }
   get parent(): LViewDebug|LContainerDebug|null { return toDebug(this._raw_lContainer[PARENT]); }
   get queries(): LQueries|null { return this._raw_lContainer[QUERIES]; }

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -9,7 +9,7 @@ import {assertEqual} from '../../util/assert';
 import {assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {executePreOrderHooks, registerPostOrderHooks} from '../hooks';
-import {ACTIVE_INDEX, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {ComponentTemplate} from '../interfaces/definition';
 import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType} from '../interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, LView, QUERIES, RENDERER, TVIEW} from '../interfaces/view';
@@ -123,11 +123,11 @@ export function ɵɵcontainerRefreshEnd(): void {
 
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Container);
 
-  const lContainer = getLView()[previousOrParentTNode.index];
+  const lContainer: LContainer = getLView()[previousOrParentTNode.index];
   const nextIndex = lContainer[ACTIVE_INDEX];
 
   // remove extra views at the end of the container
-  while (nextIndex < lContainer[VIEWS].length) {
+  while (nextIndex < lContainer.length - CONTAINER_HEADER_OFFSET) {
     removeView(lContainer, nextIndex);
   }
 }

--- a/packages/core/src/render3/instructions/embedded_view.ts
+++ b/packages/core/src/render3/instructions/embedded_view.ts
@@ -8,7 +8,7 @@
 
 import {assertDefined, assertEqual} from '../../util/assert';
 import {assertLContainerOrUndefined} from '../assert';
-import {ACTIVE_INDEX, LContainer, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {RenderFlags} from '../interfaces/definition';
 import {TContainerNode, TNodeType} from '../interfaces/node';
 import {FLAGS, LView, LViewFlags, PARENT, QUERIES, TVIEW, TView, T_HOST} from '../interfaces/view';
@@ -104,17 +104,15 @@ function getOrCreateEmbeddedTView(
  * @param lContainer to search for views
  * @param startIdx starting index in the views array to search from
  * @param viewBlockId exact view block id to look for
- * @returns index of a found view or -1 if not found
  */
 function scanForView(lContainer: LContainer, startIdx: number, viewBlockId: number): LView|null {
-  const views = lContainer[VIEWS];
-  for (let i = startIdx; i < views.length; i++) {
-    const viewAtPositionId = views[i][TVIEW].id;
+  for (let i = startIdx + CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
+    const viewAtPositionId = lContainer[i][TVIEW].id;
     if (viewAtPositionId === viewBlockId) {
-      return views[i];
+      return lContainer[i];
     } else if (viewAtPositionId < viewBlockId) {
       // found a view that should not be at this position - remove
-      removeView(lContainer, i);
+      removeView(lContainer, i - CONTAINER_HEADER_OFFSET);
     } else {
       // found a view with id greater than the one we are searching for
       // which means that required view doesn't exist and can't be found at

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -19,7 +19,7 @@ import {attachLContainerDebug, attachLViewDebug} from '../debug';
 import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
 import {executeHooks, executePreOrderHooks, registerPreOrderHooks} from '../hooks';
-import {ACTIVE_INDEX, LContainer, VIEWS} from '../interfaces/container';
+import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {INJECTOR_BLOOM_PARENT_SIZE, NodeInjectorFactory} from '../interfaces/injector';
 import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
@@ -37,7 +37,7 @@ import {NO_CHANGE} from '../tokens';
 import {attrsStylingIndexOf} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, stringifyForError} from '../util/misc_utils';
 import {getLViewParent, getRootContext} from '../util/view_traversal_utils';
-import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isComponent, isComponentDef, isContentQueryHost, isRootView, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
+import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isComponent, isComponentDef, isContentQueryHost, isLContainer, isRootView, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
 
 
 
@@ -1436,7 +1436,6 @@ export function createLContainer(
     null,                            // queries
     tNode,                           // t_host
     native,                          // native
-    [],                              // views
   ];
   ngDevMode && attachLContainerDebug(lContainer);
   return lContainer;
@@ -1452,10 +1451,9 @@ function refreshDynamicEmbeddedViews(lView: LView) {
     // Note: current can be an LView or an LContainer instance, but here we are only interested
     // in LContainer. We can tell it's an LContainer because its length is less than the LView
     // header.
-    if (current.length < HEADER_OFFSET && current[ACTIVE_INDEX] === -1) {
-      const container = current as LContainer;
-      for (let i = 0; i < container[VIEWS].length; i++) {
-        const dynamicViewData = container[VIEWS][i];
+    if (current[ACTIVE_INDEX] === -1 && isLContainer(current)) {
+      for (let i = CONTAINER_HEADER_OFFSET; i < current.length; i++) {
+        const dynamicViewData = current[i];
         // The directives and pipes are not needed here as an existing view is only being refreshed.
         ngDevMode && assertDefined(dynamicViewData[TVIEW], 'TView must be allocated');
         renderEmbeddedTemplate(dynamicViewData, dynamicViewData[TVIEW], dynamicViewData[CONTEXT] !);

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -28,7 +28,14 @@ export const ACTIVE_INDEX = 2;
 // PARENT, NEXT, QUERIES and T_HOST are indices 3, 4, 5 and 6.
 // As we already have these constants in LView, we don't need to re-create them.
 export const NATIVE = 7;
-export const VIEWS = 8;
+
+/**
+ * Size of LContainer's header. Represents the index after which all views in the
+ * container will be inserted. We need to keep a record of current views so we know
+ * which views are already in the DOM (and don't need to be re-added) and so we can
+ * remove views from the DOM when they are no longer required.
+ */
+export const CONTAINER_HEADER_OFFSET = 8;
 
 /**
  * The state associated with a container.
@@ -92,15 +99,6 @@ export interface LContainer extends Array<any> {
   /** The comment element that serves as an anchor for this LContainer. */
   readonly[NATIVE]:
       RComment;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
-
-  /**
-*A list of the container's currently active child views. Views will be inserted
-*here as they are added and spliced from here when they are removed. We need
-*to keep a record of current views so we know which views are already in the DOM
-*(and don't need to be re-added) and so we can remove views from the DOM when they
-*are no longer required.
-*/
-  [VIEWS]: LView[];
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "CONTEXT"
   },
   {
@@ -142,9 +145,6 @@
   },
   {
     "name": "UnsubscriptionErrorImpl"
-  },
-  {
-    "name": "VIEWS"
   },
   {
     "name": "ViewEncapsulation"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -18,6 +18,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "CONTEXT"
   },
   {
@@ -121,9 +124,6 @@
   },
   {
     "name": "UnsubscriptionErrorImpl"
-  },
-  {
-    "name": "VIEWS"
   },
   {
     "name": "ViewEncapsulation"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -30,6 +30,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "CONTEXT"
   },
   {
@@ -253,9 +256,6 @@
   },
   {
     "name": "UnsubscriptionErrorImpl"
-  },
-  {
-    "name": "VIEWS"
   },
   {
     "name": "ViewContainerRef"


### PR DESCRIPTION
Stores the views that are part of a container directly on the `LContainer`, rather than maintaining a dedicated sub-array.

This PR resolves FW-1288.
