### PR TITLE
fix(core): static-query migration should gracefully exit if AOT compiler throws

### DIFF
--- a/packages/core/schematics/migrations/injectable-pipe/index.ts
+++ b/packages/core/schematics/migrations/injectable-pipe/index.ts
@@ -53,10 +53,11 @@ function runInjectablePipeMigration(tree: Tree, tsconfigPath: string, basePath: 
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const visitor = new InjectablePipeVisitor(typeChecker);
-  const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
+  const sourceFiles = program.getSourceFiles().filter(
+      f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
   const printer = ts.createPrinter();
 
-  rootSourceFiles.forEach(sourceFile => visitor.visitNode(sourceFile));
+  sourceFiles.forEach(sourceFile => visitor.visitNode(sourceFile));
 
   visitor.missingInjectablePipes.forEach(data => {
     const {classDeclaration, importDeclarationMissingImport} = data;

--- a/packages/core/schematics/migrations/move-document/index.ts
+++ b/packages/core/schematics/migrations/move-document/index.ts
@@ -54,10 +54,11 @@ function runMoveDocumentMigration(tree: Tree, tsconfigPath: string, basePath: st
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const visitor = new DocumentImportVisitor(typeChecker);
-  const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
+  const sourceFiles = program.getSourceFiles().filter(
+      f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
 
   // Analyze source files by finding imports.
-  rootSourceFiles.forEach(sourceFile => visitor.visitNode(sourceFile));
+  sourceFiles.forEach(sourceFile => visitor.visitNode(sourceFile));
 
   const {importsMap} = visitor;
 

--- a/packages/core/schematics/migrations/static-queries/angular/directive_inputs.ts
+++ b/packages/core/schematics/migrations/static-queries/angular/directive_inputs.ts
@@ -68,7 +68,8 @@ function getInputNamesFromMetadata(
   // where inputs could be declared. This is an edge case because there
   // always needs to be an object literal, but in case there isn't we just
   // want to skip the invalid decorator and return null.
-  if (!ts.isObjectLiteralExpression(decoratorCall.arguments[0])) {
+  if (decoratorCall.arguments.length !== 1 ||
+      !ts.isObjectLiteralExpression(decoratorCall.arguments[0])) {
     return null;
   }
 

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -117,7 +117,8 @@ function analyzeProject(tree: Tree, tsconfigPath: string, basePath: string):
 
       const program = ts.createProgram(parsed.fileNames, parsed.options, host);
       const typeChecker = program.getTypeChecker();
-      const sourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
+      const sourceFiles = program.getSourceFiles().filter(
+          f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
       const queryVisitor = new NgQueryResolveVisitor(typeChecker);
 
       // Analyze all project source-files and collect all queries that

--- a/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
@@ -63,14 +63,12 @@ export class QueryTemplateStrategy implements TimingStrategy {
     ];
 
     if (ngDiagnostics.length) {
-      this._printDiagnosticFailures(ngDiagnostics);
-      return false;
+      throw this._createDiagnosticsError(ngDiagnostics);
     }
 
     analyzedModules.files.forEach(file => {
       file.directives.forEach(directive => this._analyzeDirective(directive, analyzedModules));
     });
-    return true;
   }
 
   /** Analyzes a given directive by determining the timing of all matched view queries. */
@@ -180,12 +178,12 @@ export class QueryTemplateStrategy implements TimingStrategy {
         .template;
   }
 
-  private _printDiagnosticFailures(diagnostics: (ts.Diagnostic|Diagnostic)[]) {
-    console.error('Could not create Angular AOT compiler to determine query timing.');
-    console.error('The following diagnostics were detected:\n');
-    console.error(diagnostics.map(d => d.messageText).join(`\n`));
-    console.error('Please make sure that there is no compilation failure. The migration');
-    console.error('can be rerun with: "ng update @angular/core --from 7 --to 8 --migrate-only"');
+  private _createDiagnosticsError(diagnostics: (ts.Diagnostic|Diagnostic)[]) {
+    return new Error(
+        `Could not create Angular AOT compiler to determine query timing.\n` +
+        `The following diagnostics were detected:\n` +
+        `${diagnostics.map(d => d.messageText).join(`\n `)}\n` +
+        `Please make sure that there is no AOT compilation failure.`);
   }
 
   private _getViewQueryUniqueKey(filePath: string, className: string, propName: string) {

--- a/packages/core/schematics/migrations/static-queries/strategies/test_strategy/test_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/test_strategy/test_strategy.ts
@@ -16,7 +16,7 @@ import {TimingResult, TimingStrategy} from '../timing-strategy';
  * of detecting the timing of queries based on how they are used in tests.
  */
 export class QueryTestStrategy implements TimingStrategy {
-  setup() { return true; }
+  setup() {}
 
   /**
    * Detects the timing for a given query. For queries within tests, we always

--- a/packages/core/schematics/migrations/static-queries/strategies/timing-strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/timing-strategy.ts
@@ -9,8 +9,8 @@
 import {NgQueryDefinition, QueryTiming} from '../angular/query-definition';
 
 export interface TimingStrategy {
-  /** Sets up the given strategy. Should return false if the strategy could not be set up. */
-  setup(): boolean;
+  /** Sets up the given strategy. Throws if the strategy could not be set up. */
+  setup(): void;
   /** Detects the timing result for a given query. */
   detectTiming(query: NgQueryDefinition): TimingResult;
 }

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/declaration_usage_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/declaration_usage_visitor.ts
@@ -240,6 +240,17 @@ export class DeclarationUsageVisitor {
       callArgs: ts.NodeArray<ts.Expression>, parameters: ts.NodeArray<ts.ParameterDeclaration>) {
     parameters.forEach((parameter, index) => {
       let argumentNode: ts.Node = callArgs[index];
+
+      if (!argumentNode) {
+        if (!parameter.initializer) {
+          return;
+        }
+
+        // Argument can be undefined in case the function parameter has a default
+        // value. In that case we want to store the parameter default value in the context.
+        argumentNode = parameter.initializer;
+      }
+
       if (ts.isIdentifier(argumentNode)) {
         this.context.set(parameter, this._resolveIdentifier(argumentNode));
       } else {
@@ -285,7 +296,7 @@ export class DeclarationUsageVisitor {
   private _getPropertyAccessSymbol(node: ts.PropertyAccessExpression): ts.Symbol|null {
     let propertySymbol = this._getDeclarationSymbolOfNode(node.name);
 
-    if (!propertySymbol) {
+    if (!propertySymbol || !propertySymbol.valueDeclaration) {
       return null;
     }
 

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
@@ -37,11 +37,7 @@ const STATIC_QUERY_LIFECYCLE_HOOKS = {
 export class QueryUsageStrategy implements TimingStrategy {
   constructor(private classMetadata: ClassMetadataMap, private typeChecker: ts.TypeChecker) {}
 
-  setup() {
-    // No setup is needed for this strategy and therefore we always return "true" as
-    // the setup is successful.
-    return true;
-  }
+  setup() {}
 
   /**
    * Analyzes the usage of the given query and determines the query timing based

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -60,10 +60,11 @@ function runTemplateVariableAssignmentCheck(
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
-  const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
+  const sourceFiles = program.getSourceFiles().filter(
+      f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
 
   // Analyze source files by detecting HTML templates.
-  rootSourceFiles.forEach(sourceFile => templateVisitor.visitNode(sourceFile));
+  sourceFiles.forEach(sourceFile => templateVisitor.visitNode(sourceFile));
 
   const {resolvedTemplates} = templateVisitor;
   const collectedFailures: string[] = [];

--- a/packages/core/schematics/test/static_queries_migration_usage_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_usage_spec.ts
@@ -1384,5 +1384,29 @@ describe('static-queries migration with usage strategy', () => {
 
       expect(testModule.promptForMigrationStrategy).toHaveBeenCalledTimes(0);
     });
+
+    it('should support function call with default parameter value', async() => {
+      writeFile('/index.ts', `
+        import {Component, ${queryType}} from '@angular/core';
+
+        @Component({template: '<span>Test</span>'})
+        export class MyComponent {
+          @${queryType}('test') query: any;
+          
+          ngOnInit() {
+            this.myFunction();
+          }
+          
+          myFunction(unused?: string, cb = () => this.query.doSomething) {
+            cb();
+          }
+        }
+      `);
+
+      await runMigration();
+
+      expect(tree.readContent('/index.ts'))
+          .toContain(`@${queryType}('test', { static: true }) query: any;`);
+    });
   }
 });


### PR DESCRIPTION
* See individual commits (except first one)

**Note**: Blocked on #30254 