### PR TITLE
refactor(core): switch google3 static-query migration rule to template strategy

### DIFF
--- a/packages/core/schematics/migrations/static-queries/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/static-queries/google3/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics/test:__pkg__"],
     deps = [
+        "//packages/compiler-cli",
         "//packages/core/schematics/migrations/static-queries",
         "//packages/core/schematics/utils",
         "@npm//tslint",

--- a/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
@@ -6,17 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {createProgram} from '@angular/compiler-cli';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
-
-import {NgComponentTemplateVisitor} from '../../../utils/ng_component_template';
 import {NgQueryResolveVisitor} from '../angular/ng_query_visitor';
 import {QueryTiming} from '../angular/query-definition';
-import {QueryUsageStrategy} from '../strategies/usage_strategy/usage_strategy';
+import {QueryTemplateStrategy} from '../strategies/template_strategy/template_strategy';
 import {getTransformedQueryCallExpr} from '../transform';
 
 const FAILURE_MESSAGE = 'Query does not explicitly specify its timing. Read more here: ' +
-    'https://github.com/angular/angular/pull/28810';
+    'https://v8.angular.io/guide/static-query-migration.';
 
 /**
  * Rule that reports if an Angular "ViewChild" or "ContentChild" query is not explicitly
@@ -25,42 +24,41 @@ const FAILURE_MESSAGE = 'Query does not explicitly specify its timing. Read more
  */
 export class Rule extends Rules.TypedRule {
   applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
-    const typeChecker = program.getTypeChecker();
     const queryVisitor = new NgQueryResolveVisitor(program.getTypeChecker());
-    const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
     const rootSourceFiles = program.getRootFileNames().map(f => program.getSourceFile(f) !);
     const printer = ts.createPrinter();
     const failures: RuleFailure[] = [];
 
     // Analyze source files by detecting queries, class relations and component templates.
-    rootSourceFiles.forEach(sourceFile => {
-      queryVisitor.visitNode(sourceFile);
-      templateVisitor.visitNode(sourceFile);
-    });
+    rootSourceFiles.forEach(sourceFile => queryVisitor.visitNode(sourceFile));
 
     const {resolvedQueries, classMetadata} = queryVisitor;
-
-    // Add all resolved templates to the class metadata so that we can also
-    // check component templates for static query usage.
-    templateVisitor.resolvedTemplates.forEach(template => {
-      if (classMetadata.has(template.container)) {
-        classMetadata.get(template.container) !.template = template;
-      }
-    });
-
     const queries = resolvedQueries.get(sourceFile);
-    const usageStrategy = new QueryUsageStrategy(classMetadata, typeChecker);
+    const host = ts.createCompilerHost(program.getCompilerOptions(), true);
+    const strategy = new QueryTemplateStrategy('', classMetadata, host);
+
+    // Overwrite the strategy "createNgProgram" method to create the program from
+    // the existing TSLint program.
+    strategy.createNgProgram = () => {
+      const compilerOptions = program.getCompilerOptions();
+      return createProgram({
+        rootNames: program.getRootFileNames(),
+        options: {...compilerOptions, basePath: program.getCurrentDirectory()}, host
+      });
+    };
 
     // No queries detected for the given source file.
     if (!queries) {
       return [];
     }
 
+    strategy.setup();
+
     // Compute the query usage for all resolved queries and update the
     // query definitions to explicitly declare the query timing (static or dynamic)
     queries.forEach(q => {
       const queryExpr = q.decorator.node.expression;
-      const {timing, message} = usageStrategy.detectTiming(q);
+      const {timing, message} = strategy.detectTiming(q);
       const result = getTransformedQueryCallExpr(q, timing, !!message);
 
       if (!result) {
@@ -72,8 +70,14 @@ export class Rule extends Rules.TypedRule {
       // Replace the existing query decorator call expression with the
       // updated call expression node.
       const fix = new Replacement(queryExpr.getStart(), queryExpr.getWidth(), newText);
-      const failureMessage = `${FAILURE_MESSAGE}. Based on analysis of the query it can be ` +
-          `marked as "{static: ${(timing === QueryTiming.STATIC).toString()}}".`;
+      let failureMessage = FAILURE_MESSAGE;
+
+      if (message || timing === null) {
+        failureMessage += ` ${message || 'Query could not be migrated automatically.'}`;
+      } else {
+        failureMessage += ` Based on analysis of the query it can be marked as ` +
+            `"{static: ${(timing === QueryTiming.STATIC).toString()}}".`;
+      }
 
       failures.push(new RuleFailure(
           sourceFile, queryExpr.getStart(), queryExpr.getEnd(), failureMessage, this.ruleName,

--- a/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
@@ -7,7 +7,7 @@
  */
 
 import {AotCompiler, CompileDirectiveMetadata, CompileMetadataResolver, CompileNgModuleMetadata, CompileStylesheetMetadata, NgAnalyzedModules, StaticSymbol, TemplateAst, findStaticQueryIds, staticViewQueryIds} from '@angular/compiler';
-import {Diagnostic, createProgram, readConfiguration} from '@angular/compiler-cli';
+import {Diagnostic, Program as NgProgram, createProgram, readConfiguration} from '@angular/compiler-cli';
 import {resolve} from 'path';
 import * as ts from 'typescript';
 
@@ -28,13 +28,18 @@ export class QueryTemplateStrategy implements TimingStrategy {
       private projectPath: string, private classMetadata: ClassMetadataMap,
       private host: ts.CompilerHost) {}
 
+  /** Creates the Angular compiler TypeScript program. */
+  createNgProgram(): NgProgram {
+    const {rootNames, options} = readConfiguration(this.projectPath);
+    return createProgram({rootNames, options, host: this.host});
+  }
+
   /**
    * Sets up the template strategy by creating the AngularCompilerProgram. Returns false if
    * the AOT compiler program could not be created due to failure diagnostics.
    */
   setup() {
-    const {rootNames, options} = readConfiguration(this.projectPath);
-    const aotProgram = createProgram({rootNames, options, host: this.host});
+    const aotProgram = this.createNgProgram();
 
     // The "AngularCompilerProgram" does not expose the "AotCompiler" instance, nor does it
     // expose the logic that is necessary to analyze the determined modules. We work around


### PR DESCRIPTION
Switches the Google3 static-query migration rule to the template strategy. This
is mostly done for testing purposes.. and it's not quite ideal since TSLint doesn't
allow us to create the Angular Compiler program once.. nor does it allow us to
figure out from which TypeScript configuration file the rule program originated.