### PR TITLE
fix(ivy): ngcc - use spaces in overwritten `package.json` content for readability

### DIFF
--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -14,23 +14,23 @@ if [[ $? != 0 ]]; then exit 1; fi
 # Did it add the appropriate build markers?
 
   # - esm2015
-  grep '"__processed_by_ivy_ngcc__":[^}]*"esm2015":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm2015": "'
   if [[ $? != 0 ]]; then exit 1; fi
 
   # - fesm2015
-  grep '"__processed_by_ivy_ngcc__":[^}]*"fesm2015":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm2015": "'
   if [[ $? != 0 ]]; then exit 1; fi
-  grep '"__processed_by_ivy_ngcc__":[^}]*"es2015":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"es2015": "'
   if [[ $? != 0 ]]; then exit 1; fi
 
   # - esm5
-  grep '"__processed_by_ivy_ngcc__":[^}]*"esm5":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm5": "'
   if [[ $? != 0 ]]; then exit 1; fi
 
   # - fesm5
-  grep '"__processed_by_ivy_ngcc__":[^}]*"module":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"module": "'
   if [[ $? != 0 ]]; then exit 1; fi
-  grep '"__processed_by_ivy_ngcc__":[^}]*"fesm5":"' node_modules/@angular/common/package.json
+  cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm5": "'
   if [[ $? != 0 ]]; then exit 1; fi
 
 # Did it replace the PRE_R3 markers correctly?

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -51,5 +51,5 @@ export function markAsProcessed(
     format: EntryPointJsonProperty) {
   if (!packageJson.__processed_by_ivy_ngcc__) packageJson.__processed_by_ivy_ngcc__ = {};
   packageJson.__processed_by_ivy_ngcc__[format] = NGCC_VERSION;
-  fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
+  fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }


### PR DESCRIPTION
When ngcc processes an entrypoint, it updates `package.json` with metadata about the processed format. Previously, it overwrote the `package.json` with the stringified JSON object without spaces. This made the file difficult to read (for example when looking at the file while debugging an ngcc failure).

This commit fixes it by using spaces in the new `package.json` content.