### PR TITLE
fix(router): type cast correctly for IE 11 bug breaking URL Unificati…

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -21,10 +21,13 @@ export function shallowEqualArrays(a: any[], b: any[]): boolean {
 }
 
 export function shallowEqual(a: {[x: string]: any}, b: {[x: string]: any}): boolean {
-  const k1 = Object.keys(a);
-  const k2 = Object.keys(b);
-  // IE 11 sometimes returns an `undefined` value here. This guard is for IE 11 only.
-  if (!(k1 || k2) || k1.length != k2.length) {
+  // Casting Object.keys return values to include `undefined` as there are some cases
+  // in IE 11 where this can happen. Cannot provide a test because the behavior only
+  // exists in certain circumstances in IE 11, therefore doing this cast ensures the
+  // logic is correct for when this edge case is hit.
+  const k1 = Object.keys(a) as string[] | undefined;
+  const k2 = Object.keys(b) as string[] | undefined;
+  if (!k1 || !k2 || k1.length != k2.length) {
     return false;
   }
   let key: string;


### PR DESCRIPTION
…on when comparing objects

PR #30393 corrected behavior where Object.keys sometimes returns an `undefined` value. However, the types didn't reflect this in the code. That fix actually missed one value that could return `undefined`. This PR corrects this by casting the types to what they can be in IE 11. This ensures the code behaves as it should when this edge case comes up.
