### PR TITLE
fix(ivy): improve error message when NgModule properties are not arrays

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -396,7 +396,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     if (!Array.isArray(resolvedList)) {
       throw new FatalDiagnosticError(
           ErrorCode.VALUE_HAS_WRONG_TYPE, expr,
-          `Expected array when reading property ${arrayName}`);
+          `Expected array when reading the NgModule.${arrayName} of ${className}`);
     }
 
     resolvedList.forEach((entry, idx) => {
@@ -413,14 +413,14 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
         if (!this.isClassDeclarationReference(entry)) {
           throw new FatalDiagnosticError(
               ErrorCode.VALUE_HAS_WRONG_TYPE, entry.node,
-              `Value at position ${idx} in the NgModule.${arrayName}s of ${className} is not a class`);
+              `Value at position ${idx} in the NgModule.${arrayName} of ${className} is not a class`);
         }
         refList.push(entry);
       } else {
         // TODO(alxhub): Produce a better diagnostic here - the array index may be an inner array.
         throw new FatalDiagnosticError(
             ErrorCode.VALUE_HAS_WRONG_TYPE, expr,
-            `Value at position ${idx} in the NgModule.${arrayName}s of ${className} is not a reference: ${entry}`);
+            `Value at position ${idx} in the NgModule.${arrayName} of ${className} is not a reference: ${entry}`);
       }
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Trying to compile our app with ivy results in this error message thrown: `ERROR in Expected array when reading property declarations`. I had to edit the source of the compiler CLI to find out which NgModule is causing the problem.

Issue Number: N/A


## What is the new behavior?
It tells me which NgModule causes the issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
