### PR TITLE
fix(ivy): align removed attribute behavior in DebugNode with ViewEngine

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -232,6 +232,8 @@ class DebugNode__POST_R3__ implements DebugNode {
 }
 
 class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugElement {
+  private _previousAttributes: {[key: string]: string | null;}|undefined;
+
   constructor(nativeNode: Element) {
     ngDevMode && assertDomNode(nativeNode);
     super(nativeNode);
@@ -282,7 +284,20 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
         const attr = eAttrs[i];
         attributes[attr.name] = attr.value;
       }
+      if (this._previousAttributes) {
+        // In ViewEngine removing an attribute by setting it to `null` still keeps it on the
+        // `DebugElement.attributes` as `null`, however since Ivy reads the attributes off the
+        // DOM, we have no way of knowing which attributes were removed. We keep track of the
+        // previous value of `attributes` so that we can add in the removed attributes as `null`.
+        const previousAttributeKeys = Object.keys(this._previousAttributes);
+        for (let i = 0; i < previousAttributeKeys.length; i++) {
+          if (!attributes.hasOwnProperty(previousAttributeKeys[i])) {
+            attributes[previousAttributeKeys[i]] = null;
+          }
+        }
+      }
     }
+    this._previousAttributes = attributes;
     return attributes;
   }
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -678,5 +678,24 @@ class TestCmptWithPropBindings {
       expect(divB.nativeElement.getAttribute('id')).toBe('b');
     });
 
+    it('should preserve removed attributes as `null` in `attributes`', () => {
+      @Component({template: '<input [attr.aria-disabled]="readonly ? true : null">'})
+      class TestComponent {
+        readonly = true;
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+      const fixture = TestBed.createComponent(TestComponent);
+      const divEl = fixture.debugElement.query(By.css('input'));
+      fixture.detectChanges();
+      expect(divEl.attributes['aria-disabled']).toBe('true');
+
+      fixture.componentInstance.readonly = false;
+      fixture.detectChanges();
+
+      // Note that we're looking specifically for `null` here.
+      expect(divEl.attributes['aria-disabled']).toBeNull();
+    });
+
   });
 }


### PR DESCRIPTION
When an attribute is removed by setting its value to `null`, ViewEngine keeps the attribute in `DebugNode.attributes`, however in Ivy the attribute won't be included anymore, because the `attributes` are built up by reading the values from the DOM. These changes add some extra logic to the Ivy `DebugNode` in order to align it with ViewEngine.
