### PR TITLE
refactor(router): remove readonly data modifier from isActive and (this as any) to match reality and remove confusion

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -87,7 +87,7 @@ export class RouterLinkActive implements OnChanges,
 
   private classes: string[] = [];
   private subscription: Subscription;
-  public readonly isActive: boolean = false;
+  public isActive: boolean = false;
 
   @Input() routerLinkActiveOptions: {exact: boolean} = {exact: false};
 
@@ -123,7 +123,7 @@ export class RouterLinkActive implements OnChanges,
     Promise.resolve().then(() => {
       const hasActiveLinks = this.hasActiveLinks();
       if (this.isActive !== hasActiveLinks) {
-        (this as any).isActive = hasActiveLinks;
+        this.isActive = hasActiveLinks;
         this.classes.forEach((c) => {
           if (hasActiveLinks) {
             this.renderer.addClass(this.element.nativeElement, c);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`isActive` field in `RouterLinkActive` was marked as `readonly` and modified through a trick (`this as any`) which kind of defeats the purpose of a `readonly` field.

Issue Number: N/A

## What is the new behavior?
Removed `readonly` modifier and replaced `(this as any).isActive` with `this.isActive`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Was not sure if this is a Refactoring or Code style update
