### PR TITLE
feat(ivy): static evaluation of TypeScript's `__spread` helper

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, Import, TsHelperFn, TypeScriptReflectionHost, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, Import, TypeScriptReflectionHost, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined} from '../utils';
@@ -1323,14 +1323,16 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected parseForModuleWithProviders(
       name: string, node: ts.Node|null, implementation: ts.Node|null = node,
       container: ts.Declaration|null = null): ModuleWithProvidersFunction|null {
-    if (implementation === null) {
+    if (implementation === null ||
+        (!ts.isFunctionDeclaration(implementation) && !ts.isMethodDeclaration(implementation) &&
+         !ts.isFunctionExpression(implementation))) {
       return null;
     }
-    const definition = this.getDefinitionOfFunction(implementation);
-    if (definition === null || definition === TsHelperFn.Spread) {
+    const declaration = implementation;
+    const definition = this.getDefinitionOfFunction(declaration);
+    if (definition === null) {
       return null;
     }
-    const declaration = definition.node;
     const body = definition.body;
     const lastStatement = body && body[body.length - 1];
     const returnExpression =

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, Import, TypeScriptReflectionHost, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, Import, TsHelperFn, TypeScriptReflectionHost, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined} from '../utils';
@@ -1323,13 +1323,15 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected parseForModuleWithProviders(
       name: string, node: ts.Node|null, implementation: ts.Node|null = node,
       container: ts.Declaration|null = null): ModuleWithProvidersFunction|null {
-    if (implementation === null ||
-        (!ts.isFunctionDeclaration(implementation) && !ts.isMethodDeclaration(implementation) &&
-         !ts.isFunctionExpression(implementation))) {
+    if (implementation === null) {
       return null;
     }
-    const declaration = implementation;
-    const body = this.getDefinitionOfFunction(declaration).body;
+    const definition = this.getDefinitionOfFunction(implementation);
+    if (definition === null || definition === TsHelperFn.Spread) {
+      return null;
+    }
+    const declaration = definition.node;
+    const body = definition.body;
     const lastStatement = body && body[body.length - 1];
     const returnExpression =
         lastStatement && ts.isReturnStatement(lastStatement) && lastStatement.expression || null;

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -148,7 +148,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * @param node the function declaration to parse.
    * @returns an object containing the node, statements and parameters of the function.
    */
-  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|TsHelperFn|null {
+  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|null {
     if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
         !ts.isFunctionExpression(node) && !ts.isVariableDeclaration(node)) {
       return null;
@@ -156,7 +156,12 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
 
     const tsHelperFn = getTsHelperFn(node);
     if (tsHelperFn !== null) {
-      return tsHelperFn;
+      return {
+        node,
+        body: null,
+        helper: tsHelperFn,
+        parameters: [],
+      };
     }
 
     // If the node was not identified to be a TypeScript helper, a variable declaration at this
@@ -176,7 +181,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
       return !lookingForParamInitializers;
     });
 
-    return {node, body: statements || null, parameters};
+    return {node, body: statements || null, helper: null, parameters};
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, FunctionDefinition, Parameter, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, FunctionDefinition, Parameter, TsHelperFn, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {isFromDtsFile} from '../../../src/ngtsc/util/src/typescript';
 import {getNameText, hasNameIdentifier} from '../utils';
 
@@ -148,8 +148,23 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * @param node the function declaration to parse.
    * @returns an object containing the node, statements and parameters of the function.
    */
-  getDefinitionOfFunction<T extends ts.FunctionDeclaration|ts.MethodDeclaration|
-                          ts.FunctionExpression>(node: T): FunctionDefinition<T> {
+  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|TsHelperFn|null {
+    if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
+        !ts.isFunctionExpression(node) && !ts.isVariableDeclaration(node)) {
+      return null;
+    }
+
+    const tsHelperFn = getTsHelperFn(node);
+    if (tsHelperFn !== null) {
+      return tsHelperFn;
+    }
+
+    // If the node was not identified to be a TypeScript helper, a variable declaration at this
+    // point cannot be resolved as a function.
+    if (ts.isVariableDeclaration(node)) {
+      return null;
+    }
+
     const parameters =
         node.parameters.map(p => ({name: getNameText(p.name), node: p, initializer: null}));
     let lookingForParamInitializers = true;
@@ -563,6 +578,21 @@ function getReturnStatement(declaration: ts.Expression | undefined): ts.ReturnSt
 
 function reflectArrayElement(element: ts.Expression) {
   return ts.isObjectLiteralExpression(element) ? reflectObjectLiteral(element) : null;
+}
+
+/**
+ * Inspects a function declaration to determine if it corresponds with a TypeScript helper function,
+ * returning its kind if so or null if the declaration does not seem to correspond with such a
+ * helper.
+ */
+function getTsHelperFn(node: ts.NamedDeclaration): TsHelperFn|null {
+  const name = node.name !== undefined && ts.isIdentifier(node.name) && node.name.text;
+
+  if (name === '__spread') {
+    return TsHelperFn.Spread;
+  } else {
+    return null;
+  }
 }
 
 /**

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -1240,7 +1240,7 @@ describe('Esm2015ReflectionHost', () => {
 
       const fooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-      const fooDef = host.getDefinitionOfFunction(fooNode);
+      const fooDef = host.getDefinitionOfFunction(fooNode) !;
       expect(fooDef.node).toBe(fooNode);
       expect(fooDef.body !.length).toEqual(1);
       expect(fooDef.body ![0].getText()).toEqual(`return x;`);
@@ -1250,7 +1250,7 @@ describe('Esm2015ReflectionHost', () => {
 
       const barNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-      const barDef = host.getDefinitionOfFunction(barNode);
+      const barDef = host.getDefinitionOfFunction(barNode) !;
       expect(barDef.node).toBe(barNode);
       expect(barDef.body !.length).toEqual(1);
       expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
@@ -1263,7 +1263,7 @@ describe('Esm2015ReflectionHost', () => {
 
       const bazNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-      const bazDef = host.getDefinitionOfFunction(bazNode);
+      const bazDef = host.getDefinitionOfFunction(bazNode) !;
       expect(bazDef.node).toBe(bazNode);
       expect(bazDef.body !.length).toEqual(3);
       expect(bazDef.parameters.length).toEqual(1);
@@ -1272,7 +1272,7 @@ describe('Esm2015ReflectionHost', () => {
 
       const quxNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-      const quxDef = host.getDefinitionOfFunction(quxNode);
+      const quxDef = host.getDefinitionOfFunction(quxNode) !;
       expect(quxDef.node).toBe(quxNode);
       expect(quxDef.body !.length).toEqual(2);
       expect(quxDef.parameters.length).toEqual(1);
@@ -1281,14 +1281,14 @@ describe('Esm2015ReflectionHost', () => {
 
       const mooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'moo', isNamedFunctionDeclaration) !;
-      const mooDef = host.getDefinitionOfFunction(mooNode);
+      const mooDef = host.getDefinitionOfFunction(mooNode) !;
       expect(mooDef.node).toBe(mooNode);
       expect(mooDef.body !.length).toEqual(3);
       expect(mooDef.parameters).toEqual([]);
 
       const juuNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'juu', isNamedFunctionDeclaration) !;
-      const juuDef = host.getDefinitionOfFunction(juuNode);
+      const juuDef = host.getDefinitionOfFunction(juuNode) !;
       expect(juuDef.node).toBe(juuNode);
       expect(juuDef.body !.length).toEqual(2);
       expect(juuDef.parameters).toEqual([]);

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassMemberKind, CtorParameter, Decorator, Import, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, CtorParameter, Decorator, FunctionDefinition, Import, TsHelperFn, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
 import {Esm5ReflectionHost, getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
@@ -1409,7 +1409,7 @@ describe('Esm5ReflectionHost', () => {
 
       const fooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-      const fooDef = host.getDefinitionOfFunction(fooNode);
+      const fooDef = host.getDefinitionOfFunction(fooNode) as FunctionDefinition;
       expect(fooDef.node).toBe(fooNode);
       expect(fooDef.body !.length).toEqual(1);
       expect(fooDef.body ![0].getText()).toEqual(`return x;`);
@@ -1419,7 +1419,7 @@ describe('Esm5ReflectionHost', () => {
 
       const barNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-      const barDef = host.getDefinitionOfFunction(barNode);
+      const barDef = host.getDefinitionOfFunction(barNode) as FunctionDefinition;
       expect(barDef.node).toBe(barNode);
       expect(barDef.body !.length).toEqual(1);
       expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
@@ -1432,7 +1432,7 @@ describe('Esm5ReflectionHost', () => {
 
       const bazNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-      const bazDef = host.getDefinitionOfFunction(bazNode);
+      const bazDef = host.getDefinitionOfFunction(bazNode) as FunctionDefinition;
       expect(bazDef.node).toBe(bazNode);
       expect(bazDef.body !.length).toEqual(3);
       expect(bazDef.parameters.length).toEqual(1);
@@ -1441,12 +1441,44 @@ describe('Esm5ReflectionHost', () => {
 
       const quxNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-      const quxDef = host.getDefinitionOfFunction(quxNode);
+      const quxDef = host.getDefinitionOfFunction(quxNode) as FunctionDefinition;
       expect(quxDef.node).toBe(quxNode);
       expect(quxDef.body !.length).toEqual(2);
       expect(quxDef.parameters.length).toEqual(1);
       expect(quxDef.parameters[0].name).toEqual('x');
       expect(quxDef.parameters[0].initializer).toBe(null);
+    });
+
+    it('should recognize TypeScript __spread helper function declaration', () => {
+      const file = {
+        name: 'declaration.d.ts',
+        contents: `export declare function __spread(...args: any[]): any[];`,
+      };
+      const program = makeTestProgram(file);
+      const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+
+      const node = getDeclaration(program, file.name, '__spread', isNamedFunctionDeclaration) !;
+
+      const definition = host.getDefinitionOfFunction(node);
+      expect(definition).toBe(TsHelperFn.Spread);
+    });
+
+    it('should recognize TypeScript __spread helper function implementation', () => {
+      const file = {
+        name: 'implementation.js',
+        contents: `
+          var __spread = (this && this.__spread) || function () {
+            for (var ar = [], i = 0; i < arguments.length; i++) ar = ar.concat(__read(arguments[i]));
+            return ar;
+          };`,
+      };
+      const program = makeTestProgram(file);
+      const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+
+      const node = getDeclaration(program, file.name, '__spread', ts.isVariableDeclaration) !;
+
+      const definition = host.getDefinitionOfFunction(node);
+      expect(definition).toBe(TsHelperFn.Spread);
     });
   });
 

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassMemberKind, CtorParameter, Decorator, FunctionDefinition, Import, TsHelperFn, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, CtorParameter, Decorator, Import, TsHelperFn, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
 import {Esm5ReflectionHost, getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
@@ -1409,7 +1409,7 @@ describe('Esm5ReflectionHost', () => {
 
       const fooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-      const fooDef = host.getDefinitionOfFunction(fooNode) as FunctionDefinition;
+      const fooDef = host.getDefinitionOfFunction(fooNode) !;
       expect(fooDef.node).toBe(fooNode);
       expect(fooDef.body !.length).toEqual(1);
       expect(fooDef.body ![0].getText()).toEqual(`return x;`);
@@ -1419,7 +1419,7 @@ describe('Esm5ReflectionHost', () => {
 
       const barNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-      const barDef = host.getDefinitionOfFunction(barNode) as FunctionDefinition;
+      const barDef = host.getDefinitionOfFunction(barNode) !;
       expect(barDef.node).toBe(barNode);
       expect(barDef.body !.length).toEqual(1);
       expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
@@ -1432,7 +1432,7 @@ describe('Esm5ReflectionHost', () => {
 
       const bazNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-      const bazDef = host.getDefinitionOfFunction(bazNode) as FunctionDefinition;
+      const bazDef = host.getDefinitionOfFunction(bazNode) !;
       expect(bazDef.node).toBe(bazNode);
       expect(bazDef.body !.length).toEqual(3);
       expect(bazDef.parameters.length).toEqual(1);
@@ -1441,7 +1441,7 @@ describe('Esm5ReflectionHost', () => {
 
       const quxNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-      const quxDef = host.getDefinitionOfFunction(quxNode) as FunctionDefinition;
+      const quxDef = host.getDefinitionOfFunction(quxNode) !;
       expect(quxDef.node).toBe(quxNode);
       expect(quxDef.body !.length).toEqual(2);
       expect(quxDef.parameters.length).toEqual(1);
@@ -1459,8 +1459,11 @@ describe('Esm5ReflectionHost', () => {
 
       const node = getDeclaration(program, file.name, '__spread', isNamedFunctionDeclaration) !;
 
-      const definition = host.getDefinitionOfFunction(node);
-      expect(definition).toBe(TsHelperFn.Spread);
+      const definition = host.getDefinitionOfFunction(node) !;
+      expect(definition.node).toBe(node);
+      expect(definition.body).toBeNull();
+      expect(definition.helper).toBe(TsHelperFn.Spread);
+      expect(definition.parameters.length).toEqual(0);
     });
 
     it('should recognize TypeScript __spread helper function implementation', () => {
@@ -1477,8 +1480,11 @@ describe('Esm5ReflectionHost', () => {
 
       const node = getDeclaration(program, file.name, '__spread', ts.isVariableDeclaration) !;
 
-      const definition = host.getDefinitionOfFunction(node);
-      expect(definition).toBe(TsHelperFn.Spread);
+      const definition = host.getDefinitionOfFunction(node) !;
+      expect(definition.node).toBe(node);
+      expect(definition.body).toBeNull();
+      expect(definition.helper).toBe(TsHelperFn.Spread);
+      expect(definition.parameters.length).toEqual(0);
     });
   });
 

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1380,7 +1380,7 @@ describe('UmdReflectionHost', () => {
 
       const fooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-      const fooDef = host.getDefinitionOfFunction(fooNode);
+      const fooDef = host.getDefinitionOfFunction(fooNode) !;
       expect(fooDef.node).toBe(fooNode);
       expect(fooDef.body !.length).toEqual(1);
       expect(fooDef.body ![0].getText()).toEqual(`return x;`);
@@ -1390,7 +1390,7 @@ describe('UmdReflectionHost', () => {
 
       const barNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-      const barDef = host.getDefinitionOfFunction(barNode);
+      const barDef = host.getDefinitionOfFunction(barNode) !;
       expect(barDef.node).toBe(barNode);
       expect(barDef.body !.length).toEqual(1);
       expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
@@ -1403,7 +1403,7 @@ describe('UmdReflectionHost', () => {
 
       const bazNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-      const bazDef = host.getDefinitionOfFunction(bazNode);
+      const bazDef = host.getDefinitionOfFunction(bazNode) !;
       expect(bazDef.node).toBe(bazNode);
       expect(bazDef.body !.length).toEqual(3);
       expect(bazDef.parameters.length).toEqual(1);
@@ -1412,7 +1412,7 @@ describe('UmdReflectionHost', () => {
 
       const quxNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-      const quxDef = host.getDefinitionOfFunction(quxNode);
+      const quxDef = host.getDefinitionOfFunction(quxNode) !;
       expect(quxDef.node).toBe(quxNode);
       expect(quxDef.body !.length).toEqual(2);
       expect(quxDef.parameters.length).toEqual(1);

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -394,7 +394,8 @@ export class StaticInterpreter {
       return DynamicValue.fromInvalidExpressionType(node.expression, lhs);
     }
 
-    if (fn === TsHelperFn.Spread) {
+    // If the function corresponds with a tslib helper function, evaluate it with custom logic.
+    if (fn.helper === TsHelperFn.Spread) {
       const args = this.evaluateFunctionArguments(node, context);
       return evaluateTsSpreadHelper(node, args);
     }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -10,14 +10,14 @@ import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
 import {OwningModule} from '../../imports/src/references';
-import {Declaration, ReflectionHost, TsHelperFn} from '../../reflection';
+import {Declaration, ReflectionHost} from '../../reflection';
 import {isDeclaration} from '../../util/src/typescript';
 
 import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
 import {DependencyTracker, ForeignFunctionResolver} from './interface';
 import {BuiltinFn, EnumValue, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './result';
-import {evaluateTsSpreadHelper} from './ts_helpers';
+import {evaluateTsHelperInline} from './ts_helpers';
 
 
 /**
@@ -395,9 +395,9 @@ export class StaticInterpreter {
     }
 
     // If the function corresponds with a tslib helper function, evaluate it with custom logic.
-    if (fn.helper === TsHelperFn.Spread) {
+    if (fn.helper !== null) {
       const args = this.evaluateFunctionArguments(node, context);
-      return evaluateTsSpreadHelper(node, args);
+      return evaluateTsHelperInline(fn.helper, node, args);
     }
 
     if (!isFunctionOrMethodReference(lhs)) {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {DynamicValue} from './dynamic';
+import {ResolvedValueArray} from './result';
+
+export function evaluateTsSpreadHelper(
+    node: ts.Node, args: ResolvedValueArray): ResolvedValueArray {
+  const result: ResolvedValueArray = [];
+  for (const arg of args) {
+    if (arg instanceof DynamicValue) {
+      result.push(DynamicValue.fromDynamicInput(node, arg));
+    } else if (Array.isArray(arg)) {
+      result.push(...arg);
+    } else {
+      result.push(arg);
+    }
+  }
+  return result;
+}

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -8,11 +8,21 @@
 
 import * as ts from 'typescript';
 
-import {DynamicValue} from './dynamic';
-import {ResolvedValueArray} from './result';
+import {TsHelperFn} from '../../reflection';
 
-export function evaluateTsSpreadHelper(
-    node: ts.Node, args: ResolvedValueArray): ResolvedValueArray {
+import {DynamicValue} from './dynamic';
+import {ResolvedValue, ResolvedValueArray} from './result';
+
+export function evaluateTsHelperInline(
+    helper: TsHelperFn, node: ts.Node, args: ResolvedValueArray): ResolvedValue {
+  if (helper === TsHelperFn.Spread) {
+    return evaluateTsSpreadHelper(node, args);
+  } else {
+    throw new Error(`Cannot evaluate unknown helper ${helper} inline`);
+  }
+}
+
+function evaluateTsSpreadHelper(node: ts.Node, args: ResolvedValueArray): ResolvedValueArray {
   const result: ResolvedValueArray = [];
   for (const arg of args) {
     if (arg instanceof DynamicValue) {

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -254,12 +254,11 @@ export interface CtorParameter {
  * itself. In ES5 code this can be more complicated, as the default values for parameters may
  * be extracted from certain body statements.
  */
-export interface FunctionDefinition<T extends ts.MethodDeclaration|ts.FunctionDeclaration|
-                                    ts.FunctionExpression> {
+export interface FunctionDefinition {
   /**
    * A reference to the node which declares the function.
    */
-  node: T;
+  node: ts.MethodDeclaration|ts.FunctionDeclaration|ts.FunctionExpression;
 
   /**
    * Statements of the function body, if a body is present, or null if no body is present.
@@ -273,6 +272,16 @@ export interface FunctionDefinition<T extends ts.MethodDeclaration|ts.FunctionDe
    * Metadata regarding the function's parameters, including possible default value expressions.
    */
   parameters: Parameter[];
+}
+
+/**
+ * Possible functions from TypeScript's helper library.
+ */
+export enum TsHelperFn {
+  /**
+   * Indicates the `__spread` function.
+   */
+  Spread,
 }
 
 /**
@@ -404,8 +413,7 @@ export interface ReflectionHost {
    *
    * @returns a `FunctionDefinition` giving metadata about the function definition.
    */
-  getDefinitionOfFunction<T extends ts.MethodDeclaration|ts.FunctionDeclaration|
-                          ts.FunctionExpression>(fn: T): FunctionDefinition<T>;
+  getDefinitionOfFunction(fn: ts.Node): FunctionDefinition|TsHelperFn|null;
 
   /**
    * Determine if an identifier was imported from another module and return `Import` metadata

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -258,15 +258,23 @@ export interface FunctionDefinition {
   /**
    * A reference to the node which declares the function.
    */
-  node: ts.MethodDeclaration|ts.FunctionDeclaration|ts.FunctionExpression;
+  node: ts.MethodDeclaration|ts.FunctionDeclaration|ts.FunctionExpression|ts.VariableDeclaration;
 
   /**
-   * Statements of the function body, if a body is present, or null if no body is present.
+   * Statements of the function body, if a body is present, or null if no body is present or the
+   * function is identified to represent a tslib helper function, in which case `helper` will
+   * indicate which helper this function represents.
    *
    * This list may have been filtered to exclude statements which perform parameter default value
    * initialization.
    */
   body: ts.Statement[]|null;
+
+  /**
+   * The type of tslib helper function, if the function is determined to represent a tslib helper
+   * function. Otherwise, this will be null.
+   */
+  helper: TsHelperFn|null;
 
   /**
    * Metadata regarding the function's parameters, including possible default value expressions.
@@ -413,7 +421,7 @@ export interface ReflectionHost {
    *
    * @returns a `FunctionDefinition` giving metadata about the function definition.
    */
-  getDefinitionOfFunction(fn: ts.Node): FunctionDefinition|TsHelperFn|null;
+  getDefinitionOfFunction(fn: ts.Node): FunctionDefinition|null;
 
   /**
    * Determine if an identifier was imported from another module and return `Import` metadata

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -125,7 +125,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return this.getDeclarationOfSymbol(symbol);
   }
 
-  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|TsHelperFn|null {
+  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|null {
     if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
         !ts.isFunctionExpression(node)) {
       return null;
@@ -133,6 +133,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {
       node,
       body: node.body !== undefined ? Array.from(node.body.statements) : null,
+      helper: null,
       parameters: node.parameters.map(param => {
         const name = parameterName(param.name);
         const initializer = param.initializer || null;

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, ReflectionHost} from './host';
+import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, ReflectionHost, TsHelperFn} from './host';
 import {typeToValue} from './type_to_value';
 
 /**
@@ -125,8 +125,11 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return this.getDeclarationOfSymbol(symbol);
   }
 
-  getDefinitionOfFunction<T extends ts.FunctionDeclaration|ts.MethodDeclaration|
-                          ts.FunctionExpression>(node: T): FunctionDefinition<T> {
+  getDefinitionOfFunction(node: ts.Node): FunctionDefinition|TsHelperFn|null {
+    if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
+        !ts.isFunctionExpression(node)) {
+      return null;
+    }
     return {
       node,
       body: node.body !== undefined ? Array.from(node.body.statements) : null,


### PR DESCRIPTION
The usage of array spread syntax in source code may be downleveled to a
call to TypeScript's `__spread` helper function from `tslib`, depending
on the options `downlevelIteration` and `emitHelpers`. This proves
problematic for ngcc when it is processing ES5 formats, as the static
evaluator won't be able to interpret those calls.

A custom foreign function resolver is not sufficient in this case, as
`tslib` may be emitted into the library code itself. In that case, a
helper function can be resolved to an actual function with body, such
that it won't be considered as foreign function. Instead, a reflection
host can now indicate that the definition of a function corresponds with
a certain TypeScript helper, such that it becomes statically evaluable
in ngtsc.

Resolves #30299
