### PR TITLE
fix(core): remove deprecated annotation for TestBed.get

### DIFF
--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -57,8 +57,14 @@ export interface TestBed {
   compileComponents(): Promise<any>;
 
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+
+  // TODO: switch back to official deprecation marker once TSLint issue is resolved
+  // https://github.com/palantir/tslint/issues/4522
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * This does not use the deprecated jsdoc tag on purpose
+   * because it renders all overloads as deprecated in TSLint
+   * due to https://github.com/palantir/tslint/issues/4522.
    */
   get(token: any, notFoundValue?: any): any;
 

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -71,7 +71,7 @@ export interface TestBed {
     }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
     get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29905 and FW-1336

## What is the new behavior?

PR #29290 introduced a new `TestBed.get` signature and deprecated the existing one.
This raises a lot of TSLint deprecation warnings in projects using a strict TS config (see #29905 for context), so we are temporarily removing the `@deprecated` annotation in favor of a plain text warning until we properly fix it.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No