### PR TITLE
fix(ivy): ngcc - prevent crash for packages without "main" property

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -123,7 +123,11 @@ export function getEntryPointFormat(
     case 'esm5':
       return 'esm5';
     case 'main':
-      const pathToMain = AbsoluteFsPath.join(entryPoint.path, entryPoint.packageJson['main'] !);
+      const mainFile = entryPoint.packageJson['main'];
+      if (mainFile === undefined) {
+        return undefined;
+      }
+      const pathToMain = AbsoluteFsPath.join(entryPoint.path, mainFile);
       return isUmdModule(fs, pathToMain) ? 'umd' : 'commonjs';
     case 'module':
       return 'esm5';

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -38,6 +38,15 @@ describe('ngcc main()', () => {
         .not.toThrow();
   });
 
+  it('should run ngcc without errors when "main" property is not present', () => {
+    expect(() => mainNgcc({
+             basePath: '/dist',
+             propertiesToConsider: ['main', 'es2015'],
+             logger: new MockLogger(),
+           }))
+        .not.toThrow();
+  });
+
   describe('with targetEntryPointPath', () => {
     it('should only compile the given package entry-point (and its dependencies).', () => {
       const STANDARD_MARKERS = {

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -39,12 +39,16 @@ describe('ngcc main()', () => {
   });
 
   it('should run ngcc without errors when "main" property is not present', () => {
-    expect(() => mainNgcc({
-             basePath: '/dist',
-             propertiesToConsider: ['main', 'es2015'],
-             logger: new MockLogger(),
-           }))
-        .not.toThrow();
+    mainNgcc({
+      basePath: '/dist',
+      propertiesToConsider: ['main', 'es2015'],
+      logger: new MockLogger(),
+    });
+
+    expect(loadPackage('local-package', '/dist').__processed_by_ivy_ngcc__).toEqual({
+      es2015: '0.0.0-PLACEHOLDER',
+      typings: '0.0.0-PLACEHOLDER',
+    });
   });
 
   describe('with targetEntryPointPath', () => {


### PR DESCRIPTION
When determining the module type of a bundle pointed to by the "main"
property, ngcc needs to read the bundle to figure out if it is CommonJS
or UMD format. However, when the "main" property does not exist ngcc
would crash while determining the path to the main bundle file.

This commit fixes the crash by checking if the "main" property is present
at all, before attempting to derive a full path to the bundle file.

Fixes #30916
Fixes FW-1369
