### PR TITLE
fix(compiler-cli): log ngcc skipping messages as debug instead of info

### DIFF
--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -63,7 +63,7 @@ if [[ $? != 0 ]]; then exit 1; fi
 
 # Can it be safely run again (as a noop)?
 # And check that it logged skipping compilation as expected
-ivy-ngcc | grep 'Skipping'
+ivy-ngcc -l debug | grep 'Skipping'
 if [[ $? != 0 ]]; then exit 1; fi
 
 # Check that running it with logging level error outputs nothing

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -90,7 +90,7 @@ export function mainNgcc(
   if (absoluteTargetEntryPointPath &&
       hasProcessedTargetEntryPoint(
           fs, absoluteTargetEntryPointPath, propertiesToConsider, compileAllFormats)) {
-    logger.info('The target entry-point has already been processed');
+    logger.debug('The target entry-point has already been processed');
     return;
   }
 
@@ -123,7 +123,7 @@ export function mainNgcc(
 
       if (hasBeenProcessed(entryPointPackageJson, property)) {
         compiledFormats.add(formatPath);
-        logger.info(`Skipping ${entryPoint.name} : ${property} (already compiled).`);
+        logger.debug(`Skipping ${entryPoint.name} : ${property} (already compiled).`);
         continue;
       }
 
@@ -146,7 +146,7 @@ export function mainNgcc(
               `Skipping ${entryPoint.name} : ${format} (no valid entry point file for this format).`);
         }
       } else if (!compileAllFormats) {
-        logger.info(`Skipping ${entryPoint.name} : ${property} (already compiled).`);
+        logger.debug(`Skipping ${entryPoint.name} : ${property} (already compiled).`);
       }
 
       // Either this format was just compiled or its underlying format was compiled because of a

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -86,7 +86,7 @@ describe('ngcc main()', () => {
           basePath: '/node_modules',
           targetEntryPointPath: '@angular/common/http/testing', logger,
         });
-        expect(logger.logs.info).toContain(['The target entry-point has already been processed']);
+        expect(logger.logs.debug).toContain(['The target entry-point has already been processed']);
       });
 
       it('should process the target if any `propertyToConsider` is not marked as processed', () => {
@@ -97,7 +97,7 @@ describe('ngcc main()', () => {
           targetEntryPointPath: '@angular/common/http/testing',
           propertiesToConsider: ['fesm2015', 'esm5', 'esm2015'], logger,
         });
-        expect(logger.logs.info).not.toContain([
+        expect(logger.logs.debug).not.toContain([
           'The target entry-point has already been processed'
         ]);
       });
@@ -115,7 +115,7 @@ describe('ngcc main()', () => {
              compileAllFormats: false, logger,
            });
 
-           expect(logger.logs.info).not.toContain([
+           expect(logger.logs.debug).not.toContain([
              'The target entry-point has already been processed'
            ]);
          });
@@ -132,7 +132,7 @@ describe('ngcc main()', () => {
              compileAllFormats: false, logger,
            });
 
-           expect(logger.logs.info).toContain([
+           expect(logger.logs.debug).toContain([
              'The target entry-point has already been processed'
            ]);
          });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
ngcc messages related to skipping are logged to info, which makes it hard to filter them out.


## What is the new behavior?
ngcc messages related to skipping are logged to debug instead of info.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Related to https://github.com/angular/angular-cli/issues/14194, https://github.com/angular/angular-cli/pull/14320