### PR TITLE
refactor(ivy): add relevant log on error with wrong type value

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -385,7 +385,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     if (!Array.isArray(resolvedList)) {
       throw new FatalDiagnosticError(
           ErrorCode.VALUE_HAS_WRONG_TYPE, expr,
-          `Expected array when reading property ${arrayName}`);
+          `Expected array when reading property ${arrayName} of ${className}`);
     }
 
     resolvedList.forEach((entry, idx) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When compiling with ivy enabled and an error gets thrown for a value with wrong type, the logged message can look like:

`Expected array when reading property declarations`

The `declarations` property being declared in virtually every module, the current message does not help with troubleshooting.

## What is the new behavior?

Adding `${className}` to the message makes it a no-brainer, and is more consistent with other log messages.
You may expect messages like:

`Expected array when reading property declarations of MarkdownModule`

...making it clear where to look at.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
