### PR TITLE
fix(ivy): module with providers are processed too early

### DIFF
--- a/packages/core/test/acceptance/BUILD.bazel
+++ b/packages/core/test/acceptance/BUILD.bazel
@@ -24,6 +24,7 @@ ts_library(
         "//packages/platform-browser/testing",
         "//packages/platform-server",
         "//packages/private/testing",
+        "//packages/router",
         "@npm//rxjs",
         "@npm//zone.js",
     ],

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Attribute, ChangeDetectorRef, Component, Directive, ElementRef, EventEmitter, Host, HostBinding, INJECTOR, Inject, Injectable, Injector, Input, LOCALE_ID, Optional, Output, Pipe, PipeTransform, Self, SkipSelf, TemplateRef, ViewChild, ViewContainerRef, forwardRef} from '@angular/core';
+import {Attribute, ChangeDetectorRef, Component, Directive, ElementRef, EventEmitter, Host, HostBinding, INJECTOR, Inject, Injectable, InjectionToken, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, Optional, Output, Pipe, PipeTransform, Self, SkipSelf, TemplateRef, ViewChild, ViewContainerRef, forwardRef} from '@angular/core';
 import {ViewRef} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
@@ -28,6 +28,32 @@ describe('di', () => {
 
       const divElement = fixture.nativeElement.querySelector('div');
       expect(divElement.textContent).toContain('Created');
+    });
+  });
+
+  describe('multi providers', () => {
+    it('should process ModuleWithProvider providers after module imports', () => {
+      const testToken = new InjectionToken<string[]>('test-multi');
+
+      @NgModule({providers: [{provide: testToken, useValue: 'A', multi: true}]})
+      class TestModuleA {
+      }
+
+      @NgModule({providers: [{provide: testToken, useValue: 'B', multi: true}]})
+      class TestModuleB {
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          {
+            ngModule: TestModuleA,
+            providers: [{provide: testToken, useValue: 'C', multi: true}],
+          },
+          TestModuleB,
+        ]
+      });
+
+      expect(TestBed.get(testToken) as string[]).toEqual(['A', 'B', 'C']);
     });
   });
 

--- a/packages/core/test/acceptance/router_integration_spec.ts
+++ b/packages/core/test/acceptance/router_integration_spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {APP_BASE_HREF} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {Router, RouterModule} from '@angular/router';
+
+describe('router integration acceptance', () => {
+  // Test case that ensures that we don't regress in multi-provider ordering
+  // which is leveraged in the router. See: FW-1349
+  it('should have correct order for multiple routes declared in different modules', () => {
+    @NgModule({
+      imports: [
+        RouterModule.forChild([
+          {path: '1a:1', redirectTo: ''},
+          {path: '1a:2', redirectTo: ''},
+        ]),
+      ],
+    })
+    class Level1AModule {
+    }
+
+    @NgModule({
+      imports: [
+        RouterModule.forChild([
+          {path: '1b:1', redirectTo: ''},
+          {path: '1b:2', redirectTo: ''},
+        ]),
+      ],
+    })
+    class Level1BModule {
+    }
+
+    @NgModule({
+      imports: [
+        RouterModule.forRoot([{path: 'root', redirectTo: ''}]),
+        Level1AModule,
+        Level1BModule,
+      ],
+      providers: [
+        {provide: APP_BASE_HREF, useValue: '/'},
+      ]
+    })
+    class RootModule {
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RootModule],
+    });
+    expect((TestBed.get(Router) as Router).config.map(r => r.path)).toEqual([
+      '1a:1',
+      '1a:2',
+      '1b:1',
+      '1b:2',
+      'root',
+    ]);
+  });
+});

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -217,6 +217,31 @@ describe('InjectorDef-based createInjector()', () => {
     });
   }
 
+  class MultiProviderA {
+    static ngInjectorDef = ɵɵdefineInjector({
+      factory: () => new MultiProviderA(),
+      providers: [{provide: LOCALE, multi: true, useValue: 'A'}],
+    });
+  }
+
+  class MultiProviderB {
+    static ngInjectorDef = ɵɵdefineInjector({
+      factory: () => new MultiProviderB(),
+      providers: [{provide: LOCALE, multi: true, useValue: 'B'}],
+    });
+  }
+
+  class WithProvidersTest {
+    static ngInjectorDef = ɵɵdefineInjector({
+      factory: () => new WithProvidersTest(),
+      imports: [
+        {ngModule: MultiProviderA, providers: [{provide: LOCALE, multi: true, useValue: 'C'}]},
+        MultiProviderB
+      ],
+      providers: [],
+    });
+  }
+
   let injector: Injector;
 
   beforeEach(() => {
@@ -272,6 +297,11 @@ describe('InjectorDef-based createInjector()', () => {
     const instance = injector.get(ServiceWithMultiDep);
     expect(instance instanceof ServiceWithMultiDep);
     expect(instance.locale).toEqual(['en', 'es']);
+  });
+
+  it('should process "InjectionTypeWithProviders" providers after imports injection type', () => {
+    injector = createInjector(WithProvidersTest);
+    expect(injector.get(LOCALE)).toEqual(['A', 'B', 'C']);
   });
 
   it('injects an injector with dependencies', () => {


### PR DESCRIPTION
Currently with Ivy, `ModuleWithProvider` providers are processed in order
of declaration in the `NgModule` imports. This technically makes makes
sense but is a potential breaking change as `ModuleWithProvider` providers
are processed after all imported modules in View Engine and the order
of multi-providers will therefore be different in Ivy (as with route definitions)

In order to keep the behavior of View Engine, the `r3_injector` is updated
to no longer process `ModuleWithProvider` providers egarly.

Resolves FW-1349