### PR TITLE
feat(forms): formControlName also accepts a number 

### DIFF
--- a/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
+++ b/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
@@ -17,7 +17,7 @@ import {FormArray, FormControl, FormGroup} from '@angular/forms';
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <div formArrayName="cities">
         <div *ngFor="let city of cities.controls; index as i">
-          <input formControlName="{{i}}" placeholder="City">
+          <input [formControlName]="i" placeholder="City">
         </div>
       </div>
       <button>Submit</button>

--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -36,7 +36,7 @@ export abstract class NgControl extends AbstractControlDirective {
    * @description
    * The name for the control
    */
-  name: string|null = null;
+  name: string|number|null = null;
 
   /**
    * @description

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -145,9 +145,13 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * @description
    * Tracks the name of the `FormControl` bound to the directive. The name corresponds
    * to a key in the parent `FormGroup` or `FormArray`.
+   * Accepts a name as a string or a number.
+   * The name in the form of a string is useful for individual forms,
+   * while the numerical form allows for form controls to be bound
+   * to indices when iterating over controls in a `FormArray`.
    */
   // TODO(issue/24571): remove '!'.
-  @Input('formControlName') name !: string;
+  @Input('formControlName') name !: string | number | null;
 
   /**
    * @description
@@ -238,7 +242,9 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * Returns an array that represents the path from the top-level form to this control.
    * Each index is the string name of the control on that level.
    */
-  get path(): string[] { return controlPath(this.name, this._parent !); }
+  get path(): string[] {
+    return controlPath(this.name == null ? this.name : this.name.toString(), this._parent !);
+  }
 
   /**
    * @description

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -28,8 +28,8 @@ import {SelectMultipleControlValueAccessor} from './select_multiple_control_valu
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 
-export function controlPath(name: string, parent: ControlContainer): string[] {
-  return [...parent.path !, name];
+export function controlPath(name: string | null, parent: ControlContainer): string[] {
+  return [...parent.path !, name !];
 }
 
 export function setUpControl(control: FormControl, dir: NgControl): void {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -255,7 +255,7 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
     readonly formDirective: any;
     isDisabled: boolean;
     /** @deprecated */ model: any;
-    name: string;
+    name: string | number | null;
     readonly path: string[];
     /** @deprecated */ update: EventEmitter<{}>;
     readonly validator: ValidatorFn | null;
@@ -353,7 +353,7 @@ export declare const NG_VALUE_ACCESSOR: InjectionToken<ControlValueAccessor>;
 
 export declare abstract class NgControl extends AbstractControlDirective {
     readonly asyncValidator: AsyncValidatorFn | null;
-    name: string | null;
+    name: string | number | null;
     readonly validator: ValidatorFn | null;
     valueAccessor: ControlValueAccessor | null;
     abstract viewToModelUpdate(newValue: any): void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when using a `FormArray`, most templates look like:

```html
<div formArrayName="tags">
  <div *ngFor="let tag of tagsArray.controls; index as i">
    <input [formControlName]="i">
  </div>
</div>
```

Here `formControlName` receives a number whereas its input type is a string.

This is fine for VE and `fullTemplateTypeCheck`, but not for Ivy which does a more thorough type checking on inputs with `fullTemplateTypeCheck` enabled and throws `Type 'number' is not assignable to type 'string'`. It is fixable by using `formControlName="{{i}}"` but you have to know the difference between `a="{{b}}"` and `[a]="b"` and change it all over the application codebase. 

## What is the new behavior?

This commit relaxes the type of the `formControlName` input to accept both a `string` and a `number`.

## Does this PR introduce a breaking change?

- [x] Yes
- [] No

Technically this is a breaking change, see @jelbourn comment https://github.com/angular/angular/pull/30606#issuecomment-507329154

## Other information

This has been discussed with @kara on Slack.

Note that this PR contains two commits:

- the first one relaxes the input type to `string | number` by changing it on the base `NgControl` class
- the second one reverts #29473 , where @piotrtomiak  ran into a similar issue and changed the example in the docs to help users avoid it. It is now no longer necessary, and the example uses `[formControlName]="i"` again, as all the other examples in the codebase.

Also note that no tests were added as the issue is already caught by our tests when `fullTemplateTypeCheck` is on, but it is currently disabled until Ivy type-checking is on par with VE (see FW-1004). For example, adding `type_check=True` in https://github.com/angular/angular/blob/master/packages/examples/forms/BUILD.bazel#L12-L14 surfaces the issue.
