### PR TITLE
build(docs-infra): upgrade cli command docs sources to 73d875a70

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && node scripts/switch-to-ivy",
     "build-with-ivy": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 8dd9b98ac",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 73d875a70",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/8dd9b98ac...73d875a70):

**Modified**
- help/build.json
- help/e2e.json
- help/serve.json
- help/test.json
- help/xi18n.json

##