### PR TITLE
fix(ivy): error for empty bindings on ng-template

### DIFF
--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -204,6 +204,20 @@ describe('NgTemplateOutlet', () => {
     fixture.componentInstance.value = 'baz';
     detectChangesAndExpectText('');
   });
+
+  // https://github.com/angular/angular/issues/30801
+  it('should not throw if the context is left blank', () => {
+    const template = `
+      <ng-template #testTemplate>test</ng-template>
+      <ng-template [ngTemplateOutlet]="testTemplate" [ngTemplateOutletContext]=""></ng-template>
+    `;
+
+    expect(() => {
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('test');
+    }).not.toThrow();
+  });
+
 });
 
 @Injectable()

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -2932,6 +2932,28 @@ describe('compiler compliance', () => {
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ngDirectiveDef');
     });
 
+    it('should not throw for empty property bindings on ng-template', () => {
+      const files = {
+        app: {
+          'example.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'my-app',
+            template: '<ng-template [id]=""></ng-template>'
+          })
+          export class MyComponent {
+          }
+
+          @NgModule({declarations: [MyComponent]})
+          export class MyModule {}`
+        }
+      };
+
+      expect(() => compile(files, angularFiles)).not.toThrow();
+    });
+
+
   });
 
   describe('inherited base classes', () => {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1021,10 +1021,13 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     attrs.forEach(input => {
       if (input instanceof t.BoundAttribute) {
         const value = input.value.visit(this._valueConverter);
-        this.allocateBindingSlots(value);
-        this.updateInstruction(
-            templateIndex, template.sourceSpan, R3.property,
-            () => [o.literal(input.name), this.convertPropertyBinding(context, value, true)]);
+
+        if (value !== undefined) {
+          this.allocateBindingSlots(value);
+          this.updateInstruction(
+              templateIndex, template.sourceSpan, R3.property,
+              () => [o.literal(input.name), this.convertPropertyBinding(context, value, true)]);
+        }
       }
     });
   }


### PR DESCRIPTION
Fixes Ivy throwing an error if it runs into an empty property binding on an `ng-template` (e.g. `<ng-template [something]=""></ng-template>`) by not generating an update instruction for it.

Fixes #30801.
This PR resoves FW-1356.
