### PR TITLE
feat(ivy): add code to transform IndexerContext to IndexedComponents in indexer module

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,6 +9,8 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/metadata",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,8 +9,8 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -46,7 +46,7 @@ export interface IndexedComponent {
   content: string;
   template: {
     identifiers: Set<TemplateIdentifier>,
-    usedComponents: Set<ts.ClassDeclaration>,
+    usedComponents: Set<ts.Declaration>,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -6,23 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InterpolationConfig, ParseSourceFile} from '@angular/compiler';
-import {ParseTemplateOptions} from '@angular/compiler/src/render3/view/template';
+import {ParseSourceFile, ParseSpan} from '@angular/compiler';
 import * as ts from 'typescript';
 
 /**
  * Describes the kind of identifier found in a template.
  */
 export enum IdentifierKind {
-  Property,
-  Method,
-}
-
-/**
- * Describes the absolute byte offsets of a text anchor in a source code.
- */
-export class AbsoluteSourceSpan {
-  constructor(public start: number, public end: number) {}
 }
 
 /**
@@ -31,7 +21,7 @@ export class AbsoluteSourceSpan {
  */
 export interface TemplateIdentifier {
   name: string;
-  span: AbsoluteSourceSpan;
+  span: ParseSpan;
   kind: IdentifierKind;
   file: ParseSourceFile;
 }
@@ -48,15 +38,4 @@ export interface IndexedComponent {
     identifiers: Set<TemplateIdentifier>,
     usedComponents: Set<ts.ClassDeclaration>,
   };
-}
-
-/**
- * Options for restoring a parsed template. See `template.ts#restoreTemplate`.
- */
-export interface RestoreTemplateOptions extends ParseTemplateOptions {
-  /**
-   * The interpolation configuration of the template is lost after it already
-   * parsed, so it must be respecified.
-   */
-  interpolationConfig: InterpolationConfig;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -6,13 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseSourceFile, ParseSpan} from '@angular/compiler';
+import {InterpolationConfig, ParseSourceFile} from '@angular/compiler';
+import {ParseTemplateOptions} from '@angular/compiler/src/render3/view/template';
 import * as ts from 'typescript';
 
 /**
  * Describes the kind of identifier found in a template.
  */
 export enum IdentifierKind {
+  Property,
+  Method,
+}
+
+/**
+ * Describes the absolute byte offsets of a text anchor in a source code.
+ */
+export class AbsoluteSourceSpan {
+  constructor(public start: number, public end: number) {}
 }
 
 /**
@@ -21,7 +31,7 @@ export enum IdentifierKind {
  */
 export interface TemplateIdentifier {
   name: string;
-  span: ParseSpan;
+  span: AbsoluteSourceSpan;
   kind: IdentifierKind;
   file: ParseSourceFile;
 }
@@ -38,4 +48,15 @@ export interface IndexedComponent {
     identifiers: Set<TemplateIdentifier>,
     usedComponents: Set<ts.ClassDeclaration>,
   };
+}
+
+/**
+ * Options for restoring a parsed template. See `template.ts#restoreTemplate`.
+ */
+export interface RestoreTemplateOptions extends ParseTemplateOptions {
+  /**
+   * The interpolation configuration of the template is lost after it already
+   * parsed, so it must be respecified.
+   */
+  interpolationConfig: InterpolationConfig;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,8 +6,57 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BoundTarget, TmplAstNode} from '@angular/compiler';
+import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+
+/**
+ * An intermediate representation of a component.
+ */
+export interface ComponentInfo {
+  /** Component TypeScript class declaration */
+  declaration: ClassDeclaration;
+
+  /** Component template selector */
+  selector: string|null;
+
+  /** Parsed component template */
+  template: TmplAstNode[];
+
+  /**
+   * BoundTarget containing the parsed template. Can be used to query for directives used in the
+   * template.
+   */
+  scope: BoundTarget<DirectiveMeta>|null;
+
+  /** Interpolation configuration for a template */
+  interpolationConfig: InterpolationConfig;
+}
+
 /**
  * Stores analysis information about components in a compilation for and provides methods for
- * querying information about components to be used in indexing.
+ * querying information about components.
  */
-export class IndexingContext {}
+export class IndexingContext {
+  readonly components = new Set<ComponentInfo>();
+
+  /**
+   * Adds a component to the context.
+   */
+  addComponent(info: ComponentInfo) { this.components.add(info); }
+
+  /**
+   * Gets the class declaration of components used in a template.
+   */
+  getUsedComponents(template: TmplAstNode[]): Set<ClassDeclaration> {
+    const components = Array.from(this.components);
+    const component = components.find(comp => comp.template === template);
+    if (!component || !component.scope) {
+      return new Set();
+    }
+    return new Set(component.scope.getUsedDirectives()
+                       .filter(dir => dir.isComponent)
+                       .map(comp => comp.ref.node));
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -12,7 +12,7 @@ import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
 /**
- * An intermediate representation of a component with information about its metadata.
+ * An intermediate representation of a component.
  */
 export interface ComponentInfo {
   /** Component TypeScript class declaration */
@@ -45,20 +45,6 @@ export class IndexingContext {
    * Adds a component to the context.
    */
   addComponent(info: ComponentInfo) { this.components.add(info); }
-
-  /**
-   * Gets the class declaration of components used in a template.
-   */
-  getUsedComponents(template: TmplAstNode[]): Set<ClassDeclaration> {
-    const components = Array.from(this.components);
-    const component = components.find(comp => comp.template === template);
-    if (!component || !component.scope) {
-      return new Set();
-    }
-    return new Set(component.scope.getUsedDirectives()
-                       .filter(dir => dir.isComponent)
-                       .map(comp => comp.ref.node));
-  }
 
   /**
    * Gets the class declaration of components used in a template.

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -12,7 +12,7 @@ import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
 /**
- * An intermediate representation of a component.
+ * An intermediate representation of a component with information about its metadata.
  */
 export interface ComponentInfo {
   /** Component TypeScript class declaration */
@@ -45,6 +45,20 @@ export class IndexingContext {
    * Adds a component to the context.
    */
   addComponent(info: ComponentInfo) { this.components.add(info); }
+
+  /**
+   * Gets the class declaration of components used in a template.
+   */
+  getUsedComponents(template: TmplAstNode[]): Set<ClassDeclaration> {
+    const components = Array.from(this.components);
+    const component = components.find(comp => comp.template === template);
+    if (!component || !component.scope) {
+      return new Set();
+    }
+    return new Set(component.scope.getUsedDirectives()
+                       .filter(dir => dir.isComponent)
+                       .map(comp => comp.ref.node));
+  }
 
   /**
    * Gets the class declaration of components used in a template.

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -11,6 +11,7 @@ import {InterpolationConfig} from '@angular/compiler/src/compiler';
 import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
+
 /**
  * An intermediate representation of a component.
  */

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, HtmlParser, Lexer, MethodCall, ParseSourceFile, PropertyRead, RecursiveAstVisitor, TmplAstNode, TokenType, visitAll} from '@angular/compiler';
+import {AST, HtmlParser, Lexer, MethodCall, ParseSourceFile, ParseSpan, PropertyRead, RecursiveAstVisitor, TmplAstNode, TokenType, visitAll} from '@angular/compiler';
 import {BoundText, Element, Node, RecursiveVisitor as RecursiveTemplateVisitor, Template} from '@angular/compiler/src/render3/r3_ast';
 import {htmlAstToRender3Ast} from '@angular/compiler/src/render3/r3_template_transform';
 import {I18nMetaVisitor} from '@angular/compiler/src/render3/view/i18n/meta';
@@ -158,8 +158,6 @@ class TemplateVisitor extends RecursiveTemplateVisitor {
  * parsed with leading trivial characters (see `parseTemplate` from the compiler package API).
  * Both of these are detrimental for indexing as they result in a manipulated AST not representing
  * the template source code.
- *
- * TODO(ayazhafiz): Remove once issues with `leadingTriviaChars` and `parseTemplate` are resolved.
  */
 function restoreTemplate(template: TmplAstNode[], options: RestoreTemplateOptions): TmplAstNode[] {
   // try to recapture the template content and URL
@@ -202,6 +200,8 @@ function restoreTemplate(template: TmplAstNode[], options: RestoreTemplateOption
  */
 export function getTemplateIdentifiers(
     template: TmplAstNode[], options: RestoreTemplateOptions): Set<TemplateIdentifier> {
+  // TODO(ayazhafiz): template restoration is the most expensive step in the indexing pipeline.
+  // Consider removing this if/when `leadingTriviaChars` inconsistency issues are resolved.
   const restoredTemplate = restoreTemplate(template, options);
   const visitor = new TemplateVisitor();
   visitor.visitAll(restoredTemplate);

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -9,6 +9,7 @@
 import * as ts from 'typescript';
 import {IndexedComponent} from './api';
 import {IndexingContext} from './context';
+import {getTemplateIdentifiers} from './template';
 
 /**
  * Generates `IndexedComponent` entries from a `IndexingContext`, which has information
@@ -17,5 +18,26 @@ import {IndexingContext} from './context';
  * The context must be populated before `generateAnalysis` is called.
  */
 export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, IndexedComponent> {
-  throw new Error('Method not implemented.');
+  const analysis = new Map<ts.Declaration, IndexedComponent>();
+
+  context.components.forEach(({declaration, selector, interpolationConfig, template}) => {
+    const name = declaration.name.getText();
+    const usedComponents = context.getUsedComponents(template);
+
+    analysis.set(declaration, {
+      name,
+      selector,
+      sourceFile: declaration.getSourceFile().fileName,
+      content: declaration.getSourceFile().getFullText(),
+      template: {
+        identifiers: getTemplateIdentifiers(template, {
+          preserveWhitespaces: true,
+          interpolationConfig,
+        }),
+        usedComponents,
+      },
+    });
+  });
+
+  return analysis;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -6,11 +6,15 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob([
-        "**/*.ts",
+        "**/transform_spec.ts",
+        "**/util.ts",
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/indexer",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -10,9 +10,7 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/indexer",
-        "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -11,7 +11,6 @@ ts_library(
     deps = [
         "//packages/compiler",
         "//packages/compiler-cli/src/ngtsc/indexer",
-        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -10,7 +10,10 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/indexer",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -16,8 +16,7 @@ describe('ComponentAnalysisContext', () => {
 
   it('should store and return information about components', () => {
     const context = new IndexingContext();
-    const declaration = util.getComponentDeclaration('class C {};');
-    const selector = 'c-selector';
+    const declaration = util.getComponentDeclaration('class C {}');
     const template = util.getParsedTemplate('<div></div>');
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
     const scope = binder.bind({template});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -16,7 +16,8 @@ describe('ComponentAnalysisContext', () => {
 
   it('should store and return information about components', () => {
     const context = new IndexingContext();
-    const declaration = util.getComponentDeclaration('class C {}');
+    const declaration = util.getComponentDeclaration('class C {};');
+    const selector = 'c-selector';
     const template = util.getParsedTemplate('<div></div>');
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
     const scope = binder.bind({template});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InterpolationConfig, R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {IndexingContext} from '../src/context';
+import * as util from './util';
+
+describe('ComponentAnalysisContext', () => {
+  const DEFAULT_INTERPOLATION = new InterpolationConfig('{{', '}}');
+
+  it('should store and return information about components', () => {
+    const context = new IndexingContext();
+    const declaration = util.getComponentDeclaration('class C {};');
+    const selector = 'c-selector';
+    const template = util.getParsedTemplate('<div></div>');
+    const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
+    const scope = binder.bind({template});
+
+    context.addComponent({
+      declaration,
+      selector: 'c-selector', template, scope,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+    context.addComponent({
+      declaration,
+      selector: null,
+      template: [],
+      scope: null,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+
+    expect(context.components).toEqual(new Set([
+      {
+        declaration,
+        selector: 'c-selector', template, scope,
+        interpolationConfig: DEFAULT_INTERPOLATION,
+      },
+      {
+        declaration,
+        selector: null,
+        template: [],
+        scope: null,
+        interpolationConfig: DEFAULT_INTERPOLATION,
+      },
+    ]));
+  });
+
+  it('should return declarations of components used in templates', () => {
+    const context = new IndexingContext();
+    const declaration = util.getComponentDeclaration('class C {}');
+    const templateStr = '<test></test>';
+    const template = util.getParsedTemplate(templateStr);
+
+    const usedDecl = util.getComponentDeclaration('class Test {}');
+    const scope = util.bindTemplate(templateStr, [{selector: 'test', declaration: usedDecl}]);
+
+    context.addComponent({
+      declaration,
+      selector: 'c-selector', template, scope,
+      interpolationConfig: DEFAULT_INTERPOLATION,
+    });
+
+    const usedComps = context.getUsedComponents(template);
+    expect(usedComps).toEqual(new Set([
+      usedDecl,
+    ]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BoundTarget} from '@angular/compiler';
+import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+import {IndexingContext} from '../src/context';
+import {getTemplateIdentifiers} from '../src/template';
+import {generateAnalysis} from '../src/transform';
+
+import * as util from './util';
+
+/**
+ * Adds information about a component to a context.
+ */
+function populateContext(
+    context: IndexingContext, component: ClassDeclaration, selector: string, template: string,
+    scope: BoundTarget<DirectiveMeta>| null) {
+  const parsedTemplate = util.getParsedTemplate(template);
+  context.addComponent({
+    declaration: component,
+    template: parsedTemplate, selector, scope,
+    interpolationConfig: new InterpolationConfig('{{', '}}')
+  });
+}
+
+describe('generateAnalysis', () => {
+  const DEFAULT_RESTORE_OPTIONS = {
+    preserveWhitespaces: true,
+    interpolationConfig: new InterpolationConfig('{{', '}}')
+  };
+
+  it('should emit analysis information', () => {
+    const context = new IndexingContext();
+    const decl = util.getComponentDeclaration('class C {}');
+    populateContext(context, decl, 'c-selector', '<div>{{foo}}</div>', null);
+    const analysis = generateAnalysis(context);
+
+    expect(analysis.size).toBe(1);
+
+    const info = analysis.get(decl);
+    expect(info).toBeDefined();
+    expect(info !.content).toBe('class C {}');
+    expect(info !.name).toBe('C');
+    expect(info !.selector).toBe('c-selector');
+    expect(info !.sourceFile).toBe(util.TESTFILE);
+    expect(info !.template.identifiers)
+        .toEqual(getTemplateIdentifiers(
+            util.getParsedTemplate('<div>{{foo}}</div>'), DEFAULT_RESTORE_OPTIONS));
+    expect(info !.template.usedComponents.size).toBe(0);
+  });
+
+  it('should emit used components', () => {
+    const context = new IndexingContext();
+
+    const templateA = '<b-selector></b-selector>';
+    const declA = util.getComponentDeclaration('class A {}');
+
+    const templateB = '<a-selector></a-selector>';
+    const declB = util.getComponentDeclaration('class B {}');
+
+    const scopeA = util.bindTemplate(templateA, [{selector: 'b-selector', declaration: declB}]);
+    const scopeB = util.bindTemplate(templateB, [{selector: 'a-selector', declaration: declA}]);
+
+    populateContext(context, declA, 'a-selector', templateA, scopeA);
+    populateContext(context, declB, 'b-selector', templateB, scopeB);
+
+    const analysis = generateAnalysis(context);
+
+    expect(analysis.size).toBe(2);
+
+    const infoA = analysis.get(declA);
+    expect(infoA).toBeDefined();
+    expect(infoA !.template.usedComponents).toEqual(new Set([declB]));
+
+    const infoB = analysis.get(declB);
+    expect(infoB).toBeDefined();
+    expect(infoB !.template.usedComponents).toEqual(new Set([declA]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -12,7 +12,6 @@ import {Reference} from '../../imports';
 import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
-
 /** Dummy file URL */
 export const TESTFILE = 'TESTFILE';
 
@@ -32,33 +31,4 @@ export function getComponentDeclaration(component: string): ClassDeclaration {
  */
 export function getParsedTemplate(template: string): TmplAstNode[] {
   return parseTemplate(template, TESTFILE).nodes;
-}
-
-/**
- * Binds information about a component on a template (a target). The BoundTarget
- * describes the scope of the template and can be queried for directives the
- * template uses.
- */
-export function bindTemplate(
-    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
-    BoundTarget<DirectiveMeta> {
-  const matcher = new SelectorMatcher<DirectiveMeta>();
-  components.forEach(({selector, declaration}) => {
-    matcher.addSelectables(CssSelector.parse(selector), {
-      ref: new Reference(declaration),
-      selector,
-      queries: [],
-      ngTemplateGuards: [],
-      hasNgTemplateContextGuard: false,
-      baseClass: null,
-      name: declaration.name.getText(),
-      isComponent: true,
-      inputs: {},
-      outputs: {},
-      exportAs: null,
-    });
-  });
-  const binder = new R3TargetBinder(matcher);
-
-  return binder.bind({template: getParsedTemplate(template)});
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -32,3 +32,32 @@ export function getComponentDeclaration(component: string): ClassDeclaration {
 export function getParsedTemplate(template: string): TmplAstNode[] {
   return parseTemplate(template, TESTFILE).nodes;
 }
+
+/**
+ * Binds information about a component on a template (a target). The BoundTarget
+ * describes the scope of the template and can be queried for directives the
+ * template uses.
+ */
+export function bindTemplate(
+    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
+    BoundTarget<DirectiveMeta> {
+  const matcher = new SelectorMatcher<DirectiveMeta>();
+  components.forEach(({selector, declaration}) => {
+    matcher.addSelectables(CssSelector.parse(selector), {
+      ref: new Reference(declaration),
+      selector,
+      queries: [],
+      ngTemplateGuards: [],
+      hasNgTemplateContextGuard: false,
+      baseClass: null,
+      name: declaration.name.getText(),
+      isComponent: true,
+      inputs: {},
+      outputs: {},
+      exportAs: null,
+    });
+  });
+  const binder = new R3TargetBinder(matcher);
+
+  return binder.bind({template: getParsedTemplate(template)});
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BoundTarget, CssSelector, R3TargetBinder, SelectorMatcher, TmplAstNode, parseTemplate} from '@angular/compiler/src/compiler';
+import * as ts from 'typescript';
+import {Reference} from '../../imports';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+
+/** Dummy file URL */
+export const TESTFILE = 'TESTFILE';
+
+/**
+ * Creates a class declaration from a component source code.
+ */
+export function getComponentDeclaration(component: string): ClassDeclaration {
+  const sourceFile = ts.createSourceFile(
+      TESTFILE, component, ts.ScriptTarget.ES2015,
+      /* setParentNodes */ true);
+
+  return sourceFile.statements.filter(ts.isClassDeclaration)[0] as ClassDeclaration;
+}
+
+/**
+ * Parses a template source code.
+ */
+export function getParsedTemplate(template: string): TmplAstNode[] {
+  return parseTemplate(template, TESTFILE).nodes;
+}
+
+/**
+ * Binds information about a component on a template (a target). The BoundTarget
+ * describes the scope of the template and can be queried for directives the
+ * template uses.
+ */
+export function bindTemplate(
+    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
+    BoundTarget<DirectiveMeta> {
+  const matcher = new SelectorMatcher<DirectiveMeta>();
+  components.forEach(({selector, declaration}) => {
+    matcher.addSelectables(CssSelector.parse(selector), {
+      ref: new Reference(declaration),
+      selector,
+      queries: [],
+      ngTemplateGuards: [],
+      hasNgTemplateContextGuard: false,
+      baseClass: null,
+      name: declaration.name.getText(),
+      isComponent: true,
+      inputs: {},
+      outputs: {},
+      exportAs: null,
+    });
+  });
+  const binder = new R3TargetBinder(matcher);
+
+  return binder.bind({template: getParsedTemplate(template)});
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -12,6 +12,7 @@ import {Reference} from '../../imports';
 import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
+
 /** Dummy file URL */
 export const TESTFILE = 'TESTFILE';
 


### PR DESCRIPTION
Do not merge. Waiting for #31039 to land first.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`IndexerContext` is standalone and no analysis of indexed components is actually generated.

## What is the new behavior?
`genearateAnalysis` in `indexer/src/transform` generates a map of component class declarations to semantically analyzed `IndexedComponent`s that can be consumed by language analysis tools.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
 
Child of #30959, #31039.