### PR TITLE
build(docs-infra): upgrade cli command docs sources to d46eb367f

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && node scripts/switch-to-ivy",
     "build-with-ivy": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js cd7920355",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js d46eb367f",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#8.0.x](https://github.com/angular/angular/tree/8.0.x) from [cli-builds#8.0.x](https://github.com/angular/cli-builds/tree/8.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/cd7920355...d46eb367f):

**Modified**
- help/build.json
- help/e2e.json
- help/serve.json
- help/test.json
- help/xi18n.json

##