### PR TITLE
test: fix test failures in master branch

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1273,7 +1273,7 @@ describe('CommonJsReflectionHost', () => {
 
       const fooNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-      const fooDef = host.getDefinitionOfFunction(fooNode);
+      const fooDef = host.getDefinitionOfFunction(fooNode) !;
       expect(fooDef.node).toBe(fooNode);
       expect(fooDef.body !.length).toEqual(1);
       expect(fooDef.body ![0].getText()).toEqual(`return x;`);
@@ -1283,7 +1283,7 @@ describe('CommonJsReflectionHost', () => {
 
       const barNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-      const barDef = host.getDefinitionOfFunction(barNode);
+      const barDef = host.getDefinitionOfFunction(barNode) !;
       expect(barDef.node).toBe(barNode);
       expect(barDef.body !.length).toEqual(1);
       expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
@@ -1296,7 +1296,7 @@ describe('CommonJsReflectionHost', () => {
 
       const bazNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-      const bazDef = host.getDefinitionOfFunction(bazNode);
+      const bazDef = host.getDefinitionOfFunction(bazNode) !;
       expect(bazDef.node).toBe(bazNode);
       expect(bazDef.body !.length).toEqual(3);
       expect(bazDef.parameters.length).toEqual(1);
@@ -1305,7 +1305,7 @@ describe('CommonJsReflectionHost', () => {
 
       const quxNode =
           getDeclaration(program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-      const quxDef = host.getDefinitionOfFunction(quxNode);
+      const quxDef = host.getDefinitionOfFunction(quxNode) !;
       expect(quxDef.node).toBe(quxNode);
       expect(quxDef.body !.length).toEqual(2);
       expect(quxDef.parameters.length).toEqual(1);

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -31,10 +31,10 @@ describe('view insertion', () => {
             `
       })
       class App {
-        @ViewChild('container', {read: ViewContainerRef})
+        @ViewChild('container', {read: ViewContainerRef, static: true})
         container: ViewContainerRef = null !;
 
-        @ViewChild('simple', {read: TemplateRef})
+        @ViewChild('simple', {read: TemplateRef, static: true})
         simple: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;
@@ -89,10 +89,10 @@ describe('view insertion', () => {
             `
       })
       class App {
-        @ViewChild('container', {read: ViewContainerRef})
+        @ViewChild('container', {read: ViewContainerRef, static: false})
         container: ViewContainerRef = null !;
 
-        @ViewChild('empty', {read: TemplateRef})
+        @ViewChild('empty', {read: TemplateRef, static: false})
         empty: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;
@@ -139,10 +139,10 @@ describe('view insertion', () => {
                 `
       })
       class Comp {
-        @ViewChild('container', {read: ViewContainerRef})
+        @ViewChild('container', {read: ViewContainerRef, static: false})
         container: ViewContainerRef = null !;
 
-        @ViewChild('projection', {read: TemplateRef})
+        @ViewChild('projection', {read: TemplateRef, static: false})
         projection: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;
@@ -200,10 +200,10 @@ describe('view insertion', () => {
                 `
       })
       class App {
-        @ViewChild('container', {read: ViewContainerRef})
+        @ViewChild('container', {read: ViewContainerRef, static: false})
         container: ViewContainerRef = null !;
 
-        @ViewChild('subContainer', {read: TemplateRef})
+        @ViewChild('subContainer', {read: TemplateRef, static: false})
         subContainer: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;


### PR DESCRIPTION
Fixes the current CI failures in the `master` branch. See for example: [this build](https://circleci.com/gh/angular/angular/352705?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

---

**test(ivy): fix strict null checks failures in ngcc tests**

9d9c9e4 has been created a few days ago and wasn't rebased on top of recent Ngcc changes
that introduced the commonjs host.

This means that tests for the commonjs host haven't been updated to work with
the changes from from #30492 and now fail in `master`.

---

**test(core): add missing static flag to view_insertion test view queries**
17d87d4 has been created before the API changes for the `@ViewChild` and `@ContentChild` decorators. Meaning that the commit still uses the queries without the `static` flag. This now results
in failures for `master` because the outdated commit has been merged on top of the API change.
