### PR TITLE
Test differential loading on legacy browsers in /integration/bazel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,17 @@ jobs:
         # fail to acquire browsers. For example:
         # 14 02 2019 19:52:33.170:WARN [launcher]: chrome beta on SauceLabs have not captured in 180000 ms, killing.
         # //packages/forms/test:web_test_sauce TIMEOUT in 315.0s
-      - run: yarn bazel test --config=saucelabs //:test_web_all
+      - run:
+          name: Run //:test_web_all on Saucelabs
+          command: yarn bazel test --config=saucelabs //:test_web_all
+        # Also test the /integration/bazel production build on Saucelabs
+        # via protractor with legacy browsers to test differential loading
+      - run:
+          name: Run /integration/bazel //test/e2e:prodserver_sauce_test on Saucelabs
+          command: |
+            cd integration/bazel
+            ./pretest.sh
+            ./run_sauce_tests.sh
       - run: ./scripts/saucelabs/stop-tunnel.sh
 
   test_aio:
@@ -716,9 +726,12 @@ workflows:
   saucelabs_tests:
     jobs:
       - setup
-      - test_saucelabs_bazel:
+      - build-npm-packages:
           requires:
             - setup
+      - test_saucelabs_bazel:
+          requires:
+            - build-npm-packages
     triggers:
       - schedule:
           # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs

--- a/integration/bazel/.bazelrc
+++ b/integration/bazel/.bazelrc
@@ -16,3 +16,18 @@ build --define=compile=legacy
 
 # Don't create symlinks
 build --symlink_prefix=/
+
+###############################
+# Saucelabs support           #
+# Turn on these settings with #
+#  --config=saucelabs         #
+###############################
+
+# Expose SauceLabs environment to actions
+# These environment variables are needed by
+# web_test_karma & protractor_web_test to run on Saucelabs
+test:saucelabs --action_env=SAUCE_USERNAME
+test:saucelabs --action_env=SAUCE_ACCESS_KEY
+test:saucelabs --action_env=SAUCE_READY_FILE
+test:saucelabs --action_env=SAUCE_PID_FILE
+test:saucelabs --action_env=SAUCE_TUNNEL_IDENTIFIER

--- a/integration/bazel/BUILD.bazel
+++ b/integration/bazel/BUILD.bazel
@@ -2,6 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "protractor.conf.js",
+    "protractor-sauce.conf.js",
     "angular-metadata.tsconfig.json",
 ])
 

--- a/integration/bazel/protractor-sauce.conf.js
+++ b/integration/bazel/protractor-sauce.conf.js
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// This protractor Saucelabs configuration is primarily for testing the
+// production bundle with differential loading against older legacy browsers.
+//
+// Legacy browsers that do not support ES modules should load
+// <script nomodule src="bundle.min.js"></script>
+// while evergreen browsers that do support ES modules should load
+// <script type="module" src="bundle.min.es2015.js"></script>
+
+const sauceCapabilities = {
+  // Chrome 74 supports ES modules
+  'SL_CHROME': {
+    browserName: "chrome",
+    version: "74",
+  },
+  // Chrome 41 does not support ES modules
+  'SL_CHROMELEGACY': {
+    browserName: "chrome",
+    version: "41",
+  },
+  // IE10 does not support ES modules
+  'SL_IE10': {
+    browserName: 'internet explorer',
+    platform: 'Windows 2012',
+    version: '10'
+  },
+  // IE11 does not support ES modules
+  'SL_IE11': {
+    browserName: 'internet explorer',
+    platform: 'Windows 8.1',
+    version: '11',
+  },
+  // Edge 14 does not support ES modules
+  'SL_EDGE': {
+    browserName: "MicrosoftEdge",
+    platform: 'Windows 10',
+    version: "14.14393",
+  },
+};
+
+if (!process.env['SAUCE_USERNAME']) {
+  throw new Error('SAUCE_USERNAME environment variable required!')
+}
+if (!process.env['SAUCE_ACCESS_KEY']) {
+  throw new Error('SAUCE_ACCESS_KEY environment variable required!')
+}
+if (!process.env['SAUCE_BROWSER']) {
+  throw new Error('SAUCE_BROWSER environment variable required!')
+}
+
+const capabilities = sauceCapabilities[process.env['SAUCE_BROWSER']];
+if (!capabilities) {
+  throw new Error(`Invalid SAUCE_BROWSER value! Choose one of ${Object.keys(sauceCapabilities)}.`)
+}
+
+capabilities.name = 'integration-bazel-sauce-test';
+
+const tunnelIdentifier = process.env['SAUCE_TUNNEL_IDENTIFIER'];
+if (tunnelIdentifier) {
+  capabilities['tunnel-identifier'] = tunnelIdentifier;
+}
+
+exports.config = {
+  sauceUser: process.env['SAUCE_USERNAME'],
+  sauceKey: process.env['SAUCE_ACCESS_KEY'],
+  getPageTimeout: 60 * 1000,
+  allScriptsTimeout: 60 * 1000,
+  capabilities: capabilities,
+  // `multiCapabilities` do not yet work under Bazel; protractor
+  // spawns a new node process for each capability in multiCapabilities
+  // and the new node processes are not able to resolve files under
+  // bazel as they don't have the overwritten Bazel resolve function.
+  // This means we can only test on one browser at a time under Bazel
+  // for the time being until this is resolved.
+};

--- a/integration/bazel/run_sauce_tests.sh
+++ b/integration/bazel/run_sauce_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+# -e: exits if a command fails
+# -u: errors if an variable is referenced before being set
+# -x: shows the commands that get run
+# -o pipefail: causes a pipeline to produce a failure return code if any command errors
+
+bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROME //test/e2e:prodserver_sauce_test
+bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROMELEGACY //test/e2e:prodserver_sauce_test
+bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_IE10 //test/e2e:prodserver_sauce_test
+bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_IE11 //test/e2e:prodserver_sauce_test
+bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_EDGE //test/e2e:prodserver_sauce_test

--- a/integration/bazel/run_sauce_tests.sh
+++ b/integration/bazel/run_sauce_tests.sh
@@ -6,8 +6,14 @@ set -eux -o pipefail
 # -x: shows the commands that get run
 # -o pipefail: causes a pipeline to produce a failure return code if any command errors
 
-bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROME //test/e2e:prodserver_sauce_test
-bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROMELEGACY //test/e2e:prodserver_sauce_test
-bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_IE10 //test/e2e:prodserver_sauce_test
-bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_IE11 //test/e2e:prodserver_sauce_test
-bazel test --config=saucelabs --define=SAUCE_BROWSER=SL_EDGE //test/e2e:prodserver_sauce_test
+if [ -x "$(command -v ../../node_modules/.bin/bazel)" ]; then
+  BAZEL=../../node_modules/.bin/bazel
+elif [ -x "$(command -v bazel)" ]; then
+  BAZEL=bazel
+fi
+
+${BAZEL} test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROME //test/e2e:prodserver_sauce_test
+${BAZEL} test --config=saucelabs --define=SAUCE_BROWSER=SL_CHROMELEGACY //test/e2e:prodserver_sauce_test
+${BAZEL} test --config=saucelabs --define=SAUCE_BROWSER=SL_IE10 //test/e2e:prodserver_sauce_test
+${BAZEL} test --config=saucelabs --define=SAUCE_BROWSER=SL_IE11 //test/e2e:prodserver_sauce_test
+${BAZEL} test --config=saucelabs --define=SAUCE_BROWSER=SL_EDGE //test/e2e:prodserver_sauce_test

--- a/integration/bazel/src/BUILD.bazel
+++ b/integration/bazel/src/BUILD.bazel
@@ -62,13 +62,30 @@ rollup_bundle(
 
 web_package(
     name = "prodapp",
+    additional_root_paths = [
+        # Root paths to the polyfills in data
+        "npm/node_modules/core-js/client",
+        "npm/node_modules/reflect-metadata",
+    ],
+    # do not sort
     assets = [
-        # do not sort
+        # We load zone.js outside the bundle. That's because it's a "pollyfill"
+        # which speculates that such features might be available in a browser.
+        # Also it's tricky to configure dead code elimination to understand that
+        # zone.js is used, given that we don't have any import statement that
+        # imports from it.
         "@npm//node_modules/zone.js:dist/zone.min.js",
+        # For differential loading, we supply both an ESModule entry point and an es5 entry point
+        # The injector will put two complimentary script tags in the example.html
         ":bundle.min.js",
+        ":bundle.min.es2015.js",
     ],
     data = [
         ":bundle",
+        # Include polyfills that will be requested by old browsers
+        "@npm//node_modules/core-js:client/core.min.js",
+        ":shims_for_IE.js",
+        "@npm//node_modules/reflect-metadata:Reflect.js",
     ],
     index_html = "index.html",
 )

--- a/integration/bazel/src/hello-world/hello-world.component.spec.ts
+++ b/integration/bazel/src/hello-world/hello-world.component.spec.ts
@@ -29,7 +29,7 @@ describe('BannerComponent (inline template)', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HelloWorldComponent);
     comp = fixture.componentInstance;
-    el = fixture.debugElement.query(By.css('div')).nativeElement;
+    el = fixture.debugElement.query(By.css('div#greeting')).nativeElement;
   });
 
   it('should display original title', () => {

--- a/integration/bazel/src/hello-world/hello-world.component.ts
+++ b/integration/bazel/src/hello-world/hello-world.component.ts
@@ -4,7 +4,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'hello-world-app',
   template: `
-    <div>Hello {{ name }}!</div>
+    <div id="greeting">Hello {{ name }}!</div>
     <input type="text" [value]="name" (input)="name = $event.target.value"/>
   `,
   styleUrls: ['./hello-world.component.scss'],

--- a/integration/bazel/src/index.html
+++ b/integration/bazel/src/index.html
@@ -9,5 +9,10 @@
   <body>
     <!-- The Angular application will be bootstrapped into this element. -->
     <app-component></app-component>
+
+    <!-- polyfills for browsers that don't support ESModules -->
+    <script nomodule src="/core.min.js"></script>
+    <script nomodule src="/shims_for_IE.js"></script>
+    <script nomodule src="/Reflect.js"></script>
   </body>
 </html>

--- a/integration/bazel/src/shims_for_IE.js
+++ b/integration/bazel/src/shims_for_IE.js
@@ -1,0 +1,1415 @@
+// This file is used for internal testing with Karma only, it should not be used in real applications.
+
+// function.name (all IE)
+/*! @source http://stackoverflow.com/questions/6903762/function-name-not-supported-in-ie*/
+if (!Object.hasOwnProperty('name')) {
+  Object.defineProperty(Function.prototype, 'name', {
+    get: function() {
+      var matches = this.toString().match(/^\s*function\s*((?![0-9])[a-zA-Z0-9_$]*)\s*\(/);
+      var name = matches && matches.length > 1 ? matches[1] : "";
+      // For better performance only parse once, and then cache the
+      // result through a new accessor for repeated access.
+      Object.defineProperty(this, 'name', {value: name});
+      return name;
+    }
+  });
+}
+
+// URL polyfill for SystemJS (all IE)
+/*! @source https://github.com/ModuleLoader/es6-module-loader/blob/master/src/url-polyfill.js*/
+// from https://gist.github.com/Yaffle/1088850
+(function(global) {
+  function URLPolyfill(url, baseURL) {
+    if (typeof url != 'string') {
+      throw new TypeError('URL must be a string');
+    }
+    var m = String(url).replace(/^\s+|\s+$/g, "").match(/^([^:\/?#]+:)?(?:\/\/(?:([^:@\/?#]*)(?::([^:@\/?#]*))?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
+    if (!m) {
+      throw new RangeError();
+    }
+    var protocol = m[1] || "";
+    var username = m[2] || "";
+    var password = m[3] || "";
+    var host = m[4] || "";
+    var hostname = m[5] || "";
+    var port = m[6] || "";
+    var pathname = m[7] || "";
+    var search = m[8] || "";
+    var hash = m[9] || "";
+    if (baseURL !== undefined) {
+      var base = baseURL instanceof URLPolyfill ? baseURL : new URLPolyfill(baseURL);
+      var flag = protocol === "" && host === "" && username === "";
+      if (flag && pathname === "" && search === "") {
+        search = base.search;
+      }
+      if (flag && pathname.charAt(0) !== "/") {
+        pathname = (pathname !== "" ? (((base.host !== "" || base.username !== "") && base.pathname === "" ? "/" : "") + base.pathname.slice(0, base.pathname.lastIndexOf("/") + 1) + pathname) : base.pathname);
+      }
+      // dot segments removal
+      var output = [];
+      pathname.replace(/^(\.\.?(\/|$))+/, "")
+        .replace(/\/(\.(\/|$))+/g, "/")
+        .replace(/\/\.\.$/, "/../")
+        .replace(/\/?[^\/]*/g, function (p) {
+          if (p === "/..") {
+            output.pop();
+          } else {
+            output.push(p);
+          }
+        });
+      pathname = output.join("").replace(/^\//, pathname.charAt(0) === "/" ? "/" : "");
+      if (flag) {
+        port = base.port;
+        hostname = base.hostname;
+        host = base.host;
+        password = base.password;
+        username = base.username;
+      }
+      if (protocol === "") {
+        protocol = base.protocol;
+      }
+    }
+
+    // convert windows file URLs to use /
+    if (protocol == 'file:')
+      pathname = pathname.replace(/\\/g, '/');
+
+    this.origin = protocol + (protocol !== "" || host !== "" ? "//" : "") + host;
+    this.href = protocol + (protocol !== "" || host !== "" ? "//" : "") + (username !== "" ? username + (password !== "" ? ":" + password : "") + "@" : "") + host + pathname + search + hash;
+    this.protocol = protocol;
+    this.username = username;
+    this.password = password;
+    this.host = host;
+    this.hostname = hostname;
+    this.port = port;
+    this.pathname = pathname;
+    this.search = search;
+    this.hash = hash;
+  }
+global.URLPolyfill = URLPolyfill;
+})(typeof self != 'undefined' ? self : global);
+
+//classList (IE9)
+/*! @license please refer to http://unlicense.org/ */
+/*! @author Eli Grey */
+/*! @source https://github.com/eligrey/classList.js */
+;if("document" in self&&!("classList" in document.createElement("_"))){(function(j){"use strict";if(!("Element" in j)){return}var a="classList",f="prototype",m=j.Element[f],b=Object,k=String[f].trim||function(){return this.replace(/^\s+|\s+$/g,"")},c=Array[f].indexOf||function(q){var p=0,o=this.length;for(;p<o;p++){if(p in this&&this[p]===q){return p}}return -1},n=function(o,p){this.name=o;this.code=DOMException[o];this.message=p},g=function(p,o){if(o===""){throw new n("SYNTAX_ERR","An invalid or illegal string was specified")}if(/\s/.test(o)){throw new n("INVALID_CHARACTER_ERR","String contains an invalid character")}return c.call(p,o)},d=function(s){var r=k.call(s.getAttribute("class")||""),q=r?r.split(/\s+/):[],p=0,o=q.length;for(;p<o;p++){this.push(q[p])}this._updateClassName=function(){s.setAttribute("class",this.toString())}},e=d[f]=[],i=function(){return new d(this)};n[f]=Error[f];e.item=function(o){return this[o]||null};e.contains=function(o){o+="";return g(this,o)!==-1};e.add=function(){var s=arguments,r=0,p=s.length,q,o=false;do{q=s[r]+"";if(g(this,q)===-1){this.push(q);o=true}}while(++r<p);if(o){this._updateClassName()}};e.remove=function(){var t=arguments,s=0,p=t.length,r,o=false;do{r=t[s]+"";var q=g(this,r);if(q!==-1){this.splice(q,1);o=true}}while(++s<p);if(o){this._updateClassName()}};e.toggle=function(p,q){p+="";var o=this.contains(p),r=o?q!==true&&"remove":q!==false&&"add";if(r){this[r](p)}return !o};e.toString=function(){return this.join(" ")};if(b.defineProperty){var l={get:i,enumerable:true,configurable:true};try{b.defineProperty(m,a,l)}catch(h){if(h.number===-2146823252){l.enumerable=false;b.defineProperty(m,a,l)}}}else{if(b[f].__defineGetter__){m.__defineGetter__(a,i)}}}(self))};
+
+//console mock (IE9)
+if (!window.console) window.console = {};
+if (!window.console.log) window.console.log = function () { };
+if (!window.console.error) window.console.error = function () { };
+if (!window.console.warn) window.console.warn = function () { };
+if (!window.console.assert) window.console.assert = function () { };
+
+//Typed Array (IE9)
+/*! @source https://github.com/inexorabletash/polyfill/blob/master/typedarray.js */
+/*
+ Copyright (c) 2010, Linden Research, Inc.
+ Copyright (c) 2014, Joshua Bell
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ $/LicenseInfo$
+ */
+
+// Original can be found at:
+//   https://bitbucket.org/lindenlab/llsd
+// Modifications by Joshua Bell inexorabletash@gmail.com
+//   https://github.com/inexorabletash/polyfill
+
+// ES3/ES5 implementation of the Krhonos Typed Array Specification
+//   Ref: http://www.khronos.org/registry/typedarray/specs/latest/
+//   Date: 2011-02-01
+//
+// Variations:
+//  * Allows typed_array.get/set() as alias for subscripts (typed_array[])
+//  * Gradually migrating structure from Khronos spec to ES2015 spec
+//
+// Caveats:
+//  * Beyond 10000 or so entries, polyfilled array accessors (ta[0],
+//    etc) become memory-prohibitive, so array creation will fail. Set
+//    self.TYPED_ARRAY_POLYFILL_NO_ARRAY_ACCESSORS=true to disable
+//    creation of accessors. Your code will need to use the
+//    non-standard get()/set() instead, and will need to add those to
+//    native arrays for interop.
+(function(global) {
+  'use strict';
+  var undefined = (void 0); // Paranoia
+
+  // Beyond this value, index getters/setters (i.e. array[0], array[1]) are so slow to
+  // create, and consume so much memory, that the browser appears frozen.
+  var MAX_ARRAY_LENGTH = 1e5;
+
+  // Approximations of internal ECMAScript conversion functions
+  function Type(v) {
+    switch(typeof v) {
+      case 'undefined': return 'undefined';
+      case 'boolean': return 'boolean';
+      case 'number': return 'number';
+      case 'string': return 'string';
+      default: return v === null ? 'null' : 'object';
+    }
+  }
+
+  // Class returns internal [[Class]] property, used to avoid cross-frame instanceof issues:
+  function Class(v) { return Object.prototype.toString.call(v).replace(/^\[object *|\]$/g, ''); }
+  function IsCallable(o) { return typeof o === 'function'; }
+  function ToObject(v) {
+    if (v === null || v === undefined) throw TypeError();
+    return Object(v);
+  }
+  function ToInt32(v) { return v >> 0; }
+  function ToUint32(v) { return v >>> 0; }
+
+  // Snapshot intrinsics
+  var LN2 = Math.LN2,
+    abs = Math.abs,
+    floor = Math.floor,
+    log = Math.log,
+    max = Math.max,
+    min = Math.min,
+    pow = Math.pow,
+    round = Math.round;
+
+  // emulate ES5 getter/setter API using legacy APIs
+  // http://blogs.msdn.com/b/ie/archive/2010/09/07/transitioning-existing-code-to-the-es5-getter-setter-apis.aspx
+  // (second clause tests for Object.defineProperty() in IE<9 that only supports extending DOM prototypes, but
+  // note that IE<9 does not support __defineGetter__ or __defineSetter__ so it just renders the method harmless)
+
+  (function() {
+    var orig = Object.defineProperty;
+    var dom_only = !(function(){try{return Object.defineProperty({},'x',{});}catch(_){return false;}}());
+
+    if (!orig || dom_only) {
+      Object.defineProperty = function (o, prop, desc) {
+        // In IE8 try built-in implementation for defining properties on DOM prototypes.
+        if (orig)
+          try { return orig(o, prop, desc); } catch (_) {}
+        if (o !== Object(o))
+          throw TypeError('Object.defineProperty called on non-object');
+        if (Object.prototype.__defineGetter__ && ('get' in desc))
+          Object.prototype.__defineGetter__.call(o, prop, desc.get);
+        if (Object.prototype.__defineSetter__ && ('set' in desc))
+          Object.prototype.__defineSetter__.call(o, prop, desc.set);
+        if ('value' in desc)
+          o[prop] = desc.value;
+        return o;
+      };
+    }
+  }());
+
+  // ES5: Make obj[index] an alias for obj._getter(index)/obj._setter(index, value)
+  // for index in 0 ... obj.length
+  function makeArrayAccessors(obj) {
+    if ('TYPED_ARRAY_POLYFILL_NO_ARRAY_ACCESSORS' in global)
+      return;
+
+    if (obj.length > MAX_ARRAY_LENGTH) throw RangeError('Array too large for polyfill');
+
+    function makeArrayAccessor(index) {
+      Object.defineProperty(obj, index, {
+        'get': function() { return obj._getter(index); },
+        'set': function(v) { obj._setter(index, v); },
+        enumerable: true,
+        configurable: false
+      });
+    }
+
+    var i;
+    for (i = 0; i < obj.length; i += 1) {
+      makeArrayAccessor(i);
+    }
+  }
+
+  // Internal conversion functions:
+  //    pack<Type>()   - take a number (interpreted as Type), output a byte array
+  //    unpack<Type>() - take a byte array, output a Type-like number
+
+  function as_signed(value, bits) { var s = 32 - bits; return (value << s) >> s; }
+  function as_unsigned(value, bits) { var s = 32 - bits; return (value << s) >>> s; }
+
+  function packI8(n) { return [n & 0xff]; }
+  function unpackI8(bytes) { return as_signed(bytes[0], 8); }
+
+  function packU8(n) { return [n & 0xff]; }
+  function unpackU8(bytes) { return as_unsigned(bytes[0], 8); }
+
+  function packU8Clamped(n) { n = round(Number(n)); return [n < 0 ? 0 : n > 0xff ? 0xff : n & 0xff]; }
+
+  function packI16(n) { return [n & 0xff, (n >> 8) & 0xff]; }
+  function unpackI16(bytes) { return as_signed(bytes[1] << 8 | bytes[0], 16); }
+
+  function packU16(n) { return [n & 0xff, (n >> 8) & 0xff]; }
+  function unpackU16(bytes) { return as_unsigned(bytes[1] << 8 | bytes[0], 16); }
+
+  function packI32(n) { return [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff]; }
+  function unpackI32(bytes) { return as_signed(bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0], 32); }
+
+  function packU32(n) { return [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff]; }
+  function unpackU32(bytes) { return as_unsigned(bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0], 32); }
+
+  function packIEEE754(v, ebits, fbits) {
+
+    var bias = (1 << (ebits - 1)) - 1;
+
+    function roundToEven(n) {
+      var w = floor(n), f = n - w;
+      if (f < 0.5)
+        return w;
+      if (f > 0.5)
+        return w + 1;
+      return w % 2 ? w + 1 : w;
+    }
+
+    // Compute sign, exponent, fraction
+    var s, e, f;
+    if (v !== v) {
+      // NaN
+      // http://dev.w3.org/2006/webapi/WebIDL/#es-type-mapping
+      e = (1 << ebits) - 1; f = pow(2, fbits - 1); s = 0;
+    } else if (v === Infinity || v === -Infinity) {
+      e = (1 << ebits) - 1; f = 0; s = (v < 0) ? 1 : 0;
+    } else if (v === 0) {
+      e = 0; f = 0; s = (1 / v === -Infinity) ? 1 : 0;
+    } else {
+      s = v < 0;
+      v = abs(v);
+
+      if (v >= pow(2, 1 - bias)) {
+        // Normalized
+        e = min(floor(log(v) / LN2), 1023);
+        var significand = v / pow(2, e);
+        if (significand < 1) {
+          e -= 1;
+          significand *= 2;
+        }
+        if (significand >= 2) {
+          e += 1;
+          significand /= 2;
+        }
+        var d = pow(2, fbits);
+        f = roundToEven(significand * d) - d;
+        e += bias;
+        if (f / d >= 1) {
+          e += 1;
+          f = 0;
+        }
+        if (e > 2 * bias) {
+          // Overflow
+          e = (1 << ebits) - 1;
+          f = 0;
+        }
+      } else {
+        // Denormalized
+        e = 0;
+        f = roundToEven(v / pow(2, 1 - bias - fbits));
+      }
+    }
+
+    // Pack sign, exponent, fraction
+    var bits = [], i;
+    for (i = fbits; i; i -= 1) { bits.push(f % 2 ? 1 : 0); f = floor(f / 2); }
+    for (i = ebits; i; i -= 1) { bits.push(e % 2 ? 1 : 0); e = floor(e / 2); }
+    bits.push(s ? 1 : 0);
+    bits.reverse();
+    var str = bits.join('');
+
+    // Bits to bytes
+    var bytes = [];
+    while (str.length) {
+      bytes.unshift(parseInt(str.substring(0, 8), 2));
+      str = str.substring(8);
+    }
+    return bytes;
+  }
+
+  function unpackIEEE754(bytes, ebits, fbits) {
+    // Bytes to bits
+    var bits = [], i, j, b, str,
+      bias, s, e, f;
+
+    for (i = 0; i < bytes.length; ++i) {
+      b = bytes[i];
+      for (j = 8; j; j -= 1) {
+        bits.push(b % 2 ? 1 : 0); b = b >> 1;
+      }
+    }
+    bits.reverse();
+    str = bits.join('');
+
+    // Unpack sign, exponent, fraction
+    bias = (1 << (ebits - 1)) - 1;
+    s = parseInt(str.substring(0, 1), 2) ? -1 : 1;
+    e = parseInt(str.substring(1, 1 + ebits), 2);
+    f = parseInt(str.substring(1 + ebits), 2);
+
+    // Produce number
+    if (e === (1 << ebits) - 1) {
+      return f !== 0 ? NaN : s * Infinity;
+    } else if (e > 0) {
+      // Normalized
+      return s * pow(2, e - bias) * (1 + f / pow(2, fbits));
+    } else if (f !== 0) {
+      // Denormalized
+      return s * pow(2, -(bias - 1)) * (f / pow(2, fbits));
+    } else {
+      return s < 0 ? -0 : 0;
+    }
+  }
+
+  function unpackF64(b) { return unpackIEEE754(b, 11, 52); }
+  function packF64(v) { return packIEEE754(v, 11, 52); }
+  function unpackF32(b) { return unpackIEEE754(b, 8, 23); }
+  function packF32(v) { return packIEEE754(v, 8, 23); }
+
+  //
+  // 3 The ArrayBuffer Type
+  //
+
+  (function() {
+
+    function ArrayBuffer(length) {
+      length = ToInt32(length);
+      if (length < 0) throw RangeError('ArrayBuffer size is not a small enough positive integer.');
+      Object.defineProperty(this, 'byteLength', {value: length});
+      Object.defineProperty(this, '_bytes', {value: Array(length)});
+
+      for (var i = 0; i < length; i += 1)
+        this._bytes[i] = 0;
+    }
+
+    global.ArrayBuffer = global.ArrayBuffer || ArrayBuffer;
+
+    //
+    // 5 The Typed Array View Types
+    //
+
+    function $TypedArray$() {
+
+      // %TypedArray% ( length )
+      if (!arguments.length || typeof arguments[0] !== 'object') {
+        return (function(length) {
+          length = ToInt32(length);
+          if (length < 0) throw RangeError('length is not a small enough positive integer.');
+          Object.defineProperty(this, 'length', {value: length});
+          Object.defineProperty(this, 'byteLength', {value: length * this.BYTES_PER_ELEMENT});
+          Object.defineProperty(this, 'buffer', {value: new ArrayBuffer(this.byteLength)});
+          Object.defineProperty(this, 'byteOffset', {value: 0});
+
+        }).apply(this, arguments);
+      }
+
+      // %TypedArray% ( typedArray )
+      if (arguments.length >= 1 &&
+        Type(arguments[0]) === 'object' &&
+        arguments[0] instanceof $TypedArray$) {
+        return (function(typedArray){
+          if (this.constructor !== typedArray.constructor) throw TypeError();
+
+          var byteLength = typedArray.length * this.BYTES_PER_ELEMENT;
+          Object.defineProperty(this, 'buffer', {value: new ArrayBuffer(byteLength)});
+          Object.defineProperty(this, 'byteLength', {value: byteLength});
+          Object.defineProperty(this, 'byteOffset', {value: 0});
+          Object.defineProperty(this, 'length', {value: typedArray.length});
+
+          for (var i = 0; i < this.length; i += 1)
+            this._setter(i, typedArray._getter(i));
+
+        }).apply(this, arguments);
+      }
+
+      // %TypedArray% ( array )
+      if (arguments.length >= 1 &&
+        Type(arguments[0]) === 'object' &&
+        !(arguments[0] instanceof $TypedArray$) &&
+        !(arguments[0] instanceof ArrayBuffer || Class(arguments[0]) === 'ArrayBuffer')) {
+        return (function(array) {
+
+          var byteLength = array.length * this.BYTES_PER_ELEMENT;
+          Object.defineProperty(this, 'buffer', {value: new ArrayBuffer(byteLength)});
+          Object.defineProperty(this, 'byteLength', {value: byteLength});
+          Object.defineProperty(this, 'byteOffset', {value: 0});
+          Object.defineProperty(this, 'length', {value: array.length});
+
+          for (var i = 0; i < this.length; i += 1) {
+            var s = array[i];
+            this._setter(i, Number(s));
+          }
+        }).apply(this, arguments);
+      }
+
+      // %TypedArray% ( buffer, byteOffset=0, length=undefined )
+      if (arguments.length >= 1 &&
+        Type(arguments[0]) === 'object' &&
+        (arguments[0] instanceof ArrayBuffer || Class(arguments[0]) === 'ArrayBuffer')) {
+        return (function(buffer, byteOffset, length) {
+
+          byteOffset = ToUint32(byteOffset);
+          if (byteOffset > buffer.byteLength)
+            throw RangeError('byteOffset out of range');
+
+          // The given byteOffset must be a multiple of the element
+          // size of the specific type, otherwise an exception is raised.
+          if (byteOffset % this.BYTES_PER_ELEMENT)
+            throw RangeError('buffer length minus the byteOffset is not a multiple of the element size.');
+
+          if (length === undefined) {
+            var byteLength = buffer.byteLength - byteOffset;
+            if (byteLength % this.BYTES_PER_ELEMENT)
+              throw RangeError('length of buffer minus byteOffset not a multiple of the element size');
+            length = byteLength / this.BYTES_PER_ELEMENT;
+
+          } else {
+            length = ToUint32(length);
+            byteLength = length * this.BYTES_PER_ELEMENT;
+          }
+
+          if ((byteOffset + byteLength) > buffer.byteLength)
+            throw RangeError('byteOffset and length reference an area beyond the end of the buffer');
+
+          Object.defineProperty(this, 'buffer', {value: buffer});
+          Object.defineProperty(this, 'byteLength', {value: byteLength});
+          Object.defineProperty(this, 'byteOffset', {value: byteOffset});
+          Object.defineProperty(this, 'length', {value: length});
+
+        }).apply(this, arguments);
+      }
+
+      // %TypedArray% ( all other argument combinations )
+      throw TypeError();
+    }
+
+    // Properties of the %TypedArray Instrinsic Object
+
+    // %TypedArray%.from ( source , mapfn=undefined, thisArg=undefined )
+    Object.defineProperty($TypedArray$, 'from', {value: function(iterable) {
+      return new this(iterable);
+    }});
+
+    // %TypedArray%.of ( ...items )
+    Object.defineProperty($TypedArray$, 'of', {value: function(/*...items*/) {
+      return new this(arguments);
+    }});
+
+    // %TypedArray%.prototype
+    var $TypedArrayPrototype$ = {};
+    $TypedArray$.prototype = $TypedArrayPrototype$;
+
+    // WebIDL: getter type (unsigned long index);
+    Object.defineProperty($TypedArray$.prototype, '_getter', {value: function(index) {
+      if (arguments.length < 1) throw SyntaxError('Not enough arguments');
+
+      index = ToUint32(index);
+      if (index >= this.length)
+        return undefined;
+
+      var bytes = [], i, o;
+      for (i = 0, o = this.byteOffset + index * this.BYTES_PER_ELEMENT;
+           i < this.BYTES_PER_ELEMENT;
+           i += 1, o += 1) {
+        bytes.push(this.buffer._bytes[o]);
+      }
+      return this._unpack(bytes);
+    }});
+
+    // NONSTANDARD: convenience alias for getter: type get(unsigned long index);
+    Object.defineProperty($TypedArray$.prototype, 'get', {value: $TypedArray$.prototype._getter});
+
+    // WebIDL: setter void (unsigned long index, type value);
+    Object.defineProperty($TypedArray$.prototype, '_setter', {value: function(index, value) {
+      if (arguments.length < 2) throw SyntaxError('Not enough arguments');
+
+      index = ToUint32(index);
+      if (index >= this.length)
+        return;
+
+      var bytes = this._pack(value), i, o;
+      for (i = 0, o = this.byteOffset + index * this.BYTES_PER_ELEMENT;
+           i < this.BYTES_PER_ELEMENT;
+           i += 1, o += 1) {
+        this.buffer._bytes[o] = bytes[i];
+      }
+    }});
+
+    // get %TypedArray%.prototype.buffer
+    // get %TypedArray%.prototype.byteLength
+    // get %TypedArray%.prototype.byteOffset
+    // -- applied directly to the object in the constructor
+
+    // %TypedArray%.prototype.constructor
+    Object.defineProperty($TypedArray$.prototype, 'constructor', {value: $TypedArray$});
+
+    // %TypedArray%.prototype.copyWithin (target, start, end = this.length )
+    Object.defineProperty($TypedArray$.prototype, 'copyWithin', {value: function(target, start) {
+      var end = arguments[2];
+
+      var o = ToObject(this);
+      var lenVal = o.length;
+      var len = ToUint32(lenVal);
+      len = max(len, 0);
+      var relativeTarget = ToInt32(target);
+      var to;
+      if (relativeTarget < 0)
+        to = max(len + relativeTarget, 0);
+      else
+        to = min(relativeTarget, len);
+      var relativeStart = ToInt32(start);
+      var from;
+      if (relativeStart < 0)
+        from = max(len + relativeStart, 0);
+      else
+        from = min(relativeStart, len);
+      var relativeEnd;
+      if (end === undefined)
+        relativeEnd = len;
+      else
+        relativeEnd = ToInt32(end);
+      var final;
+      if (relativeEnd < 0)
+        final = max(len + relativeEnd, 0);
+      else
+        final = min(relativeEnd, len);
+      var count = min(final - from, len - to);
+      var direction;
+      if (from < to && to < from + count) {
+        direction = -1;
+        from = from + count - 1;
+        to = to + count - 1;
+      } else {
+        direction = 1;
+      }
+      while (count > 0) {
+        o._setter(to, o._getter(from));
+        from = from + direction;
+        to = to + direction;
+        count = count - 1;
+      }
+      return o;
+    }});
+
+    // %TypedArray%.prototype.entries ( )
+    // -- defined in es6.js to shim browsers w/ native TypedArrays
+
+    // %TypedArray%.prototype.every ( callbackfn, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'every', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      var thisArg = arguments[1];
+      for (var i = 0; i < len; i++) {
+        if (!callbackfn.call(thisArg, t._getter(i), i, t))
+          return false;
+      }
+      return true;
+    }});
+
+    // %TypedArray%.prototype.fill (value, start = 0, end = this.length )
+    Object.defineProperty($TypedArray$.prototype, 'fill', {value: function(value) {
+      var start = arguments[1],
+        end = arguments[2];
+
+      var o = ToObject(this);
+      var lenVal = o.length;
+      var len = ToUint32(lenVal);
+      len = max(len, 0);
+      var relativeStart = ToInt32(start);
+      var k;
+      if (relativeStart < 0)
+        k = max((len + relativeStart), 0);
+      else
+        k = min(relativeStart, len);
+      var relativeEnd;
+      if (end === undefined)
+        relativeEnd = len;
+      else
+        relativeEnd = ToInt32(end);
+      var final;
+      if (relativeEnd < 0)
+        final = max((len + relativeEnd), 0);
+      else
+        final = min(relativeEnd, len);
+      while (k < final) {
+        o._setter(k, value);
+        k += 1;
+      }
+      return o;
+    }});
+
+    // %TypedArray%.prototype.filter ( callbackfn, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'filter', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      var res = [];
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++) {
+        var val = t._getter(i); // in case fun mutates this
+        if (callbackfn.call(thisp, val, i, t))
+          res.push(val);
+      }
+      return new this.constructor(res);
+    }});
+
+    // %TypedArray%.prototype.find (predicate, thisArg = undefined)
+    Object.defineProperty($TypedArray$.prototype, 'find', {value: function(predicate) {
+      var o = ToObject(this);
+      var lenValue = o.length;
+      var len = ToUint32(lenValue);
+      if (!IsCallable(predicate)) throw TypeError();
+      var t = arguments.length > 1 ? arguments[1] : undefined;
+      var k = 0;
+      while (k < len) {
+        var kValue = o._getter(k);
+        var testResult = predicate.call(t, kValue, k, o);
+        if (Boolean(testResult))
+          return kValue;
+        ++k;
+      }
+      return undefined;
+    }});
+
+    // %TypedArray%.prototype.findIndex ( predicate, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'findIndex', {value: function(predicate) {
+      var o = ToObject(this);
+      var lenValue = o.length;
+      var len = ToUint32(lenValue);
+      if (!IsCallable(predicate)) throw TypeError();
+      var t = arguments.length > 1 ? arguments[1] : undefined;
+      var k = 0;
+      while (k < len) {
+        var kValue = o._getter(k);
+        var testResult = predicate.call(t, kValue, k, o);
+        if (Boolean(testResult))
+          return k;
+        ++k;
+      }
+      return -1;
+    }});
+
+    // %TypedArray%.prototype.forEach ( callbackfn, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'forEach', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++)
+        callbackfn.call(thisp, t._getter(i), i, t);
+    }});
+
+    // %TypedArray%.prototype.indexOf (searchElement, fromIndex = 0 )
+    Object.defineProperty($TypedArray$.prototype, 'indexOf', {value: function(searchElement) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (len === 0) return -1;
+      var n = 0;
+      if (arguments.length > 0) {
+        n = Number(arguments[1]);
+        if (n !== n) {
+          n = 0;
+        } else if (n !== 0 && n !== (1 / 0) && n !== -(1 / 0)) {
+          n = (n > 0 || -1) * floor(abs(n));
+        }
+      }
+      if (n >= len) return -1;
+      var k = n >= 0 ? n : max(len - abs(n), 0);
+      for (; k < len; k++) {
+        if (t._getter(k) === searchElement) {
+          return k;
+        }
+      }
+      return -1;
+    }});
+
+    // %TypedArray%.prototype.join ( separator )
+    Object.defineProperty($TypedArray$.prototype, 'join', {value: function(separator) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      var tmp = Array(len);
+      for (var i = 0; i < len; ++i)
+        tmp[i] = t._getter(i);
+      return tmp.join(separator === undefined ? ',' : separator); // Hack for IE7
+    }});
+
+    // %TypedArray%.prototype.keys ( )
+    // -- defined in es6.js to shim browsers w/ native TypedArrays
+
+    // %TypedArray%.prototype.lastIndexOf ( searchElement, fromIndex = this.length-1 )
+    Object.defineProperty($TypedArray$.prototype, 'lastIndexOf', {value: function(searchElement) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (len === 0) return -1;
+      var n = len;
+      if (arguments.length > 1) {
+        n = Number(arguments[1]);
+        if (n !== n) {
+          n = 0;
+        } else if (n !== 0 && n !== (1 / 0) && n !== -(1 / 0)) {
+          n = (n > 0 || -1) * floor(abs(n));
+        }
+      }
+      var k = n >= 0 ? min(n, len - 1) : len - abs(n);
+      for (; k >= 0; k--) {
+        if (t._getter(k) === searchElement)
+          return k;
+      }
+      return -1;
+    }});
+
+    // get %TypedArray%.prototype.length
+    // -- applied directly to the object in the constructor
+
+    // %TypedArray%.prototype.map ( callbackfn, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'map', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      var res = []; res.length = len;
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++)
+        res[i] = callbackfn.call(thisp, t._getter(i), i, t);
+      return new this.constructor(res);
+    }});
+
+    // %TypedArray%.prototype.reduce ( callbackfn [, initialValue] )
+    Object.defineProperty($TypedArray$.prototype, 'reduce', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      // no value to return if no initial value and an empty array
+      if (len === 0 && arguments.length === 1) throw TypeError();
+      var k = 0;
+      var accumulator;
+      if (arguments.length >= 2) {
+        accumulator = arguments[1];
+      } else {
+        accumulator = t._getter(k++);
+      }
+      while (k < len) {
+        accumulator = callbackfn.call(undefined, accumulator, t._getter(k), k, t);
+        k++;
+      }
+      return accumulator;
+    }});
+
+    // %TypedArray%.prototype.reduceRight ( callbackfn [, initialValue] )
+    Object.defineProperty($TypedArray$.prototype, 'reduceRight', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      // no value to return if no initial value, empty array
+      if (len === 0 && arguments.length === 1) throw TypeError();
+      var k = len - 1;
+      var accumulator;
+      if (arguments.length >= 2) {
+        accumulator = arguments[1];
+      } else {
+        accumulator = t._getter(k--);
+      }
+      while (k >= 0) {
+        accumulator = callbackfn.call(undefined, accumulator, t._getter(k), k, t);
+        k--;
+      }
+      return accumulator;
+    }});
+
+    // %TypedArray%.prototype.reverse ( )
+    Object.defineProperty($TypedArray$.prototype, 'reverse', {value: function() {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      var half = floor(len / 2);
+      for (var i = 0, j = len - 1; i < half; ++i, --j) {
+        var tmp = t._getter(i);
+        t._setter(i, t._getter(j));
+        t._setter(j, tmp);
+      }
+      return t;
+    }});
+
+    // %TypedArray%.prototype.set(array, offset = 0 )
+    // %TypedArray%.prototype.set(typedArray, offset = 0 )
+    // WebIDL: void set(TypedArray array, optional unsigned long offset);
+    // WebIDL: void set(sequence<type> array, optional unsigned long offset);
+    Object.defineProperty($TypedArray$.prototype, 'set', {value: function(index, value) {
+      if (arguments.length < 1) throw SyntaxError('Not enough arguments');
+      var array, sequence, offset, len,
+        i, s, d,
+        byteOffset, byteLength, tmp;
+
+      if (typeof arguments[0] === 'object' && arguments[0].constructor === this.constructor) {
+        // void set(TypedArray array, optional unsigned long offset);
+        array = arguments[0];
+        offset = ToUint32(arguments[1]);
+
+        if (offset + array.length > this.length) {
+          throw RangeError('Offset plus length of array is out of range');
+        }
+
+        byteOffset = this.byteOffset + offset * this.BYTES_PER_ELEMENT;
+        byteLength = array.length * this.BYTES_PER_ELEMENT;
+
+        if (array.buffer === this.buffer) {
+          tmp = [];
+          for (i = 0, s = array.byteOffset; i < byteLength; i += 1, s += 1) {
+            tmp[i] = array.buffer._bytes[s];
+          }
+          for (i = 0, d = byteOffset; i < byteLength; i += 1, d += 1) {
+            this.buffer._bytes[d] = tmp[i];
+          }
+        } else {
+          for (i = 0, s = array.byteOffset, d = byteOffset;
+               i < byteLength; i += 1, s += 1, d += 1) {
+            this.buffer._bytes[d] = array.buffer._bytes[s];
+          }
+        }
+      } else if (typeof arguments[0] === 'object' && typeof arguments[0].length !== 'undefined') {
+        // void set(sequence<type> array, optional unsigned long offset);
+        sequence = arguments[0];
+        len = ToUint32(sequence.length);
+        offset = ToUint32(arguments[1]);
+
+        if (offset + len > this.length) {
+          throw RangeError('Offset plus length of array is out of range');
+        }
+
+        for (i = 0; i < len; i += 1) {
+          s = sequence[i];
+          this._setter(offset + i, Number(s));
+        }
+      } else {
+        throw TypeError('Unexpected argument type(s)');
+      }
+    }});
+
+    // %TypedArray%.prototype.slice ( start, end )
+    Object.defineProperty($TypedArray$.prototype, 'slice', {value: function(start, end) {
+      var o = ToObject(this);
+      var lenVal = o.length;
+      var len = ToUint32(lenVal);
+      var relativeStart = ToInt32(start);
+      var k = (relativeStart < 0) ? max(len + relativeStart, 0) : min(relativeStart, len);
+      var relativeEnd = (end === undefined) ? len : ToInt32(end);
+      var final = (relativeEnd < 0) ? max(len + relativeEnd, 0) : min(relativeEnd, len);
+      var count = final - k;
+      var c = o.constructor;
+      var a = new c(count);
+      var n = 0;
+      while (k < final) {
+        var kValue = o._getter(k);
+        a._setter(n, kValue);
+        ++k;
+        ++n;
+      }
+      return a;
+    }});
+
+    // %TypedArray%.prototype.some ( callbackfn, thisArg = undefined )
+    Object.defineProperty($TypedArray$.prototype, 'some', {value: function(callbackfn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      if (!IsCallable(callbackfn)) throw TypeError();
+      var thisp = arguments[1];
+      for (var i = 0; i < len; i++) {
+        if (callbackfn.call(thisp, t._getter(i), i, t)) {
+          return true;
+        }
+      }
+      return false;
+    }});
+
+    // %TypedArray%.prototype.sort ( comparefn )
+    Object.defineProperty($TypedArray$.prototype, 'sort', {value: function(comparefn) {
+      if (this === undefined || this === null) throw TypeError();
+      var t = Object(this);
+      var len = ToUint32(t.length);
+      var tmp = Array(len);
+      for (var i = 0; i < len; ++i)
+        tmp[i] = t._getter(i);
+      if (comparefn) tmp.sort(comparefn); else tmp.sort(); // Hack for IE8/9
+      for (i = 0; i < len; ++i)
+        t._setter(i, tmp[i]);
+      return t;
+    }});
+
+    // %TypedArray%.prototype.subarray(begin = 0, end = this.length )
+    // WebIDL: TypedArray subarray(long begin, optional long end);
+    Object.defineProperty($TypedArray$.prototype, 'subarray', {value: function(start, end) {
+      function clamp(v, min, max) { return v < min ? min : v > max ? max : v; }
+
+      start = ToInt32(start);
+      end = ToInt32(end);
+
+      if (arguments.length < 1) { start = 0; }
+      if (arguments.length < 2) { end = this.length; }
+
+      if (start < 0) { start = this.length + start; }
+      if (end < 0) { end = this.length + end; }
+
+      start = clamp(start, 0, this.length);
+      end = clamp(end, 0, this.length);
+
+      var len = end - start;
+      if (len < 0) {
+        len = 0;
+      }
+
+      return new this.constructor(
+        this.buffer, this.byteOffset + start * this.BYTES_PER_ELEMENT, len);
+    }});
+
+    // %TypedArray%.prototype.toLocaleString ( )
+    // %TypedArray%.prototype.toString ( )
+    // %TypedArray%.prototype.values ( )
+    // %TypedArray%.prototype [ @@iterator ] ( )
+    // get %TypedArray%.prototype [ @@toStringTag ]
+    // -- defined in es6.js to shim browsers w/ native TypedArrays
+
+    function makeTypedArray(elementSize, pack, unpack) {
+      // Each TypedArray type requires a distinct constructor instance with
+      // identical logic, which this produces.
+      var TypedArray = function() {
+        Object.defineProperty(this, 'constructor', {value: TypedArray});
+        $TypedArray$.apply(this, arguments);
+        makeArrayAccessors(this);
+      };
+      if ('__proto__' in TypedArray) {
+        TypedArray.__proto__ = $TypedArray$;
+      } else {
+        TypedArray.from = $TypedArray$.from;
+        TypedArray.of = $TypedArray$.of;
+      }
+
+      TypedArray.BYTES_PER_ELEMENT = elementSize;
+
+      var TypedArrayPrototype = function() {};
+      TypedArrayPrototype.prototype = $TypedArrayPrototype$;
+
+      TypedArray.prototype = new TypedArrayPrototype();
+
+      Object.defineProperty(TypedArray.prototype, 'BYTES_PER_ELEMENT', {value: elementSize});
+      Object.defineProperty(TypedArray.prototype, '_pack', {value: pack});
+      Object.defineProperty(TypedArray.prototype, '_unpack', {value: unpack});
+
+      return TypedArray;
+    }
+
+    var Int8Array = makeTypedArray(1, packI8, unpackI8);
+    var Uint8Array = makeTypedArray(1, packU8, unpackU8);
+    var Uint8ClampedArray = makeTypedArray(1, packU8Clamped, unpackU8);
+    var Int16Array = makeTypedArray(2, packI16, unpackI16);
+    var Uint16Array = makeTypedArray(2, packU16, unpackU16);
+    var Int32Array = makeTypedArray(4, packI32, unpackI32);
+    var Uint32Array = makeTypedArray(4, packU32, unpackU32);
+    var Float32Array = makeTypedArray(4, packF32, unpackF32);
+    var Float64Array = makeTypedArray(8, packF64, unpackF64);
+
+    global.Int8Array = global.Int8Array || Int8Array;
+    global.Uint8Array = global.Uint8Array || Uint8Array;
+    global.Uint8ClampedArray = global.Uint8ClampedArray || Uint8ClampedArray;
+    global.Int16Array = global.Int16Array || Int16Array;
+    global.Uint16Array = global.Uint16Array || Uint16Array;
+    global.Int32Array = global.Int32Array || Int32Array;
+    global.Uint32Array = global.Uint32Array || Uint32Array;
+    global.Float32Array = global.Float32Array || Float32Array;
+    global.Float64Array = global.Float64Array || Float64Array;
+  }());
+
+  //
+  // 6 The DataView View Type
+  //
+
+  (function() {
+    function r(array, index) {
+      return IsCallable(array.get) ? array.get(index) : array[index];
+    }
+
+    var IS_BIG_ENDIAN = (function() {
+      var u16array = new Uint16Array([0x1234]),
+        u8array = new Uint8Array(u16array.buffer);
+      return r(u8array, 0) === 0x12;
+    }());
+
+    // DataView(buffer, byteOffset=0, byteLength=undefined)
+    // WebIDL: Constructor(ArrayBuffer buffer,
+    //                     optional unsigned long byteOffset,
+    //                     optional unsigned long byteLength)
+    function DataView(buffer, byteOffset, byteLength) {
+      if (!(buffer instanceof ArrayBuffer || Class(buffer) === 'ArrayBuffer')) throw TypeError();
+
+      byteOffset = ToUint32(byteOffset);
+      if (byteOffset > buffer.byteLength)
+        throw RangeError('byteOffset out of range');
+
+      if (byteLength === undefined)
+        byteLength = buffer.byteLength - byteOffset;
+      else
+        byteLength = ToUint32(byteLength);
+
+      if ((byteOffset + byteLength) > buffer.byteLength)
+        throw RangeError('byteOffset and length reference an area beyond the end of the buffer');
+
+      Object.defineProperty(this, 'buffer', {value: buffer});
+      Object.defineProperty(this, 'byteLength', {value: byteLength});
+      Object.defineProperty(this, 'byteOffset', {value: byteOffset});
+    };
+
+    // get DataView.prototype.buffer
+    // get DataView.prototype.byteLength
+    // get DataView.prototype.byteOffset
+    // -- applied directly to instances by the constructor
+
+    function makeGetter(arrayType) {
+      return function GetViewValue(byteOffset, littleEndian) {
+        byteOffset = ToUint32(byteOffset);
+
+        if (byteOffset + arrayType.BYTES_PER_ELEMENT > this.byteLength)
+          throw RangeError('Array index out of range');
+
+        byteOffset += this.byteOffset;
+
+        var uint8Array = new Uint8Array(this.buffer, byteOffset, arrayType.BYTES_PER_ELEMENT),
+          bytes = [];
+        for (var i = 0; i < arrayType.BYTES_PER_ELEMENT; i += 1)
+          bytes.push(r(uint8Array, i));
+
+        if (Boolean(littleEndian) === Boolean(IS_BIG_ENDIAN))
+          bytes.reverse();
+
+        return r(new arrayType(new Uint8Array(bytes).buffer), 0);
+      };
+    }
+
+    Object.defineProperty(DataView.prototype, 'getUint8', {value: makeGetter(Uint8Array)});
+    Object.defineProperty(DataView.prototype, 'getInt8', {value: makeGetter(Int8Array)});
+    Object.defineProperty(DataView.prototype, 'getUint16', {value: makeGetter(Uint16Array)});
+    Object.defineProperty(DataView.prototype, 'getInt16', {value: makeGetter(Int16Array)});
+    Object.defineProperty(DataView.prototype, 'getUint32', {value: makeGetter(Uint32Array)});
+    Object.defineProperty(DataView.prototype, 'getInt32', {value: makeGetter(Int32Array)});
+    Object.defineProperty(DataView.prototype, 'getFloat32', {value: makeGetter(Float32Array)});
+    Object.defineProperty(DataView.prototype, 'getFloat64', {value: makeGetter(Float64Array)});
+
+    function makeSetter(arrayType) {
+      return function SetViewValue(byteOffset, value, littleEndian) {
+        byteOffset = ToUint32(byteOffset);
+        if (byteOffset + arrayType.BYTES_PER_ELEMENT > this.byteLength)
+          throw RangeError('Array index out of range');
+
+        // Get bytes
+        var typeArray = new arrayType([value]),
+          byteArray = new Uint8Array(typeArray.buffer),
+          bytes = [], i, byteView;
+
+        for (i = 0; i < arrayType.BYTES_PER_ELEMENT; i += 1)
+          bytes.push(r(byteArray, i));
+
+        // Flip if necessary
+        if (Boolean(littleEndian) === Boolean(IS_BIG_ENDIAN))
+          bytes.reverse();
+
+        // Write them
+        byteView = new Uint8Array(this.buffer, byteOffset, arrayType.BYTES_PER_ELEMENT);
+        byteView.set(bytes);
+      };
+    }
+
+    Object.defineProperty(DataView.prototype, 'setUint8', {value: makeSetter(Uint8Array)});
+    Object.defineProperty(DataView.prototype, 'setInt8', {value: makeSetter(Int8Array)});
+    Object.defineProperty(DataView.prototype, 'setUint16', {value: makeSetter(Uint16Array)});
+    Object.defineProperty(DataView.prototype, 'setInt16', {value: makeSetter(Int16Array)});
+    Object.defineProperty(DataView.prototype, 'setUint32', {value: makeSetter(Uint32Array)});
+    Object.defineProperty(DataView.prototype, 'setInt32', {value: makeSetter(Int32Array)});
+    Object.defineProperty(DataView.prototype, 'setFloat32', {value: makeSetter(Float32Array)});
+    Object.defineProperty(DataView.prototype, 'setFloat64', {value: makeSetter(Float64Array)});
+
+    global.DataView = global.DataView || DataView;
+
+  }());
+
+}(self));
+
+//Blob (IE9)
+/*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
+/* Blob.js
+ * A Blob implementation.
+ * 2014-07-24
+ *
+ * By Eli Grey, http://eligrey.com
+ * By Devin Samarin, https://github.com/dsamarin
+ * License: MIT
+ *   See https://github.com/eligrey/Blob.js/blob/master/LICENSE.md
+ */
+
+/*global self, unescape */
+/*jslint bitwise: true, regexp: true, confusion: true, es5: true, vars: true, white: true,
+ plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
+
+(function (view) {
+  "use strict";
+
+  view.URL = view.URL || view.webkitURL;
+
+  if (view.Blob && view.URL) {
+    try {
+      new Blob;
+      return;
+    } catch (e) {}
+  }
+
+  // Internally we use a BlobBuilder implementation to base Blob off of
+  // in order to support older browsers that only have BlobBuilder
+  var BlobBuilder = view.BlobBuilder || view.WebKitBlobBuilder || view.MozBlobBuilder || (function(view) {
+      var
+        get_class = function(object) {
+          return Object.prototype.toString.call(object).match(/^\[object\s(.*)\]$/)[1];
+        }
+        , FakeBlobBuilder = function BlobBuilder() {
+          this.data = [];
+        }
+        , FakeBlob = function Blob(data, type, encoding) {
+          this.data = data;
+          this.size = data.length;
+          this.type = type;
+          this.encoding = encoding;
+        }
+        , FBB_proto = FakeBlobBuilder.prototype
+        , FB_proto = FakeBlob.prototype
+        , FileReaderSync = view.FileReaderSync
+        , FileException = function(type) {
+          this.code = this[this.name = type];
+        }
+        , file_ex_codes = (
+          "NOT_FOUND_ERR SECURITY_ERR ABORT_ERR NOT_READABLE_ERR ENCODING_ERR "
+          + "NO_MODIFICATION_ALLOWED_ERR INVALID_STATE_ERR SYNTAX_ERR"
+        ).split(" ")
+        , file_ex_code = file_ex_codes.length
+        , real_URL = view.URL || view.webkitURL || view
+        , real_create_object_URL = real_URL.createObjectURL
+        , real_revoke_object_URL = real_URL.revokeObjectURL
+        , URL = real_URL
+        , btoa = view.btoa
+        , atob = view.atob
+
+        , ArrayBuffer = view.ArrayBuffer
+        , Uint8Array = view.Uint8Array
+
+        , origin = /^[\w-]+:\/*\[?[\w\.:-]+\]?(?::[0-9]+)?/
+        ;
+      FakeBlob.fake = FB_proto.fake = true;
+      while (file_ex_code--) {
+        FileException.prototype[file_ex_codes[file_ex_code]] = file_ex_code + 1;
+      }
+      // Polyfill URL
+      if (!real_URL.createObjectURL) {
+        URL = view.URL = function(uri) {
+          var
+            uri_info = document.createElementNS("http://www.w3.org/1999/xhtml", "a")
+            , uri_origin
+            ;
+          uri_info.href = uri;
+          if (!("origin" in uri_info)) {
+            if (uri_info.protocol.toLowerCase() === "data:") {
+              uri_info.origin = null;
+            } else {
+              uri_origin = uri.match(origin);
+              uri_info.origin = uri_origin && uri_origin[1];
+            }
+          }
+          return uri_info;
+        };
+      }
+      URL.createObjectURL = function(blob) {
+        var
+          type = blob.type
+          , data_URI_header
+          ;
+        if (type === null) {
+          type = "application/octet-stream";
+        }
+        if (blob instanceof FakeBlob) {
+          data_URI_header = "data:" + type;
+          if (blob.encoding === "base64") {
+            return data_URI_header + ";base64," + blob.data;
+          } else if (blob.encoding === "URI") {
+            return data_URI_header + "," + decodeURIComponent(blob.data);
+          } if (btoa) {
+            return data_URI_header + ";base64," + btoa(blob.data);
+          } else {
+            return data_URI_header + "," + encodeURIComponent(blob.data);
+          }
+        } else if (real_create_object_URL) {
+          return real_create_object_URL.call(real_URL, blob);
+        }
+      };
+      URL.revokeObjectURL = function(object_URL) {
+        if (object_URL.substring(0, 5) !== "data:" && real_revoke_object_URL) {
+          real_revoke_object_URL.call(real_URL, object_URL);
+        }
+      };
+      FBB_proto.append = function(data/*, endings*/) {
+        var bb = this.data;
+        // decode data to a binary string
+        if (Uint8Array && (data instanceof ArrayBuffer || data instanceof Uint8Array)) {
+          var
+            str = ""
+            , buf = new Uint8Array(data)
+            , i = 0
+            , buf_len = buf.length
+            ;
+          for (; i < buf_len; i++) {
+            str += String.fromCharCode(buf[i]);
+          }
+          bb.push(str);
+        } else if (get_class(data) === "Blob" || get_class(data) === "File") {
+          if (FileReaderSync) {
+            var fr = new FileReaderSync;
+            bb.push(fr.readAsBinaryString(data));
+          } else {
+            // async FileReader won't work as BlobBuilder is sync
+            throw new FileException("NOT_READABLE_ERR");
+          }
+        } else if (data instanceof FakeBlob) {
+          if (data.encoding === "base64" && atob) {
+            bb.push(atob(data.data));
+          } else if (data.encoding === "URI") {
+            bb.push(decodeURIComponent(data.data));
+          } else if (data.encoding === "raw") {
+            bb.push(data.data);
+          }
+        } else {
+          if (typeof data !== "string") {
+            data += ""; // convert unsupported types to strings
+          }
+          // decode UTF-16 to binary string
+          bb.push(unescape(encodeURIComponent(data)));
+        }
+      };
+      FBB_proto.getBlob = function(type) {
+        if (!arguments.length) {
+          type = null;
+        }
+        return new FakeBlob(this.data.join(""), type, "raw");
+      };
+      FBB_proto.toString = function() {
+        return "[object BlobBuilder]";
+      };
+      FB_proto.slice = function(start, end, type) {
+        var args = arguments.length;
+        if (args < 3) {
+          type = null;
+        }
+        return new FakeBlob(
+          this.data.slice(start, args > 1 ? end : this.data.length)
+          , type
+          , this.encoding
+        );
+      };
+      FB_proto.toString = function() {
+        return "[object Blob]";
+      };
+      FB_proto.close = function() {
+        this.size = 0;
+        delete this.data;
+      };
+      return FakeBlobBuilder;
+    }(view));
+
+  view.Blob = function(blobParts, options) {
+    var type = options ? (options.type || "") : "";
+    var builder = new BlobBuilder();
+    if (blobParts) {
+      for (var i = 0, len = blobParts.length; i < len; i++) {
+        if (Uint8Array && blobParts[i] instanceof Uint8Array) {
+          builder.append(blobParts[i].buffer);
+        }
+        else {
+          builder.append(blobParts[i]);
+        }
+      }
+    }
+    var blob = builder.getBlob(type);
+    if (!blob.slice && blob.webkitSlice) {
+      blob.slice = blob.webkitSlice;
+    }
+    return blob;
+  };
+
+  var getPrototypeOf = Object.getPrototypeOf || function(object) {
+      return object.__proto__;
+    };
+  view.Blob.prototype = getPrototypeOf(new view.Blob());
+}(typeof self !== "undefined" && self || typeof window !== "undefined" && window || this.content || this));
+
+//FormData (IE9)
+/*! @source https://github.com/francois2metz/html5-formdata/blob/master/formdata.js */
+/**
+ * Emulate FormData for some browsers
+ * MIT License
+ * (c) 2010 François de Metz
+ */
+(function(w) {
+  if (w.FormData)
+    return;
+  function FormData() {
+    this.fake = true;
+    this.boundary = "--------FormData" + Math.random();
+    this._fields = [];
+  }
+  FormData.prototype.append = function(key, value) {
+    this._fields.push([key, value]);
+  }
+  FormData.prototype.toString = function() {
+    var boundary = this.boundary;
+    var body = "";
+    this._fields.forEach(function(field) {
+      body += "--" + boundary + "\r\n";
+      // file upload
+      if (field[1].name) {
+        var file = field[1];
+        body += "Content-Disposition: form-data; name=\""+ field[0] +"\"; filename=\""+ file.name +"\"\r\n";
+        body += "Content-Type: "+ file.type +"\r\n\r\n";
+        body += file.getAsBinary() + "\r\n";
+      } else {
+        body += "Content-Disposition: form-data; name=\""+ field[0] +"\";\r\n\r\n";
+        body += field[1] + "\r\n";
+      }
+    });
+    body += "--" + boundary +"--";
+    return body;
+  }
+  w.FormData = FormData;
+})(window);
+
+// Intl (IE9, IE10, all Safari, all Android)
+/*! @source https://github.com/andyearnshaw/Intl.js */
+/*! @licence https://github.com/andyearnshaw/Intl.js/blob/master/LICENSE.txt */
+!function(e,r){"object"==typeof exports&&"undefined"!=typeof module?module.exports=r():"function"==typeof define&&define.amd?define(r):e.IntlPolyfill=r()}(this,function(){"use strict";function e(e){if("function"==typeof Math.log10)return Math.floor(Math.log10(e));var r=Math.round(Math.log(e)*Math.LOG10E);return r-(Number("1e"+r)>e)}function r(e){for(var t in e)(e instanceof r||ee.call(e,t))&&re(this,t,{value:e[t],enumerable:!0,writable:!0,configurable:!0})}function t(){re(this,"length",{writable:!0,value:0}),arguments.length&&oe.apply(this,ae.call(arguments))}function n(){if(ue.disableRegExpRestore)return function(){};for(var e={lastMatch:RegExp.lastMatch||"",leftContext:RegExp.leftContext,multiline:RegExp.multiline,input:RegExp.input},r=!1,n=1;n<=9;n++)r=(e["$"+n]=RegExp["$"+n])||r;return function(){var n=/[.?*+^$[\]\\(){}|-]/g,a=e.lastMatch.replace(n,"\\$&"),i=new t;if(r)for(var o=1;o<=9;o++){var s=e["$"+o];s?(s=s.replace(n,"\\$&"),a=a.replace(s,"("+s+")")):a="()"+a,oe.call(i,a.slice(0,a.indexOf("(")+1)),a=a.slice(a.indexOf("(")+1)}var l=se.call(i,"")+a;l=l.replace(/(\\\(|\\\)|[^()])+/g,function(e){return"[\\s\\S]{"+e.replace("\\","").length+"}"});var c=new RegExp(l,e.multiline?"gm":"g");c.lastIndex=e.leftContext.length,c.exec(e.input)}}function a(e){if(null===e)throw new TypeError("Cannot convert null or undefined to object");return Object(e)}function i(e){return ee.call(e,"__getInternalProperties")?e.__getInternalProperties(ge):ne(null)}function o(e){Se=e}function s(e){for(var r=e.length;r--;){var t=e.charAt(r);t>="a"&&t<="z"&&(e=e.slice(0,r)+t.toUpperCase()+e.slice(r+1))}return e}function l(e){return!!ze.test(e)&&(!ke.test(e)&&!Fe.test(e))}function c(e){var r=void 0,t=void 0;e=e.toLowerCase(),t=e.split("-");for(var n=1,a=t.length;n<a;n++)if(2===t[n].length)t[n]=t[n].toUpperCase();else if(4===t[n].length)t[n]=t[n].charAt(0).toUpperCase()+t[n].slice(1);else if(1===t[n].length&&"x"!==t[n])break;e=se.call(t,"-"),(r=e.match(Oe))&&r.length>1&&(r.sort(),e=e.replace(RegExp("(?:"+Oe.source+")+","i"),se.call(r,""))),ee.call(Ee.tags,e)&&(e=Ee.tags[e]),t=e.split("-");for(var i=1,o=t.length;i<o;i++)ee.call(Ee.subtags,t[i])?t[i]=Ee.subtags[t[i]]:ee.call(Ee.extLang,t[i])&&(t[i]=Ee.extLang[t[i]][0],1===i&&Ee.extLang[t[1]][1]===t[0]&&(t=ae.call(t,i++),o-=1));return se.call(t,"-")}function u(){return Se}function g(e){var r=String(e),t=s(r);return Le.test(t)!==!1}function f(e){if(void 0===e)return new t;var r=new t;e="string"==typeof e?[e]:e;for(var n=a(e),i=n.length,o=0;o<i;){var s=String(o),u=s in n;if(u){var g=n[s];if(null===g||"string"!=typeof g&&"object"!==("undefined"==typeof g?"undefined":ir.typeof(g)))throw new TypeError("String or Object type expected");var f=String(g);if(!l(f))throw new RangeError("'"+f+"' is not a structurally valid language tag");f=c(f),te.call(r,f)===-1&&oe.call(r,f)}o++}return r}function m(e,r){for(var t=r;t;){if(te.call(e,t)>-1)return t;var n=t.lastIndexOf("-");if(n<0)return;n>=2&&"-"===t.charAt(n-2)&&(n-=2),t=t.substring(0,n)}}function v(e,t){for(var n=0,a=t.length,i=void 0,o=void 0,s=void 0;n<a&&!i;)o=t[n],s=String(o).replace(or,""),i=m(e,s),n++;var l=new r;if(void 0!==i){if(l["[[locale]]"]=i,String(o)!==String(s)){var c=o.match(or)[0],g=o.indexOf("-u-");l["[[extension]]"]=c,l["[[extensionIndex]]"]=g}}else l["[[locale]]"]=u();return l}function d(e,r){return v(e,r)}function h(e,t,n,a,i){if(0===e.length)throw new ReferenceError("No locale data has been provided for this object yet.");var o=n["[[localeMatcher]]"],s=void 0;s="lookup"===o?v(e,t):d(e,t);var l=s["[[locale]]"],u=void 0,g=void 0;if(ee.call(s,"[[extension]]")){var f=s["[[extension]]"],m=String.prototype.split;u=m.call(f,"-"),g=u.length}var h=new r;h["[[dataLocale]]"]=l;for(var p="-u",y=0,b=a.length;y<b;){var w=a[y],x=i[l],D=x[w],j=D[0],z="",k=te;if(void 0!==u){var F=k.call(u,w);if(F!==-1)if(F+1<g&&u[F+1].length>2){var O=u[F+1],S=k.call(D,O);S!==-1&&(j=O,z="-"+w+"-"+j)}else{var E=k(D,"true");E!==-1&&(j="true")}}if(ee.call(n,"[["+w+"]]")){var L=n["[["+w+"]]"];k.call(D,L)!==-1&&L!==j&&(j=L,z="")}h["[["+w+"]]"]=j,p+=z,y++}if(p.length>2){var P=l.indexOf("-x-");if(P===-1)l+=p;else{var N=l.substring(0,P),T=l.substring(P);l=N+p+T}l=c(l)}return h["[[locale]]"]=l,h}function p(e,r){for(var n=r.length,a=new t,i=0;i<n;){var o=r[i],s=String(o).replace(or,""),l=m(e,s);void 0!==l&&oe.call(a,o),i++}var c=ae.call(a);return c}function y(e,r){return p(e,r)}function b(e,t,n){var i=void 0,o=void 0;if(void 0!==n&&(n=new r(a(n)),i=n.localeMatcher,void 0!==i&&(i=String(i),"lookup"!==i&&"best fit"!==i)))throw new RangeError('matcher should be "lookup" or "best fit"');o=void 0===i||"best fit"===i?y(e,t):p(e,t);for(var s in o)ee.call(o,s)&&re(o,s,{writable:!1,configurable:!1,value:o[s]});return re(o,"length",{writable:!1}),o}function w(e,r,t,n,a){var i=e[r];if(void 0!==i){if(i="boolean"===t?Boolean(i):"string"===t?String(i):i,void 0!==n&&te.call(n,i)===-1)throw new RangeError("'"+i+"' is not an allowed value for `"+r+"`");return i}return a}function x(e,r,t,n,a){var i=e[r];if(void 0!==i){if(i=Number(i),isNaN(i)||i<t||i>n)throw new RangeError("Value is not a number or outside accepted range");return Math.floor(i)}return a}function D(){var e=arguments[0],r=arguments[1];return this&&this!==sr?j(a(this),e,r):new sr.NumberFormat(e,r)}function j(e,o,s){var l=i(e),c=n();if(l["[[initializedIntlObject]]"]===!0)throw new TypeError("`this` object has already been initialized as an Intl object");re(e,"__getInternalProperties",{value:function(){if(arguments[0]===ge)return l}}),l["[[initializedIntlObject]]"]=!0;var u=f(o);s=void 0===s?{}:a(s);var m=new r,v=w(s,"localeMatcher","string",new t("lookup","best fit"),"best fit");m["[[localeMatcher]]"]=v;var d=ue.NumberFormat["[[localeData]]"],p=h(ue.NumberFormat["[[availableLocales]]"],u,m,ue.NumberFormat["[[relevantExtensionKeys]]"],d);l["[[locale]]"]=p["[[locale]]"],l["[[numberingSystem]]"]=p["[[nu]]"],l["[[dataLocale]]"]=p["[[dataLocale]]"];var y=p["[[dataLocale]]"],b=w(s,"style","string",new t("decimal","percent","currency"),"decimal");l["[[style]]"]=b;var D=w(s,"currency","string");if(void 0!==D&&!g(D))throw new RangeError("'"+D+"' is not a valid currency code");if("currency"===b&&void 0===D)throw new TypeError("Currency code is required when style is currency");var j=void 0;"currency"===b&&(D=D.toUpperCase(),l["[[currency]]"]=D,j=z(D));var F=w(s,"currencyDisplay","string",new t("code","symbol","name"),"symbol");"currency"===b&&(l["[[currencyDisplay]]"]=F);var O=x(s,"minimumIntegerDigits",1,21,1);l["[[minimumIntegerDigits]]"]=O;var S="currency"===b?j:0,E=x(s,"minimumFractionDigits",0,20,S);l["[[minimumFractionDigits]]"]=E;var L="currency"===b?Math.max(E,j):"percent"===b?Math.max(E,0):Math.max(E,3),P=x(s,"maximumFractionDigits",E,20,L);l["[[maximumFractionDigits]]"]=P;var N=s.minimumSignificantDigits,T=s.maximumSignificantDigits;void 0===N&&void 0===T||(N=x(s,"minimumSignificantDigits",1,21,1),T=x(s,"maximumSignificantDigits",N,21,21),l["[[minimumSignificantDigits]]"]=N,l["[[maximumSignificantDigits]]"]=T);var _=w(s,"useGrouping","boolean",void 0,!0);l["[[useGrouping]]"]=_;var I=d[y],A=I.patterns,M=A[b];return l["[[positivePattern]]"]=M.positivePattern,l["[[negativePattern]]"]=M.negativePattern,l["[[boundFormat]]"]=void 0,l["[[initializedNumberFormat]]"]=!0,Q&&(e.format=k.call(e)),c(),e}function z(e){return void 0!==lr[e]?lr[e]:2}function k(){var e=null!==this&&"object"===ir.typeof(this)&&i(this);if(!e||!e["[[initializedNumberFormat]]"])throw new TypeError("`this` value for format() is not an initialized Intl.NumberFormat object.");if(void 0===e["[[boundFormat]]"]){var r=function(e){return S(this,Number(e))},t=ce.call(r,this);e["[[boundFormat]]"]=t}return e["[[boundFormat]]"]}function F(e,r){for(var t=O(e,r),n=[],a=0,i=0;t.length>i;i++){var o=t[i],s={};s.type=o["[[type]]"],s.value=o["[[value]]"],n[a]=s,a+=1}return n}function O(e,r){var n=i(e),a=n["[[dataLocale]]"],o=n["[[numberingSystem]]"],s=ue.NumberFormat["[[localeData]]"][a],l=s.symbols[o]||s.symbols.latn,c=void 0;!isNaN(r)&&r<0?(r=-r,c=n["[[negativePattern]]"]):c=n["[[positivePattern]]"];for(var u=new t,g=c.indexOf("{",0),f=0,m=0,v=c.length;g>-1&&g<v;){if(f=c.indexOf("}",g),f===-1)throw new Error;if(g>m){var d=c.substring(m,g);oe.call(u,{"[[type]]":"literal","[[value]]":d})}var h=c.substring(g+1,f);if("number"===h)if(isNaN(r)){var p=l.nan;oe.call(u,{"[[type]]":"nan","[[value]]":p})}else if(isFinite(r)){"percent"===n["[[style]]"]&&isFinite(r)&&(r*=100);var y=void 0;y=ee.call(n,"[[minimumSignificantDigits]]")&&ee.call(n,"[[maximumSignificantDigits]]")?E(r,n["[[minimumSignificantDigits]]"],n["[[maximumSignificantDigits]]"]):L(r,n["[[minimumIntegerDigits]]"],n["[[minimumFractionDigits]]"],n["[[maximumFractionDigits]]"]),cr[o]?!function(){var e=cr[o];y=String(y).replace(/\d/g,function(r){return e[r]})}():y=String(y);var b=void 0,w=void 0,x=y.indexOf(".",0);if(x>0?(b=y.substring(0,x),w=y.substring(x+1,x.length)):(b=y,w=void 0),n["[[useGrouping]]"]===!0){var D=l.group,j=[],z=s.patterns.primaryGroupSize||3,k=s.patterns.secondaryGroupSize||z;if(b.length>z){var F=b.length-z,O=F%k,S=b.slice(0,O);for(S.length&&oe.call(j,S);O<F;)oe.call(j,b.slice(O,O+k)),O+=k;oe.call(j,b.slice(F))}else oe.call(j,b);if(0===j.length)throw new Error;for(;j.length;){var P=le.call(j);oe.call(u,{"[[type]]":"integer","[[value]]":P}),j.length&&oe.call(u,{"[[type]]":"group","[[value]]":D})}}else oe.call(u,{"[[type]]":"integer","[[value]]":b});if(void 0!==w){var N=l.decimal;oe.call(u,{"[[type]]":"decimal","[[value]]":N}),oe.call(u,{"[[type]]":"fraction","[[value]]":w})}}else{var T=l.infinity;oe.call(u,{"[[type]]":"infinity","[[value]]":T})}else if("plusSign"===h){var _=l.plusSign;oe.call(u,{"[[type]]":"plusSign","[[value]]":_})}else if("minusSign"===h){var I=l.minusSign;oe.call(u,{"[[type]]":"minusSign","[[value]]":I})}else if("percentSign"===h&&"percent"===n["[[style]]"]){var A=l.percentSign;oe.call(u,{"[[type]]":"literal","[[value]]":A})}else if("currency"===h&&"currency"===n["[[style]]"]){var M=n["[[currency]]"],R=void 0;"code"===n["[[currencyDisplay]]"]?R=M:"symbol"===n["[[currencyDisplay]]"]?R=s.currencies[M]||M:"name"===n["[[currencyDisplay]]"]&&(R=M),oe.call(u,{"[[type]]":"currency","[[value]]":R})}else{var q=c.substring(g,f);oe.call(u,{"[[type]]":"literal","[[value]]":q})}m=f+1,g=c.indexOf("{",m)}if(m<v){var C=c.substring(m,v);oe.call(u,{"[[type]]":"literal","[[value]]":C})}return u}function S(e,r){for(var t=O(e,r),n="",a=0;t.length>a;a++){var i=t[a];n+=i["[[value]]"]}return n}function E(r,t,n){var a=n,i=void 0,o=void 0;if(0===r)i=se.call(Array(a+1),"0"),o=0;else{o=e(Math.abs(r));var s=Math.round(Math.exp(Math.abs(o-a+1)*Math.LN10));i=String(Math.round(o-a+1<0?r*s:r/s))}if(o>=a)return i+se.call(Array(o-a+1+1),"0");if(o===a-1)return i;if(o>=0?i=i.slice(0,o+1)+"."+i.slice(o+1):o<0&&(i="0."+se.call(Array(-(o+1)+1),"0")+i),i.indexOf(".")>=0&&n>t){for(var l=n-t;l>0&&"0"===i.charAt(i.length-1);)i=i.slice(0,-1),l--;"."===i.charAt(i.length-1)&&(i=i.slice(0,-1))}return i}function L(e,r,t,n){var a=n,i=Math.pow(10,a)*e,o=0===i?"0":i.toFixed(0),s=void 0,l=(s=o.indexOf("e"))>-1?o.slice(s+1):0;l&&(o=o.slice(0,s).replace(".",""),o+=se.call(Array(l-(o.length-1)+1),"0"));var c=void 0;if(0!==a){var u=o.length;if(u<=a){var g=se.call(Array(a+1-u+1),"0");o=g+o,u=a+1}var f=o.substring(0,u-a),m=o.substring(u-a,o.length);o=f+"."+m,c=f.length}else c=o.length;for(var v=n-t;v>0&&"0"===o.slice(-1);)o=o.slice(0,-1),v--;if("."===o.slice(-1)&&(o=o.slice(0,-1)),c<r){var d=se.call(Array(r-c+1),"0");o=d+o}return o}function P(e){for(var r=0;r<vr.length;r+=1)if(e.hasOwnProperty(vr[r]))return!1;return!0}function N(e){for(var r=0;r<mr.length;r+=1)if(e.hasOwnProperty(mr[r]))return!1;return!0}function T(e,r){for(var t={_:{}},n=0;n<mr.length;n+=1)e[mr[n]]&&(t[mr[n]]=e[mr[n]]),e._[mr[n]]&&(t._[mr[n]]=e._[mr[n]]);for(var a=0;a<vr.length;a+=1)r[vr[a]]&&(t[vr[a]]=r[vr[a]]),r._[vr[a]]&&(t._[vr[a]]=r._[vr[a]]);return t}function _(e){return e.pattern12=e.extendedPattern.replace(/'([^']*)'/g,function(e,r){return r?r:"'"}),e.pattern=e.pattern12.replace("{ampm}","").replace(gr,""),e}function I(e,r){switch(e.charAt(0)){case"G":return r.era=["short","short","short","long","narrow"][e.length-1],"{era}";case"y":case"Y":case"u":case"U":case"r":return r.year=2===e.length?"2-digit":"numeric","{year}";case"Q":case"q":return r.quarter=["numeric","2-digit","short","long","narrow"][e.length-1],"{quarter}";case"M":case"L":return r.month=["numeric","2-digit","short","long","narrow"][e.length-1],"{month}";case"w":return r.week=2===e.length?"2-digit":"numeric","{weekday}";case"W":return r.week="numeric","{weekday}";case"d":return r.day=2===e.length?"2-digit":"numeric","{day}";case"D":case"F":case"g":return r.day="numeric","{day}";case"E":return r.weekday=["short","short","short","long","narrow","short"][e.length-1],"{weekday}";case"e":return r.weekday=["numeric","2-digit","short","long","narrow","short"][e.length-1],"{weekday}";case"c":return r.weekday=["numeric",void 0,"short","long","narrow","short"][e.length-1],"{weekday}";case"a":case"b":case"B":return r.hour12=!0,"{ampm}";case"h":case"H":return r.hour=2===e.length?"2-digit":"numeric","{hour}";case"k":case"K":return r.hour12=!0,r.hour=2===e.length?"2-digit":"numeric","{hour}";case"m":return r.minute=2===e.length?"2-digit":"numeric","{minute}";case"s":return r.second=2===e.length?"2-digit":"numeric","{second}";case"S":case"A":return r.second="numeric","{second}";case"z":case"Z":case"O":case"v":case"V":case"X":case"x":return r.timeZoneName=e.length<4?"short":"long","{timeZoneName}"}}function A(e,r){if(!fr.test(r)){var t={originalPattern:r,_:{}};return t.extendedPattern=r.replace(ur,function(e){return I(e,t._)}),e.replace(ur,function(e){return I(e,t)}),_(t)}}function M(e){var r=e.availableFormats,t=e.timeFormats,n=e.dateFormats,a=[],i=void 0,o=void 0,s=void 0,l=void 0,c=void 0,u=[],g=[];for(i in r)r.hasOwnProperty(i)&&(o=r[i],s=A(i,o),s&&(a.push(s),P(s)?g.push(s):N(s)&&u.push(s)));for(i in t)t.hasOwnProperty(i)&&(o=t[i],s=A(i,o),s&&(a.push(s),u.push(s)));for(i in n)n.hasOwnProperty(i)&&(o=n[i],s=A(i,o),s&&(a.push(s),g.push(s)));for(l=0;l<u.length;l+=1)for(c=0;c<g.length;c+=1)o="long"===g[c].month?g[c].weekday?e.full:e.long:"short"===g[c].month?e.medium:e.short,s=T(g[c],u[l]),s.originalPattern=o,s.extendedPattern=o.replace("{0}",u[l].extendedPattern).replace("{1}",g[c].extendedPattern).replace(/^[,\s]+|[,\s]+$/gi,""),a.push(_(s));return a}function R(e,r){if(dr[e]&&dr[e][r]){var t;return t={originalPattern:dr[e][r],_:Re({},e,r),extendedPattern:"{"+e+"}"},Re(t,e,r),Re(t,"pattern12","{"+e+"}"),Re(t,"pattern","{"+e+"}"),t}}function q(e,r,t,n,a){var i=e[r]&&e[r][t]?e[r][t]:e.gregory[t],o={narrow:["short","long"],short:["long","narrow"],long:["short","narrow"]},s=ee.call(i,n)?i[n]:ee.call(i,o[n][0])?i[o[n][0]]:i[o[n][1]];return null!==a?s[a]:s}function C(){var e=arguments[0],r=arguments[1];return this&&this!==sr?G(a(this),e,r):new sr.DateTimeFormat(e,r)}function G(e,a,o){var l=i(e),c=n();if(l["[[initializedIntlObject]]"]===!0)throw new TypeError("`this` object has already been initialized as an Intl object");re(e,"__getInternalProperties",{value:function(){if(arguments[0]===ge)return l}}),l["[[initializedIntlObject]]"]=!0;var u=f(a);o=B(o,"any","date");var g=new r,m=w(o,"localeMatcher","string",new t("lookup","best fit"),"best fit");g["[[localeMatcher]]"]=m;var v=ue.DateTimeFormat,d=v["[[localeData]]"],p=h(v["[[availableLocales]]"],u,g,v["[[relevantExtensionKeys]]"],d);l["[[locale]]"]=p["[[locale]]"],l["[[calendar]]"]=p["[[ca]]"],l["[[numberingSystem]]"]=p["[[nu]]"],l["[[dataLocale]]"]=p["[[dataLocale]]"];var y=p["[[dataLocale]]"],b=o.timeZone;if(void 0!==b&&(b=s(b),"UTC"!==b))throw new RangeError("timeZone is not supported.");l["[[timeZone]]"]=b,g=new r;for(var x in pr)if(ee.call(pr,x)){var D=w(o,x,"string",pr[x]);g["[["+x+"]]"]=D}var j=void 0,z=d[y],k=Z(z.formats);if(m=w(o,"formatMatcher","string",new t("basic","best fit"),"best fit"),z.formats=k,"basic"===m)j=U(g,k);else{var F=w(o,"hour12","boolean");g.hour12=void 0===F?z.hour12:F,j=$(g,k)}for(var O in pr)if(ee.call(pr,O)&&ee.call(j,O)){var S=j[O];S=j._&&ee.call(j._,O)?j._[O]:S,l["[["+O+"]]"]=S}var E=void 0,L=w(o,"hour12","boolean");if(l["[[hour]]"])if(L=void 0===L?z.hour12:L,l["[[hour12]]"]=L,L===!0){var P=z.hourNo0;l["[[hourNo0]]"]=P,E=j.pattern12}else E=j.pattern;else E=j.pattern;return l["[[pattern]]"]=E,l["[[boundFormat]]"]=void 0,l["[[initializedDateTimeFormat]]"]=!0,Q&&(e.format=K.call(e)),c(),e}function Z(e){return"[object Array]"===Object.prototype.toString.call(e)?e:M(e)}function B(e,t,n){if(void 0===e)e=null;else{var i=a(e);e=new r;for(var o in i)e[o]=i[o]}var s=ne;e=s(e);var l=!0;return"date"!==t&&"any"!==t||void 0===e.weekday&&void 0===e.year&&void 0===e.month&&void 0===e.day||(l=!1),"time"!==t&&"any"!==t||void 0===e.hour&&void 0===e.minute&&void 0===e.second||(l=!1),!l||"date"!==n&&"all"!==n||(e.year=e.month=e.day="numeric"),!l||"time"!==n&&"all"!==n||(e.hour=e.minute=e.second="numeric"),e}function U(e,r){for(var t=120,n=20,a=8,i=6,o=6,s=3,l=-(1/0),c=void 0,u=0,g=r.length;u<g;){var f=r[u],m=0;for(var v in pr)if(ee.call(pr,v)){var d=e["[["+v+"]]"],h=ee.call(f,v)?f[v]:void 0;if(void 0===d&&void 0!==h)m-=n;else if(void 0!==d&&void 0===h)m-=t;else{var p=["2-digit","numeric","narrow","short","long"],y=te.call(p,d),b=te.call(p,h),w=Math.max(Math.min(b-y,2),-2);2===w?m-=i:1===w?m-=s:w===-1?m-=o:w===-2&&(m-=a)}}m>l&&(l=m,c=f),u++}return c}function $(e,r){var t=[];for(var n in pr)ee.call(pr,n)&&void 0!==e["[["+n+"]]"]&&t.push(n);if(1===t.length){var a=R(t[0],e["[["+t[0]+"]]"]);if(a)return a}for(var i=120,o=20,s=8,l=6,c=6,u=3,g=2,f=1,m=-(1/0),v=void 0,d=0,h=r.length;d<h;){var p=r[d],y=0;for(var b in pr)if(ee.call(pr,b)){var w=e["[["+b+"]]"],x=ee.call(p,b)?p[b]:void 0,D=ee.call(p._,b)?p._[b]:void 0;if(w!==D&&(y-=g),void 0===w&&void 0!==x)y-=o;else if(void 0!==w&&void 0===x)y-=i;else{var j=["2-digit","numeric","narrow","short","long"],z=te.call(j,w),k=te.call(j,x),F=Math.max(Math.min(k-z,2),-2);k<=1&&z>=2||k>=2&&z<=1?F>0?y-=l:F<0&&(y-=s):F>1?y-=u:F<-1&&(y-=c)}}p._.hour12!==e.hour12&&(y-=f),y>m&&(m=y,v=p),d++}return v}function K(){var e=null!==this&&"object"===ir.typeof(this)&&i(this);if(!e||!e["[[initializedDateTimeFormat]]"])throw new TypeError("`this` value for format() is not an initialized Intl.DateTimeFormat object.");if(void 0===e["[[boundFormat]]"]){var r=function(){var e=Number(0===arguments.length?Date.now():arguments[0]);return H(this,e)},t=ce.call(r,this);e["[[boundFormat]]"]=t}return e["[[boundFormat]]"]}function Y(e,r){if(!isFinite(r))throw new RangeError("Invalid valid date passed to format");var a=e.__getInternalProperties(ge);n();for(var i=a["[[locale]]"],o=new sr.NumberFormat([i],{useGrouping:!1}),s=new sr.NumberFormat([i],{minimumIntegerDigits:2,useGrouping:!1}),l=X(r,a["[[calendar]]"],a["[[timeZone]]"]),c=a["[[pattern]]"],u=new t,g=0,f=c.indexOf("{"),m=0,v=a["[[dataLocale]]"],d=ue.DateTimeFormat["[[localeData]]"][v].calendars,h=a["[[calendar]]"];f!==-1;){var p=void 0;if(m=c.indexOf("}",f),m===-1)throw new Error("Unclosed pattern");f>g&&oe.call(u,{type:"literal",value:c.substring(g,f)});var y=c.substring(f+1,m);if(pr.hasOwnProperty(y)){var b=a["[["+y+"]]"],w=l["[["+y+"]]"];if("year"===y&&w<=0?w=1-w:"month"===y?w++:"hour"===y&&a["[[hour12]]"]===!0&&(w%=12,0===w&&a["[[hourNo0]]"]===!0&&(w=12)),"numeric"===b)p=S(o,w);else if("2-digit"===b)p=S(s,w),p.length>2&&(p=p.slice(-2));else if(b in hr)switch(y){case"month":p=q(d,h,"months",b,l["[["+y+"]]"]);break;case"weekday":try{p=q(d,h,"days",b,l["[["+y+"]]"])}catch(e){throw new Error("Could not find weekday data for locale "+i)}break;case"timeZoneName":p="";break;case"era":try{p=q(d,h,"eras",b,l["[["+y+"]]"])}catch(e){throw new Error("Could not find era data for locale "+i)}break;default:p=l["[["+y+"]]"]}oe.call(u,{type:y,value:p})}else if("ampm"===y){var x=l["[[hour]]"];p=q(d,h,"dayPeriods",x>11?"pm":"am",null),oe.call(u,{type:"dayPeriod",value:p})}else oe.call(u,{type:"literal",value:c.substring(f,m+1)});g=m+1,f=c.indexOf("{",g)}return m<c.length-1&&oe.call(u,{type:"literal",value:c.substr(m+1)}),u}function H(e,r){for(var t=Y(e,r),n="",a=0;t.length>a;a++){var i=t[a];n+=i.value}return n}function W(e,r){for(var t=Y(e,r),n=[],a=0;t.length>a;a++){var i=t[a];n.push({type:i.type,value:i.value})}return n}function X(e,t,n){var a=new Date(e),i="get"+(n||"");return new r({"[[weekday]]":a[i+"Day"](),"[[era]]":+(a[i+"FullYear"]()>=0),"[[year]]":a[i+"FullYear"](),"[[month]]":a[i+"Month"](),"[[day]]":a[i+"Date"](),"[[hour]]":a[i+"Hours"](),"[[minute]]":a[i+"Minutes"](),"[[second]]":a[i+"Seconds"](),"[[inDST]]":!1})}function V(e,r){if(!e.number)throw new Error("Object passed doesn't contain locale data for Intl.NumberFormat");var t=void 0,n=[r],a=r.split("-");for(a.length>2&&4===a[1].length&&oe.call(n,a[0]+"-"+a[2]);t=le.call(n);)oe.call(ue.NumberFormat["[[availableLocales]]"],t),ue.NumberFormat["[[localeData]]"][t]=e.number,e.date&&(e.date.nu=e.number.nu,oe.call(ue.DateTimeFormat["[[availableLocales]]"],t),ue.DateTimeFormat["[[localeData]]"][t]=e.date);void 0===Se&&o(r)}var J=function(){var e={};try{return Object.defineProperty(e,"a",{get:function(){return 1}}),1===e.a}catch(e){return!1}}(),Q=!J&&!Object.prototype.__defineGetter__,ee=Object.prototype.hasOwnProperty,re=J?Object.defineProperty:function(e,r,t){"get"in t&&e.__defineGetter__?e.__defineGetter__(r,t.get):(!ee.call(e,r)||"value"in t)&&(e[r]=t.value)},te=Array.prototype.indexOf||function(e){var r=this;if(!r.length)return-1;for(var t=arguments[1]||0,n=r.length;t<n;t++)if(r[t]===e)return t;return-1},ne=Object.create||function(e,r){function t(){}var n=void 0;t.prototype=e,n=new t;for(var a in r)ee.call(r,a)&&re(n,a,r[a]);return n},ae=Array.prototype.slice,ie=Array.prototype.concat,oe=Array.prototype.push,se=Array.prototype.join,le=Array.prototype.shift,ce=Function.prototype.bind||function(e){var r=this,t=ae.call(arguments,1);return 1===r.length?function(){return r.apply(e,ie.call(t,ae.call(arguments)))}:function(){return r.apply(e,ie.call(t,ae.call(arguments)))}},ue=ne(null),ge=Math.random();r.prototype=ne(null),t.prototype=ne(null);var fe="[a-z]{3}(?:-[a-z]{3}){0,2}",me="(?:[a-z]{2,3}(?:-"+fe+")?|[a-z]{4}|[a-z]{5,8})",ve="[a-z]{4}",de="(?:[a-z]{2}|\\d{3})",he="(?:[a-z0-9]{5,8}|\\d[a-z0-9]{3})",pe="[0-9a-wy-z]",ye=pe+"(?:-[a-z0-9]{2,8})+",be="x(?:-[a-z0-9]{1,8})+",we="(?:en-GB-oed|i-(?:ami|bnn|default|enochian|hak|klingon|lux|mingo|navajo|pwn|tao|tay|tsu)|sgn-(?:BE-FR|BE-NL|CH-DE))",xe="(?:art-lojban|cel-gaulish|no-bok|no-nyn|zh-(?:guoyu|hakka|min|min-nan|xiang))",De="(?:"+we+"|"+xe+")",je=me+"(?:-"+ve+")?(?:-"+de+")?(?:-"+he+")*(?:-"+ye+")*(?:-"+be+")?",ze=RegExp("^(?:"+je+"|"+be+"|"+De+")$","i"),ke=RegExp("^(?!x).*?-("+he+")-(?:\\w{4,8}-(?!x-))*\\1\\b","i"),Fe=RegExp("^(?!x).*?-("+pe+")-(?:\\w+-(?!x-))*\\1\\b","i"),Oe=RegExp("-"+ye,"ig"),Se=void 0,Ee={tags:{"art-lojban":"jbo","i-ami":"ami","i-bnn":"bnn","i-hak":"hak","i-klingon":"tlh","i-lux":"lb","i-navajo":"nv","i-pwn":"pwn","i-tao":"tao","i-tay":"tay","i-tsu":"tsu","no-bok":"nb","no-nyn":"nn","sgn-BE-FR":"sfb","sgn-BE-NL":"vgt","sgn-CH-DE":"sgg","zh-guoyu":"cmn","zh-hakka":"hak","zh-min-nan":"nan","zh-xiang":"hsn","sgn-BR":"bzs","sgn-CO":"csn","sgn-DE":"gsg","sgn-DK":"dsl","sgn-ES":"ssp","sgn-FR":"fsl","sgn-GB":"bfi","sgn-GR":"gss","sgn-IE":"isg","sgn-IT":"ise","sgn-JP":"jsl","sgn-MX":"mfs","sgn-NI":"ncs","sgn-NL":"dse","sgn-NO":"nsl","sgn-PT":"psr","sgn-SE":"swl","sgn-US":"ase","sgn-ZA":"sfs","zh-cmn":"cmn","zh-cmn-Hans":"cmn-Hans","zh-cmn-Hant":"cmn-Hant","zh-gan":"gan","zh-wuu":"wuu","zh-yue":"yue"},subtags:{BU:"MM",DD:"DE",FX:"FR",TP:"TL",YD:"YE",ZR:"CD",heploc:"alalc97",in:"id",iw:"he",ji:"yi",jw:"jv",mo:"ro",ayx:"nun",bjd:"drl",ccq:"rki",cjr:"mom",cka:"cmr",cmk:"xch",drh:"khk",drw:"prs",gav:"dev",hrr:"jal",ibi:"opa",kgh:"kml",lcq:"ppr",mst:"mry",myt:"mry",sca:"hle",tie:"ras",tkk:"twm",tlw:"weo",tnf:"prs",ybd:"rki",yma:"lrr"},extLang:{aao:["aao","ar"],abh:["abh","ar"],abv:["abv","ar"],acm:["acm","ar"],acq:["acq","ar"],acw:["acw","ar"],acx:["acx","ar"],acy:["acy","ar"],adf:["adf","ar"],ads:["ads","sgn"],aeb:["aeb","ar"],aec:["aec","ar"],aed:["aed","sgn"],aen:["aen","sgn"],afb:["afb","ar"],afg:["afg","sgn"],ajp:["ajp","ar"],apc:["apc","ar"],apd:["apd","ar"],arb:["arb","ar"],arq:["arq","ar"],ars:["ars","ar"],ary:["ary","ar"],arz:["arz","ar"],ase:["ase","sgn"],asf:["asf","sgn"],asp:["asp","sgn"],asq:["asq","sgn"],asw:["asw","sgn"],auz:["auz","ar"],avl:["avl","ar"],ayh:["ayh","ar"],ayl:["ayl","ar"],ayn:["ayn","ar"],ayp:["ayp","ar"],bbz:["bbz","ar"],bfi:["bfi","sgn"],bfk:["bfk","sgn"],bjn:["bjn","ms"],bog:["bog","sgn"],bqn:["bqn","sgn"],bqy:["bqy","sgn"],btj:["btj","ms"],bve:["bve","ms"],bvl:["bvl","sgn"],bvu:["bvu","ms"],bzs:["bzs","sgn"],cdo:["cdo","zh"],cds:["cds","sgn"],cjy:["cjy","zh"],cmn:["cmn","zh"],coa:["coa","ms"],cpx:["cpx","zh"],csc:["csc","sgn"],csd:["csd","sgn"],cse:["cse","sgn"],csf:["csf","sgn"],csg:["csg","sgn"],csl:["csl","sgn"],csn:["csn","sgn"],csq:["csq","sgn"],csr:["csr","sgn"],czh:["czh","zh"],czo:["czo","zh"],doq:["doq","sgn"],dse:["dse","sgn"],dsl:["dsl","sgn"],dup:["dup","ms"],ecs:["ecs","sgn"],esl:["esl","sgn"],esn:["esn","sgn"],eso:["eso","sgn"],eth:["eth","sgn"],fcs:["fcs","sgn"],fse:["fse","sgn"],fsl:["fsl","sgn"],fss:["fss","sgn"],gan:["gan","zh"],gds:["gds","sgn"],gom:["gom","kok"],gse:["gse","sgn"],gsg:["gsg","sgn"],gsm:["gsm","sgn"],gss:["gss","sgn"],gus:["gus","sgn"],hab:["hab","sgn"],haf:["haf","sgn"],hak:["hak","zh"],hds:["hds","sgn"],hji:["hji","ms"],hks:["hks","sgn"],hos:["hos","sgn"],hps:["hps","sgn"],hsh:["hsh","sgn"],hsl:["hsl","sgn"],hsn:["hsn","zh"],icl:["icl","sgn"],ils:["ils","sgn"],inl:["inl","sgn"],ins:["ins","sgn"],ise:["ise","sgn"],isg:["isg","sgn"],isr:["isr","sgn"],jak:["jak","ms"],jax:["jax","ms"],jcs:["jcs","sgn"],jhs:["jhs","sgn"],jls:["jls","sgn"],jos:["jos","sgn"],jsl:["jsl","sgn"],jus:["jus","sgn"],kgi:["kgi","sgn"],knn:["knn","kok"],kvb:["kvb","ms"],kvk:["kvk","sgn"],kvr:["kvr","ms"],kxd:["kxd","ms"],lbs:["lbs","sgn"],lce:["lce","ms"],lcf:["lcf","ms"],liw:["liw","ms"],lls:["lls","sgn"],lsg:["lsg","sgn"],lsl:["lsl","sgn"],lso:["lso","sgn"],lsp:["lsp","sgn"],lst:["lst","sgn"],lsy:["lsy","sgn"],ltg:["ltg","lv"],lvs:["lvs","lv"],lzh:["lzh","zh"],max:["max","ms"],mdl:["mdl","sgn"],meo:["meo","ms"],mfa:["mfa","ms"],mfb:["mfb","ms"],mfs:["mfs","sgn"],min:["min","ms"],mnp:["mnp","zh"],mqg:["mqg","ms"],mre:["mre","sgn"],msd:["msd","sgn"],msi:["msi","ms"],msr:["msr","sgn"],mui:["mui","ms"],mzc:["mzc","sgn"],mzg:["mzg","sgn"],mzy:["mzy","sgn"],nan:["nan","zh"],nbs:["nbs","sgn"],ncs:["ncs","sgn"],nsi:["nsi","sgn"],nsl:["nsl","sgn"],nsp:["nsp","sgn"],nsr:["nsr","sgn"],nzs:["nzs","sgn"],okl:["okl","sgn"],orn:["orn","ms"],ors:["ors","ms"],pel:["pel","ms"],pga:["pga","ar"],pks:["pks","sgn"],prl:["prl","sgn"],prz:["prz","sgn"],psc:["psc","sgn"],psd:["psd","sgn"],pse:["pse","ms"],psg:["psg","sgn"],psl:["psl","sgn"],pso:["pso","sgn"],psp:["psp","sgn"],psr:["psr","sgn"],pys:["pys","sgn"],rms:["rms","sgn"],rsi:["rsi","sgn"],rsl:["rsl","sgn"],sdl:["sdl","sgn"],sfb:["sfb","sgn"],sfs:["sfs","sgn"],sgg:["sgg","sgn"],sgx:["sgx","sgn"],shu:["shu","ar"],slf:["slf","sgn"],sls:["sls","sgn"],sqk:["sqk","sgn"],sqs:["sqs","sgn"],ssh:["ssh","ar"],ssp:["ssp","sgn"],ssr:["ssr","sgn"],svk:["svk","sgn"],swc:["swc","sw"],swh:["swh","sw"],swl:["swl","sgn"],syy:["syy","sgn"],tmw:["tmw","ms"],tse:["tse","sgn"],tsm:["tsm","sgn"],tsq:["tsq","sgn"],tss:["tss","sgn"],tsy:["tsy","sgn"],tza:["tza","sgn"],ugn:["ugn","sgn"],ugy:["ugy","sgn"],ukl:["ukl","sgn"],uks:["uks","sgn"],urk:["urk","ms"],uzn:["uzn","uz"],uzs:["uzs","uz"],vgt:["vgt","sgn"],vkk:["vkk","ms"],vkt:["vkt","ms"],vsi:["vsi","sgn"],vsl:["vsl","sgn"],vsv:["vsv","sgn"],wuu:["wuu","zh"],xki:["xki","sgn"],xml:["xml","sgn"],xmm:["xmm","ms"],xms:["xms","sgn"],yds:["yds","sgn"],ysl:["ysl","sgn"],yue:["yue","zh"],zib:["zib","sgn"],zlm:["zlm","ms"],zmi:["zmi","ms"],zsl:["zsl","sgn"],zsm:["zsm","ms"]}},Le=/^[A-Z]{3}$/,Pe="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol?"symbol":typeof e},Ne=function(){var e="function"==typeof Symbol&&Symbol.for&&Symbol.for("react.element")||60103;return function(r,t,n,a){var i=r&&r.defaultProps,o=arguments.length-3;if(t||0===o||(t={}),t&&i)for(var s in i)void 0===t[s]&&(t[s]=i[s]);else t||(t=i||{});if(1===o)t.children=a;else if(o>1){for(var l=Array(o),c=0;c<o;c++)l[c]=arguments[c+3];t.children=l}return{$$typeof:e,type:r,key:void 0===n?null:""+n,ref:null,props:t,_owner:null}}}(),Te=function(e){return function(){var r=e.apply(this,arguments);return new Promise(function(e,t){function n(a,i){try{var o=r[a](i),s=o.value}catch(e){return void t(e)}return o.done?void e(s):Promise.resolve(s).then(function(e){return n("next",e)},function(e){return n("throw",e)})}return n("next")})}},_e=function(e,r){if(!(e instanceof r))throw new TypeError("Cannot call a class as a function")},Ie=function(){function e(e,r){for(var t=0;t<r.length;t++){var n=r[t];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(r,t,n){return t&&e(r.prototype,t),n&&e(r,n),r}}(),Ae=function(e,r){for(var t in r){var n=r[t];n.configurable=n.enumerable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,t,n)}return e},Me=function(e,r){for(var t=Object.getOwnPropertyNames(r),n=0;n<t.length;n++){var a=t[n],i=Object.getOwnPropertyDescriptor(r,a);i&&i.configurable&&void 0===e[a]&&Object.defineProperty(e,a,i)}return e},Re=function(e,r,t){return r in e?Object.defineProperty(e,r,{value:t,enumerable:!0,configurable:!0,writable:!0}):e[r]=t,e},qe=Object.assign||function(e){for(var r=1;r<arguments.length;r++){var t=arguments[r];for(var n in t)Object.prototype.hasOwnProperty.call(t,n)&&(e[n]=t[n])}return e},Ce=function e(r,t,n){null===r&&(r=Function.prototype);var a=Object.getOwnPropertyDescriptor(r,t);if(void 0===a){var i=Object.getPrototypeOf(r);return null===i?void 0:e(i,t,n)}if("value"in a)return a.value;var o=a.get;if(void 0!==o)return o.call(n)},Ge=function(e,r){if("function"!=typeof r&&null!==r)throw new TypeError("Super expression must either be null or a function, not "+typeof r);e.prototype=Object.create(r&&r.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),r&&(Object.setPrototypeOf?Object.setPrototypeOf(e,r):e.__proto__=r)},Ze=function(e,r){return null!=r&&"undefined"!=typeof Symbol&&r[Symbol.hasInstance]?r[Symbol.hasInstance](e):e instanceof r},Be=function(e){return e&&e.__esModule?e:{default:e}},Ue=function(e){if(e&&e.__esModule)return e;var r={};if(null!=e)for(var t in e)Object.prototype.hasOwnProperty.call(e,t)&&(r[t]=e[t]);return r.default=e,r},$e=function(e,r){if(e!==r)throw new TypeError("Cannot instantiate an arrow function")},Ke=function(e){if(null==e)throw new TypeError("Cannot destructure undefined")},Ye=function(e,r){var t={};for(var n in e)r.indexOf(n)>=0||Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t},He=function(e,r){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!r||"object"!=typeof r&&"function"!=typeof r?e:r},We="undefined"==typeof global?self:global,Xe=function e(r,t,n,a){var i=Object.getOwnPropertyDescriptor(r,t);if(void 0===i){var o=Object.getPrototypeOf(r);null!==o&&e(o,t,n,a)}else if("value"in i&&i.writable)i.value=n;else{var s=i.set;void 0!==s&&s.call(a,n)}return n},Ve=function(){function e(e,r){var t=[],n=!0,a=!1,i=void 0;try{for(var o,s=e[Symbol.iterator]();!(n=(o=s.next()).done)&&(t.push(o.value),!r||t.length!==r);n=!0);}catch(e){a=!0,i=e}finally{try{!n&&s.return&&s.return()}finally{if(a)throw i}}return t}return function(r,t){if(Array.isArray(r))return r;if(Symbol.iterator in Object(r))return e(r,t);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),Je=function(e,r){if(Array.isArray(e))return e;if(Symbol.iterator in Object(e)){for(var t,n=[],a=e[Symbol.iterator]();!(t=a.next()).done&&(n.push(t.value),
+!r||n.length!==r););return n}throw new TypeError("Invalid attempt to destructure non-iterable instance")},Qe=function(e,r){return Object.freeze(Object.defineProperties(e,{raw:{value:Object.freeze(r)}}))},er=function(e,r){return e.raw=r,e},rr=function(e,r,t){if(e===t)throw new ReferenceError(r+" is not defined - temporal dead zone");return e},tr={},nr=function(e){return Array.isArray(e)?e:Array.from(e)},ar=function(e){if(Array.isArray(e)){for(var r=0,t=Array(e.length);r<e.length;r++)t[r]=e[r];return t}return Array.from(e)},ir=Object.freeze({jsx:Ne,asyncToGenerator:Te,classCallCheck:_e,createClass:Ie,defineEnumerableProperties:Ae,defaults:Me,defineProperty:Re,get:Ce,inherits:Ge,interopRequireDefault:Be,interopRequireWildcard:Ue,newArrowCheck:$e,objectDestructuringEmpty:Ke,objectWithoutProperties:Ye,possibleConstructorReturn:He,selfGlobal:We,set:Xe,slicedToArray:Ve,slicedToArrayLoose:Je,taggedTemplateLiteral:Qe,taggedTemplateLiteralLoose:er,temporalRef:rr,temporalUndefined:tr,toArray:nr,toConsumableArray:ar,typeof:Pe,extends:qe,instanceof:Ze}),or=/-u(?:-[0-9a-z]{2,8})+/gi,sr={};sr.getCanonicalLocales=function(e){var r=f(e),t=[];for(var n in r)t.push(r[n]);return t};var lr={BHD:3,BYR:0,XOF:0,BIF:0,XAF:0,CLF:4,CLP:0,KMF:0,DJF:0,XPF:0,GNF:0,ISK:0,IQD:3,JPY:0,JOD:3,KRW:0,KWD:3,LYD:3,OMR:3,PYG:0,RWF:0,TND:3,UGX:0,UYI:0,VUV:0,VND:0};re(sr,"NumberFormat",{configurable:!0,writable:!0,value:D}),re(sr.NumberFormat,"prototype",{writable:!1}),ue.NumberFormat={"[[availableLocales]]":[],"[[relevantExtensionKeys]]":["nu"],"[[localeData]]":{}},re(sr.NumberFormat,"supportedLocalesOf",{configurable:!0,writable:!0,value:ce.call(function(e){if(!ee.call(this,"[[availableLocales]]"))throw new TypeError("supportedLocalesOf() is not a constructor");var r=n(),t=arguments[1],a=this["[[availableLocales]]"],i=f(e);return r(),b(a,i,t)},ue.NumberFormat)}),re(sr.NumberFormat.prototype,"format",{configurable:!0,get:k}),sr.NumberFormat.prototype.formatToParts=function(e){var r=null!==this&&"object"===ir.typeof(this)&&i(this);if(!r||!r["[[initializedNumberFormat]]"])throw new TypeError("`this` value for formatToParts() is not an initialized Intl.NumberFormat object.");var t=Number(e);return F(this,t)};var cr={arab:["٠","١","٢","٣","٤","٥","٦","٧","٨","٩"],arabext:["۰","۱","۲","۳","۴","۵","۶","۷","۸","۹"],bali:["᭐","᭑","᭒","᭓","᭔","᭕","᭖","᭗","᭘","᭙"],beng:["০","১","২","৩","৪","৫","৬","৭","৮","৯"],deva:["०","१","२","३","४","५","६","७","८","९"],fullwide:["０","１","２","３","４","５","６","７","８","９"],gujr:["૦","૧","૨","૩","૪","૫","૬","૭","૮","૯"],guru:["੦","੧","੨","੩","੪","੫","੬","੭","੮","੯"],hanidec:["〇","一","二","三","四","五","六","七","八","九"],khmr:["០","១","២","៣","៤","៥","៦","៧","៨","៩"],knda:["೦","೧","೨","೩","೪","೫","೬","೭","೮","೯"],laoo:["໐","໑","໒","໓","໔","໕","໖","໗","໘","໙"],latn:["0","1","2","3","4","5","6","7","8","9"],limb:["᥆","᥇","᥈","᥉","᥊","᥋","᥌","᥍","᥎","᥏"],mlym:["൦","൧","൨","൩","൪","൫","൬","൭","൮","൯"],mong:["᠐","᠑","᠒","᠓","᠔","᠕","᠖","᠗","᠘","᠙"],mymr:["၀","၁","၂","၃","၄","၅","၆","၇","၈","၉"],orya:["୦","୧","୨","୩","୪","୫","୬","୭","୮","୯"],tamldec:["௦","௧","௨","௩","௪","௫","௬","௭","௮","௯"],telu:["౦","౧","౨","౩","౪","౫","౬","౭","౮","౯"],thai:["๐","๑","๒","๓","๔","๕","๖","๗","๘","๙"],tibt:["༠","༡","༢","༣","༤","༥","༦","༧","༨","༩"]};re(sr.NumberFormat.prototype,"resolvedOptions",{configurable:!0,writable:!0,value:function(){var e=void 0,t=new r,n=["locale","numberingSystem","style","currency","currencyDisplay","minimumIntegerDigits","minimumFractionDigits","maximumFractionDigits","minimumSignificantDigits","maximumSignificantDigits","useGrouping"],a=null!==this&&"object"===ir.typeof(this)&&i(this);if(!a||!a["[[initializedNumberFormat]]"])throw new TypeError("`this` value for resolvedOptions() is not an initialized Intl.NumberFormat object.");for(var o=0,s=n.length;o<s;o++)ee.call(a,e="[["+n[o]+"]]")&&(t[n[o]]={value:a[e],writable:!0,configurable:!0,enumerable:!0});return ne({},t)}});var ur=/(?:[Eec]{1,6}|G{1,5}|[Qq]{1,5}|(?:[yYur]+|U{1,5})|[ML]{1,5}|d{1,2}|D{1,3}|F{1}|[abB]{1,5}|[hkHK]{1,2}|w{1,2}|W{1}|m{1,2}|s{1,2}|[zZOvVxX]{1,4})(?=([^']*'[^']*')*[^']*$)/g,gr=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,fr=/[rqQASjJgwWIQq]/,mr=["era","year","month","day","weekday","quarter"],vr=["hour","minute","second","hour12","timeZoneName"],dr={second:{numeric:"s","2-digit":"ss"},minute:{numeric:"m","2-digit":"mm"},year:{numeric:"y","2-digit":"yy"},day:{numeric:"d","2-digit":"dd"},month:{numeric:"L","2-digit":"LL",narrow:"LLLLL",short:"LLL",long:"LLLL"},weekday:{narrow:"ccccc",short:"ccc",long:"cccc"}},hr=ne(null,{narrow:{},short:{},long:{}});re(sr,"DateTimeFormat",{configurable:!0,writable:!0,value:C}),re(C,"prototype",{writable:!1});var pr={weekday:["narrow","short","long"],era:["narrow","short","long"],year:["2-digit","numeric"],month:["2-digit","numeric","narrow","short","long"],day:["2-digit","numeric"],hour:["2-digit","numeric"],minute:["2-digit","numeric"],second:["2-digit","numeric"],timeZoneName:["short","long"]};ue.DateTimeFormat={"[[availableLocales]]":[],"[[relevantExtensionKeys]]":["ca","nu"],"[[localeData]]":{}},re(sr.DateTimeFormat,"supportedLocalesOf",{configurable:!0,writable:!0,value:ce.call(function(e){if(!ee.call(this,"[[availableLocales]]"))throw new TypeError("supportedLocalesOf() is not a constructor");var r=n(),t=arguments[1],a=this["[[availableLocales]]"],i=f(e);return r(),b(a,i,t)},ue.NumberFormat)}),re(sr.DateTimeFormat.prototype,"format",{configurable:!0,get:K}),sr.DateTimeFormat.prototype.formatToParts=function(){var e=null!==this&&"object"===ir.typeof(this)&&i(this);if(!e||!e["[[initializedDateTimeFormat]]"])throw new TypeError("`this` value for formatToParts() is not an initialized Intl.DateTimeFormat object.");if(void 0===e["[[boundFormatToParts]]"]){var r=function(){var e=Number(0===arguments.length?Date.now():arguments[0]);return W(this,e)},t=ce.call(r,this);e["[[boundFormatToParts]]"]=t}return e["[[boundFormatToParts]]"]},re(sr.DateTimeFormat.prototype,"resolvedOptions",{writable:!0,configurable:!0,value:function(){var e=void 0,t=new r,n=["locale","calendar","numberingSystem","timeZone","hour12","weekday","era","year","month","day","hour","minute","second","timeZoneName"],a=null!==this&&"object"===ir.typeof(this)&&i(this);if(!a||!a["[[initializedDateTimeFormat]]"])throw new TypeError("`this` value for resolvedOptions() is not an initialized Intl.DateTimeFormat object.");for(var o=0,s=n.length;o<s;o++)ee.call(a,e="[["+n[o]+"]]")&&(t[n[o]]={value:a[e],writable:!0,configurable:!0,enumerable:!0});return ne({},t)}});var yr=sr.__localeSensitiveProtos={Number:{},Date:{}};if(yr.Number.toLocaleString=function(){if("[object Number]"!==Object.prototype.toString.call(this))throw new TypeError("`this` value must be a number for Number.prototype.toLocaleString()");return S(new D(arguments[0],arguments[1]),this)},yr.Date.toLocaleString=function(){if("[object Date]"!==Object.prototype.toString.call(this))throw new TypeError("`this` value must be a Date instance for Date.prototype.toLocaleString()");var e=+this;if(isNaN(e))return"Invalid Date";var r=arguments[0],t=arguments[1];t=B(t,"any","all");var n=new C(r,t);return H(n,e)},yr.Date.toLocaleDateString=function(){if("[object Date]"!==Object.prototype.toString.call(this))throw new TypeError("`this` value must be a Date instance for Date.prototype.toLocaleDateString()");var e=+this;if(isNaN(e))return"Invalid Date";var r=arguments[0],t=arguments[1];t=B(t,"date","date");var n=new C(r,t);return H(n,e)},yr.Date.toLocaleTimeString=function(){if("[object Date]"!==Object.prototype.toString.call(this))throw new TypeError("`this` value must be a Date instance for Date.prototype.toLocaleTimeString()");var e=+this;if(isNaN(e))return"Invalid Date";var r=arguments[0],t=arguments[1];t=B(t,"time","time");var n=new C(r,t);return H(n,e)},re(sr,"__applyLocaleSensitivePrototypes",{writable:!0,configurable:!0,value:function(){re(Number.prototype,"toLocaleString",{writable:!0,configurable:!0,value:yr.Number.toLocaleString}),re(Date.prototype,"toLocaleString",{writable:!0,configurable:!0,value:yr.Date.toLocaleString});for(var e in yr.Date)ee.call(yr.Date,e)&&re(Date.prototype,e,{writable:!0,configurable:!0,value:yr.Date[e]})}}),re(sr,"__addLocaleData",{value:function(e){if(!l(e.locale))throw new Error("Object passed doesn't identify itself with a valid language tag");V(e,e.locale)}}),re(sr,"__disableRegExpRestore",{value:function(){ue.disableRegExpRestore=!0}}),"undefined"==typeof Intl)try{window.Intl=sr,sr.__applyLocaleSensitivePrototypes()}catch(e){}return sr});
+IntlPolyfill.__addLocaleData({locale:"en-US",date:{ca:["gregory","buddhist","chinese","coptic","dangi","ethioaa","ethiopic","generic","hebrew","indian","islamic","islamicc","japanese","persian","roc"],hourNo0:true,hour12:true,formats:{short:"{1}, {0}",medium:"{1}, {0}",full:"{1} 'at' {0}",long:"{1} 'at' {0}",availableFormats:{"d":"d","E":"ccc",Ed:"d E",Ehm:"E h:mm a",EHm:"E HH:mm",Ehms:"E h:mm:ss a",EHms:"E HH:mm:ss",Gy:"y G",GyMMM:"MMM y G",GyMMMd:"MMM d, y G",GyMMMEd:"E, MMM d, y G","h":"h a","H":"HH",hm:"h:mm a",Hm:"HH:mm",hms:"h:mm:ss a",Hms:"HH:mm:ss",hmsv:"h:mm:ss a v",Hmsv:"HH:mm:ss v",hmv:"h:mm a v",Hmv:"HH:mm v","M":"L",Md:"M/d",MEd:"E, M/d",MMM:"LLL",MMMd:"MMM d",MMMEd:"E, MMM d",MMMMd:"MMMM d",ms:"mm:ss","y":"y",yM:"M/y",yMd:"M/d/y",yMEd:"E, M/d/y",yMMM:"MMM y",yMMMd:"MMM d, y",yMMMEd:"E, MMM d, y",yMMMM:"MMMM y",yQQQ:"QQQ y",yQQQQ:"QQQQ y"},dateFormats:{yMMMMEEEEd:"EEEE, MMMM d, y",yMMMMd:"MMMM d, y",yMMMd:"MMM d, y",yMd:"M/d/yy"},timeFormats:{hmmsszzzz:"h:mm:ss a zzzz",hmsz:"h:mm:ss a z",hms:"h:mm:ss a",hm:"h:mm a"}},calendars:{buddhist:{months:{narrow:["J","F","M","A","M","J","J","A","S","O","N","D"],short:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],long:["January","February","March","April","May","June","July","August","September","October","November","December"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["BE"],short:["BE"],long:["BE"]},dayPeriods:{am:"AM",pm:"PM"}},chinese:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Mo1","Mo2","Mo3","Mo4","Mo5","Mo6","Mo7","Mo8","Mo9","Mo10","Mo11","Mo12"],long:["Month1","Month2","Month3","Month4","Month5","Month6","Month7","Month8","Month9","Month10","Month11","Month12"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},dayPeriods:{am:"AM",pm:"PM"}},coptic:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12","13"],short:["Tout","Baba","Hator","Kiahk","Toba","Amshir","Baramhat","Baramouda","Bashans","Paona","Epep","Mesra","Nasie"],long:["Tout","Baba","Hator","Kiahk","Toba","Amshir","Baramhat","Baramouda","Bashans","Paona","Epep","Mesra","Nasie"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["ERA0","ERA1"],short:["ERA0","ERA1"],long:["ERA0","ERA1"]},dayPeriods:{am:"AM",pm:"PM"}},dangi:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Mo1","Mo2","Mo3","Mo4","Mo5","Mo6","Mo7","Mo8","Mo9","Mo10","Mo11","Mo12"],long:["Month1","Month2","Month3","Month4","Month5","Month6","Month7","Month8","Month9","Month10","Month11","Month12"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},dayPeriods:{am:"AM",pm:"PM"}},ethiopic:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12","13"],short:["Meskerem","Tekemt","Hedar","Tahsas","Ter","Yekatit","Megabit","Miazia","Genbot","Sene","Hamle","Nehasse","Pagumen"],long:["Meskerem","Tekemt","Hedar","Tahsas","Ter","Yekatit","Megabit","Miazia","Genbot","Sene","Hamle","Nehasse","Pagumen"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["ERA0","ERA1"],short:["ERA0","ERA1"],long:["ERA0","ERA1"]},dayPeriods:{am:"AM",pm:"PM"}},ethioaa:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12","13"],short:["Meskerem","Tekemt","Hedar","Tahsas","Ter","Yekatit","Megabit","Miazia","Genbot","Sene","Hamle","Nehasse","Pagumen"],long:["Meskerem","Tekemt","Hedar","Tahsas","Ter","Yekatit","Megabit","Miazia","Genbot","Sene","Hamle","Nehasse","Pagumen"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["ERA0"],short:["ERA0"],long:["ERA0"]},dayPeriods:{am:"AM",pm:"PM"}},generic:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["M01","M02","M03","M04","M05","M06","M07","M08","M09","M10","M11","M12"],long:["M01","M02","M03","M04","M05","M06","M07","M08","M09","M10","M11","M12"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["ERA0","ERA1"],short:["ERA0","ERA1"],long:["ERA0","ERA1"]},dayPeriods:{am:"AM",pm:"PM"}},gregory:{months:{narrow:["J","F","M","A","M","J","J","A","S","O","N","D"],short:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],long:["January","February","March","April","May","June","July","August","September","October","November","December"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["B","A","BCE","CE"],short:["BC","AD","BCE","CE"],long:["Before Christ","Anno Domini","Before Common Era","Common Era"]},dayPeriods:{am:"AM",pm:"PM"}},hebrew:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12","13","7"],short:["Tishri","Heshvan","Kislev","Tevet","Shevat","Adar I","Adar","Nisan","Iyar","Sivan","Tamuz","Av","Elul","Adar II"],long:["Tishri","Heshvan","Kislev","Tevet","Shevat","Adar I","Adar","Nisan","Iyar","Sivan","Tamuz","Av","Elul","Adar II"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["AM"],short:["AM"],long:["AM"]},dayPeriods:{am:"AM",pm:"PM"}},indian:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Chaitra","Vaisakha","Jyaistha","Asadha","Sravana","Bhadra","Asvina","Kartika","Agrahayana","Pausa","Magha","Phalguna"],long:["Chaitra","Vaisakha","Jyaistha","Asadha","Sravana","Bhadra","Asvina","Kartika","Agrahayana","Pausa","Magha","Phalguna"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["Saka"],short:["Saka"],long:["Saka"]},dayPeriods:{am:"AM",pm:"PM"}},islamic:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Muh.","Saf.","Rab. I","Rab. II","Jum. I","Jum. II","Raj.","Sha.","Ram.","Shaw.","Dhuʻl-Q.","Dhuʻl-H."],long:["Muharram","Safar","Rabiʻ I","Rabiʻ II","Jumada I","Jumada II","Rajab","Shaʻban","Ramadan","Shawwal","Dhuʻl-Qiʻdah","Dhuʻl-Hijjah"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["AH"],short:["AH"],long:["AH"]},dayPeriods:{am:"AM",pm:"PM"}},islamicc:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Muh.","Saf.","Rab. I","Rab. II","Jum. I","Jum. II","Raj.","Sha.","Ram.","Shaw.","Dhuʻl-Q.","Dhuʻl-H."],long:["Muharram","Safar","Rabiʻ I","Rabiʻ II","Jumada I","Jumada II","Rajab","Shaʻban","Ramadan","Shawwal","Dhuʻl-Qiʻdah","Dhuʻl-Hijjah"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["AH"],short:["AH"],long:["AH"]},dayPeriods:{am:"AM",pm:"PM"}},japanese:{months:{narrow:["J","F","M","A","M","J","J","A","S","O","N","D"],short:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],long:["January","February","March","April","May","June","July","August","September","October","November","December"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["Taika (645–650)","Hakuchi (650–671)","Hakuhō (672–686)","Shuchō (686–701)","Taihō (701–704)","Keiun (704–708)","Wadō (708–715)","Reiki (715–717)","Yōrō (717–724)","Jinki (724–729)","Tenpyō (729–749)","Tenpyō-kampō (749-749)","Tenpyō-shōhō (749-757)","Tenpyō-hōji (757-765)","Tenpyō-jingo (765-767)","Jingo-keiun (767-770)","Hōki (770–780)","Ten-ō (781-782)","Enryaku (782–806)","Daidō (806–810)","Kōnin (810–824)","Tenchō (824–834)","Jōwa (834–848)","Kajō (848–851)","Ninju (851–854)","Saikō (854–857)","Ten-an (857-859)","Jōgan (859–877)","Gangyō (877–885)","Ninna (885–889)","Kanpyō (889–898)","Shōtai (898–901)","Engi (901–923)","Enchō (923–931)","Jōhei (931–938)","Tengyō (938–947)","Tenryaku (947–957)","Tentoku (957–961)","Ōwa (961–964)","Kōhō (964–968)","Anna (968–970)","Tenroku (970–973)","Ten’en (973–976)","Jōgen (976–978)","Tengen (978–983)","Eikan (983–985)","Kanna (985–987)","Eien (987–989)","Eiso (989–990)","Shōryaku (990–995)","Chōtoku (995–999)","Chōhō (999–1004)","Kankō (1004–1012)","Chōwa (1012–1017)","Kannin (1017–1021)","Jian (1021–1024)","Manju (1024–1028)","Chōgen (1028–1037)","Chōryaku (1037–1040)","Chōkyū (1040–1044)","Kantoku (1044–1046)","Eishō (1046–1053)","Tengi (1053–1058)","Kōhei (1058–1065)","Jiryaku (1065–1069)","Enkyū (1069–1074)","Shōho (1074–1077)","Shōryaku (1077–1081)","Eihō (1081–1084)","Ōtoku (1084–1087)","Kanji (1087–1094)","Kahō (1094–1096)","Eichō (1096–1097)","Jōtoku (1097–1099)","Kōwa (1099–1104)","Chōji (1104–1106)","Kashō (1106–1108)","Tennin (1108–1110)","Ten-ei (1110-1113)","Eikyū (1113–1118)","Gen’ei (1118–1120)","Hōan (1120–1124)","Tenji (1124–1126)","Daiji (1126–1131)","Tenshō (1131–1132)","Chōshō (1132–1135)","Hōen (1135–1141)","Eiji (1141–1142)","Kōji (1142–1144)","Ten’yō (1144–1145)","Kyūan (1145–1151)","Ninpei (1151–1154)","Kyūju (1154–1156)","Hōgen (1156–1159)","Heiji (1159–1160)","Eiryaku (1160–1161)","Ōho (1161–1163)","Chōkan (1163–1165)","Eiman (1165–1166)","Nin’an (1166–1169)","Kaō (1169–1171)","Shōan (1171–1175)","Angen (1175–1177)","Jishō (1177–1181)","Yōwa (1181–1182)","Juei (1182–1184)","Genryaku (1184–1185)","Bunji (1185–1190)","Kenkyū (1190–1199)","Shōji (1199–1201)","Kennin (1201–1204)","Genkyū (1204–1206)","Ken’ei (1206–1207)","Jōgen (1207–1211)","Kenryaku (1211–1213)","Kenpō (1213–1219)","Jōkyū (1219–1222)","Jōō (1222–1224)","Gennin (1224–1225)","Karoku (1225–1227)","Antei (1227–1229)","Kanki (1229–1232)","Jōei (1232–1233)","Tenpuku (1233–1234)","Bunryaku (1234–1235)","Katei (1235–1238)","Ryakunin (1238–1239)","En’ō (1239–1240)","Ninji (1240–1243)","Kangen (1243–1247)","Hōji (1247–1249)","Kenchō (1249–1256)","Kōgen (1256–1257)","Shōka (1257–1259)","Shōgen (1259–1260)","Bun’ō (1260–1261)","Kōchō (1261–1264)","Bun’ei (1264–1275)","Kenji (1275–1278)","Kōan (1278–1288)","Shōō (1288–1293)","Einin (1293–1299)","Shōan (1299–1302)","Kengen (1302–1303)","Kagen (1303–1306)","Tokuji (1306–1308)","Enkyō (1308–1311)","Ōchō (1311–1312)","Shōwa (1312–1317)","Bunpō (1317–1319)","Genō (1319–1321)","Genkō (1321–1324)","Shōchū (1324–1326)","Karyaku (1326–1329)","Gentoku (1329–1331)","Genkō (1331–1334)","Kenmu (1334–1336)","Engen (1336–1340)","Kōkoku (1340–1346)","Shōhei (1346–1370)","Kentoku (1370–1372)","Bunchū (1372–1375)","Tenju (1375–1379)","Kōryaku (1379–1381)","Kōwa (1381–1384)","Genchū (1384–1392)","Meitoku (1384–1387)","Kakei (1387–1389)","Kōō (1389–1390)","Meitoku (1390–1394)","Ōei (1394–1428)","Shōchō (1428–1429)","Eikyō (1429–1441)","Kakitsu (1441–1444)","Bun’an (1444–1449)","Hōtoku (1449–1452)","Kyōtoku (1452–1455)","Kōshō (1455–1457)","Chōroku (1457–1460)","Kanshō (1460–1466)","Bunshō (1466–1467)","Ōnin (1467–1469)","Bunmei (1469–1487)","Chōkyō (1487–1489)","Entoku (1489–1492)","Meiō (1492–1501)","Bunki (1501–1504)","Eishō (1504–1521)","Taiei (1521–1528)","Kyōroku (1528–1532)","Tenbun (1532–1555)","Kōji (1555–1558)","Eiroku (1558–1570)","Genki (1570–1573)","Tenshō (1573–1592)","Bunroku (1592–1596)","Keichō (1596–1615)","Genna (1615–1624)","Kan’ei (1624–1644)","Shōho (1644–1648)","Keian (1648–1652)","Jōō (1652–1655)","Meireki (1655–1658)","Manji (1658–1661)","Kanbun (1661–1673)","Enpō (1673–1681)","Tenna (1681–1684)","Jōkyō (1684–1688)","Genroku (1688–1704)","Hōei (1704–1711)","Shōtoku (1711–1716)","Kyōhō (1716–1736)","Genbun (1736–1741)","Kanpō (1741–1744)","Enkyō (1744–1748)","Kan’en (1748–1751)","Hōreki (1751–1764)","Meiwa (1764–1772)","An’ei (1772–1781)","Tenmei (1781–1789)","Kansei (1789–1801)","Kyōwa (1801–1804)","Bunka (1804–1818)","Bunsei (1818–1830)","Tenpō (1830–1844)","Kōka (1844–1848)","Kaei (1848–1854)","Ansei (1854–1860)","Man’en (1860–1861)","Bunkyū (1861–1864)","Genji (1864–1865)","Keiō (1865–1868)","M","T","S","H"],short:["Taika (645–650)","Hakuchi (650–671)","Hakuhō (672–686)","Shuchō (686–701)","Taihō (701–704)","Keiun (704–708)","Wadō (708–715)","Reiki (715–717)","Yōrō (717–724)","Jinki (724–729)","Tenpyō (729–749)","Tenpyō-kampō (749-749)","Tenpyō-shōhō (749-757)","Tenpyō-hōji (757-765)","Tenpyō-jingo (765-767)","Jingo-keiun (767-770)","Hōki (770–780)","Ten-ō (781-782)","Enryaku (782–806)","Daidō (806–810)","Kōnin (810–824)","Tenchō (824–834)","Jōwa (834–848)","Kajō (848–851)","Ninju (851–854)","Saikō (854–857)","Ten-an (857-859)","Jōgan (859–877)","Gangyō (877–885)","Ninna (885–889)","Kanpyō (889–898)","Shōtai (898–901)","Engi (901–923)","Enchō (923–931)","Jōhei (931–938)","Tengyō (938–947)","Tenryaku (947–957)","Tentoku (957–961)","Ōwa (961–964)","Kōhō (964–968)","Anna (968–970)","Tenroku (970–973)","Ten’en (973–976)","Jōgen (976–978)","Tengen (978–983)","Eikan (983–985)","Kanna (985–987)","Eien (987–989)","Eiso (989–990)","Shōryaku (990–995)","Chōtoku (995–999)","Chōhō (999–1004)","Kankō (1004–1012)","Chōwa (1012–1017)","Kannin (1017–1021)","Jian (1021–1024)","Manju (1024–1028)","Chōgen (1028–1037)","Chōryaku (1037–1040)","Chōkyū (1040–1044)","Kantoku (1044–1046)","Eishō (1046–1053)","Tengi (1053–1058)","Kōhei (1058–1065)","Jiryaku (1065–1069)","Enkyū (1069–1074)","Shōho (1074–1077)","Shōryaku (1077–1081)","Eihō (1081–1084)","Ōtoku (1084–1087)","Kanji (1087–1094)","Kahō (1094–1096)","Eichō (1096–1097)","Jōtoku (1097–1099)","Kōwa (1099–1104)","Chōji (1104–1106)","Kashō (1106–1108)","Tennin (1108–1110)","Ten-ei (1110-1113)","Eikyū (1113–1118)","Gen’ei (1118–1120)","Hōan (1120–1124)","Tenji (1124–1126)","Daiji (1126–1131)","Tenshō (1131–1132)","Chōshō (1132–1135)","Hōen (1135–1141)","Eiji (1141–1142)","Kōji (1142–1144)","Ten’yō (1144–1145)","Kyūan (1145–1151)","Ninpei (1151–1154)","Kyūju (1154–1156)","Hōgen (1156–1159)","Heiji (1159–1160)","Eiryaku (1160–1161)","Ōho (1161–1163)","Chōkan (1163–1165)","Eiman (1165–1166)","Nin’an (1166–1169)","Kaō (1169–1171)","Shōan (1171–1175)","Angen (1175–1177)","Jishō (1177–1181)","Yōwa (1181–1182)","Juei (1182–1184)","Genryaku (1184–1185)","Bunji (1185–1190)","Kenkyū (1190–1199)","Shōji (1199–1201)","Kennin (1201–1204)","Genkyū (1204–1206)","Ken’ei (1206–1207)","Jōgen (1207–1211)","Kenryaku (1211–1213)","Kenpō (1213–1219)","Jōkyū (1219–1222)","Jōō (1222–1224)","Gennin (1224–1225)","Karoku (1225–1227)","Antei (1227–1229)","Kanki (1229–1232)","Jōei (1232–1233)","Tenpuku (1233–1234)","Bunryaku (1234–1235)","Katei (1235–1238)","Ryakunin (1238–1239)","En’ō (1239–1240)","Ninji (1240–1243)","Kangen (1243–1247)","Hōji (1247–1249)","Kenchō (1249–1256)","Kōgen (1256–1257)","Shōka (1257–1259)","Shōgen (1259–1260)","Bun’ō (1260–1261)","Kōchō (1261–1264)","Bun’ei (1264–1275)","Kenji (1275–1278)","Kōan (1278–1288)","Shōō (1288–1293)","Einin (1293–1299)","Shōan (1299–1302)","Kengen (1302–1303)","Kagen (1303–1306)","Tokuji (1306–1308)","Enkyō (1308–1311)","Ōchō (1311–1312)","Shōwa (1312–1317)","Bunpō (1317–1319)","Genō (1319–1321)","Genkō (1321–1324)","Shōchū (1324–1326)","Karyaku (1326–1329)","Gentoku (1329–1331)","Genkō (1331–1334)","Kenmu (1334–1336)","Engen (1336–1340)","Kōkoku (1340–1346)","Shōhei (1346–1370)","Kentoku (1370–1372)","Bunchū (1372–1375)","Tenju (1375–1379)","Kōryaku (1379–1381)","Kōwa (1381–1384)","Genchū (1384–1392)","Meitoku (1384–1387)","Kakei (1387–1389)","Kōō (1389–1390)","Meitoku (1390–1394)","Ōei (1394–1428)","Shōchō (1428–1429)","Eikyō (1429–1441)","Kakitsu (1441–1444)","Bun’an (1444–1449)","Hōtoku (1449–1452)","Kyōtoku (1452–1455)","Kōshō (1455–1457)","Chōroku (1457–1460)","Kanshō (1460–1466)","Bunshō (1466–1467)","Ōnin (1467–1469)","Bunmei (1469–1487)","Chōkyō (1487–1489)","Entoku (1489–1492)","Meiō (1492–1501)","Bunki (1501–1504)","Eishō (1504–1521)","Taiei (1521–1528)","Kyōroku (1528–1532)","Tenbun (1532–1555)","Kōji (1555–1558)","Eiroku (1558–1570)","Genki (1570–1573)","Tenshō (1573–1592)","Bunroku (1592–1596)","Keichō (1596–1615)","Genna (1615–1624)","Kan’ei (1624–1644)","Shōho (1644–1648)","Keian (1648–1652)","Jōō (1652–1655)","Meireki (1655–1658)","Manji (1658–1661)","Kanbun (1661–1673)","Enpō (1673–1681)","Tenna (1681–1684)","Jōkyō (1684–1688)","Genroku (1688–1704)","Hōei (1704–1711)","Shōtoku (1711–1716)","Kyōhō (1716–1736)","Genbun (1736–1741)","Kanpō (1741–1744)","Enkyō (1744–1748)","Kan’en (1748–1751)","Hōreki (1751–1764)","Meiwa (1764–1772)","An’ei (1772–1781)","Tenmei (1781–1789)","Kansei (1789–1801)","Kyōwa (1801–1804)","Bunka (1804–1818)","Bunsei (1818–1830)","Tenpō (1830–1844)","Kōka (1844–1848)","Kaei (1848–1854)","Ansei (1854–1860)","Man’en (1860–1861)","Bunkyū (1861–1864)","Genji (1864–1865)","Keiō (1865–1868)","Meiji","Taishō","Shōwa","Heisei"],long:["Taika (645–650)","Hakuchi (650–671)","Hakuhō (672–686)","Shuchō (686–701)","Taihō (701–704)","Keiun (704–708)","Wadō (708–715)","Reiki (715–717)","Yōrō (717–724)","Jinki (724–729)","Tenpyō (729–749)","Tenpyō-kampō (749-749)","Tenpyō-shōhō (749-757)","Tenpyō-hōji (757-765)","Tenpyō-jingo (765-767)","Jingo-keiun (767-770)","Hōki (770–780)","Ten-ō (781-782)","Enryaku (782–806)","Daidō (806–810)","Kōnin (810–824)","Tenchō (824–834)","Jōwa (834–848)","Kajō (848–851)","Ninju (851–854)","Saikō (854–857)","Ten-an (857-859)","Jōgan (859–877)","Gangyō (877–885)","Ninna (885–889)","Kanpyō (889–898)","Shōtai (898–901)","Engi (901–923)","Enchō (923–931)","Jōhei (931–938)","Tengyō (938–947)","Tenryaku (947–957)","Tentoku (957–961)","Ōwa (961–964)","Kōhō (964–968)","Anna (968–970)","Tenroku (970–973)","Ten’en (973–976)","Jōgen (976–978)","Tengen (978–983)","Eikan (983–985)","Kanna (985–987)","Eien (987–989)","Eiso (989–990)","Shōryaku (990–995)","Chōtoku (995–999)","Chōhō (999–1004)","Kankō (1004–1012)","Chōwa (1012–1017)","Kannin (1017–1021)","Jian (1021–1024)","Manju (1024–1028)","Chōgen (1028–1037)","Chōryaku (1037–1040)","Chōkyū (1040–1044)","Kantoku (1044–1046)","Eishō (1046–1053)","Tengi (1053–1058)","Kōhei (1058–1065)","Jiryaku (1065–1069)","Enkyū (1069–1074)","Shōho (1074–1077)","Shōryaku (1077–1081)","Eihō (1081–1084)","Ōtoku (1084–1087)","Kanji (1087–1094)","Kahō (1094–1096)","Eichō (1096–1097)","Jōtoku (1097–1099)","Kōwa (1099–1104)","Chōji (1104–1106)","Kashō (1106–1108)","Tennin (1108–1110)","Ten-ei (1110-1113)","Eikyū (1113–1118)","Gen’ei (1118–1120)","Hōan (1120–1124)","Tenji (1124–1126)","Daiji (1126–1131)","Tenshō (1131–1132)","Chōshō (1132–1135)","Hōen (1135–1141)","Eiji (1141–1142)","Kōji (1142–1144)","Ten’yō (1144–1145)","Kyūan (1145–1151)","Ninpei (1151–1154)","Kyūju (1154–1156)","Hōgen (1156–1159)","Heiji (1159–1160)","Eiryaku (1160–1161)","Ōho (1161–1163)","Chōkan (1163–1165)","Eiman (1165–1166)","Nin’an (1166–1169)","Kaō (1169–1171)","Shōan (1171–1175)","Angen (1175–1177)","Jishō (1177–1181)","Yōwa (1181–1182)","Juei (1182–1184)","Genryaku (1184–1185)","Bunji (1185–1190)","Kenkyū (1190–1199)","Shōji (1199–1201)","Kennin (1201–1204)","Genkyū (1204–1206)","Ken’ei (1206–1207)","Jōgen (1207–1211)","Kenryaku (1211–1213)","Kenpō (1213–1219)","Jōkyū (1219–1222)","Jōō (1222–1224)","Gennin (1224–1225)","Karoku (1225–1227)","Antei (1227–1229)","Kanki (1229–1232)","Jōei (1232–1233)","Tenpuku (1233–1234)","Bunryaku (1234–1235)","Katei (1235–1238)","Ryakunin (1238–1239)","En’ō (1239–1240)","Ninji (1240–1243)","Kangen (1243–1247)","Hōji (1247–1249)","Kenchō (1249–1256)","Kōgen (1256–1257)","Shōka (1257–1259)","Shōgen (1259–1260)","Bun’ō (1260–1261)","Kōchō (1261–1264)","Bun’ei (1264–1275)","Kenji (1275–1278)","Kōan (1278–1288)","Shōō (1288–1293)","Einin (1293–1299)","Shōan (1299–1302)","Kengen (1302–1303)","Kagen (1303–1306)","Tokuji (1306–1308)","Enkyō (1308–1311)","Ōchō (1311–1312)","Shōwa (1312–1317)","Bunpō (1317–1319)","Genō (1319–1321)","Genkō (1321–1324)","Shōchū (1324–1326)","Karyaku (1326–1329)","Gentoku (1329–1331)","Genkō (1331–1334)","Kenmu (1334–1336)","Engen (1336–1340)","Kōkoku (1340–1346)","Shōhei (1346–1370)","Kentoku (1370–1372)","Bunchū (1372–1375)","Tenju (1375–1379)","Kōryaku (1379–1381)","Kōwa (1381–1384)","Genchū (1384–1392)","Meitoku (1384–1387)","Kakei (1387–1389)","Kōō (1389–1390)","Meitoku (1390–1394)","Ōei (1394–1428)","Shōchō (1428–1429)","Eikyō (1429–1441)","Kakitsu (1441–1444)","Bun’an (1444–1449)","Hōtoku (1449–1452)","Kyōtoku (1452–1455)","Kōshō (1455–1457)","Chōroku (1457–1460)","Kanshō (1460–1466)","Bunshō (1466–1467)","Ōnin (1467–1469)","Bunmei (1469–1487)","Chōkyō (1487–1489)","Entoku (1489–1492)","Meiō (1492–1501)","Bunki (1501–1504)","Eishō (1504–1521)","Taiei (1521–1528)","Kyōroku (1528–1532)","Tenbun (1532–1555)","Kōji (1555–1558)","Eiroku (1558–1570)","Genki (1570–1573)","Tenshō (1573–1592)","Bunroku (1592–1596)","Keichō (1596–1615)","Genna (1615–1624)","Kan’ei (1624–1644)","Shōho (1644–1648)","Keian (1648–1652)","Jōō (1652–1655)","Meireki (1655–1658)","Manji (1658–1661)","Kanbun (1661–1673)","Enpō (1673–1681)","Tenna (1681–1684)","Jōkyō (1684–1688)","Genroku (1688–1704)","Hōei (1704–1711)","Shōtoku (1711–1716)","Kyōhō (1716–1736)","Genbun (1736–1741)","Kanpō (1741–1744)","Enkyō (1744–1748)","Kan’en (1748–1751)","Hōreki (1751–1764)","Meiwa (1764–1772)","An’ei (1772–1781)","Tenmei (1781–1789)","Kansei (1789–1801)","Kyōwa (1801–1804)","Bunka (1804–1818)","Bunsei (1818–1830)","Tenpō (1830–1844)","Kōka (1844–1848)","Kaei (1848–1854)","Ansei (1854–1860)","Man’en (1860–1861)","Bunkyū (1861–1864)","Genji (1864–1865)","Keiō (1865–1868)","Meiji","Taishō","Shōwa","Heisei"]},dayPeriods:{am:"AM",pm:"PM"}},persian:{months:{narrow:["1","2","3","4","5","6","7","8","9","10","11","12"],short:["Farvardin","Ordibehesht","Khordad","Tir","Mordad","Shahrivar","Mehr","Aban","Azar","Dey","Bahman","Esfand"],long:["Farvardin","Ordibehesht","Khordad","Tir","Mordad","Shahrivar","Mehr","Aban","Azar","Dey","Bahman","Esfand"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["AP"],short:["AP"],long:["AP"]},dayPeriods:{am:"AM",pm:"PM"}},roc:{months:{narrow:["J","F","M","A","M","J","J","A","S","O","N","D"],short:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],long:["January","February","March","April","May","June","July","August","September","October","November","December"]},days:{narrow:["S","M","T","W","T","F","S"],short:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],long:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]},eras:{narrow:["Before R.O.C.","Minguo"],short:["Before R.O.C.","Minguo"],long:["Before R.O.C.","Minguo"]},dayPeriods:{am:"AM",pm:"PM"}}}},number:{nu:["latn"],patterns:{decimal:{positivePattern:"{number}",negativePattern:"{minusSign}{number}"},currency:{positivePattern:"{currency}{number}",negativePattern:"{minusSign}{currency}{number}"},percent:{positivePattern:"{number}{percentSign}",negativePattern:"{minusSign}{number}{percentSign}"}},symbols:{latn:{decimal:".",group:",",nan:"NaN",plusSign:"+",minusSign:"-",percentSign:"%",infinity:"∞"}},currencies:{AUD:"A$",BRL:"R$",CAD:"CA$",CNY:"CN¥",EUR:"€",GBP:"£",HKD:"HK$",ILS:"₪",INR:"₹",JPY:"¥",KRW:"₩",MXN:"MX$",NZD:"NZ$",TWD:"NT$",USD:"$",VND:"₫",XAF:"FCFA",XCD:"EC$",XOF:"CFA",XPF:"CFPF"}}});

--- a/integration/bazel/test/e2e/BUILD.bazel
+++ b/integration/bazel/test/e2e/BUILD.bazel
@@ -1,10 +1,13 @@
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
+load("@npm_angular_bazel//:index.bzl", "protractor_web_test", "protractor_web_test_suite")
 
 ts_library(
     name = "e2e",
     testonly = 1,
-    srcs = ["app.spec.ts"],
+    srcs = [
+        "app.po.ts",
+        "app.spec.ts",
+    ],
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@types",
@@ -45,5 +48,34 @@ protractor_web_test_suite(
     ],
     on_prepare = ":ts_on_prepare",
     server = "//src:prodserver",
+    deps = [":e2e"],
+)
+
+# To run this protractor_web_test target locally on SauceLabs:
+# 1) have SAUCE_USERNAME, SAUCE_ACCESS_KEY (and optionally a SAUCE_TUNNEL_IDENTIFIER) set in your environment
+# 2) open a sauce connection with `./scripts/saucelabs/start-tunnel.sh`
+#    NOTE: start-tunnel.sh uses `node_modules/sauce-connect` which is current linux specific:
+#          "sauce-connect": "https://saucelabs.com/downloads/sc-4.5.3-linux.tar.gz".
+#          On OSX or Windows you'll need to use the appropriate sauce-connect binary.
+# 3) run target with `yarn bazel test --define=SAUCE_BROWSER=<browser> --config=saucelabs <target>`
+#    where <browser> is one of the keys of sauceCapabilities in /integration/bazel/protractor-sauce.conf.js
+#    such as SL_CHROMELEGACY.
+#    NOTE: --config=saucelabs is required as it makes the SAUCE_XXX environment variables available to
+#          the action. See /.bazelrc.
+protractor_web_test(
+    name = "prodserver_sauce_test",
+    configuration = "//:protractor-sauce.conf.js",
+    configuration_env_vars = ["SAUCE_BROWSER"],
+    data = [
+        "@npm//@angular/bazel",
+        "@npm//protractor",
+    ],
+    on_prepare = ":ts_on_prepare",
+    server = "//src:prodserver",
+    tags = [
+        "local",
+        "manual",
+        "saucelabs",
+    ],
     deps = [":e2e"],
 )

--- a/integration/bazel/test/e2e/app.po.ts
+++ b/integration/bazel/test/e2e/app.po.ts
@@ -1,0 +1,30 @@
+import { browser, by, element } from 'protractor';
+
+export class AppPage {
+  async navigateTo() {
+    await browser.get(global['protractorBaseUrl']);
+    return browser.waitForAngular();
+  }
+
+  async waitForElement(el, timeout = 10000) {
+    await browser.wait(() => el.isPresent(), timeout);
+    await browser.wait(() => el.isDisplayed(), timeout);
+    return el;
+  }
+
+  async waitForAngular() {
+    return browser.waitForAngular();
+  }
+
+  async getParagraphText() {
+    return (await this.waitForElement(element(by.css('div#greeting')))).getText();
+  }
+
+  async clearInput() {
+    return (await this.waitForElement(element(by.css('input')))).clear();
+  }
+
+  async typeInInput(s: string) {
+    return (await this.waitForElement(element(by.css('input')))).sendKeys(s);
+  }
+}

--- a/integration/bazel/test/e2e/app.spec.ts
+++ b/integration/bazel/test/e2e/app.spec.ts
@@ -1,14 +1,18 @@
-import {browser, by, element} from 'protractor';
-
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
+import { AppPage } from './app.po';
 
 describe('angular example application', () => {
-  it('should display: Hello World!', (done) => {
-    browser.get('');
-    const div = element(by.css('div'));
-    div.getText().then(t => expect(t).toEqual(`Hello world!`));
-    element(by.css('input')).sendKeys('!');
-    div.getText().then(t => expect(t).toEqual(`Hello world!!`));
-    done();
+  let page: AppPage;
+
+  beforeEach(() => {
+    page = new AppPage();
+  });
+
+  it('should display: Hello World!', async () => {
+    await page.navigateTo();
+    expect(await page.getParagraphText()).toEqual(`Hello world!`);
+    await page.clearInput();
+    await page.typeInInput('!');
+    await page.waitForAngular();
+    expect(await page.getParagraphText()).toEqual(`Hello !!`);
   });
 });

--- a/integration/bazel/test/e2e/on-prepare.ts
+++ b/integration/bazel/test/e2e/on-prepare.ts
@@ -1,12 +1,11 @@
-import { browser } from 'protractor';
-import {OnPrepareConfig, runServer} from '@angular/bazel/protractor-utils';
+import {OnPrepareConfig, startServer} from '@angular/bazel/protractor-utils';
 
 export = function(config: OnPrepareConfig) {
   const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
-  return runServer(config.workspace, config.server, portFlag, [])
+  return startServer({config, portFlag})
     .then(serverSpec => {
       const serverUrl = `http://localhost:${serverSpec.port}`;
       console.log(`Server has been started, starting tests against ${serverUrl}`);
-      browser.baseUrl = serverUrl;
+      global['protractorBaseUrl'] = serverUrl;
     });
 }

--- a/packages/bazel/src/protractor/protractor_web_test.bzl
+++ b/packages/bazel/src/protractor/protractor_web_test.bzl
@@ -132,6 +132,7 @@ _protractor_web_test = rule(
         ),
         "data": attr.label_list(
             doc = "Runtime dependencies",
+            allow_files = True,
         ),
         "on_prepare": attr.label(
             doc = """A file with a node.js script to run once before all tests run.
@@ -173,6 +174,7 @@ def protractor_web_test(
         data = [],
         server = None,
         tags = [],
+        configuration_env_vars = None,
         **kwargs):
     """Runs a protractor test in a browser.
 
@@ -197,6 +199,7 @@ def protractor_web_test(
         entry_point = "protractor/bin/protractor",
         data = srcs + deps + data,
         testonly = 1,
+        configuration_env_vars = configuration_env_vars,
         visibility = ["//visibility:private"],
     )
 

--- a/packages/bazel/src/protractor/utils/index.ts
+++ b/packages/bazel/src/protractor/utils/index.ts
@@ -8,7 +8,23 @@
 
 import * as child_process from 'child_process';
 import * as net from 'net';
-import * as path from 'path';
+
+const DEFAULT_TIMEOUT = 5000;
+
+// By default use the set of ports 57 ports >= 2000 that work
+// SauceLabs is able to proxy through SourceConnect for all
+// browsers. See
+// https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+FAQS#SauceConnectProxyFAQS-CanIAccessApplicationsonlocalhost?.
+// The work-around for this limited set of ports in SauceLabs
+// is to add an entry to /etc/hosts such as `127.0.0.1 localtestsite`
+// on the machine running SauceConnect and use this hostname in protractor instead
+// of localhost as some browsers restrict which localhost ports can be proxied.
+const DEFAULT_PORTS = [
+  2000, 2001, 2020, 2109, 2222, 2310, 3000, 3001, 3010, 3030, 3210,  3333, 4000, 4001, 4201,
+  4040, 4321, 4502, 4503, 4567, 5000, 5001, 5002, 5050, 5555, 5432,  6000, 6001, 6060, 6666,
+  6543, 7000, 7070, 7774, 7777, 8000, 8001, 8003, 8031, 8080, 8081,  8443, 8765, 8777, 8888,
+  9000, 9001, 9031, 9080, 9081, 9090, 9191, 9876, 9877, 9999, 49221, 55001
+];
 
 export function isTcpPortFree(port: number): Promise<boolean> {
   return new Promise((resolve, reject) => {
@@ -28,18 +44,18 @@ export function isTcpPortBound(port: number): Promise<boolean> {
   });
 }
 
-export async function findFreeTcpPort(): Promise<number> {
-  const range = {
-    min: 32768,
-    max: 60000,
-  };
-  for (let i = 0; i < 100; i++) {
-    let port = Math.floor(Math.random() * (range.max - range.min) + range.min);
+export async function findFreeTcpPort(set?: number[]): Promise<number> {
+  // Clone and shuffle the ports passed in
+  const ports = (set ? set : DEFAULT_PORTS).slice(0).sort(() => Math.random() - 0.5);
+  while (true) {
+    if (!ports.length) {
+      throw new Error('Unable to find a free port');
+    }
+    const port = ports.shift();
     if (await isTcpPortFree(port)) {
       return port;
     }
   }
-  throw new Error('Unable to find a free port');
 }
 
 // Interface for config parameter of the protractor_web_test_suite onPrepare function
@@ -65,10 +81,41 @@ export function waitForServer(port: number, timeout: number): Promise<boolean> {
   });
 }
 
-// Return type from runServer function
+export interface StartServerOptions {
+  // The OnPrepareConfig config passed to the protractor
+  // onPrepare function when using the `on_prepare` attribute
+  // of protractor_web_test.
+  config: OnPrepareConfig;
+
+  // The flag to use for passing the port
+  portFlag: string;
+
+  // Additional server arguments
+  serverArgs?: string[];
+
+  // An array of ports to choose from.
+  // Defaults to DEFAULT_PORTS if not set
+  ports?: number[];
+
+  // Timeout for the server to start
+  // Defaults to DEFAULT_TIMEOUT if not set
+  timeout?: number;
+}
+
+// Return type from startServer function
 export interface ServerSpec {
   // Port number that the server is running on
   port: number;
+}
+
+/**
+ * Legacy version of startServer
+ */
+export async function runServer(
+    workspace: string, server: string, portFlag: string, serverArgs: string[],
+    timeout = DEFAULT_TIMEOUT): Promise<ServerSpec> {
+  const config: OnPrepareConfig = {workspace, server};
+  return startServer({config, portFlag, serverArgs, timeout});
 }
 
 /**
@@ -77,15 +124,17 @@ export interface ServerSpec {
  * the server will be launched with a random free port in order to support test concurrency
  * with Bazel.
  */
-export async function runServer(
-    workspace: string, serverTarget: string, portFlag: string, serverArgs: string[],
-    timeout = 5000): Promise<ServerSpec> {
-  const serverPath = require.resolve(`${workspace}/${serverTarget}`);
-  const port = await findFreeTcpPort();
+export async function startServer(options: StartServerOptions): Promise<ServerSpec> {
+  const timeout = options.timeout || DEFAULT_TIMEOUT;
+  const ports = options.ports || DEFAULT_PORTS;
+  const serverArgs = options.serverArgs || [];
+
+  const serverPath = require.resolve(`${options.config.workspace}/${options.config.server}`);
+  const port = await findFreeTcpPort(ports);
 
   // Start the Bazel server binary with a random free TCP port.
   const serverProcess = child_process.spawn(
-      serverPath, serverArgs.concat([portFlag, port.toString()]), {stdio: 'inherit'});
+      serverPath, serverArgs.concat([options.portFlag, port.toString()]), {stdio: 'inherit'});
 
   // In case the process exited with an error, we want to propagate the error.
   serverProcess.on('exit', exitCode => {

--- a/packages/bazel/src/schematics/ng-add/files/e2e/protractor.on-prepare.js.template
+++ b/packages/bazel/src/schematics/ng-add/files/e2e/protractor.on-prepare.js.template
@@ -10,12 +10,12 @@ const protractor = require('protractor');
 
 module.exports = function(config) {
   // In this example, `@angular/bazel/protractor-utils` is used to run
-  // the server. protractorUtils.runServer() runs the server on a randomly
+  // the server. protractorUtils.startServer() runs the server on a randomly
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
   const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
-  return protractorUtils.runServer(config.workspace, config.server, portFlag, [])
+  return protractorUtils.startServer({config, portFlag})
       .then(serverSpec => {
         const serverUrl = `http://localhost:${serverSpec.port}`;
         protractor.browser.baseUrl = serverUrl;


### PR DESCRIPTION
`test_saucelabs_bazel` CircleCI cronjob tested in https://github.com/angular/angular/pull/30571.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

No tests for differential loading.

No way to use protractor_web_test to test on Saucelabs with certain browsers that don't proxy localhost for all ports.

## What is the new behavior?

protractor_web_test by default now uses ports that are proxied for localhost by all browsers. See https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+FAQS#SauceConnectProxyFAQS-CanIAccessApplicationsonlocalhost?.

Differential loading of `rollup_bundle` bundles using `web_package` to setup differential loading and `http_server` as server tested against legacy browsers in /integration/bazel e2e test.

@alexeagle A follow up PR should also add a test for differential loading in the non-bazel case but not sure the best way to accomplish this. This PR shows how to use protractor_web_test to test with SauceLabs. In this case the server is an `http_server` that relies on `web_package` to setup the differential loading. How to test the non-bazel angular-cli production bundle with differential loading?

**Note: protractor multiCapabilties not supported under Bazel**

Using a SAUCE_BROWSER environment variable to control which browser is tested against in //test/e2e:prodserver_sauce_test. This is because `multiCapabilities` do not work with protractor under Bazel as protractor spawns new processes for each browser test and new nodejs processes under Bazel don't know how to resolve runfiles. No obvious easy fix for this problem. A shell script /integration/bazel/run_sauce_tests.sh is added to test all the browser variants listed in /integration/bazel/protractor-sauce.conf.js.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
