### PR TITLE
fix(ivy): Ensure CSS sanitization matches VE

### DIFF
--- a/packages/core/src/sanitization/style_sanitizer.ts
+++ b/packages/core/src/sanitization/style_sanitizer.ts
@@ -55,6 +55,7 @@ const SAFE_STYLE_VALUE = new RegExp(
  * code is permissive and allows URLs that sanitize otherwise.
  */
 const URL_RE = /^url\(([^)]+)\)$/;
+// const URL_RE = /^url\((.*)\)$/;
 
 /**
  * Checks that quotes (" and ') are properly balanced inside a string. Assumes
@@ -83,6 +84,7 @@ function hasBalancedQuotes(value: string) {
  * value) and returns a value that is safe to use in a browser environment.
  */
 export function _sanitizeStyle(value: string): string {
+  debugger;
   value = String(value).trim();  // Make sure it's actually a string.
   if (!value) return '';
 
@@ -99,7 +101,7 @@ export function _sanitizeStyle(value: string): string {
         `WARNING: sanitizing unsafe style value ${value} (see http://g.co/ng/security#xss).`);
   }
 
-  return 'unsafe';
+  return '';
 }
 
 

--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -36,9 +36,6 @@ import {isDevMode} from '../util/is_dev_mode';
  */
 const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi;
 
-/* A pattern that matches safe srcset values */
-const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;
-
 /** A pattern that matches safe data URLs. Only matches image, video and audio types. */
 const DATA_URL_PATTERN =
     /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;


### PR DESCRIPTION
- Fixes a minor issue with the initial regex that was attempting to match `url(...)`, where it wouldn't appropriately capture the internals if it had a closing paren in it like `url(javascript:alert())`
- Ensures that the sanitized output is just an empty string to match ViewEngine behavior (before it was `unsafe`
- Adds a test to ensure proper behavior with new ivy feature for style maps
