### PR TITLE
build(docs-infra): upgrade cli command docs sources to 9a3d36c98

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && node scripts/switch-to-ivy",
     "build-with-ivy": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js fa429865e",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 9a3d36c98",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#8.0.x](https://github.com/angular/angular/tree/8.0.x) from [cli-builds#8.0.x](https://github.com/angular/cli-builds/tree/8.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/fa429865e...9a3d36c98):

**Modified**
- help/analytics.json
- help/build.json
- help/e2e.json
- help/serve.json
- help/test.json
- help/xi18n.json

##