### PR TITLE
docs(core): adds explanation for static option

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -206,18 +206,28 @@ export interface ContentChildDecorator {
    * **How do I choose which `static` flag value to use: `true` or `false`?**
    *
    * We have always recommended retrieving query results in `ngAfterContentInit` for content queries.
-   * This is because by the time this lifecycle hook runs, change detection has completed for the relevant nodes and we can guarantee that we have collected all the possible query results.
+   * This is because by the time this lifecycle hook runs, change detection has completed for the
+   * relevant nodes and we can guarantee that we have collected all the possible query results.
    *
-   * Most applications will want to use `{static: false}` for this reason. This setting will ensure query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or `*ngFor`s) will be found by the query.
-   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to do so in `ngAfterContentInit`.
-   * Change detection has already run on that view, so creating a new view with the template will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * Most applications will want to use `{static: false}` for this reason. This setting will ensure
+   * query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or
+   *  `*ngFor`s) will be found by the query.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to
+   *  do so in `ngAfterContentInit`.
+   * Change detection has already run on that view, so creating a new view with the template will cause
+   *  an `ExpressionHasChangedAfterChecked` error to be thrown.
    * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
    * In most other cases, the best practice is to use `{static: false}`.
    *
-   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to `true` if your component code already depends on the query results being available some time **before** `ngAfterContentInit`.
-   * For example, if your component relies on the query results being populated in the `ngOnInit` hook or in `@Input` setters, you will need to either set the flag to `true` or re-work your component to adjust to later timing.
+   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to
+   *  `true` if your component code already depends on the query results being available some time
+   * **before** `ngAfterContentInit`.
+   * For example, if your component relies on the query results being populated in the `ngOnInit` hook
+   *  or in `@Input` setters, you will need to either set the flag to `true` or re-work your component
+   *  to adjust to later timing.
    *
-   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will not be found by the query.
+   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will
+   * not be found by the query.
    * These results are only retrievable after change detection runs.
    *
    * @usageNotes
@@ -337,21 +347,31 @@ export interface ViewChildDecorator {
    * **How do I choose which `static` flag value to use: `true` or `false`?**
    *
    * We have always recommended retrieving query results in `ngAfterViewInit` for view queries.
-   * This is because by the time this lifecycle hook runs, change detection has completed for the relevant nodes and we can guarantee that we have collected all the possible query results.
+   * This is because by the time this lifecycle hook runs, change detection has completed for the
+   * relevant nodes and we can guarantee that we have collected all the possible query results.
    *
-   * Most applications will want to use `{static: false}` for this reason. This setting will ensure query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or `*ngFor`s) will be found by the query.
-   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to do so in `ngAfterViewInit`.
-   * Change detection has already run on that view, so creating a new view with the template will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * Most applications will want to use `{static: false}` for this reason. This setting will ensure
+   * query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s
+   * or `*ngFor`s) will be found by the query.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to
+   * do so in `ngAfterViewInit`.
+   * Change detection has already run on that view, so creating a new view with the template will cause
+   * an `ExpressionHasChangedAfterChecked` error to be thrown.
    * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
    * In most other cases, the best practice is to use `{static: false}`.
    *
-   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to `true` if your component code already depends on the query results being available some time **before** `ngAfterViewInit`.
-   * For example, if your component relies on the query results being populated in the `ngOnInit` hook or in `@Input` setters, you will need to either set the flag to `true` or re-work your component to adjust to later timing.
+   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to
+   *  `true` if your component code already depends on the query results being available some time
+   * **before** `ngAfterViewInit`.
+   * For example, if your component relies on the query results being populated in the `ngOnInit` hook
+   * or in `@Input` setters, you will need to either set the flag to `true` or re-work your
+   * component to adjust to later timing.
    *
-   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will not be found by the query.
+   * **Note:** Selecting the static option means that query results nested in `*ngIf` or
+   * `*ngFor` will not be found by the query.
    * These results are only retrievable after change detection runs.
    *
-   * Supported selectors include:
+   * **Supported selectors include:**
    *   * any class with the `@Component` or `@Directive` decorator
    *   * a template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ViewChild('cmp')`)

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -201,11 +201,24 @@ export interface ContentChildDecorator {
    * * **selector** - the directive type or the name used for querying.
    * * **read** - read a different token from the queried element.
    * * **static** - whether or not to resolve query results before change detection runs (i.e.
-   * return static results only). If this option is not provided, the compiler will fall back
-   * to its default behavior, which is to use query results to determine the timing of query
-   * resolution. If any query results are inside a nested view (e.g. *ngIf), the query will be
-   * resolved after change detection runs. Otherwise, it will be resolved before change detection
-   * runs.
+   * return static results only).
+   *
+   * **How do I choose which `static` flag value to use: `true` or `false`?**
+   *
+   * We have always recommended retrieving query results in `ngAfterContentInit` for content queries.
+   * This is because by the time this lifecycle hook runs, change detection has completed for the relevant nodes and we can guarantee that we have collected all the possible query results.
+   *
+   * Most applications will want to use `{static: false}` for this reason. This setting will ensure query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or `*ngFor`s) will be found by the query.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to do so in `ngAfterContentInit`.
+   * Change detection has already run on that view, so creating a new view with the template will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
+   * In most other cases, the best practice is to use `{static: false}`.
+   *
+   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to `true` if your component code already depends on the query results being available some time **before** `ngAfterContentInit`.
+   * For example, if your component relies on the query results being populated in the `ngOnInit` hook or in `@Input` setters, you will need to either set the flag to `true` or re-work your component to adjust to later timing.
+   *
+   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will not be found by the query.
+   * These results are only retrievable after change detection runs.
    *
    * @usageNotes
    * ### Example
@@ -319,11 +332,24 @@ export interface ViewChildDecorator {
    * * **selector** - the directive type or the name used for querying.
    * * **read** - read a different token from the queried elements.
    * * **static** - whether or not to resolve query results before change detection runs (i.e.
-   * return static results only). If this option is not provided, the compiler will fall back
-   * to its default behavior, which is to use query results to determine the timing of query
-   * resolution. If any query results are inside a nested view (e.g. *ngIf), the query will be
-   * resolved after change detection runs. Otherwise, it will be resolved before change detection
-   * runs.
+   * return static results only).
+   *
+   * **How do I choose which `static` flag value to use: `true` or `false`?**
+   *
+   * We have always recommended retrieving query results in `ngAfterViewInit` for view queries.
+   * This is because by the time this lifecycle hook runs, change detection has completed for the relevant nodes and we can guarantee that we have collected all the possible query results.
+   *
+   * Most applications will want to use `{static: false}` for this reason. This setting will ensure query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or `*ngFor`s) will be found by the query.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to do so in `ngAfterViewInit`.
+   * Change detection has already run on that view, so creating a new view with the template will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
+   * In most other cases, the best practice is to use `{static: false}`.
+   *
+   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to `true` if your component code already depends on the query results being available some time **before** `ngAfterViewInit`.
+   * For example, if your component relies on the query results being populated in the `ngOnInit` hook or in `@Input` setters, you will need to either set the flag to `true` or re-work your component to adjust to later timing.
+   *
+   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will not be found by the query.
+   * These results are only retrievable after change detection runs.
    *
    * Supported selectors include:
    *   * any class with the `@Component` or `@Directive` decorator

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -205,29 +205,32 @@ export interface ContentChildDecorator {
    *
    * **How do I choose which `static` flag value to use: `true` or `false`?**
    *
-   * We have always recommended retrieving query results in `ngAfterContentInit` for content queries.
+   * We have always recommended retrieving query results in `ngAfterContentInit` for content
+   * queries.
    * This is because by the time this lifecycle hook runs, change detection has completed for the
    * relevant nodes and we can guarantee that we have collected all the possible query results.
    *
    * Most applications will want to use `{static: false}` for this reason. This setting will ensure
    * query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s or
    *  `*ngFor`s) will be found by the query.
-   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to
-   *  do so in `ngAfterContentInit`.
-   * Change detection has already run on that view, so creating a new view with the template will cause
-   *  an `ExpressionHasChangedAfterChecked` error to be thrown.
-   * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically,
+   * you won't be able to do so in `ngAfterContentInit`.
+   * Change detection has already run on that view, so creating a new view with the template
+   * will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * In this case, you will want to set the `static` flag to `true` and
+   * create your view in `ngOnInit`.
    * In most other cases, the best practice is to use `{static: false}`.
    *
    * However, to facilitate the migration to version 8, you may also want to set the `static` flag to
    *  `true` if your component code already depends on the query results being available some time
    * **before** `ngAfterContentInit`.
-   * For example, if your component relies on the query results being populated in the `ngOnInit` hook
-   *  or in `@Input` setters, you will need to either set the flag to `true` or re-work your component
-   *  to adjust to later timing.
+   * For example, if your component relies on the query results being populated in
+   * the `ngOnInit` hook or in `@Input` setters,
+   * you will need to either set the flag to `true`
+   * or re-work your componentto adjust to later timing.
    *
-   * **Note:** Selecting the static option means that query results nested in `*ngIf` or `*ngFor` will
-   * not be found by the query.
+   * **Note:** Selecting the static option means that query results nested in `*ngIf`
+   * or `*ngFor` will not be found by the query.
    * These results are only retrievable after change detection runs.
    *
    * @usageNotes
@@ -346,24 +349,28 @@ export interface ViewChildDecorator {
    *
    * **How do I choose which `static` flag value to use: `true` or `false`?**
    *
-   * We have always recommended retrieving query results in `ngAfterViewInit` for view queries.
+   * We have always recommended retrieving query results in `ngAfterViewInit`
+   * for view queries.
    * This is because by the time this lifecycle hook runs, change detection has completed for the
    * relevant nodes and we can guarantee that we have collected all the possible query results.
    *
    * Most applications will want to use `{static: false}` for this reason. This setting will ensure
    * query matches that are dependent on binding resolution (e.g. results inside `*ngIf`s
    * or `*ngFor`s) will be found by the query.
-   * If you need access to a `TemplateRef` in a query to create a view dynamically, you won't be able to
-   * do so in `ngAfterViewInit`.
-   * Change detection has already run on that view, so creating a new view with the template will cause
-   * an `ExpressionHasChangedAfterChecked` error to be thrown.
-   * In this case, you will want to set the `static` flag to `true` and create your view in `ngOnInit`.
+   * If you need access to a `TemplateRef` in a query to create a view dynamically,
+   * you won't be able to do so in `ngAfterViewInit`.
+   * Change detection has already run on that view, so creating a new view with the
+   * template will cause an `ExpressionHasChangedAfterChecked` error to be thrown.
+   * In this case, you will want to set the `static` flag to `true`
+   * and create your view in `ngOnInit`.
    * In most other cases, the best practice is to use `{static: false}`.
    *
-   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to
-   *  `true` if your component code already depends on the query results being available some time
-   * **before** `ngAfterViewInit`.
-   * For example, if your component relies on the query results being populated in the `ngOnInit` hook
+   * However, to facilitate the migration to version 8, you may also want to
+   * set the `static` flag to
+   *  `true` if your component code already depends on the query results being
+   * available some time **before** `ngAfterViewInit`.
+   * For example, if your component relies on the query results being populated in
+   * the `ngOnInit` hook
    * or in `@Input` setters, you will need to either set the flag to `true` or re-work your
    * component to adjust to later timing.
    *

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -221,9 +221,9 @@ export interface ContentChildDecorator {
    * create your view in `ngOnInit`.
    * In most other cases, the best practice is to use `{static: false}`.
    *
-   * However, to facilitate the migration to version 8, you may also want to set the `static` flag to
-   *  `true` if your component code already depends on the query results being available some time
-   * **before** `ngAfterContentInit`.
+   * However, to facilitate the migration to version 8, you may also want to set the `static` flag
+   * to `true` if your component code already depends
+   * on the query results being available some time **before** `ngAfterContentInit`.
    * For example, if your component relies on the query results being populated in
    * the `ngOnInit` hook or in `@Input` setters,
    * you will need to either set the flag to `true`


### PR DESCRIPTION
The static option being used in the ViewChildDecorator and ContentChildDecorator
needed some explanation. This has now been added to the documentation.

resolves #31034

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #31034


## What is the new behavior?
Added explanation on the static option for the ViewChildDecorator and ContentChildDecorator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
