### PR TITLE
refactor(ivy): rewrite flatten function to be more memory efficient

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1497,
-        "main": 166739,
+        "main": 166799,
         "polyfills": 43626
       }
     }

--- a/integration/side-effects/snapshots/core/esm2015.js
+++ b/integration/side-effects/snapshots/core/esm2015.js
@@ -30,20 +30,16 @@ function getSymbolIterator() {
 
 if ("undefined" === typeof ngI18nClosureMode) _global["ngI18nClosureMode"] = "undefined" !== typeof goog && "function" === typeof goog.getMsg;
 
-function flatten(list, mapFn) {
-    const result = [];
-    let i = 0;
-    while (i < list.length) {
-        const item = list[i];
-        if (Array.isArray(item)) if (item.length > 0) {
-            list = item.concat(list.slice(i + 1));
-            i = 0;
-        } else i++; else {
-            result.push(mapFn ? mapFn(item) : item);
-            i++;
-        }
+function flatten(list, dst) {
+    if (void 0 === dst) dst = list;
+    for (let i = 0; i < list.length; i++) {
+        let item = list[i];
+        if (Array.isArray(item)) {
+            if (dst === list) dst = list.slice(0, i);
+            flatten(item, dst);
+        } else if (dst !== list) dst.push(item);
     }
-    return result;
+    return dst;
 }
 
 class EventEmitter extends Subject {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -108,11 +108,13 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
         ngModuleDef = getCompilerFacade().compileNgModule(
             angularCoreEnv, `ng:///${moduleType.name}/ngModuleDef.js`, {
               type: moduleType,
-              bootstrap: flatten(ngModule.bootstrap || EMPTY_ARRAY, resolveForwardRef),
+              bootstrap: flatten(ngModule.bootstrap || EMPTY_ARRAY).map(resolveForwardRef),
               declarations: declarations.map(resolveForwardRef),
-              imports: flatten(ngModule.imports || EMPTY_ARRAY, resolveForwardRef)
+              imports: flatten(ngModule.imports || EMPTY_ARRAY)
+                           .map(resolveForwardRef)
                            .map(expandModuleWithProviders),
-              exports: flatten(ngModule.exports || EMPTY_ARRAY, resolveForwardRef)
+              exports: flatten(ngModule.exports || EMPTY_ARRAY)
+                           .map(resolveForwardRef)
                            .map(expandModuleWithProviders),
               emitInline: true,
               schemas: ngModule.schemas ? flatten(ngModule.schemas) : null,
@@ -156,12 +158,12 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
   const errors: string[] = [];
   const declarations = maybeUnwrapFn(ngModuleDef.declarations);
   const imports = maybeUnwrapFn(ngModuleDef.imports);
-  flatten(imports, unwrapModuleWithProvidersImports).forEach(verifySemanticsOfNgModuleDef);
+  flatten(imports).map(unwrapModuleWithProvidersImports).forEach(verifySemanticsOfNgModuleDef);
   const exports = maybeUnwrapFn(ngModuleDef.exports);
   declarations.forEach(verifyDeclarationsHaveDefinitions);
   const combinedDeclarations: Type<any>[] = [
     ...declarations.map(resolveForwardRef),  //
-    ...flatten(imports.map(computeCombinedExports), resolveForwardRef),
+    ...flatten(imports.map(computeCombinedExports)).map(resolveForwardRef),
   ];
   exports.forEach(verifyExportsAreDeclaredOrReExported);
   declarations.forEach(verifyDeclarationIsUnique);
@@ -170,7 +172,8 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
   const ngModule = getAnnotation<NgModule>(moduleType, 'NgModule');
   if (ngModule) {
     ngModule.imports &&
-        flatten(ngModule.imports, unwrapModuleWithProvidersImports)
+        flatten(ngModule.imports)
+            .map(unwrapModuleWithProvidersImports)
             .forEach(verifySemanticsOfNgModuleDef);
     ngModule.bootstrap && ngModule.bootstrap.forEach(verifyCorrectBootstrapType);
     ngModule.bootstrap && ngModule.bootstrap.forEach(verifyComponentIsPartOfNgModule);

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -21,7 +21,7 @@ export function addAllToArray(items: any[], arr: any[]) {
 /**
  * A stack used by flatten to prevent recursive implementation.
  */
-const flattenQueue: (any[] | number)[] = [];
+const flattenQueue: (any[] | number | null)[] = [];
 
 /**
  * Flattens an array in non-recursive way. Input arrays are not modified.
@@ -59,6 +59,7 @@ export function flatten(list: any[]): any[] {
       // There are items in the flattenQueue which need to be processed.
       // Pop them.
       list = flattenQueue[--queueIndex] as any[];
+      flattenQueue[queueIndex] = null;
       length = list.length;
       index = flattenQueue[--queueIndex] as number;
       // The array is not cleared because doing so would take extra time.

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -19,55 +19,23 @@ export function addAllToArray(items: any[], arr: any[]) {
 }
 
 /**
- * A stack used by flatten to prevent recursive implementation.
+ * Flattens an array.
  */
-const flattenQueue: (any[] | number | null)[] = [];
-
-/**
- * Flattens an array in non-recursive way. Input arrays are not modified.
- *
- * This implementation is memory efficient and only allocates objects when needed.
- */
-export function flatten(list: any[]): any[] {
-  // This is an optimization so that we don't allocate memory until we have to.
-  // We assume that list is already flat.
-  let flat: any[] = list;
-  let queueIndex = 0;
-  let index = 0;
-  let length = list.length;
-  while (true) {
-    while (index < length) {
-      let item = list[index++];
-      if (Array.isArray(item)) {
-        // we need to inline it.
-        if (flat === list) {
-          // Our assumption that the list was already flat was wrong and
-          // we need to clone flat since we need to write to it.
-          flat = list.slice(0, index - 1);
-        }
-        // push current position on the stack.
-        flattenQueue[queueIndex++] = index;
-        flattenQueue[queueIndex++] = list;
-        list = item;
-        index = 0;
-        length = list.length;
-      } else if (flat !== list) {
-        flat.push(item);
+export function flatten(list: any[], dst?: any[]): any[] {
+  if (dst === undefined) dst = list;
+  for (let i = 0; i < list.length; i++) {
+    let item = list[i];
+    if (Array.isArray(item)) {
+      // we need to inline it.
+      if (dst === list) {
+        // Our assumption that the list was already flat was wrong and
+        // we need to clone flat since we need to write to it.
+        dst = list.slice(0, i);
       }
-    }
-    if (queueIndex > 0) {
-      // There are items in the flattenQueue which need to be processed.
-      // Pop them.
-      list = flattenQueue[--queueIndex] as any[];
-      flattenQueue[queueIndex] = null;
-      length = list.length;
-      index = flattenQueue[--queueIndex] as number;
-      // The array is not cleared because doing so would take extra time.
-      // Any memory leaks would be just temporary until next flattening.
-    } else {
-      break;
+      flatten(item, dst);
+    } else if (dst !== list) {
+      dst.push(item);
     }
   }
-
-  return flat;
+  return dst;
 }

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -19,24 +19,54 @@ export function addAllToArray(items: any[], arr: any[]) {
 }
 
 /**
- * Flattens an array in non-recursive way. Input arrays are not modified.
+ * A stack used by flatten to prevent recursive implementation.
  */
-export function flatten(list: any[], mapFn?: (value: any) => any): any[] {
-  const result: any[] = [];
-  let i = 0;
-  while (i < list.length) {
-    const item = list[i];
-    if (Array.isArray(item)) {
-      if (item.length > 0) {
-        list = item.concat(list.slice(i + 1));
-        i = 0;
-      } else {
-        i++;
+const flattenQueue: (any[] | number)[] = [];
+
+/**
+ * Flattens an array in non-recursive way. Input arrays are not modified.
+ *
+ * This implementation is memory efficient and only allocates objects when needed.
+ */
+export function flatten(list: any[]): any[] {
+  // This is an optimization so that we don't allocate memory until we have to.
+  // We assume that list is already flat.
+  let flat: any[] = list;
+  let queueIndex = 0;
+  let index = 0;
+  let length = list.length;
+  while (true) {
+    while (index < length) {
+      let item = list[index++];
+      if (Array.isArray(item)) {
+        // we need to inline it.
+        if (flat === list) {
+          // Our assumption that the list was already flat was wrong and
+          // we need to clone flat since we need to write to it.
+          flat = list.slice(0, index - 1);
+        }
+        // push current position on the stack.
+        flattenQueue[queueIndex++] = index;
+        flattenQueue[queueIndex++] = list;
+        list = item;
+        index = 0;
+        length = list.length;
+      } else if (flat !== list) {
+        flat.push(item);
       }
+    }
+    if (queueIndex > 0) {
+      // There are items in the flattenQueue which need to be processed.
+      // Pop them.
+      list = flattenQueue[--queueIndex] as any[];
+      length = list.length;
+      index = flattenQueue[--queueIndex] as number;
+      // The array is not cleared because doing so would take extra time.
+      // Any memory leaks would be just temporary until next flattening.
     } else {
-      result.push(mapFn ? mapFn(item) : item);
-      i++;
+      break;
     }
   }
-  return result;
+
+  return flat;
 }


### PR DESCRIPTION
The `flatten` function used `concat` and `slice` which created a lot of intermediary
object allocations. Because `flatten` is used from query any benchmark which
used query would exhibit high minor GC counts.

My primarily benchmarks show that this change saves 200MB on https://github.com/angular/angular/pull/30403 benchmark.

All benchmarks are from google3 and are from the https://github.com/angular/angular/pull/30403 port. Here are the results.

*ViewEngine* (Baseline)
```
forcedGcAmount |       forcedGcTime |           gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
           4131.06 |             132.88 |           38971.97 |              84.84 |               0.00 |            1178.70 |             424.98 |            1263.54 (first run)
           3890.86 |             181.08 |           37962.68 |              87.37 |               0.00 |             931.52 |             324.67 |            1013.18 (stable)
================== | ================== | ================== | ================== | ================== | ================== | ================== | ==================
       3918.89+-0% |         177.51+-6% |       37942.22+-0% |          90.48+-3% |               0.00 |         954.83+-4% |         324.43+-5% |        1039.32+-4%
```

*Ivy* before https://github.com/angular/angular/pull/30468
```
forcedGcAmount |       forcedGcTime |           gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
           3838.34 |             132.09 |          233064.11 |             143.26 |               0.00 |            1838.28 |             410.40 |            1981.04 (first run)
          10316.45 |             137.48 |          224838.71 |             241.96 |             126.27 |            1332.78 |             262.76 |            1574.66 (stable)
================== | ================== | ================== | ================== | ================== | ================== | ================== | ==================
      7274.74+-47% |         144.16+-5% |      227913.43+-1% |         245.05+-4% |         125.87+-5% |        1353.97+-2% |         267.33+-7% |        1598.88+-2%
```

*Ivy* after https://github.com/angular/angular/pull/30468
```
forcedGcAmount |       forcedGcTime |           gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
           3486.84 |             157.62 |           28478.15 |             116.09 |               0.00 |            1200.38 |             332.20 |            1308.35 (first run)
          72440.90 |             200.99 |           24051.99 |             146.36 |               0.00 |             775.92 |             285.74 |             912.97 (stable)
================== | ================== | ================== | ================== | ================== | ================== | ================== | ==================
      72435.22+-0% |         172.33+-7% |       24097.43+-0% |         125.68+-5% |               0.00 |         730.33+-3% |         284.07+-0% |         848.06+-3%
```

Memory: VE 38Mb (100%) Ivy before: 228Mb (600%) => Ivy after 24MB (63%)
Script: VE 954ms(100%) Ivy before: 1353ms(142%) => Ivy after: 730ms(77%)