### PR TITLE
fix(router): include null in UrlMatchResult type

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -35,8 +35,9 @@ export type Routes = Route[];
  * @see `UrlMatcher()`
  * @publicApi
  */
-export type UrlMatchResult = {
-  consumed: UrlSegment[]; posParams?: {[name: string]: UrlSegment};
+export type UrlMatchResult = null | {
+  consumed: UrlSegment[];
+  posParams?: {[name: string]: UrlSegment};
 };
 
 /**
@@ -93,16 +94,16 @@ export type ResolveData = {
 /**
  *
  * A function that is called to resolve a collection of lazy-loaded routes.
- * 
+ *
  * Often this function will be implemented using an ES dynamic `import()` expression. For example:
- * 
+ *
  * ```
  * [{
  *   path: 'lazy',
  *   loadChildren: () => import('./lazy-route/lazy.module').then(mod => mod.LazyModule),
  * }];
  * ```
- * 
+ *
  * This function _must_ match the form above: an arrow function of the form
  * `() => import('...').then(mod => mod.MODULE)`.
  *

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -497,7 +497,7 @@ export declare abstract class UrlHandlingStrategy {
 
 export declare type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult;
 
-export declare type UrlMatchResult = {
+export declare type UrlMatchResult = null | {
     consumed: UrlSegment[];
     posParams?: {
         [name: string]: UrlSegment;


### PR DESCRIPTION
include null in UrlMatchResult type

Fixes #29824

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, Type 'null' is not assignable to type 'UrlMatchResult'.

Issue Number: #29824


## What is the new behavior?
Can return null when using UrlMatchResult type in matcher.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
