### PR TITLE
refactor(ivy): remove LView argument from locateDirectiveOrProvider

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -481,8 +481,8 @@ function searchTokensOnInjector<T>(
   // on the host element node.
   const isHostSpecialCase = (flags & InjectFlags.Host) && hostTElementNode === tNode;
 
-  const injectableIdx =
-      locateDirectiveOrProvider(tNode, lView, token, canAccessViewProviders, isHostSpecialCase);
+  const injectableIdx = locateDirectiveOrProvider(
+      tNode, currentTView, token, canAccessViewProviders, isHostSpecialCase);
   if (injectableIdx !== null) {
     return getNodeInjectable(currentTView.data, lView, injectableIdx, tNode as TElementNode);
   } else {
@@ -494,16 +494,15 @@ function searchTokensOnInjector<T>(
  * Searches for the given token among the node's directives and providers.
  *
  * @param tNode TNode on which directives are present.
- * @param lView The view we are currently processing
+ * @param tView The tView we are currently processing
  * @param token Provider token or type of a directive to look for.
  * @param canAccessViewProviders Whether view providers should be considered.
  * @param isHostSpecialCase Whether the host special case applies.
  * @returns Index of a found directive or provider, or null when none found.
  */
 export function locateDirectiveOrProvider<T>(
-    tNode: TNode, lView: LView, token: Type<T>| InjectionToken<T>, canAccessViewProviders: boolean,
+    tNode: TNode, tView: TView, token: Type<T>| InjectionToken<T>, canAccessViewProviders: boolean,
     isHostSpecialCase: boolean | number): number|null {
-  const tView = lView[TVIEW];
   const nodeProviderIndexes = tNode.providerIndexes;
   const tInjectables = tView.data;
 

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -230,11 +230,10 @@ function queryByReadToken(read: any, tNode: TNode, currentView: LView): any {
   if (typeof factoryFn === 'function') {
     return factoryFn();
   } else {
-    const matchingIdx =
-        locateDirectiveOrProvider(tNode, currentView, read as Type<any>, false, false);
+    const tView = currentView[TVIEW];
+    const matchingIdx = locateDirectiveOrProvider(tNode, tView, read as Type<any>, false, false);
     if (matchingIdx !== null) {
-      return getNodeInjectable(
-          currentView[TVIEW].data, currentView, matchingIdx, tNode as TElementNode);
+      return getNodeInjectable(tView.data, currentView, matchingIdx, tNode as TElementNode);
     }
   }
   return null;
@@ -285,7 +284,8 @@ function queryRead(tNode: TNode, currentView: LView, read: any, matchingIdx: num
 function add(
     query: LQuery<any>| null, tNode: TElementNode | TContainerNode | TElementContainerNode,
     insertBeforeContainer: boolean) {
-  const currentView = getLView();
+  const lView = getLView();
+  const tView = lView[TVIEW];
 
   while (query) {
     const predicate = query.predicate;
@@ -293,11 +293,11 @@ function add(
     if (type) {
       let result = null;
       if (type === ViewEngine_TemplateRef) {
-        result = queryByTemplateRef(type, tNode, currentView, predicate.read);
+        result = queryByTemplateRef(type, tNode, lView, predicate.read);
       } else {
-        const matchingIdx = locateDirectiveOrProvider(tNode, currentView, type, false, false);
+        const matchingIdx = locateDirectiveOrProvider(tNode, tView, type, false, false);
         if (matchingIdx !== null) {
-          result = queryRead(tNode, currentView, predicate.read, matchingIdx);
+          result = queryRead(tNode, lView, predicate.read, matchingIdx);
         }
       }
       if (result !== null) {
@@ -308,7 +308,7 @@ function add(
       for (let i = 0; i < selector.length; i++) {
         const matchingIdx = getIdxOfMatchingSelector(tNode, selector[i]);
         if (matchingIdx !== null) {
-          const result = queryRead(tNode, currentView, predicate.read, matchingIdx);
+          const result = queryRead(tNode, lView, predicate.read, matchingIdx);
           if (result !== null) {
             addMatch(query, result, insertBeforeContainer);
           }


### PR DESCRIPTION
The DI's `locateDirectiveOrProvider` function operates on `TView` / `TNode`
data structures only so doesn't need to access `LView`. This refactoring
changes the argument list so the mentioned function takes less info to do
its work.

This refactoring is also mandatory for the upcoming query matching move
to TView.
