### PR TITLE
fix(core): allow child services to inherit their @Injectable decorator

### DIFF
--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -182,12 +182,34 @@ export function ΔdefineInjector(options: {factory: () => any, providers?: any[]
 }
 
 /**
- * Read the `ngInjectableDef` type in a way which is immune to accidentally reading inherited value.
+ * Read the `ngInjectableDef` for `type` in a way which is immune to accidentally reading inherited
+ * value.
  *
- * @param type type which may have `ngInjectableDef`
+ * @param type A type which may have its own (non-inherited) `ngInjectableDef`.
  */
 export function getInjectableDef<T>(type: any): ΔInjectableDef<T>|null {
-  return type && type.hasOwnProperty(NG_INJECTABLE_DEF) ? (type as any)[NG_INJECTABLE_DEF] : null;
+  return type && type.hasOwnProperty(NG_INJECTABLE_DEF) ? type[NG_INJECTABLE_DEF] : null;
+}
+
+/**
+ * Read the `ngInjectableDef` for `type` or read the `ngInjectableDef` from one of its ancestors.
+ *
+ * @param type A type which may have `ngInjectableDef`, via inheritance.
+ *
+ * @deprecated Will be removed in v10, where an error will occur in the scenario if we find the
+ * `ngInjectableDef` on an ancestor only.
+ */
+export function getInheritedInjectableDef<T>(type: any): ΔInjectableDef<T>|null {
+  if (type && type[NG_INJECTABLE_DEF]) {
+    // TODO(FW-1307): Re-add ngDevMode when closure can handle it
+    // ngDevMode &&
+    console.warn(
+        `DEPRECATED: DI is instantiating a token "${type.name}" that inherits its @Injectable decorator but does not provide one itself.\n` +
+        `This will become an error in v10. Please add @Injectable() to the "${type.name}" class.`);
+    return type[NG_INJECTABLE_DEF];
+  } else {
+    return null;
+  }
 }
 
 /**

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -123,6 +123,9 @@
     "name": "getGlobal"
   },
   {
+    "name": "getInheritedInjectableDef"
+  },
+  {
     "name": "getInjectableDef"
   },
   {
@@ -130,6 +133,9 @@
   },
   {
     "name": "getNullInjector"
+  },
+  {
+    "name": "getUndecoratedInjectableFactory"
   },
   {
     "name": "hasDeps"


### PR DESCRIPTION
fix(ivy): support sub-class services that only inherit `@Injectable`  …

 In View engine it is possible to instantiate a service that that has no
`@Injectable` decorator as long as it satisfies one of:

1) It has no dependencies and so a constructor with no parameters.
This is already supported in Ivy.
2) It has no constructor of its own and sub-classes a service which has
dependencies but has its own `@Injectable` decorator. This second
scenario was broken in Ivy.

In Ivy, previous to this commit, if a class to be instantiated did not have
its own `@Injectable` decorator and did not provide a constructor of
its own, then it would be created using `new` with no arguments -
i.e. falling back to the first scenario.

After this commit Ivy correctly uses the `ngInjectableDef` inherited
from the super-class to provide the `factory` for instantiating the
sub-class.

FW-1314