### PR TITLE
docs: update link to static queries in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ queries have a 'static' flag specifying whether the query is 'static' or
 'dynamic'. The compiler previously sorted queries automatically, but in
 8.0 developers are required to explicitly specify which behavior is wanted.
 This is a temporary requirement as part of a migration; see
-https://angular.io/guide/static-query-migration for more details.
+https://v8.angular.io/guide/static-query-migration for more details.
 
 @ViewChildren and @ContentChildren queries are always dynamic, and so are
 unaffected.

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -58,7 +58,7 @@ async function runMigration(tree: Tree, context: SchematicContext) {
   logger.info('With Angular version 8, developers need to');
   logger.info('explicitly specify the timing of ViewChild and');
   logger.info('ContentChild queries. Read more about this here:');
-  logger.info('https://angular.io/guide/static-query-migration');
+  logger.info('https://v8.angular.io/guide/static-query-migration');
 
   if (!buildPaths.length && !testPaths.length) {
     throw new SchematicsException(
@@ -101,7 +101,7 @@ async function runMigration(tree: Tree, context: SchematicContext) {
     logger.info('Some queries could not be migrated automatically. Please go');
     logger.info('through these manually and apply the appropriate timing.');
     logger.info('For more info on how to choose a flag, please see: ');
-    logger.info('https://angular.io/guide/static-query-migration');
+    logger.info('https://v8.angular.io/guide/static-query-migration');
     failures.forEach(failure => logger.warn(`⮑   ${failure}`));
   }
 


### PR DESCRIPTION
At the moment this link is broken.