### PR TITLE
[WIP]fix(forms): do not clear error is enable is called on enabled control

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -537,16 +537,16 @@ export abstract class AbstractControl {
   enable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     // If parent has been marked artificially dirty we don't want to re-calculate the
     // parent's dirtiness based on the children.
-      const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+    const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
 
-      (this as{status: string}).status = VALID;
-      this._forEachChild(
-          (control: AbstractControl) => { control.enable({...opts, onlySelf: true}); });
-      if (this.enabled !== true) {
-        this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
-      }
-      this._updateAncestors({...opts, skipPristineCheck});
-      this._onDisabledChange.forEach((changeFn) => changeFn(false));
+    (this as{status: string}).status = VALID;
+    this._forEachChild(
+        (control: AbstractControl) => { control.enable({...opts, onlySelf: true}); });
+    if (this.enabled !== true) {
+      this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
+    }
+    this._updateAncestors({...opts, skipPristineCheck});
+    this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
   private _updateAncestors(

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -537,15 +537,16 @@ export abstract class AbstractControl {
   enable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     // If parent has been marked artificially dirty we don't want to re-calculate the
     // parent's dirtiness based on the children.
-    const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+      const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
 
-    (this as{status: string}).status = VALID;
-    this._forEachChild(
-        (control: AbstractControl) => { control.enable({...opts, onlySelf: true}); });
-    this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
-
-    this._updateAncestors({...opts, skipPristineCheck});
-    this._onDisabledChange.forEach((changeFn) => changeFn(false));
+      (this as{status: string}).status = VALID;
+      this._forEachChild(
+          (control: AbstractControl) => { control.enable({...opts, onlySelf: true}); });
+      if (this.enabled !== true) {
+        this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
+      }
+      this._updateAncestors({...opts, skipPristineCheck});
+      this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
   private _updateAncestors(

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -512,6 +512,21 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
+      describe('enable controls', () => {
+        it('should not clear validation errors if enabled control is enabled again ', () => {
+          const fixture = initTest(FormControlComp);
+          const control = new FormControl({value: 'some value'});
+          fixture.componentInstance.control = control;
+          control.setErrors({error: true});
+          fixture.detectChanges();
+
+          expect(control.errors).toBe({error: true});
+
+          control.enable();
+          fixture.detectChanges();
+          expect(control.errors).toBe({error: true});
+        });
+      });
       describe('disabled controls', () => {
         it('should add disabled attribute to an individual control when instantiated as disabled',
            () => {


### PR DESCRIPTION
Fixes #30665

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #30665


## What is the new behavior?

Do not call enabled in if control is already enabled.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If anyone has written code to enable the control, which is already in the enabled state, the validation might behave incorrectly.

## Other information
