### PR TITLE
fix(ivy): fix PR collision with static: true and new test

### DIFF
--- a/packages/core/test/acceptance/styling_next_spec.ts
+++ b/packages/core/test/acceptance/styling_next_spec.ts
@@ -383,7 +383,7 @@ describe('new styling integration', () => {
               map: any = {width: '111px', opacity: '0.5'};
               width: string|null = '555px';
 
-              @ViewChild('dir', {read: DirThatSetsStyling})
+              @ViewChild('dir', {read: DirThatSetsStyling, static: true})
               dir !: DirThatSetsStyling;
             }
 
@@ -458,7 +458,7 @@ describe('new styling integration', () => {
 
               map: any = {width: '555px', height: '555px'};
 
-              @ViewChild('dir', {read: DirThatSetsStyling})
+              @ViewChild('dir', {read: DirThatSetsStyling, static: true})
               dir !: DirThatSetsStyling;
             }
 


### PR DESCRIPTION
This fixes a collision between #30639 and #30543 where the latter added
usages of @ViewChild without the static flag present, but the former
made the flag required.
