### PR TITLE
fix(ivy): unable to project into multiple slots with default selector [patch]

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1158,7 +1158,7 @@ describe('compiler compliance', () => {
             type: SimpleComponent,
             selectors: [["simple"]],
             factory: function SimpleComponent_Factory(t) { return new (t || SimpleComponent)(); },
-            ngContentSelectors: _c0,
+            ngContentSelectors: $c0$,
             consts: 2,
             vars: 0,
             template:  function SimpleComponent_Template(rf, ctx) {
@@ -1188,10 +1188,10 @@ describe('compiler compliance', () => {
               if (rf & 1) {
                 $r3$.ɵɵprojectionDef($c1$);
                 $r3$.ɵɵelementStart(0, "div", $c3$);
-                $r3$.ɵɵprojection(1, 1);
+                $r3$.ɵɵprojection(1);
                 $r3$.ɵɵelementEnd();
                 $r3$.ɵɵelementStart(2, "div", $c4$);
-                $r3$.ɵɵprojection(3, 2);
+                $r3$.ɵɵprojection(3, 1);
                 $r3$.ɵɵelementEnd();
               }
             },
@@ -1206,6 +1206,54 @@ describe('compiler compliance', () => {
             result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
         expectEmit(
             result.source, ComplexComponentDefinition, 'Incorrect ComplexComponent definition');
+      });
+
+      it('should support multi-slot content projection with multiple wildcard slots', () => {
+        const files = {
+          app: {
+            'spec.ts': `
+              import {Component, NgModule} from '@angular/core';
+
+              @Component({
+                template: \`
+                  <ng-content></ng-content>
+                  <ng-content select="[spacer]"></ng-content>
+                  <ng-content></ng-content>
+                \`,
+              })
+              class Cmp {}
+
+              @NgModule({ declarations: [Cmp] })
+              class Module {}
+            `,
+          }
+        };
+
+        const output = `
+          const $c0$ = ["*", [["", "spacer", ""]], "*"];
+          const $c1$ = ["*", "[spacer]", "*"];
+          …
+          Cmp.ngComponentDef = $r3$.ɵɵdefineComponent({
+            type: Cmp,
+            selectors: [["ng-component"]],
+            factory: function Cmp_Factory(t) { return new (t || Cmp)(); },
+            ngContentSelectors: $c1$,
+            consts: 3,
+            vars: 0,
+            template: function Cmp_Template(rf, ctx) {
+              if (rf & 1) {
+                i0.ɵɵprojectionDef($c0$);
+                i0.ɵɵprojection(0);
+                i0.ɵɵprojection(1, 1);
+                i0.ɵɵprojection(2, 2);
+              }
+            },
+            encapsulation: 2
+          });
+        `;
+
+        const {source} = compile(files, angularFiles);
+        expectEmit(source, output, 'Invalid content projection instructions generated');
       });
 
       it('should support content projection in nested templates', () => {
@@ -1240,7 +1288,7 @@ describe('compiler compliance', () => {
           const $_c2$ = ["id", "second"];
           function Cmp_div_0_Template(rf, ctx) { if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", $_c2$);
-            $r3$.ɵɵprojection(1, 1);
+            $r3$.ɵɵprojection(1);
             $r3$.ɵɵelementEnd();
           } }
           const $_c3$ = ["id", "third"];
@@ -1254,10 +1302,10 @@ describe('compiler compliance', () => {
           function Cmp_ng_template_2_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵtext(0, " '*' selector: ");
-              $r3$.ɵɵprojection(1);
+              $r3$.ɵɵprojection(1, 1);
             }
           }
-          const $_c4$ = [[["span", "title", "tofirst"]]];
+          const $_c4$ = [[["span", "title", "tofirst"]], "*"];
           …
           template: function Cmp_Template(rf, ctx) {
             if (rf & 1) {
@@ -1311,31 +1359,31 @@ describe('compiler compliance', () => {
         const output = `
           function Cmp_ng_template_1_ng_template_1_Template(rf, ctx) {
               if (rf & 1) {
-                $r3$.ɵɵprojection(0, 4);
+                $r3$.ɵɵprojection(0, 3);
             }
           }
           function Cmp_ng_template_1_Template(rf, ctx) {
             if (rf & 1) {
-              $r3$.ɵɵprojection(0, 3);
+              $r3$.ɵɵprojection(0, 2);
               $r3$.ɵɵtemplate(1, Cmp_ng_template_1_ng_template_1_Template, 1, 0, "ng-template");
             }
           }
           function Cmp_ng_template_2_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵtext(0, " '*' selector in a template: ");
-              $r3$.ɵɵprojection(1);
+              $r3$.ɵɵprojection(1, 4);
             }
           }
-          const $_c0$ = [[["", "id", "tomainbefore"]], [["", "id", "tomainafter"]], [["", "id", "totemplate"]], [["", "id", "tonestedtemplate"]]];
-          const $_c1$ = ["[id=toMainBefore]", "[id=toMainAfter]", "[id=toTemplate]", "[id=toNestedTemplate]"];
+          const $_c0$ = [[["", "id", "tomainbefore"]], [["", "id", "tomainafter"]], [["", "id", "totemplate"]], [["", "id", "tonestedtemplate"]], "*"];
+          const $_c1$ = ["[id=toMainBefore]", "[id=toMainAfter]", "[id=toTemplate]", "[id=toNestedTemplate]", "*"];
           …
           template: function Cmp_Template(rf, ctx) {
             if (rf & 1) {
-              $r3$.ɵɵprojectionDef($_c2$);
-              $r3$.ɵɵprojection(0, 1);
+              $r3$.ɵɵprojectionDef($_c0$);
+              $r3$.ɵɵprojection(0);
               $r3$.ɵɵtemplate(1, Cmp_ng_template_1_Template, 2, 0, "ng-template");
               $r3$.ɵɵtemplate(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
-              $r3$.ɵɵprojection(3, 2);
+              $r3$.ɵɵprojection(3, 1);
             }
           }
         `;

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -334,7 +334,7 @@ describe('template source-mapping', () => {
             {source: '<h3>', generated: 'i0.ɵɵelementStart(0, "h3")', sourceUrl: '../test.ts'});
         expect(mappings).toContain({
           source: '<ng-content select="title">',
-          generated: 'i0.ɵɵprojection(1, 1)',
+          generated: 'i0.ɵɵprojection(1)',
           sourceUrl: '../test.ts'
         });
         expect(mappings).toContain(
@@ -342,7 +342,7 @@ describe('template source-mapping', () => {
         expect(mappings).toContain(
             {source: '<div>', generated: 'i0.ɵɵelementStart(2, "div")', sourceUrl: '../test.ts'});
         expect(mappings).toContain(
-            {source: '<ng-content>', generated: 'i0.ɵɵprojection(3)', sourceUrl: '../test.ts'});
+            {source: '<ng-content>', generated: 'i0.ɵɵprojection(3, 1)', sourceUrl: '../test.ts'});
         expect(mappings).toContain(
             {source: '</div>', generated: 'i0.ɵɵelementEnd()', sourceUrl: '../test.ts'});
       });

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -123,10 +123,8 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     super();
     this.componentType = componentDef.type;
     this.selector = componentDef.selectors[0][0] as string;
-    // The component definition does not include the wildcard ('*') selector in its list.
-    // It is implicitly expected as the first item in the projectable nodes array.
     this.ngContentSelectors =
-        componentDef.ngContentSelectors ? ['*', ...componentDef.ngContentSelectors] : [];
+        componentDef.ngContentSelectors ? componentDef.ngContentSelectors : [];
     this.isBoundToModule = !!ngModule;
   }
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -100,7 +100,7 @@ export {
   ɵɵtext,
   ɵɵtextBinding} from './instructions/all';
 export {RenderFlags} from './interfaces/definition';
-export {CssSelectorList} from './interfaces/projection';
+export {CssSelectorList, ProjectionSlots} from './interfaces/projection';
 
 export {
   ɵɵrestoreView,

--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -6,15 +6,45 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {TAttributes, TElementNode, TNode, TNodeType} from '../interfaces/node';
-import {CssSelectorList} from '../interfaces/projection';
+import {ProjectionSlots} from '../interfaces/projection';
 import {T_HOST} from '../interfaces/view';
 import {appendProjectedNodes} from '../node_manipulation';
-import {matchingProjectionSelectorIndex} from '../node_selector_matcher';
+import {getProjectAsAttrValue, isNodeMatchingSelectorList, isSelectorInSelectorList} from '../node_selector_matcher';
 import {getLView, setIsParent} from '../state';
 import {findComponentView} from '../util/view_traversal_utils';
 
 import {createNodeAtIndex} from './shared';
 
+/**
+ * Checks a given node against matching projection slots and returns the
+ * determined slot index. Returns "null" if no slot matched the given node.
+ *
+ * This function takes into account the parsed ngProjectAs selector from the
+ * node's attributes. If present, it will check whether the ngProjectAs selector
+ * matches any of the projection slot selectors.
+ */
+export function matchingProjectionSlotIndex(tNode: TNode, projectionSlots: ProjectionSlots): number|
+    null {
+  let wildcardNgContentIndex = null;
+  const ngProjectAsAttrVal = getProjectAsAttrValue(tNode);
+  for (let i = 0; i < projectionSlots.length; i++) {
+    const slotValue = projectionSlots[i];
+    // The last wildcard projection slot should match all nodes which aren't matching
+    // any selector. This is necessary to be backwards compatible with view engine.
+    if (slotValue === '*') {
+      wildcardNgContentIndex = i;
+      continue;
+    }
+    // If we ran into an `ngProjectAs` attribute, we should match its parsed selector
+    // to the list of selectors, otherwise we fall back to matching against the node.
+    if (ngProjectAsAttrVal === null ?
+            isNodeMatchingSelectorList(tNode, slotValue, /* isProjectionMode */ true) :
+            isSelectorInSelectorList(ngProjectAsAttrVal, slotValue)) {
+      return i;  // first matching selector "captures" a given node
+    }
+  }
+  return wildcardNgContentIndex;
+}
 
 /**
  * Instruction to distribute projectable nodes among <ng-content> occurrences in a given template.
@@ -34,32 +64,38 @@ import {createNodeAtIndex} from './shared';
  * - we can't have only a parsed as we can't re-construct textual form from it (as entered by a
  * template author).
  *
- * @param selectors A collection of parsed CSS selectors
- * @param rawSelectors A collection of CSS selectors in the raw, un-parsed form
+ * @param projectionSlots? A collection of projection slots. A projection slot can be based
+ *        on a parsed CSS selectors or set to the wildcard selector ("*") in order to match
+ *        all nodes which do not match any selector. If not specified, a single wildcard
+ *        selector projection slot will be defined.
  *
  * @codeGenApi
  */
-export function ɵɵprojectionDef(selectors?: CssSelectorList[]): void {
+export function ɵɵprojectionDef(projectionSlots?: ProjectionSlots): void {
   const componentNode = findComponentView(getLView())[T_HOST] as TElementNode;
 
   if (!componentNode.projection) {
-    const noOfNodeBuckets = selectors ? selectors.length + 1 : 1;
+    // If no explicit projection slots are defined, fall back to a single
+    // projection slot with the wildcard selector.
+    const numProjectionSlots = projectionSlots ? projectionSlots.length : 1;
     const projectionHeads: (TNode | null)[] = componentNode.projection =
-        new Array(noOfNodeBuckets).fill(null);
+        new Array(numProjectionSlots).fill(null);
     const tails: (TNode | null)[] = projectionHeads.slice();
 
     let componentChild: TNode|null = componentNode.child;
 
     while (componentChild !== null) {
-      const bucketIndex =
-          selectors ? matchingProjectionSelectorIndex(componentChild, selectors) : 0;
+      const slotIndex =
+          projectionSlots ? matchingProjectionSlotIndex(componentChild, projectionSlots) : 0;
 
-      if (tails[bucketIndex]) {
-        tails[bucketIndex] !.projectionNext = componentChild;
-      } else {
-        projectionHeads[bucketIndex] = componentChild;
+      if (slotIndex !== null) {
+        if (tails[slotIndex]) {
+          tails[slotIndex] !.projectionNext = componentChild;
+        } else {
+          projectionHeads[slotIndex] = componentChild;
+        }
+        tails[slotIndex] = componentChild;
       }
-      tails[bucketIndex] = componentChild;
 
       componentChild = componentChild.next;
     }

--- a/packages/core/src/render3/interfaces/projection.ts
+++ b/packages/core/src/render3/interfaces/projection.ts
@@ -50,6 +50,16 @@ export type CssSelector = (string | SelectorFlags)[];
  */
 export type CssSelectorList = CssSelector[];
 
+/**
+ * List of slots for a projection. A slot can be either based on a parsed CSS selector
+ * which will be used to determine nodes which are projected into that slot.
+ *
+ * When set to "*", the slot is reserved and can be used for multi-slot projection
+ * using {@link ViewContainerRef#createComponent}. The last slot that specifies the
+ * wildcard selector will retrieve all projectable nodes which do not match any selector.
+ */
+export type ProjectionSlots = (CssSelectorList | '*')[];
+
 /** Flags used to build up CssSelectors */
 export const enum SelectorFlags {
   /** Indicates this is the beginning of a new negative selector */

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -255,29 +255,6 @@ export function getProjectAsAttrValue(tNode: TNode): CssSelector|null {
   return null;
 }
 
-/**
- * Checks a given node against matching projection selectors and returns
- * selector index (or 0 if none matched).
- *
- * This function takes into account the parsed ngProjectAs selector from the node's attributes.
- * If present, it will check whether the ngProjectAs selector matches any of the projection
- * selectors.
- */
-export function matchingProjectionSelectorIndex(
-    tNode: TNode, selectors: CssSelectorList[]): number {
-  const ngProjectAsAttrVal = getProjectAsAttrValue(tNode);
-  for (let i = 0; i < selectors.length; i++) {
-    // If we ran into an `ngProjectAs` attribute, we should match its parsed selector
-    // to the list of selectors, otherwise we fall back to matching against the node.
-    if (ngProjectAsAttrVal === null ?
-            isNodeMatchingSelectorList(tNode, selectors[i], /* isProjectionMode */ true) :
-            isSelectorInSelectorList(ngProjectAsAttrVal, selectors[i])) {
-      return i + 1;  // first matching selector "captures" a given node
-    }
-  }
-  return 0;
-}
-
 function getNameOnlyMarkerIndex(nodeAttrs: TAttributes) {
   for (let i = 0; i < nodeAttrs.length; i++) {
     const nodeAttr = nodeAttrs[i];
@@ -305,7 +282,7 @@ function matchTemplateAttribute(attrs: TAttributes, name: string): number {
  * @param selector Selector to be checked.
  * @param list List in which to look for the selector.
  */
-function isSelectorInSelectorList(selector: CssSelector, list: CssSelectorList): boolean {
+export function isSelectorInSelectorList(selector: CssSelector, list: CssSelectorList): boolean {
   selectorListLoop: for (let i = 0; i < list.length; i++) {
     const currentSelectorInList = list[i];
     if (selector.length !== currentSelectorInList.length) {

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -48,7 +48,7 @@ describe('ComponentFactory', () => {
           consts: 0,
           vars: 0,
           template: () => undefined,
-          ngContentSelectors: ['a', 'b'],
+          ngContentSelectors: ['*', 'a', 'b'],
           factory: () => new TestComponent(),
           inputs: {
             in1: 'in1',

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -913,7 +913,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['span', 'title', 'toFirst']], [['span', 'title', 'toSecond']]]);
+          ɵɵprojectionDef(['*', [['span', 'title', 'toFirst']], [['span', 'title', 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
           { ɵɵprojection(1, 1); }
           ɵɵelementEnd();
@@ -958,7 +958,7 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([
-            [['span', SelectorFlags.CLASS, 'toFirst']],
+            '*', [['span', SelectorFlags.CLASS, 'toFirst']],
             [['span', SelectorFlags.CLASS, 'toSecond']]
           ]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1005,7 +1005,7 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           ɵɵprojectionDef([
-            [['span', SelectorFlags.CLASS, 'toFirst']],
+            '*', [['span', SelectorFlags.CLASS, 'toFirst']],
             [['span', SelectorFlags.CLASS, 'toSecond']]
           ]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
@@ -1051,7 +1051,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['span']], [['span', SelectorFlags.CLASS, 'toSecond']]]);
+          ɵɵprojectionDef(['*', [['span']], [['span', SelectorFlags.CLASS, 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
           { ɵɵprojection(1, 1); }
           ɵɵelementEnd();
@@ -1095,7 +1095,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['span', SelectorFlags.CLASS, 'toFirst']]]);
+          ɵɵprojectionDef(['*', [['span', SelectorFlags.CLASS, 'toFirst']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
           { ɵɵprojection(1, 1); }
           ɵɵelementEnd();
@@ -1140,7 +1140,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['span', SelectorFlags.CLASS, 'toSecond']]]);
+          ɵɵprojectionDef(['*', [['span', SelectorFlags.CLASS, 'toSecond']]]);
           ɵɵelementStart(0, 'div', ['id', 'first']);
           { ɵɵprojection(1); }
           ɵɵelementEnd();
@@ -1192,7 +1192,7 @@ describe('content projection', () => {
        */
       const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['span']]]);
+          ɵɵprojectionDef(['*', [['span']]]);
           ɵɵprojection(0, 1);
           ɵɵelement(1, 'hr');
           ɵɵprojection(2);
@@ -1253,7 +1253,7 @@ describe('content projection', () => {
        */
       const Card = createComponent('card', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['', 'card-title', '']], [['', 'card-content', '']]]);
+          ɵɵprojectionDef(['*', [['', 'card-title', '']], [['', 'card-content', '']]]);
           ɵɵprojection(0, 1);
           ɵɵelement(1, 'hr');
           ɵɵprojection(2, 2);
@@ -1306,7 +1306,7 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          ɵɵprojectionDef([[['div']]]);
+          ɵɵprojectionDef(['*', [['div']]]);
           ɵɵprojection(0, 1);
         }
       }, 1);

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -2059,7 +2059,7 @@ describe('Runtime i18n', () => {
             template: (rf: RenderFlags, cmp: Child) => {
               if (rf & RenderFlags.Create) {
                 ɵɵprojectionDef([[['span']]]);
-                ɵɵprojection(0, 1);
+                ɵɵprojection(0);
               }
             }
           });

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -1129,101 +1129,6 @@ describe('ViewContainerRef', () => {
 
         });
       });
-
-      class EmbeddedComponentWithNgContent {
-        static ngComponentDef = ɵɵdefineComponent({
-          type: EmbeddedComponentWithNgContent,
-          encapsulation: ViewEncapsulation.None,
-          selectors: [['embedded-cmp-with-ngcontent']],
-          factory: () => new EmbeddedComponentWithNgContent(),
-          consts: 3,
-          vars: 0,
-          template: (rf: RenderFlags, cmp: EmbeddedComponentWithNgContent) => {
-            if (rf & RenderFlags.Create) {
-              ɵɵprojectionDef();
-              ɵɵprojection(0, 0);
-              ɵɵelement(1, 'hr');
-              ɵɵprojection(2, 1);
-            }
-          }
-        });
-      }
-
-      it('should support projectable nodes', () => {
-        const fixture =
-            new TemplateFixture(createTemplate, updateTemplate, 3, 1, [DirectiveWithVCRef]);
-        expect(fixture.html).toEqual('<p vcref=""></p>');
-
-        const myNode = document.createElement('div');
-        const myText = document.createTextNode('bar');
-        const myText2 = document.createTextNode('baz');
-        myNode.appendChild(myText);
-        myNode.appendChild(myText2);
-
-        directiveInstance !.vcref.createComponent(
-            directiveInstance !.cfr.resolveComponentFactory(EmbeddedComponentWithNgContent), 0,
-            undefined, [[myNode]]);
-        fixture.update();
-        expect(fixture.html)
-            .toEqual(
-                '<p vcref=""></p><embedded-cmp-with-ngcontent><div>barbaz</div><hr></embedded-cmp-with-ngcontent>');
-      });
-
-      it('should support reprojection of projectable nodes', () => {
-        class Reprojector {
-          static ngComponentDef = ɵɵdefineComponent({
-            type: Reprojector,
-            encapsulation: ViewEncapsulation.None,
-            selectors: [['reprojector']],
-            factory: () => new Reprojector(),
-            consts: 2,
-            vars: 0,
-            template: (rf: RenderFlags, cmp: Reprojector) => {
-              if (rf & RenderFlags.Create) {
-                ɵɵprojectionDef();
-                ɵɵelementStart(0, 'embedded-cmp-with-ngcontent');
-                { ɵɵprojection(1, 0); }
-                ɵɵelementEnd();
-              }
-            },
-            directives: [EmbeddedComponentWithNgContent]
-          });
-        }
-
-        const fixture =
-            new TemplateFixture(createTemplate, updateTemplate, 3, 1, [DirectiveWithVCRef]);
-        expect(fixture.html).toEqual('<p vcref=""></p>');
-
-        const myNode = document.createElement('div');
-        const myText = document.createTextNode('bar');
-        const myText2 = document.createTextNode('baz');
-        myNode.appendChild(myText);
-        myNode.appendChild(myText2);
-
-        directiveInstance !.vcref.createComponent(
-            directiveInstance !.cfr.resolveComponentFactory(Reprojector), 0, undefined, [[myNode]]);
-        fixture.update();
-        expect(fixture.html)
-            .toEqual(
-                '<p vcref=""></p><reprojector><embedded-cmp-with-ngcontent><div>barbaz</div><hr></embedded-cmp-with-ngcontent></reprojector>');
-      });
-
-      it('should support many projectable nodes with many slots', () => {
-        const fixture =
-            new TemplateFixture(createTemplate, updateTemplate, 3, 1, [DirectiveWithVCRef]);
-        expect(fixture.html).toEqual('<p vcref=""></p>');
-
-        directiveInstance !.vcref.createComponent(
-            directiveInstance !.cfr.resolveComponentFactory(EmbeddedComponentWithNgContent), 0,
-            undefined, [
-              [document.createTextNode('1'), document.createTextNode('2')],
-              [document.createTextNode('3'), document.createTextNode('4')]
-            ]);
-        fixture.update();
-        expect(fixture.html)
-            .toEqual(
-                '<p vcref=""></p><embedded-cmp-with-ngcontent>12<hr>34</embedded-cmp-with-ngcontent>');
-      });
     });
 
     describe('getters', () => {
@@ -1475,12 +1380,12 @@ describe('ViewContainerRef', () => {
           vars: 0,
           template: (rf: RenderFlags, cmp: ChildWithSelector) => {
             if (rf & RenderFlags.Create) {
-              ɵɵprojectionDef([[['header']]]);
+              ɵɵprojectionDef([[['header']], '*']);
               ɵɵelementStart(0, 'first');
-              { ɵɵprojection(1, 1); }
+              { ɵɵprojection(1, 0); }
               ɵɵelementEnd();
               ɵɵelementStart(2, 'second');
-              { ɵɵprojection(3); }
+              { ɵɵprojection(3, 1); }
               ɵɵelementEnd();
             }
           },

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -939,7 +939,7 @@ export declare type ɵɵPipeDefWithMeta<T, Name extends string> = PipeDef<T>;
 
 export declare function ɵɵprojection(nodeIndex: number, selectorIndex?: number, attrs?: TAttributes): void;
 
-export declare function ɵɵprojectionDef(selectors?: CssSelectorList[]): void;
+export declare function ɵɵprojectionDef(projectionSlots?: ProjectionSlots): void;
 
 export declare function ɵɵproperty<T>(propName: string, value: T, sanitizer?: SanitizerFn | null, nativeOnly?: boolean): TsickleIssue1009;
 


### PR DESCRIPTION
With View engine it was possible to declare multiple projection
definitions and to programmatically project nodes into the slots.

e.g.

```html
<ng-content></ng-content>
<ng-content></ng-content>
```

Using `ViewContainerRef#createComponent` allowed projecting
nodes into one of the projection defs (through index)

This no longer works with Ivy as the `projectionDef` instruction only
retrieves a list of selectors instead of also retrieving entries for
reserved projection slots which appear when using the default
selector multiple times (as seen above).

In order to fix this issue, the Ivy compiler now passes all
projection slots to the `projectionDef` instruction. Meaning that
there can be multiple projection slots with the same wildcard
selector. This allows multi-slot projection as seen in the
example above, and it also allows us to match the multi-slot node
projection order from View Engine (to avoid breaking changes).

It basically ensures that Ivy fully matches the View Engine behavior
except of a very small edge case that has already been discussed
in FW-886 (with the conclusion of working as intended).

Read more here: https://hackmd.io/s/Sy2kQlgTE

NOTE: This is the patch version of #30561