### PR TITLE
docs: merge duplicated platform-webworker content in Deprecation Guide

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -369,33 +369,27 @@ These two properties have subtle differences, so switching to `textContent` unde
 
 All of the `wtf*` APIs are deprecated and will be removed in a future version.
 
-{@a platform-webworker}
-### `platform-webworker`
-
-The `@angular/platform-*` packages enable Angular to be run in different contexts. Some examples are running Angular on the server (`@angular/platform-server`), in the browser (`@angular/platform-browser`), or in a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) (`@angular/platform-webworker`).
-
-Though web worker is useful to offload things requiring lots of processing, pushing whole apps to run in the web worker isn't a winning strategy due to many unresolved issues.
-
-Angular CLI doesn't allow use of these APIs because the build system and bundling doesn't support them. This whole package is deprecated in Angular version 8 and will be removed in the future. If you're currently using the `@angular/platform-webworker` APIs in production, please reach out to devrel@angular.io and let us know - we're interested in hearing your use cases.
-
-Instead, use web workers primarily for offloading CPU intensive, but functionally not critical, work needed for initial rendering (for example, in memory search, image processing, and so on).
-
-
-
 {@a webworker-apps}
-### platform-webworker Angular applications
+### Running Angular applications in platform-webworker 
 
+The `@angular/platform-*` packages enable Angular to be run in different contexts. For examples,
+`@angular/platform-server` enables Angular to be run on the server, and `@angular/platform-browser`
+enables Angular to be run in a web browser.
 
-platform-webworker has been around since the initial release of Angular version 2. It began as an experiment to leverage Angular's rendering architecture and try something different: to run an entire web application in a web worker.
+`@angular/platform-webworker` was introduced in Angular version 2 as an experiment in leveraging
+Angular's rendering architecture to run an entire web application in a
+[web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). We've learned a lot
+from this experiment and have come to the conclusion that running the entire application in a web
+worker is not the best strategy for most applications.
 
-We've learned a lot from this experiment, and have come to the conclusion that pushing entire applications to run in a web worker is not a recipe for success for most applications. This is due to a number of unresolved issues, including:
+Going forward, we will focus our efforts related to web workers around their primary use case of
+offloading CPU-intensive, non-critical work needed for initial rendering (such as in-memory search
+and image processing). Learn more in the 
+[guide to Using Web Workers with the Angular CLI](guide/web-worker).
 
-* Poor or non-existent support for web worker APIs in web crawlers/indexers.
-* Poor support in build and bundling tooling.
-
-As a result, as of Angular version 8, we are deprecating the `platform-webworker` APIs in Angular. This consists of both NPM packages, `@angular/platform-webworker` and `@angular/platform-webworker-dynamic`.
-
-Going forward, we will focus our efforts related to web workers around their primary use case of offloading CPU-intensive but not critical work.
+As of Angular version 8, all  `platform-webworker` APIs are deprecated.
+This includes both packages: `@angular/platform-webworker` and
+`@angular/platform-webworker-dynamic`.
 
 {@a removed}
 ## Removed APIs


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
We now have duplicated anchors and platform-webworker deprecation sections.

The one from PR #30598:
is right above https://next.angular.io/guide/deprecations#platform-webworker-angular-applications

The one from PR https://github.com/angular/angular/pull/30642:
https://next.angular.io/guide/deprecations#platform-webworker-angular-applications

The `platform-webworker` id is defined twice:
- https://github.com/angular/angular/blame/250887244eba4e156b56dbec7185a1b0c85f21a4/aio/content/guide/deprecations.md#L125
- https://github.com/angular/angular/blame/250887244eba4e156b56dbec7185a1b0c85f21a4/aio/content/guide/deprecations.md#L366

Issue Number: N/A


## What is the new behavior?
- merge duplicated platform-webworker content
- fix issue of duplicate anchors/ids

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
cc @alxhub @kapunahelewong 