### PR TITLE
Ivy query instructions refactor

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -97,9 +97,9 @@ export class LQueries_ implements LQueries {
   track<T>(queryList: QueryList<T>, predicate: Type<T>|string[], descend?: boolean, read?: Type<T>):
       void {
     if (descend) {
-      this.deep = createQuery(this.deep, queryList, predicate, read != null ? read : null);
+      this.deep = createLQuery(this.deep, queryList, predicate, read != null ? read : null);
     } else {
-      this.shallow = createQuery(this.shallow, queryList, predicate, read != null ? read : null);
+      this.shallow = createLQuery(this.shallow, queryList, predicate, read != null ? read : null);
     }
   }
 
@@ -347,7 +347,7 @@ function createPredicate<T>(predicate: Type<T>| string[], read: Type<T>| null): 
   };
 }
 
-function createQuery<T>(
+function createLQuery<T>(
     previous: LQuery<any>| null, queryList: QueryList<T>, predicate: Type<T>| string[],
     read: Type<T>| null): LQuery<T> {
   return {
@@ -362,14 +362,14 @@ function createQuery<T>(
 type QueryList_<T> = QueryList<T>& {_valuesTree: any[], _static: boolean};
 
 /**
- * Creates and returns a QueryList.
+ * Creates a QueryList and stores it in LView's collection of active queries (LQueries).
  *
  * @param predicate The type for which the query will search
  * @param descend Whether or not to descend into children
  * @param read What to save in the query
  * @returns QueryList<T>
  */
-function query<T>(
+function createQueryListInLView<T>(
     // TODO: "read" should be an AbstractType (FW-486)
     lView: LView, predicate: Type<any>| string[], descend: boolean, read: any,
     isStatic: boolean): QueryList<T> {
@@ -448,7 +448,8 @@ function viewQueryInternal<T>(
     tView.expandoStartIndex++;
   }
   const index = getCurrentQueryIndex();
-  const queryList: QueryList<T> = query<T>(lView, predicate, descend, read, isStatic);
+  const queryList: QueryList<T> =
+      createQueryListInLView<T>(lView, predicate, descend, read, isStatic);
   store(index - HEADER_OFFSET, queryList);
   setCurrentQueryIndex(index + 1);
   return queryList;
@@ -491,7 +492,8 @@ function contentQueryInternal<T>(
     descend: boolean,
     // TODO(FW-486): "read" should be an AbstractType
     read: any, isStatic: boolean): QueryList<T> {
-  const contentQuery: QueryList<T> = query<T>(lView, predicate, descend, read, isStatic);
+  const contentQuery: QueryList<T> =
+      createQueryListInLView<T>(lView, predicate, descend, read, isStatic);
   (lView[CONTENT_QUERIES] || (lView[CONTENT_QUERIES] = [])).push(contentQuery);
   if (tView.firstTemplatePass) {
     const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -18,7 +18,7 @@ import {assertDataInRange, assertDefined, assertEqual} from '../util/assert';
 import {assertPreviousIsParent} from './assert';
 import {getNodeInjectable, locateDirectiveOrProvider} from './di';
 import {NG_ELEMENT_ID} from './fields';
-import {store, ɵɵload} from './instructions/all';
+import {store} from './instructions/all';
 import {storeCleanupWithContext} from './instructions/shared';
 import {unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
@@ -26,6 +26,7 @@ import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, u
 import {LQueries, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
 import {CONTENT_QUERIES, HEADER_OFFSET, LView, QUERIES, TVIEW} from './interfaces/view';
 import {getCurrentQueryIndex, getIsParent, getLView, isCreationMode, setCurrentQueryIndex} from './state';
+import {loadInternal} from './util/view_utils';
 import {createElementRef, createTemplateRef} from './view_engine_compatibility';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4;
@@ -457,7 +458,7 @@ export function ɵɵviewQuery<T>(
 export function ɵɵloadViewQuery<T>(): T {
   const index = getCurrentQueryIndex();
   setCurrentQueryIndex(index + 1);
-  return ɵɵload<T>(index - HEADER_OFFSET);
+  return loadInternal<T>(getLView(), index - HEADER_OFFSET);
 }
 
 /**

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -369,11 +369,10 @@ type QueryList_<T> = QueryList<T>& {_valuesTree: any[], _static: boolean};
  * @param read What to save in the query
  * @returns QueryList<T>
  */
-export function query<T>(
+function query<T>(
     // TODO: "read" should be an AbstractType (FW-486)
-    predicate: Type<any>| string[], descend: boolean, read: any): QueryList<T> {
+    lView: LView, predicate: Type<any>| string[], descend: boolean, read: any): QueryList<T> {
   ngDevMode && assertPreviousIsParent(getIsParent());
-  const lView = getLView();
   const queryList = new QueryList<T>() as QueryList_<T>;
   const queries = lView[QUERIES] || (lView[QUERIES] = new LQueries_(null, null, null));
   queryList._valuesTree = [];
@@ -444,7 +443,7 @@ export function ɵɵviewQuery<T>(
     tView.expandoStartIndex++;
   }
   const index = getCurrentQueryIndex();
-  const viewQuery: QueryList<T> = query<T>(predicate, descend, read);
+  const viewQuery: QueryList<T> = query<T>(lView, predicate, descend, read);
   store(index - HEADER_OFFSET, viewQuery);
   setCurrentQueryIndex(index + 1);
   return viewQuery;
@@ -479,7 +478,7 @@ export function ɵɵcontentQuery<T>(
     read: any): QueryList<T> {
   const lView = getLView();
   const tView = lView[TVIEW];
-  const contentQuery: QueryList<T> = query<T>(predicate, descend, read);
+  const contentQuery: QueryList<T> = query<T>(lView, predicate, descend, read);
   (lView[CONTENT_QUERIES] || (lView[CONTENT_QUERIES] = [])).push(contentQuery);
   if (tView.firstTemplatePass) {
     const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -24,7 +24,7 @@ import {unusedValueExportToPlacateAjd as unused1} from './interfaces/definition'
 import {unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQueries, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
-import {CONTENT_QUERIES, HEADER_OFFSET, LView, QUERIES, TVIEW} from './interfaces/view';
+import {CONTENT_QUERIES, HEADER_OFFSET, LView, QUERIES, TVIEW, TView} from './interfaces/view';
 import {getCurrentQueryIndex, getIsParent, getLView, isCreationMode, setCurrentQueryIndex} from './state';
 import {loadInternal} from './util/view_utils';
 import {createElementRef, createTemplateRef} from './view_engine_compatibility';
@@ -371,12 +371,13 @@ type QueryList_<T> = QueryList<T>& {_valuesTree: any[], _static: boolean};
  */
 function query<T>(
     // TODO: "read" should be an AbstractType (FW-486)
-    lView: LView, predicate: Type<any>| string[], descend: boolean, read: any): QueryList<T> {
+    lView: LView, predicate: Type<any>| string[], descend: boolean, read: any,
+    isStatic: boolean): QueryList<T> {
   ngDevMode && assertPreviousIsParent(getIsParent());
   const queryList = new QueryList<T>() as QueryList_<T>;
   const queries = lView[QUERIES] || (lView[QUERIES] = new LQueries_(null, null, null));
   queryList._valuesTree = [];
-  queryList._static = false;
+  queryList._static = isStatic;
   queries.track(queryList, predicate, descend, read);
   storeCleanupWithContext(lView, queryList, queryList.destroy);
   return queryList;
@@ -416,12 +417,10 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
 export function ɵɵstaticViewQuery<T>(
     // TODO(FW-486): "read" should be an AbstractType
     predicate: Type<any>| string[], descend: boolean, read: any): void {
-  const queryList = ɵɵviewQuery(predicate, descend, read) as QueryList_<T>;
-  const tView = getLView()[TVIEW];
-  queryList._static = true;
-  if (!tView.staticViewQueries) {
-    tView.staticViewQueries = true;
-  }
+  const lView = getLView();
+  const tView = lView[TVIEW];
+  viewQueryInternal(lView, tView, predicate, descend, read, true);
+  tView.staticViewQueries = true;
 }
 
 /**
@@ -439,14 +438,20 @@ export function ɵɵviewQuery<T>(
     predicate: Type<any>| string[], descend: boolean, read: any): QueryList<T> {
   const lView = getLView();
   const tView = lView[TVIEW];
+  return viewQueryInternal(lView, tView, predicate, descend, read, false);
+}
+
+function viewQueryInternal<T>(
+    lView: LView, tView: TView, predicate: Type<any>| string[], descend: boolean, read: any,
+    isStatic: boolean): QueryList<T> {
   if (tView.firstTemplatePass) {
     tView.expandoStartIndex++;
   }
   const index = getCurrentQueryIndex();
-  const viewQuery: QueryList<T> = query<T>(lView, predicate, descend, read);
-  store(index - HEADER_OFFSET, viewQuery);
+  const queryList: QueryList<T> = query<T>(lView, predicate, descend, read, isStatic);
+  store(index - HEADER_OFFSET, queryList);
   setCurrentQueryIndex(index + 1);
-  return viewQuery;
+  return queryList;
 }
 
 /**
@@ -478,7 +483,15 @@ export function ɵɵcontentQuery<T>(
     read: any): QueryList<T> {
   const lView = getLView();
   const tView = lView[TVIEW];
-  const contentQuery: QueryList<T> = query<T>(lView, predicate, descend, read);
+  return contentQueryInternal(lView, tView, directiveIndex, predicate, descend, read, false);
+}
+
+function contentQueryInternal<T>(
+    lView: LView, tView: TView, directiveIndex: number, predicate: Type<any>| string[],
+    descend: boolean,
+    // TODO(FW-486): "read" should be an AbstractType
+    read: any, isStatic: boolean): QueryList<T> {
+  const contentQuery: QueryList<T> = query<T>(lView, predicate, descend, read, isStatic);
   (lView[CONTENT_QUERIES] || (lView[CONTENT_QUERIES] = [])).push(contentQuery);
   if (tView.firstTemplatePass) {
     const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);
@@ -507,12 +520,10 @@ export function ɵɵstaticContentQuery<T>(
     directiveIndex: number, predicate: Type<any>| string[], descend: boolean,
     // TODO(FW-486): "read" should be an AbstractType
     read: any): void {
-  const queryList = ɵɵcontentQuery(directiveIndex, predicate, descend, read) as QueryList_<T>;
-  const tView = getLView()[TVIEW];
-  queryList._static = true;
-  if (!tView.staticContentQueries) {
-    tView.staticContentQueries = true;
-  }
+  const lView = getLView();
+  const tView = lView[TVIEW];
+  contentQueryInternal(lView, tView, directiveIndex, predicate, descend, read, true);
+  tView.staticContentQueries = true;
 }
 
 /**

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -12,7 +12,7 @@ import {EventEmitter} from '../..';
 import {AttributeMarker, detectChanges, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
 import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵload, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-import {query, ɵɵcontentQuery, ɵɵloadContentQuery, ɵɵloadViewQuery, ɵɵqueryRefresh, ɵɵviewQuery} from '../../src/render3/query';
+import {ɵɵcontentQuery, ɵɵloadContentQuery, ɵɵloadViewQuery, ɵɵqueryRefresh, ɵɵviewQuery} from '../../src/render3/query';
 import {getLView} from '../../src/render3/state';
 import {getNativeByIndex} from '../../src/render3/util/view_utils';
 import {ɵɵtemplateRefExtractor} from '../../src/render3/view_engine_compatibility_prebound';


### PR DESCRIPTION
This PR contains small commits with refactorings that:
* avoid calling instructions from other instructions
* avoid repeated LView / TView reads
* improve code readability / clarity with renames