### PR TITLE
fix(ivy): ngcc - remove unused import to make linting pass

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {writeFileSync, writeFile} from 'fs';
+import {writeFileSync} from 'fs';
 
 import {AbsoluteFsPath} from '../../../src/ngtsc/path';
 


### PR DESCRIPTION
The failure is caused by 65f20107f. The unused [`writeFile` import][1] seems to be a result of merge conflict resolution (since it is not present on the original PR (#30831).

[1]: https://github.com/angular/angular/commit/65f20107fe90a410f0172bef31e2457644e5fb15#diff-4840f884874632c2fbfdb64a26213396R9
