### PR TITLE
docs: fix closing tags in deprecation summary 

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -348,13 +348,13 @@ In the following example, the two-way binding means that `optionName`
 should be written when the `valueChange` event fires.
 
 ```html
-<option *ngFor="let optionName of options" [(value)]="optionName"></cmp>
+<option *ngFor="let optionName of options" [(value)]="optionName"></option>
 ```
 
 However, in practice, Angular simply ignores two-way bindings to template variables. Starting in version 8, attempting to write to template variables is deprecated. In a future version, we will throw to indicate that the write is not supported.
 
 ```html
-<option *ngFor="let optionName of options" [value]="optionName"></cmp>
+<option *ngFor="let optionName of options" [value]="optionName"></option>
 ```
 
 {@a binding-to-innertext}


### PR DESCRIPTION
 fix closing tags in "Cannot assign to template variables" section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

