### PR TITLE
Ivy query predicate

### DIFF
--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -11,6 +11,26 @@ import {QueryList} from '../../linker';
 
 import {TContainerNode, TElementContainerNode, TElementNode, TNode} from './node';
 
+/**
+ * A predicate which determines if a given element/directive should be included in the query
+ * results.
+ */
+export interface QueryPredicate<T> {
+  /**
+   * If looking for directives then it contains the directive type.
+   */
+  type: Type<T>|null;
+
+  /**
+   * If selector then contains local names to query for.
+   */
+  selector: string[]|null;
+
+  /**
+   * Indicates which token should be read from DI for this query.
+   */
+  read: Type<T>|null;
+}
 
 /** Used for tracking queries (e.g. ViewChild, ContentChild). */
 export interface LQueries {
@@ -93,13 +113,11 @@ export interface LQueries {
    * Add additional `QueryList` to track.
    *
    * @param queryList `QueryList` to update with changes.
-   * @param predicate Either `Type` or selector array of [key, value] predicates.
+   * @param predicate A predicate which determines if a given element/directive should be included
+   * in the query results.
    * @param descend If true the query will recursively apply to the children.
-   * @param read Indicates which token should be read from DI for this query.
    */
-  track<T>(
-      queryList: QueryList<T>, predicate: Type<any>|string[], descend?: boolean,
-      read?: Type<T>): void;
+  track<T>(queryList: QueryList<T>, predicate: QueryPredicate<T>, descend?: boolean): void;
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -18,7 +18,7 @@ import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefList, HostBin
 import {I18nUpdateOpCodes, TI18n} from './i18n';
 import {TElementNode, TNode, TViewNode} from './node';
 import {PlayerHandler} from './player';
-import {LQueries} from './query';
+import {LQueries, QueryPredicate} from './query';
 import {RElement, Renderer3, RendererFactory3} from './renderer';
 import {StylingContext} from './styling';
 
@@ -642,11 +642,14 @@ export type HookData = (number | (() => void))[];
  *  v1 value   |   'b'
  *  v2 value   |   id � prefix � suffix
  *
+ * Each view query predicate is stored here at the same index as its QueryList instance in
+ * the data array.
+ *
  * Injector bloom filters are also stored here.
  */
 export type TData =
     (TNode | PipeDef<any>| DirectiveDef<any>| ComponentDef<any>| number | Type<any>|
-     InjectionToken<any>| TI18n | I18nUpdateOpCodes | null | string)[];
+     InjectionToken<any>| TI18n | I18nUpdateOpCodes | QueryPredicate<any>| null | string)[];
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -398,13 +398,15 @@ export function ɵɵviewQuery<T>(
 function viewQueryInternal<T>(
     lView: LView, tView: TView, predicate: Type<any>| string[], descend: boolean, read: any,
     isStatic: boolean): QueryList<T> {
+  const index = getCurrentQueryIndex();
+  const headerAdjustedIdx = index - HEADER_OFFSET;
   if (tView.firstTemplatePass) {
     tView.expandoStartIndex++;
+    tView.data[headerAdjustedIdx] = createPredicate<T>(predicate, read);
   }
-  const index = getCurrentQueryIndex();
-  const queryList: QueryList<T> =
-      createQueryListInLView<T>(lView, createPredicate<T>(predicate, read), descend, isStatic, -1);
-  store(index - HEADER_OFFSET, queryList);
+  const queryList: QueryList<T> = createQueryListInLView<T>(
+      lView, tView.data[headerAdjustedIdx] as QueryPredicate<T>, descend, isStatic, -1);
+  store(headerAdjustedIdx, queryList);
   setCurrentQueryIndex(index + 1);
   return queryList;
 }


### PR DESCRIPTION
Queries have concept of a predicate which represents data needed to match a node and read data from it (to be precise it has fields like `type`, `selector` and `read`). It turned out that we are creating a _new_ instance of a predicate object for each and every instance of a query (`QueryList`). This is totally wasteful as a predicate (and other metadata associated with a given query, like `isStatic`) don't change from query instance to another. 

In practical terms repeated creation of query predicate "costs" us ~480KB of allocated memory in the expanding rows benchmark. Again, this is totally unnecessary as the "cost"  of queries meta-data totals to ~0.3KB for the mentioned benchmark.

This PR takes the approach of "caching" predicates for view queries on `TView` level. Unfortunately this is not the greatest solutions as: we don't have a good place to "cache" predicate for content queries (at least I can't see any obvious place)...   

Another approach I could think of would be to have a predicate object (and other metadata) to be generated by the compiler, ex., instead of generating:

```typescript
ɵɵcontentQuery(1, ['foo'], true, null);
```

we would generate:

```typescript
const _queryMetaX = [
  ['foo'], //local ref selector
  null,     //type selector
  null,     //read
  true,    //descend
  false,   //isStatic,
  true    //is single element
];
ɵɵcontentQuery(1 , _queryMetaX);
```

The drawback here is more of the generated code for each query but as a bonus we could drop some instructions (ex. static query would be denoted by metadata so we wouldn't need 2 different instructions to handle static and dynamic queries.

WDYT?