### PR TITLE
fix(ivy): add back ngDevMode to r3_injector

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import '../util/ng_dev_mode';
+
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
 import {throwCyclicDependencyError, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors';
@@ -249,8 +251,7 @@ export class R3Injector {
         (ngModule === undefined) ? (defOrWrappedDef as InjectorType<any>) : ngModule;
 
     // Check for circular dependencies.
-    // TODO(FW-1307): Re-add ngDevMode when closure can handle it
-    if (parents.indexOf(defType) !== -1) {
+    if (ngDevMode && parents.indexOf(defType) !== -1) {
       const defName = stringify(defType);
       throw new Error(
           `Circular dependency in DI detected for type ${defName}. Dependency path: ${parents.map(defType => stringify(defType)).join(' > ')} > ${defName}.`);
@@ -286,8 +287,7 @@ export class R3Injector {
     if (def.imports != null && !isDuplicate) {
       // Before processing defType's imports, add it to the set of parents. This way, if it ends
       // up deeply importing itself, this can be detected.
-      // TODO(FW-1307): Re-add ngDevMode when closure can handle it
-      parents.push(defType);
+      ngDevMode && parents.push(defType);
       // Add it to the set of dedups. This way we can detect multiple imports of the same module
       dedupStack.push(defType);
 
@@ -296,8 +296,7 @@ export class R3Injector {
             def.imports, imported => this.processInjectorType(imported, parents, dedupStack));
       } finally {
         // Remove it from the parents set when finished.
-        // TODO(FW-1307): Re-add ngDevMode when closure can handle it
-        parents.pop();
+        ngDevMode && parents.pop();
       }
     }
 


### PR DESCRIPTION
Import the definition so that it doesn't cause breakage with closure conformance rules.

FW-1307 #resolve

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
