### PR TITLE
perf(ivy): don't initialize `TNode` inputs multiple times

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1747,10 +1747,10 @@ export function storeBindingMetadata(lView: LView, prefix = '', suffix = ''): st
 export const CLEAN_PROMISE = _CLEAN_PROMISE;
 
 export function initializeTNodeInputs(tNode: TNode | null): PropertyAliases|null {
-  // If tNode.inputs is undefined, a listener has created outputs, but inputs haven't
+  // If tNode.inputs is undefined or null, a listener has created outputs, but inputs haven't
   // yet been checked.
   if (tNode) {
-    if (tNode.inputs === undefined) {
+    if (!tNode.inputs) {
       // mark inputs as checked
       tNode.inputs = generatePropertyAliases(tNode, BindingDirection.Input);
     }


### PR DESCRIPTION
I noticed that `tNode.inputs` can be `undefined | null`, so the test was not working and we were setting the `TNode` inputs multiple times.