### PR TITLE
test(compiler-cli): compliance tests not always reporting test failure

### DIFF
--- a/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
@@ -82,6 +82,34 @@ describe('mock_compiler', () => {
           result.source, 'name   \n\n   .  \n    length',
           'name length expression not found (whitespace)');
     });
+
+    it('should throw if the expected output contains unknown characters', () => {
+      const files = {
+        app: {
+          'test.ts': `ɵsayHello();`,
+        }
+      };
+
+      const result = compile(files, angularFiles);
+
+      expect(() => {
+        expectEmit(result.source, `ΔsayHello();`, 'Output does not match.');
+      }).toThrowError(/Invalid test, no token found for "Δ"/);
+    });
+
+    it('should be able to properly handle string literals with escaped quote', () => {
+      const files = {
+        app: {
+          'test.ts': String.raw `const identifier = "\"quoted\"";`,
+        }
+      };
+
+      const result = compile(files, angularFiles);
+
+      expect(() => {
+        expectEmit(result.source, String.raw `const $a$ = "\"quoted\"";`, 'Output does not match.');
+      }).not.toThrow();
+    });
   });
 
   it('should be able to skip untested regions (… and // ...)', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -2692,7 +2692,7 @@ describe('i18n support in the view compiler', () => {
               "startItalicText": "\uFFFD#4\uFFFD",
               "closeItalicText": "\uFFFD/#4\uFFFD",
               "closeTagDiv": "\uFFFD/#3\uFFFD",
-              "icu": I18N_APP_SPEC_TS_1
+              "icu": $I18N_1$
             });
             $I18N_0$ = $MSG_EXTERNAL_5791551881115084301$$APP_SPEC_TS_0$;
         }
@@ -2704,7 +2704,7 @@ describe('i18n support in the view compiler', () => {
               "startItalicText": "\uFFFD#4\uFFFD",
               "closeItalicText": "\uFFFD/#4\uFFFD",
               "closeTagDiv": "\uFFFD/#3\uFFFD",
-              "icu": I18N_APP_SPEC_TS_1
+              "icu": $I18N_1$
             });
         }
         …
@@ -2715,14 +2715,14 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵɵelementStart(0, "div");
             $r3$.ɵɵi18nStart(1, $I18N_0$);
             $r3$.ɵɵelement(2, "b");
-            $r3$.ɵɵelementStart(3, "div");
-            $r3$.ɵɵstyling($_c2$);
+            $r3$.ɵɵelementStart(3, "div", $_c2$);
             $r3$.ɵɵelement(4, "i");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
+            $r3$.ɵɵselect(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵbind(ctx.gender));
             $r3$.ɵɵi18nApply(1);
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -144,9 +144,19 @@ describe('compiler compliance: providers', () => {
         result.source, `
     export class MyComponent {
     }
-    MyComponent.ngComponentDef = i0.ÉµdefineComponent({ type: MyComponent, selectors: [["my-component"]], factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }, consts: 1, vars: 0, template: function MyComponent_Template(rf, ctx) { if (rf & 1) {
-            i0.Éµelement(0, "div");
-        } } });`,
+    MyComponent.ngComponentDef = i0.ɵɵdefineComponent({
+      type: MyComponent,
+      selectors: [["my-component"]],
+      factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
+      consts: 1,
+      vars: 0,
+      template: function MyComponent_Template(rf, ctx) {
+        if (rf & 1) {
+          i0.ɵɵelement(0, "div");
+        }
+      },
+      encapsulation: 2
+    });`,
         'Incorrect features');
   });
 });


### PR DESCRIPTION
Currently the `@angular/compiler-cli` compliance tests sometimes do
not throw an exception if the expected output does not match the
generated JavaScript output. This can happen for the following cases:

1. Expected code includes character that is not part of known alphabet
    (e.g. `Δ` is still used in a new compliance test after rebasing a PR)
2. Expected code asserts that a string literal matches a string with
    escaped quotes. e.g. expects `const $var$ = "\"quoted\"";`)

This commit also fixes the various compliance tests which were previously
ignored due to unknown characters / escaped quotes in string literals.

cc. @JoostK 