### PR TITLE
test(platform-browser-dynamic): fix `CachedResourceLoader` tests

### DIFF
--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
@@ -36,9 +36,9 @@ if (isBrowser) {
 
     it('should reject the Promise on failure', async(() => {
          resourceLoader = createCachedResourceLoader();
-         resourceLoader.get('unknown.html')
-             .then((text) => { throw new Error('Not expected to succeed.'); })
-             .catch((error) => {/** success */});
+         resourceLoader.get('unknown.html').then(() => {
+           throw new Error('Not expected to succeed.');
+         }, () => {/* success */});
        }));
 
     it('should allow fakeAsync Tests to load components with templateUrl synchronously',

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
@@ -21,17 +21,6 @@ if (isBrowser) {
       setTemplateCache({'test.html': '<div>Hello</div>'});
       return new CachedResourceLoader();
     }
-    beforeEach(fakeAsync(() => {
-      TestBed.configureCompiler({
-        providers: [
-          {provide: UrlResolver, useClass: TestUrlResolver, deps: []},
-          {provide: ResourceLoader, useFactory: createCachedResourceLoader, deps: []}
-        ]
-      });
-
-      TestBed.configureTestingModule({declarations: [TestComponent]});
-      TestBed.compileComponents();
-    }));
 
     it('should throw exception if $templateCache is not found', () => {
       setTemplateCache(null);
@@ -41,13 +30,12 @@ if (isBrowser) {
     });
 
     it('should resolve the Promise with the cached file content on success', async(() => {
-         setTemplateCache({'test.html': '<div>Hello</div>'});
-         resourceLoader = new CachedResourceLoader();
+         resourceLoader = createCachedResourceLoader();
          resourceLoader.get('test.html').then((text) => { expect(text).toBe('<div>Hello</div>'); });
        }));
 
     it('should reject the Promise on failure', async(() => {
-         resourceLoader = new CachedResourceLoader();
+         resourceLoader = createCachedResourceLoader();
          resourceLoader.get('unknown.html')
              .then((text) => { throw new Error('Not expected to succeed.'); })
              .catch((error) => {/** success */});
@@ -55,6 +43,12 @@ if (isBrowser) {
 
     it('should allow fakeAsync Tests to load components with templateUrl synchronously',
        fakeAsync(() => {
+         TestBed.configureCompiler({
+           providers: [
+             {provide: UrlResolver, useClass: TestUrlResolver, deps: []},
+             {provide: ResourceLoader, useFactory: createCachedResourceLoader, deps: []}
+           ]
+         });
          TestBed.configureTestingModule({declarations: [TestComponent]});
          TestBed.compileComponents();
          tick();


### PR DESCRIPTION
Fixes the `CachedResourceLoader` tests and makes them more reliable on CI. (See individual commit messages for more details.)

Fixes #30499.