### PR TITLE
fix(ivy): allow empty cases for ICU expressions

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -121,7 +121,7 @@ function extractParts(pattern: string): (string | IcuExpression)[] {
         const block = pattern.substring(prevPos, pos);
         if (ICU_BLOCK_REGEXP.test(block)) {
           results.push(parseICUBlock(block));
-        } else if (block) {  // Don't push empty strings
+        } else {
           results.push(block);
         }
 
@@ -138,10 +138,7 @@ function extractParts(pattern: string): (string | IcuExpression)[] {
   }
 
   const substring = pattern.substring(prevPos);
-  if (substring != '') {
-    results.push(substring);
-  }
-
+  results.push(substring);
   return results;
 }
 
@@ -180,7 +177,7 @@ function parseICUBlock(pattern: string): IcuExpression {
     }
 
     const blocks = extractParts(parts[pos++]) as string[];
-    if (blocks.length) {
+    if (cases.length > values.length) {
       values.push(blocks);
     }
   }

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -618,6 +618,13 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
 
       expect(fixture.nativeElement.innerHTML).toContain('at least');
     });
+
+    it('with empty values', () => {
+      const fixture = initWithTemplate(AppComp, `{count, select, 10 {} 20 {twenty} other {other}}`);
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText('other');
+    });
   });
 
   describe('should support attributes', () => {


### PR DESCRIPTION
We used to ignore empty strings for optimization purposes, but it turns out that empty strings are also valid values for ICU cases and we shouldn't ignore those.