### PR TITLE
fix(bazel): ability to pass in node options to protractor

### DIFF
--- a/packages/bazel/src/protractor/protractor_web_test.bzl
+++ b/packages/bazel/src/protractor/protractor_web_test.bzl
@@ -173,6 +173,7 @@ def protractor_web_test(
         data = [],
         server = None,
         tags = [],
+        protractor_node_options = [],
         **kwargs):
     """Runs a protractor test in a browser.
 
@@ -198,6 +199,7 @@ def protractor_web_test(
         data = srcs + deps + data,
         testonly = 1,
         visibility = ["//visibility:private"],
+        templated_args = protractor_node_options,
     )
 
     # Our binary dependency must be in data[] for collect_data to pick it up
@@ -244,6 +246,7 @@ def protractor_web_test_suite(
         visibility = None,
         web_test_data = [],
         wrapped_test_tags = None,
+        protractor_node_options = [],
         **remaining_keyword_args):
     """Defines a test_suite of web_test targets that wrap a protractor_web_test target.
 
@@ -298,6 +301,7 @@ def protractor_web_test_suite(
         data = srcs + deps + data,
         testonly = 1,
         visibility = ["//visibility:private"],
+        templated_args = protractor_node_options,
     )
 
     # Our binary dependency must be in data[] for collect_data to pick it up


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines:https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is no option to start protractor in debug mode.


## What is the new behavior?
`--inspect-brk` can be passed to the protractor node options to start it in debug mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No, because the node options default to [].


## Other information
N/A