### PR TITLE
ci: temporarily disable compiler tests on windows

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -21,4 +21,6 @@ steps:
     - copy .codefresh\bazel.rc %ProgramData%\bazel.bazelrc
     # Run tests
     - yarn test-ivy-aot //packages/animations/test //packages/common/test //packages/forms/test //packages/http/test //packages/platform-browser/test //packages/platform-browser-dynamic/test //packages/router/test
-    - yarn bazel test //tools/ts-api-guardian:all //tools/public_api_guard/... //packages/language-service/test //packages/compiler-cli/ngcc/test:test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance //packages/compiler/test //packages/compiler-cli/test:ngc //packages/compiler-cli/test/ngtsc:ngtsc
+    # //packages/compiler/test should also be part of the cmmand below, but we have been seeing
+    # intermittent failures on it and are still investigating it.
+    - yarn bazel test //tools/ts-api-guardian:all //tools/public_api_guard/... //packages/language-service/test //packages/compiler-cli/ngcc/test:test //packages/compiler-cli/integrationtest:integrationtest //packages/compiler-cli/test/compliance:compliance //packages/compiler-cli/test:ngc //packages/compiler-cli/test/ngtsc:ngtsc


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`//packages/compiler/test` tests are intermittently failing with the error below:

```
Error: Errors from TypeScript:
Cannot write file '/node_modules/@angular/core/core.ngfactory.d.ts' because it would overwrite input file.
  Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
```

This only happens on the Windows Codefresh CI track.

We're not sure why, but it doesn't always happen. Currently we suspect it's related the the implicit caching model in Codefresh surfacing a problem in our setup.


## What is the new behavior?

Test is disabled while we investigate. Rest of the CI should still be green.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
