### PR TITLE
build(docs-infra): update `browserlist` configuration file

### DIFF
--- a/aio/browserslist
+++ b/aio/browserslist
@@ -6,8 +6,7 @@
 # For additional information see: https://developers.google.com/search/docs/guides/rendering
 
 > 0.5%
-last 2 versions
+last 2 major versions
 Firefox ESR
 not dead
-IE 9-11 # For IE 9-11 support.
-Chrome 41 # For Googlebot support.
+IE 11


### PR DESCRIPTION
More specifically:
- Remove Chrome 41, which was needed for googlebot support but not any
  more.
- Remove IE 9-10, because we don't expect developers to be using them.
- Expand support from _last 2 versions_ to _last 2 **major** versions_.
