### PR TITLE
refactor(ivy): enable sanitization support for the new styling algorithm

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -1507,5 +1507,80 @@ describe('compiler compliance: styling', () => {
          const result = compile(files, angularFiles);
          expectEmit(result.source, template, 'Incorrect template');
        });
+
+    it('should generate a `styleSanitizer` instruction when a `styleMap` instruction is used',
+       () => {
+         const files = {
+           app: {
+             'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-app',
+              template: \`
+                <div [style]="mapExp"></div>
+              \`
+            })
+            export class MyAppComp {
+              mapExp = {};
+            }
+          `
+           }
+         };
+
+         const template = `
+        template: function MyAppComp_Template(rf, ctx) {
+          …
+          if (rf & 2) {
+            $r3$.ɵɵselect(0);
+            $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
+            $r3$.ɵɵstyleMap(ctx.mapExp);
+            $r3$.ɵɵstylingApply();
+          }
+          …
+        }
+      `;
+
+         const result = compile(files, angularFiles);
+         expectEmit(result.source, template, 'Incorrect template');
+       });
+
+    it('shouldn\'t generate a `styleSanitizer` instruction when class-based instructions are used',
+       () => {
+         const files = {
+           app: {
+             'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-app',
+              template: \`
+                <div [class]="mapExp" [class.name]="nameExp"></div>
+              \`
+            })
+            export class MyAppComp {
+              mapExp = {};
+              nameExp = true;
+            }
+          `
+           }
+         };
+
+         const template = `
+        template: function MyAppComp_Template(rf, ctx) {
+          …
+          if (rf & 2) {
+            $r3$.ɵɵselect(0);
+            $r3$.ɵɵclassMap(ctx.mapExp);
+            $r3$.ɵɵclassProp(0, ctx.nameExp);
+            $r3$.ɵɵstylingApply();
+          }
+          …
+        }
+      `;
+
+         const result = compile(files, angularFiles);
+         expectEmit(result.source, template, 'Incorrect template');
+       });
   });
 });

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -80,6 +80,8 @@ export class Identifiers {
 
   static stylingApply: o.ExternalReference = {name: 'ɵɵstylingApply', moduleName: CORE};
 
+  static styleSanitizer: o.ExternalReference = {name: 'ɵɵstyleSanitizer', moduleName: CORE};
+
   static elementHostAttrs: o.ExternalReference = {name: 'ɵɵelementHostAttrs', moduleName: CORE};
 
   static containerCreate: o.ExternalReference = {name: 'ɵɵcontainer', moduleName: CORE};

--- a/packages/core/src/render3/debug.ts
+++ b/packages/core/src/render3/debug.ts
@@ -195,8 +195,8 @@ export function toDebugNodes(tNode: TNode | null, lView: LView): DebugNode[]|nul
       let styles: DebugNewStyling|null = null;
       let classes: DebugNewStyling|null = null;
       if (runtimeIsNewStylingInUse()) {
-        styles = tNode.newStyles ? new NodeStylingDebug(tNode.newStyles, lView) : null;
-        classes = tNode.newClasses ? new NodeStylingDebug(tNode.newClasses, lView) : null;
+        styles = tNode.newStyles ? new NodeStylingDebug(tNode.newStyles, lView, false) : null;
+        classes = tNode.newClasses ? new NodeStylingDebug(tNode.newClasses, lView, true) : null;
       }
 
       debugNodes.push({

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -102,6 +102,7 @@ export {
   ɵɵselect,
   ɵɵstyleMap,
   ɵɵstyleProp,
+  ɵɵstyleSanitizer,
   ɵɵstyling,
   ɵɵstylingApply,
   ɵɵtemplate,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -45,6 +45,6 @@ export * from './property';
 export * from './property_interpolation';
 export * from './select';
 export * from './styling';
-export * from './text';
 export {styleSanitizer as ɵɵstyleSanitizer} from '../styling_next/instructions';
+export * from './text';
 export * from './text_interpolation';

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -46,4 +46,5 @@ export * from './property_interpolation';
 export * from './select';
 export * from './styling';
 export * from './text';
+export {styleSanitizer as ɵɵstyleSanitizer} from '../styling_next/instructions';
 export * from './text_interpolation';

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -121,6 +121,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵstyling': r3.ɵɵstyling,
        'ɵɵstyleMap': r3.ɵɵstyleMap,
        'ɵɵstyleProp': r3.ɵɵstyleProp,
+       'ɵɵstyleSanitizer': r3.ɵɵstyleSanitizer,
        'ɵɵstylingApply': r3.ɵɵstylingApply,
        'ɵɵclassProp': r3.ɵɵclassProp,
        'ɵɵselect': r3.ɵɵselect,

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -5,7 +5,7 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
-import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
+import {StyleSanitizeFn, StyleSanitizeMode} from '../../sanitization/style_sanitizer';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
 import {AttributeMarker, TAttributes} from '../interfaces/node';
 import {BindingStore, BindingType, Player, PlayerBuilder, PlayerFactory, PlayerIndex} from '../interfaces/player';
@@ -943,7 +943,9 @@ function updateSingleStylingValue(
     if (currDirective !== directiveIndex) {
       const prop = getProp(context, singleIndex);
       const sanitizer = getStyleSanitizer(context, directiveIndex);
-      setSanitizeFlag(context, singleIndex, (sanitizer && sanitizer(prop)) ? true : false);
+      setSanitizeFlag(
+          context, singleIndex,
+          (sanitizer && sanitizer(prop, null, StyleSanitizeMode.ValidateProperty)) ? true : false);
     }
 
     // the value will always get updated (even if the dirty flag is skipped)
@@ -1141,7 +1143,8 @@ export function setStyle(
     native: any, prop: string, value: string | null, renderer: Renderer3,
     sanitizer: StyleSanitizeFn | null, store?: BindingStore | null,
     playerBuilder?: ClassAndStylePlayerBuilder<any>| null) {
-  value = sanitizer && value ? sanitizer(prop, value) : value;
+  value =
+      sanitizer && value ? sanitizer(prop, value, StyleSanitizeMode.ValidateAndSanitize) : value;
   if (store || playerBuilder) {
     if (store) {
       store.setValue(prop, value);
@@ -1461,7 +1464,9 @@ function valueExists(value: string | null | boolean, isClassBased?: boolean) {
 function prepareInitialFlag(
     context: StylingContext, prop: string, entryIsClassBased: boolean,
     sanitizer?: StyleSanitizeFn | null) {
-  let flag = (sanitizer && sanitizer(prop)) ? StylingFlags.Sanitize : StylingFlags.None;
+  let flag = (sanitizer && sanitizer(prop, null, StyleSanitizeMode.ValidateProperty)) ?
+      StylingFlags.Sanitize :
+      StylingFlags.None;
 
   let initialIndex: number;
   if (entryIsClassBased) {

--- a/packages/core/src/render3/styling_next/bindings.ts
+++ b/packages/core/src/render3/styling_next/bindings.ts
@@ -5,10 +5,11 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
+import {StyleSanitizeFn, StyleSanitizeMode} from '../../sanitization/style_sanitizer';
 import {ProceduralRenderer3, RElement, Renderer3, RendererStyleFlags3, isProceduralRenderer} from '../interfaces/renderer';
 
-import {ApplyStylingFn, LStylingData, LStylingMap, StylingMapsSyncMode, SyncStylingMapsFn, TStylingContext, TStylingContextIndex} from './interfaces';
-import {allowStylingFlush, getBindingValue, getGuardMask, getProp, getPropValuesStartPosition, getValuesCount, hasValueChanged, isContextLocked, isStylingValueDefined, lockContext} from './util';
+import {ApplyStylingFn, LStylingData, LStylingMap, StylingMapsSyncMode, SyncStylingMapsFn, TStylingContext, TStylingContextIndex, TStylingContextPropConfigFlags} from './interfaces';
+import {allowStylingFlush, getBindingValue, getGuardMask, getProp, getPropValuesStartPosition, getValuesCount, hasValueChanged, isContextLocked, isSanitizationRequired, isStylingValueDefined, lockContext, setGuardMask} from './util';
 
 
 /**
@@ -49,7 +50,7 @@ let currentStyleIndex = STYLING_INDEX_START_VALUE;
 let currentClassIndex = STYLING_INDEX_START_VALUE;
 let stylesBitMask = 0;
 let classesBitMask = 0;
-let deferredBindingQueue: (TStylingContext | number | string | null)[] = [];
+let deferredBindingQueue: (TStylingContext | number | string | null | boolean)[] = [];
 
 /**
  * Visits a class-based binding and updates the new value (if changed).
@@ -64,11 +65,11 @@ let deferredBindingQueue: (TStylingContext | number | string | null)[] = [];
 export function updateClassBinding(
     context: TStylingContext, data: LStylingData, prop: string | null, bindingIndex: number,
     value: boolean | string | null | undefined | LStylingMap, deferRegistration: boolean,
-    forceUpdate?: boolean): void {
+    forceUpdate: boolean): void {
   const isMapBased = !prop;
   const index = isMapBased ? STYLING_INDEX_FOR_MAP_BINDING : currentClassIndex++;
   const updated = updateBindingData(
-      context, data, index, prop, bindingIndex, value, deferRegistration, forceUpdate);
+      context, data, index, prop, bindingIndex, value, deferRegistration, forceUpdate, false);
   if (updated || forceUpdate) {
     classesBitMask |= 1 << index;
   }
@@ -86,12 +87,16 @@ export function updateClassBinding(
  */
 export function updateStyleBinding(
     context: TStylingContext, data: LStylingData, prop: string | null, bindingIndex: number,
-    value: String | string | number | null | undefined | LStylingMap, deferRegistration: boolean,
-    forceUpdate?: boolean): void {
+    value: String | string | number | null | undefined | LStylingMap,
+    sanitizer: StyleSanitizeFn | null, deferRegistration: boolean, forceUpdate: boolean): void {
   const isMapBased = !prop;
   const index = isMapBased ? STYLING_INDEX_FOR_MAP_BINDING : currentStyleIndex++;
+  const sanitizationRequired = isMapBased ?
+      true :
+      (sanitizer ? sanitizer(prop !, null, StyleSanitizeMode.ValidateProperty) : false);
   const updated = updateBindingData(
-      context, data, index, prop, bindingIndex, value, deferRegistration, forceUpdate);
+      context, data, index, prop, bindingIndex, value, deferRegistration, forceUpdate,
+      sanitizationRequired);
   if (updated || forceUpdate) {
     stylesBitMask |= 1 << index;
   }
@@ -114,10 +119,10 @@ function updateBindingData(
     context: TStylingContext, data: LStylingData, counterIndex: number, prop: string | null,
     bindingIndex: number,
     value: string | String | number | boolean | null | undefined | LStylingMap,
-    deferRegistration?: boolean, forceUpdate?: boolean): boolean {
+    deferRegistration: boolean, forceUpdate: boolean, sanitizationRequired: boolean): boolean {
   if (!isContextLocked(context)) {
     if (deferRegistration) {
-      deferBindingRegistration(context, counterIndex, prop, bindingIndex);
+      deferBindingRegistration(context, counterIndex, prop, bindingIndex, sanitizationRequired);
     } else {
       deferredBindingQueue.length && flushDeferredBindings();
 
@@ -127,7 +132,7 @@ function updateBindingData(
       // update pass is executed (remember that all styling instructions
       // are run in the update phase, and, as a result, are no more
       // styling instructions that are run in the creation phase).
-      registerBinding(context, counterIndex, prop, bindingIndex);
+      registerBinding(context, counterIndex, prop, bindingIndex, sanitizationRequired);
     }
   }
 
@@ -150,8 +155,10 @@ function updateBindingData(
  * after the inheritance chain exits.
  */
 function deferBindingRegistration(
-    context: TStylingContext, counterIndex: number, prop: string | null, bindingIndex: number) {
-  deferredBindingQueue.splice(0, 0, context, counterIndex, prop, bindingIndex);
+    context: TStylingContext, counterIndex: number, prop: string | null, bindingIndex: number,
+    sanitizationRequired: boolean) {
+  deferredBindingQueue.splice(
+      0, 0, context, counterIndex, prop, bindingIndex, sanitizationRequired);
 }
 
 /**
@@ -165,7 +172,8 @@ function flushDeferredBindings() {
     const count = deferredBindingQueue[i++] as number;
     const prop = deferredBindingQueue[i++] as string;
     const bindingIndex = deferredBindingQueue[i++] as number | null;
-    registerBinding(context, count, prop, bindingIndex);
+    const sanitizationRequired = deferredBindingQueue[i++] as boolean;
+    registerBinding(context, count, prop, bindingIndex, sanitizationRequired);
   }
   deferredBindingQueue.length = 0;
 }
@@ -208,7 +216,7 @@ function flushDeferredBindings() {
  */
 export function registerBinding(
     context: TStylingContext, countId: number, prop: string | null,
-    bindingValue: number | null | string | boolean) {
+    bindingValue: number | null | string | boolean, sanitizationRequired?: boolean) {
   // prop-based bindings (e.g `<div [style.width]="w" [class.foo]="f">`)
   if (prop) {
     let found = false;
@@ -220,7 +228,7 @@ export function registerBinding(
       if (found) {
         // all style/class bindings are sorted by property name
         if (prop < p) {
-          allocateNewContextEntry(context, i, prop);
+          allocateNewContextEntry(context, i, prop, sanitizationRequired);
         }
         addBindingIntoContext(context, false, i, bindingValue, countId);
         break;
@@ -229,7 +237,7 @@ export function registerBinding(
     }
 
     if (!found) {
-      allocateNewContextEntry(context, context.length, prop);
+      allocateNewContextEntry(context, context.length, prop, sanitizationRequired);
       addBindingIntoContext(context, false, i, bindingValue, countId);
     }
   } else {
@@ -241,15 +249,18 @@ export function registerBinding(
   }
 }
 
-function allocateNewContextEntry(context: TStylingContext, index: number, prop: string) {
+function allocateNewContextEntry(
+    context: TStylingContext, index: number, prop: string, sanitizationRequired?: boolean) {
   // 1,2: splice index locations
-  // 3: each entry gets a guard mask value that is used to check against updates
+  // 3: each entry gets a config value (guard mask + flags)
   // 4. each entry gets a size value (which is always one because there is always a default binding
   // value)
   // 5. the property that is getting allocated into the context
   // 6. the default binding value (usually `null`)
-  context.splice(
-      index, 0, DEFAULT_GUARD_MASK_VALUE, DEFAULT_SIZE_VALUE, prop, DEFAULT_BINDING_VALUE);
+  const config = sanitizationRequired ? TStylingContextPropConfigFlags.SanitizationRequired :
+                                        TStylingContextPropConfigFlags.Default;
+  context.splice(index, 0, config, DEFAULT_SIZE_VALUE, prop, DEFAULT_BINDING_VALUE);
+  setGuardMask(context, index, DEFAULT_GUARD_MASK_VALUE);
 }
 
 /**
@@ -285,7 +296,12 @@ function addBindingIntoContext(
   if (typeof bindingValue === 'number') {
     context.splice(lastValueIndex, 0, bindingValue);
     (context[index + TStylingContextIndex.ValuesCountOffset] as number)++;
-    (context[index + TStylingContextIndex.GuardOffset] as number) |= 1 << countId;
+
+    // now that a new binding index has been added to the property
+    // the guard mask bit value (at the `countId` position) needs
+    // to be included into the existing mask value.
+    const guardMask = getGuardMask(context, index) | (1 << countId);
+    setGuardMask(context, index, guardMask);
   } else if (typeof bindingValue === 'string' && context[lastValueIndex] == null) {
     context[lastValueIndex] = bindingValue;
   }
@@ -294,37 +310,49 @@ function addBindingIntoContext(
 /**
  * Applies all class entries in the provided context to the provided element and resets
  * any counter and/or bitMask values associated with class bindings.
+ *
+ * @returns whether or not the classes were flushed to the element.
  */
 export function applyClasses(
     renderer: Renderer3 | ProceduralRenderer3 | null, data: LStylingData, context: TStylingContext,
-    element: RElement, directiveIndex: number) {
+    element: RElement, directiveIndex: number): boolean {
+  let classesFlushed = false;
   if (allowStylingFlush(context, directiveIndex)) {
     const isFirstPass = !isContextLocked(context);
     isFirstPass && lockContext(context);
     if (classesBitMask) {
-      applyStyling(context, renderer, element, data, classesBitMask, setClass);
+      // there is no way to sanitize a class value therefore `sanitizer=null`
+      applyStyling(context, renderer, element, data, classesBitMask, setClass, null);
       classesBitMask = 0;
+      classesFlushed = true;
     }
     currentClassIndex = STYLING_INDEX_START_VALUE;
   }
+  return classesFlushed;
 }
 
 /**
  * Applies all style entries in the provided context to the provided element and resets
  * any counter and/or bitMask values associated with style bindings.
+ *
+ * @returns whether or not the styles were flushed to the element.
  */
 export function applyStyles(
     renderer: Renderer3 | ProceduralRenderer3 | null, data: LStylingData, context: TStylingContext,
-    element: RElement, directiveIndex: number) {
+    element: RElement, directiveIndex: number, sanitizer: StyleSanitizeFn | null): boolean {
+  let stylesFlushed = false;
   if (allowStylingFlush(context, directiveIndex)) {
     const isFirstPass = !isContextLocked(context);
     isFirstPass && lockContext(context);
     if (stylesBitMask) {
-      applyStyling(context, renderer, element, data, stylesBitMask, setStyle);
+      applyStyling(context, renderer, element, data, stylesBitMask, setStyle, sanitizer);
       stylesBitMask = 0;
+      stylesFlushed = true;
     }
     currentStyleIndex = STYLING_INDEX_START_VALUE;
+    return true;
   }
+  return stylesFlushed;
 }
 
 /**
@@ -355,7 +383,8 @@ export function applyStyles(
  */
 export function applyStyling(
     context: TStylingContext, renderer: Renderer3 | ProceduralRenderer3 | null, element: RElement,
-    bindingData: LStylingData, bitMaskValue: number | boolean, applyStylingFn: ApplyStylingFn) {
+    bindingData: LStylingData, bitMaskValue: number | boolean, applyStylingFn: ApplyStylingFn,
+    sanitizer: StyleSanitizeFn | null) {
   deferredBindingQueue.length && flushDeferredBindings();
 
   const bitMask = normalizeBitMaskValue(bitMaskValue);
@@ -380,9 +409,12 @@ export function applyStyling(
       // value gets set for the styling binding
       for (let j = 0; j < valuesCountUpToDefault; j++) {
         const bindingIndex = getBindingValue(context, i, j) as number;
-        const valueToApply = bindingData[bindingIndex];
-        if (isStylingValueDefined(valueToApply)) {
-          applyStylingFn(renderer, element, prop, valueToApply, bindingIndex);
+        const value = bindingData[bindingIndex];
+        if (isStylingValueDefined(value)) {
+          const finalValue = sanitizer && isSanitizationRequired(context, i) ?
+              sanitizer(prop, value, StyleSanitizeMode.SanitizeOnly) :
+              value;
+          applyStylingFn(renderer, element, prop, finalValue, bindingIndex);
           valueApplied = true;
           break;
         }
@@ -397,7 +429,8 @@ export function applyStyling(
         const mode = mapsMode | (valueApplied ? StylingMapsSyncMode.SkipTargetProp :
                                                 StylingMapsSyncMode.ApplyTargetProp);
         const valueAppliedWithinMap = stylingMapsSyncFn(
-            context, renderer, element, bindingData, applyStylingFn, mode, prop, defaultValue);
+            context, renderer, element, bindingData, applyStylingFn, sanitizer, mode, prop,
+            defaultValue);
         valueApplied = valueApplied || valueAppliedWithinMap;
       }
 
@@ -417,7 +450,7 @@ export function applyStyling(
   // values. For this reason, one more call to the sync function
   // needs to be issued at the end.
   if (stylingMapsSyncFn) {
-    stylingMapsSyncFn(context, renderer, element, bindingData, applyStylingFn, mapsMode);
+    stylingMapsSyncFn(context, renderer, element, bindingData, applyStylingFn, sanitizer, mapsMode);
   }
 }
 

--- a/packages/core/src/render3/styling_next/bindings.ts
+++ b/packages/core/src/render3/styling_next/bindings.ts
@@ -157,8 +157,7 @@ function updateBindingData(
 function deferBindingRegistration(
     context: TStylingContext, counterIndex: number, prop: string | null, bindingIndex: number,
     sanitizationRequired: boolean) {
-  deferredBindingQueue.splice(
-      0, 0, context, counterIndex, prop, bindingIndex, sanitizationRequired);
+  deferredBindingQueue.unshift(context, counterIndex, prop, bindingIndex, sanitizationRequired);
 }
 
 /**

--- a/packages/core/src/render3/styling_next/instructions.ts
+++ b/packages/core/src/render3/styling_next/instructions.ts
@@ -21,7 +21,7 @@ import {applyClasses, applyStyles, registerBinding, updateClassBinding, updateSt
 import {TStylingContext} from './interfaces';
 import {activeStylingMapFeature, normalizeIntoStylingMap} from './map_based_bindings';
 import {attachStylingDebugObject} from './styling_debug';
-import {allocStylingContext, hasValueChanged, updateContextDirectiveIndex} from './util';
+import {allocTStylingContext, hasValueChanged, updateContextDirectiveIndex} from './util';
 
 
 
@@ -302,7 +302,7 @@ function getClassesContext(tNode: TNode): TStylingContext {
 function getContext(tNode: TNode, isClassBased: boolean) {
   let context = isClassBased ? tNode.newClasses : tNode.newStyles;
   if (!context) {
-    context = allocStylingContext();
+    context = allocTStylingContext();
     if (ngDevMode) {
       attachStylingDebugObject(context);
     }

--- a/packages/core/src/render3/styling_next/state.ts
+++ b/packages/core/src/render3/styling_next/state.ts
@@ -5,6 +5,8 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
+import {Sanitizer} from '../../sanitization/security';
+import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 
 /**
  * --------
@@ -47,4 +49,13 @@ export function runtimeIsNewStylingInUse() {
 
 export function runtimeAllowOldStyling() {
   return _stylingMode < RuntimeStylingMode.UseNew;
+}
+
+let _currentSanitizer: Sanitizer|StyleSanitizeFn|null;
+export function setCurrentStyleSanitizer(sanitizer: Sanitizer | StyleSanitizeFn | null) {
+  _currentSanitizer = sanitizer;
+}
+
+export function getCurrentStyleSanitizer() {
+  return _currentSanitizer;
 }

--- a/packages/core/src/render3/styling_next/state.ts
+++ b/packages/core/src/render3/styling_next/state.ts
@@ -7,6 +7,19 @@
 */
 
 /**
+ * --------
+ *
+ * This file contains temporary code to incorporate the new styling refactor
+ * code to work alongside the existing instruction set.
+ *
+ * This file will be removed once `select(n)` is fully functional (once
+ * it is able to evaluate host bindings in sync element-by-element
+ * with template code).
+ *
+ * --------
+ */
+
+/**
  * A temporary enum of states that inform the core whether or not
  * to defer all styling instruction calls to the old or new
  * styling implementation.

--- a/packages/core/src/render3/styling_next/styling_debug.ts
+++ b/packages/core/src/render3/styling_next/styling_debug.ts
@@ -5,13 +5,17 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
+import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {RElement} from '../interfaces/renderer';
+import {LView} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
 
 import {applyStyling} from './bindings';
+import {getCurrentStyleSanitizer} from './instructions';
 import {ApplyStylingFn, LStylingData, TStylingContext, TStylingContextIndex} from './interfaces';
 import {activeStylingMapFeature} from './map_based_bindings';
-import {getDefaultValue, getGuardMask, getProp, getValuesCount, isContextLocked, isMapBased} from './util';
+import {getDefaultValue, getGuardMask, getProp, getValuesCount, isContextLocked, isMapBased, isSanitizationRequired} from './util';
+
 
 /**
  * --------
@@ -59,6 +63,11 @@ export interface DebugStyling {
    * runtime values.
    */
   values: {[key: string]: string | number | null | boolean};
+
+  /**
+   * Overrides the sanitizer used to process styles.
+   */
+  overrideSanitizer(sanitizer: StyleSanitizeFn|null): void;
 }
 
 /**
@@ -76,6 +85,11 @@ export interface TStylingTupleSummary {
    * styling changes when and styling bindings update
    */
   guardMask: number;
+
+  /**
+   * Whether or not the entry requires sanitization
+   */
+  sanitizationRequired: boolean;
 
   /**
    * The default value that will be applied if any bindings are falsy.
@@ -127,6 +141,7 @@ class TStylingContextDebug {
         const prop = getProp(context, i);
         const guardMask = getGuardMask(context, i);
         const defaultValue = getDefaultValue(context, i);
+        const sanitizationRequired = isSanitizationRequired(context, i);
         const bindingsStartPosition = i + TStylingContextIndex.BindingsStartOffset;
 
         const sources: (number | string | null)[] = [];
@@ -134,7 +149,7 @@ class TStylingContextDebug {
           sources.push(context[bindingsStartPosition + j] as number | string | null);
         }
 
-        entries[prop] = {prop, guardMask, valuesCount, defaultValue, sources};
+        entries[prop] = {prop, guardMask, sanitizationRequired, valuesCount, defaultValue, sources};
       }
 
       i += TStylingContextIndex.BindingsStartOffset + valuesCount;
@@ -150,7 +165,16 @@ class TStylingContextDebug {
  * application has `ngDevMode` activated.
  */
 export class NodeStylingDebug implements DebugStyling {
-  constructor(public context: TStylingContext, private _data: LStylingData) {}
+  private _sanitizer: StyleSanitizeFn|null = null;
+
+  constructor(
+      public context: TStylingContext, private _data: LStylingData,
+      private _isClassBased?: boolean) {}
+
+  /**
+   * Overrides the sanitizer used to process styles.
+   */
+  overrideSanitizer(sanitizer: StyleSanitizeFn|null) { this._sanitizer = sanitizer; }
 
   /**
    * Returns a detailed summary of each styling entry in the context and
@@ -190,6 +214,8 @@ export class NodeStylingDebug implements DebugStyling {
           fn(prop, value, bindingIndex || null);
         };
 
-    applyStyling(this.context, null, mockElement, this._data, true, mapFn);
+    const sanitizer = this._isClassBased ? null : (this._sanitizer ||
+                                                   getCurrentStyleSanitizer(this._data as LView));
+    applyStyling(this.context, null, mockElement, this._data, true, mapFn, sanitizer);
   }
 }

--- a/packages/core/src/render3/styling_next/styling_debug.ts
+++ b/packages/core/src/render3/styling_next/styling_debug.ts
@@ -5,16 +5,18 @@
 * Use of this source code is governed by an MIT-style license that can be
 * found in the LICENSE file at https://angular.io/license
 */
+import {Sanitizer} from '../../sanitization/security';
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {RElement} from '../interfaces/renderer';
-import {LView} from '../interfaces/view';
+import {LView, SANITIZER} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
 
 import {applyStyling} from './bindings';
-import {getCurrentStyleSanitizer} from './instructions';
 import {ApplyStylingFn, LStylingData, TStylingContext, TStylingContextIndex} from './interfaces';
 import {activeStylingMapFeature} from './map_based_bindings';
-import {getDefaultValue, getGuardMask, getProp, getValuesCount, isContextLocked, isMapBased, isSanitizationRequired} from './util';
+import {getCurrentStyleSanitizer} from './state';
+import {getCurrentOrLViewSanitizer, getDefaultValue, getGuardMask, getProp, getValuesCount, isContextLocked, isMapBased, isSanitizationRequired} from './util';
+
 
 
 /**
@@ -215,7 +217,7 @@ export class NodeStylingDebug implements DebugStyling {
         };
 
     const sanitizer = this._isClassBased ? null : (this._sanitizer ||
-                                                   getCurrentStyleSanitizer(this._data as LView));
+                                                   getCurrentOrLViewSanitizer(this._data as LView));
     applyStyling(this.context, null, mockElement, this._data, true, mapFn, sanitizer);
   }
 }

--- a/packages/core/src/render3/styling_next/util.ts
+++ b/packages/core/src/render3/styling_next/util.ts
@@ -18,7 +18,7 @@ const MAP_BASED_ENTRY_PROP_NAME = '--MAP--';
  * This function will also pre-fill the context with data
  * for map-based bindings.
  */
-export function allocStylingContext(): TStylingContext {
+export function allocTStylingContext(): TStylingContext {
   // because map-based bindings deal with a dynamic set of values, there
   // is no way to know ahead of time whether or not sanitization is required.
   // For this reason the configuration will always mark sanitization as active

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -13,7 +13,7 @@ import {renderStringify} from '../render3/util/misc_utils';
 import {BypassType, allowSanitizationBypass} from './bypass';
 import {_sanitizeHtml as _sanitizeHtml} from './html_sanitizer';
 import {Sanitizer, SecurityContext} from './security';
-import {StyleSanitizeFn, _sanitizeStyle as _sanitizeStyle} from './style_sanitizer';
+import {StyleSanitizeFn, StyleSanitizeMode, _sanitizeStyle as _sanitizeStyle} from './style_sanitizer';
 import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
 
 
@@ -183,15 +183,22 @@ export function ɵɵsanitizeUrlOrResourceUrl(unsafeUrl: any, tag: string, prop: 
  *
  * @publicApi
  */
-export const ɵɵdefaultStyleSanitizer = (function(prop: string, value?: string): string | boolean {
-  if (value === undefined) {
-    return prop === 'background-image' || prop === 'background' || prop === 'border-image' ||
-        prop === 'filter' || prop === 'list-style' || prop === 'list-style-image' ||
-        prop === 'clip-path';
-  }
+export const ɵɵdefaultStyleSanitizer =
+    (function(prop: string, value: string|null, mode?: StyleSanitizeMode): string | boolean | null {
+      mode = mode || StyleSanitizeMode.ValidateAndSanitize;
+      let doSanitizeValue = true;
+      if (mode & StyleSanitizeMode.ValidateProperty) {
+        doSanitizeValue = prop === 'background-image' || prop === 'background' ||
+            prop === 'border-image' || prop === 'filter' || prop === 'list-style' ||
+            prop === 'list-style-image' || prop === 'clip-path';
+      }
 
-  return ɵɵsanitizeStyle(value);
-} as StyleSanitizeFn);
+      if (mode & StyleSanitizeMode.SanitizeOnly) {
+        return doSanitizeValue ? ɵɵsanitizeStyle(value) : value;
+      } else {
+        return doSanitizeValue;
+      }
+    } as StyleSanitizeFn);
 
 export function validateAgainstEventProperties(name: string) {
   if (name.toLowerCase().startsWith('on')) {

--- a/packages/core/src/sanitization/style_sanitizer.ts
+++ b/packages/core/src/sanitization/style_sanitizer.ts
@@ -104,6 +104,30 @@ export function _sanitizeStyle(value: string): string {
 
 
 /**
+ * A series of flags to instruct a style sanitizer to either validate
+ * or sanitize a value.
+ *
+ * Because sanitization is dependent on the style property (i.e. style
+ * sanitization for `width` is much different than for `background-image`)
+ * the sanitization function (e.g. `StyleSanitizerFn`) needs to check a
+ * property value first before it actually sanitizes any values.
+ *
+ * This enum exist to allow a style sanitization function to either only
+ * do validation (check the property to see whether a value will be
+ * sanitized or not) or to sanitize the value (or both).
+ *
+ * @publicApi
+ */
+export const enum StyleSanitizeMode {
+  /** Just check to see if the property is required to be sanitized or not */
+  ValidateProperty = 0b01,
+  /** Skip checking the property; just sanitize the value */
+  SanitizeOnly = 0b10,
+  /** Check the property and (if true) then sanitize the value */
+  ValidateAndSanitize = 0b11,
+}
+
+/**
  * Used to intercept and sanitize style values before they are written to the renderer.
  *
  * This function is designed to be called in two modes. When a value is not provided
@@ -111,9 +135,5 @@ export function _sanitizeStyle(value: string): string {
  * If a value is provided then the sanitized version of that will be returned.
  */
 export interface StyleSanitizeFn {
-  /** This mode is designed to instruct whether the property will be used for sanitization
-   * at a later point */
-  (prop: string): boolean;
-  /** This mode is designed to sanitize the provided value */
-  (prop: string, value: string): string;
+  (prop: string, value: string|null, mode?: StyleSanitizeMode): any;
 }

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -192,7 +192,7 @@
     "name": "allocStylingContext"
   },
   {
-    "name": "allocStylingContext"
+    "name": "allocTStylingContext"
   },
   {
     "name": "allocateNewContextEntry"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -363,6 +363,9 @@
     "name": "getGlobal"
   },
   {
+    "name": "getGuardMask"
+  },
+  {
     "name": "getHighestElementOrICUContainer"
   },
   {
@@ -433,6 +436,9 @@
   },
   {
     "name": "getProp"
+  },
+  {
+    "name": "getPropConfig"
   },
   {
     "name": "getPropValuesStartPosition"
@@ -685,6 +691,9 @@
   },
   {
     "name": "setCurrentQueryIndex"
+  },
+  {
+    "name": "setGuardMask"
   },
   {
     "name": "setHostBindings"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -447,7 +447,7 @@
     "name": "allocStylingContext"
   },
   {
-    "name": "allocStylingContext"
+    "name": "allocTStylingContext"
   },
   {
     "name": "allocateNewContextEntry"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -231,6 +231,9 @@
     "name": "SWITCH_VIEW_CONTAINER_REF_FACTORY"
   },
   {
+    "name": "SecurityContext"
+  },
+  {
     "name": "SkipSelf"
   },
   {
@@ -786,6 +789,9 @@
     "name": "getContextLView"
   },
   {
+    "name": "getCurrentStyleSanitizer"
+  },
+  {
     "name": "getDebugContext"
   },
   {
@@ -934,6 +940,9 @@
   },
   {
     "name": "getProp"
+  },
+  {
+    "name": "getPropConfig"
   },
   {
     "name": "getPropValuesStartPosition"
@@ -1152,6 +1161,9 @@
     "name": "isRootView"
   },
   {
+    "name": "isSanitizationRequired"
+  },
+  {
     "name": "isStylingContext"
   },
   {
@@ -1344,6 +1356,9 @@
     "name": "runtimeIsNewStylingInUse"
   },
   {
+    "name": "sanitizeUsingSanitizerObject"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {
@@ -1392,10 +1407,16 @@
     "name": "setCurrentQueryIndex"
   },
   {
+    "name": "setCurrentStyleSanitizer"
+  },
+  {
     "name": "setDirty"
   },
   {
     "name": "setFlag"
+  },
+  {
+    "name": "setGuardMask"
   },
   {
     "name": "setHostBindings"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -789,6 +789,9 @@
     "name": "getContextLView"
   },
   {
+    "name": "getCurrentOrLViewSanitizer"
+  },
+  {
     "name": "getCurrentStyleSanitizer"
   },
   {

--- a/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
+++ b/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
@@ -23,7 +23,7 @@ import {registerHostDirective} from '../../../src/render3/styling/host_instructi
 import {BoundPlayerFactory, bindPlayerFactory} from '../../../src/render3/styling/player_factory';
 import {allocStylingContext, createEmptyStylingContext} from '../../../src/render3/styling/util';
 import {ɵɵdefaultStyleSanitizer} from '../../../src/sanitization/sanitization';
-import {StyleSanitizeFn} from '../../../src/sanitization/style_sanitizer';
+import {StyleSanitizeFn, StyleSanitizeMode} from '../../../src/sanitization/style_sanitizer';
 import {ComponentFixture, renderToHtml} from '../render_util';
 
 import {MockPlayer} from './mock_player';
@@ -2991,11 +2991,16 @@ describe('style and class based bindings', () => {
     });
 
     it('should sanitize styles before they are passed into the player', () => {
-      const sanitizer = (function(prop: string, value?: string): string | boolean {
-        if (value === undefined) {
-          return prop === 'width' || prop === 'height';
+      const sanitizer = (function(prop: string, value: string, mode: StyleSanitizeMode): any {
+        let allow = true;
+        if (mode & StyleSanitizeMode.ValidateProperty) {
+          allow = prop === 'width' || prop === 'height';
+        }
+
+        if (mode & StyleSanitizeMode.SanitizeOnly) {
+          return allow ? `${value}-safe!` : value;
         } else {
-          return `${value}-safe!`;
+          return allow;
         }
       }) as StyleSanitizeFn;
 

--- a/packages/core/test/render3/styling_next/styling_context_spec.ts
+++ b/packages/core/test/render3/styling_next/styling_context_spec.ts
@@ -7,7 +7,6 @@
  */
 import {DEFAULT_GUARD_MASK_VALUE, registerBinding} from '@angular/core/src/render3/styling_next/bindings';
 import {attachStylingDebugObject} from '@angular/core/src/render3/styling_next/styling_debug';
-
 import {allocStylingContext} from '../../../src/render3/styling_next/util';
 
 describe('styling context', () => {
@@ -20,6 +19,7 @@ describe('styling context', () => {
     expect(debug.entries['width']).toEqual({
       prop: 'width',
       valuesCount: 1,
+      sanitizationRequired: false,
       guardMask: buildGuardMask(),
       defaultValue: '100px',
       sources: ['100px'],
@@ -28,6 +28,7 @@ describe('styling context', () => {
     registerBinding(context, 2, 'width', 20);
     expect(debug.entries['width']).toEqual({
       prop: 'width',
+      sanitizationRequired: false,
       valuesCount: 2,
       guardMask: buildGuardMask(2),
       defaultValue: '100px',
@@ -39,6 +40,7 @@ describe('styling context', () => {
     expect(debug.entries['height']).toEqual({
       prop: 'height',
       valuesCount: 3,
+      sanitizationRequired: false,
       guardMask: buildGuardMask(3, 4),
       defaultValue: null,
       sources: [10, 15, null],
@@ -50,9 +52,11 @@ describe('styling context', () => {
     const context = debug.context;
 
     registerBinding(context, 1, 'width', null);
+    const x = debug.entries['width'];
     expect(debug.entries['width']).toEqual({
       prop: 'width',
       valuesCount: 1,
+      sanitizationRequired: false,
       guardMask: buildGuardMask(),
       defaultValue: null,
       sources: [null]
@@ -62,6 +66,7 @@ describe('styling context', () => {
     expect(debug.entries['width']).toEqual({
       prop: 'width',
       valuesCount: 1,
+      sanitizationRequired: false,
       guardMask: buildGuardMask(),
       defaultValue: '100px',
       sources: ['100px']
@@ -71,6 +76,7 @@ describe('styling context', () => {
     expect(debug.entries['width']).toEqual({
       prop: 'width',
       valuesCount: 1,
+      sanitizationRequired: false,
       guardMask: buildGuardMask(),
       defaultValue: '100px',
       sources: ['100px']

--- a/packages/core/test/render3/styling_next/styling_context_spec.ts
+++ b/packages/core/test/render3/styling_next/styling_context_spec.ts
@@ -7,7 +7,7 @@
  */
 import {DEFAULT_GUARD_MASK_VALUE, registerBinding} from '@angular/core/src/render3/styling_next/bindings';
 import {attachStylingDebugObject} from '@angular/core/src/render3/styling_next/styling_debug';
-import {allocStylingContext} from '../../../src/render3/styling_next/util';
+import {allocTStylingContext} from '../../../src/render3/styling_next/util';
 
 describe('styling context', () => {
   it('should register a series of entries into the context', () => {
@@ -85,7 +85,7 @@ describe('styling context', () => {
 });
 
 function makeContextWithDebug() {
-  const ctx = allocStylingContext();
+  const ctx = allocTStylingContext();
   return attachStylingDebugObject(ctx);
 }
 

--- a/packages/core/test/render3/styling_next/styling_debug_spec.ts
+++ b/packages/core/test/render3/styling_next/styling_debug_spec.ts
@@ -7,7 +7,7 @@
  */
 import {registerBinding} from '@angular/core/src/render3/styling_next/bindings';
 import {NodeStylingDebug, attachStylingDebugObject} from '@angular/core/src/render3/styling_next/styling_debug';
-import {allocStylingContext} from '@angular/core/src/render3/styling_next/util';
+import {allocTStylingContext} from '@angular/core/src/render3/styling_next/util';
 
 describe('styling debugging tools', () => {
   describe('NodeStylingDebug', () => {
@@ -64,6 +64,6 @@ describe('styling debugging tools', () => {
 });
 
 function makeContextWithDebug() {
-  const ctx = allocStylingContext();
+  const ctx = allocTStylingContext();
   return attachStylingDebugObject(ctx);
 }


### PR DESCRIPTION
This patch is one of the final patches to refactor the styling algorithm
to be more efficient, performant and less complex.

This patch enables sanitization support for map-based and prop-based
style bindings.