### PR TITLE
Remove ɵɵelementProperty

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -138,7 +138,7 @@ describe('compiler compliance: bindings', () => {
         }
       };
       const result = compile(files, angularFiles);
-      expect(result.source).not.toContain('i0.ɵɵelementProperty');
+      expect(result.source).not.toContain('i0.ɵɵproperty');
     });
 
     it('should not remap property names whose names do not correspond to their attribute names',

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2043,7 +2043,7 @@ describe('ngtsc behavioral tests', () => {
     `);
     env.driveMain();
     const jsContents = env.getContents('test.js');
-    expect(jsContents).not.toContain('i0.ɵɵelementProperty');
+    expect(jsContents).not.toContain('i0.ɵɵproperty');
   });
 
   it('should correctly recognize local symbols', () => {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -29,8 +29,6 @@ export class Identifiers {
 
   static elementEnd: o.ExternalReference = {name: 'ɵɵelementEnd', moduleName: CORE};
 
-  static elementProperty: o.ExternalReference = {name: 'ɵɵelementProperty', moduleName: CORE};
-
   static select: o.ExternalReference = {name: 'ɵɵselect', moduleName: CORE};
 
   static updateSyntheticHostBinding:

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -108,7 +108,6 @@ export {
   ɵɵcontentQuery,
   ɵɵloadContentQuery,
   ɵɵelementEnd,
-  ɵɵelementProperty,
   ɵɵproperty,
   ɵɵpropertyInterpolate,
   ɵɵpropertyInterpolate1,

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -98,8 +98,10 @@ class MyApp {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'title', ɵɵbind(ctx.name));
-        ɵɵtextBinding(1, ɵɵinterpolation1('Hello ', ctx.name, '!'));
+        ɵɵselect(0);
+        ɵɵproperty('title', ctx.name);
+        ɵɵselect(1);
+        ɵɵtextInterpolate1('Hello ', ctx.name, '!');
       }
       ...
     }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -54,7 +54,6 @@ export {
   ɵɵelementEnd,
 
   ɵɵelementHostAttrs,
-  ɵɵelementProperty,
   ɵɵelementStart,
   ɵɵembeddedViewEnd,
 

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -62,32 +62,6 @@ export function ɵɵbind<T>(value: T): T|NO_CHANGE {
 }
 
 /**
-* **TODO: Remove this function after `property` is in use**
-* Update a property on an element.
-*
-* If the property name also exists as an input property on one of the element's directives,
-* the component property will be set instead of the element property. This check must
-* be conducted at runtime so child components that add new @Inputs don't have to be re-compiled.
-*
-* @param index The index of the element to update in the data array
-* @param propName Name of property. Because it is going to DOM, this is not subject to
-*        renaming as part of minification.
-* @param value New value to write.
-* @param sanitizer An optional function used to sanitize the value.
-* @param nativeOnly Whether or not we should only set native properties and skip input check
-* (this is necessary for host property bindings)
- *
- * @codeGenApi
-*/
-export function ɵɵelementProperty<T>(
-    index: number, propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null,
-    nativeOnly?: boolean): void {
-  if (value !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, value, sanitizer, nativeOnly);
-  }
-}
-
-/**
  * Updates a synthetic host binding (e.g. `[@foo]`) on a component.
  *
  * This instruction is for compatibility purposes and is designed to ensure that a

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -87,7 +87,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵlistener': r3.ɵɵlistener,
        'ɵɵload': r3.ɵɵload,
        'ɵɵprojection': r3.ɵɵprojection,
-       'ɵɵelementProperty': r3.ɵɵelementProperty,
        'ɵɵupdateSyntheticHostBinding': r3.ɵɵupdateSyntheticHostBinding,
        'ɵɵcomponentHostSyntheticListener': r3.ɵɵcomponentHostSyntheticListener,
        'ɵɵpipeBind1': r3.ɵɵpipeBind1,

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -10,8 +10,8 @@ import {withBody} from '@angular/private/testing';
 
 import {ChangeDetectionStrategy, DoCheck} from '../../src/core';
 import {whenRendered} from '../../src/render3/component';
-import {LifecycleHooksFeature, getRenderedText, ɵɵdefineComponent, ɵɵgetCurrentView} from '../../src/render3/index';
-import {detectChanges, markDirty, tick, ɵɵbind, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵlistener, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {LifecycleHooksFeature, getRenderedText, ɵɵdefineComponent, ɵɵgetCurrentView, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {detectChanges, markDirty, tick, ɵɵbind, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵinterpolation1, ɵɵinterpolation2, ɵɵlistener, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
 import {FLAGS, LViewFlags} from '../../src/render3/interfaces/view';
@@ -186,7 +186,8 @@ describe('change detection', () => {
               ɵɵelement(0, 'manual-comp');
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'name', ɵɵbind(ctx.name));
+              ɵɵselect(0);
+              ɵɵproperty('name', ctx.name);
             }
 
           },

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -8,8 +8,8 @@
 
 import {ViewEncapsulation, ɵɵdefineInjectable, ɵɵdefineInjector} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
-import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵtemplate} from '../../src/render3/index';
-import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
+import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {ComponentDef, RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -137,7 +137,8 @@ describe('component', () => {
         ɵɵelement(4097, 'comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(4097, 'name', ɵɵbind(ctx.name));
+        ɵɵselect(4097);
+        ɵɵproperty('name', ctx.name);
       }
     }, 4098, 1, [Comp]);
 
@@ -188,7 +189,8 @@ it('should not invoke renderer destroy method for embedded views', () => {
               2, MyComponent_div_Template_2, 2, 0, 'div', [AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(ctx.visible));
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', ctx.visible);
         }
       }
     });
@@ -269,7 +271,8 @@ describe('component with a container', () => {
       ɵɵelement(0, 'wrapper');
     }
     if (rf & RenderFlags.Update) {
-      ɵɵelementProperty(0, 'items', ɵɵbind(ctx.items));
+      ɵɵselect(0);
+      ɵɵproperty('items', ctx.items);
     }
   }
 
@@ -339,7 +342,8 @@ describe('recursive components', () => {
                 ɵɵelement(0, 'tree-comp');
               }
               if (rf0 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'data', ɵɵbind(ctx.data.left));
+                ɵɵselect(0);
+                ɵɵproperty('data', ctx.data.left);
               }
               ɵɵembeddedViewEnd();
             }
@@ -353,7 +357,8 @@ describe('recursive components', () => {
                 ɵɵelement(0, 'tree-comp');
               }
               if (rf0 & RenderFlags.Update) {
-                ɵɵelementProperty(0, 'data', ɵɵbind(ctx.data.right));
+                ɵɵselect(0);
+                ɵɵproperty('data', ctx.data.right);
               }
               ɵɵembeddedViewEnd();
             }
@@ -400,8 +405,10 @@ describe('recursive components', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵtextBinding(0, ɵɵbind(ctx.data.value));
-          ɵɵelementProperty(1, 'ngIf', ɵɵbind(ctx.data.left));
-          ɵɵelementProperty(2, 'ngIf', ɵɵbind(ctx.data.right));
+          ɵɵselect(1);
+          ɵɵproperty('ngIf', ɵɵbind(ctx.data.left));
+          ɵɵselect(2);
+          ɵɵproperty('ngIf', ctx.data.right);
         }
 
       },
@@ -416,7 +423,8 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵelementProperty(0, 'data', ɵɵbind(parent.data.left));
+      ɵɵselect(0);
+      ɵɵproperty('data', parent.data.left);
     }
   }
 
@@ -427,7 +435,8 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵelementProperty(0, 'data', ɵɵbind(parent.data.right));
+      ɵɵselect(0);
+      ɵɵproperty('data', parent.data.right);
     }
   }
 

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -9,7 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {RenderFlags, ɵɵbind, ɵɵclassMap, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵinterpolation1, ɵɵproperty, ɵɵselect, ɵɵstyleMap, ɵɵstyleProp, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
+import {RenderFlags, ɵɵbind, ɵɵclassMap, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementStart, ɵɵinterpolation1, ɵɵproperty, ɵɵselect, ɵɵstyleMap, ɵɵstyleProp, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl} from '../../src/sanitization/bypass';
 import {ɵɵdefaultStyleSanitizer, ɵɵsanitizeHtml, ɵɵsanitizeResourceUrl, ɵɵsanitizeScript, ɵɵsanitizeStyle, ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
@@ -58,10 +58,16 @@ describe('instructions', () => {
     it('should update bindings when value changes with the correct perf counters', () => {
       const t = new TemplateFixture(createAnchor, () => {}, 1, 1);
 
-      t.update(() => ɵɵelementProperty(0, 'title', ɵɵbind('Hello')));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'Hello');
+      });
       expect(t.html).toEqual('<a title="Hello"></a>');
 
-      t.update(() => ɵɵelementProperty(0, 'title', ɵɵbind('World')));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('title', 'World');
+      });
       expect(t.html).toEqual('<a title="World"></a>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
@@ -74,7 +80,10 @@ describe('instructions', () => {
 
     it('should not update bindings when value does not change, with the correct perf counters',
        () => {
-         const idempotentUpdate = () => ɵɵelementProperty(0, 'title', ɵɵbind('Hello'));
+         const idempotentUpdate = () => {
+           ɵɵselect(0);
+           ɵɵproperty('title', 'Hello');
+         };
          const t = new TemplateFixture(createAnchor, idempotentUpdate, 1, 1);
 
          t.update();
@@ -295,7 +304,8 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const row_r2 = ctx0.$implicit;
-          ɵɵelementProperty(1, 'ngForOf', ɵɵbind(row_r2));
+          ɵɵselect(1);
+          ɵɵproperty('ngForOf', row_r2);
         }
       }
 
@@ -331,7 +341,8 @@ describe('instructions', () => {
               ɵɵtemplate(0, ToDoAppComponent_NgForOf_Template_0, 2, 1, 'ul', _c0);
             }
             if (rf & RenderFlags.Update) {
-              ɵɵelementProperty(0, 'ngForOf', ɵɵbind(ctx.rows));
+              ɵɵselect(0);
+              ɵɵproperty('ngForOf', ctx.rows);
             }
           },
           directives: [NgForOf]
@@ -448,66 +459,84 @@ describe('instructions', () => {
 
     it('should work for script sanitization', () => {
       const s = new LocalMockSanitizer(value => `${value} //sanitized`);
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = 'fn();';
       const outputValue = 'fn(); //sanitized';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toEqual(outputValue);
     });
 
     it('should bypass script sanitization if marked by the service', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = s.bypassSecurityTrustScript('alert("bar")');
       const outputValue = 'alert("bar")';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should bypass ivy-level script sanitization if a custom sanitizer is used', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createScript, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createScript, undefined, 1, 1, null, null, s);
       const inputValue = bypassSanitizationTrustScript('alert("bar")');
       const outputValue = 'alert("bar")-ivy';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeScript));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeScript);
+      });
       expect(t.html).toEqual(`<script>${outputValue}</script>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should work for html sanitization', () => {
       const s = new LocalMockSanitizer(value => `${value} <!--sanitized-->`);
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = '<header></header>';
       const outputValue = '<header></header> <!--sanitized-->';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toEqual(outputValue);
     });
 
     it('should bypass html sanitization if marked by the service', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = s.bypassSecurityTrustHtml('<div onclick="alert(123)"></div>');
       const outputValue = '<div onclick="alert(123)"></div>';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });
 
     it('should bypass ivy-level script sanitization if a custom sanitizer is used', () => {
       const s = new LocalMockSanitizer(value => '');
-      const t = new TemplateFixture(createDiv, undefined, 1, 0, null, null, s);
+      const t = new TemplateFixture(createDiv, undefined, 1, 1, null, null, s);
       const inputValue = bypassSanitizationTrustHtml('<div onclick="alert(123)"></div>');
       const outputValue = '<div onclick="alert(123)"></div>-ivy';
 
-      t.update(() => ɵɵelementProperty(0, 'innerHTML', inputValue, ɵɵsanitizeHtml));
+      t.update(() => {
+        ɵɵselect(0);
+        ɵɵproperty('innerHTML', inputValue, ɵɵsanitizeHtml);
+      });
       expect(t.html).toEqual(`<div>${outputValue}</div>`);
       expect(s.lastSanitizedValue).toBeFalsy();
     });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -8,8 +8,8 @@
 
 import {RendererType2} from '../../src/render/api';
 import {getLContext} from '../../src/render3/context_discovery';
-import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
+import {ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementAttribute, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {MONKEY_PATCH_KEY_NAME} from '../../src/render3/interfaces/context';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -159,8 +159,9 @@ describe('render3 integration test', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'beforeTree', ɵɵbind(ctx.beforeTree));
-        ɵɵelementProperty(0, 'afterTree', ɵɵbind(ctx.afterTree));
+        ɵɵselect(0);
+        ɵɵproperty('beforeTree', ctx.beforeTree);
+        ɵɵproperty('afterTree', ctx.afterTree);
         ɵɵcontainerRefreshStart(1);
         {
           const rf0 = ɵɵembeddedViewStart(0, 3, 0);
@@ -335,48 +336,54 @@ describe('component animations', () => {
        expect(attr).toEqual('@fooAnimation');
      });
 
-  it('should allow host binding animations to be picked up and rendered', () => {
-    class ChildCompWithAnim {
-      static ngDirectiveDef = ɵɵdefineDirective({
-        type: ChildCompWithAnim,
-        factory: () => new ChildCompWithAnim(),
-        selectors: [['child-comp-with-anim']],
-        hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
-          if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, '@fooAnim', ctx.exp);
-          }
-        },
-      });
+  // TODO(benlesh): this test does not seem to be testing anything we could actually generate with
+  // these instructions. ɵɵbind should be present in the ɵɵelementProperty call in the hostBindings,
+  // however adding that causes an error because the slot has not been allocated. There is a
+  // directive called `comp-with-anim`, that seems to want to be a component, but is defined as a
+  // directive that is looking for a property `@fooAnim` to update.
 
-      exp = 'go';
-    }
+  //   it('should allow host binding animations to be picked up and rendered', () => {
+  //     class ChildCompWithAnim {
+  //       static ngDirectiveDef = ɵɵdefineDirective({
+  //         type: ChildCompWithAnim,
+  //         factory: () => new ChildCompWithAnim(),
+  //         selectors: [['child-comp-with-anim']],
+  //         hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
+  //           if (rf & RenderFlags.Update) {
+  //             ɵɵelementProperty(0, '@fooAnim', ctx.exp);
+  //           }
+  //         },
+  //       });
 
-    class ParentComp {
-      static ngComponentDef = ɵɵdefineComponent({
-        type: ParentComp,
-        consts: 1,
-        vars: 1,
-        selectors: [['foo']],
-        factory: () => new ParentComp(),
-        template: (rf: RenderFlags, ctx: ParentComp) => {
-          if (rf & RenderFlags.Create) {
-            ɵɵelement(0, 'child-comp-with-anim');
-          }
-        },
-        directives: [ChildCompWithAnim]
-      });
-    }
+  //       exp = 'go';
+  //     }
 
-    const rendererFactory = new MockRendererFactory(['setProperty']);
-    const fixture = new ComponentFixture(ParentComp, {rendererFactory});
+  //     class ParentComp {
+  //       static ngComponentDef = ɵɵdefineComponent({
+  //         type: ParentComp,
+  //         consts: 1,
+  //         vars: 1,
+  //         selectors: [['foo']],
+  //         factory: () => new ParentComp(),
+  //         template: (rf: RenderFlags, ctx: ParentComp) => {
+  //           if (rf & RenderFlags.Create) {
+  //             ɵɵelement(0, 'child-comp-with-anim');
+  //           }
+  //         },
+  //         directives: [ChildCompWithAnim]
+  //       });
+  //     }
 
-    const renderer = rendererFactory.lastRenderer !;
-    fixture.update();
+  //     const rendererFactory = new MockRendererFactory(['setProperty']);
+  //     const fixture = new ComponentFixture(ParentComp, {rendererFactory});
 
-    const spy = renderer.spies['setProperty'];
-    const [elm, attr, value] = spy.calls.mostRecent().args;
-    expect(attr).toEqual('@fooAnim');
-  });
+  //     const renderer = rendererFactory.lastRenderer !;
+  //     fixture.update();
+
+  //     const spy = renderer.spies['setProperty'];
+  //     const [elm, attr, value] = spy.calls.mostRecent().args;
+  //     expect(attr).toEqual('@fooAnim');
+  //   });
 });
 
 describe('element discovery', () => {
@@ -485,7 +492,8 @@ describe('element discovery', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(1, 'ngIf', true);
+            ɵɵselect(1);
+            ɵɵproperty('ngIf', true);
           }
         }
       });
@@ -1087,7 +1095,8 @@ describe('sanitization', () => {
             ɵɵelement(0, 'a');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(0, 'href', ɵɵbind(ctx.href), ɵɵsanitizeUrl);
+            ɵɵselect(0);
+            ɵɵproperty('href', ctx.href, ɵɵsanitizeUrl);
           }
         }
       });
@@ -1127,7 +1136,8 @@ describe('sanitization', () => {
             ɵɵallocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵelementProperty(elementIndex, 'cite', ɵɵbind(ctx.cite), ɵɵsanitizeUrl, true);
+            ɵɵselect(elementIndex);
+            ɵɵproperty('cite', ctx.cite, ɵɵsanitizeUrl, true);
           }
         }
       });

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {OnDestroy} from '../../src/core';
-import {AttributeMarker, ComponentTemplate, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, ComponentTemplate, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
+import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -22,7 +22,8 @@ describe('lifecycles', () => {
         ɵɵelement(0, name);
       }
       if (rf & RenderFlags.Update) {
-        ɵɵelementProperty(0, 'val', ɵɵbind(ctx.val));
+        ɵɵselect(0);
+        ɵɵproperty('val', ctx.val);
       }
     };
   }

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵɵdefineComponent} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementProperty, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart} from '../../src/render3/instructions/all';
+import {ɵɵdefineComponent, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
+import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵpureFunction2} from '../../src/render3/pure_function';
 import {getDirectiveOnNode, renderToHtml} from '../../test/render3/render_util';
@@ -58,9 +58,10 @@ describe('object literals', () => {
               ɵɵelementEnd();
             }
             if (rf1 & RenderFlags.Update) {
-              ɵɵelementProperty(
-                  0, 'config', ɵɵbind(ɵɵpureFunction2(
-                                   1, e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
+              ɵɵselect(0);
+              ɵɵproperty(
+                  'config',
+                  ɵɵpureFunction2(1, e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration));
             }
             ɵɵembeddedViewEnd();
           }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -828,8 +828,6 @@ export declare function ɵɵelementEnd(): void;
 
 export declare function ɵɵelementHostAttrs(attrs: TAttributes): void;
 
-export declare function ɵɵelementProperty<T>(index: number, propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null, nativeOnly?: boolean): void;
-
 export declare function ɵɵelementStart(index: number, name: string, attrs?: TAttributes | null, localRefs?: string[] | null): void;
 
 export declare function ɵɵembeddedViewEnd(): void;


### PR DESCRIPTION
Removes `ɵɵelementProperty`, as it is no longer used.