### PR TITLE
fix(docs-infra): enable only vertical scrolling for contributors bio

### DIFF
--- a/aio/src/styles/2-modules/_contributor.scss
+++ b/aio/src/styles/2-modules/_contributor.scss
@@ -188,7 +188,7 @@ aio-contributor {
     line-height: 18px;
     margin: 8px 16px;
     text-overflow: ellipsis;
-    overflow: scroll;
+    overflow-y: auto;
     font-weight: 400;
   }
 }


### PR DESCRIPTION
- `auto` will enable scrolling only when needed
- `overflow-y` will ensure to keep the scrolling horizontally only

Before
![image](https://user-images.githubusercontent.com/17563226/59331762-00372180-8cf5-11e9-81c7-3017c7b3a53e.png)

![image](https://user-images.githubusercontent.com/17563226/59331748-f4e3f600-8cf4-11e9-9a90-f5b9bf3a7e4b.png)

After
![image](https://user-images.githubusercontent.com/17563226/59331787-0b8a4d00-8cf5-11e9-8f92-eafe5176bfcd.png)


![image](https://user-images.githubusercontent.com/17563226/59331736-eeee1500-8cf4-11e9-87b0-93ffa3b0e3f0.png)

