### PR TITLE
fix(ivy): ngcc - capture entry-points in top-level path-mapped folders

### DIFF
--- a/packages/compiler-cli/ngcc/test/packages/entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_finder_spec.ts
@@ -52,6 +52,21 @@ describe('findEntryPoints()', () => {
     ]);
   });
 
+  it('should find entry-points via `pathMappings', () => {
+    const {entryPoints} = finder.findEntryPoints(
+        _('/pathMappings/node_modules'), undefined,
+        {baseUrl: _('/pathMappings'), paths: {'my-lib': ['dist/my-lib']}});
+    const entryPointPaths = entryPoints.map(x => [x.package, x.path]);
+    expect(entryPointPaths).toEqual([
+      [_('/pathMappings/dist/my-lib'), _('/pathMappings/dist/my-lib')],
+      [_('/pathMappings/dist/my-lib'), _('/pathMappings/dist/my-lib/sub-lib')],
+      [
+        _('/pathMappings/node_modules/@angular/common'),
+        _('/pathMappings/node_modules/@angular/common')
+      ],
+    ]);
+  });
+
   it('should return an empty array if there are no packages', () => {
     const {entryPoints} = finder.findEntryPoints(_('/no_packages'));
     expect(entryPoints).toEqual([]);
@@ -104,6 +119,26 @@ describe('findEntryPoints()', () => {
             'testing.metadata.json': 'metadata info',
           },
         },
+      },
+      '/pathMappings': {
+        'dist': {
+          'my-lib': {
+            'package.json': createPackageJson('my-lib'),
+            'my-lib.metadata.json': 'metadata info',
+            'sub-lib': {
+              'package.json': createPackageJson('sub-lib'),
+              'sub-lib.metadata.json': 'metadata info',
+            },
+          },
+        },
+        'node_modules': {
+          '@angular': {
+            'common': {
+              'package.json': createPackageJson('common'),
+              'common.metadata.json': 'metadata info',
+            },
+          },
+        }
       },
       '/namespaced': {
         '@angular': {


### PR DESCRIPTION
The `EntryPointFinder` computes the base paths to consider
when searching for entry-points. When there are `pathMappings`
provided it works out the best top level base-paths that cover all
the potential mappings.

If this computed basePath happens to coincide with an entry-point
path itself then we were missing it.

Now we check for an entry-point even at the base-path itself.

Related to https://github.com/angular/angular-cli/pull/14755

