### PR TITLE
fix: disable injectable-pipe migration

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "npm_package")
 exports_files([
     "tsconfig.json",
     "migrations.json",
+    "test-migrations.json",
 ])
 
 npm_package(

--- a/packages/core/schematics/test-migrations.json
+++ b/packages/core/schematics/test-migrations.json
@@ -1,19 +1,20 @@
 {
   "schematics": {
-    "migration-v8-move-document": {
-      "version": "8-beta",
+    "migration-move-document": {
       "description": "Migrates DOCUMENT Injection token from platform-browser imports to common import",
       "factory": "./migrations/move-document/index"
     },
-    "migration-v8-static-queries": {
-      "version": "8-beta",
+    "migration-static-queries": {
       "description": "Migrates ViewChild and ContentChild to explicit query timing",
       "factory": "./migrations/static-queries/index"
     },
-    "migration-v8-template-local-variables": {
-      "version": "8-beta",
+    "migration-template-local-variables": {
       "description": "Warns developers if values are assigned to template variables",
       "factory": "./migrations/template-var-assignment/index"
+    },
+    "migration-injectable-pipe": {
+      "description": "Migrates all Pipe classes so that they have an Injectable annotation",
+      "factory": "./migrations/injectable-pipe/index"
     }
   }
 }

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -5,7 +5,7 @@ ts_library(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
-        "//packages/core/schematics:migrations.json",
+        "//packages/core/schematics:test-migrations.json",
     ],
     deps = [
         "//packages/core/schematics/migrations/injectable-pipe",

--- a/packages/core/schematics/test/injectable_pipe_migration_spec.ts
+++ b/packages/core/schematics/test/injectable_pipe_migration_spec.ts
@@ -20,7 +20,7 @@ describe('injectable pipe migration', () => {
   let previousWorkingDir: string;
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('../test-migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 
@@ -121,5 +121,5 @@ describe('injectable pipe migration', () => {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
   }
 
-  function runMigration() { runner.runSchematic('migration-v8-injectable-pipe', {}, tree); }
+  function runMigration() { runner.runSchematic('migration-injectable-pipe', {}, tree); }
 });

--- a/packages/core/schematics/test/move_document_migration_spec.ts
+++ b/packages/core/schematics/test/move_document_migration_spec.ts
@@ -20,7 +20,7 @@ describe('move-document migration', () => {
   let previousWorkingDir: string;
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('../test-migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 
@@ -151,5 +151,5 @@ describe('move-document migration', () => {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
   }
 
-  function runMigration() { runner.runSchematic('migration-v8-move-document', {}, tree); }
+  function runMigration() { runner.runSchematic('migration-move-document', {}, tree); }
 });

--- a/packages/core/schematics/test/static_queries_migration_template_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_template_spec.ts
@@ -21,7 +21,7 @@ describe('static-queries migration with template strategy', () => {
   let warnOutput: string[];
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('../test-migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 
@@ -97,7 +97,7 @@ describe('static-queries migration with template strategy', () => {
   }
 
   async function runMigration() {
-    await runner.runSchematicAsync('migration-v8-static-queries', {}, tree).toPromise();
+    await runner.runSchematicAsync('migration-static-queries', {}, tree).toPromise();
   }
 
   describe('ViewChild', () => {
@@ -105,7 +105,7 @@ describe('static-queries migration with template strategy', () => {
     it('should detect queries selecting elements through template reference', async() => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
-                        
+
         @Component({template: \`
           <ng-template>
             <button #myButton>My Button</button>
@@ -118,7 +118,7 @@ describe('static-queries migration with template strategy', () => {
           private @ViewChild('myButton') query: any;
           private @ViewChild('myStaticButton') query2: any;
         }
-        
+
         @NgModule({declarations: [MyComp]})
         export class MyModule {}
       `);
@@ -134,7 +134,7 @@ describe('static-queries migration with template strategy', () => {
     it('should detect queries selecting ng-template as static', async() => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
-                        
+
         @Component({template: \`
           <ng-template #myTmpl>
             My template
@@ -143,7 +143,7 @@ describe('static-queries migration with template strategy', () => {
         export class MyComp {
           private @ViewChild('myTmpl') query: any;
         }
-        
+
         @NgModule({declarations: [MyComp]})
         export class MyModule {}
       `);
@@ -157,7 +157,7 @@ describe('static-queries migration with template strategy', () => {
     it('should detect queries selecting component view providers through string token', async() => {
       writeFile('/index.ts', `
         import {Component, Directive, NgModule, ViewChild} from '@angular/core';
-                
+
         @Directive({
           selector: '[myDirective]',
           providers: [
@@ -165,7 +165,7 @@ describe('static-queries migration with template strategy', () => {
           ]
         })
         export class MyDirective {}
-        
+
         @Directive({
           selector: '[myDirective2]',
           providers: [
@@ -173,13 +173,13 @@ describe('static-queries migration with template strategy', () => {
           ]
         })
         export class MyDirective2 {}
-             
+
         @Component({templateUrl: './my-tmpl.html'})
         export class MyComp {
           private @ViewChild('my-token') query: any;
           private @ViewChild('my-token-2') query2: any;
         }
-        
+
         @NgModule({declarations: [MyComp, MyDirective, MyDirective2]})
         export class MyModule {}
       `);
@@ -202,28 +202,28 @@ describe('static-queries migration with template strategy', () => {
     it('should detect queries selecting component view providers using class token', async() => {
       writeFile('/index.ts', `
         import {Component, Directive, NgModule, ViewChild} from '@angular/core';
-        
+
         export class MyService {}
         export class MyService2 {}
-                
+
         @Directive({
           selector: '[myDirective]',
           providers: [MyService]
         })
         export class MyDirective {}
-        
+
         @Directive({
           selector: '[myDirective2]',
           providers: [MyService2]
         })
         export class MyDirective2 {}
-             
+
         @Component({templateUrl: './my-tmpl.html'})
         export class MyComp {
           private @ViewChild(MyService) query: any;
           private @ViewChild(MyService2) query2: any;
         }
-        
+
         @NgModule({declarations: [MyComp, MyDirective, MyDirective2]})
         export class MyModule {}
       `);
@@ -247,7 +247,7 @@ describe('static-queries migration with template strategy', () => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
         import {HomeComponent, HomeComponent2} from './home-comp';
-                        
+
         @Component({
           template: \`
             <home-comp></home-comp>
@@ -260,20 +260,20 @@ describe('static-queries migration with template strategy', () => {
           private @ViewChild(HomeComponent) query: any;
           private @ViewChild(HomeComponent2) query2: any;
         }
-        
+
         @NgModule({declarations: [MyComp, HomeComponent, HomeComponent2]})
         export class MyModule {}
       `);
 
       writeFile(`/home-comp.ts`, `
         import {Component} from '@angular/core';
-        
+
         @Component({
           selector: 'home-comp',
           template: '<span>Home</span>'
         })
         export class HomeComponent {}
-        
+
         @Component({
           selector: 'home-comp2',
           template: '<span>Home 2</span>'
@@ -294,12 +294,12 @@ describe('static-queries migration with template strategy', () => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
         import {MyLibComponent} from 'my-lib';
-                        
+
         @Component({templateUrl: './my-tmpl.html'})
         export class MyComp {
           private @ViewChild(MyLibComponent) query: any;
         }
-        
+
         @NgModule({declarations: [MyComp, MyLibComponent]})
         export class MyModule {}
       `);
@@ -319,12 +319,12 @@ describe('static-queries migration with template strategy', () => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
         import {MyLibComponent} from 'my-lib';
-                        
+
         @Component({templateUrl: './my-tmpl.html'})
         export class MyComp {
           private @ViewChild(MyLibComponent) query: any;
         }
-        
+
         @NgModule({declarations: [MyComp, MyLibComponent]})
         export class MyModule {}
       `);
@@ -345,16 +345,16 @@ describe('static-queries migration with template strategy', () => {
     it('should detect queries within structural directive', async() => {
       writeFile('/index.ts', `
         import {Component, Directive, NgModule, ViewChild} from '@angular/core';
-        
+
         @Directive({selector: '[ngIf]'})
         export class FakeNgIf {}
-                        
+
         @Component({templateUrl: 'my-tmpl.html'})
         export class MyComp {
           private @ViewChild('myRef') query: any;
           private @ViewChild('myRef2') query2: any;
         }
-        
+
         @NgModule({declarations: [MyComp, FakeNgIf]})
         export class MyModule {}
       `);
@@ -375,14 +375,14 @@ describe('static-queries migration with template strategy', () => {
     it('should detect inherited queries', async() => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
-        
+
         export class BaseClass {
           @ViewChild('myRef') query: any;
         }
-                        
+
         @Component({templateUrl: 'my-tmpl.html'})
         export class MyComp extends BaseClass {}
-        
+
         @NgModule({declarations: [MyComp]})
         export class MyModule {}
       `);
@@ -400,7 +400,7 @@ describe('static-queries migration with template strategy', () => {
     it('should add a todo if a query is not declared in any component', async() => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild, SomeToken} from '@angular/core';
-          
+
         export class NotAComponent {
           @ViewChild('myRef', {read: SomeToken}) query: any;
         }
@@ -420,17 +420,17 @@ describe('static-queries migration with template strategy', () => {
     it('should add a todo if a query is used multiple times with different timing', async() => {
       writeFile('/index.ts', `
         import {Component, NgModule, ViewChild} from '@angular/core';
-          
+
         export class BaseClass {
           @ViewChild('myRef') query: any;
         }
-        
+
         @Component({template: '<ng-template><p #myRef></p></ng-template>'})
         export class FirstComp extends BaseClass {}
-        
+
         @Component({template: '<span #myRef></span>'})
         export class SecondComp extends BaseClass {}
-        
+
         @NgModule({declarations: [FirstComp, SecondComp]})
         export class MyModule {}
       `);
@@ -448,12 +448,12 @@ describe('static-queries migration with template strategy', () => {
     it('should gracefully exit migration if queries could not be analyzed', async() => {
       writeFile('/index.ts', `
         import {Component, ViewChild} from '@angular/core';
-             
+
         @Component({template: '<ng-template><p #myRef></p></ng-template>'})
         export class MyComp {
           @ViewChild('myRef') query: any;
         }
-        
+
         // **NOTE**: Analysis will fail as there is no "NgModule" that declares the component.
       `);
 
@@ -533,7 +533,7 @@ describe('static-queries migration with template strategy', () => {
       writeFile('/src/test.ts', `
         import {ViewChild} from '@angular/core';
         import {AppComponent} from './app.component';
-        
+
         @Component({template: '<span #test>Test</span>'})
         class MyTestComponent {
           @ViewChild('test') query: any;
@@ -542,7 +542,7 @@ describe('static-queries migration with template strategy', () => {
 
       writeFile('/src/app.component.ts', `
         import {Component, ViewChild} from '@angular/core';
-        
+
         @Component({template: '<span #test></span>'})
         export class AppComponent {
           @ViewChild('test') query: any;
@@ -552,7 +552,7 @@ describe('static-queries migration with template strategy', () => {
       writeFile('/src/app.module.ts', `
         import {NgModule} from '@angular/core';
         import {AppComponent} from './app.component';
-        
+
         @NgModule({declarations: [AppComponent]})
         export class MyModule {}
       `);

--- a/packages/core/schematics/test/template_var_assignment_migration_spec.ts
+++ b/packages/core/schematics/test/template_var_assignment_migration_spec.ts
@@ -21,7 +21,7 @@ describe('template variable assignment migration', () => {
   let warnOutput: string[];
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('../test-migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 
@@ -58,14 +58,12 @@ describe('template variable assignment migration', () => {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
   }
 
-  function runMigration() {
-    runner.runSchematic('migration-v8-template-local-variables', {}, tree);
-  }
+  function runMigration() { runner.runSchematic('migration-template-local-variables', {}, tree); }
 
   it('should warn for two-way data binding variable assignment', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         template: '<cmp *ngFor="let optionName of options" [(opt)]="optionName"></cmp>',
       })
@@ -81,7 +79,7 @@ describe('template variable assignment migration', () => {
   it('should warn for two-way data binding assigning to "as" variable', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './tmpl.html',
       })
@@ -103,7 +101,7 @@ describe('template variable assignment migration', () => {
   it('should warn for bound event assignments to "as" variable', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -127,7 +125,7 @@ describe('template variable assignment migration', () => {
   it('should warn for bound event assignments to template "let" variables', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -151,7 +149,7 @@ describe('template variable assignment migration', () => {
   it('should not warn for bound event assignments to component property', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -168,7 +166,7 @@ describe('template variable assignment migration', () => {
   it('should not warn for bound event assignments to template variable object property', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -188,7 +186,7 @@ describe('template variable assignment migration', () => {
      () => {
        writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -213,7 +211,7 @@ describe('template variable assignment migration', () => {
   it('should not warn for property writes with template variable name but different scope', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -236,7 +234,7 @@ describe('template variable assignment migration', () => {
   it('should not throw an error if a detected template fails parsing', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         templateUrl: './sub_dir/tmpl.html',
       })
@@ -253,12 +251,12 @@ describe('template variable assignment migration', () => {
   it('should be able to report multiple templates within the same source file', () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';
-      
+
       @Component({
         template: '<ng-template let-one><a (sayHello)="one=true"></a></ng-template>',
       })
       export class MyComp {}
-      
+
       @Component({
         template: '<ng-template let-two><b (greet)="two=true"></b></ng-template>',
       })


### PR DESCRIPTION
Disables the injectable pipe migration until we can decide whether this is the right solution for Ivy. Rolling it out properly will involve a more detailed plan and more changes like updating the styleguide, scaffolding schematics etc.

Context for the new `test-migrations.json`: since we use the `migrations.json` both for the real migrations and for tests, it doesn't allow us to disable a schematic while continuing to run its tests. This change adds the test-specific file so that we can continue running the `injectable-pipe` tests, even though the schematic itself is disabled.