### PR TITLE
docs: remove mention of project settings from analytics

### DIFF
--- a/aio/content/marketing/analytics.md
+++ b/aio/content/marketing/analytics.md
@@ -15,8 +15,7 @@ include the following information:
 - For Schematics commands (add, generate, new and update), a list of whitelisted flags.
 - For build commands (build, serve), the number and size of bundles (initial and lazy),
   compilation units, the time it took to build and rebuild, and basic Angular-specific
-  API usage. *This data is collected only if usage analytics gathering is enabled for
-  the project.*
+  API usage.
 - Error code of exceptions and crash data. No stack trace is collected.
 
 Only Angular owned and developed schematics and builders are reported. Third-party schematics and
@@ -25,9 +24,6 @@ builders do not send data to the Angular Team.
 ## Opting in
 When installing the Angular CLI or upgrading an existing version, you are prompted to allow global
 collection of usage statistics. If you say no or skip the prompt, no data is collected.
-
-The first time a command affecting the project is run, you are prompted to allow collection of data
-related to the project. If you say no or skip the prompt, no data is collected for that project.
 
 Starting with version 8, we added the `analytics` command to the CLI. You can change your opt-in
 decision at any time using this command.
@@ -38,9 +34,6 @@ To disable analytics gathering, run the following command:
 ```bash
 # Disable all usage analytics.
 ng analytics off
-
-# Disable project-specific usage analytics.
-ng analytics project off
 ```
 
 ### Enabling usage analytics
@@ -49,9 +42,6 @@ To enable usage analytics, run the following command:
 ```bash
 # Enable all usage analytics.
 ng analytics on
-
-# Enable project-specific usage analytics.
-ng analytics project on
 ```
 
 ### Prompting
@@ -60,7 +50,4 @@ To prompt the user again about usage analytics, run the following command:
 ```bash
 # Prompt for all usage analytics.
 ng analytics prompt
-
-# Prompt for project-specific usage analytics.
-ng analytics project prompt
 ```


### PR DESCRIPTION
These settings are not yet implemented and will be available in 8.1.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Analytics project settings are not yet implemented in 8.0 but are present in the documentation.


## What is the new behavior?

References to analytics project settings have been removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
