### PR TITLE
fix(common): ignore question mark when parsing url with HttpParams

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -43,7 +43,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
 function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, string[]> {
   const map = new Map<string, string[]>();
   if (rawParams.length > 0) {
-    const params: string[] = rawParams.split('&');
+    const params: string[] = (rawParams[0] === '?' ? rawParams.slice(1) : rawParams).split('&');
     params.forEach((param: string) => {
       const eqIdx = param.indexOf('=');
       const [key, val]: string[] = eqIdx == -1 ?

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -21,6 +21,13 @@ import {HttpParams} from '@angular/common/http/src/params';
         expect(body.getAll('a')).toEqual(['b']);
         expect(body.getAll('c')).toEqual(['d', 'e']);
       });
+
+      it('should ignore question mark when parsing existing url', () => {
+        const body = new HttpParams({fromString: '?a=b&c=d&c=e'});
+        expect(body.keys()).toEqual(['a', 'c'])
+        expect(body.getAll('a')).toEqual(['b']);
+        expect(body.getAll('c')).toEqual(['d', 'e']);
+      });
     });
 
     describe('lazy mutation', () => {

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -24,7 +24,7 @@ import {HttpParams} from '@angular/common/http/src/params';
 
       it('should ignore question mark when parsing existing url', () => {
         const body = new HttpParams({fromString: '?a=b&c=d&c=e'});
-        expect(body.keys()).toEqual(['a', 'c'])
+        expect(body.keys()).toEqual(['a', 'c']);
         expect(body.getAll('a')).toEqual(['b']);
         expect(body.getAll('c')).toEqual(['d', 'e']);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28722


## What is the new behavior?

HttpParams will skip leading `?` during parse.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
