### PR TITLE
fix(ngcc): do not crash if missing entry-point dependencies

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -128,9 +128,11 @@ export class DependencyResolver {
       } else {
         dependencies.forEach(dependencyPath => {
           if (graph.hasNode(dependencyPath)) {
-            // The dependency path maps to an entry point that exists in the graph
-            // so add the dependency.
-            graph.addDependency(entryPoint.path, dependencyPath);
+            if (graph.hasNode(entryPoint.path)) {
+              // The entry-point is still valid (i.e. has no missing dependencies) and
+              // the dependency maps to an entry point that exists in the graph so add it
+              graph.addDependency(entryPoint.path, dependencyPath);
+            }
           } else if (invalidEntryPoints.some(i => i.entryPoint.path === dependencyPath)) {
             // The dependency path maps to an entry-point that was previously removed
             // from the graph, so remove this entry-point as well.

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -100,7 +100,8 @@ export function mainNgcc(
   invalidEntryPoints.forEach(invalidEntryPoint => {
     logger.debug(
         `Invalid entry-point ${invalidEntryPoint.entryPoint.path}.`,
-        `It is missing required dependencies: ${invalidEntryPoint.missingDependencies.join(',')}`);
+        `It is missing required dependencies:\n` +
+            invalidEntryPoint.missingDependencies.map(dep => ` - ${dep}`).join('\n'));
   });
 
   if (absoluteTargetEntryPointPath && entryPoints.length === 0) {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -94,8 +94,14 @@ export function mainNgcc(
     return;
   }
 
-  const {entryPoints} = finder.findEntryPoints(
+  const {entryPoints, invalidEntryPoints} = finder.findEntryPoints(
       AbsoluteFsPath.from(basePath), absoluteTargetEntryPointPath, pathMappings);
+
+  invalidEntryPoints.forEach(invalidEntryPoint => {
+    logger.debug(
+        `Invalid entry-point ${invalidEntryPoint.entryPoint.path}.`,
+        `It is missing required dependencies: ${invalidEntryPoint.missingDependencies.join(',')}`);
+  });
 
   if (absoluteTargetEntryPointPath && entryPoints.length === 0) {
     markNonAngularPackageAsProcessed(fs, absoluteTargetEntryPointPath, propertiesToConsider);

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -78,7 +78,7 @@ describe('DependencyResolver', () => {
 
     it('should remove entry points that depended upon an invalid entry-point', () => {
       spyOn(host, 'findDependencies').and.callFake(createFakeComputeDependencies({
-        [_('/first/index.js')]: {resolved: [second.path], missing: []},
+        [_('/first/index.js')]: {resolved: [second.path, third.path], missing: []},
         [_('/second/sub/index.js')]: {resolved: [], missing: ['/missing']},
         [_('/third/index.js')]: {resolved: [], missing: []},
       }));
@@ -93,7 +93,7 @@ describe('DependencyResolver', () => {
 
     it('should remove entry points that will depend upon an invalid entry-point', () => {
       spyOn(host, 'findDependencies').and.callFake(createFakeComputeDependencies({
-        [_('/first/index.js')]: {resolved: [second.path], missing: []},
+        [_('/first/index.js')]: {resolved: [second.path, third.path], missing: []},
         [_('/second/sub/index.js')]: {resolved: [], missing: ['/missing']},
         [_('/third/index.js')]: {resolved: [], missing: []},
       }));


### PR DESCRIPTION
Fixes #29624 