### PR TITLE
refactor(core): migrations should parse cli workspace config as json5

### DIFF
--- a/packages/core/schematics/test/project_tsconfig_paths_spec.ts
+++ b/packages/core/schematics/test/project_tsconfig_paths_spec.ts
@@ -25,6 +25,26 @@ describe('project tsconfig paths', () => {
     expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-custom-config.json']);
   });
 
+  it('should be able to read workspace configuration which is using JSON5 features', () => {
+    testTree.create('/my-build-config.json', '');
+    testTree.create('/angular.json', `{
+      // Comments, unquoted properties or trailing commas are only supported in JSON5.
+      projects: {
+        with_tests: {
+          targets: {
+            build: {
+              options: {
+                tsConfig: './my-build-config.json',
+              }
+            }
+          }
+        }
+      },
+    }`);
+
+    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-build-config.json']);
+  });
+
   it('should detect test tsconfig path inside of angular.json file', () => {
     testTree.create('/my-test-config.json', '');
     testTree.create('/angular.json', JSON.stringify({

--- a/packages/core/schematics/utils/project_tsconfig_paths.ts
+++ b/packages/core/schematics/utils/project_tsconfig_paths.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {normalize} from '@angular-devkit/core';
+import {JsonParseMode, normalize, parseJson} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
 import {WorkspaceProject} from '@schematics/angular/utility/workspace-models';
 
@@ -78,8 +78,10 @@ function getWorkspaceConfigGracefully(tree: Tree): any {
   }
 
   try {
-    return JSON.parse(configBuffer.toString());
-  } catch {
+    // Parse the workspace file as JSON5 which is also supported for CLI
+    // workspace configurations.
+    return parseJson(configBuffer.toString(), JsonParseMode.Json5);
+  } catch (e) {
     return null;
   }
 }


### PR DESCRIPTION
Currently we try to parse CLI workspace configurations gracefully by
using the native `JSON.parse()` method. This means that the CLI workspace
configuration needs to follow the strict JSON specification because otherwise
the migrations would not be able to find TypeScript configurations in the CLI
project where JSON5 workspace configurations are supported.

In order to handle such workspace configurations, we leverage the JSON
parsing logic from `@angular-devkit/core` which is also used by the CLI.