### PR TITLE
fix(bazel): exclude components schematics from build

### DIFF
--- a/integration/bazel/angular-metadata.tsconfig.json
+++ b/integration/bazel/angular-metadata.tsconfig.json
@@ -24,6 +24,8 @@
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/**/testing/**",
     "node_modules/@angular/common/upgrade*",
-    "node_modules/@angular/router/upgrade*"
+    "node_modules/@angular/router/upgrade*",
+    "node_modules/@angular/cdk/schematics*",
+    "node_modules/@angular/material/schematics*"
   ]
 }

--- a/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
+++ b/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
@@ -21,6 +21,8 @@
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/**/testing/**",
     "node_modules/@angular/common/upgrade*",
-    "node_modules/@angular/router/upgrade*"
+    "node_modules/@angular/router/upgrade*",
+    "node_modules/@angular/cdk/schematics*",
+    "node_modules/@angular/material/schematics*"
   ]
 }


### PR DESCRIPTION
See https://github.com/angular/components/issues/16189

Without this, bazel attempts to build schematics templates as srcs