### PR TITLE
Windows ngcc infinite loop

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -23,3 +23,4 @@ steps:
     - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
     - yarn bazel test //tools/public_api_guard/...
+    - yarn bazel test //packages/compiler-cli/ngcc/test:test

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -118,7 +118,7 @@ export class ModuleResolver {
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
-    while (AbsoluteFsPath.dirname(folder) !== folder) {
+    while (!isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (folder.endsWith('node_modules')) {
         // Skip up if the folder already ends in node_modules
@@ -225,7 +225,7 @@ export class ModuleResolver {
    */
   private findPackagePath(path: AbsoluteFsPath): AbsoluteFsPath|null {
     let folder = path;
-    while (AbsoluteFsPath.dirname(folder) !== folder) {
+    while (!isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (this.fs.exists(AbsoluteFsPath.join(folder, 'package.json'))) {
         return folder;
@@ -265,6 +265,10 @@ export class ResolvedDeepImport {
 function splitOnStar(str: string): PathMappingPattern {
   const [prefix, postfix] = str.split('*', 2);
   return {prefix, postfix: postfix || '', hasWildcard: postfix !== undefined};
+}
+
+function isRoot(path: AbsoluteFsPath): boolean {
+  return AbsoluteFsPath.dirname(path) === path;
 }
 
 interface ProcessedPathMapping {

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -118,7 +118,7 @@ export class ModuleResolver {
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
-    while (folder !== '/') {
+    while (AbsoluteFsPath.dirname(folder) !== folder) {
       folder = AbsoluteFsPath.dirname(folder);
       if (folder.endsWith('node_modules')) {
         // Skip up if the folder already ends in node_modules
@@ -225,7 +225,7 @@ export class ModuleResolver {
    */
   private findPackagePath(path: AbsoluteFsPath): AbsoluteFsPath|null {
     let folder = path;
-    while (folder !== '/') {
+    while (AbsoluteFsPath.dirname(folder) !== folder) {
       folder = AbsoluteFsPath.dirname(folder);
       if (this.fs.exists(AbsoluteFsPath.join(folder, 'package.json'))) {
         return folder;

--- a/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
+++ b/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
@@ -26,7 +26,7 @@ export class NgccCompilerHost implements ts.CompilerHost {
   }
 
   getDefaultLibLocation(): string {
-    const nodeLibPath = AbsoluteFsPath.fromUnchecked(require.resolve('typescript'));
+    const nodeLibPath = AbsoluteFsPath.from(require.resolve('typescript'));
     return AbsoluteFsPath.join(nodeLibPath, '..');
   }
 

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -70,7 +70,7 @@ describe('DependencyHost', () => {
       expect(dependencies.size).toBe(0);
       expect(missing.size).toBe(0);
       expect(deepImports.size).toBe(1);
-      expect(deepImports.has('/node_modules/lib-1/deep/import')).toBe(true);
+      expect(deepImports.has(_('/node_modules/lib-1/deep/import'))).toBe(true);
     });
 
     it('should recurse into internal dependencies', () => {

--- a/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
@@ -14,7 +14,7 @@ import {FileStats, FileSystem} from '../../src/file_system/file_system';
 export class MockFileSystem implements FileSystem {
   files: Folder = {};
   constructor(...folders: Folder[]) {
-    folders.forEach(files => this.processFiles(this.files, files));
+    folders.forEach(files => this.processFiles(this.files, files, true));
   }
 
   exists(path: AbsoluteFsPath): boolean { return this.findFromPath(path) !== null; }
@@ -82,9 +82,10 @@ export class MockFileSystem implements FileSystem {
 
   ensureDir(path: AbsoluteFsPath): void { this.ensureFolders(this.files, path.split('/')); }
 
-  private processFiles(current: Folder, files: Folder): void {
+  private processFiles(current: Folder, files: Folder, isRootPath = false): void {
     Object.keys(files).forEach(path => {
-      const segments = (path.startsWith('/') ? AbsoluteFsPath.from(path) : path).split('/');
+      const pathResolved = isRootPath ? AbsoluteFsPath.from(path) : path;
+      const segments = pathResolved.split('/');
       const lastSegment = segments.pop() !;
       const containingFolder = this.ensureFolders(current, segments);
       const entity = files[path];

--- a/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
@@ -67,7 +67,7 @@ export class MockFileSystem implements FileSystem {
     return new MockFileStats(fileOrFolder);
   }
 
-  pwd(): AbsoluteFsPath { return AbsoluteFsPath.fromUnchecked('/'); }
+  pwd(): AbsoluteFsPath { return AbsoluteFsPath.from('/'); }
 
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
     this.writeFile(to, this.readFile(from));
@@ -84,7 +84,7 @@ export class MockFileSystem implements FileSystem {
 
   private processFiles(current: Folder, files: Folder): void {
     Object.keys(files).forEach(path => {
-      const segments = path.split('/');
+      const segments = (path.startsWith('/') ? AbsoluteFsPath.from(path) : path).split('/');
       const lastSegment = segments.pop() !;
       const containingFolder = this.ensureFolders(current, segments);
       const entity = files[path];

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -12,7 +12,7 @@ import {getEntryPointInfo} from '../../src/packages/entry_point';
 import {MockFileSystem} from '../helpers/mock_file_system';
 import {MockLogger} from '../helpers/mock_logger';
 
-const _ = AbsoluteFsPath.fromUnchecked;
+const _ = AbsoluteFsPath.from;
 
 describe('getEntryPointInfo()', () => {
   const SOME_PACKAGE = _('/some_package');

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -158,7 +158,7 @@ describe('Renderer', () => {
           decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses,
           moduleWithProvidersAnalyses);
       const addDefinitionsSpy = renderer.addDefinitions as jasmine.Spy;
-      expect(addDefinitionsSpy.calls.first().args[2])
+      expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
           .toEqual(
               `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
@@ -203,7 +203,7 @@ describe('Renderer', () => {
              name: _('A'),
              decorators: [jasmine.objectContaining({name: _('Directive')})]
            }));
-           expect(addDefinitionsSpy.calls.first().args[2])
+           expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
                .toEqual(
                    `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -11,7 +11,7 @@ import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {InPlaceFileWriter} from '../../src/writing/in_place_file_writer';
 import {MockFileSystem} from '../helpers/mock_file_system';
 
-const _ = AbsoluteFsPath.fromUnchecked;
+const _ = AbsoluteFsPath.from;
 
 function createMockFileSystem() {
   return new MockFileSystem({
@@ -71,13 +71,14 @@ describe('InPlaceFileWriter', () => {
   it('should error if the backup file already exists', () => {
     const fs = createMockFileSystem();
     const fileWriter = new InPlaceFileWriter(fs);
+    const absoluteBackupPath = _('/package/path/already-backed-up.js');
     expect(
         () => fileWriter.writeBundle(
             {} as EntryPoint, {} as EntryPointBundle,
             [
-              {path: _('/package/path/already-backed-up.js'), contents: 'MODIFIED BACKED UP'},
+              {path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'},
             ]))
         .toThrowError(
-            'Tried to overwrite /package/path/already-backed-up.js.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.');
+            `Tried to overwrite ${absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.`);
   });
 });

--- a/packages/compiler-cli/src/ngtsc/path/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/types.ts
@@ -40,6 +40,12 @@ export const AbsoluteFsPath = {
    * Convert the path `str` to an `AbsoluteFsPath`, throwing an error if it's not an absolute path.
    */
   from: function(str: string): AbsoluteFsPath {
+    if (str.startsWith('/') && process.platform === 'win32') {
+      // in Windows if it's absolute path and starts with `/` we shall
+      // resolve it and return it including the drive.
+      str = path.resolve(str);
+    }
+
     const normalized = normalizeSeparators(str);
     if (!isAbsolutePath(normalized)) {
       throw new Error(`Internal Error: AbsoluteFsPath.from(${str}): path is not absolute`);


### PR DESCRIPTION
fix(ivy): handle windows drives correctly

At the moment the module resolver will end up in an infinite loop in Windows because we are assuming that the root directory is always `/` however in windows this can be any drive letter example `c:/` or `d:/` etc...

With this change we also resolve the drive letter in windows, when using `AbsoluteFsPath.from` for consistence so under `/foo` will be converted to `c:/foo` this is also needed because of relative paths with different drive letters.

test: fix ngcc unit tests in windows

```
//packages/compiler-cli/ngcc/test:test
```
Partially addresses #29785