### PR TITLE
fix(ivy): ensure that changes to component resources trigger incremental builds

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -24,7 +24,8 @@ export function main(
     args: string[], consoleError: (s: string) => void = console.error,
     config?: NgcParsedConfiguration, customTransformers?: api.CustomTransformers, programReuse?: {
       program: api.Program | undefined,
-    }): number {
+    },
+    modifiedResourceFiles?: Set<string>): number {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {
@@ -45,7 +46,7 @@ export function main(
     options,
     emitFlags,
     oldProgram,
-    emitCallback: createEmitCallback(options), customTransformers
+    emitCallback: createEmitCallback(options), customTransformers, modifiedResourceFiles
   });
   if (programReuse !== undefined) {
     programReuse.program = program;

--- a/packages/compiler-cli/src/ngtsc/annotations/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/scope",
         "//packages/compiler-cli/src/ngtsc/testing",
         "//packages/compiler-cli/src/ngtsc/translator",
+        "//packages/compiler-cli/src/ngtsc/util",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/util",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -67,7 +67,7 @@ export class NgtscProgram implements api.Program {
   private incrementalState: IncrementalState;
   private typeCheckFilePath: AbsoluteFsPath;
 
-  private modifiedResourceFiles: Set<string>|undefined;
+  private modifiedResourceFiles: Set<string>|null;
 
   constructor(
       rootNames: ReadonlyArray<string>, private options: api.CompilerOptions,
@@ -78,7 +78,7 @@ export class NgtscProgram implements api.Program {
     }
 
     this.modifiedResourceFiles =
-        this.host.getModifiedResourceFiles && this.host.getModifiedResourceFiles();
+        this.host.getModifiedResourceFiles && this.host.getModifiedResourceFiles() || null;
     this.rootDirs = getRootDirs(host, options);
     this.closureCompilerEnabled = !!options.annotateForClosureCompiler;
     this.resourceManager = new HostResourceLoader(host, options);

--- a/packages/compiler-cli/src/ngtsc/util/src/resource_recorder.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/resource_recorder.ts
@@ -1,0 +1,20 @@
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+/**
+ * Implement this interface to record what resources a source file depends upon.
+ */
+export interface ResourceDependencyRecorder {
+  recordResourceDependency(file: ts.SourceFile, resourcePath: string): void;
+}
+
+export class NoopResourceDependencyRecorder implements ResourceDependencyRecorder {
+  recordResourceDependency(): void {}
+}

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -220,26 +220,30 @@ export function exitCodeFromResult(diags: Diagnostics | undefined): number {
   return diags.some(d => d.source === 'angular' && d.code === api.UNKNOWN_ERROR_CODE) ? 2 : 1;
 }
 
-export function performCompilation({rootNames, options, host, oldProgram, emitCallback,
-                                    mergeEmitResultsCallback,
-                                    gatherDiagnostics = defaultGatherDiagnostics,
-                                    customTransformers, emitFlags = api.EmitFlags.Default}: {
-  rootNames: string[],
-  options: api.CompilerOptions,
-  host?: api.CompilerHost,
-  oldProgram?: api.Program,
-  emitCallback?: api.TsEmitCallback,
-  mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
-  gatherDiagnostics?: (program: api.Program) => Diagnostics,
-  customTransformers?: api.CustomTransformers,
-  emitFlags?: api.EmitFlags
-}): PerformCompilationResult {
+export function performCompilation(
+    {rootNames, options, host, oldProgram, emitCallback, mergeEmitResultsCallback,
+     gatherDiagnostics = defaultGatherDiagnostics, customTransformers,
+     emitFlags = api.EmitFlags.Default, modifiedResourceFiles}: {
+      rootNames: string[],
+      options: api.CompilerOptions,
+      host?: api.CompilerHost,
+      oldProgram?: api.Program,
+      emitCallback?: api.TsEmitCallback,
+      mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
+      gatherDiagnostics?: (program: api.Program) => Diagnostics,
+      customTransformers?: api.CustomTransformers,
+      emitFlags?: api.EmitFlags,
+      modifiedResourceFiles?: Set<string>,
+    }): PerformCompilationResult {
   let program: api.Program|undefined;
   let emitResult: ts.EmitResult|undefined;
   let allDiagnostics: Array<ts.Diagnostic|api.Diagnostic> = [];
   try {
     if (!host) {
       host = ng.createCompilerHost({options});
+    }
+    if (modifiedResourceFiles) {
+      host.getModifiedResourceFiles = () => modifiedResourceFiles;
     }
 
     program = ng.createProgram({rootNames, host, options, oldProgram});

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -281,6 +281,12 @@ export interface CompilerHost extends ts.CompilerHost {
    * rather than by path. See http://requirejs.org/docs/whyamd.html#namedmodules
    */
   amdModuleName?(sf: ts.SourceFile): string|undefined;
+
+  /**
+   * Get the absolute paths to the changed files that triggered the current compilation
+   * or `undefined` if this is not an incremental build.
+   */
+  getModifiedResourceFiles?(): Set<string>|undefined;
 }
 
 export enum EmitFlags {

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/path",
         "//packages/compiler-cli/src/ngtsc/routing",
         "//packages/compiler-cli/src/ngtsc/util",
         "//packages/compiler-cli/test:test_utils",


### PR DESCRIPTION
Optimisations to skip compiling source files that had not changed
did not account for there being only changes to a resource file,
such as a template or style file.

Now we track such dependencies and trigger a recompilation
if any of the previously tracked resources have changed.

Closes #30947
