### PR TITLE
ci(docs-infra): minor refactorings

### DIFF
--- a/aio/scripts/switch-to-ivy.js
+++ b/aio/scripts/switch-to-ivy.js
@@ -13,8 +13,6 @@ const ROOT_DIR = resolve(__dirname, '..');
 const NG_JSON = join(ROOT_DIR, 'angular.json');
 const NG_COMPILER_OPTS = {
   angularCompilerOptions: {
-    // Related Jira issue: FW-737
-    allowEmptyCodegenFiles: true,
     enableIvy: true,
   },
 };


### PR DESCRIPTION
- ~~Run PWA score tests after unit/e2e tests (to get more relevant error messages sooner).~~
- Remove unneeded `allowEmptyCodegenFiles` option in Ivy mode.
