### PR TITLE
test: improve language service tests performance

### DIFF
--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -18,9 +18,14 @@ describe('reflector_host_spec', () => {
   // Regression #21811
   it('should be able to find angular under windows', () => {
     const originalJoin = path.join;
-    let mockHost = new MockTypescriptHost(
-        ['/app/main.ts', '/app/parsing-cases.ts'], toh, 'app/node_modules',
-        {...path, join: (...args: string[]) => originalJoin.apply(path, args)});
+    const originalPosixJoin = path.posix.join;
+    let mockHost =
+        new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh, 'app/node_modules', {
+          ...path,
+          join: (...args: string[]) => originalJoin.apply(path, args),
+          posix:
+              {...path.posix, join: (...args: string[]) => originalPosixJoin.apply(path, args)}
+        });
     const reflectorHost = new ReflectorHost(() => undefined as any, mockHost, {basePath: '\\app'});
 
     if (process.platform !== 'win32') {


### PR DESCRIPTION
With this change we reduce the amount of IO operations. This is especially a huge factor in windows since IO ops are slower.

With this change mainly we cache `existsSync` and `readFileSync` calls

Here's the results

Before
```
//packages/language-service/test:test
INFO: Elapsed time: 258.755s, Critical Path: 253.91s
```

After
```
//packages/language-service/test:test
INFO: Elapsed time: 66.403s, Critical Path: 63.13s
```
