### PR TITLE
test(compiler-cli): fix failing ivy template compliance test

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -220,7 +220,6 @@ describe('compiler compliance: template', () => {
           $r3$.ɵɵelement(0, "div", $_c3$);
         } if (rf & 2) {
           const $ctx_0$ = i0.ɵɵnextContext();
-          $r3$.ɵɵselect(0);
           $r3$.ɵɵproperty("id", $ctx_0$);
         }
       }


### PR DESCRIPTION
Commit 58be2ff88400d7dc876d357f8cc3eb01b0912aae has been created before c0386757b1d4a4f1e9eaf190819abe358342b9ad landed, and therefore
the newly created compliance test was using an outdated expectation.

This commit updates the compliance test to no longer contain
the outdated expectation.