### PR TITLE
test(ivy): add onlyInIvy perf counter expectations

### DIFF
--- a/packages/core/test/acceptance/BUILD.bazel
+++ b/packages/core/test/acceptance/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler/testing",
         "//packages/core",
+        "//packages/core/src/util",
         "//packages/core/testing",
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -6,11 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Component, Directive, ElementRef} from '@angular/core';
+import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeStyle} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {onlyInIvy} from '@angular/private/testing';
 
 describe('styling', () => {
+  beforeEach(ngDevModeResetPerfCounters);
+
   it('should render inline style and class attribute values on the element before a directive is instantiated',
      () => {
        @Component({
@@ -147,5 +151,13 @@ describe('styling', () => {
 
     const div = fixture.nativeElement.querySelector('div') as HTMLDivElement;
     expect(div.style.backgroundImage).toBe('url("#test")');
+
+    onlyInIvy('perf counters').expectPerfCounters({
+      stylingApply: 2,
+      stylingApplyCacheMiss: 1,
+      stylingProp: 2,
+      stylingPropCacheMiss: 1,
+      tNode: 3,
+    });
   });
 });

--- a/packages/private/testing/src/ivy_test_selectors.ts
+++ b/packages/private/testing/src/ivy_test_selectors.ts
@@ -90,23 +90,49 @@ export interface JasmineMethods {
   fit: typeof fit;
   describe: typeof describe;
   fdescribe: typeof fdescribe;
+
+  /**
+   * Runs jasmine expectations against the provided keys for `ngDevMode`.
+   *
+   * Will not perform expectations for keys that are not provided.
+   *
+   * ```ts
+   * // Expect that `ngDevMode.styleMap` is `1`, and `ngDevMode.tNode` is `3`, but we don't care
+   * // about the other values.
+   * onlyInIvy('perf counters').expectPerfCounters({
+   *   stylingMap: 1,
+   *   tNode: 3,
+   * })
+   * ```
+   */
+  expectPerfCounters: (expectedCounters: Partial<NgDevModePerfCounters>) => void;
   isEnabled: boolean;
 }
 
 const PASSTHROUGH: JasmineMethods = {
-  it: it,
-  fit: fit,
-  describe: describe,
-  fdescribe: fdescribe,
+  it,
+  fit,
+  describe,
+  fdescribe,
+  expectPerfCounters,
   isEnabled: true,
 };
 
 function noop() {}
+
+function expectPerfCounters(expectedCounters: Partial<NgDevModePerfCounters>) {
+  Object.keys(expectedCounters).forEach(key => {
+    const expected = (expectedCounters as any)[key];
+    const actual = (ngDevMode as any)[key];
+    expect(actual).toBe(expected, `ngDevMode.${key}`);
+  });
+}
 
 const IGNORE: JasmineMethods = {
   it: noop,
   fit: noop,
   describe: noop,
   fdescribe: noop,
+  expectPerfCounters: noop,
   isEnabled: false,
 };


### PR DESCRIPTION
We have an issue where we would like to be able to test perf counter metrics in acceptance tests, but we are unable to do so, because it will break when those same tests are run with ViewEngine. This PR adds a testing utility to `onlyInIvy` that allows for testing of performance counters, and even gives readable errors for what value on `ngDevMode` is incorrect. Has typings for decent auto-completion as well.

- Adds `onlyInIvy.expectPerfCounters` utility.
- Adds one test to show usage
- Adds dep to BUILD file to support importing necessary type

It is not the intention of this PR to add counter expectations to all acceptance tests.
