### PR TITLE
Windows ngcc infinite loop and tests under windows

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -20,7 +20,5 @@ steps:
     # Add Bazel CI config
     - copy .codefresh\bazel.rc %ProgramData%\bazel.bazelrc
     # Run tests
-    - yarn bazel test //tools/ts-api-guardian:all //packages/language-service/test //packages/compiler/test //packages/compiler-cli/test:ngc //packages/compiler-cli/test/ngtsc:ngtsc
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
-    - yarn bazel test //tools/public_api_guard/...
-    - yarn bazel test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance
+    - yarn bazel test //tools/ts-api-guardian:all //tools/public_api_guard/... //packages/language-service/test //packages/compiler-cli/ngcc/test:test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance //packages/compiler/test //packages/compiler-cli/test:ngc //packages/compiler-cli/test/ngtsc:ngtsc

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -118,7 +118,7 @@ export class ModuleResolver {
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
-    while (!isRoot(folder)) {
+    while (!AbsoluteFsPath.isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (folder.endsWith('node_modules')) {
         // Skip up if the folder already ends in node_modules
@@ -225,7 +225,7 @@ export class ModuleResolver {
    */
   private findPackagePath(path: AbsoluteFsPath): AbsoluteFsPath|null {
     let folder = path;
-    while (!isRoot(folder)) {
+    while (!AbsoluteFsPath.isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (this.fs.exists(AbsoluteFsPath.join(folder, 'package.json'))) {
         return folder;
@@ -265,10 +265,6 @@ export class ResolvedDeepImport {
 function splitOnStar(str: string): PathMappingPattern {
   const [prefix, postfix] = str.split('*', 2);
   return {prefix, postfix: postfix || '', hasWildcard: postfix !== undefined};
-}
-
-function isRoot(path: AbsoluteFsPath): boolean {
-  return AbsoluteFsPath.dirname(path) === path;
 }
 
 interface ProcessedPathMapping {

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -118,7 +118,7 @@ export class ModuleResolver {
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
-    while (AbsoluteFsPath.dirname(folder) !== folder) {
+    while (!isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (folder.endsWith('node_modules')) {
         // Skip up if the folder already ends in node_modules
@@ -225,7 +225,7 @@ export class ModuleResolver {
    */
   private findPackagePath(path: AbsoluteFsPath): AbsoluteFsPath|null {
     let folder = path;
-    while (AbsoluteFsPath.dirname(folder) !== folder) {
+    while (!isRoot(folder)) {
       folder = AbsoluteFsPath.dirname(folder);
       if (this.fs.exists(AbsoluteFsPath.join(folder, 'package.json'))) {
         return folder;
@@ -265,6 +265,10 @@ export class ResolvedDeepImport {
 function splitOnStar(str: string): PathMappingPattern {
   const [prefix, postfix] = str.split('*', 2);
   return {prefix, postfix: postfix || '', hasWildcard: postfix !== undefined};
+}
+
+function isRoot(path: AbsoluteFsPath): boolean {
+  return AbsoluteFsPath.dirname(path) === path;
 }
 
 interface ProcessedPathMapping {

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -118,7 +118,7 @@ export class ModuleResolver {
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
-    while (folder !== '/') {
+    while (AbsoluteFsPath.dirname(folder) !== folder) {
       folder = AbsoluteFsPath.dirname(folder);
       if (folder.endsWith('node_modules')) {
         // Skip up if the folder already ends in node_modules
@@ -225,7 +225,7 @@ export class ModuleResolver {
    */
   private findPackagePath(path: AbsoluteFsPath): AbsoluteFsPath|null {
     let folder = path;
-    while (folder !== '/') {
+    while (AbsoluteFsPath.dirname(folder) !== folder) {
       folder = AbsoluteFsPath.dirname(folder);
       if (this.fs.exists(AbsoluteFsPath.join(folder, 'package.json'))) {
         return folder;

--- a/packages/compiler-cli/ngcc/src/file_system/node_js_file_system.ts
+++ b/packages/compiler-cli/ngcc/src/file_system/node_js_file_system.ts
@@ -23,7 +23,7 @@ export class NodeJSFileSystem implements FileSystem {
   readdir(path: AbsoluteFsPath): PathSegment[] { return fs.readdirSync(path) as PathSegment[]; }
   lstat(path: AbsoluteFsPath): fs.Stats { return fs.lstatSync(path); }
   stat(path: AbsoluteFsPath): fs.Stats { return fs.statSync(path); }
-  pwd() { return AbsoluteFsPath.fromUnchecked(process.cwd()); }
+  pwd() { return AbsoluteFsPath.from(process.cwd()); }
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { cp(from, to); }
   moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { mv(from, to); }
   ensureDir(path: AbsoluteFsPath): void { mkdir('-p', path); }

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_finder.ts
@@ -92,7 +92,7 @@ export class EntryPointFinder {
             entryPoints.push(...this.getEntryPointsForPackage(packagePath));
 
             // Also check for any nested node_modules in this package
-            const nestedNodeModulesPath = AbsoluteFsPath.resolve(packagePath, 'node_modules');
+            const nestedNodeModulesPath = AbsoluteFsPath.join(packagePath, 'node_modules');
             if (this.fs.exists(nestedNodeModulesPath)) {
               entryPoints.push(...this.walkDirectoryForEntryPoints(nestedNodeModulesPath));
             }

--- a/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
+++ b/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
@@ -27,7 +27,7 @@ export class NgccCompilerHost implements ts.CompilerHost {
   }
 
   getDefaultLibLocation(): string {
-    const nodeLibPath = AbsoluteFsPath.fromUnchecked(require.resolve('typescript'));
+    const nodeLibPath = AbsoluteFsPath.from(require.resolve('typescript'));
     return AbsoluteFsPath.join(nodeLibPath, '..');
   }
 

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -173,7 +173,7 @@ export abstract class Renderer {
   renderDtsFile(dtsFile: ts.SourceFile, renderInfo: DtsRenderInfo): FileInfo[] {
     const input = this.extractSourceMap(dtsFile);
     const outputText = new MagicString(input.source);
-    const printer = ts.createPrinter();
+    const printer = createPrinter();
     const importManager = new ImportManager(
         this.getImportRewriter(this.bundle.dts !.r3SymbolsFile, false), IMPORT_PREFIX);
 
@@ -476,7 +476,7 @@ export function mergeSourceMaps(
  */
 export function renderConstantPool(
     sourceFile: ts.SourceFile, constantPool: ConstantPool, imports: ImportManager): string {
-  const printer = ts.createPrinter();
+  const printer = createPrinter();
   return constantPool.statements
       .map(stmt => translateStatement(stmt, imports, NOOP_DEFAULT_IMPORT_RECORDER))
       .map(stmt => printer.printNode(ts.EmitHint.Unspecified, stmt, sourceFile))
@@ -493,7 +493,7 @@ export function renderConstantPool(
  */
 export function renderDefinitions(
     sourceFile: ts.SourceFile, compiledClass: CompiledClass, imports: ImportManager): string {
-  const printer = ts.createPrinter();
+  const printer = createPrinter();
   const name = compiledClass.declaration.name;
   const translate = (stmt: Statement) =>
       translateStatement(stmt, imports, NOOP_DEFAULT_IMPORT_RECORDER);
@@ -528,4 +528,8 @@ function getImportString(
     importManager: ImportManager, importPath: string | null, importName: string) {
   const importAs = importPath ? importManager.generateNamedImport(importPath, importName) : null;
   return importAs ? `${importAs.moduleImport}.${importAs.symbol}` : `${importName}`;
+}
+
+function createPrinter(): ts.Printer {
+  return ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
 }

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -70,7 +70,7 @@ describe('DependencyHost', () => {
       expect(dependencies.size).toBe(0);
       expect(missing.size).toBe(0);
       expect(deepImports.size).toBe(1);
-      expect(deepImports.has('/node_modules/lib-1/deep/import')).toBe(true);
+      expect(deepImports.has(_('/node_modules/lib-1/deep/import'))).toBe(true);
     });
 
     it('should recurse into internal dependencies', () => {

--- a/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
@@ -14,7 +14,7 @@ import {FileStats, FileSystem} from '../../src/file_system/file_system';
 export class MockFileSystem implements FileSystem {
   files: Folder = {};
   constructor(...folders: Folder[]) {
-    folders.forEach(files => this.processFiles(this.files, files));
+    folders.forEach(files => this.processFiles(this.files, files, true));
   }
 
   exists(path: AbsoluteFsPath): boolean { return this.findFromPath(path) !== null; }
@@ -82,9 +82,10 @@ export class MockFileSystem implements FileSystem {
 
   ensureDir(path: AbsoluteFsPath): void { this.ensureFolders(this.files, path.split('/')); }
 
-  private processFiles(current: Folder, files: Folder): void {
+  private processFiles(current: Folder, files: Folder, isRootPath = false): void {
     Object.keys(files).forEach(path => {
-      const segments = (path.startsWith('/') ? AbsoluteFsPath.from(path) : path).split('/');
+      const pathResolved = isRootPath ? AbsoluteFsPath.from(path) : path;
+      const segments = pathResolved.split('/');
       const lastSegment = segments.pop() !;
       const containingFolder = this.ensureFolders(current, segments);
       const entity = files[path];

--- a/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_file_system.ts
@@ -67,7 +67,7 @@ export class MockFileSystem implements FileSystem {
     return new MockFileStats(fileOrFolder);
   }
 
-  pwd(): AbsoluteFsPath { return AbsoluteFsPath.fromUnchecked('/'); }
+  pwd(): AbsoluteFsPath { return AbsoluteFsPath.from('/'); }
 
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
     this.writeFile(to, this.readFile(from));
@@ -84,7 +84,7 @@ export class MockFileSystem implements FileSystem {
 
   private processFiles(current: Folder, files: Folder): void {
     Object.keys(files).forEach(path => {
-      const segments = path.split('/');
+      const segments = (path.startsWith('/') ? AbsoluteFsPath.from(path) : path).split('/');
       const lastSegment = segments.pop() !;
       const containingFolder = this.ensureFolders(current, segments);
       const entity = files[path];

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -7,8 +7,9 @@
  */
 
 import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/path';
-import {existsSync, readFileSync, readdirSync, statSync, writeFileSync} from 'fs';
+import {existsSync, readFileSync, readdirSync, statSync, symlinkSync} from 'fs';
 import * as mockFs from 'mock-fs';
+import * as path from 'path';
 
 import {getAngularPackagesFromRunfiles, resolveNpmTreeArtifact} from '../../../test/runfile_helpers';
 import {NodeJSFileSystem} from '../../src/file_system/node_js_file_system';
@@ -333,10 +334,15 @@ describe('ngcc main()', () => {
 
 
 function createMockFileSystem() {
+  const typeScriptPath = path.join(process.env.RUNFILES !, 'typescript');
+  if (!existsSync(typeScriptPath)) {
+    symlinkSync(resolveNpmTreeArtifact('typescript'), typeScriptPath, 'junction');
+  }
+
   mockFs({
     '/node_modules/@angular': loadAngularPackages(),
-    '/node_modules/rxjs': loadDirectory(resolveNpmTreeArtifact('rxjs', 'index.js')),
-    '/node_modules/tslib': loadDirectory(resolveNpmTreeArtifact('tslib', 'tslib.js')),
+    '/node_modules/rxjs': loadDirectory(resolveNpmTreeArtifact('rxjs')),
+    '/node_modules/tslib': loadDirectory(resolveNpmTreeArtifact('tslib')),
     '/node_modules/test-package': {
       'package.json': '{"name": "test-package", "es2015": "./index.js", "typings": "./index.d.ts"}',
       // no metadata.json file so not compiled by Angular.

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -12,7 +12,7 @@ import {getEntryPointInfo} from '../../src/packages/entry_point';
 import {MockFileSystem} from '../helpers/mock_file_system';
 import {MockLogger} from '../helpers/mock_logger';
 
-const _ = AbsoluteFsPath.fromUnchecked;
+const _ = AbsoluteFsPath.from;
 
 describe('getEntryPointInfo()', () => {
   const SOME_PACKAGE = _('/some_package');

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -158,7 +158,7 @@ describe('Renderer', () => {
           decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses,
           moduleWithProvidersAnalyses);
       const addDefinitionsSpy = renderer.addDefinitions as jasmine.Spy;
-      expect(addDefinitionsSpy.calls.first().args[2])
+      expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
           .toEqual(
               `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
@@ -203,7 +203,7 @@ describe('Renderer', () => {
              name: _('A'),
              decorators: [jasmine.objectContaining({name: _('Directive')})]
            }));
-           expect(addDefinitionsSpy.calls.first().args[2])
+           expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
                .toEqual(
                    `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -158,7 +158,7 @@ describe('Renderer', () => {
           decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses,
           moduleWithProvidersAnalyses);
       const addDefinitionsSpy = renderer.addDefinitions as jasmine.Spy;
-      expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
+      expect(addDefinitionsSpy.calls.first().args[2])
           .toEqual(
               `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
@@ -203,7 +203,7 @@ describe('Renderer', () => {
              name: _('A'),
              decorators: [jasmine.objectContaining({name: _('Directive')})]
            }));
-           expect(addDefinitionsSpy.calls.first().args[2].replace(/\r\n/g, '\n'))
+           expect(addDefinitionsSpy.calls.first().args[2])
                .toEqual(
                    `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -11,7 +11,7 @@ import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {InPlaceFileWriter} from '../../src/writing/in_place_file_writer';
 import {MockFileSystem} from '../helpers/mock_file_system';
 
-const _ = AbsoluteFsPath.fromUnchecked;
+const _ = AbsoluteFsPath.from;
 
 function createMockFileSystem() {
   return new MockFileSystem({
@@ -71,13 +71,14 @@ describe('InPlaceFileWriter', () => {
   it('should error if the backup file already exists', () => {
     const fs = createMockFileSystem();
     const fileWriter = new InPlaceFileWriter(fs);
+    const absoluteBackupPath = _('/package/path/already-backed-up.js');
     expect(
         () => fileWriter.writeBundle(
             {} as EntryPoint, {} as EntryPointBundle,
             [
-              {path: _('/package/path/already-backed-up.js'), contents: 'MODIFIED BACKED UP'},
+              {path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'},
             ]))
         .toThrowError(
-            'Tried to overwrite /package/path/already-backed-up.js.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.');
+            `Tried to overwrite ${absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.`);
   });
 });

--- a/packages/compiler-cli/src/ngtsc/path/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/types.ts
@@ -86,6 +86,9 @@ export const AbsoluteFsPath = {
    */
   resolve: function(basePath: string, ...paths: string[]):
       AbsoluteFsPath { return AbsoluteFsPath.from(path.resolve(basePath, ...paths));},
+
+  /** Returns true when the path provided is the root path. */
+  isRoot: function(path: AbsoluteFsPath): boolean { return AbsoluteFsPath.dirname(path) === path;},
 };
 
 /**

--- a/packages/compiler-cli/src/ngtsc/path/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/types.ts
@@ -40,6 +40,12 @@ export const AbsoluteFsPath = {
    * Convert the path `str` to an `AbsoluteFsPath`, throwing an error if it's not an absolute path.
    */
   from: function(str: string): AbsoluteFsPath {
+    if (str.startsWith('/') && process.platform === 'win32') {
+      // in Windows if it's absolute path and starts with `/` we shall
+      // resolve it and return it including the drive.
+      str = path.resolve(str);
+    }
+
     const normalized = normalizeSeparators(str);
     if (!isAbsolutePath(normalized)) {
       throw new Error(`Internal Error: AbsoluteFsPath.from(${str}): path is not absolute`);


### PR DESCRIPTION
fix(ivy): handle windows drives correctly

At the moment the module resolver will end up in an infinite loop in Windows because we are assuming that the root directory is always / however in windows this can be any drive letter example c:/ or d:/ etc...

With this change we also resolve the drive letter in windows, when using AbsoluteFsPath.from for consistence so under /foo will be converted to c:/foo this is also needed because of relative paths with different drive letters.

This also fixes these test targets
```
//packages/compiler-cli/ngcc/test:integration                            PASSED in 90.9s                                                                                                  
//packages/compiler-cli/ngcc/test:test                                        PASSED in 5.2s      
```
Partially addresses #29785

