### PR TITLE
ci(docs-infra): disable payload size tracking for `test_aio_local` and `test_aio_local_ivy`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,8 @@ jobs:
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Check the bundle sizes.
-      - run: yarn --cwd aio payload-size aio-local
+      # Temporary disabled due to a problem with patch branch (8.0.x)
+      # - run: yarn --cwd aio payload-size aio-local
 
   test_aio_local_ivy:
     <<: *job_defaults
@@ -309,7 +310,8 @@ jobs:
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Check the bundle sizes.
-      - run: yarn --cwd aio payload-size aio-local-ivy
+      # Temporary disabled due to a problem with patch branch (8.0.x)
+      # - run: yarn --cwd aio payload-size aio-local-ivy
 
   test_aio_tools:
     <<: *job_defaults


### PR DESCRIPTION
Payload size tracking for AIO introduced in the previous commit (c596795e6475524e53418653cdabeeed2d25852d) works fine for master branch, but fails in patch branch. In order to keep CI for patch branch healthy, the size tracking is temporary disabled and will be turned on again after additional investigation.
