### PR TITLE
fix(core): CSS sanitizer now allows parens in file names

### DIFF
--- a/packages/core/src/sanitization/style_sanitizer.ts
+++ b/packages/core/src/sanitization/style_sanitizer.ts
@@ -54,7 +54,7 @@ const SAFE_STYLE_VALUE = new RegExp(
  * Given the common use case, low likelihood of attack vector, and low impact of an attack, this
  * code is permissive and allows URLs that sanitize otherwise.
  */
-const URL_RE = /^url\(([^)]+)\)$/;
+const URL_RE = /^url\(([\w\W]*)\)$/;
 
 /**
  * Checks that quotes (" and ') are properly balanced inside a string. Assumes

--- a/packages/core/test/sanitization/style_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/style_sanitizer_spec.ts
@@ -32,7 +32,7 @@ import {_sanitizeStyle} from '../../src/sanitization/style_sanitizer';
       expectSanitize('rgb(255, 0, 0)').toEqual('rgb(255, 0, 0)');
       expectSanitize('expression(haha)').toEqual('unsafe');
     });
-    t.it('rejects unblanaced quotes', () => { expectSanitize('"value" "').toEqual('unsafe'); });
+    t.it('rejects unbalanced quotes', () => { expectSanitize('"value" "').toEqual('unsafe'); });
     t.it('accepts transform functions', () => {
       expectSanitize('rotate(90deg)').toEqual('rotate(90deg)');
       expectSanitize('rotate(javascript:evil())').toEqual('unsafe');
@@ -58,6 +58,7 @@ import {_sanitizeStyle} from '../../src/sanitization/style_sanitizer';
     t.it('accepts quoted URLs', () => {
       expectSanitize('url("foo/bar.png")').toEqual('url("foo/bar.png")');
       expectSanitize(`url('foo/bar.png')`).toEqual(`url('foo/bar.png')`);
+      expectSanitize(`url('foo/bar (1).png')`).toEqual(`url('foo/bar (1).png')`);
       expectSanitize(`url(  'foo/bar.png'\n )`).toEqual(`url(  'foo/bar.png'\n )`);
       expectSanitize('url("javascript:evil()")').toEqual('unsafe');
       expectSanitize('url( " javascript:evil() " )').toEqual('unsafe');


### PR DESCRIPTION
Resolves an issue where images that were created with a name like `'foo (1).png'` would not pass CSS url sanitization.
