### PR TITLE
fix(router): IE 11 bug can break URL unification when comparing objects

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -23,7 +23,8 @@ export function shallowEqualArrays(a: any[], b: any[]): boolean {
 export function shallowEqual(a: {[x: string]: any}, b: {[x: string]: any}): boolean {
   const k1 = Object.keys(a);
   const k2 = Object.keys(b);
-  if (k1.length != k2.length) {
+  // IE 11 sometimes returns an `undefined` value here. This guard is for IE 11 only.
+  if (!(k1 || k2) || k1.length != k2.length) {
     return false;
   }
   let key: string;


### PR DESCRIPTION
This PR fixes an issue where IE 11 can return `undefined` in with an `Object.keys` call. Solution is to add a runtime check on the value. Based on the types being passed, this shouldn't be necessary, but is needed only for IE 11. Unit test doesn't work for this PR because it can't be replicated easily.
