### PR TITLE
fix(forms): check this._validator for null in Validator.validate

### DIFF
--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -136,11 +136,11 @@ export const CHECKBOX_REQUIRED_VALIDATOR: StaticProvider = {
  * @description
  * A directive that adds the `required` validator to any controls marked with the
  * `required` attribute. The directive is provided with the `NG_VALIDATORS` multi-provider list.
- * 
+ *
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
- * 
+ *
  * ### Adding a required validator using template-driven forms
  *
  * ```
@@ -197,15 +197,15 @@ export class RequiredValidator implements Validator {
 /**
  * A Directive that adds the `required` validator to checkbox controls marked with the
  * `required` attribute. The directive is provided with the `NG_VALIDATORS` multi-provider list.
- * 
+ *
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
- * 
+ *
  * ### Adding a required checkbox validator using template-driven forms
  *
  * The following example shows how to add a checkbox required validator to an input attached to an ngModel binding.
- * 
+ *
  * ```
  * <input type="checkbox" name="active" ngModel required>
  * ```
@@ -248,11 +248,11 @@ export const EMAIL_VALIDATOR: any = {
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
- * 
+ *
  * ### Adding an email validator
  *
  * The following example shows how to add an email validator to an input attached to an ngModel binding.
- * 
+ *
  * ```
  * <input type="email" name="email" ngModel email>
  * <input type="email" name="email" ngModel email="true">
@@ -334,7 +334,7 @@ export const MIN_LENGTH_VALIDATOR: any = {
 /**
  * A directive that adds minimum length validation to controls marked with the
  * `minlength` attribute. The directive is provided with the `NG_VALIDATORS` mult-provider list.
- * 
+ *
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
@@ -391,7 +391,13 @@ export class MinLengthValidator implements Validator,
    * requirement. Returns the validation result if enabled, otherwise null.
    */
   validate(control: AbstractControl): ValidationErrors|null {
-    return this.minlength == null ? null : this._validator(control);
+    if (!this.minlength) {
+      return null;
+    }
+    if (!this._validator) {
+      this._createValidator();
+    }
+    return this._validator(control);
   }
 
   /**
@@ -420,7 +426,7 @@ export const MAX_LENGTH_VALIDATOR: any = {
 /**
  * A directive that adds max length validation to controls marked with the
  * `maxlength` attribute. The directive is provided with the `NG_VALIDATORS` multi-provider list.
- * 
+ *
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
@@ -477,7 +483,13 @@ export class MaxLengthValidator implements Validator,
    * the maximum length requirement.
    */
   validate(control: AbstractControl): ValidationErrors|null {
-    return this.maxlength != null ? this._validator(control) : null;
+    if (!this.maxlength) {
+      return null;
+    }
+    if (!this._validator) {
+      this._createValidator();
+    }
+    return this._validator(control);
   }
 
   /**
@@ -509,7 +521,7 @@ export const PATTERN_VALIDATOR: any = {
  * A directive that adds regex pattern validation to controls marked with the
  * `pattern` attribute. The regex must match the entire control value.
  * The directive is provided with the `NG_VALIDATORS` multi-provider list.
- * 
+ *
  * @see [Form Validation](guide/form-validation)
  *
  * @usageNotes
@@ -522,7 +534,7 @@ export const PATTERN_VALIDATOR: any = {
  * ```html
  * <input name="firstName" ngModel pattern="[a-zA-Z ]*">
  * ```
- * 
+ *
  * @ngModule ReactiveFormsModule
  * @ngModule FormsModule
  * @publicApi
@@ -565,7 +577,12 @@ export class PatternValidator implements Validator,
    * Method that validates whether the value matches the
    * the pattern requirement.
    */
-  validate(control: AbstractControl): ValidationErrors|null { return this._validator(control); }
+  validate(control: AbstractControl): ValidationErrors|null {
+    if (!this._validator) {
+      this._createValidator();
+    }
+    return this._validator(control);
+  }
 
   /**
    * @description

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -10,7 +10,7 @@ import {fakeAsync, tick} from '@angular/core/testing';
 import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, AsyncValidatorFn, FormArray, FormControl, Validators} from '@angular/forms';
 import {normalizeAsyncValidator} from '@angular/forms/src/directives/normalize_validator';
-import {AsyncValidator, ValidationErrors, ValidatorFn} from '@angular/forms/src/directives/validators';
+import {AsyncValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, ValidationErrors, ValidatorFn} from '@angular/forms/src/directives/validators';
 import {Observable, of , timer} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 
@@ -199,6 +199,14 @@ import {first, map} from 'rxjs/operators';
           'minlength': {'requiredLength': 2, 'actualLength': 1}
         });
       });
+
+      it('should not error when AOT calls validate before onChanges', () => {
+        const validator = new MinLengthValidator();
+        validator.minlength = '10';
+        expect(validator.validate(new FormControl('a'))).toEqual({
+          'minlength': {'requiredLength': 10, 'actualLength': 1}
+        });
+      });
     });
 
     describe('maxLength', () => {
@@ -229,6 +237,14 @@ import {first, map} from 'rxjs/operators';
         const fa = new FormArray([new FormControl(''), new FormControl('')]);
         expect(Validators.maxLength(1)(fa)).toEqual({
           'maxlength': {'requiredLength': 1, 'actualLength': 2}
+        });
+      });
+
+      it('should not error when AOT calls validate before onChanges', () => {
+        const validator = new MaxLengthValidator();
+        validator.maxlength = '10';
+        expect(validator.validate(new FormControl('abcdefghijklmnopqrstuvwxyz'))).toEqual({
+          'maxlength': {'requiredLength': 10, 'actualLength': 26}
         });
       });
     });
@@ -285,6 +301,14 @@ import {first, map} from 'rxjs/operators';
 
       it('should work with pattern string not containing any boundary symbols',
          () => expect(Validators.pattern('[aA]*')(new FormControl('aaAA'))).toBeNull());
+
+      it('should not error when AOT calls validate before onChanges', () => {
+        const validator = new PatternValidator();
+        validator.pattern = new RegExp('^[a-zA-Z ]*$');
+        expect(validator.validate(new FormControl('aaa0'))).toEqual({
+          'pattern': {'requiredPattern': '/^[a-zA-Z ]*$/', 'actualValue': 'aaa0'}
+        });
+      });
     });
 
     describe('compose', () => {


### PR DESCRIPTION
If validate() is called between setting the Input() and calling ngOnChanges then call _createValidator before calling _validator.

fixes #30784

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 30784


## What is the new behavior?
If validate() is called between setting the Input() and calling ngOnChanges then call _createValidator before calling _validator. (This happens when using AOT)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
