### PR TITLE
fix(docs-infra): update manifest names

### DIFF
--- a/aio/src/pwa-manifest.json
+++ b/aio/src/pwa-manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Angular",
-  "name": "Angular",
+  "short_name": "Angular Docs",
+  "name": "Angular Documentation",
   "icons": [
     {
       "src":"assets/images/favicons/favicon-194x194.png",

--- a/aio/src/pwa-manifest.json
+++ b/aio/src/pwa-manifest.json
@@ -1,14 +1,14 @@
 {
-  "short_name": "Angular Docs",
+  "short_name": "angular.io",
   "name": "Angular Documentation",
   "icons": [
     {
-      "src":"assets/images/favicons/favicon-194x194.png",
+      "src": "assets/images/favicons/favicon-194x194.png",
       "sizes": "194x194 512x512",
       "type": "image/png"
     },
     {
-      "src":"assets/images/favicons/favicon-144x144.png",
+      "src": "assets/images/favicons/favicon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Chrome presents the option to install PWAs using the app's name. Currently for angular.io we see:
![image](https://user-images.githubusercontent.com/9759954/56905535-62520500-6a6e-11e9-9c72-6f841962b612.png)
This might lead someone to believe that clicking this will install the Angular framework.

Issue Number: #30192 

## What is the new behavior?
The change to the names will either show `Install Angular Documentation...`

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
