### PR TITLE
ci(docs-infra): change test order and track payload size for local and Ivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,16 +250,14 @@ jobs:
       - run: yarn --cwd aio build --progress=false
         # Lint the code
       - run: yarn --cwd aio lint
-        # Run PWA-score tests
-        # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
-        # Check the bundle sizes.
-        # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio payload-size
         # Run unit tests
       - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests
       - run: yarn --cwd aio e2e --configuration=ci
+        # Run PWA-score tests
+      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+        # Check the bundle sizes.
+      - run: yarn --cwd aio payload-size
         # Run unit tests for Firebase redirects
       - run: yarn --cwd aio redirects-test
 
@@ -285,13 +283,12 @@ jobs:
       - *init_environment
         # Build aio (with local Angular packages)
       - run: yarn --cwd aio build-local --progress=false
-        # Run PWA-score tests
-        # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Run unit tests
       - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests
       - run: yarn --cwd aio e2e --configuration=ci
+        # Run PWA-score tests
+      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
 
   test_aio_local_ivy:
     <<: *job_defaults
@@ -303,13 +300,12 @@ jobs:
       - *init_environment
         # Build aio with Ivy (using local Angular packages)
       - run: yarn --cwd aio build-with-ivy --progress=false
-        # Run PWA-score tests
-        # (Run before unit and e2e tests, which destroy the `dist/` directory.)
-      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Run unit tests
       - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests
       - run: yarn --cwd aio e2e --configuration=ci
+        # Run PWA-score tests
+      - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
 
   test_aio_tools:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,8 @@ jobs:
       - run: yarn --cwd aio e2e --configuration=ci
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+        # Check the bundle sizes.
+      - run: yarn --cwd aio payload-size aio-local
 
   test_aio_local_ivy:
     <<: *job_defaults
@@ -306,6 +308,8 @@ jobs:
       - run: yarn --cwd aio e2e --configuration=ci
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
+        # Check the bundle sizes.
+      - run: yarn --cwd aio payload-size aio-local-ivy
 
   test_aio_tools:
     <<: *job_defaults

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -32,6 +32,7 @@
         "main-es2015": 582731,
         "polyfills-es5": 129161,
         "polyfills-es2015": 53295
+      }
     }
   }
 }

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -10,5 +10,28 @@
         "polyfills-es2015": 53295
       }
     }
+  },
+  "aio-local": {
+    "master": {
+      "uncompressed": {
+        "runtime-es5": 3005,
+        "runtime-es2015": 3011,
+        "main-es5": 511054,
+        "main-es2015": 450560,
+        "polyfills-es5": 129161,
+        "polyfills-es2015": 53295
+      }
+    }
+  },
+  "aio-local-ivy": {
+    "master": {
+      "uncompressed": {
+        "runtime-es5": 2895,
+        "runtime-es2015": 2901,
+        "main-es5": 564586,
+        "main-es2015": 582731,
+        "polyfills-es5": 129161,
+        "polyfills-es2015": 53295
+    }
   }
 }

--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -4,6 +4,7 @@ set -eu -o pipefail
 
 readonly thisDir=$(cd $(dirname $0); pwd)
 readonly parentDir=$(dirname $thisDir)
+readonly target=${1:-aio}
 
 # Track payload size functions
 source ../scripts/ci/payload-size.sh
@@ -11,5 +12,4 @@ source ../scripts/ci/payload-size.sh
 # Provide node_modules from aio
 NODE_MODULES_BIN=$PROJECT_ROOT/aio/node_modules/.bin/
 
-trackPayloadSize "aio" "dist/*.js" true true "${thisDir}/_payload-limits.json"
-
+trackPayloadSize "$target" "dist/*.js" true true "${thisDir}/_payload-limits.json"


### PR DESCRIPTION
Small CI-related improvements:
- Run PWA score tests after unit/e2e tests.
- Check and track payload sizes for `test_aio_local` and `test_aio_local_ivy`

(See individual commits for more details.)