### PR TITLE
feat(compiler): support arrow function in template

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_type.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_type.ts
@@ -7,6 +7,7 @@
  */
 
 import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, visitAstChildren} from '@angular/compiler';
+import {ArrowFunction, LexicalReceiver} from '@angular/compiler/src/compiler';
 
 import {BuiltinType, Signature, Span, Symbol, SymbolQuery, SymbolTable} from './symbols';
 
@@ -230,6 +231,8 @@ export class AstType implements AstVisitor {
     };
   }
 
+  visitLexicalReceiver(ast: LexicalReceiver): Symbol { return this.anyType; }
+
   visitInterpolation(ast: Interpolation): Symbol {
     // If we are producing diagnostics, visit the children.
     if (this.diagnostics) {
@@ -334,6 +337,8 @@ export class AstType implements AstVisitor {
   visitSafePropertyRead(ast: SafePropertyRead) {
     return this.resolvePropertyRead(this.query.getNonNullableType(this.getType(ast.receiver)), ast);
   }
+
+  visitArrowFunction(ast: ArrowFunction) { return this.anyType; }
 
   // TODO(issue/24571): remove '!'.
   private _anyType !: Symbol;

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -131,8 +131,14 @@ class _Scanner {
     this.advance();
   }
 
+  peekAt(offset: number): number {
+    const targetIndex = this.index + offset;
+    return targetIndex >= this.length ? chars.$EOF : this.input.charCodeAt(targetIndex);
+  }
+
   advance() {
-    this.peek = ++this.index >= this.length ? chars.$EOF : this.input.charCodeAt(this.index);
+    this.peek = this.peekAt(1);
+    this.index++;
   }
 
   scanToken(): Token|null {
@@ -193,7 +199,12 @@ class _Scanner {
       case chars.$GT:
         return this.scanComplexOperator(start, String.fromCharCode(peek), chars.$EQ, '=');
       case chars.$BANG:
+        return this.scanComplexOperator(
+            start, String.fromCharCode(peek), chars.$EQ, '=', chars.$EQ, '=');
       case chars.$EQ:
+        if (this.peekAt(1) === chars.$GT) {
+          return this.scanComplexOperator(start, String.fromCharCode(peek), chars.$GT, '>');
+        }
         return this.scanComplexOperator(
             start, String.fromCharCode(peek), chars.$EQ, '=', chars.$EQ, '=');
       case chars.$AMPERSAND:

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -174,6 +174,13 @@ function expectErrorToken(token: Token, index: any, message: string) {
         expectOperatorToken(tokens[8], 22, '!==');
       });
 
+      it('should tokenize fat arrow', () => {
+        const tokens: Token[] = lex('a=>b');
+        expectIdentifierToken(tokens[0], 0, 'a');
+        expectOperatorToken(tokens[1], 1, '=>');
+        expectIdentifierToken(tokens[2], 3, 'b');
+      });
+
       it('should tokenize statements', () => {
         const tokens: Token[] = lex('a;b;');
         expectIdentifierToken(tokens[0], 0, 'a');

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead} from '../../../src/expression_parser/ast';
+import {AST, ArrowFunction, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead} from '../../../src/expression_parser/ast';
 
 import {unparse} from './unparser';
 
@@ -108,6 +108,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
     this.validate(ast, () => super.visitSafePropertyRead(ast, context));
+  }
+
+  visitArrowFunction(ast: ArrowFunction, context: any): any {
+    this.validate(ast, () => super.visitArrowFunction(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -137,7 +137,7 @@ describe('R3 template transform', () => {
   describe('Bound text nodes', () => {
     it('should parse bound text nodes', () => {
       expectFromHtml('{{a}}').toEqual([
-        ['BoundText', '{{ a }}'],
+        ['BoundText', '{{ this.a }}'],
       ]);
     });
   });
@@ -146,70 +146,70 @@ describe('R3 template transform', () => {
     it('should parse mixed case bound properties', () => {
       expectFromHtml('<div [someProp]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'someProp', 'v'],
+        ['BoundAttribute', BindingType.Property, 'someProp', 'this.v'],
       ]);
     });
 
     it('should parse bound properties via bind- ', () => {
       expectFromHtml('<div bind-prop="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'prop', 'v'],
+        ['BoundAttribute', BindingType.Property, 'prop', 'this.v'],
       ]);
     });
 
     it('should parse bound properties via {{...}}', () => {
       expectFromHtml('<div prop="{{v}}"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'prop', '{{ v }}'],
+        ['BoundAttribute', BindingType.Property, 'prop', '{{ this.v }}'],
       ]);
     });
 
     it('should parse dash case bound properties', () => {
       expectFromHtml('<div [some-prop]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'some-prop', 'v'],
+        ['BoundAttribute', BindingType.Property, 'some-prop', 'this.v'],
       ]);
     });
 
     it('should parse dotted name bound properties', () => {
       expectFromHtml('<div [d.ot]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'd.ot', 'v'],
+        ['BoundAttribute', BindingType.Property, 'd.ot', 'this.v'],
       ]);
     });
 
     it('should not normalize property names via the element schema', () => {
       expectFromHtml('<div [mappedAttr]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'mappedAttr', 'v'],
+        ['BoundAttribute', BindingType.Property, 'mappedAttr', 'this.v'],
       ]);
     });
 
     it('should parse mixed case bound attributes', () => {
       expectFromHtml('<div [attr.someAttr]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Attribute, 'someAttr', 'v'],
+        ['BoundAttribute', BindingType.Attribute, 'someAttr', 'this.v'],
       ]);
     });
 
     it('should parse and dash case bound classes', () => {
       expectFromHtml('<div [class.some-class]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Class, 'some-class', 'v'],
+        ['BoundAttribute', BindingType.Class, 'some-class', 'this.v'],
       ]);
     });
 
     it('should parse mixed case bound classes', () => {
       expectFromHtml('<div [class.someClass]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Class, 'someClass', 'v'],
+        ['BoundAttribute', BindingType.Class, 'someClass', 'this.v'],
       ]);
     });
 
     it('should parse mixed case bound styles', () => {
       expectFromHtml('<div [style.someStyle]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Style, 'someStyle', 'v'],
+        ['BoundAttribute', BindingType.Style, 'someStyle', 'this.v'],
       ]);
     });
   });
@@ -268,8 +268,8 @@ describe('R3 template transform', () => {
     it('should parse bound attributes', () => {
       expectFromHtml('<ng-template [k1]="v1" [k2]="v2"></ng-template>').toEqual([
         ['Template'],
-        ['BoundAttribute', BindingType.Property, 'k1', 'v1'],
-        ['BoundAttribute', BindingType.Property, 'k2', 'v2'],
+        ['BoundAttribute', BindingType.Property, 'k1', 'this.v1'],
+        ['BoundAttribute', BindingType.Property, 'k2', 'this.v2'],
       ]);
     });
   });
@@ -278,8 +278,8 @@ describe('R3 template transform', () => {
     it('should support attribute and bound attributes', () => {
       expectFromHtml('<div *ngFor="item of items"></div>').toEqual([
         ['Template'],
-        ['BoundAttribute', BindingType.Property, 'ngFor', 'item'],
-        ['BoundAttribute', BindingType.Property, 'ngForOf', 'items'],
+        ['BoundAttribute', BindingType.Property, 'ngFor', 'this.item'],
+        ['BoundAttribute', BindingType.Property, 'ngForOf', 'this.items'],
         ['Element', 'div'],
       ]);
     });
@@ -296,7 +296,7 @@ describe('R3 template transform', () => {
     it('should parse variables via as ...', () => {
       expectFromHtml('<div *ngIf="expr as local"></div>').toEqual([
         ['Template'],
-        ['BoundAttribute', BindingType.Property, 'ngIf', 'expr'],
+        ['BoundAttribute', BindingType.Property, 'ngIf', 'this.expr'],
         ['Variable', 'local', 'ngIf'],
         ['Element', 'div'],
       ]);
@@ -307,41 +307,41 @@ describe('R3 template transform', () => {
     it('should parse bound events with a target', () => {
       expectFromHtml('<div (window:event)="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundEvent', 'event', 'window', 'v'],
+        ['BoundEvent', 'event', 'window', 'this.v'],
       ]);
     });
 
     it('should parse event names case sensitive', () => {
       expectFromHtml('<div (some-event)="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundEvent', 'some-event', null, 'v'],
+        ['BoundEvent', 'some-event', null, 'this.v'],
       ]);
       expectFromHtml('<div (someEvent)="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundEvent', 'someEvent', null, 'v'],
+        ['BoundEvent', 'someEvent', null, 'this.v'],
       ]);
     });
 
     it('should parse bound events via on-', () => {
       expectFromHtml('<div on-event="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundEvent', 'event', null, 'v'],
+        ['BoundEvent', 'event', null, 'this.v'],
       ]);
     });
 
     it('should parse bound events and properties via [(...)]', () => {
       expectFromHtml('<div [(prop)]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'prop', 'v'],
-        ['BoundEvent', 'propChange', null, 'v = $event'],
+        ['BoundAttribute', BindingType.Property, 'prop', 'this.v'],
+        ['BoundEvent', 'propChange', null, 'this.v = this.$event'],
       ]);
     });
 
     it('should parse bound events and properties via bindon-', () => {
       expectFromHtml('<div bindon-prop="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'prop', 'v'],
-        ['BoundEvent', 'propChange', null, 'v = $event'],
+        ['BoundAttribute', BindingType.Property, 'prop', 'this.v'],
+        ['BoundEvent', 'propChange', null, 'this.v = this.$event'],
       ]);
     });
 

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -565,7 +565,7 @@ class ArrayConsole implements Console {
       });
 
       it('should parse bound text nodes', () => {
-        expect(humanizeTplAst(parse('{{a}}', []))).toEqual([[BoundTextAst, '{{ a }}']]);
+        expect(humanizeTplAst(parse('{{a}}', []))).toEqual([[BoundTextAst, '{{ this.a }}']]);
       });
 
       it('should parse with custom interpolation config',
@@ -608,7 +608,7 @@ class ArrayConsole implements Console {
            expect(humanizeTplAst(
                       parser.parse(component, '{%a%}', [], [], [], 'TestComp', true).template,
                       {start: '{%', end: '%}'}))
-               .toEqual([[BoundTextAst, '{% a %}']]);
+               .toEqual([[BoundTextAst, '{% this.a %}']]);
          }));
 
       describe('bound properties', () => {
@@ -616,56 +616,56 @@ class ArrayConsole implements Console {
         it('should parse mixed case bound properties', () => {
           expect(humanizeTplAst(parse('<div [someProp]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'this.v', null]
           ]);
         });
 
         it('should parse dash case bound properties', () => {
           expect(humanizeTplAst(parse('<div [some-prop]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'some-prop', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'some-prop', 'this.v', null]
           ]);
         });
 
         it('should parse dotted name bound properties', () => {
           expect(humanizeTplAst(parse('<div [dot.name]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'dot.name', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'dot.name', 'this.v', null]
           ]);
         });
 
         it('should normalize property names via the element schema', () => {
           expect(humanizeTplAst(parse('<div [mappedAttr]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'mappedProp', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'mappedProp', 'this.v', null]
           ]);
         });
 
         it('should parse mixed case bound attributes', () => {
           expect(humanizeTplAst(parse('<div [attr.someAttr]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr', 'this.v', null]
           ]);
         });
 
         it('should parse and dash case bound classes', () => {
           expect(humanizeTplAst(parse('<div [class.some-class]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Class, 'some-class', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Class, 'some-class', 'this.v', null]
           ]);
         });
 
         it('should parse mixed case bound classes', () => {
           expect(humanizeTplAst(parse('<div [class.someClass]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Class, 'someClass', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Class, 'someClass', 'this.v', null]
           ]);
         });
 
         it('should parse mixed case bound styles', () => {
           expect(humanizeTplAst(parse('<div [style.someStyle]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Style, 'someStyle', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Style, 'someStyle', 'this.v', null]
           ]);
         });
 
@@ -719,21 +719,21 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
         it('should parse bound properties via [...] and not report them as attributes', () => {
           expect(humanizeTplAst(parse('<div [prop]="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'this.v', null]
           ]);
         });
 
         it('should parse bound properties via bind- and not report them as attributes', () => {
           expect(humanizeTplAst(parse('<div bind-prop="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'this.v', null]
           ]);
         });
 
         it('should parse bound properties via {{...}} and not report them as attributes', () => {
           expect(humanizeTplAst(parse('<div prop="{{v}}">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', '{{ v }}', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', '{{ this.v }}', null]
           ]);
         });
 
@@ -744,7 +744,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                    [ElementAst, 'div'],
                    [
                      BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation',
-                     'value2', null
+                     'this.value2', null
                    ]
                  ]);
            });
@@ -806,8 +806,8 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
           expect(humanizeTplAst(parse('<div [@someAnimation]="value2">', [], [], []))).toEqual([
             [ElementAst, 'div'],
             [
-              BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation', 'value2',
-              null
+              BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation',
+              'this.value2', null
             ]
           ]);
         });
@@ -847,7 +847,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
         it('should parse bound events with a target', () => {
           expect(humanizeTplAst(parse('<div (window:event)="v">', []))).toEqual([
             [ElementAst, 'div'],
-            [BoundEventAst, 'event', 'window', 'v'],
+            [BoundEventAst, 'event', 'window', 'this.v'],
           ]);
         });
 
@@ -861,19 +861,19 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
 
         it('should parse bound events via (...) and not report them as attributes', () => {
           expect(humanizeTplAst(parse('<div (event)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']]);
+          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'this.v']]);
         });
 
         it('should parse event names case sensitive', () => {
           expect(humanizeTplAst(parse('<div (some-event)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'some-event', null, 'v']]);
+          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'some-event', null, 'this.v']]);
           expect(humanizeTplAst(parse('<div (someEvent)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'someEvent', null, 'v']]);
+          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'someEvent', null, 'this.v']]);
         });
 
         it('should parse bound events via on- and not report them as attributes', () => {
           expect(humanizeTplAst(parse('<div on-event="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']]);
+          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'this.v']]);
         });
 
         it('should allow events on explicit embedded templates that are emitted by a directive',
@@ -887,7 +887,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
 
              expect(humanizeTplAst(parse('<ng-template (e)="f"></ng-template>', [dirA]))).toEqual([
                [EmbeddedTemplateAst],
-               [BoundEventAst, 'e', null, 'f'],
+               [BoundEventAst, 'e', null, 'this.f'],
                [DirectiveAst, dirA],
              ]);
            });
@@ -898,8 +898,8 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
            () => {
              expect(humanizeTplAst(parse('<div [(prop)]="v">', []))).toEqual([
                [ElementAst, 'div'],
-               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
-               [BoundEventAst, 'propChange', null, 'v = $event']
+               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'this.v', null],
+               [BoundEventAst, 'propChange', null, 'this.v = this.$event']
              ]);
            });
 
@@ -907,8 +907,8 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
            () => {
              expect(humanizeTplAst(parse('<div bindon-prop="v">', []))).toEqual([
                [ElementAst, 'div'],
-               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
-               [BoundEventAst, 'propChange', null, 'v = $event']
+               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'this.v', null],
+               [BoundEventAst, 'propChange', null, 'this.v = this.$event']
              ]);
            });
 
@@ -949,7 +949,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
           expect(humanizeTplAst(parse('<div [dot.name]="expr"></div>', [dirA]))).toEqual([
             [ElementAst, 'div'],
             [DirectiveAst, dirA],
-            [BoundDirectivePropertyAst, 'localName', 'expr'],
+            [BoundDirectivePropertyAst, 'localName', 'this.expr'],
           ]);
         });
 
@@ -966,7 +966,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
               }).toSummary();
           expect(humanizeTplAst(parse('<div [a]="b">', [dirA, dirB]))).toEqual([
             [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'b', null],
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'this.b', null],
             [DirectiveAst, dirA]
           ]);
         });
@@ -980,7 +980,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
           expect(humanizeTplAst(parse('<div *ngIf="cond">', [ngIf, dirTemplate]))).toEqual([
             [EmbeddedTemplateAst],
             [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'cond'],
+            [BoundDirectivePropertyAst, 'ngIf', 'this.cond'],
             [DirectiveAst, dirTemplate],
             [ElementAst, 'div'],
           ]);
@@ -994,7 +994,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
               }).toSummary();
 
           expect(humanizeTplAst(parse('<div (a)="b">', [dirA]))).toEqual([
-            [ElementAst, 'div'], [BoundEventAst, 'a', null, 'b'], [DirectiveAst, dirA]
+            [ElementAst, 'div'], [BoundEventAst, 'a', null, 'this.b'], [DirectiveAst, dirA]
           ]);
         });
 
@@ -1006,7 +1006,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                        }).toSummary();
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
             [ElementAst, 'div'], [DirectiveAst, dirA],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'expr', null]
+            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'this.expr', null]
           ]);
         });
 
@@ -1017,7 +1017,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                          host: {'(a)': 'expr'}
                        }).toSummary();
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a', null, 'expr']
+            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a', null, 'this.expr']
           ]);
         });
 
@@ -1029,7 +1029,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                        }).toSummary();
           expect(humanizeTplAst(parse('<div [aProp]="expr"></div>', [dirA]))).toEqual([
             [ElementAst, 'div'], [DirectiveAst, dirA],
-            [BoundDirectivePropertyAst, 'aProp', 'expr']
+            [BoundDirectivePropertyAst, 'aProp', 'this.expr']
           ]);
         });
 
@@ -1040,7 +1040,8 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                          inputs: ['b:a']
                        }).toSummary();
           expect(humanizeTplAst(parse('<div [a]="expr"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'b', 'expr']
+            [ElementAst, 'div'], [DirectiveAst, dirA],
+            [BoundDirectivePropertyAst, 'b', 'this.expr']
           ]);
         });
 
@@ -1594,7 +1595,7 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
             [EmbeddedTemplateAst],
             [VariableAst, 'local', 'ngIf'],
             [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'expr'],
+            [BoundDirectivePropertyAst, 'ngIf', 'this.expr'],
             [ElementAst, 'div'],
           ];
 
@@ -1615,8 +1616,9 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
                   type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
                 }).toSummary();
             expect(humanizeTplAst(parse('<div *a="b" b>', [dirA, dirB]))).toEqual([
-              [EmbeddedTemplateAst], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'a', 'b'],
-              [ElementAst, 'div'], [AttrAst, 'b', ''], [DirectiveAst, dirB]
+              [EmbeddedTemplateAst], [DirectiveAst, dirA],
+              [BoundDirectivePropertyAst, 'a', 'this.b'], [ElementAst, 'div'], [AttrAst, 'b', ''],
+              [DirectiveAst, dirB]
             ]);
           });
 
@@ -1653,7 +1655,7 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           expect(humanizeTplAst(parse('<div *ngIf="test">', [ngIf]))).toEqual([
             [EmbeddedTemplateAst],
             [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'test'],
+            [BoundDirectivePropertyAst, 'ngIf', 'this.test'],
             [ElementAst, 'div'],
 
           ]);
@@ -2069,7 +2071,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
       it('should support events', () => {
         expect(humanizeTplAstSourceSpans(parse('<div (window:event)="v">', []))).toEqual([
           [ElementAst, 'div', '<div (window:event)="v">'],
-          [BoundEventAst, 'event', 'window', 'v', '(window:event)="v"']
+          [BoundEventAst, 'event', 'window', 'this.v', '(window:event)="v"']
         ]);
 
       });
@@ -2078,7 +2080,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
         expect(humanizeTplAstSourceSpans(parse('<div [someProp]="v">', []))).toEqual([
           [ElementAst, 'div', '<div [someProp]="v">'],
           [
-            BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null,
+            BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'this.v', null,
             '[someProp]="v"'
           ]
         ]);
@@ -2086,7 +2088,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
 
       it('should support bound text', () => {
         expect(humanizeTplAstSourceSpans(parse('{{a}}', [
-        ]))).toEqual([[BoundTextAst, '{{ a }}', '{{a}}']]);
+        ]))).toEqual([[BoundTextAst, '{{ this.a }}', '{{a}}']]);
       });
 
       it('should support text nodes', () => {
@@ -2142,7 +2144,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
                      }).toSummary();
         expect(humanizeTplAstSourceSpans(parse('<div [aProp]="foo"></div>', [dirA]))).toEqual([
           [ElementAst, 'div', '<div [aProp]="foo">'], [DirectiveAst, dirA, '<div [aProp]="foo">'],
-          [BoundDirectivePropertyAst, 'aProp', 'foo', '[aProp]="foo"']
+          [BoundDirectivePropertyAst, 'aProp', 'this.foo', '[aProp]="foo"']
         ]);
       });
 

--- a/packages/core/test/acceptance/properties_spec.ts
+++ b/packages/core/test/acceptance/properties_spec.ts
@@ -175,6 +175,25 @@ describe('property instructions', () => {
     expect(img.src).toBe('http://somecooldomain:1234/cool_image.png');
   });
 
+  it('should handle inline arrow function', () => {
+    @Component({template: '', selector: 'my-comp'})
+    class MyComp {
+      @Input() fn !: Function;
+    }
+
+    @Component({template: '<my-comp [fn]="(foo, bar) => foo + bar"></my-comp>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, MyComp]});
+    const fixture = TestBed.createComponent(App);
+    const myCompNode = fixture.debugElement.query(By.directive(MyComp));
+    fixture.detectChanges();
+
+    const myComp = myCompNode.injector.get(MyComp);
+    expect(myComp.fn(1, 2)).toBe(3);
+  });
+
   it('should not allow unsanitary urls in interpolated properties', () => {
     @Component({
       template: `

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -54,6 +54,7 @@ export function getExpressionCompletions(
     visitConditional(ast) {},
     visitFunctionCall(ast) {},
     visitImplicitReceiver(ast) {},
+    visitLexicalReceiver(ast) {},
     visitInterpolation(ast) { result = undefined; },
     visitKeyedRead(ast) {},
     visitKeyedWrite(ast) {},
@@ -90,6 +91,7 @@ export function getExpressionCompletions(
       const receiverType = getType(ast.receiver);
       result = receiverType ? receiverType.members() : scope;
     },
+    visitArrowFunction(ast) {},
   });
 
   return result && result.values();
@@ -116,6 +118,7 @@ export function getExpressionSymbol(
     visitConditional(ast) {},
     visitFunctionCall(ast) {},
     visitImplicitReceiver(ast) {},
+    visitLexicalReceiver(ast) {},
     visitInterpolation(ast) {},
     visitKeyedRead(ast) {},
     visitKeyedWrite(ast) {},
@@ -161,6 +164,7 @@ export function getExpressionSymbol(
       symbol = receiverType && receiverType.members().get(ast.name);
       span = ast.span;
     },
+    visitArrowFunction(ast) {},
   });
 
   if (symbol && span) {


### PR DESCRIPTION
closes #14129

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/14129

Suggested by @mhevery in https://github.com/angular/angular/issues/12969#issuecomment-411154343.

## What is the new behavior?

Arrow functions are now supported in template expression, like:

```html
<li *ngFor="let item of items trackBy item => item.id">{{ item.name }}</li>
```

Restrictions from JavaScript syntax:

+ No async/await;
+ No generator/yield;
+ No default parameter;
+ No parameter destruction;
+ No block body;

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
