### PR TITLE
Add platform to glossary

### DIFF
--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -622,6 +622,19 @@ A class which is preceded by the `@Pipe{}` decorator and which defines a functio
 
 To learn more, see [Pipes](guide/pipes).
 
+{@a platform}
+
+## platform
+
+In Angular terminology, a platform is the context in which an Angular application runs.
+The most common platform for Angular applications is a web browser, but it can also be an operating system for a mobile device, or a web server.
+
+Support for the various Angular run-time platforms is provided by the `@angular/platform-*` packages. These packages allow applications that make use of `@angular/core` and `@angular/common` to execute in different environments by providing implementation for gathering user input and rendering UIs for the given platform. Isolating platform-specific functionality allows the developer to make platform-independent use of the rest of the framework.
+
+* When running in a web browser, [`BrowserModule`](api/platform-browser/BrowserModule) is imported from the `platform-browser` package, and supports services that simplify security and event processing, and allows applications to access browser-specific features, such as interpreting keyboard input and controlling the title of the document being displayed. All applications running in the browser use the same platform service.
+
+* When [server-side rendering](#server-side-rendering) (SSR) is used, the [`platform-server`](api/platform-server) package provides web server implementations of the `DOM`, `XMLHttpRequest`, and other low-level features that don't rely on a browser.
+
 {@a polyfill}
 
 ## polyfill

--- a/packages/platform-browser/PACKAGE.md
+++ b/packages/platform-browser/PACKAGE.md
@@ -1,7 +1,7 @@
-Supports delivery of Angular apps on different supported browsers. 
+Supports execution of Angular apps on different supported browsers.
 
-The `BrowserModule` is included by default in any app created through the CLI, 
-and it re-exports the `CommonModule` and `ApplicationModule` exports, 
+The `BrowserModule` is included by default in any app created through the CLI,
+and it re-exports the `CommonModule` and `ApplicationModule` exports,
 making basic Angular functionality available to the app.
 
 For more information, see [Browser Support](guide/browser-support).

--- a/packages/platform-server/PACKAGE.md
+++ b/packages/platform-server/PACKAGE.md
@@ -1,0 +1,3 @@
+Supports delivery of Angular apps on a server, for use with [server-side rendering](guide/glossary#server-side-rendering) (SSR).
+
+For more information, see [Server-side Rendering: An intro to Angular Universal](guide/universal).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
"Platform" term not in glossary

Issue Number: https://github.com/angular/angular/issues/27096


## What is the new behavior?

Adds "platform" term with ref to API doc and Browser Support page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

API doc for PlatformRef/PlatformBrowser is not adequate, and there is no usage doc except a detached cookbook page, https://angular.io/guide/set-document-title