### PR TITLE
perf(ivy): avoid unnecessary function call in i18n instruction

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -1315,13 +1315,14 @@ const LOCALIZE_PH_REGEXP = /\{\$(.*?)\}/g;
  * @codeGenApi
  * @deprecated this method is temporary & should not be used as it will be removed soon
  */
-export function ɵɵi18nLocalize(input: string, placeholders: {[key: string]: string} = {}) {
+export function ɵɵi18nLocalize(input: string, placeholders?: {[key: string]: string}) {
   if (typeof TRANSLATIONS[input] !== 'undefined') {  // to account for empty string
     input = TRANSLATIONS[input];
   }
-  return Object.keys(placeholders).length ?
-      input.replace(LOCALIZE_PH_REGEXP, (match, key) => placeholders[key] || '') :
-      input;
+  if (placeholders !== undefined && Object.keys(placeholders).length) {
+    return input.replace(LOCALIZE_PH_REGEXP, (_, key) => placeholders[key] || '');
+  }
+  return input;
 }
 
 /**


### PR DESCRIPTION
Currently the `placeholders` parameter inside `i18nLocalize` is defaulted to `{}`, which means that we'll always hit the `Object.keys` call below. Since it's very likely that we won't have placeholders in the majority of strings, these changes add an extra guard so that we don't hit it on every invocation.
