### PR TITLE
feat(common): add ability to watch for AngularJS URL updates through …

### DIFF
--- a/tools/public_api_guard/common/upgrade.d.ts
+++ b/tools/public_api_guard/common/upgrade.d.ts
@@ -6,6 +6,7 @@ export declare class $locationShim {
     hash(hash: string | number | null): this;
     hash(): string;
     host(): string;
+    onChange(fn: (url: string, state: unknown, oldUrl: string, oldState: unknown) => void, err?: (e: Error) => void): void;
     path(): string;
     path(path: string | number | null): this;
     port(): number | null;


### PR DESCRIPTION
…`onUrlChange` hook

The LocationShim (replacement for `$location` was added to centralize dealing with the browser URL. Additionally, an `onUrlChange` method was added to Angular's Location service. This PR adds a corresponding method to the LocationShim so updates from AngularJS can be tracked in Angular.
