### PR TITLE
refactor(core): remove unnecessary '!' from QueryList

### DIFF
--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -45,10 +45,8 @@ export class QueryList<T>/* implements Iterable<T> */ {
   public readonly changes: Observable<any> = new EventEmitter();
 
   readonly length: number = 0;
-  // TODO(issue/24571): remove '!'.
-  readonly first !: T;
-  // TODO(issue/24571): remove '!'.
-  readonly last !: T;
+  readonly first: T | undefined;
+  readonly last: T | undefined;
 
   /**
    * See

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -1092,8 +1092,8 @@ export declare abstract class Query {
 export declare class QueryList<T> {
     readonly changes: Observable<any>;
     readonly dirty = true;
-    readonly first: T;
-    readonly last: T;
+    readonly first: T | undefined;
+    readonly last: T | undefined;
     readonly length: number;
     destroy(): void;
     filter(fn: (item: T, index: number, array: T[]) => boolean): T[];


### PR DESCRIPTION
QueryList#first and QueryList#last can both sensibly be undefined if
the QueryList doesn't match anything.

Signed-off-by: Ingo Bürk <admin@airblader.de>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24571 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
