### PR TITLE
build: update buildifier to version that supports windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ Try running `yarn bazel` instead.
 #   - 0.27.12 Adds NodeModuleSources provider for transtive npm deps support
 #   - 0.30.0 yarn_install now uses symlinked node_modules with new managed directories Bazel 0.26.0 feature
 #   - 0.31.1 entry_point attribute of nodejs_binary & rollup_bundle is now a label
-check_rules_nodejs_version("0.31.1")
+check_rules_nodejs_version(minimum_version_string = "0.31.1")
 
 # Setup the Node.js toolchain
 node_repositories(

--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults.bzl", "ng_module", "ng_rollup_bundle")
+load("//tools:defaults.bzl", "ng_module", "ng_rollup_bundle", "ts_library")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
 load("//modules/benchmarks:benchmark_test.bzl", "benchmark_test")
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "bazel:format": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=args-order,attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable",
+    "bazel:format": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable",
     "bazel:lint": "yarn bazel:format --lint=warn",
     "bazel:lint-fix": "yarn bazel:format --lint=fix",
     "preinstall": "node tools/yarn/check-yarn.js",
@@ -118,7 +118,7 @@
   "devDependencies": {
     "@angular/cli": "^8.0.0-beta.15",
     "@bazel/bazel": "0.26.1",
-    "@bazel/buildifier": "^0.19.2",
+    "@bazel/buildifier": "^0.25.1",
     "@bazel/ibazel": "~0.9.0",
     "@types/minimist": "^1.2.0",
     "@types/systemjs": "0.19.32",

--- a/packages/bazel/src/builders/BUILD.bazel
+++ b/packages/bazel/src/builders/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/common/upgrade/test/BUILD.bazel
+++ b/packages/common/upgrade/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "jasmine_node_test", "ts_library", "ts_web_test_suite")
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 ts_library(
     name = "test_lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,23 +114,29 @@
     "@bazel/bazel-linux_x64" "0.26.1"
     "@bazel/bazel-win32_x64" "0.26.1"
 
-"@bazel/buildifier-darwin_x64@0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.19.2.tgz#1182862b4a3578fb9367ab42e807131187a61702"
-  integrity sha512-f6CITRj8jFhhZFrQkIao3IgJjZAXGYwUkW/QBSeAu0HIltBerJ0FTt/Nmu9ji1QZYT2aO4RpZ8oJksG6xv1dcQ==
+"@bazel/buildifier-darwin_x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.25.1.tgz#bcb8643ae46c6aa4f4981f59648ecd9087b30a11"
+  integrity sha512-9fD3tXYgSjpZCEUGFBadfwDw89b3z3acYLd8+a0F6Sb/9LB0jzXOCMzqFMA7m1b3wOh1ecgWOyT0TyPUDSLRkg==
 
-"@bazel/buildifier-linux_x64@0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier-linux_x64/-/buildifier-linux_x64-0.19.2.tgz#8b26eaf1f091cd3846a7dd7ea94008b55498401e"
-  integrity sha512-kJjzbrjuAW4yVms5mbTWSHpJF6ogDLkuq4MjVP6a03umQ7E15o9YoxbDoiN+CzAj9ZMWPWfc5/N5TouiwXkGzA==
+"@bazel/buildifier-linux_x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-linux_x64/-/buildifier-linux_x64-0.25.1.tgz#50cc7c3b8f9dfa818ea6cc9f2ec761cbd39471ea"
+  integrity sha512-Wt2yA+yeimi6i0USHoE1T2EhRJwtKDBmDLQx2E8Q+QXysULLm4usMEIGPdQYbHqKyjL75jbwlwZTlm9EzdXgCg==
 
-"@bazel/buildifier@^0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-0.19.2.tgz#3e077de346ad98561cee703297aa8db50cfb3c76"
-  integrity sha512-MwkuoQdOdZ/VYKJvZe3qVCn3/20pLJyJpzNl3cBmaccWeUtdDKhtOm8YlLU08lxrt0VcKNcTYt4uiA62e/315A==
+"@bazel/buildifier-win32_x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-win32_x64/-/buildifier-win32_x64-0.25.1.tgz#d990afed296f65675c1406ae36580473cab65f4c"
+  integrity sha512-ak91iv940z04NJfEhWHMSudjlZK5PrpDNL8k/cmYowi1JSfYvCchfABiXWxfWURmvqgSGE+KV72xxZ0HLU60bw==
+
+"@bazel/buildifier@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-0.25.1.tgz#e29ab77802d99d70a891b9a471f62e80030fc326"
+  integrity sha512-d3+DgsGmQ3cSLCm99321cl+vKD/c3pNSQINCBnipmNeNd7UA3/UQ2Ibp6MXZslF8fMQDpuLxhhCFUOnFAoNWsw==
   optionalDependencies:
-    "@bazel/buildifier-darwin_x64" "0.19.2"
-    "@bazel/buildifier-linux_x64" "0.19.2"
+    "@bazel/buildifier-darwin_x64" "0.25.1"
+    "@bazel/buildifier-linux_x64" "0.25.1"
+    "@bazel/buildifier-win32_x64" "0.25.1"
 
 "@bazel/ibazel@~0.9.0":
   version "0.9.0"


### PR DESCRIPTION
* Updates buildifier to a version that also comes with windows binaries.
* Fixes a few new formatting/lint warnings
* Removes the `args-order` warning because it is no longer a warning.. and is now part of the formatter (https://github.com/bazelbuild/buildtools/commit/1d995e7e310f8de3c4749c2052b2d26184a86e1b)