### PR TITLE
feat(router): add method to convert an Url to RouterStateSnapshot

### DIFF
--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -94,6 +94,41 @@ describe('Router', () => {
        }));
   });
 
+  describe('urlToRouteStateSnapshot', () => {
+    beforeEach(() => { TestBed.configureTestingModule({imports: [RouterTestingModule]}); });
+
+    it('should return snapshot or exception', inject([Router], async(r: Router) => {
+         r.resetConfig([
+           {
+             path: 'a',
+             component: ComponentA,
+             data: {state: 'i am A'},
+             children: [{path: 'b', component: ComponentB, data: {state: 'i am B'}}]
+           },
+           {path: 'c', component: ComponentC, data: {state: 'i am C'}}
+         ]);
+         const a = await r.urlToRouteStateSnapshot('/a').toPromise().then(
+             s => s && s.root !.firstChild !.data);
+         expect(a).toEqual({state: 'i am A'});
+
+         const b = await r.urlToRouteStateSnapshot('/a/b').toPromise().then(
+             s => s && s.root.firstChild !.firstChild !.data);
+         expect(b).toEqual({state: 'i am B'});
+
+         const c = await r.urlToRouteStateSnapshot('/a').toPromise().then(
+             s => s && s.root !.firstChild !.data);
+         expect(c).toEqual({state: 'i am A'});
+
+         let errorMessage = 'No error thrown.';
+         try {
+           await r.urlToRouteStateSnapshot('/x').toPromise();
+         } catch (error) {
+           errorMessage = error.message;
+         }
+         expect(errorMessage).toEqual('Cannot match any routes. URL Segment: \'x\'');
+       }));
+  });
+
   describe('PreActivation', () => {
     const serializer = new DefaultUrlSerializer();
     const inj = {get: (token: any) => () => `${token}_value`};
@@ -704,3 +739,7 @@ function checkGuards(
         error(e) { throw e; }
       });
 }
+
+class ComponentA {}
+class ComponentB {}
+class ComponentC {}

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -349,6 +349,7 @@ export declare class Router {
     resetConfig(config: Routes): void;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
+    urlToRouteStateSnapshot(url: string | UrlTree): Observable<RouterStateSnapshot | null>;
 }
 
 export declare const ROUTER_CONFIGURATION: InjectionToken<ExtraOptions>;


### PR DESCRIPTION
convert any Url to a routeStateSnapshot (if they exist).
This allows to check if user can access link before displaying it

fixes #15750

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Enable to retrieve RouterStateSnapshot from URL

Issue Number: 15750

## What is the new behavior?
Router allows to retrieve RouterStateSnapshot from Url

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
