### PR TITLE
test: restore "async" around tests where "await" is used

### DIFF
--- a/packages/core/schematics/test/injectable_pipe_migration_spec.ts
+++ b/packages/core/schematics/test/injectable_pipe_migration_spec.ts
@@ -74,7 +74,7 @@ describe('injectable pipe migration', () => {
         .toMatch(/@Injectable\(\)\s+@Pipe\(\{ name: 'myPipe' \}\)\s+export class MyPipe/);
   });
 
-  it('should add an import for Injectable to the @angular/core import declaration', () => {
+  it('should add an import for Injectable to the @angular/core import declaration', async() => {
     writeFile('/index.ts', `
       import { Pipe } from '@angular/core';
 

--- a/packages/core/schematics/test/move_document_migration_spec.ts
+++ b/packages/core/schematics/test/move_document_migration_spec.ts
@@ -73,7 +73,7 @@ describe('move-document migration', () => {
       expect(content).not.toContain(`import {DOCUMENT} from '@angular/platform-browser';`);
     });
 
-    it('should properly apply import replacement with existing import', () => {
+    it('should properly apply import replacement with existing import', async() => {
       writeFile('/index.ts', `
         import {DOCUMENT} from '@angular/platform-browser';
         import {someImport} from '@angular/common';


### PR DESCRIPTION
The "async" around a couple tests was removed because of the merge conflict in one of the previous commits (80394ce08b12ff95167cf1c4aec61044bb78fbe6). This change restores missing "async"s.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No