### PR TITLE
fix(common): do not notify URL change listeners more than once per `PopStateEvent`

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -73,6 +73,7 @@ export class Location {
         'type': ev.type,
       });
     });
+    this.subscribe(v => { this._notifyUrlChangeListeners(v.url, v.state); });
   }
 
   /**
@@ -180,10 +181,7 @@ export class Location {
    * Register URL change listeners. This API can be used to catch updates performed by the Angular
    * framework. These are not detectible through "popstate" or "hashchange" events.
    */
-  onUrlChange(fn: (url: string, state: unknown) => void) {
-    this._urlChangeListeners.push(fn);
-    this.subscribe(v => { this._notifyUrlChangeListeners(v.url, v.state); });
-  }
+  onUrlChange(fn: (url: string, state: unknown) => void) { this._urlChangeListeners.push(fn); }
 
   /** @internal */
   _notifyUrlChangeListeners(url: string = '', state: unknown) {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -107,5 +107,20 @@ describe('Location Class', () => {
 
        }));
 
+    it('should notify url change listeners about pop state events (once per event)',
+       inject([Location], (location: Location) => {
+         let notificationCount1 = 0;
+         let notificationCount2 = 0;
+
+         (location as any)._subject.emit({});
+         location.onUrlChange(() => notificationCount1++);
+         (location as any)._subject.emit({});
+         location.onUrlChange(() => notificationCount2++);
+         (location as any)._subject.emit({});
+
+         expect(notificationCount1).toBe(2);
+         expect(notificationCount2).toBe(1);
+       }));
+
   });
 });

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -31,6 +31,10 @@ export class SpyLocation implements Location {
   /** @internal */
   _urlChangeListeners: ((url: string, state: unknown) => void)[] = [];
 
+  constructor() {
+    this.subscribe(v => { this._notifyUrlChangeListeners(v.url, v.state); });
+  }
+
   setInitialPath(url: string) { this._history[this._historyIndex].path = url; }
 
   setBaseHref(url: string) { this._baseHref = url; }
@@ -113,10 +117,8 @@ export class SpyLocation implements Location {
       this._subject.emit({'url': this.path(), 'state': this.getState(), 'pop': true});
     }
   }
-  onUrlChange(fn: (url: string, state: unknown) => void) {
-    this._urlChangeListeners.push(fn);
-    this.subscribe(v => { this._notifyUrlChangeListeners(v.url, v.state); });
-  }
+
+  onUrlChange(fn: (url: string, state: unknown) => void) { this._urlChangeListeners.push(fn); }
 
   /** @internal */
   _notifyUrlChangeListeners(url: string = '', state: unknown) {


### PR DESCRIPTION
Every time a URL change listener is registered via `Location.onUrlChange` a new subscription is
made to `Location` itself to notify listeners whenever a `PopStateEvent` occurs. This causes the
notifications to be duplicated by the number of URL change listeners.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Calling `Location.onUrlChange` more than once (with different) listeners, will cause these listeners to be notified multiple times for a single `PopStateEvent`.

Issue Number: N/A


## What is the new behavior?

Calling `Location.onUrlChange` more than once (with different) listeners, will cause these listeners to be notified only once for a single `PopStateEvent`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No




## Other information
