### PR TITLE
feat(core): support strict compilation mode

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -23,6 +23,12 @@ ts_config(
     deps = [":tsconfig-build.json"],
 )
 
+ts_config(
+    name = "tsconfig-build-strict",
+    src = "tsconfig-build-strict.json",
+    deps = [":tsconfig-build.json"],
+)
+
 exports_files([
     "license-banner.txt",
     "README.md",

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -132,7 +132,7 @@ export class StaticReflector implements CompileReflector {
 
   public tryAnnotations(type: StaticSymbol): any[] {
     const originalRecorder = this.errorRecorder;
-    this.errorRecorder = (error: any, fileName: string) => {};
+    this.errorRecorder = (error: any, fileName?: string) => {};
     try {
       return this.annotations(type);
     } finally {
@@ -429,7 +429,7 @@ export class StaticReflector implements CompileReflector {
    */
   private trySimplify(context: StaticSymbol, value: any): any {
     const originalRecorder = this.errorRecorder;
-    this.errorRecorder = (error: any, fileName: string) => {};
+    this.errorRecorder = (error: any, fileName?: string) => {};
     const result = this.simplify(context, value);
     this.errorRecorder = originalRecorder;
     return result;

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -273,7 +273,7 @@ class KeyVisitor implements o.ExpressionVisitor {
   visitCommaExpr = invalid;
 }
 
-function invalid<T>(arg: o.Expression | o.Statement): never {
+function invalid<T>(this: o.ExpressionVisitor, arg: o.Expression | o.Statement): never {
   throw new Error(
       `Invalid state: Visitor ${this.constructor.name} doesn't handle ${arg.constructor.name}`);
 }

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -210,7 +210,7 @@ const USE_FACTORY = Object.keys({useFactory: null})[0];
 const USE_VALUE = Object.keys({useValue: null})[0];
 const USE_EXISTING = Object.keys({useExisting: null})[0];
 
-const wrapReference = function(value: Type): R3Reference {
+const wrapReference = function(value: any): R3Reference {
   const wrapped = new WrappedNodeExpr(value);
   return {value: wrapped, type: wrapped};
 };

--- a/packages/compiler/src/metadata_resolver.ts
+++ b/packages/compiler/src/metadata_resolver.ts
@@ -83,7 +83,7 @@ export class CompileMetadataResolver {
 
   private _createProxyClass(baseType: any, name: string): cpl.ProxyClass {
     let delegate: any = null;
-    const proxyClass: cpl.ProxyClass = <any>function() {
+    const proxyClass: cpl.ProxyClass = <any>function(this: any) {
       if (!delegate) {
         throw new Error(
             `Illegal state: Class ${name} for type ${stringify(baseType)} is not compiled yet!`);

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -112,7 +112,7 @@ export class RecursiveVisitor implements Visitor {
       if (children) results.push(visitAll(t, children, context));
     }
     cb(visit);
-    return [].concat.apply([], results);
+    return Array.prototype.concat.apply([], results);
   }
 }
 

--- a/packages/compiler/src/output/output_interpreter.ts
+++ b/packages/compiler/src/output/output_interpreter.ts
@@ -79,7 +79,7 @@ function createDynamicClass(
 
   const ctorParamNames = _classStmt.constructorMethod.params.map(param => param.name);
   // Note: use `function` instead of arrow function to capture `this`
-  const ctor = function(...args: any[]) {
+  const ctor = function(this: any, ...args: any[]) {
     const instanceCtx = new _ExecutionContext(_ctx, this, _classStmt.name, _ctx.vars);
     _classStmt.fields.forEach((field) => { this[field.name] = undefined; });
     _executeFunctionStatements(

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -15,7 +15,7 @@ import {ParseTreeResult} from '../../../ml_parser/parser';
 
 import {I18N_ATTR, I18N_ATTR_PREFIX, I18nMeta, hasI18nAttrs, icuFromI18nMessage, metaFromI18nMessage, parseI18nMeta} from './util';
 
-function setI18nRefs(html: html.Node & {i18n: i18n.AST}, i18n: i18n.Node) {
+function setI18nRefs(html: html.Node & {i18n?: i18n.AST}, i18n: i18n.Node) {
   html.i18n = i18n;
 }
 

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -165,7 +165,8 @@ export function assembleBoundTextPlaceholders(
       meta instanceof i18n.Message ? meta.nodes.find(node => node instanceof i18n.Container) : meta;
   if (node) {
     (node as i18n.Container)
-        .children.filter((child: i18n.Node) => child instanceof i18n.Placeholder)
+        .children
+        .filter((child: i18n.Node): child is i18n.Placeholder => child instanceof i18n.Placeholder)
         .forEach((child: i18n.Placeholder, idx: number) => {
           const content = wrapI18nPlaceholder(startIdx + idx, contextId);
           updatePlaceholderMap(placeholders, child.name, content);

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -58,14 +58,14 @@ export function temporaryAllocator(statements: o.Statement[], name: string): () 
 }
 
 
-export function unsupported(feature: string): never {
+export function unsupported(this: void|Function, feature: string): never {
   if (this) {
     throw new Error(`Builder ${this.constructor.name} doesn't support ${feature} yet`);
   }
   throw new Error(`Feature ${feature} is not supported yet`);
 }
 
-export function invalid<T>(arg: o.Expression | o.Statement | t.Node): never {
+export function invalid<T>(this: t.Visitor, arg: o.Expression | o.Statement | t.Node): never {
   throw new Error(
       `Invalid state: Visitor ${this.constructor.name} doesn't handle ${arg.constructor.name}`);
 }

--- a/packages/compiler/src/template_parser/template_ast.ts
+++ b/packages/compiler/src/template_parser/template_ast.ts
@@ -359,7 +359,7 @@ export class RecursiveTemplateAstVisitor extends NullTemplateVisitor implements 
       if (children && children.length) results.push(templateVisitAll(t, children, context));
     }
     cb(visit);
-    return [].concat.apply([], results);
+    return Array.prototype.concat.apply([], results);
   }
 }
 

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    build_strict_mode = True,
     deps = [
         "//packages:types",
         "//packages/core/src/compiler",

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -411,7 +411,7 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
 
   queryAll(predicate: Predicate<DebugElement>): DebugElement[] {
     const matches: DebugElement[] = [];
-    _queryAllR3(this, predicate, matches, true);
+    _queryAllR3(this, predicate as Predicate<DebugNode>, matches, true);
     return matches;
   }
 

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -86,10 +86,10 @@ export interface InjectableType<T> extends Type<T> { ngInjectableDef: ɵɵInject
  * Supports @Injectable() in JIT mode for Render2.
  */
 function render2CompileInjectable(
-    injectableType: InjectableType<any>,
-    options: {providedIn?: Type<any>| 'root' | null} & InjectableProvider): void {
+    injectableType: Type<any>,
+    options?: {providedIn?: Type<any>| 'root' | null} & InjectableProvider): void {
   if (options && options.providedIn !== undefined && !getInjectableDef(injectableType)) {
-    injectableType.ngInjectableDef = ɵɵdefineInjectable({
+    (injectableType as InjectableType<any>).ngInjectableDef = ɵɵdefineInjectable({
       token: injectableType,
       providedIn: options.providedIn,
       factory: convertInjectableProviderToFactory(injectableType, options),

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -68,8 +68,8 @@ export function setCurrentInjector(injector: Injector | null | undefined): Injec
  *  1. `Injector` should not depend on ivy logic.
  *  2. To maintain tree shake-ability we don't want to bring in unnecessary code.
  */
-let _injectImplementation: (<T>(token: Type<T>| InjectionToken<T>, flags: InjectFlags) => T | null)|
-    undefined;
+let _injectImplementation:
+    (<T>(token: Type<T>| InjectionToken<T>, flags?: InjectFlags) => T | null)|undefined;
 
 /**
  * Sets the current inject implementation.

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -11,6 +11,7 @@ import '../util/ng_dev_mode';
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
 import {throwCyclicDependencyError, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors';
+import {deepForEach} from '../util/array_utils';
 import {stringify} from '../util/stringify';
 
 import {resolveForwardRef} from './forward_ref';
@@ -495,10 +496,6 @@ function makeRecord<T>(
     value: value,
     multi: multi ? [] : undefined,
   };
-}
-
-function deepForEach<T>(input: (T | any[])[], fn: (value: T) => void): void {
-  input.forEach(value => Array.isArray(value) ? deepForEach(value, fn) : fn(value));
 }
 
 function isValueProvider(value: SingleProvider): value is ValueProvider {

--- a/packages/core/src/di/reflective_provider.ts
+++ b/packages/core/src/di/reflective_provider.ts
@@ -180,10 +180,11 @@ export function mergeResolvedReflectiveProviders(
   return normalizedProvidersMap;
 }
 
-function _normalizeProviders(providers: Provider[], res: Provider[]): Provider[] {
+function _normalizeProviders(
+    providers: Provider[], res: NormalizedProvider[]): NormalizedProvider[] {
   providers.forEach(b => {
     if (b instanceof Type) {
-      res.push({provide: b, useClass: b});
+      res.push({ provide: b, useClass: b } as NormalizedProvider);
 
     } else if (b && typeof b == 'object' && (b as any).provide !== undefined) {
       res.push(b as NormalizedProvider);

--- a/packages/core/src/linker/ng_module_factory_registration.ts
+++ b/packages/core/src/linker/ng_module_factory_registration.ts
@@ -50,7 +50,7 @@ export function registerNgModuleType(ngModuleType: NgModuleType) {
     imports = imports();
   }
   if (imports) {
-    imports.forEach((i: NgModuleType<any>) => registerNgModuleType(i));
+    imports.forEach((i: Type<any>) => registerNgModuleType(i as NgModuleType));
   }
 }
 

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -320,7 +320,7 @@ export const NgModule: NgModuleDecorator = makeDecorator(
      * * The `imports` and `exports` options bring in members from other modules, and make
      * this module's members available to others.
      */
-    (type: NgModuleType, meta: NgModule) => SWITCH_COMPILE_NGMODULE(type, meta));
+    (type: Type<any>, meta: NgModule) => SWITCH_COMPILE_NGMODULE(type, meta));
 
 /**
  * @description
@@ -344,13 +344,13 @@ export const NgModule: NgModuleDecorator = makeDecorator(
  */
 export interface DoBootstrap { ngDoBootstrap(appRef: ApplicationRef): void; }
 
-function preR3NgModuleCompile(moduleType: InjectorType<any>, metadata: NgModule): void {
+function preR3NgModuleCompile(moduleType: Type<any>, metadata?: NgModule): void {
   let imports = (metadata && metadata.imports) || [];
   if (metadata && metadata.exports) {
     imports = [...imports, metadata.exports];
   }
 
-  moduleType.ngInjectorDef = ɵɵdefineInjector({
+  (moduleType as InjectorType<any>).ngInjectorDef = ɵɵdefineInjector({
     factory: convertInjectableProviderToFactory(moduleType, {useClass: moduleType}),
     providers: metadata && metadata.providers,
     imports: imports,

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -273,7 +273,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
     pipeDefs: null !,       // assigned in noSideEffects
     selectors: componentDefinition.selectors,
     viewQuery: componentDefinition.viewQuery || null,
-    features: componentDefinition.features || null,
+    features: componentDefinition.features as DirectiveDefFeature[] || null,
     data: componentDefinition.data || {},
     // TODO(misko): convert ViewEncapsulation into const enum so that it can be used directly in the
     // next line. Also `None` should be 0 not 2.
@@ -324,8 +324,7 @@ export function ɵɵsetComponentScope(
   def.pipeDefs = () => pipes.map(extractPipeDef);
 }
 
-export function extractDirectiveDef(type: DirectiveType<any>& ComponentType<any>):
-    DirectiveDef<any>|ComponentDef<any> {
+export function extractDirectiveDef(type: Type<any>): DirectiveDef<any>|ComponentDef<any> {
   const def = getComponentDef(type) || getDirectiveDef(type);
   if (ngDevMode && !def) {
     throw new Error(`'${type.name}' is neither 'ComponentType' or 'DirectiveType'.`);
@@ -333,7 +332,7 @@ export function extractDirectiveDef(type: DirectiveType<any>& ComponentType<any>
   return def !;
 }
 
-export function extractPipeDef(type: PipeType<any>): PipeDef<any> {
+export function extractPipeDef(type: Type<any>): PipeDef<any> {
   const def = getPipeDef(type);
   if (ngDevMode && !def) {
     throw new Error(`'${type.name}' is not a 'PipeType'.`);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -557,7 +557,7 @@ export function getNodeInjectable(
     const saveLView = getLView();
     setTNodeAndViewData(tNode, lData);
     try {
-      value = lData[index] = factory.factory(null, tData, lData, tNode);
+      value = lData[index] = factory.factory(undefined, tData, lData, tNode);
     } finally {
       if (factory.injectImpl) setInjectImplementation(previousInjectImplementation);
       setIncludeViewProviders(previousIncludeViewProviders);

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -204,7 +204,8 @@ function indexOf(item: any, arr: any[], begin: number, end: number) {
  * Use this with `multi` `providers`.
  */
 function multiProvidersFactoryResolver(
-    this: NodeInjectorFactory, _: null, tData: TData, lData: LView, tNode: TElementNode): any[] {
+    this: NodeInjectorFactory, _: undefined, tData: TData, lData: LView,
+    tNode: TElementNode): any[] {
   return multiResolve(this.multi !, []);
 }
 
@@ -214,7 +215,8 @@ function multiProvidersFactoryResolver(
  * This factory knows how to concatenate itself with the existing `multi` `providers`.
  */
 function multiViewProvidersFactoryResolver(
-    this: NodeInjectorFactory, _: null, tData: TData, lData: LView, tNode: TElementNode): any[] {
+    this: NodeInjectorFactory, _: undefined, tData: TData, lData: LView,
+    tNode: TElementNode): any[] {
   const factories = this.multi !;
   let result: any[];
   if (this.providerFactory) {
@@ -252,7 +254,8 @@ function multiResolve(factories: Array<() => any>, result: any[]): any[] {
  */
 function multiFactory(
     factoryFn: (
-        this: NodeInjectorFactory, _: null, tData: TData, lData: LView, tNode: TElementNode) => any,
+        this: NodeInjectorFactory, _: undefined, tData: TData, lData: LView, tNode: TElementNode) =>
+        any,
     index: number, isViewProvider: boolean, isComponent: boolean,
     f: () => any): NodeInjectorFactory {
   const factory = new NodeInjectorFactory(factoryFn, isViewProvider, ɵɵdirectiveInject);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -20,7 +20,7 @@ import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} f
 import {throwMultipleComponentError} from '../errors';
 import {executeHooks, executePreOrderHooks, registerPreOrderHooks} from '../hooks';
 import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
-import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
+import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, FactoryFn, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {INJECTOR_BLOOM_PARENT_SIZE, NodeInjectorFactory} from '../interfaces/injector';
 import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
 import {LQueries} from '../interfaces/query';
@@ -1276,8 +1276,7 @@ export function initNodeFlags(tNode: TNode, index: number, numberOfDirectives: n
 }
 
 function baseResolveDirective<T>(
-    tView: TView, viewData: LView, def: DirectiveDef<T>,
-    directiveFactory: (t: Type<T>| null) => any) {
+    tView: TView, viewData: LView, def: DirectiveDef<T>, directiveFactory: FactoryFn<T>) {
   tView.data.push(def);
   const nodeInjectorFactory = new NodeInjectorFactory(directiveFactory, isComponentDef(def), null);
   tView.blueprint.push(nodeInjectorFactory);

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -397,7 +397,7 @@ export type DirectiveDefList = (DirectiveDef<any>| ComponentDef<any>)[];
 export type DirectiveTypesOrFactory = (() => DirectiveTypeList) | DirectiveTypeList;
 
 export type DirectiveTypeList =
-    (DirectiveDef<any>| ComponentDef<any>|
+    (DirectiveType<any>| ComponentType<any>|
      Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
 export type HostBindingsFunction<T> =
@@ -412,10 +412,10 @@ export type PipeDefListOrFactory = (() => PipeDefList) | PipeDefList;
 
 export type PipeDefList = PipeDef<any>[];
 
-export type PipeTypesOrFactory = (() => DirectiveTypeList) | DirectiveTypeList;
+export type PipeTypesOrFactory = (() => PipeTypeList) | PipeTypeList;
 
 export type PipeTypeList =
-    (PipeDef<any>| Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
+    (PipeType<any>| Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -132,7 +132,7 @@ export class NodeInjectorFactory {
   /**
    * The inject implementation to be activated when using the factory.
    */
-  injectImpl: null|(<T>(token: Type<T>|InjectionToken<T>, flags: InjectFlags) => T);
+  injectImpl: null|(<T>(token: Type<T>|InjectionToken<T>, flags?: InjectFlags) => T);
 
   /**
    * Marker set to true during factory invocation to see if we get into recursive loop.
@@ -216,7 +216,7 @@ export class NodeInjectorFactory {
        * Factory to invoke in order to create a new instance.
        */
       public factory:
-          (this: NodeInjectorFactory, _: null,
+          (this: NodeInjectorFactory, _: undefined,
            /**
             * array where injectables tokens are stored. This is used in
             * case of an error reporting to produce friendlier errors.
@@ -234,8 +234,8 @@ export class NodeInjectorFactory {
       /**
        * Set to `true` if the token is declared in `viewProviders` (or if it is component).
        */
-      isViewProvider: boolean,
-      injectImplementation: null|(<T>(token: Type<T>|InjectionToken<T>, flags: InjectFlags) => T)) {
+      isViewProvider: boolean, injectImplementation: null|
+      (<T>(token: Type<T>|InjectionToken<T>, flags?: InjectFlags) => T)) {
     this.canSeeViewProviders = isViewProvider;
     this.injectImpl = injectImplementation;
   }

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -13,7 +13,7 @@ import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {Component} from '../../metadata';
 import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes} from '../../metadata/ng_module';
-import {flatten} from '../../util/array_utils';
+import {deepForEach, flatten} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from '../fields';
@@ -183,9 +183,10 @@ function verifySemanticsOfNgModuleDef(
         flatten(ngModule.imports)
             .map(unwrapModuleWithProvidersImports)
             .forEach(mod => verifySemanticsOfNgModuleDef(mod, false));
-    ngModule.bootstrap && ngModule.bootstrap.forEach(verifyCorrectBootstrapType);
-    ngModule.bootstrap && ngModule.bootstrap.forEach(verifyComponentIsPartOfNgModule);
-    ngModule.entryComponents && ngModule.entryComponents.forEach(verifyComponentIsPartOfNgModule);
+    ngModule.bootstrap && deepForEach(ngModule.bootstrap, verifyCorrectBootstrapType);
+    ngModule.bootstrap && deepForEach(ngModule.bootstrap, verifyComponentIsPartOfNgModule);
+    ngModule.entryComponents &&
+        deepForEach(ngModule.entryComponents, verifyComponentIsPartOfNgModule);
   }
 
   // Throw Error if any errors were detected.
@@ -256,7 +257,7 @@ function verifySemanticsOfNgModuleDef(
       // We know we are component
       const component = getAnnotation<Component>(type, 'Component');
       if (component && component.entryComponents) {
-        component.entryComponents.forEach(verifyComponentIsPartOfNgModule);
+        deepForEach(component.entryComponents, verifyComponentIsPartOfNgModule);
       }
     }
   }

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -166,7 +166,7 @@ export function ɵɵpipeBind4(
  *
  * @codeGenApi
  */
-export function ɵɵpipeBindV(index: number, slotOffset: number, values: any[]): any {
+export function ɵɵpipeBindV(index: number, slotOffset: number, values: [any, ...any[]]): any {
   const pipeInstance = ɵɵload<PipeTransform>(index);
   return unwrapValue(
       isPure(index) ? ɵɵpureFunctionV(slotOffset, pipeInstance.transform, values, pipeInstance) :

--- a/packages/core/src/render3/styling/host_instructions_queue.ts
+++ b/packages/core/src/render3/styling/host_instructions_queue.ts
@@ -61,7 +61,7 @@ function findNextInsertionIndex(buffer: HostInstructionsQueue, priority: number)
  * Iterates through the host instructions queue (if present within the provided
  * context) and executes each queued instruction entry.
  */
-export function flushQueue(context: StylingContext): void {
+export function flushQueue(this: any, context: StylingContext): void {
   const buffer = context[StylingIndex.HostInstructionsQueue];
   if (buffer) {
     for (let i = HostInstructionsQueueIndex.ValuesStartPosition; i < buffer.length;

--- a/packages/core/src/render3/styling_next/styling_debug.ts
+++ b/packages/core/src/render3/styling_next/styling_debug.ts
@@ -201,7 +201,7 @@ export class NodeStylingDebug implements DebugStyling {
     return entries;
   }
 
-  private _mapValues(fn: (prop: string, value: any, bindingIndex: number|null) => any) {
+  private _mapValues(fn: (prop: string, value: string|null, bindingIndex: number|null) => any) {
     // there is no need to store/track an element instance. The
     // element is only used when the styling algorithm attempts to
     // style the value (and we mock out the stylingApplyFn anyway).
@@ -212,9 +212,8 @@ export class NodeStylingDebug implements DebugStyling {
     }
 
     const mapFn: ApplyStylingFn =
-        (renderer: any, element: RElement, prop: string, value: any, bindingIndex: number) => {
-          fn(prop, value, bindingIndex || null);
-        };
+        (renderer: any, element: RElement, prop: string, value: string | null,
+         bindingIndex?: number | null) => { fn(prop, value, bindingIndex || null); };
 
     const sanitizer = this._isClassBased ? null : (this._sanitizer ||
                                                    getCurrentOrLViewSanitizer(this._data as LView));

--- a/packages/core/src/render3/styling_next/util.ts
+++ b/packages/core/src/render3/styling_next/util.ts
@@ -163,10 +163,10 @@ export function getCurrentOrLViewSanitizer(lView: LView): StyleSanitizeFn|null {
  * sanitization.
  */
 const sanitizeUsingSanitizerObject: StyleSanitizeFn =
-    (prop: string, value: string, mode: StyleSanitizeMode) => {
+    (prop: string, value: string | null, mode?: StyleSanitizeMode) => {
       const sanitizer = getCurrentStyleSanitizer() as Sanitizer;
       if (sanitizer) {
-        if (mode & StyleSanitizeMode.SanitizeOnly) {
+        if (mode !== undefined && mode & StyleSanitizeMode.SanitizeOnly) {
           return sanitizer.sanitize(SecurityContext.STYLE, value);
         } else {
           return true;

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -39,3 +39,7 @@ export function flatten(list: any[], dst?: any[]): any[] {
   }
   return dst;
 }
+
+export function deepForEach<T>(input: (T | any[])[], fn: (value: T) => void): void {
+  input.forEach(value => Array.isArray(value) ? deepForEach(value, fn) : fn(value));
+}

--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -49,10 +49,11 @@ export function makeDecorator<T>(
     {new (...args: any[]): any; (...args: any[]): any; (...args: any[]): (cls: any) => any;} {
   const metaCtor = makeMetadataCtor(props);
 
-  function DecoratorFactory(...args: any[]): (cls: Type<T>) => any {
+  function DecoratorFactory(this: void|typeof DecoratorFactory, ...args: any[]): (cls: Type<T>) =>
+      any {
     if (this instanceof DecoratorFactory) {
       metaCtor.call(this, ...args);
-      return this;
+      return this as typeof DecoratorFactory;
     }
 
     const annotationInstance = new (DecoratorFactory as any)(...args);
@@ -82,7 +83,7 @@ export function makeDecorator<T>(
 }
 
 function makeMetadataCtor(props?: (...args: any[]) => any): any {
-  return function ctor(...args: any[]) {
+  return function ctor(this: any, ...args: any[]) {
     if (props) {
       const values = props(...args);
       for (const propName in values) {
@@ -95,7 +96,7 @@ function makeMetadataCtor(props?: (...args: any[]) => any): any {
 export function makeParamDecorator(
     name: string, props?: (...args: any[]) => any, parentClass?: any): any {
   const metaCtor = makeMetadataCtor(props);
-  function ParamDecoratorFactory(...args: any[]): any {
+  function ParamDecoratorFactory(this: void|typeof ParamDecoratorFactory, ...args: any[]): any {
     if (this instanceof ParamDecoratorFactory) {
       metaCtor.apply(this, args);
       return this;
@@ -135,7 +136,7 @@ export function makePropDecorator(
     additionalProcessing?: (target: any, name: string, ...args: any[]) => void): any {
   const metaCtor = makeMetadataCtor(props);
 
-  function PropDecoratorFactory(...args: any[]): any {
+  function PropDecoratorFactory(this: void|typeof PropDecoratorFactory, ...args: any[]): any {
     if (this instanceof PropDecoratorFactory) {
       metaCtor.apply(this, args);
       return this;

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -267,7 +267,7 @@ function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
 
 
     onInvoke: (delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function,
-               applyThis: any, applyArgs: any[], source: string): any => {
+               applyThis: any, applyArgs?: any[], source?: string): any => {
       try {
         onEnter(zone);
         return delegate.invoke(target, callback, applyThis, applyArgs, source);

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+describe('NgModule', () => {
+  @Component({template: 'hello'})
+  class TestCmp {
+  }
+
+  @Component({template: 'hello'})
+  class TestCmp2 {
+  }
+
+  describe('entryComponents', () => {
+    it('should throw when specified entry component is not added to a module', () => {
+      @NgModule({entryComponents: [TestCmp, [TestCmp2]]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => TestBed.createComponent(TestCmp)).toThrowError(/not part of any NgModule/);
+    });
+
+    it('should not throw when specified entry component is added to a module', () => {
+      @NgModule({declarations: [TestCmp, TestCmp2], entryComponents: [TestCmp, [TestCmp2]]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => TestBed.createComponent(TestCmp)).not.toThrow();
+    });
+  });
+
+  describe('bootstrap', () => {
+    it('should throw when specified bootstrap component is not added to a module', () => {
+      @NgModule({bootstrap: [TestCmp, [TestCmp2]]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => TestBed.createComponent(TestCmp)).toThrowError(/not part of any NgModule/);
+    });
+
+    it('should not throw when specified bootstrap component is added to a module', () => {
+      @NgModule({declarations: [TestCmp, TestCmp2], bootstrap: [TestCmp, [TestCmp2]]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => TestBed.createComponent(TestCmp)).not.toThrow();
+    });
+  });
+
+});

--- a/packages/tsconfig-build-strict.json
+++ b/packages/tsconfig-build-strict.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig-build.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true,
+    "devmodeTargetOverride": "es5"
+  }
+}

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -8,6 +8,7 @@ load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_p
 load("//packages/bazel/src:ng_rollup_bundle.bzl", _ng_rollup_bundle = "ng_rollup_bundle")
 
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
+_DEFAULT_TSCONFIG_BUILD_STRICT = "//packages:tsconfig-build-strict"
 _INTERNAL_NG_MODULE_API_EXTRACTOR = "//packages/bazel/src/api-extractor:api_extractor"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
 _INTERNAL_NG_MODULE_XI18N = "//packages/bazel/src/ngc-wrapped:xi18n"
@@ -97,7 +98,7 @@ def ts_library(tsconfig = None, testonly = False, deps = [], module_name = None,
         **kwargs
     )
 
-def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], module_name = None, bundle_dts = True, **kwargs):
+def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], module_name = None, bundle_dts = True, build_strict_mode = False, **kwargs):
     """Default values for ng_module"""
     deps = deps + ["@npm//tslib"]
     if testonly:
@@ -106,6 +107,8 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         deps.append("@npm//@types/node")
     if not tsconfig and testonly:
         tsconfig = _DEFAULT_TSCONFIG_TEST
+    if not tsconfig and build_strict_mode:
+        tsconfig = _DEFAULT_TSCONFIG_BUILD_STRICT
 
     if not module_name:
         module_name = _default_module_name(testonly)


### PR DESCRIPTION
As part of FW-1265, the `@angular/core` package is made compatible with the
TypeScript `--strict` flag. This already unveiled a few bugs, so the strictness flag
seems to help with increasing the overall code health.

Read more about the strict flag [here](https://www.typescriptlang.org/docs/handbook/compiler-options.html)