### PR TITLE
Revert "fix(core): CSS sanitizer now allows parens in file names (#30322)"

### DIFF
--- a/packages/core/src/sanitization/style_sanitizer.ts
+++ b/packages/core/src/sanitization/style_sanitizer.ts
@@ -54,7 +54,7 @@ const SAFE_STYLE_VALUE = new RegExp(
  * Given the common use case, low likelihood of attack vector, and low impact of an attack, this
  * code is permissive and allows URLs that sanitize otherwise.
  */
-const URL_RE = /^url\(([\w\W]*)\)$/;
+const URL_RE = /^url\(([^)]+)\)$/;
 
 /**
  * Checks that quotes (" and ') are properly balanced inside a string. Assumes

--- a/packages/core/test/sanitization/style_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/style_sanitizer_spec.ts
@@ -32,7 +32,7 @@ import {_sanitizeStyle} from '../../src/sanitization/style_sanitizer';
       expectSanitize('rgb(255, 0, 0)').toEqual('rgb(255, 0, 0)');
       expectSanitize('expression(haha)').toEqual('unsafe');
     });
-    t.it('rejects unbalanced quotes', () => { expectSanitize('"value" "').toEqual('unsafe'); });
+    t.it('rejects unblanaced quotes', () => { expectSanitize('"value" "').toEqual('unsafe'); });
     t.it('accepts transform functions', () => {
       expectSanitize('rotate(90deg)').toEqual('rotate(90deg)');
       expectSanitize('rotate(javascript:evil())').toEqual('unsafe');
@@ -58,7 +58,6 @@ import {_sanitizeStyle} from '../../src/sanitization/style_sanitizer';
     t.it('accepts quoted URLs', () => {
       expectSanitize('url("foo/bar.png")').toEqual('url("foo/bar.png")');
       expectSanitize(`url('foo/bar.png')`).toEqual(`url('foo/bar.png')`);
-      expectSanitize(`url('foo/bar (1).png')`).toEqual(`url('foo/bar (1).png')`);
       expectSanitize(`url(  'foo/bar.png'\n )`).toEqual(`url(  'foo/bar.png'\n )`);
       expectSanitize('url("javascript:evil()")').toEqual('unsafe');
       expectSanitize('url( " javascript:evil() " )').toEqual('unsafe');


### PR DESCRIPTION
This reverts commit 728db882808869e1f52d20535676756d3b63b58a.

We're reverting this commit for now, until it can be subjected to a more
thorough security review.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
