### PR TITLE
docs: remove core.module.ts from file tree in style guide

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -1986,10 +1986,6 @@ Here is a compliant folder and file structure:
         <div class='children'>
 
           <div class='file'>
-            core.module.ts
-          </div>
-
-          <div class='file'>
             exception.service.ts|spec.ts
           </div>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

After https://github.com/angular/angular/pull/28434 merged, `core.module.ts` is left in the styleguide.


## What is the new behavior?

`core.module.ts` has been removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
