### PR TITLE
build: unable to run build-packages-dist script on windows

### DIFF
--- a/scripts/package-builder.sh
+++ b/scripts/package-builder.sh
@@ -23,8 +23,10 @@ readonly bazel_bin=$(yarn bin)/bazel
 readonly bin=$(${bazel_bin} info bazel-bin)
 
 function buildTargetPackages() {
-  # List of targets to build, e.g. core, common, compiler, etc.
-  targets=$(${bazel_bin} query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)')
+  # List of targets to build, e.g. core, common, compiler, etc. Note that we want to
+  # remove all carriage return ("\r") characters form the query output because otherwise
+  # the carriage return is part of the bazel target name and bazel will complain.
+  targets=$(${bazel_bin} query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)' | tr -d "\r")
 
   # Path to the output directory into which we copy the npm packages.
   dest_path="$1"


### PR DESCRIPTION
Currently it's not possible to run the `./scripts/build-packages-dist.sh` script on Windows because
`bazel query` returns CRLF line-endings which result on array expansion in Bazel target names
that end with a carriage return (e.g. `//packages/core\r`). This then results in a build failure where
Bazel complains that target names should not end with a carriage return.

In order to fix this, we just strip off the carriage return line-endings from the bazel query stdout. Ideally
the script will be ported to a plain Node script eventually, but for now it prevents Windows users from
building the release packages and the simple workaround seems reasonable and sufficient.