### PR TITLE
fix(router): empty outlet component respecting the current outlet

### DIFF
--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -18,7 +18,7 @@ import {ActivatedRoute} from '../router_state';
  * In order to render, there needs to be a component on this config, which will default
  * to this `EmptyOutletComponent`.
  */
-@Component({template: `<router-outlet [name]="route.outlet"></router-outlet>`})
+@Component({template: `<router-outlet lazy [name]="route.outlet"></router-outlet>`})
 export class ɵEmptyOutletComponent {
   constructor(public route: ActivatedRoute) {}
 }

--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -7,6 +7,7 @@
  */
 
 import {Component} from '@angular/core';
+import {ActivatedRoute} from '../router_state';
 
 /**
  * This component is used internally within the router to be a placeholder when an empty
@@ -17,8 +18,9 @@ import {Component} from '@angular/core';
  * In order to render, there needs to be a component on this config, which will default
  * to this `EmptyOutletComponent`.
  */
-@Component({template: `<router-outlet></router-outlet>`})
+@Component({template: `<router-outlet [name]="route.outlet"></router-outlet>`})
 export class ɵEmptyOutletComponent {
+  constructor(public route: ActivatedRoute) {}
 }
 
 export {ɵEmptyOutletComponent as EmptyOutletComponent};

--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 import {ActivatedRoute} from '../router_state';
+import {PRIMARY_OUTLET} from '../shared';
 
 /**
  * This component is used internally within the router to be a placeholder when an empty
@@ -18,9 +19,16 @@ import {ActivatedRoute} from '../router_state';
  * In order to render, there needs to be a component on this config, which will default
  * to this `EmptyOutletComponent`.
  */
-@Component({template: `<router-outlet lazy [name]="route.outlet"></router-outlet>`})
+@Component({template: `<router-outlet lazy [name]="name"></router-outlet>`})
 export class ɵEmptyOutletComponent {
-  constructor(public route: ActivatedRoute) {}
+  name!: string;
+
+  constructor(public route: ActivatedRoute) {
+    // lazy loaded children are handled as primary routes
+    this.name = route.snapshot.routeConfig?.loadChildren
+      ? PRIMARY_OUTLET
+      : route.outlet;
+  }
 }
 
 export {ɵEmptyOutletComponent as EmptyOutletComponent};

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -189,7 +189,7 @@ export class ActivateRoutes {
           } else if (isDevMode() && console && console.warn) {
             console.warn(
                 `A router outlet has not been instantiated during routes activation. URL Segment: '${
-                    future.snapshot._urlSegment}'`);
+                    context.route.outlet}: ${future.snapshot._urlSegment}'`);
           }
 
           this.activateChildRoutes(futureNode, null, context.children);

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -105,11 +105,16 @@ function getFullPath(parentPath: string, currentRoute: Route): string {
 /**
  * Makes a copy of the config and adds any default required properties.
  */
-export function standardizeConfig(r: Route): Route {
-  const children = r.children && r.children.map(standardizeConfig);
-  const c = children ? {...r, children} : {...r};
-  if (!c.component && (children || c.loadChildren) && (c.outlet && c.outlet !== PRIMARY_OUTLET)) {
-    c.component = EmptyOutletComponent;
+export function standardizeConfig(i: Route): Route {
+  const children = i.children && i.children.map(c => {
+    if (i.outlet && i.outlet !== PRIMARY_OUTLET && (c.outlet === PRIMARY_OUTLET || c.outlet === undefined)) {
+      c.outlet = i.outlet;
+    }
+    return standardizeConfig(c);
+  });
+  const r = children ? {...i, children} : {...i};
+  if (!r.component && (children || r.loadChildren) && (r.outlet && r.outlet !== PRIMARY_OUTLET)) {
+    r.component = EmptyOutletComponent;
   }
-  return c;
+  return r;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Currently, the `EmptyOutletComponent` doesn't include a `router-outlet` for the current named route, and it doesn't display the component of the current route.

Issue Number: #10981

Refs: https://github.com/angular/angular/issues/10981#issuecomment-492062160

## What is the new behavior?

It will pass the current outlet name to the `router-outlet`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

@jasonaden Do you know if moving the `RouterOutlet.name` from `@Attribute` to `@Input` has a lifecycle implication? any collateral issue will be seen in the tests? Thanks in advance!