### PR TITLE
ci: temporarily disable payload size tracking

### DIFF
--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -136,15 +136,17 @@ trackPayloadSize() {
   # Save the file sizes to be retrieved from `payload-size.js`.
   echo "$(payloadToJson)" > /tmp/current.log
 
+  # TODO: Temporarily disabled until we get back `CIRCLE_COMPARE_URL` or another way to get the
+  #       commit range. Re-enable once the issue is resolved.
   # If this is a non-PR build, upload the data to firebase.
-  if [[ "$CI_PULL_REQUEST" == "false" ]]; then
-    if [[ $trackChangeType = true ]]; then
-      addChangeType $CI_COMMIT_RANGE
-    fi
-    addTimestamp
-    addMessage $CI_COMMIT_RANGE
-    uploadData $name
-  fi
+  # if [[ "$CI_PULL_REQUEST" == "false" ]]; then
+  #   if [[ $trackChangeType = true ]]; then
+  #     addChangeType $CI_COMMIT_RANGE
+  #   fi
+  #   addTimestamp
+  #   addMessage $CI_COMMIT_RANGE
+  #   uploadData $name
+  # fi
 
   # Check the file sizes against the specified limits.
   if [[ $checkSize = true ]]; then


### PR DESCRIPTION
The `CIRCLE_COMPARE_URL` is not available in builds any more since we enabled `Pipelines` on CircleCI. We have contected CircleCI, but until this is solved we cannot get the commit range and thus disabling uploading of payload size data to avoid broken builds.
