### PR TITLE
refactor(language-service): Remove NgLSHost -> NgLS dependency

### DIFF
--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -7,47 +7,11 @@
  */
 
 import {NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
-import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli/src/language_services';
-
 import {AstResult} from './common';
 import {Declarations, Diagnostic, DiagnosticKind, DiagnosticMessageChain, Diagnostics, Span, TemplateSource} from './types';
-import {offsetSpan, spanOf} from './utils';
 
 export interface AstProvider {
   getTemplateAst(template: TemplateSource, fileName: string): AstResult;
-}
-
-export function getTemplateDiagnostics(
-    fileName: string, astProvider: AstProvider, templates: TemplateSource[]): Diagnostics {
-  const results: Diagnostics = [];
-  for (const template of templates) {
-    const ast = astProvider.getTemplateAst(template, fileName);
-    if (ast) {
-      if (ast.parseErrors && ast.parseErrors.length) {
-        results.push(...ast.parseErrors.map<Diagnostic>(
-            e => ({
-              kind: DiagnosticKind.Error,
-              span: offsetSpan(spanOf(e.span), template.span.start),
-              message: e.msg
-            })));
-      } else if (ast.templateAst && ast.htmlAst) {
-        const info: DiagnosticTemplateInfo = {
-          templateAst: ast.templateAst,
-          htmlAst: ast.htmlAst,
-          offset: template.span.start,
-          query: template.query,
-          members: template.members
-        };
-        const expressionDiagnostics = getTemplateExpressionDiagnostics(info);
-        results.push(...expressionDiagnostics);
-      }
-      if (ast.errors) {
-        results.push(...ast.errors.map<Diagnostic>(
-            e => ({kind: e.kind, span: e.span || template.span, message: e.message})));
-      }
-    }
-  }
-  return results;
 }
 
 export function getDeclarationDiagnostics(

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -81,7 +81,6 @@ export function create(info: tss.server.PluginCreateInfo): ts.LanguageService {
 
   const serviceHost = new TypeScriptServiceHost(info.languageServiceHost, oldLS);
   const ls = createLanguageService(serviceHost);
-  serviceHost.setSite(ls);
   projectHostMap.set(info.project, serviceHost);
 
   proxy.getCompletionsAtPosition = function(

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -8,6 +8,7 @@
 
 import {CompileDirectiveMetadata, CompileMetadataResolver, CompilePipeSummary, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli/src/language_services';
+import {AstResult, TemplateInfo} from './common';
 
 export {
   BuiltinType,
@@ -203,6 +204,16 @@ export interface LanguageServiceHost {
    * Return a list all the template files referenced by the project.
    */
   getTemplateReferences(): string[];
+
+  /**
+   * Return the AST for both HTML and template for the contextFile.
+   */
+  getTemplateAst(template: TemplateSource, contextFile: string): AstResult;
+
+  /**
+   * Return the template AST for the node that corresponds to the position.
+   */
+  getTemplateAstAtPosition(fileName: string, position: number): TemplateInfo|undefined;
 }
 
 /**

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -22,7 +22,6 @@ describe('completions', () => {
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
-  ngHost.setSite(ngService);
 
   it('should be able to get entity completions',
      () => { contains('/app/test.ng', 'entity-amp', '&amp;', '&gt;', '&lt;', '&iota;'); });

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -22,7 +22,6 @@ describe('definitions', () => {
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
-  ngHost.setSite(ngService);
 
   it('should be able to find field in an interpolation', () => {
     localReference(

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -26,7 +26,6 @@ describe('diagnostics', () => {
     const service = ts.createLanguageService(mockHost, documentRegistry);
     ngHost = new TypeScriptServiceHost(mockHost, service);
     ngService = createLanguageService(ngHost);
-    ngHost.setSite(ngService);
   });
 
   it('should be no diagnostics for test.ng',

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -23,7 +23,6 @@ describe('hover', () => {
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
-  ngHost.setSite(ngService);
 
 
   it('should be able to find field in an interpolation', () => {

--- a/packages/language-service/test/template_references_spec.ts
+++ b/packages/language-service/test/template_references_spec.ts
@@ -27,7 +27,6 @@ describe('references', () => {
     service = ts.createLanguageService(mockHost, documentRegistry);
     ngHost = new TypeScriptServiceHost(mockHost, service);
     ngService = createLanguageService(ngHost);
-    ngHost.setSite(ngService);
   });
 
   it('should be able to get template references',


### PR DESCRIPTION
```
NgLSHost: AngularLanguageServiceHost
NgLS: AngularLanguageService
```

Currently, `NgLS` depends on `NgLSHost`, and vice versa.
This circular dependency is not desirable because the relationship
should be strictly unidirectional, `NgLS` -> `NgLSHost`.
To achieve that, the `getTemplateAst` and `getTemplatAstAtPosition` methods should
be moved to `NgLSHost` and exposed as public methods.
Removing the circular dependency also removes the need for the
awkward `setSite` method in NgLSHost.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
