### PR TITLE
fix(compiler): support multiple methods with same host listener

### DIFF
--- a/packages/compiler/src/compile_metadata.ts
+++ b/packages/compiler/src/compile_metadata.ts
@@ -16,7 +16,7 @@ import {splitAtColon, stringify} from './util';
 // group 1: "prop" from "[prop]"
 // group 2: "event" from "(event)"
 // group 3: "@trigger" from "@trigger"
-const HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))|(\@[-\w]+)$/;
+export const HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))|(\@[-\w]+)$/;
 
 export function sanitizeIdentifier(name: string): string {
   return name.replace(/\W/g, '_');

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -391,6 +391,22 @@ class SomeDirectiveWithoutMetadata {}
           '[c2]': 'p2'
         });
       });
+
+      it('should support multiple methods with same host listener', () => {
+        @Directive({selector: 'p', host: {'(a)': 'onA1()'}})
+        class SomeDirectiveWithMultipleMethods {
+          onA1() {}
+          @HostListener('a')
+          onA2() {}
+          @HostListener('a')
+          onA3() {}
+        }
+
+        const directiveMetadata = resolver.resolve(SomeDirectiveWithMultipleMethods);
+        expect(directiveMetadata.host).toEqual({
+          '(a)': 'onA1();onA2();onA3()',
+        });
+      });
     });
 
     describe('queries', () => {


### PR DESCRIPTION
Merge methods bound to same host listener by separating it with semicolon. Previously, methods were overriden.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26729

Attaching HostListeners with the same event to multiple methods within a component results in only the latest one being fired. HostListener methods higher up in the file are never fired.


## What is the new behavior?

Multiple methods can be bound to same HostListener, both by attaching HostListener decorator or specifying it in host component metadata.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
