### PR TITLE
Revert "fix(router): fix a problem with router not responding to back…

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -556,7 +556,6 @@ export class Router {
                      * way the next navigation will be coming from the current URL in the browser.
                      */
                     this.rawUrlTree = t.rawUrl;
-                    this.browserUrlTree = t.urlAfterRedirects;
                     t.resolve(null);
                     return EMPTY;
                   }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -662,33 +662,6 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/login');
        })));
 
-    it('should set browserUrlTree with urlUpdateStrategy="eagar" and false `shouldProcessUrl`',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
-
-         router.urlUpdateStrategy = 'eager';
-
-         router.resetConfig([
-           {path: 'team/:id', component: SimpleCmp},
-           {path: 'login', component: AbsoluteSimpleLinkCmp}
-         ]);
-
-         router.navigateByUrl('/team/22');
-         advance(fixture, 1);
-
-         expect((router as any).browserUrlTree.toString()).toBe('/team/22');
-
-         // Force to not process URL changes
-         router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
-
-         router.navigateByUrl('/login');
-         advance(fixture, 1);
-
-         // Because we now can't process any URL, we will end up back at the root.
-         expect((router as any).browserUrlTree.toString()).toBe('/');
-       })));
-
     it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);


### PR DESCRIPTION
… button (#30160)"

This reverts commit 3327bd8eab0cf5bfb9a6a21d6ee4a8e081aab630.

This is being reverted because of a test failure in Google.

The test navigates to a route, then navigates to the same route again, which in the router codebase falls into a path that essentially marks it to do nothing. Upon marking it to do nothing, we attempt to get the state right for the next navigation. The second navigation had been kicked off using a value from `this.transitions`, which doesn't actually have the previous `urlAfterRedirects` value.

So the next navigation they are performing in the test is hitting `back`, which goes to the root. Because they happened to start on root, then navigate twice to the same place, then specifically go `back` to the root again, the `back` operation does nothing because the router thinks it’s already there.

The fix to this should be ensuring `Router.getTransition()` method returns the most recent `NavigationTransition` after all changes have been applied to it (the value that lands in the `subscribe` on `this.navigations`).