### PR TITLE
fix(ivy): error when using forwardRef in Injectable's useClass

### DIFF
--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -57,11 +57,11 @@ export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
  * @publicApi
  */
 export function resolveForwardRef<T>(type: T): T {
-  const fn: any = type;
-  if (typeof fn === 'function' && fn.hasOwnProperty(__forward_ref__) &&
-      fn.__forward_ref__ === forwardRef) {
-    return fn();
-  } else {
-    return type;
-  }
+  return isForwardRef(type) ? type() : type;
+}
+
+/** Checks whether a function is wrapped by a `forwardRef`. */
+export function isForwardRef(fn: any): fn is() => any {
+  return typeof fn === 'function' && fn.hasOwnProperty(__forward_ref__) &&
+      fn.__forward_ref__ === forwardRef;
 }

--- a/packages/core/src/di/jit/environment.ts
+++ b/packages/core/src/di/jit/environment.ts
@@ -26,10 +26,15 @@ export const angularCoreDiEnv: {[name: string]: Function} = {
 };
 
 function getFactoryOf<T>(type: Type<any>): ((type?: Type<T>) => T)|null {
-  if (isForwardRef(type)) {
-    return () => resolveForwardRef(type as any);
-  }
   const typeAny = type as any;
+
+  if (isForwardRef(type)) {
+    return (() => {
+      const factory = getFactoryOf<T>(resolveForwardRef(typeAny));
+      return factory ? factory() : null;
+    }) as any;
+  }
+
   const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
   if (!def || def.factory === undefined) {
     return null;

--- a/packages/core/src/di/jit/environment.ts
+++ b/packages/core/src/di/jit/environment.ts
@@ -7,6 +7,7 @@
  */
 
 import {Type} from '../../interface/type';
+import {isForwardRef, resolveForwardRef} from '../forward_ref';
 import {ɵɵinject} from '../injector_compatibility';
 import {getInjectableDef, getInjectorDef, ɵɵdefineInjectable, ɵɵdefineInjector} from '../interface/defs';
 
@@ -25,6 +26,9 @@ export const angularCoreDiEnv: {[name: string]: Function} = {
 };
 
 function getFactoryOf<T>(type: Type<any>): ((type?: Type<T>) => T)|null {
+  if (isForwardRef(type)) {
+    return () => resolveForwardRef(type as any);
+  }
   const typeAny = type as any;
   const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
   if (!def || def.factory === undefined) {

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -13,6 +13,7 @@ import {getInjectableDef, getInjectorDef} from '../di/interface/defs';
 import {InjectFlags} from '../di/interface/injector';
 import {Type} from '../interface/type';
 import {assertDefined, assertEqual} from '../util/assert';
+import {isForwardRef, resolveForwardRef} from '../util/forward_ref';
 
 import {getComponentDef, getDirectiveDef, getPipeDef} from './definition';
 import {NG_ELEMENT_ID} from './fields';
@@ -632,6 +633,9 @@ export class NodeInjector implements Injector {
  * @codeGenApi
  */
 export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
+  if (isForwardRef(type)) {
+    return () => resolveForwardRef(type as any);
+  }
   const typeAny = type as any;
   const def = getComponentDef<T>(typeAny) || getDirectiveDef<T>(typeAny) ||
       getPipeDef<T>(typeAny) || getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -319,6 +319,27 @@ describe('providers', () => {
       expect(fixture.componentInstance.myService.dep.value).toBe('one');
     });
 
+    it('should support forward refs in useClass', () => {
+      @Injectable({providedIn: 'root', useClass: forwardRef(() => SomeProviderImpl)})
+      class SomeProvider {
+      }
+
+      @Injectable()
+      class SomeProviderImpl {
+      }
+
+      @Component({template: '', providers: [SomeProvider]})
+      class App {
+        constructor(public foo: SomeProvider) {}
+      }
+
+      TestBed.configureTestingModule({declarations: [App]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.foo).toBeTruthy();
+    });
+
   });
 
   describe('flags', () => {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -156,6 +156,9 @@
     "name": "isFactoryProvider"
   },
   {
+    "name": "isForwardRef"
+  },
+  {
     "name": "isTypeProvider"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1044,6 +1044,9 @@
     "name": "isFactory"
   },
   {
+    "name": "isForwardRef"
+  },
+  {
     "name": "isJsObject"
   },
   {


### PR DESCRIPTION
Fixes Ivy throwing an error when something is passed in as a `forwardRef` into `@Injectable`'s `useClass` option. The error was being thrown, because we were trying to get the provider factory off of the wrapper function, rather than the value itself.

This PR resolves FW-1335.
