### PR TITLE
ci(docs-infra): fix `test_docs_examples_ivy` job

### DIFF
--- a/aio/tools/examples/example-boilerplate.js
+++ b/aio/tools/examples/example-boilerplate.js
@@ -75,9 +75,9 @@ class ExampleBoilerPlate {
     }
 
     if (ivy) {
-      // We only need the "fesm5" bundles as the CLI webpack build does not need
+      // We only need the "es2015" bundles as the CLI webpack build does not need
       // any other formats for building and serving.
-      shelljs.exec(`yarn --cwd ${SHARED_PATH} ivy-ngcc --properties module`);
+      shelljs.exec(`yarn --cwd ${SHARED_PATH} ivy-ngcc --properties es2015`);
     }
 
     exampleFolders.forEach(exampleFolder => {


### PR DESCRIPTION
Context:
As part of the `test_docs_examples_ivy` job, we run 5 concurrent builds on each VM (each for a different example/project). Additionally, all example projects share the same `node_modules/` (via a symlink to `aio/tools/examples/shared/node_modules/`), so all concurrent builds operate on the same files.

Previously, we pre-ran ngcc with `--properties module` to process the fesm5 bundles. Since we have switched to es2015 in 661a57d9e, we now need the fesm2015 bundles. As a result, the initial ngcc run is redundant and ngcc runs again during each build (to process the fesm2015 bundles). Since there are 5 concurrent builds, we often end up with multiple ngcc instances processing the same package and trying to write to the same directories at the same time, causing a `file already exists` error.

This commit fixes it by pre-processing the fesm2015 bundles, so there is no need to re-run ngcc during each concurrent build.

Fixes #30577.
