### PR TITLE
fix(bazel): Load global stylesheet in dev and prod

### DIFF
--- a/packages/bazel/src/builders/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/builders/files/src/BUILD.bazel.template
@@ -5,11 +5,20 @@ load("@npm_bazel_karma//:index.bzl", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle", "history_server")
 load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_package")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver", "ts_library")
-load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
+load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary", "sass_binary")
+
+sass_binary(
+  name = "global_stylesheet",
+  src = glob(["styles.css", "styles.scss"])[0],
+  output_name = "global_stylesheet.css",
+)
 
 multi_sass_binary(
     name = "styles",
-    srcs = glob(["**/*.scss"]),
+    srcs = glob(
+      include = ["**/*.scss"],
+      exclude = ["styles.scss"],
+    ),
 )
 
 ng_module(
@@ -52,6 +61,7 @@ web_package(
         # do not sort
         "@npm//node_modules/zone.js:dist/zone.min.js",
         ":bundle.min.js",
+        ":global_stylesheet",
     ],
     data = [
         "favicon.ico",
@@ -85,6 +95,7 @@ ts_devserver(
     ],
     static_files = [
         "@npm//node_modules/zone.js:dist/zone.min.js",
+        ":global_stylesheet",
     ],
     data = [
         "favicon.ico",


### PR DESCRIPTION
Global stylesheet should be injected as a `<link>` tag in index.html for
both dev and prod app.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
