### PR TITLE
fix(core): remove TestBed.deprecatedOverrideProvider

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -60,13 +60,6 @@ Tip: In the [API reference section](api) of this doc site, deprecated APIs are i
 | [`RootRenderer`](api/core/RootRenderer) | [`RendererFactory2`](api/core/RendererFactory2) | v4 | none |
 | [`ViewEncapsulation.Native`](api/core/ViewEncapsulation#Native) | [`ViewEncapsulation.ShadowDom`](api/core/ViewEncapsulation#ShadowDom) | v6 | Use the native encapsulation mechanism of the renderer. See [view.ts](https://github.com/angular/angular/blob/3e992e18ebf51d6036818f26c3d77b52d3ec48eb/packages/core/src/metadata/view.ts#L32).
 
-#### @angular/core/testing
-
-| API | Replacement | Deprecation announced | Notes |
-| --- | ----------- | --------------------- | ----- |
-| [`TestBed.deprecatedOverrideProvider()`](api/core/testing/TestBed#deprecatedoverrideprovider) | [`TestBed.overrideProvider()`] (api/core/testing/TestBed#overrideprovider) | v7 | none |
-| [`TestBedStatic.deprecatedOverrideProvider()`](api/core/testing/TestBedStatic#deprecatedoverrideprovider) | [`TestBedStatic.overrideProvider()`](api/core/testing/TestBedStatic#overrideprovider) | v5 | none |
-
 
 #### @angular/forms
 
@@ -253,6 +246,8 @@ The following APIs have been removed starting with version 8.0.0:
 | [`@angular/http`](https://v7.angular.io/api/http) | All exports | [`@angular/common/http`](https://v7.angular.io/api/common/http) | See [below](#http). |
 [`@angular/http/testing`](https://v7.angular.io/api/http/testing) | All exports | [`@angular/common/http/testing`](https://v7.angular.io/api/common/http/testing) | See [below](#http). |
 | `@angular/platform-browser` | [`DOCUMENT`](https://v7.angular.io/api/platform-browser/DOCUMENT) | [`DOCUMENT` in `@angular/common`](https://v7.angular.io/api/common/DOCUMENT) | Updating to version 8 with [`ng update`](cli/update) changes this automatically.  |
+| `@angular/core/testing` | [`TestBed.deprecatedOverrideProvider()`](https://v7.angular.io/api/core/testing/TestBed#deprecatedoverrideprovider) | [`TestBed.overrideProvider()`] (api/core/testing/TestBed#overrideprovider) | none |
+| `@angular/core/testing` | [`TestBedStatic.deprecatedOverrideProvider()`](https://v7.angular.io/api/core/testing/TestBedStatic#deprecatedoverrideprovider) | [`TestBedStatic.overrideProvider()`](api/core/testing/TestBedStatic#overrideprovider) | none |
 
 
 

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -150,25 +150,6 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3 as any as TestBedStatic;
   }
 
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  static deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  static deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  static deprecatedOverrideProvider(token: any, provider: {
-    useFactory?: Function,
-    useValue?: any,
-    deps?: any[],
-  }): TestBedStatic {
-    _getTestBedRender3().deprecatedOverrideProvider(token, provider as any);
-    return TestBedRender3 as any as TestBedStatic;
-  }
-
   static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
   /**
    * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
@@ -315,30 +296,6 @@ export class TestBedRender3 implements Injector, TestBed {
   overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
       void {
     this.compiler.overrideProvider(token, provider);
-  }
-
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  deprecatedOverrideProvider(
-      token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}): void {
-    // HACK: This is NOT the correct implementation for deprecatedOverrideProvider.
-    // To implement it in a backward compatible way, we would need to record some state
-    // so we know to prevent eager instantiation of NgModules. However, we don't plan
-    // to implement this at all since the API is deprecated and scheduled for removal
-    // in V8. This hack is here temporarily for Ivy testing until we transition apps
-    // inside Google to the overrideProvider API. At that point, we will be able to
-    // remove this method entirely. In the meantime, we can use overrideProvider to
-    // test apps with Ivy that don't care about eager instantiation. This fixes 85%
-    // of cases in our blueprint.
-    this.overrideProvider(token, provider as any);
   }
 
   createComponent<T>(type: Type<T>): ComponentFixture<T> {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -83,20 +83,6 @@ export interface TestBed {
   overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
       void;
 
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  deprecatedOverrideProvider(
-      token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}): void;
-
-
   overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;
@@ -221,25 +207,6 @@ export class TestBedViewEngine implements Injector, TestBed {
     deps?: any[],
   }): TestBedStatic {
     _getTestBedViewEngine().overrideProvider(token, provider as any);
-    return TestBedViewEngine as any as TestBedStatic;
-  }
-
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  static deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  static deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  static deprecatedOverrideProvider(token: any, provider: {
-    useFactory?: Function,
-    useValue?: any,
-    deps?: any[],
-  }): TestBedStatic {
-    _getTestBedViewEngine().deprecatedOverrideProvider(token, provider as any);
     return TestBedViewEngine as any as TestBedStatic;
   }
 
@@ -535,21 +502,6 @@ export class TestBedViewEngine implements Injector, TestBed {
   overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
       void {
     this.overrideProviderImpl(token, provider);
-  }
-
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  deprecatedOverrideProvider(
-      token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}): void {
-    this.overrideProviderImpl(token, provider, /* deprecated */ true);
   }
 
   private overrideProviderImpl(

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -114,22 +114,6 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
-  /**
-   * Overwrites all providers for the given token with the given provider definition.
-   *
-   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
-   */
-  deprecatedOverrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): void;
-  deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
-  deprecatedOverrideProvider(token: any, provider: {
-    useFactory?: Function,
-    useValue?: any,
-    deps?: any[],
-  }): TestBedStatic;
-
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
   /**
    * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -494,27 +494,6 @@ class CompWithUrlTemplate {
             expect(someModule).toBeAnInstanceOf(SomeModule);
           });
 
-          obsoleteInIvy(`deprecated method, won't be reimplemented for Render3`)
-              .it('should keep imported NgModules lazy with deprecatedOverrideProvider', () => {
-                let someModule: SomeModule|undefined;
-
-                @NgModule()
-                class SomeModule {
-                  constructor() { someModule = this; }
-                }
-
-                TestBed.configureTestingModule({
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                  ],
-                  imports: [SomeModule]
-                });
-                TestBed.deprecatedOverrideProvider('a', {useValue: 'mockValue'});
-
-                expect(TestBed.get('a')).toBe('mockValue');
-                expect(someModule).toBeUndefined();
-              });
-
           describe('injecting eager providers into an eager overwritten provider', () => {
             @NgModule({
               providers: [

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -57,18 +57,6 @@ export interface TestBed {
     }): void;
     configureTestingModule(moduleDef: TestModuleMetadata): void;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
-    deprecatedOverrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
-    }): void;
-    deprecatedOverrideProvider(token: any, provider: {
-        useValue: any;
-    }): void;
-    /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
-    }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
     get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     /** @deprecated */ get(token: any, notFoundValue?: any): any;
@@ -78,16 +66,16 @@ export interface TestBed {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void;
     overrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
+        useFactory: Function;
+        deps: any[];
     }): void;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
+        useFactory?: Function;
+        useValue?: any;
+        deps?: any[];
     }): void;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
@@ -105,36 +93,24 @@ export interface TestBedStatic {
     }): TestBedStatic;
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
-    deprecatedOverrideProvider(token: any, provider: {
-        useFactory?: Function;
-        useValue?: any;
-        deps?: any[];
-    }): TestBedStatic;
-    deprecatedOverrideProvider(token: any, provider: {
-        useValue: any;
-    }): void;
-    /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
-    }): void;
-    /** @deprecated */ get(token: any, notFoundValue?: any): any;
     get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+    /** @deprecated */ get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): TestBedStatic;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): TestBedStatic;
     overrideProvider(token: any, provider: {
+        useFactory: Function;
+        deps: any[];
+    }): TestBedStatic;
+    overrideProvider(token: any, provider: {
         useValue: any;
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
         useFactory?: Function;
         useValue?: any;
         deps?: any[];
-    }): TestBedStatic;
-    overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
     }): TestBedStatic;
     overrideTemplate(component: Type<any>, template: string): TestBedStatic;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBedStatic;


### PR DESCRIPTION
BREAKING CHANGE

In PR #19558, we fixed a bug in `TestBed.overrideProvider` where
eager providers were not being instantiated correctly. However,
it turned out that since this bug had been around for quite a bit,
many apps were relying on the broken behavior where the providers
would not be instantiated. To assist in the transition, the
`TestBed.deprecatedOverrideProvider` method was temporarily
introduced to mimic the old behavior so that apps would have a
longer time period to migrate their code.

2 years and 3 versions later, it is time to remove the temporary
method. This commit removes `TestBed.deprecatedOverrideProvider`
altogether. Any usages of `TestBed.deprecatedOverrideProvider`
should be replaced with `TestBed.overrideProvider`. This may mean
that providers that were not created before will now be instantiated,
which could mean that your tests need to provide more mocks or stubs
for the dependencies of the newly instantiated providers.