### PR TITLE
fix(core): static-query migration should not fallback to test strategy

### DIFF
--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -192,7 +192,7 @@ async function runStaticQueryMigration(
           `the update cannot use the template migration strategy. Please ensure ` +
           `there are no AOT compilation errors.`);
     }
-    logger.error(e);
+    logger.error(e.toString());
     logger.info(
         'Migration can be rerun with: "ng update @angular/core --from 7 --to 8 --migrate-only"');
     return [];

--- a/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
@@ -179,11 +179,7 @@ export class QueryTemplateStrategy implements TimingStrategy {
   }
 
   private _createDiagnosticsError(diagnostics: (ts.Diagnostic|Diagnostic)[]) {
-    return new Error(
-        `Could not create Angular AOT compiler to determine query timing.\n` +
-        `The following diagnostics were detected:\n` +
-        `${diagnostics.map(d => d.messageText).join(`\n `)}\n` +
-        `Please make sure that there is no AOT compilation failure.`);
+    return new Error(`${diagnostics.map(d => d.messageText).join(`\n `)}`);
   }
 
   private _getViewQueryUniqueKey(filePath: string, className: string, propName: string) {

--- a/packages/core/schematics/migrations/static-queries/transform.ts
+++ b/packages/core/schematics/migrations/static-queries/transform.ts
@@ -72,7 +72,7 @@ export function getTransformedQueryCallExpr(
       // we create a transformation failure message that shows developers that they need
       // to set the query timing manually to the determined query timing.
       if (timing !== null) {
-        failureMessage = 'Cannot update query declaration to explicit timing. Please manually ' +
+        failureMessage = 'Cannot update query to set explicit timing. Please manually ' +
             `set the query timing to: "{static: ${(timing === QueryTiming.STATIC).toString()}}"`;
       }
     }

--- a/packages/core/schematics/test/static_queries_migration_template_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_template_spec.ts
@@ -602,7 +602,7 @@ describe('static-queries migration with template strategy', () => {
           .toContain(`@ViewChild('myRef', /* TODO: add static flag */ myOptionsVar) query: any;`);
       expect(warnOutput.length).toBe(1);
       expect(warnOutput[0])
-          .toMatch(/^⮑ {3}index.ts@8:11: Cannot update query declaration to explicit timing./);
+          .toMatch(/^⮑ {3}index.ts@8:11: Cannot update query to set explicit timing./);
       expect(warnOutput[0]).toMatch(/Please manually set the query timing to.*static: true/);
     });
 


### PR DESCRIPTION
Various improvements for the static-query migration. See individual commits