### PR TITLE
docs: clarify usage of using /deep/ in component styles guide

### DIFF
--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -106,10 +106,11 @@ if some ancestor element has the CSS class `theme-light`.
 
 Component styles normally apply only to the HTML in the component's own template.
 
-Use the `/deep/` shadow-piercing descendant combinator to force a style down through the child
-component tree into all the child component views.
-The `/deep/` combinator works to any depth of nested components, and it applies to both the view
-children and content children of the component.
+Applying the `::ng-deep` pseudo-class to any CSS rule completely disables view-encapsulation for
+that rule. Any style with `::ng-deep` applied becomes a global style. In order to scope the specified style
+to the current component and all its descendants, be sure to include the `:host` selector before
+`::ng-deep`. If the `::ng-deep` combinator is used without the `:host` pseudo-class selector, the style
+can bleed into other components.
 
 The following example targets all `<h3>` elements, from the host element down
 through this component to all of its child elements in the DOM.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The docs regarding /deep/ don't clearly express the full scope of using an /deep/ without :host

Issue Number: #29967


## What is the new behavior?
Updated the description regarding the (deprecated) /deep/ pseudo-selector to clarify its propensity to bleed styles across components and its solution

closes #29967

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
