### PR TITLE
fix(ivy): support injection flags for provider deps without new

### DIFF
--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -145,13 +145,14 @@ export function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[]): an
 
       for (let j = 0; j < arg.length; j++) {
         const meta = arg[j];
-        if (meta instanceof Optional || meta.ngMetadataName === 'Optional') {
+        if (meta instanceof Optional || meta.ngMetadataName === 'Optional' || meta === Optional) {
           flags |= InjectFlags.Optional;
-        } else if (meta instanceof SkipSelf || meta.ngMetadataName === 'SkipSelf') {
+        } else if (
+            meta instanceof SkipSelf || meta.ngMetadataName === 'SkipSelf' || meta === SkipSelf) {
           flags |= InjectFlags.SkipSelf;
-        } else if (meta instanceof Self || meta.ngMetadataName === 'Self') {
+        } else if (meta instanceof Self || meta.ngMetadataName === 'Self' || meta === Self) {
           flags |= InjectFlags.Self;
-        } else if (meta instanceof Inject) {
+        } else if (meta instanceof Inject || meta === Inject) {
           type = meta.token;
         } else {
           type = meta;

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Inject, Injectable, InjectionToken, NgModule, forwardRef} from '@angular/core';
+import {Component, Directive, Inject, Injectable, InjectionToken, Injector, NgModule, Optional, forwardRef} from '@angular/core';
 import {TestBed, async, inject} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {onlyInIvy} from '@angular/private/testing';
@@ -321,4 +321,25 @@ describe('providers', () => {
 
   });
 
+  describe('flags', () => {
+
+    class MyService {
+      constructor(public value: OtherService|null) {}
+    }
+
+    class OtherService {}
+
+    it('should support Optional flag in deps', () => {
+      const injector =
+          Injector.create([{provide: MyService, deps: [[new Optional(), OtherService]]}]);
+
+      expect(injector.get(MyService).value).toBe(null);
+    });
+
+    it('should support Optional flag in deps without instantiating it', () => {
+      const injector = Injector.create([{provide: MyService, deps: [[Optional, OtherService]]}]);
+
+      expect(injector.get(MyService).value).toBe(null);
+    });
+  });
 });


### PR DESCRIPTION
Previously, we were supporting injection flags for provider deps, but only
if they fit the format `new Optional()`. This commit fixes resolution of
provider deps to also support `Optional` (without the new). This keeps us
backwards compatible with what View Engine supported.
