### PR TITLE
refactor: using ᐱ instead of Δ in tests

### DIFF
--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -26,22 +26,22 @@ describe('definitions', () => {
 
   it('should be able to find field in an interpolation', () => {
     localReference(
-        ` @Component({template: '{{«name»}}'}) export class MyComponent { «ΔnameΔ: string;» }`);
+        ` @Component({template: '{{«name»}}'}) export class MyComponent { «ᐱnameᐱ: string;» }`);
   });
 
   it('should be able to find a field in a attribute reference', () => {
     localReference(
-        ` @Component({template: '<input [(ngModel)]="«name»">'}) export class MyComponent { «ΔnameΔ: string;» }`);
+        ` @Component({template: '<input [(ngModel)]="«name»">'}) export class MyComponent { «ᐱnameᐱ: string;» }`);
   });
 
   it('should be able to find a method from a call', () => {
     localReference(
-        ` @Component({template: '<div (click)="«myClick»();"></div>'}) export class MyComponent { «ΔmyClickΔ() { }»}`);
+        ` @Component({template: '<div (click)="«myClick»();"></div>'}) export class MyComponent { «ᐱmyClickᐱ() { }»}`);
   });
 
   it('should be able to find a field reference in an *ngIf', () => {
     localReference(
-        ` @Component({template: '<div *ngIf="«include»"></div>'}) export class MyComponent { «ΔincludeΔ = true;»}`);
+        ` @Component({template: '<div *ngIf="«include»"></div>'}) export class MyComponent { «ᐱincludeᐱ = true;»}`);
   });
 
   it('should be able to find a reference to a component', () => {

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -40,7 +40,7 @@ describe('hover', () => {
 
   it('should be able to find a method from a call', () => {
     hover(
-        ` @Component({template: '<div (click)="«ΔmyClickΔ()»;"></div>'}) export class MyComponent { myClick() { }}`,
+        ` @Component({template: '<div (click)="«ᐱmyClickᐱ()»;"></div>'}) export class MyComponent { myClick() { }}`,
         'method myClick of MyComponent');
   });
 
@@ -52,19 +52,19 @@ describe('hover', () => {
 
   it('should be able to find a reference to a component', () => {
     hover(
-        ` @Component({template: '«<ΔtestΔ-comp></test-comp>»'}) export class MyComponent { }`,
+        ` @Component({template: '«<ᐱtestᐱ-comp></test-comp>»'}) export class MyComponent { }`,
         'component TestComponent');
   });
 
   it('should be able to find an event provider', () => {
     hover(
-        ` @Component({template: '<test-comp «(ΔtestΔ)="myHandler()"»></div>'}) export class MyComponent { myHandler() {} }`,
+        ` @Component({template: '<test-comp «(ᐱtestᐱ)="myHandler()"»></div>'}) export class MyComponent { myHandler() {} }`,
         'event testEvent of TestComponent');
   });
 
   it('should be able to find an input provider', () => {
     hover(
-        ` @Component({template: '<test-comp «[ΔtcNameΔ]="name"»></div>'}) export class MyComponent { name = 'my name'; }`,
+        ` @Component({template: '<test-comp «[ᐱtcNameᐱ]="name"»></div>'}) export class MyComponent { name = 'my name'; }`,
         'property name of TestComponent');
   });
 

--- a/packages/language-service/test/test_data.ts
+++ b/packages/language-service/test/test_data.ts
@@ -143,8 +143,8 @@ export class References {}
 
 @Component({selector: 'test-comp', template: '<div>Testing: {{name}}</div>'})
 export class TestComponent {
-  «@Input('ΔtcNameΔ') name = 'test';»
-  «@Output('ΔtestΔ') testEvent = new EventEmitter();»
+  «@Input('ᐱtcNameᐱ') name = 'test';»
+  «@Output('ᐱtestᐱ') testEvent = new EventEmitter();»
 }
 
 @Component({templateUrl: 'test.ng'})

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -278,7 +278,7 @@ function getLocationMarkers(value: string): {[name: string]: number} {
   return result;
 }
 
-const referenceMarker = /«(((\w|\-)+)|([^Δ]*Δ(\w+)Δ.[^»]*))»/g;
+const referenceMarker = /«(((\w|\-)+)|([^ᐱ]*ᐱ(\w+)ᐱ.[^»]*))»/g;
 const definitionMarkerGroup = 1;
 const nameMarkerGroup = 2;
 
@@ -300,7 +300,7 @@ function getReferenceMarkers(value: string): ReferenceResult {
   const text = value.replace(
       referenceMarker, (match: string, text: string, reference: string, _: string,
                         definition: string, definitionName: string, index: number): string => {
-        const result = reference ? text : text.replace(/Δ/g, '');
+        const result = reference ? text : text.replace(/ᐱ/g, '');
         const span: Span = {start: index - adjustment, end: index - adjustment + result.length};
         const markers = reference ? references : definitions;
         const name = reference || definitionName;
@@ -313,7 +313,7 @@ function getReferenceMarkers(value: string): ReferenceResult {
 }
 
 function removeReferenceMarkers(value: string): string {
-  return value.replace(referenceMarker, (match, text) => text.replace(/Δ/g, ''));
+  return value.replace(referenceMarker, (match, text) => text.replace(/ᐱ/g, ''));
 }
 
 export function noDiagnostics(diagnostics: Diagnostics) {


### PR DESCRIPTION
This is in preparation to move instructions back to using `Δ` prefix
