### PR TITLE
docs: improve consistency of style guide example

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -2468,11 +2468,11 @@ Here is a compliant folder and file structure:
           </div>
 
           <div class='file'>
-            text-filter.component.ts|spec.ts
+            filter-text.component.ts|spec.ts
           </div>
 
           <div class='file'>
-            text-filter.service.ts|spec.ts
+            filter-text.service.ts|spec.ts
           </div>
 
         </div>
@@ -3019,11 +3019,11 @@ Yet there is a real danger of that happening if the `SharedModule` provides a se
         </div>
 
         <div class='file'>
-          text-filter.component.ts|spec.ts
+          filter-text.component.ts|spec.ts
         </div>
 
         <div class='file'>
-          text-filter.service.ts|spec.ts
+          filter-text.service.ts|spec.ts
         </div>
 
       </div>


### PR DESCRIPTION
The text for entry Style 04-10 of the angular.io style guide talks about FilterTextService and the code example has the filename filter-text-service, however, the example folder structure has the inversed filename (text-filter). I changed all occurrences of text-filter in the file to be consistent.

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
