### PR TITLE
feat(ivy): add IndexerContext class

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,6 +9,8 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/metadata",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,8 +9,8 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,8 +6,57 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BoundTarget, TmplAstNode} from '@angular/compiler';
+import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+
+/**
+ * An intermediate representation of a component.
+ */
+export interface ComponentInfo {
+  /** Component TypeScript class declaration */
+  declaration: ClassDeclaration;
+
+  /** Component template selector */
+  selector: string|null;
+
+  /** Parsed component template */
+  template: TmplAstNode[];
+
+  /**
+   * BoundTarget containing the parsed template. Can be used to query for directives used in the
+   * template.
+   */
+  scope: BoundTarget<DirectiveMeta>|null;
+
+  /** Interpolation configuration for a template */
+  interpolationConfig: InterpolationConfig;
+}
+
 /**
  * Stores analysis information about components in a compilation for and provides methods for
- * querying information about components to be used in indexing.
+ * querying information about components.
  */
-export class IndexingContext {}
+export class IndexingContext {
+  readonly components = new Set<ComponentInfo>();
+
+  /**
+   * Adds a component to the context.
+   */
+  addComponent(info: ComponentInfo) { this.components.add(info); }
+
+  /**
+   * Gets the class declaration of components used in a template.
+   */
+  getUsedComponents(template: TmplAstNode[]): Set<ClassDeclaration> {
+    const components = Array.from(this.components);
+    const component = components.find(comp => comp.template === template);
+    if (!component || !component.scope) {
+      return new Set();
+    }
+    return new Set(component.scope.getUsedDirectives()
+                       .filter(dir => dir.isComponent)
+                       .map(comp => comp.ref.node));
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,10 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, TmplAstNode} from '@angular/compiler';
+import {BoundTarget, DirectiveMeta, TmplAstNode} from '@angular/compiler';
 import {InterpolationConfig} from '@angular/compiler/src/compiler';
-import {DirectiveMeta} from '../../metadata';
+import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
+
+export interface ComponentMeta extends DirectiveMeta {
+  ref: Reference<ClassDeclaration>;
+  /**
+   * Unparsed selector of the directive.
+   */
+  selector: string;
+}
 
 /**
  * An intermediate representation of a component.
@@ -28,7 +36,7 @@ export interface ComponentInfo {
    * BoundTarget containing the parsed template. Can be used to query for directives used in the
    * template.
    */
-  scope: BoundTarget<DirectiveMeta>|null;
+  scope: BoundTarget<ComponentMeta>|null;
 
   /** Interpolation configuration for a template */
   interpolationConfig: InterpolationConfig;
@@ -49,9 +57,9 @@ export class IndexingContext {
   /**
    * Gets the class declaration of components used in a template.
    */
-  getUsedComponents(template: TmplAstNode[]): Set<ClassDeclaration> {
+  getUsedComponents(compDecl: ClassDeclaration): Set<ClassDeclaration> {
     const components = Array.from(this.components);
-    const component = components.find(comp => comp.template === template);
+    const component = components.find(comp => comp.declaration === compDecl);
     if (!component || !component.scope) {
       return new Set();
     }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -57,7 +57,7 @@ export class IndexingContext {
   /**
    * Gets the class declaration of components used in a template.
    */
-  getUsedComponents(compDecl: ClassDeclaration): Set<ClassDeclaration> {
+  getUsedComponentsOf(compDecl: ClassDeclaration): Set<ClassDeclaration> {
     const components = Array.from(this.components);
     const component = components.find(comp => comp.declaration === compDecl);
     if (!component || !component.scope) {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/testing",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -10,7 +10,10 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/indexer",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -16,7 +16,7 @@ describe('ComponentAnalysisContext', () => {
 
   it('should store and return information about components', () => {
     const context = new IndexingContext();
-    const declaration = util.getComponentDeclaration('class C {};');
+    const declaration = util.getComponentDeclaration('class C {};', 'C');
     const selector = 'c-selector';
     const template = util.getParsedTemplate('<div></div>');
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
@@ -53,11 +53,11 @@ describe('ComponentAnalysisContext', () => {
 
   it('should return declarations of components used in templates', () => {
     const context = new IndexingContext();
-    const declaration = util.getComponentDeclaration('class C {}');
+    const declaration = util.getComponentDeclaration('class C {}', 'C');
     const templateStr = '<test></test>';
     const template = util.getParsedTemplate(templateStr);
 
-    const usedDecl = util.getComponentDeclaration('class Test {}');
+    const usedDecl = util.getComponentDeclaration('class Test {}', 'Test');
     const scope = util.bindTemplate(templateStr, [{selector: 'test', declaration: usedDecl}]);
 
     context.addComponent({
@@ -66,7 +66,7 @@ describe('ComponentAnalysisContext', () => {
       interpolationConfig: DEFAULT_INTERPOLATION,
     });
 
-    const usedComps = context.getUsedComponents(template);
+    const usedComps = context.getUsedComponents(declaration);
     expect(usedComps).toEqual(new Set([
       usedDecl,
     ]));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -66,7 +66,7 @@ describe('ComponentAnalysisContext', () => {
       interpolationConfig: DEFAULT_INTERPOLATION,
     });
 
-    const usedComps = context.getUsedComponents(declaration);
+    const usedComps = context.getUsedComponentsOf(declaration);
     expect(usedComps).toEqual(new Set([
       usedDecl,
     ]));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InterpolationConfig, R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {IndexingContext} from '../src/context';
+import * as util from './util';
+
+describe('ComponentAnalysisContext', () => {
+  const DEFAULT_INTERPOLATION = new InterpolationConfig('{{', '}}');
+
+  it('should store and return information about components', () => {
+    const context = new IndexingContext();
+    const declaration = util.getComponentDeclaration('class C {};');
+    const selector = 'c-selector';
+    const template = util.getParsedTemplate('<div></div>');
+    const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
+    const scope = binder.bind({template});
+
+    context.addComponent({
+      declaration,
+      selector: 'c-selector', template, scope,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+    context.addComponent({
+      declaration,
+      selector: null,
+      template: [],
+      scope: null,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+
+    expect(context.components).toEqual(new Set([
+      {
+        declaration,
+        selector: 'c-selector', template, scope,
+        interpolationConfig: DEFAULT_INTERPOLATION,
+      },
+      {
+        declaration,
+        selector: null,
+        template: [],
+        scope: null,
+        interpolationConfig: DEFAULT_INTERPOLATION,
+      },
+    ]));
+  });
+
+  it('should return declarations of components used in templates', () => {
+    const context = new IndexingContext();
+    const declaration = util.getComponentDeclaration('class C {}');
+    const templateStr = '<test></test>';
+    const template = util.getParsedTemplate(templateStr);
+
+    const usedDecl = util.getComponentDeclaration('class Test {}');
+    const scope = util.bindTemplate(templateStr, [{selector: 'test', declaration: usedDecl}]);
+
+    context.addComponent({
+      declaration,
+      selector: 'c-selector', template, scope,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+
+    const usedComps = context.getUsedComponents(template);
+    expect(usedComps).toEqual(new Set([
+      usedDecl,
+    ]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BoundTarget, CssSelector, R3TargetBinder, SelectorMatcher, TmplAstNode, parseTemplate} from '@angular/compiler/src/compiler';
+import * as ts from 'typescript';
+import {Reference} from '../../imports';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+
+/** Dummy file URL */
+export const TESTFILE = 'TESTFILE';
+
+/**
+ * Creates a class declaration from a component source code.
+ */
+export function getComponentDeclaration(component: string): ClassDeclaration {
+  const sourceFile = ts.createSourceFile(
+      TESTFILE, component, ts.ScriptTarget.ES2015,
+      /* setParentNodes */ true);
+
+  return sourceFile.statements.filter(ts.isClassDeclaration)[0] as ClassDeclaration;
+}
+
+/**
+ * Parses a template source code.
+ */
+export function getParsedTemplate(template: string): TmplAstNode[] {
+  return parseTemplate(template, TESTFILE).nodes;
+}
+
+/**
+ * Binds information about a component on a template (a target). The BoundTarget
+ * describes the scope of the template and can be queried for directives the
+ * template uses.
+ */
+export function bindTemplate(
+    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
+    BoundTarget<DirectiveMeta> {
+  const matcher = new SelectorMatcher<DirectiveMeta>();
+  components.forEach(({selector, declaration}) => {
+    matcher.addSelectables(CssSelector.parse(selector), {
+      ref: new Reference(declaration),
+      selector,
+      queries: [],
+      ngTemplateGuards: [],
+      hasNgTemplateContextGuard: false,
+      baseClass: null,
+      name: declaration.name.getText(),
+      isComponent: true,
+      inputs: {},
+      outputs: {},
+      exportAs: null,
+    });
+  });
+  const binder = new R3TargetBinder(matcher);
+
+  return binder.bind({template: getParsedTemplate(template)});
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -11,19 +11,20 @@ import * as ts from 'typescript';
 import {Reference} from '../../imports';
 import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
+import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
 
 /** Dummy file URL */
-export const TESTFILE = 'TESTFILE';
+export const TESTFILE = './TESTFILE.ts';
 
 /**
  * Creates a class declaration from a component source code.
  */
-export function getComponentDeclaration(component: string): ClassDeclaration {
-  const sourceFile = ts.createSourceFile(
-      TESTFILE, component, ts.ScriptTarget.ES2015,
-      /* setParentNodes */ true);
+export function getComponentDeclaration(componentStr: string, className: string): ClassDeclaration {
+  const program = makeProgram([{name: TESTFILE, contents: componentStr}]);
 
-  return sourceFile.statements.filter(ts.isClassDeclaration)[0] as ClassDeclaration;
+  return getDeclaration(
+      program.program, TESTFILE, className,
+      (value: ts.Declaration): value is ClassDeclaration => ts.isClassDeclaration(value));
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No stateful context for building program-wide information about components, in a manner that can be used by an indexing step, exists.

Issue Number: #30959

## What is the new behavior?
Adds a context (`IndexingContext`) that stores information about components in an intermediate representation that can then be consumed by an indexer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Child of #30959, #30961