### PR TITLE
docs: clarify what is meant with an "active" router link

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -199,8 +199,8 @@ The `RouterLinkActive` directive toggles css classes for active `RouterLink` bin
 On each anchor tag, you see a [property binding](guide/template-syntax#property-binding) to the `RouterLinkActive` directive that look like `routerLinkActive="..."`.
 
 The template expression to the right of the equals (=) contains a space-delimited string of CSS classes
-that the Router will add when this link is active (and remove when the link is inactive). You set the `RouterLinkActive`
-directive to a string of classes such as `[routerLinkActive]="'active fluffy'"` or bind it to a component
+that the Router will add when this link concurs with the active route (and remove when the link is different from the active route).
+You set the `RouterLinkActive` directive to a string of classes such as `[routerLinkActive]="'active fluffy'"` or bind it to a component
 property that returns such a string.
 
 Active route links cascade down through each level of the route tree, so parent and child router links can be active at the same time. To override this behavior, you can bind to the `[routerLinkActiveOptions]` input binding with the `{ exact: true }` expression. By using `{ exact: true }`, a given `RouterLink` will only be active if its URL is an exact match to the current URL.


### PR DESCRIPTION
# Clearer description of  RouterLinkActive in the docs

This is a minor doc change only.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See description of the RouterLinkActive directive here: https://angular.io/guide/router#active-router-links

The phrase "link is active" is ambiguous because it means something different in CSS, where you can use the selector ":active" for styling active links. Since this directive also help with styling links using CSS, some readers might be confused.

## What is the new behavior?

The explanation now describes more exactly what is meant with "active link", namely that the link corresponds to the currently active route.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
