### PR TITLE
fix(ivy): R3TestBed doesn't allow template overrides with an empty string

### DIFF
--- a/packages/core/src/metadata/resource_loading.ts
+++ b/packages/core/src/metadata/resource_loading.ts
@@ -103,7 +103,7 @@ export function isComponentDefPendingResolution(type: Type<any>): boolean {
 
 export function componentNeedsResolution(component: Component): boolean {
   return !!(
-      (component.templateUrl && !component.template) ||
+      (component.templateUrl && !component.hasOwnProperty('template')) ||
       component.styleUrls && component.styleUrls.length);
 }
 export function clearResolutionOfComponentResourcesQueue(): Map<Type<any>, Component> {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -423,6 +423,14 @@ describe('TestBed', () => {
           const fixture = TestBed.createComponent(SomeComponent);
           expect(fixture.nativeElement.innerHTML).toBe('Template override');
         });
+
+        it('should have an ability to override template with empty string', () => {
+          const SomeComponent = getAOTCompiledComponent();
+          TestBed.configureTestingModule({declarations: [SomeComponent]});
+          TestBed.overrideTemplateUsingTestingModule(SomeComponent, '');
+          const fixture = TestBed.createComponent(SomeComponent);
+          expect(fixture.nativeElement.innerHTML).toBe('');
+        });
       });
 
   onlyInIvy('patched ng defs should be removed after resetting TestingModule')


### PR DESCRIPTION
Prior to this change a component was considered unresolved (i.e. having dynamic resources that should be loaded, like external template or stylesheets) even if template override was provided as an empty string (for example, via TestBed.overrideTemplateUsingTestingModule call). This commit fixes the condition that previously treated empty string as an absent template value.

This PR resolves FW-1346.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No