### PR TITLE
build(docs-infra): ensure hidden cli commands are excluded from `sitemap.xml`

### DIFF
--- a/aio/tools/transforms/cli-docs-package/processors/filterHiddenCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/filterHiddenCommands.js
@@ -1,7 +1,7 @@
 module.exports = function filterHiddenCommands() {
   return {
     $runAfter: ['files-read'],
-    $runBefore: ['processCliContainerDoc'],
+    $runBefore: ['processCliContainerDoc', 'createSitemap'],
     $process(docs) {
       return docs.filter(doc => doc.docType !== 'cli-command' || doc.hidden !== true);
     }

--- a/aio/tools/transforms/cli-docs-package/processors/filterHiddenCommands.spec.js
+++ b/aio/tools/transforms/cli-docs-package/processors/filterHiddenCommands.spec.js
@@ -18,7 +18,7 @@ describe('filterHiddenCommands processor', () => {
 
   it('should run before the correct processor', () => {
     const processor = processorFactory();
-    expect(processor.$runBefore).toEqual(['processCliContainerDoc']);
+    expect(processor.$runBefore).toEqual(['processCliContainerDoc', 'createSitemap']);
   });
 
   it('should remove CLI command docs that are hidden', () => {


### PR DESCRIPTION
Previously, the processor that excludes certain cli commands (`filterHiddenCommand`) was being run after the `createSitemap` processor, resulting in those commands to be present in `sitemap.xml`, while the actual pages where missing. This also resulted in 404s, when search engine crawlers tried to index the missing URLs.

This commit fixes it by ensuring that the `filterHiddenCommand` processor is run before the `createSitemap` processor.
