### PR TITLE
 feat(ivy): ngcc - recognize static properties on the outer symbol in ES5

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -435,8 +435,9 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * Try to retrieve the symbol of a static property on a class.
    *
    * In ES5, a static property can either be set on the inner function declaration inside the class'
-   * IIFE, or it can be set on the outer variable declaration. Therefore, the ES2015 host's behavior
-   * is extended to check both places.
+   * IIFE, or it can be set on the outer variable declaration. Therefore, the ES5 host checks both
+   * places, first looking up the property on the inner symbol, and if the property is not found it
+   * will fall back to looking up the property on the outer symbol.
    *
    * @param symbol the class whose property we are interested in.
    * @param propertyName the name of static property.

--- a/packages/compiler-cli/ngcc/src/packages/bundle_program.ts
+++ b/packages/compiler-cli/ngcc/src/packages/bundle_program.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../../src/ngtsc/path';
 import {FileSystem} from '../file_system/file_system';
+import {patchTsGetExpandoInitializer, restoreGetExpandoInitializer} from './patch_ts_expando_initializer';
 
 /**
 * An entry point bundle contains one or two programs, e.g. `src` and `dts`,
@@ -37,7 +38,11 @@ export function makeBundleProgram(
   const r3SymbolsPath =
       isCore ? findR3SymbolsPath(fs, AbsoluteFsPath.dirname(path), r3FileName) : null;
   const rootPaths = r3SymbolsPath ? [path, r3SymbolsPath] : [path];
+
+  const originalGetExpandoInitializer = patchTsGetExpandoInitializer();
   const program = ts.createProgram(rootPaths, options, host);
+  restoreGetExpandoInitializer(originalGetExpandoInitializer);
+
   const file = program.getSourceFile(path) !;
   const r3SymbolsFile = r3SymbolsPath && program.getSourceFile(r3SymbolsPath) || null;
 

--- a/packages/compiler-cli/ngcc/src/packages/patch_ts_expando_initializer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/patch_ts_expando_initializer.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+/**
+ * Consider the following ES5 code that may have been generated for a class:
+ *
+ * ```
+ * var A = (function(){
+ *   function A() {}
+ *   return A;
+ * }());
+ * A.staticProp = true;
+ * ```
+ *
+ * Here, TypeScript marks the symbol for "A" as a so-called "expando symbol", which causes
+ * "staticProp" to be added as an export of the "A" symbol.
+ *
+ * In the example above, symbol "A" has been assigned some flags to indicate that it represents a
+ * class. Due to this flag, the symbol is considered an expando symbol and as such, "staticProp" is
+ * stored in `ts.Symbol.exports`.
+ *
+ * A problem arises when "A" is not at the top-level, i.e. in UMD bundles. In that case, the symbol
+ * does not have the flag that marks the symbol as a class. Therefore, TypeScript inspects "A"'s
+ * initializer expression, which is an IIFE in the above example. Unfortunately however, only IIFEs
+ * of the form `(function(){})()` qualify as initializer for an "expando symbol"; the slightly
+ * different form seen in the example above, `(function(){}())`, does not. This prevents the "A"
+ * symbol from being considered an expando symbol, in turn preventing "staticProp" from being stored
+ * in `ts.Symbol.exports`.
+ *
+ * The logic for identifying symbols as "expando symbols" can be found here:
+ * https://github.com/microsoft/TypeScript/blob/v3.4.5/src/compiler/binder.ts#L2656-L2685
+ *
+ * Notice how the `getExpandoInitializer` function is available on the "ts" namespace in the
+ * compiled bundle, so we are able to override this function to accommodate for the alternative
+ * IIFE notation. The original implementation can be found at:
+ * https://github.com/Microsoft/TypeScript/blob/v3.4.5/src/compiler/utilities.ts#L1864-L1887
+ *
+ * @returns the function to pass to `restoreGetExpandoInitializer` to undo the patch.
+ */
+export function patchTsGetExpandoInitializer(): unknown {
+  const originalGetExpandoInitializer = (ts as any).getExpandoInitializer;
+  (ts as any).getExpandoInitializer =
+      (initializer: ts.Node, isPrototypeAssignment: boolean): ts.Expression | undefined => {
+        if (ts.isParenthesizedExpression(initializer) &&
+            ts.isCallExpression(initializer.expression)) {
+          initializer = initializer.expression;
+        }
+        return originalGetExpandoInitializer(initializer, isPrototypeAssignment);
+      };
+  return originalGetExpandoInitializer;
+}
+
+export function restoreGetExpandoInitializer(originalGetExpandoInitializer: unknown): void {
+  (ts as any).getExpandoInitializer = originalGetExpandoInitializer;
+}

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -12,6 +12,7 @@ import {makeProgram} from '../../../src/ngtsc/testing/in_memory_typescript';
 import {BundleProgram} from '../../src/packages/bundle_program';
 import {EntryPointFormat, EntryPointJsonProperty} from '../../src/packages/entry_point';
 import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
+import {patchTsGetExpandoInitializer, restoreGetExpandoInitializer} from '../../src/packages/patch_ts_expando_initializer';
 import {Folder} from './mock_file_system';
 
 export {getDeclaration} from '../../../src/ngtsc/testing/in_memory_typescript';
@@ -53,7 +54,11 @@ function makeTestProgramInternal(
   host: ts.CompilerHost,
   options: ts.CompilerOptions,
 } {
-  return makeProgram([getFakeCore(), getFakeTslib(), ...files], {allowJs: true, checkJs: false});
+  const originalTsGetExpandoInitializer = patchTsGetExpandoInitializer();
+  const program =
+      makeProgram([getFakeCore(), getFakeTslib(), ...files], {allowJs: true, checkJs: false});
+  restoreGetExpandoInitializer(originalTsGetExpandoInitializer);
+  return program;
 }
 
 export function makeTestProgram(

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -79,18 +79,6 @@ const TOPLEVEL_DECORATORS_FILE = {
   `,
 };
 
-const CTOR_DECORATORS_ARRAY_FILE = {
-  name: '/ctor_decorated_as_array.js',
-  contents: `
-    var CtorDecoratedAsArray = (function() {
-      function CtorDecoratedAsArray(arg1) {
-      }
-      CtorDecoratedAsArray.ctorParameters = [{ type: ParamType, decorators: [{ type: Inject },] }];
-      return CtorDecoratedAsArray;
-    }());
-  `,
-};
-
 const ACCESSORS_FILE = {
   name: '/accessors.js',
   contents: `

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -50,6 +50,47 @@ const SOME_DIRECTIVE_FILE = {
     }());
   `,
 };
+
+const TOPLEVEL_DECORATORS_FILE = {
+  name: '/toplevel_decorators.js',
+  contents: `
+    import { Directive, Inject, InjectionToken, Input } from '@angular/core';
+
+    var INJECTED_TOKEN = new InjectionToken('injected');
+    var ViewContainerRef = {};
+    var TemplateRef = {};
+
+    var SomeDirective = (function() {
+      function SomeDirective(_viewContainer, _template, injected) {}
+      return SomeDirective;
+    }());
+    SomeDirective.decorators = [
+      { type: Directive, args: [{ selector: '[someDirective]' },] }
+    ];
+    SomeDirective.ctorParameters = function() { return [
+      { type: ViewContainerRef, },
+      { type: TemplateRef, },
+      { type: undefined, decorators: [{ type: Inject, args: [INJECTED_TOKEN,] },] },
+    ]; };
+    SomeDirective.propDecorators = {
+      "input1": [{ type: Input },],
+      "input2": [{ type: Input },],
+    };
+  `,
+};
+
+const CTOR_DECORATORS_ARRAY_FILE = {
+  name: '/ctor_decorated_as_array.js',
+  contents: `
+    var CtorDecoratedAsArray = (function() {
+      function CtorDecoratedAsArray(arg1) {
+      }
+      CtorDecoratedAsArray.ctorParameters = [{ type: ParamType, decorators: [{ type: Inject },] }];
+      return CtorDecoratedAsArray;
+    }());
+  `,
+};
+
 const ACCESSORS_FILE = {
   name: '/accessors.js',
   contents: `
@@ -758,6 +799,24 @@ describe('Esm5ReflectionHost', () => {
       ]);
     });
 
+    it('should find the decorators on a class at the top level', () => {
+      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+      const classNode = getDeclaration(
+          program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+      const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+      expect(decorators).toBeDefined();
+      expect(decorators.length).toEqual(1);
+
+      const decorator = decorators[0];
+      expect(decorator.name).toEqual('Directive');
+      expect(decorator.import).toEqual({name: 'Directive', from: ANGULAR_CORE_SPECIFIER});
+      expect(decorator.args !.map(arg => arg.getText())).toEqual([
+        '{ selector: \'[someDirective]\' }',
+      ]);
+    });
+
     it('should return null if the symbol is not a class', () => {
       const program = makeTestProgram(FOO_FUNCTION_FILE);
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
@@ -884,6 +943,24 @@ describe('Esm5ReflectionHost', () => {
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
       const classNode = getDeclaration(
           program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+      const members = host.getMembersOfClass(classNode);
+
+      const input1 = members.find(member => member.name === 'input1') !;
+      expect(input1.kind).toEqual(ClassMemberKind.Property);
+      expect(input1.isStatic).toEqual(false);
+      expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+
+      const input2 = members.find(member => member.name === 'input2') !;
+      expect(input2.kind).toEqual(ClassMemberKind.Property);
+      expect(input2.isStatic).toEqual(false);
+      expect(input2.decorators !.map(d => d.name)).toEqual(['Input']);
+    });
+
+    it('should find decorated members on a class at the top level', () => {
+      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+      const classNode = getDeclaration(
+          program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
       const members = host.getMembersOfClass(classNode);
 
       const input1 = members.find(member => member.name === 'input1') !;
@@ -1143,6 +1220,24 @@ describe('Esm5ReflectionHost', () => {
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
       const classNode = getDeclaration(
           program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+      const parameters = host.getConstructorParameters(classNode);
+
+      expect(parameters).toBeDefined();
+      expect(parameters !.map(parameter => parameter.name)).toEqual([
+        '_viewContainer', '_template', 'injected'
+      ]);
+      expectTypeValueReferencesForParameters(parameters !, [
+        'ViewContainerRef',
+        'TemplateRef',
+        null,
+      ]);
+    });
+
+    it('should find the decorated constructor parameters at the top level', () => {
+      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+      const classNode = getDeclaration(
+          program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
       const parameters = host.getConstructorParameters(classNode);
 
       expect(parameters).toBeDefined();

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -800,7 +800,7 @@ describe('Esm5ReflectionHost', () => {
     });
 
     it('should find the decorators on a class at the top level', () => {
-      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const program = makeTestProgram(TOPLEVEL_DECORATORS_FILE);
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
       const classNode = getDeclaration(
           program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
@@ -811,7 +811,7 @@ describe('Esm5ReflectionHost', () => {
 
       const decorator = decorators[0];
       expect(decorator.name).toEqual('Directive');
-      expect(decorator.import).toEqual({name: 'Directive', from: ANGULAR_CORE_SPECIFIER});
+      expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
       expect(decorator.args !.map(arg => arg.getText())).toEqual([
         '{ selector: \'[someDirective]\' }',
       ]);
@@ -957,7 +957,7 @@ describe('Esm5ReflectionHost', () => {
     });
 
     it('should find decorated members on a class at the top level', () => {
-      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const program = makeTestProgram(TOPLEVEL_DECORATORS_FILE);
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
       const classNode = getDeclaration(
           program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
@@ -1234,7 +1234,7 @@ describe('Esm5ReflectionHost', () => {
     });
 
     it('should find the decorated constructor parameters at the top level', () => {
-      const program = makeTestProgram([TOPLEVEL_DECORATORS_FILE]);
+      const program = makeTestProgram(TOPLEVEL_DECORATORS_FILE);
       const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
       const classNode = getDeclaration(
           program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -90,26 +90,6 @@ const TOPLEVEL_DECORATORS_FILE = {
 })));`,
 };
 
-const CTOR_DECORATORS_ARRAY_FILE = {
-  name: '/ctor_decorated_as_array.js',
-  contents: `
-  (function (global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
-    typeof define === 'function' && define.amd ? define('ctor_decorated_as_array', ['exports', '@angular/core'], factory) :
-    (factory(global.ctor_decorated_as_array,global.ng.core));
-  }(this, (function (exports,core) { 'use strict';
-      var CtorDecoratedAsArray = (function() {
-      function CtorDecoratedAsArray(arg1) {
-      }
-      CtorDecoratedAsArray.ctorParameters = [{ type: ParamType, decorators: [{ type: Inject },] }];
-      return CtorDecoratedAsArray;
-    }());
-    exports.CtorDecoratedAsArray = CtorDecoratedAsArray;
-  })));`,
-};
-
-
-
 const SIMPLE_ES2015_CLASS_FILE = {
   name: '/simple_es2015_class.d.ts',
   contents: `


### PR DESCRIPTION
**feat(ivy): ngcc - recognize static properties on the outer symbol in ES5**

Packages that have been compiled using an older version of TypeScript
can have their decorators at the top-level of the ES5 bundles, instead
of inside the IIFE that is emitted for the class. Before this change,
ngcc only took static property assignments inside the IIFE into account,
therefore missing the decorators that were assigned at the top-level.

This commit extends the ES5 host to look for static properties in two
places. Testcases for all bundle formats that contain ES5 have been added
to ensure that this works in the various flavours.

A patch is included to support UMD bundles. The UMD factory affects how
TypeScripts binds the static properties to symbols, see the docblock of
the patch function for more details.