### PR TITLE
fix(bazel): pass correct arguments to http_server in Windows

### DIFF
--- a/integration/bazel/test/e2e/on-prepare.ts
+++ b/integration/bazel/test/e2e/on-prepare.ts
@@ -2,7 +2,7 @@ import { browser } from 'protractor';
 import {OnPrepareConfig, runServer} from '@angular/bazel/protractor-utils';
 
 export = function(config: OnPrepareConfig) {
-  const portFlag = config.server.endsWith('prodserver') ? '-p' : '-port';
+  const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
   return runServer(config.workspace, config.server, portFlag, [])
     .then(serverSpec => {
       const serverUrl = `http://localhost:${serverSpec.port}`;

--- a/packages/bazel/src/schematics/ng-add/files/e2e/protractor.on-prepare.js.template
+++ b/packages/bazel/src/schematics/ng-add/files/e2e/protractor.on-prepare.js.template
@@ -14,7 +14,7 @@ module.exports = function(config) {
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
-  const portFlag = config.server.endsWith('prodserver') ? '-p' : '-port';
+  const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
   return protractorUtils.runServer(config.workspace, config.server, portFlag, [])
       .then(serverSpec => {
         const serverUrl = `http://localhost:${serverSpec.port}`;

--- a/packages/bazel/test/protractor-2/on-prepare.js
+++ b/packages/bazel/test/protractor-2/on-prepare.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
   if (!global.userOnPrepareGotCalled) {
     throw new Error('Expecting user configuration onPrepare to have been called');
   }
-  const portFlag = config.server.endsWith('prodserver') ? '-p' : '-port';
+  const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
   return protractorUtils.runServer(config.workspace, config.server, portFlag, [])
       .then(serverSpec => {
         const serverUrl = `http://localhost:${serverSpec.port}`;


### PR DESCRIPTION
Under Windows, the server binary has an extension of  `.exe` and the current logic is not handling that.

Partially addresses: #29785
