### PR TITLE
feat(docs-infra): return code typo styling

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -177,11 +177,6 @@ th {
   text-align: left;
 }
 
-code {
-  font-family: $code-font;
-  font-size: 90%;
-}
-
 .sidenav-content a {
   color: $blue;
   &:hover {

--- a/aio/src/styles/2-modules/_api-pages.scss
+++ b/aio/src/styles/2-modules/_api-pages.scss
@@ -139,7 +139,7 @@
 
   .method-table, .option-table, .list-table {
     td > code {
-      background-color: inherit;
+      // background-color: inherit;
       white-space: pre;
     }
 

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -1,10 +1,76 @@
-code-example, code-tabs {
-    clear: both;
-    display: block;
+code {
+  font-family: $code-font;
+  font-size: 90%;
+  background-color: $backgroundgray;
+  padding: 2px 4px;
+  border-radius: 3px;
+  letter-spacing: 0;
+  border: 1px solid darken($backgroundgray, 5%);
+
+  table td:first-child &,
+  table th &,
+  aio-code &,
+  code-example.no-box &,
+  aio-toc &,
+  h1 &,
+  h2 &,
+  h3 &,
+  h4 &,
+  h5 &,
+  h6 & {
+    background-color: transparent;
+    padding: 0;
+    border-color: transparent;
+
+    .sidenav-content & {
+      code a {
+        border-bottom: none;
+      }
+    }
+  }
+
+  h1 &,
+  h2 &,
+  h3 &,
+  h4 &,
+  h5 &,
+  h6 & {
+    font-family: inherit;
+  }
+
+  .alert &,
+  .callout & {
+    background-color: darken($backgroundgray, 4%);
+    border: 1px solid darken($backgroundgray, 8%);
+  }
+}
+
+.sidenav-content code a {
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+
+  &:hover {
+    color: darken($darkgray, 60%);
+    text-decoration: none;
+  }
+}
+
+code-example,
+code-tabs {
+  clear: both;
+  display: block;
+
+  .mat-card {
+    padding: 0;
+    border-radius: 5px;
+  }
+  code {
+    overflow: auto;
+  }
 }
 
 code-example {
-
   &:not(.no-box) {
     background-color: rgba($backgroundgray, 0.2);
     border: 0.5px solid $lightgray;
@@ -17,21 +83,16 @@ code-example {
     pre {
       margin: 0;
     }
-    code {
-      background-color: transparent;
-    }
   }
 
-  code {
-    overflow: auto;
+  header {
+    background-color: $accentblue;
+    border-radius: 5px 5px 0 0;
+    color: $offwhite;
+    font-size: 16px;
+    padding: 8px 16px;
   }
-}
 
-code-example, code-tabs {
-  .mat-card {
-    padding: 0;
-    border-radius: 5px;
-  }
   code {
     overflow: auto;
   }
@@ -43,16 +104,27 @@ code-tabs {
 
 // TERMINAL / SHELL TEXT STYLES
 
-code-example.code-shell, code-example[language=sh], code-example[language=bash] {
+code-example.code-shell,
+code-example[language="sh"],
+code-example[language="bash"] {
   background-color: $darkgray;
-}
 
-code-example header {
-  background-color: $accentblue;
-  border-radius: 5px 5px 0 0;
-  color: $offwhite;
-  font-size: 16px;
-  padding: 8px 16px;
+  .pnk,
+  .blk,
+  .pln,
+  .otl,
+  .kwd,
+  .typ,
+  .tag,
+  .str,
+  .atv,
+  .atn,
+  .com,
+  .lit,
+  .pun,
+  .dec {
+    color: $codegreen;
+  }
 }
 
 code-example.avoid header,
@@ -68,35 +140,35 @@ code-tabs.avoidFile mat-tab-body {
   border: 0.5px solid $anti-pattern;
 }
 
-code-tabs div .mat-tab-body-content {
-  height: auto;
-}
+code-tabs {
+  div .mat-tab-body-content {
+    height: auto;
+  }
 
-code-tabs .mat-tab-body-wrapper mat-tab-body .mat-tab-body {
-  overflow-y: hidden;
-}
+  .mat-tab-body-wrapper mat-tab-body .mat-tab-body {
+    overflow-y: hidden;
+  }
 
-code-tabs mat-tab-body-content .fadeIn {
-  animation: opacity 2s ease-in;
+  mat-tab-body-content .fadeIn {
+    animation: opacity 2s ease-in;
+  }
 }
 
 aio-code pre {
-    display: flex;
-    min-height: 32px;
-    margin: 16px 24px;
-    white-space: pre-wrap;
-    align-items: center;
+  display: flex;
+  min-height: 32px;
+  margin: 16px 24px;
+  white-space: pre-wrap;
+  align-items: center;
 
-    code span {
-      line-height: 24px;
-    }
+  code span {
+    line-height: 24px;
+  }
 }
-
 
 .code-missing {
   color: $darkred;
 }
-
 
 .copy-button {
   position: absolute;
@@ -113,34 +185,30 @@ aio-code pre {
   }
 }
 
-.lang-sh .copy-button, .lang-bash .copy-button {
+.lang-sh .copy-button,
+.lang-bash .copy-button {
   color: $mediumgray;
   &:hover {
     color: $lightgray;
   }
 }
 
-.code-tab-group .mat-tab-label {
-  &:hover {
-    background: rgba(black, 0.04);
+.code-tab-group {
+  .mat-tab-label {
+    &:hover {
+      background: rgba(black, 0.04);
+    }
+    white-space: nowrap;
   }
-  white-space: nowrap;
-}
 
-.code-tab-group .mat-tab-body-content {
-  height: auto;
-  transform: none;
+  .mat-tab-body-content {
+    height: auto;
+    transform: none;
+  }
 }
-
 
 [role="tabpanel"] {
-    transition: none;
-}
-
-.sidenav-content code a {
-  color: inherit;
-  font-size: inherit;
-  font-weight: inherit;
+  transition: none;
 }
 
 /* PRETTY PRINTING STYLES for prettify.js. */
@@ -166,40 +234,83 @@ ol.linenums {
 /* The following class|color styles are derived from https://github.com/google/code-prettify/blob/master/src/prettify.css*/
 
 /* SPAN elements with the classes below are added by prettyprint. */
-.pln { color: #000 }  /* plain text */
+.pln {
+  color: #000;
+} /* plain text */
 
 @media screen {
-  .str { color: #800 }  /* string content */
-  .kwd { color: #00f }  /* a keyword */
-  .com { color: #060 }  /* a comment */
-  .typ { color: red }  /* a type name */
-  .lit { color: #08c }  /* a literal value */
+  .str {
+    color: #800;
+  } /* string content */
+  .kwd {
+    color: #00f;
+  } /* a keyword */
+  .com {
+    color: #060;
+  } /* a comment */
+  .typ {
+    color: red;
+  } /* a type name */
+  .lit {
+    color: #08c;
+  } /* a literal value */
   /* punctuation, lisp open bracket, lisp close bracket */
-  .pun, .opn, .clo { color: #660 }
-  .tag { color: #008 }  /* a markup tag name */
-  .atn { color: #606 }  /* a markup attribute name */
-  .atv { color: #800 }  /* a markup attribute value */
-  .dec, .var { color: #606 }  /* a declaration; a variable name */
-  .fun { color: red }  /* a function name */
+  .pun,
+  .opn,
+  .clo {
+    color: #660;
+  }
+  .tag {
+    color: #008;
+  } /* a markup tag name */
+  .atn {
+    color: #606;
+  } /* a markup attribute name */
+  .atv {
+    color: #800;
+  } /* a markup attribute value */
+  .dec,
+  .var {
+    color: #606;
+  } /* a declaration; a variable name */
+  .fun {
+    color: red;
+  } /* a function name */
 }
 
 /* Use higher contrast and text-weight for printable form. */
 @media print, projection {
-  .str { color: #060 }
-  .kwd { color: #006; font-weight: bold }
-  .com { color: #600; font-style: italic }
-  .typ { color: #404; font-weight: bold }
-  .lit { color: #044 }
-  .pun, .opn, .clo { color: #440 }
-  .tag { color: #006; font-weight: bold }
-  .atn { color: #404 }
-  .atv { color: #060 }
-}
-
-/* SHELL / TERMINAL CODE BLOCKS */
-
-code-example.code-shell, code-example[language=sh], code-example[language=bash] {
-  .pnk, .blk, .pln, .otl, .kwd, .typ, .tag, .str, .atv, .atn, .com, .lit, .pun, .dec {
-    color: $codegreen;
+  .str {
+    color: #060;
+  }
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+  .lit {
+    color: #044;
+  }
+  .pun,
+  .opn,
+  .clo {
+    color: #440;
+  }
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+  .atn {
+    color: #404;
+  }
+  .atv {
+    color: #060;
   }
 }

--- a/aio/src/styles/2-modules/_table.scss
+++ b/aio/src/styles/2-modules/_table.scss
@@ -97,7 +97,6 @@ table {
 
       code {
         padding: 0;
-        background-color: inherit;
       }
     }
 


### PR DESCRIPTION
Returned code typography styling and added code link styles.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Code styles outside of code blocks and examples were accidentally removed.

Issue Number: N/A

## What is the new behavior?
- Returned code styles
- Added styles to links that are also code text so that the user knows that they can click on the links

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No