### PR TITLE
fix(core): fix interpolate identifier in AOT

### DIFF
--- a/packages/compiler/src/identifiers.ts
+++ b/packages/compiler/src/identifiers.ts
@@ -92,7 +92,7 @@ export class Identifiers {
     name: 'ɵinlineInterpolate',
     moduleName: CORE,
   };
-  static interpolate: o.ExternalReference = {name: 'ɵɵinterpolate', moduleName: CORE};
+  static interpolate: o.ExternalReference = {name: 'ɵinterpolate', moduleName: CORE};
   static EMPTY_ARRAY: o.ExternalReference = {name: 'ɵEMPTY_ARRAY', moduleName: CORE};
   static EMPTY_MAP: o.ExternalReference = {name: 'ɵEMPTY_MAP', moduleName: CORE};
   static Renderer: o.ExternalReference = {name: 'Renderer', moduleName: CORE};

--- a/packages/core/test/acceptance/properties_spec.ts
+++ b/packages/core/test/acceptance/properties_spec.ts
@@ -212,4 +212,22 @@ describe('property instructions', () => {
 
     expect(img.src.indexOf('unsafe:')).toBe(0);
   });
+
+  it('should handle interpolations with 10+ values', () => {
+    @Component({
+      selector: 'app-comp',
+      template: `
+        <a href="http://g.com/?one={{'1'}}&two={{'2'}}&three={{'3'}}&four={{'4'}}&five={{'5'}}&six={{'6'}}&seven={{'7'}}&eight={{'8'}}&nine={{'9'}}&ten={{'10'}}">link2</a>`
+    })
+    class AppComp {
+    }
+
+    TestBed.configureTestingModule({declarations: [AppComp]});
+    const fixture = TestBed.createComponent(AppComp);
+    fixture.detectChanges();
+    const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+    expect(anchor.getAttribute('href'))
+        .toEqual(
+            `http://g.com/?one=1&two=2&three=3&four=4&five=5&six=6&seven=7&eight=8&nine=9&ten=10`);
+  });
 });


### PR DESCRIPTION
This commit fixes a regression introduced in PR 29692 where
the interpolate symbol in View Engine was improperly prefixed
with the ɵɵ that signifies private instructions for Ivy. It
resulted in interpolations of 10+ values not working correctly
in AOT mode. This commit removes the prefix.

(I'm unable to add a good test for AOT given the way VE tests 
are set up, but I've added one for JIT).