### PR TITLE
fix(bazel): allow ts_library interop with list-typed inputs

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -489,6 +489,14 @@ def _compile_action(ctx, inputs, outputs, dts_bundles_out, messages_out, tsconfi
     # Give the Angular compiler all the user-listed assets
     file_inputs = list(ctx.files.assets)
 
+    if (type(inputs) == type([])):
+        file_inputs.extend(inputs)
+    else:
+        # inputs ought to be a list, but allow depset as well
+        # so that this can change independently of rules_typescript
+        # TODO(alexeagle): remove this case after update (July 2019)
+        file_inputs.extend(inputs.to_list())
+
     if hasattr(ctx.attr, "node_modules"):
         file_inputs.extend(_filter_ts_inputs(ctx.files.node_modules))
 
@@ -508,7 +516,7 @@ def _compile_action(ctx, inputs, outputs, dts_bundles_out, messages_out, tsconfi
     # Collect the inputs and summary files from our deps
     action_inputs = depset(
         file_inputs,
-        transitive = [inputs] + [
+        transitive = [
             dep.collect_summaries_aspect_result
             for dep in ctx.attr.deps
             if hasattr(dep, "collect_summaries_aspect_result")


### PR DESCRIPTION
_compile_action should take a list since we compute it within one node in the build graph
This needs to be cleaned up since Bazel is getting stricter with
disallowing iteration over depsets
