### PR TITLE
feat(ivy): add more DOM manipulation counters to ngDevMode

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -620,6 +620,7 @@ function getHostNative(currentView: LView): RElement|null {
  */
 export function nativeInsertBefore(
     renderer: Renderer3, parent: RElement, child: RNode, beforeNode: RNode | null): void {
+  ngDevMode && ngDevMode.rendererInsertBefore++;
   if (isProceduralRenderer(renderer)) {
     renderer.insertBefore(parent, child, beforeNode);
   } else {
@@ -628,6 +629,7 @@ export function nativeInsertBefore(
 }
 
 function nativeAppendChild(renderer: Renderer3, parent: RElement, child: RNode): void {
+  ngDevMode && ngDevMode.rendererAppendChild++;
   if (isProceduralRenderer(renderer)) {
     renderer.appendChild(parent, child);
   } else {

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -30,6 +30,8 @@ declare global {
     rendererDestroyNode: number;
     rendererMoveNode: number;
     rendererRemoveNode: number;
+    rendererAppendChild: number;
+    rendererInsertBefore: number;
     rendererCreateComment: number;
     styleMap: number;
     styleMapCacheMiss: number;
@@ -63,6 +65,8 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     rendererDestroyNode: 0,
     rendererMoveNode: 0,
     rendererRemoveNode: 0,
+    rendererAppendChild: 0,
+    rendererInsertBefore: 0,
     rendererCreateComment: 0,
     styleMap: 0,
     styleMapCacheMiss: 0,


### PR DESCRIPTION
This is a tiny PR that adds DOM manipulation counters (for missing `appendChild ` and `insertBefore`) to `ngDevMode`. Lack of those counters was identified while reviewing performance of an existing app build with ngIvy.