### PR TITLE
docs: add cross-platform support to the schematics for libraries guide

### DIFF
--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
@@ -5,11 +5,8 @@
   "version": "0.0.1",
 // #enddocregion collection
   "scripts": {
-    "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
-    "copy:schemas": "cp --parents schematics/*/schema.json ../../dist/my-lib/",
-    "copy:files": "cp --parents -p schematics/*/files/** ../../dist/my-lib/",
-    "copy:collection": "cp schematics/collection.json ../../dist/my-lib/schematics/collection.json",
-    "postbuild": "npm run copy:schemas && npm run copy:files && npm run copy:collection"
+    "build": "tsc -p tsconfig.schematics.json",
+    "postbuild": "copyfiles schematics/*/schema.json schematics/*/files/** schematics/collection.json ../../dist/my-lib/"
   },
   "peerDependencies": {
     "@angular/common": "^7.2.0",
@@ -21,7 +18,11 @@
 // #docregion ng-add
   "ng-add": {
     "save": "devDependencies"
-  }
+  },
 // #enddocregion ng-add
+  "devDependencies": {
+    "copyfiles": "file:../../node_modules/copyfiles",
+    "typescript": "file:../../node_modules/typescript"
+  }
 // #docregion collection
 }

--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts
@@ -42,12 +42,12 @@ export function myService(options: MyServiceSchema): Rule {
 
 // #docregion project-info
 // #docregion project-fallback
-    if (!options.project) {
+    if (!options.project && typeof workspace.extensions.defaultProject === 'string') {
       options.project = workspace.extensions.defaultProject;
     }
 // #enddocregion project-fallback
 
-    const project = workspace.projects.get(options.project);
+    const project = (options.project != null) ? workspace.projects.get(options.project) : null;
     if (!project) {
       throw new SchematicsException(`Invalid project name: ${options.project}`);
     }

--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/index.ts
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/index.ts
@@ -2,7 +2,7 @@ import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
 // Just return the tree
-export function ngAdd(options: any): Rule {
+export function ngAdd(): Rule {
   return (tree: Tree, context: SchematicContext) => {
     context.addTask(new NodePackageInstallTask());
     return tree;

--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -98,8 +98,9 @@ To tell the library how to build the schematics, add a `tsconfig.schematics.json
     </code-example>
 
     * The `build` script compiles your schematic using the custom `tsconfig.schematics.json` file.
-    * The `copy:*` statements copy compiled schematic files into the proper locations in the library output folder in order to preserve the file structure.
     * The `postbuild` script copies the schematic files after the `build` script completes.
+    * Both the `build` and the `postbuild` scripts require dependencies that are found in their parent directory.
+      They can be installed by running `npm install` prior to running the scripts.
 
 ## Providing generation support
 

--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -32,6 +32,7 @@
     "@angular/compiler-cli": "~13.0.0-next.0",
     "@types/jasmine": "~3.10.0",
     "@types/node": "^12.11.1",
+    "copyfiles": "^2.4.1",
     "jasmine-core": "~3.10.0",
     "jasmine-marbles": "~0.8.3",
     "jasmine-spec-reporter": "~7.0.0",


### PR DESCRIPTION
Add Windows friendly commands for copying schematics into the library.

Fixes #29952

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The [schematics for libraries guide](https://angular.io/guide/schematics-for-libraries) uses the `cp` command to copy schematics into the library's output directory (in the `package.json` file). The `cp` command is not a valid command in Windows cmd.exe and will throw an error it the scripts are executed.
Issue Number: 29952


## What is the new behavior?
Additional documentation explains that Windows users should use the `copy` command or look into a cross-platform solution such as [ncp](https://www.npmjs.com/package/ncp).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This fix is similar to the #30018 pull request, however it adds a reference to the Linux subsystem for Windows 10 (per recommendation by @Splaktar in #29952).