### PR TITLE
fix(animations): handle structured AnimateTimings

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -561,10 +561,11 @@ function consumeOffset(styles: OffsetStyles|Array<OffsetStyles>): number|null {
 }
 
 function constructTimingAst(value: string|number|AnimateTimings, errors: Error[]) {
-  let timings: AnimateTimings|null = null;
   if (value.hasOwnProperty('duration')) {
-    timings = value as AnimateTimings;
-  } else if (typeof value == 'number') {
+    return value as AnimateTimings;
+  }
+
+  if (typeof value == 'number') {
     const duration = resolveTiming(value, errors).duration;
     return makeTimingAst(duration, 0, '');
   }
@@ -578,7 +579,7 @@ function constructTimingAst(value: string|number|AnimateTimings, errors: Error[]
     return ast as DynamicTimingAst;
   }
 
-  timings = timings || resolveTiming(strValue, errors);
+  const timings = resolveTiming(strValue, errors);
   return makeTimingAst(timings.duration, timings.delay, timings.easing);
 }
 

--- a/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AnimationMetadata, AnimationMetadataType} from '@angular/animations';
+
+import {buildAnimationAst} from '../../src/dsl/animation_ast_builder';
+import {MockAnimationDriver} from '../../testing';
+
+{
+  describe('buildAnimationAst', () => {
+    it('should build the AST without any errors and warnings', () => {
+      const driver = new MockAnimationDriver();
+      const errors: Error[] = [];
+      const warnings: string[] = [];
+      const animationAst = buildAnimationAst(
+          driver, <AnimationMetadata>{
+            animation: [{
+              styles: {
+                offset: null,
+                styles: {backgroundColor: '#000'},
+                type: AnimationMetadataType.Style
+              },
+              timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
+              type: AnimationMetadataType.Animate
+            }],
+            options: null,
+            selector: 'body',
+            type: AnimationMetadataType.Query
+          },
+          errors, warnings);
+
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+      expect(animationAst).toEqual(<ReturnType<typeof buildAnimationAst>>{
+        type: 11,
+        selector: 'body',
+        limit: 0,
+        optional: false,
+        includeSelf: false,
+        animation: {
+          type: 4,
+          timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
+          style: {
+            type: 6,
+            styles: [new Map([['backgroundColor', '#000']])],
+            easing: null,
+            offset: null,
+            containsDynamicStyles: false,
+            options: null,
+            isEmptyStep: false
+          },
+          options: null
+        },
+        originalSelector: 'body',
+        options: {}
+      });
+    });
+  });
+}


### PR DESCRIPTION
Fixes: #22752

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 22752


## What is the new behavior?

Due to the missing return statement structured AnimateTimings where tried to parse as if they were a string. Now the function returns early if there is no need to parse the input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I would be happy to add an additional test for this but I wasn't able to find the corresponding test suite.