### PR TITLE
fix(service-worker): avoid uncaught rejection warning when registration fails

### DIFF
--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -115,10 +115,11 @@ export function ngswAppInitializer(
       }
     }
 
-    // Don't return anything to avoid blocking the application until the SW is registered or
-    // causing a crash if the SW registration fails.
+    // Don't return anything to avoid blocking the application until the SW is registered.
+    // Catch and log the error if SW registration fails to avoid uncaught rejection warning.
     readyToRegister$.pipe(take(1)).subscribe(
-        () => navigator.serviceWorker.register(script, {scope: options.scope}));
+        () => navigator.serviceWorker.register(script, {scope: options.scope})
+                  .catch(err => console.error('Service worker registration failed with:', err)));
   };
   return initializer;
 }

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -28,7 +28,9 @@ describe('ServiceWorkerModule', () => {
     return appRef.isStable.pipe(filter(Boolean), take(1)).toPromise();
   };
 
-  beforeEach(() => swRegisterSpy = spyOn(navigator.serviceWorker, 'register'));
+  beforeEach(
+      () => swRegisterSpy =
+          spyOn(navigator.serviceWorker, 'register').and.returnValue(Promise.resolve()));
 
   describe('register()', () => {
     const configTestBed = async(opts: SwRegistrationOptions) => {
@@ -66,6 +68,15 @@ describe('ServiceWorkerModule', () => {
 
       expect(TestBed.get(SwUpdate).isEnabled).toBe(true);
       expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+    });
+
+    it('catches and a logs registration errors', async() => {
+      const consoleErrorSpy = spyOn(console, 'error');
+      swRegisterSpy.and.returnValue(Promise.reject('no reason'));
+
+      await configTestBed({enabled: true, scope: 'foo'});
+      expect(consoleErrorSpy)
+          .toHaveBeenCalledWith('Service worker registration failed with:', 'no reason');
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

After using `ServiceWorkerModule.register('/ngsw-worker.js'),`, if you have an unstable internet connection, `navigator.serviceWorker.register('/ngsw-worker.js')` call can fail and your application can crash.
I think that the error can't be caught on the user side.

## What is the new behavior?

If `navigator.serviceWorker.register('/ngsw-worker.js')` fail, there is no uncaught error anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (I'm not completely sure)

## Other information

N/A