### PR TITLE
fix(ivy): DebugNode.queryAll matching sibling nodes

### DIFF
--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -695,5 +695,46 @@ class TestCmptWithPropBindings {
       expect(childTestElsSecond[0]).toBe(childTestElsFirst[0]);
     });
 
+    it('should not query the descendants of a sibling node', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `
+          <div class="div.1">
+            <p class="p.1">
+              <span class="span.1">span.1</span>
+              <span class="span.2">span.2</span>
+            </p>
+            <p class="p.2">
+              <span class="span.3">span.3</span>
+              <span class="span.4">span.4</span>
+            </p>
+          </div>
+          <div class="div.2">
+            <p class="p.3">
+              <span class="span.5">span.5</span>
+              <span class="span.6">span.6</span>
+            </p>
+            <p class="p.4">
+              <span class="span.7">span.7</span>
+              <span class="span.8">span.8</span>
+            </p>
+          </div>
+        `
+      })
+      class MyComp {
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComp]});
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
+
+      const firstDiv = fixture.debugElement.query(By.css('div'));
+      const firstDivChildren = firstDiv.queryAll(By.css('span'));
+
+      expect(firstDivChildren.map(child => child.nativeNode.textContent.trim())).toEqual([
+        'span.1', 'span.2', 'span.3', 'span.4'
+      ]);
+    });
+
   });
 }


### PR DESCRIPTION
Inside of `DebugNode.queryAll` we walk through all of the descendants of the node that we're querying against, however the logic that walks sideways through a node siblings also applies to the root node. This means that eventually we'll match against its nodes as well which will give us invalid results. These changes add an extra check to ensure that we aren't matching against the siblings of the root node.

This PR resolves FW-1353.
