### PR TITLE
BACKPORT TO PATCH - fix(ivy): ngcc - handle missing entry-point dependencies better

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -91,8 +91,16 @@ export function mainNgcc({basePath, targetEntryPointPath,
     return;
   }
 
-  const {entryPoints} =
+  const {entryPoints, invalidEntryPoints} =
       finder.findEntryPoints(AbsoluteFsPath.from(basePath), absoluteTargetEntryPointPath);
+
+
+  invalidEntryPoints.forEach(invalidEntryPoint => {
+    logger.debug(
+        `Invalid entry-point ${invalidEntryPoint.entryPoint.path}.`,
+        `It is missing required dependencies:\n` +
+            invalidEntryPoint.missingDependencies.map(dep => ` - ${dep}`).join('\n'));
+  });
 
   if (absoluteTargetEntryPointPath && entryPoints.every(entryPoint => {
         return entryPoint.path !== absoluteTargetEntryPointPath;

--- a/packages/compiler-cli/ngcc/src/packages/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/packages/dependency_resolver.ts
@@ -120,9 +120,11 @@ export class DependencyResolver {
       } else {
         dependencies.forEach(dependencyPath => {
           if (graph.hasNode(dependencyPath)) {
-            // The dependency path maps to an entry point that exists in the graph
-            // so add the dependency.
-            graph.addDependency(entryPoint.path, dependencyPath);
+            if (graph.hasNode(entryPoint.path)) {
+              // The entry-point is still valid (i.e. has no missing dependencies) and
+              // the dependency maps to an entry point that exists in the graph so add it
+              graph.addDependency(entryPoint.path, dependencyPath);
+            }
           } else if (invalidEntryPoints.some(i => i.entryPoint.path === dependencyPath)) {
             // The dependency path maps to an entry-point that was previously removed
             // from the graph, so remove this entry-point as well.

--- a/packages/compiler-cli/ngcc/test/packages/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/dependency_resolver_spec.ts
@@ -55,7 +55,7 @@ describe('DependencyResolver', () => {
 
     it('should remove entry points that depended upon an invalid entry-point', () => {
       spyOn(host, 'computeDependencies').and.callFake(createFakeComputeDependencies({
-        [_('/first/index.ts')]: {resolved: [second.path], missing: []},
+        [_('/first/index.ts')]: {resolved: [second.path, third.path], missing: []},
         [_('/second/sub/index.ts')]: {resolved: [], missing: ['/missing']},
         [_('/third/index.ts')]: {resolved: [], missing: []},
       }));
@@ -70,7 +70,7 @@ describe('DependencyResolver', () => {
 
     it('should remove entry points that will depend upon an invalid entry-point', () => {
       spyOn(host, 'computeDependencies').and.callFake(createFakeComputeDependencies({
-        [_('/first/index.ts')]: {resolved: [second.path], missing: []},
+        [_('/first/index.ts')]: {resolved: [second.path, third.path], missing: []},
         [_('/second/sub/index.ts')]: {resolved: [], missing: ['/missing']},
         [_('/third/index.ts')]: {resolved: [], missing: []},
       }));


### PR DESCRIPTION
Caretaker: This is a backport to patch of https://github.com/angular/angular/pull/30270 so it has been reviewed and presubmitted already.