### PR TITLE
fix: remove points in short months in NL locale

### DIFF
--- a/packages/common/locales/nl.ts
+++ b/packages/common/locales/nl.ts
@@ -27,7 +27,7 @@ export default [
   u,
   [
     ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'],
-    ['jan.', 'feb.', 'mrt.', 'apr.', 'mei', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.'],
+    ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
     [
       'januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september',
       'oktober', 'november', 'december'


### PR DESCRIPTION
This makes the short months consistent with the EN locale and prevents duplicate
points after short months.

No issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When using the date pipe with LLL for the short month name in combination with the NL locale, a point after the short month name will be shown. The EN locale does not add a point after a short month name, so when using a combination of locales, you will encounter inconsistent behaviour.

Issue Number: N/A


## What is the new behavior?

When using the date pipe with LLL for the short month in combination with the NL locale, a point after the short month name will not be shown anymore. This is consistent with the EN locale.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

-