### PR TITLE
fix(docs-infra): do not redirect docs URLs on archive deployments

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -820,11 +820,10 @@ describe('AppComponent', () => {
         const doRedirect = redirectionPerMode[mode];
         const description =
             `should ${doRedirect ? '' : 'not '}redirect to 'docs' if deployment mode is '${mode}' ` +
-            'and not at a docs page';
+            'and at a marketing page';
         const verifyNoRedirection = () => expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-        const verifyPossibleRedirection = doRedirect
-            ? () => expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs')
-            : verifyNoRedirection;
+        const verifyRedirection = () => expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs');
+        const verifyPossibleRedirection = doRedirect ? verifyRedirection : verifyNoRedirection;
 
         it(description, () => {
           createTestingModule('', mode);

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -838,6 +838,10 @@ describe('AppComponent', () => {
           initializeTest(false);
           verifyNoRedirection();
 
+          createTestingModule('start', mode);
+          initializeTest(false);
+          verifyNoRedirection();
+
           createTestingModule('tutorial', mode);
           initializeTest(false);
           verifyNoRedirection();
@@ -847,6 +851,10 @@ describe('AppComponent', () => {
           verifyNoRedirection();
 
           createTestingModule('docs', mode);
+          initializeTest(false);
+          verifyNoRedirection();
+
+          createTestingModule('cli', mode);
           initializeTest(false);
           verifyNoRedirection();
 

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -809,106 +809,55 @@ describe('AppComponent', () => {
     });
 
     describe('archive redirection', () => {
-      it('should redirect to `docs` if deployment mode is `archive` and not at a docs page', () => {
-        createTestingModule('', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs');
+      const redirectionPerMode: {[mode: string]: boolean} = {
+        archive: true,
+        next: false,
+        stable: false,
+      };
 
-        createTestingModule('resources', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs');
+      Object.keys(redirectionPerMode).forEach(mode => {
+        const doRedirect = redirectionPerMode[mode];
+        const description =
+            `should ${doRedirect ? '' : 'not '}redirect to 'docs' if deployment mode is '${mode}' ` +
+            'and not at a docs page';
+        const verifyNoRedirection = () => expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+        const verifyPossibleRedirection = doRedirect
+            ? () => expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs')
+            : verifyNoRedirection;
 
-        createTestingModule('guide/aot-compiler', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+        it(description, () => {
+          createTestingModule('', mode);
+          initializeTest(false);
+          verifyPossibleRedirection();
 
-        createTestingModule('tutorial', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('resources', mode);
+          initializeTest(false);
+          verifyPossibleRedirection();
 
-        createTestingModule('tutorial/toh-pt1', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('guide/aot-compiler', mode);
+          initializeTest(false);
+          verifyNoRedirection();
 
-        createTestingModule('docs', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('tutorial', mode);
+          initializeTest(false);
+          verifyNoRedirection();
 
-        createTestingModule('api', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('tutorial/toh-pt1', mode);
+          initializeTest(false);
+          verifyNoRedirection();
 
-        createTestingModule('api/core/getPlatform', 'archive');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-      });
+          createTestingModule('docs', mode);
+          initializeTest(false);
+          verifyNoRedirection();
 
-      it('should not redirect if deployment mode is `next`', () => {
-        createTestingModule('', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('api', mode);
+          initializeTest(false);
+          verifyNoRedirection();
 
-        createTestingModule('resources', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('guide/aot-compiler', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('tutorial', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('tutorial/toh-pt1', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('docs', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('api', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('api/core/getPlatform', 'next');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-      });
-
-      it('should not redirect to `docs` if deployment mode is `stable`', () => {
-        createTestingModule('', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('resources', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('guide/aot-compiler', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('tutorial', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('tutorial/toh-pt1', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('docs', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('api', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
-
-        createTestingModule('api/core/getPlatform', 'stable');
-        initializeTest(false);
-        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
+          createTestingModule('api/core/getPlatform', mode);
+          initializeTest(false);
+          verifyNoRedirection();
+        });
       });
     });
   });

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -7,11 +7,12 @@ import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatSidenav } from '@angular/material/sidenav';
 import { By } from '@angular/platform-browser';
 
-import { of, timer } from 'rxjs';
+import { Subject, of, timer } from 'rxjs';
 import { first, mapTo } from 'rxjs/operators';
 
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
+import { CurrentNodes } from 'app/navigation/navigation.model';
 import { DocumentService } from 'app/documents/document.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { Deployment } from 'app/shared/deployment.service';
@@ -22,7 +23,7 @@ import { Logger } from 'app/shared/logger.service';
 import { MockLocationService } from 'testing/location.service';
 import { MockLogger } from 'testing/logger.service';
 import { MockSearchService } from 'testing/search.service';
-import { NavigationNode } from 'app/navigation/navigation.service';
+import { NavigationNode, NavigationService } from 'app/navigation/navigation.service';
 import { ScrollService } from 'app/shared/scroll.service';
 import { SearchBoxComponent } from 'app/search/search-box/search-box.component';
 import { SearchResultsComponent } from 'app/shared/search-results/search-results.component';
@@ -827,43 +828,24 @@ describe('AppComponent', () => {
 
         it(description, () => {
           createTestingModule('', mode);
+
+          const navService = TestBed.get(NavigationService) as NavigationService;
+          const testCurrentNodes = navService.currentNodes = new Subject<CurrentNodes>();
+
           initializeTest(false);
+
+          testCurrentNodes.next({SideNav: {url: 'foo', view: 'SideNav', nodes: []}});
+          verifyNoRedirection();
+
+          testCurrentNodes.next({NoSideNav: {url: 'bar', view: 'SideNav', nodes: []}});
           verifyPossibleRedirection();
 
-          createTestingModule('resources', mode);
-          initializeTest(false);
+          locationService.replace.calls.reset();
+          testCurrentNodes.next({});
           verifyPossibleRedirection();
 
-          createTestingModule('guide/aot-compiler', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('start', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('tutorial', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('tutorial/toh-pt1', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('docs', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('cli', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('api', mode);
-          initializeTest(false);
-          verifyNoRedirection();
-
-          createTestingModule('api/core/getPlatform', mode);
-          initializeTest(false);
+          locationService.replace.calls.reset();
+          testCurrentNodes.next({SideNav: {url: 'baz', view: 'SideNav', nodes: []}});
           verifyNoRedirection();
         });
       });

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -120,11 +120,6 @@ export class AppComponent implements OnInit {
     this.documentService.currentDocument.subscribe(doc => this.currentDocument = doc);
 
     this.locationService.currentPath.subscribe(path => {
-      // Redirect to docs if we are in archive mode and are not hitting a docs page
-      // (i.e. we have arrived at a marketing page)
-      if (this.deployment.mode === 'archive' && !/^(docs$|api|cli|guide|start|tutorial)/.test(path)) {
-        this.locationService.replace('docs');
-      }
       if (path === this.currentPath) {
         // scroll only if on same page (most likely a change to the hash)
         this.scrollService.scroll();
@@ -138,7 +133,15 @@ export class AppComponent implements OnInit {
       }
     });
 
-    this.navigationService.currentNodes.subscribe(currentNodes => this.currentNodes = currentNodes);
+    this.navigationService.currentNodes.subscribe(currentNodes => {
+      this.currentNodes = currentNodes;
+
+      // Redirect to docs if we are in archive mode and are not hitting a docs page
+      // (i.e. we have arrived at a marketing page)
+      if (this.deployment.mode === 'archive' && !currentNodes[sideNavView]) {
+        this.locationService.replace('docs');
+      }
+    });
 
     // Compute the version picker list from the current version and the versions in the navigation map
     combineLatest(

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -122,7 +122,7 @@ export class AppComponent implements OnInit {
     this.locationService.currentPath.subscribe(path => {
       // Redirect to docs if we are in archive mode and are not hitting a docs page
       // (i.e. we have arrived at a marketing page)
-      if (this.deployment.mode === 'archive' && !/^(docs$|api|guide|tutorial)/.test(path)) {
+      if (this.deployment.mode === 'archive' && !/^(docs$|api|cli|guide|start|tutorial)/.test(path)) {
         this.locationService.replace('docs');
       }
       if (path === this.currentPath) {


### PR DESCRIPTION
To avoid showing outdated info (such as events, resources, etc.) but still allow people to see docs for older versions, we redirect non-documentation URLs to `/docs`. Recently(-ish) we have added documentation content under the `/cli/...` and `/start/...` path-prefixes, but we haven't added them to the list of documentation URLs that should not be redirected. As a result, on archive deployments (e.g. https://v7.angular.io/cli), they are redirected to `/docs`, making it impossible to see the documentation for these versions (unless you know about the `?mode=stable` work-around).

This commit fixes it by adding `cli` and `start` to the list of documentation URLs that are excluded from redirection.

##
Current incorrect behavior (redirects to `/docs`): https://v7.angular.io/cli
New correct behavior (stays on `/cli`): https://pr30894-0c145e8.ngbuilds.io/cli?mode=archive
