### PR TITLE
build: ignore `.devcontainer/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/gulp-tasks/cldr/cldr-data/
 pubspec.lock
 .c9
 .idea/
+.devcontainer
 .settings/
 .vscode/launch.json
 .vscode/settings.json


### PR DESCRIPTION
This makes it easier to experiment with VSCode's [remote development using docker containers][1] feature.

In the future, we may check in the necessary files for users to use this feature, but for now ignoring the directory makes it easier play around and evaluate the feature.

[1]: https://code.visualstudio.com/docs/remote/containers
