### PR TITLE
build: enable shard_count for some jasmine tests that have many specs

### DIFF
--- a/packages/compiler-cli/test/compliance/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/BUILD.bazel
@@ -21,6 +21,7 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
+    shard_count = 4,
     tags = [
         "ivy-only",
     ],

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -23,6 +23,7 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
+    shard_count = 4,
     deps = [
         ":ngtsc_lib",
         "//tools/testing:node_no_angular",

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -59,6 +59,7 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    shard_count = 4,
     deps = [
         ":test_lib",
         ":test_node_only_lib",


### PR DESCRIPTION
This partitions the spects across multiple processes so they run in parallel.

/cc @kara this is a roll-forward of the feature that caused problems before, and we had a post-mortem - we should confirm we've dealt with the post-mortem issues.