### PR TITLE
build: ts-api-guardian npm package contains invalid references

### DIFF
--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -61,7 +61,7 @@ def ts_api_guardian_test(
     nodejs_test(
         name = name,
         data = data,
-        entry_point = "//tools/ts-api-guardian:bin/ts-api-guardian",
+        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
         templated_args = args + ["--verify", golden, actual],
         **kwargs
     )
@@ -70,7 +70,7 @@ def ts_api_guardian_test(
         name = name + ".accept",
         testonly = True,
         data = data,
-        entry_point = "//tools/ts-api-guardian:bin/ts-api-guardian",
+        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
         templated_args = args + ["--out", golden, actual],
         **kwargs
     )


### PR DESCRIPTION
Currently when building the `ts-api-guardian` npm package,
the labels are not properly replaced after recent changes to
the `entry_point` attribute. This means that the `ts-api-guardian`
package is currently not usable externally.