### PR TITLE
perf(ivy): remove check for function type in renderStringify

### DIFF
--- a/packages/core/src/render3/util/misc_utils.ts
+++ b/packages/core/src/render3/util/misc_utils.ts
@@ -26,7 +26,6 @@ export function isDifferent(a: any, b: any): boolean {
  * be extra careful not to introduce megamorphic reads in it.
  */
 export function renderStringify(value: any): string {
-  if (typeof value === 'function') return value.name || value;
   if (typeof value === 'string') return value;
   if (value == null) return '';
   return '' + value;
@@ -38,9 +37,10 @@ export function renderStringify(value: any): string {
  * Important! This function contains a megamorphic read and should only be
  * used for error messages.
  */
-export function stringifyForError(value: any) {
+export function stringifyForError(value: any): string {
+  if (typeof value === 'function') return value.name || value.toString();
   if (typeof value === 'object' && value != null && typeof value.type === 'function') {
-    return value.type.name || value.type;
+    return value.type.name || value.type.toString();
   }
 
   return renderStringify(value);

--- a/packages/core/test/acceptance/text_spec.ts
+++ b/packages/core/test/acceptance/text_spec.ts
@@ -112,4 +112,20 @@ describe('text instructions', () => {
 
     expect(div.innerHTML).toBe('&lt;h1&gt;LOL, big text&lt;/h1&gt;');
   });
+
+  it('should stringify functions used in bindings', () => {
+    @Component({
+      template: '<div>{{test}}</div>',
+    })
+    class App {
+      test = function foo() {};
+    }
+
+    TestBed.configureTestingModule({declarations: [App]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const div = fixture.nativeElement.querySelector('div');
+
+    expect(div.innerHTML).toBe('function foo() { }');
+  });
 });


### PR DESCRIPTION
The `renderStringify` function shows up pretty high in the CPU profiling.
Turns out that this function contained unnecessary `typeof` check for
function types - the check only makes sense / is used in error messages.

The PR also aligns how ivy and view engine stringify functions used in
interpolations.