### PR TITLE
Ivy perf 05 17

### DIFF
--- a/modules/benchmarks/src/expanding_rows/index.html
+++ b/modules/benchmarks/src/expanding_rows/index.html
@@ -30,7 +30,7 @@
         }
         // zone.js must be loaded and processed before Angular bundle gets executed
         loadScript('/npm/node_modules/zone.js/dist/zone.js').then(function () {
-          loadScript(document.location.search.endsWith('debug') ? 'bundle.min_debug.js' : 'bundle.min.js');
+          loadScript('bundle.min_debug.js');
         });
       }
     });

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -111,13 +111,13 @@ export function ΔelementStart(
 
   // we render the styling again below in case any directives have set any `style` and/or
   // `class` host attribute values...
-  if (tNode.stylingTemplate) {
+  if (tNode.stylingTemplate !== null) {
     renderInitialClasses(native, tNode.stylingTemplate, renderer, initialClassesIndex);
     renderInitialStyles(native, tNode.stylingTemplate, renderer, initialStylesIndex);
   }
 
   const currentQueries = lView[QUERIES];
-  if (currentQueries) {
+  if (currentQueries !== null) {
     currentQueries.addNode(tNode);
     lView[QUERIES] = currentQueries.clone();
   }


### PR DESCRIPTION
This PR contains 3 commits that aim at addressing hot-spots seen under profiler. Collectively those changes (numbers from my machine with the expanding rows benchmark) save us ~30-40MB of memory and ~100ms of time. Raw data (each entry corresponds to a separate benchpress run with sample size  = 20):

**Before:**
```
          gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
================== | ================== | ================== | ================== | ================== | ==================
    161440.51+-67% |        474.39+-49% |        239.79+-93% |       1297.37+-20% |        345.23+-10% |       1750.98+-27%
    159178.34+-55% |        338.38+-55% |       134.67+-129% |       1239.76+-18% |        344.28+-17% |       1575.01+-22%
    150898.17+-54% |        327.71+-38% |        126.90+-97% |       1139.36+-13% |        330.11+-11% |       1456.52+-16%
    149242.39+-67% |        365.79+-52% |       167.76+-112% |       1180.43+-19% |        342.11+-13% |       1523.84+-20%
    152152.33+-73% |        460.34+-49% |        251.59+-91% |       1098.74+-19% |         316.94+-9% |       1555.79+-24%


```
**After:**
```  
          gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
================== | ================== | ================== | ================== | ================== | ==================
    124833.94+-73% |        384.12+-55% |       180.49+-112% |       1200.66+-14% |         354.57+-9% |       1571.41+-20%
    133101.34+-78% |        378.30+-54% |       175.17+-110% |       1150.86+-19% |        349.07+-17% |       1518.76+-26%
    117834.40+-93% |        425.20+-55% |        231.22+-99% |       1062.82+-19% |         307.85+-9% |       1483.23+-27%
   111510.76+-103% |        399.75+-70% |       213.08+-128% |       1058.99+-23% |        303.78+-10% |       1454.01+-30%
    113097.28+-89% |        329.53+-49% |       148.90+-106% |        941.54+-14% |         302.39+-7% |       1267.66+-21%
    117457.99+-86% |        368.45+-51% |        187.67+-98% |        966.20+-13% |         298.45+-8% |       1331.42+-21%
```