### PR TITLE
build: size-tracking test should support max-byte threshold

### DIFF
--- a/packages/core/test/bundling/core_all/BUILD.bazel
+++ b/packages/core/test/bundling/core_all/BUILD.bazel
@@ -32,8 +32,9 @@ js_size_tracking_test(
         ":bundle",
         ":bundle.golden_size_map.json",
     ],
-    diffThreshold = 3,
     goldenFile = "angular/packages/core/test/bundling/core_all/bundle.golden_size_map.json",
+    maxByteDiff = 250,
+    maxPercentageDiff = 15,
     sourceMap = "angular/packages/core/test/bundling/core_all/bundle.min.js.map",
     tags = [
         "ivy-only",

--- a/packages/core/test/bundling/core_all/bundle.golden_size_map.json
+++ b/packages/core/test/bundling/core_all/bundle.golden_size_map.json
@@ -1,17 +1,17 @@
 {
   "unmapped": 25,
   "files": {
-    "size": 268455,
+    "size": 266196,
     "@angular/": {
-      "size": 248616,
+      "size": 246357,
       "core/": {
-        "size": 248616,
+        "size": 246357,
         "src/": {
-          "size": 248535,
-          "application_init.ts": 626,
+          "size": 246276,
+          "application_init.ts": 625,
           "application_module.ts": 634,
-          "application_ref.ts": 7371,
-          "application_tokens.ts": 307,
+          "application_ref.ts": 7369,
+          "application_tokens.ts": 302,
           "change_detection/": {
             "size": 14119,
             "change_detection.ts": 46,
@@ -32,52 +32,52 @@
           },
           "console.ts": 217,
           "debug/": {
-            "size": 7621,
-            "debug_node.ts": 7621
+            "size": 7614,
+            "debug_node.ts": 7614
           },
           "di/": {
-            "size": 20079,
+            "size": 17344,
             "forward_ref.ts": 211,
             "injectable.ts": 82,
-            "injection_token.ts": 322,
-            "injector.ts": 3872,
-            "injector_compatibility.ts": 1005,
+            "injection_token.ts": 325,
+            "injector.ts": 312,
+            "injector_compatibility.ts": 1850,
             "interface/": {
               "size": 484,
               "defs.ts": 339,
               "injector.ts": 145
             },
             "jit/": {
-              "size": 1988,
-              "environment.ts": 162,
+              "size": 1985,
+              "environment.ts": 158,
               "injectable.ts": 803,
-              "util.ts": 1023
+              "util.ts": 1024
             },
             "metadata.ts": 157,
-            "r3_injector.ts": 4765,
+            "r3_injector.ts": 4750,
             "reflective_errors.ts": 1376,
-            "reflective_injector.ts": 3062,
+            "reflective_injector.ts": 3059,
             "reflective_key.ts": 661,
-            "reflective_provider.ts": 2000,
-            "scope.ts": 90,
+            "reflective_provider.ts": 1999,
+            "scope.ts": 89,
             "util.ts": 4
           },
           "error_handler.ts": 444,
           "errors.ts": 175,
           "event_emitter.ts": 952,
           "i18n/": {
-            "size": 178,
-            "tokens.ts": 178
+            "size": 175,
+            "tokens.ts": 175
           },
           "interface/": {
-            "size": 222,
+            "size": 223,
             "simple_change.ts": 170,
-            "type.ts": 52
+            "type.ts": 53
           },
-          "ivy_switch.ts": 936,
+          "ivy_switch.ts": 937,
           "linker/": {
-            "size": 4923,
-            "compiler.ts": 825,
+            "size": 4922,
+            "compiler.ts": 824,
             "component_factory.ts": 91,
             "component_factory_resolver.ts": 1003,
             "element_ref.ts": 119,
@@ -90,12 +90,12 @@
             "view_ref.ts": 196
           },
           "metadata/": {
-            "size": 3522,
-            "di.ts": 547,
+            "size": 3519,
+            "di.ts": 546,
             "directives.ts": 604,
             "ng_module.ts": 95,
             "resource_loading.ts": 839,
-            "schema.ts": 1306,
+            "schema.ts": 1304,
             "view.ts": 131
           },
           "platform_core_providers.ts": 118,
@@ -105,9 +105,9 @@
             "wtf_impl.ts": 272
           },
           "reflection/": {
-            "size": 4878,
-            "reflection.ts": 15,
-            "reflection_capabilities.ts": 3678,
+            "size": 4896,
+            "reflection.ts": 16,
+            "reflection_capabilities.ts": 3695,
             "reflector.ts": 1185
           },
           "render/": {
@@ -115,19 +115,19 @@
             "api.ts": 482
           },
           "render3/": {
-            "size": 103297,
+            "size": 103782,
             "bindings.ts": 300,
             "component.ts": 4000,
-            "component_ref.ts": 2512,
+            "component_ref.ts": 2510,
             "context_discovery.ts": 2098,
-            "definition.ts": 2486,
+            "definition.ts": 2520,
             "di.ts": 3651,
             "di_setup.ts": 1584,
             "empty.ts": 16,
-            "errors.ts": 89,
+            "errors.ts": 472,
             "features/": {
-              "size": 2677,
-              "inherit_definition_feature.ts": 1993,
+              "size": 2725,
+              "inherit_definition_feature.ts": 2041,
               "ng_onchanges_feature.ts": 571,
               "providers_feature.ts": 113
             },
@@ -135,14 +135,14 @@
             "hooks.ts": 1843,
             "i18n.ts": 14527,
             "instructions/": {
-              "size": 20030,
+              "size": 20007,
               "alloc_host_vars.ts": 290,
               "change_detection.ts": 91,
-              "container.ts": 758,
+              "container.ts": 757,
               "di.ts": 129,
               "element.ts": 1214,
               "element_container.ts": 335,
-              "embedded_view.ts": 678,
+              "embedded_view.ts": 676,
               "get_current_view.ts": 26,
               "listener.ts": 1401,
               "next_context.ts": 44,
@@ -150,7 +150,7 @@
               "property.ts": 193,
               "property_interpolation.ts": 2584,
               "select.ts": 51,
-              "shared.ts": 10205,
+              "shared.ts": 10185,
               "storage.ts": 169,
               "styling.ts": 1329,
               "text.ts": 185
@@ -165,15 +165,15 @@
               "view.ts": 110
             },
             "jit/": {
-              "size": 9479,
-              "directive.ts": 3409,
+              "size": 9550,
+              "directive.ts": 3480,
               "environment.ts": 2758,
               "module.ts": 3047,
               "pipe.ts": 265
             },
             "metadata.ts": 615,
-            "ng_module_ref.ts": 986,
-            "node_manipulation.ts": 4571,
+            "ng_module_ref.ts": 985,
+            "node_manipulation.ts": 4563,
             "node_selector_matcher.ts": 1780,
             "node_util.ts": 335,
             "pipe.ts": 958,
@@ -191,18 +191,18 @@
               "state.ts": 55,
               "util.ts": 1381
             },
-            "tokens.ts": 10,
+            "tokens.ts": 6,
             "util/": {
-              "size": 4102,
+              "size": 4133,
               "attrs_utils.ts": 423,
               "discovery_utils.ts": 1489,
-              "global_utils.ts": 374,
+              "global_utils.ts": 405,
               "injector_utils.ts": 150,
               "misc_utils.ts": 625,
               "view_traversal_utils.ts": 221,
               "view_utils.ts": 820
             },
-            "view_engine_compatibility.ts": 3815,
+            "view_engine_compatibility.ts": 3771,
             "view_engine_compatibility_prebound.ts": 38,
             "view_ref.ts": 2212
           },
@@ -221,13 +221,13 @@
             "testability.ts": 3796
           },
           "util/": {
-            "size": 4317,
+            "size": 4313,
             "array_utils.ts": 210,
             "assert.ts": 81,
             "closure.ts": 37,
             "comparison.ts": 90,
             "decorators.ts": 1640,
-            "errors.ts": 164,
+            "errors.ts": 160,
             "global.ts": 271,
             "is_dev_mode.ts": 358,
             "lang.ts": 109,
@@ -240,20 +240,20 @@
           },
           "version.ts": 179,
           "view/": {
-            "size": 55747,
+            "size": 55744,
             "element.ts": 3814,
             "entrypoint.ts": 962,
             "errors.ts": 642,
             "ng_content.ts": 447,
-            "ng_module.ts": 2448,
-            "provider.ts": 5363,
+            "ng_module.ts": 2447,
+            "provider.ts": 5362,
             "pure_expression.ts": 2279,
             "query.ts": 2385,
             "refs.ts": 9337,
             "services.ts": 11639,
             "text.ts": 1551,
             "types.ts": 768,
-            "util.ts": 4728,
+            "util.ts": 4727,
             "view.ts": 8143,
             "view_attach.ts": 1241
           },

--- a/tools/size-tracking/file_size_compare.ts
+++ b/tools/size-tracking/file_size_compare.ts
@@ -71,7 +71,7 @@ function compareActualSizeToExpected(
   if (byteDiff > threshold.maxByteDiff) {
     diffs.push({
       filePath: filePath,
-      message: `Differs by ${byteDiff}b from the expected size ` +
+      message: `Differs by ${byteDiff}B from the expected size ` +
           `(actual = ${actualSize}, expected = ${expectedSize})`
     });
   }

--- a/tools/size-tracking/file_size_compare.ts
+++ b/tools/size-tracking/file_size_compare.ts
@@ -13,24 +13,35 @@ export interface SizeDifference {
   message: string;
 }
 
+export interface Threshold {
+  /**
+   * Maximum difference percentage. Exceeding this causes a reported size
+   * difference. Percentage difference is helpful for small files where
+   * the byte threshold is not exceeded but the change is relatively large
+   * for the small file and should be reported.
+   */
+  maxPercentageDiff: number;
+  /**
+   * Maximum byte difference. Exceeding this causes a reported size difference.
+   * The max byte threshold works good for large files where change is relatively
+   * small but still needs to reported as it causes an overall size regression.
+   */
+  maxByteDiff: number;
+}
+
 /** Compares two file size data objects and returns an array of size differences. */
 export function compareFileSizeData(
-    actual: FileSizeData, expected: FileSizeData, threshold: number) {
-  const diffs: SizeDifference[] = compareSizeEntry(actual.files, expected.files, '/', threshold);
-  const unmappedBytesDiff = getDifferencePercentage(actual.unmapped, expected.unmapped);
-  if (unmappedBytesDiff > threshold) {
-    diffs.push({
-      message: `Unmapped bytes differ by ${unmappedBytesDiff.toFixed(2)}% from ` +
-          `the expected size (actual = ${actual.unmapped}, expected = ${expected.unmapped})`
-    });
-  }
-  return diffs;
+    actual: FileSizeData, expected: FileSizeData, threshold: Threshold) {
+  return [
+    ...compareSizeEntry(actual.files, expected.files, '/', threshold),
+    ...compareActualSizeToExpected(actual.unmapped, expected.unmapped, '<unmapped>', threshold)
+  ];
 }
 
 /** Compares two file size entries and returns an array of size differences. */
 function compareSizeEntry(
     actual: DirectorySizeEntry | number, expected: DirectorySizeEntry | number, filePath: string,
-    threshold: number) {
+    threshold: Threshold) {
   if (typeof actual !== 'number' && typeof expected !== 'number') {
     return compareDirectorySizeEntry(
         <DirectorySizeEntry>actual, <DirectorySizeEntry>expected, filePath, threshold);
@@ -40,21 +51,31 @@ function compareSizeEntry(
 }
 
 /**
- * Compares two size numbers and returns a size difference when the percentage difference
- * exceeds the specified threshold.
+ * Compares two size numbers and returns a size difference if the difference
+ * percentage exceeds the specified maximum percentage or the byte size
+ * difference exceeds the maximum byte difference.
  */
 function compareActualSizeToExpected(
     actualSize: number, expectedSize: number, filePath: string,
-    threshold: number): SizeDifference[] {
+    threshold: Threshold): SizeDifference[] {
   const diffPercentage = getDifferencePercentage(actualSize, expectedSize);
-  if (diffPercentage > threshold) {
-    return [{
+  const byteDiff = Math.abs(expectedSize - actualSize);
+  const diffs: SizeDifference[] = [];
+  if (diffPercentage > threshold.maxPercentageDiff) {
+    diffs.push({
       filePath: filePath,
       message: `Differs by ${diffPercentage.toFixed(2)}% from the expected size ` +
           `(actual = ${actualSize}, expected = ${expectedSize})`
-    }];
+    });
   }
-  return [];
+  if (byteDiff > threshold.maxByteDiff) {
+    diffs.push({
+      filePath: filePath,
+      message: `Differs by ${byteDiff}b from the expected size ` +
+          `(actual = ${actualSize}, expected = ${expectedSize})`
+    });
+  }
+  return diffs;
 }
 
 /**
@@ -63,7 +84,7 @@ function compareActualSizeToExpected(
  */
 function compareDirectorySizeEntry(
     actual: DirectorySizeEntry, expected: DirectorySizeEntry, filePath: string,
-    threshold: number): SizeDifference[] {
+    threshold: Threshold): SizeDifference[] {
   const diffs: SizeDifference[] =
       [...compareActualSizeToExpected(actual.size, expected.size, filePath, threshold)];
 

--- a/tools/size-tracking/file_size_compare_spec.ts
+++ b/tools/size-tracking/file_size_compare_spec.ts
@@ -10,7 +10,7 @@ import {compareFileSizeData} from './file_size_compare';
 
 describe('file size compare', () => {
 
-  it('should report if size entry differ by more than the specified threshold', () => {
+  it('should report if size entry differ by more than the specified max percentage diff', () => {
     const diffs = compareFileSizeData(
         {
           unmapped: 0,
@@ -26,13 +26,48 @@ describe('file size compare', () => {
             'a.ts': 75,
           }
         },
-        0);
+        {maxPercentageDiff: 0, maxByteDiff: 25});
 
     expect(diffs.length).toBe(2);
     expect(diffs[0].filePath).toBe('/');
     expect(diffs[0].message).toMatch(/40.00% from the expected size/);
     expect(diffs[1].filePath).toBe('/a.ts');
     expect(diffs[1].message).toMatch(/40.00% from the expected size/);
+  });
+
+  it('should report if size entry differ by more than the specified max byte diff', () => {
+    const diffs = compareFileSizeData(
+        {
+          unmapped: 0,
+          files: {
+            size: 1000,
+            'a.ts': 1000,
+          }
+        },
+        {
+          unmapped: 0,
+          files: {
+            size: 1055,
+            'a.ts': 1055,
+          }
+        },
+        {maxPercentageDiff: 6, maxByteDiff: 50});
+
+    expect(diffs.length).toBe(2);
+    expect(diffs[0].filePath).toBe('/');
+    expect(diffs[0].message).toMatch(/55b from the expected size/);
+    expect(diffs[1].filePath).toBe('/a.ts');
+    expect(diffs[1].message).toMatch(/55b from the expected size/);
+  });
+
+  it('should report if unmapped bytes differ by more than specified threshold', () => {
+    const diffs = compareFileSizeData(
+        {unmapped: 1000, files: {size: 0}}, {unmapped: 1055, files: {size: 0}},
+        {maxPercentageDiff: 6, maxByteDiff: 50});
+
+    expect(diffs.length).toBe(1);
+    expect(diffs[0].filePath).toBe('<unmapped>');
+    expect(diffs[0].message).toMatch(/55b from the expected size/);
   });
 
   it('should not report if size percentage difference does not exceed threshold', () => {
@@ -51,7 +86,7 @@ describe('file size compare', () => {
             'a.ts': 75,
           }
         },
-        40);
+        {maxPercentageDiff: 40, maxByteDiff: 25});
 
     expect(diffs.length).toBe(0);
   });
@@ -67,7 +102,7 @@ describe('file size compare', () => {
             'b.ts': 1,
           }
         },
-        {unmapped: 0, files: {size: 100, 'a.ts': 100}}, 1);
+        {unmapped: 0, files: {size: 100, 'a.ts': 100}}, {maxByteDiff: 10, maxPercentageDiff: 1});
 
     expect(diffs.length).toBe(1);
     expect(diffs[0].filePath).toBe('/b.ts');
@@ -83,7 +118,8 @@ describe('file size compare', () => {
             'a.ts': 100,
           }
         },
-        {unmapped: 0, files: {size: 101, 'a.ts': 100, 'b.ts': 1}}, 1);
+        {unmapped: 0, files: {size: 101, 'a.ts': 100, 'b.ts': 1}},
+        {maxByteDiff: 10, maxPercentageDiff: 1});
 
     expect(diffs.length).toBe(1);
     expect(diffs[0].filePath).toBe('/b.ts');

--- a/tools/size-tracking/file_size_compare_spec.ts
+++ b/tools/size-tracking/file_size_compare_spec.ts
@@ -55,9 +55,9 @@ describe('file size compare', () => {
 
     expect(diffs.length).toBe(2);
     expect(diffs[0].filePath).toBe('/');
-    expect(diffs[0].message).toMatch(/55b from the expected size/);
+    expect(diffs[0].message).toMatch(/55B from the expected size/);
     expect(diffs[1].filePath).toBe('/a.ts');
-    expect(diffs[1].message).toMatch(/55b from the expected size/);
+    expect(diffs[1].message).toMatch(/55B from the expected size/);
   });
 
   it('should report if unmapped bytes differ by more than specified threshold', () => {
@@ -67,7 +67,7 @@ describe('file size compare', () => {
 
     expect(diffs.length).toBe(1);
     expect(diffs[0].filePath).toBe('<unmapped>');
-    expect(diffs[0].message).toMatch(/55b from the expected size/);
+    expect(diffs[0].message).toMatch(/55B from the expected size/);
   });
 
   it('should not report if size percentage difference does not exceed threshold', () => {

--- a/tools/size-tracking/index.bzl
+++ b/tools/size-tracking/index.bzl
@@ -11,7 +11,15 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
   file size data against previously approved file size data
 """
 
-def js_size_tracking_test(name, src, sourceMap, goldenFile, diffThreshold, data = [], **kwargs):
+def js_size_tracking_test(
+        name,
+        src,
+        sourceMap,
+        goldenFile,
+        maxPercentageDiff,
+        maxByteDiff,
+        data = [],
+        **kwargs):
     all_data = data + [
         "//tools/size-tracking",
         "@npm//source-map",
@@ -24,7 +32,7 @@ def js_size_tracking_test(name, src, sourceMap, goldenFile, diffThreshold, data 
         data = all_data,
         entry_point = entry_point,
         configuration_env_vars = ["compile"],
-        templated_args = [src, sourceMap, goldenFile, "%d" % diffThreshold, "false"],
+        templated_args = [src, sourceMap, goldenFile, "%d" % maxPercentageDiff, "%d" % maxByteDiff, "false"],
         **kwargs
     )
 
@@ -34,6 +42,6 @@ def js_size_tracking_test(name, src, sourceMap, goldenFile, diffThreshold, data 
         data = all_data,
         entry_point = entry_point,
         configuration_env_vars = ["compile"],
-        templated_args = [src, sourceMap, goldenFile, "%d" % diffThreshold, "true"],
+        templated_args = [src, sourceMap, goldenFile, "0", "0", "true"],
         **kwargs
     )

--- a/tools/size-tracking/index.ts
+++ b/tools/size-tracking/index.ts
@@ -13,17 +13,19 @@ import {compareFileSizeData} from './file_size_compare';
 import {FileSizeData} from './file_size_data';
 
 if (require.main === module) {
-  const [filePath, sourceMapPath, goldenPath, thresholdArg, writeGoldenArg] = process.argv.slice(2);
+  const
+      [filePath, sourceMapPath, goldenPath, maxPercentageDiffArg, maxSizeDiffArg, writeGoldenArg] =
+          process.argv.slice(2);
   const status = main(
       require.resolve(filePath), require.resolve(sourceMapPath), require.resolve(goldenPath),
-      writeGoldenArg === 'true', parseInt(thresholdArg));
+      writeGoldenArg === 'true', parseInt(maxPercentageDiffArg), parseInt(maxSizeDiffArg));
 
   process.exit(status ? 0 : 1);
 }
 
 export function main(
     filePath: string, sourceMapPath: string, goldenSizeMapPath: string, writeGolden: boolean,
-    diffThreshold: number): boolean {
+    maxPercentageDiff: number, maxByteDiff: number): boolean {
   const {sizeResult} = new SizeTracker(filePath, sourceMapPath);
 
   if (writeGolden) {
@@ -33,7 +35,8 @@ export function main(
   }
 
   const expectedSizeData = <FileSizeData>JSON.parse(readFileSync(goldenSizeMapPath, 'utf8'));
-  const differences = compareFileSizeData(sizeResult, expectedSizeData, diffThreshold);
+  const differences =
+      compareFileSizeData(sizeResult, expectedSizeData, {maxByteDiff, maxPercentageDiff});
 
   if (!differences.length) {
     return true;


### PR DESCRIPTION
Based on discussion that happened on the PR that introduced
the size-tracking tool, we want to have another threshold for
the raw byte difference. This allows us to better control for
which changes the size-tracking tool should report a difference.

See: https://github.com/angular/angular/pull/30070#discussion_r278332315
