### PR TITLE
docs: fix the payload in event-binding sample code

### DIFF
--- a/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.ts
+++ b/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.ts
@@ -21,7 +21,7 @@ export class ItemDetailComponent {
   @Output() deleteRequest = new EventEmitter<Item>();
 
   delete() {
-    this.deleteRequest.emit(this.item.name);
+    this.deleteRequest.emit(this.item);
     this.displayNone = this.displayNone ? '' : 'none';
     this.lineThrough = this.lineThrough ? '' : 'line-through';
   }


### PR DESCRIPTION

after reading the context. there are  some clues to infer the payload should be the `item`, not `item.name`.
1.  EventEmitter<Item>.
2.  the desc say that:
The component defines a deleteRequest property that returns an EventEmitter. When the user clicks delete, the component invokes the delete() method, telling the EventEmitter to emit an **Item** object.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
