### PR TITLE
fix(ivy): generate explicit type annotation for NgModuleFactory calls in ngfactories

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -73,7 +73,8 @@ export class FactoryGenerator implements ShimGenerator {
       // This will encompass a lot of symbols which don't need factories, but that's okay
       // because it won't miss any that do.
       const varLines = symbolNames.map(
-          name => `export const ${name}NgFactory = new i0.ɵNgModuleFactory(${name});`);
+          name =>
+              `export const ${name}NgFactory: i0.ɵNgModuleFactory<any> = new i0.ɵNgModuleFactory(${name});`);
       sourceText += [
         // This might be incorrect if the current package being compiled is Angular core, but it's
         // okay to leave in at type checking time. TypeScript can handle this reference via its path

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2149,6 +2149,22 @@ describe('ngtsc behavioral tests', () => {
     expect(emptyFactory).toContain(`export var \u0275NonEmptyModule = true;`);
   });
 
+  it('should generate correct type annotation for NgModuleFactory calls in ngfactories', () => {
+    env.tsconfig({'allowEmptyCodegenFiles': true});
+    env.write('test.ts', `
+      import {Component} from '@angular/core';
+      @Component({
+        selector: 'test',
+        template: '...',
+      })
+      export class TestCmp {}
+    `);
+    env.driveMain();
+
+    const ngfactoryContents = env.getContents('test.ngfactory.d.ts');
+    expect(ngfactoryContents).toContain(`i0.ɵNgModuleFactory<typeof TestCmp>`);
+  });
+
   it('should copy a top-level comment into a factory stub', () => {
     env.tsconfig({'allowEmptyCodegenFiles': true});
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2162,7 +2162,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
 
     const ngfactoryContents = env.getContents('test.ngfactory.d.ts');
-    expect(ngfactoryContents).toContain(`i0.ɵNgModuleFactory<typeof TestCmp>`);
+    expect(ngfactoryContents).toContain(`i0.ɵNgModuleFactory<any>`);
   });
 
   it('should copy a top-level comment into a factory stub', () => {


### PR DESCRIPTION
Prior to this commit there were no explicit types setup for NgModuleFactory calls in ngfactories, so TypeScript inferred the type based on a given call. In some cases (when generic types were used for Components/Directives) that turned out to be problematic, so we add explicit typing for NgModuleFactory calls.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No