### PR TITLE
refactor: clean up language service from unused code and imports

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -13,7 +13,7 @@ import {getTemplateCompletions} from './completions';
 import {getDefinition} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics} from './diagnostics';
 import {getHover} from './hover';
-import {Completions, Definition, Diagnostic, DiagnosticKind, Diagnostics, Hover, LanguageService, LanguageServiceHost, Pipes, Span, TemplateSource} from './types';
+import {Completions, Definition, Diagnostic, DiagnosticKind, Diagnostics, Hover, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
 
 
 /**

--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -48,7 +48,6 @@ class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost, Me
 }
 
 export class ReflectorHost implements StaticSymbolResolverHost {
-  private moduleResolutionCache: ts.ModuleResolutionCache;
   private hostAdapter: ReflectorModuleModuleResolutionHost;
   private metadataReaderCache = createMetadataReaderCache();
 
@@ -56,8 +55,6 @@ export class ReflectorHost implements StaticSymbolResolverHost {
       getProgram: () => ts.Program, serviceHost: ts.LanguageServiceHost,
       private options: CompilerOptions) {
     this.hostAdapter = new ReflectorModuleModuleResolutionHost(serviceHost, getProgram);
-    this.moduleResolutionCache =
-        ts.createModuleResolutionCache(serviceHost.getCurrentDirectory(), (s) => s);
   }
 
   getMetadataFor(modulePath: string): {[key: string]: any}[]|undefined {

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, FormattedError, FormattedMessageChain, HtmlParser, InterpolationConfig, JitSummaryResolver, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, analyzeNgModules, createOfflineCompileUrlResolver, isFormattedError} from '@angular/compiler';
+import {AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, FormattedError, FormattedMessageChain, HtmlParser, JitSummaryResolver, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, analyzeNgModules, createOfflineCompileUrlResolver, isFormattedError} from '@angular/compiler';
 import {CompilerOptions, getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli/src/language_services';
 import {ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as fs from 'fs';

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -86,12 +86,10 @@ describe('completions', () => {
 
     expect(() => {
       let chance = 0.05;
-      let requests = 0;
       function tryCompletionsAt(position: number) {
         try {
           if (Math.random() < chance) {
             ngService.getCompletionsAt(fileName, position);
-            requests++;
           }
         } catch (e) {
           // Emit enough diagnostic information to reproduce the error.

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -103,7 +103,7 @@ describe('diagnostics', () => {
 
     it('should not report an error for a form\'s host directives', () => {
       const code = '\n@Component({template: \'<form></form>\'}) export class MyComponent {}';
-      addCode(code, (fileName, content) => {
+      addCode(code, fileName => {
         const diagnostics = ngService.getDiagnostics(fileName);
         expectOnlyModuleDiagnostics(diagnostics);
       });

--- a/packages/language-service/test/language_service_spec.ts
+++ b/packages/language-service/test/language_service_spec.ts
@@ -9,7 +9,6 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions, LanguageService} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';

--- a/packages/language-service/test/template_references_spec.ts
+++ b/packages/language-service/test/template_references_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions, Diagnostic, Diagnostics, LanguageService} from '../src/types';
+import {LanguageService} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
@@ -19,14 +19,12 @@ describe('references', () => {
   let documentRegistry = ts.createDocumentRegistry();
   let mockHost: MockTypescriptHost;
   let service: ts.LanguageService;
-  let program: ts.Program;
   let ngHost: TypeScriptServiceHost;
   let ngService: LanguageService = createLanguageService(undefined !);
 
   beforeEach(() => {
     mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
     service = ts.createLanguageService(mockHost, documentRegistry);
-    program = service.getProgram() !;
     ngHost = new TypeScriptServiceHost(mockHost, service);
     ngService = createLanguageService(ngHost);
     ngHost.setSite(ngService);

--- a/packages/language-service/test/test_data.ts
+++ b/packages/language-service/test/test_data.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MockData} from './test_utils';
-
 export const toh = {
   'foo.ts': `export * from './app/app.component.ts';`,
   app: {

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -212,12 +212,6 @@ describe('plugin', () => {
         locationMarker, plugin.getCompletionsAtPosition(fileName, location, undefined) !, ...names);
   }
 
-  function expectEmpty(fileName: string, locationMarker: string) {
-    const location = getMarkerLocation(fileName, locationMarker);
-    expect(plugin.getCompletionsAtPosition(fileName, location, undefined) !.entries || []).toEqual([
-    ]);
-  }
-
   function expectSemanticError(fileName: string, locationMarker: string, message: string) {
     const start = getMarkerLocation(fileName, locationMarker);
     const end = getMarkerLocation(fileName, locationMarker + '-end');


### PR DESCRIPTION
Small clean up in the language service code