### PR TITLE
fix(docs-infra): fix search result header color

### DIFF
--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -5,7 +5,7 @@
 <ng-template #searchResults>
   <h2 class="visually-hidden">Search Results</h2>
   <div class="search-area" *ngFor="let area of searchAreas">
-    <h3>{{area.name}} ({{area.pages.length + area.priorityPages.length}})</h3>
+    <h3 class="search-section-header">{{area.name}} ({{area.pages.length + area.priorityPages.length}})</h3>
     <ul class="priority-pages" >
       <li class="search-page" *ngFor="let page of area.priorityPages">
         <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page, $event)">

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -53,11 +53,12 @@ aio-search-results.embedded .search-results {
     margin: 16px 16px;
     height: 100%;
 
-    h3 {
+    .search-section-header {
         font-size: 16px;
         font-weight: 400;
         margin: 10px 0px 5px;
         text-transform: uppercase;
+        color: $white;
     }
 
     ul {


### PR DESCRIPTION
Before:
<img width="897" alt="Screen Shot 2019-06-07 at 3 07 24 PM" src="https://user-images.githubusercontent.com/2958442/59136002-082e4480-8936-11e9-8261-d802eb1ef06f.png">

After:
<img width="895" alt="Screen Shot 2019-06-07 at 3 07 35 PM" src="https://user-images.githubusercontent.com/2958442/59136007-0fede900-8936-11e9-9c01-f84be227fc30.png">

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Search result header showing up black (caused by PR #30899) instead of white as it should.

Issue Number: N/A


## What is the new behavior?
Returned original styles.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No