### PR TITLE
docs: add core and cli version alignment note

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -31,6 +31,11 @@ The version number is incremented based on the level of change included in the r
 
 * **Patch releases** are low risk, bug fix releases. No developer assistance is expected during update.
 
+<div class="alert is-helpful">
+
+**Note:** As of Angular version 7, the major versions of Angular core and the CLI are aligned. This means that in order to use the CLI as you develop an Angular app, the version of `@angular/core` and the CLI need to be the same.
+
+</div>
 
 {@a updating}
 ### Supported update paths


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The issue tracks the problem of a missing information about the suitable versions of Angular core and cli. Due to no updates of the v2.angular.io docs there should be a note in the current documentation.

This PR adds a note in the chapter [Angular versioning](https://angular.io/guide/releases#angular-versioning). This note can be linked in the Getting Started later.

Issue Number: #30261


## What is the new behavior?
Added a note about the version alignment between Angular core and cli.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information