### PR TITLE
fix(bazel): Directly spawn native Bazel binary

### DIFF
--- a/packages/bazel/src/builders/bazel.ts
+++ b/packages/bazel/src/builders/bazel.ts
@@ -8,7 +8,7 @@
 
 /// <reference types='node'/>
 
-import {fork} from 'child_process';
+import {spawn} from 'child_process';
 import {copyFileSync, existsSync, readdirSync, statSync, unlinkSync} from 'fs';
 import {dirname, join, normalize} from 'path';
 
@@ -24,7 +24,7 @@ export function runBazel(
   projectDir = normalize(projectDir);
   binary = normalize(binary);
   return new Promise((resolve, reject) => {
-    const buildProcess = fork(binary, [command, workspaceTarget, ...flags], {
+    const buildProcess = spawn(binary, [command, workspaceTarget, ...flags], {
       cwd: projectDir,
       stdio: 'inherit',
     });
@@ -51,12 +51,12 @@ export function runBazel(
  */
 export function checkInstallation(name: Executable, projectDir: string): string {
   projectDir = normalize(projectDir);
-  const packageName = `@bazel/${name}/package.json`;
+  const packageName = `@bazel/${name}`;
   try {
     const bazelPath = require.resolve(packageName, {
       paths: [projectDir],
     });
-    return dirname(bazelPath);
+    return require(bazelPath).getNativeBinary();
   } catch (error) {
     if (error.code === 'MODULE_NOT_FOUND') {
       throw new Error(

--- a/packages/bazel/src/builders/files/__dot__bazelrc.template
+++ b/packages/bazel/src/builders/files/__dot__bazelrc.template
@@ -23,6 +23,8 @@ build --incompatible_strict_action_env
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env
 
+build --incompatible_bzl_disallow_load_after_statement=false
+
 test --test_output=errors
 
 # Use the Angular 6 compiler

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -48,8 +48,8 @@ function addDevDependenciesToPackageJson(options: Schema) {
 
     const devDependencies: {[k: string]: string} = {
       '@angular/bazel': angularCoreVersion,
-      '@bazel/bazel': '^0.24.0',
-      '@bazel/ibazel': '^0.10.1',
+      '@bazel/bazel': '^0.25.1',
+      '@bazel/ibazel': '^0.10.2',
       '@bazel/karma': '0.27.12',
       '@bazel/typescript': '0.27.12',
     };


### PR DESCRIPTION
Instead of launching a Node.js process that in turn spawns Bazel binary,
the Builder could now directly spawn the native binary. This makes the
bootup process slightly more efficient, and allows the Builder to
control spawn options. This works with both Bazel and iBazel.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
