### PR TITLE
refactor(ivy): use FatalDiagnosticError to throw more descriptive errors while extracting queries

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -435,16 +435,24 @@ export function queriesFromFields(
     fields: {member: ClassMember, decorators: Decorator[]}[], reflector: ReflectionHost,
     evaluator: PartialEvaluator): R3QueryMetadata[] {
   return fields.map(({member, decorators}) => {
+    const decorator = decorators[0];
+    const node = member.node || decorator.node;
+
     // Throw in case of `@Input() @ContentChild('foo') foo: any`, which is not supported in Ivy
     if (member.decorators !.some(v => v.name === 'Input')) {
-      throw new Error(`Cannot combine @Input decorators with query decorators`);
+      throw new FatalDiagnosticError(
+          ErrorCode.DECORATOR_COLLISION, node,
+          'Cannot combine @Input decorators with query decorators');
     }
     if (decorators.length !== 1) {
-      throw new Error(`Cannot have multiple query decorators on the same class member`);
+      throw new FatalDiagnosticError(
+          ErrorCode.DECORATOR_COLLISION, node,
+          'Cannot have multiple query decorators on the same class member');
     } else if (!isPropertyTypeMember(member)) {
-      throw new Error(`Query decorator must go on a property-type member`);
+      throw new FatalDiagnosticError(
+          ErrorCode.DECORATOR_UNEXPECTED, node,
+          'Query decorator must go on a property-type member');
     }
-    const decorator = decorators[0];
     return extractQueryMetadata(
         decorator.node, decorator.name, decorator.args || [], member.name, reflector, evaluator);
   });

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -14,7 +14,7 @@ export enum ErrorCode {
   DECORATOR_UNEXPECTED = 1005,
 
   /**
-   * This error code indicates that there are incompatible decorators on a type.
+   * This error code indicates that there are incompatible decorators on a type or a class field.
    */
   DECORATOR_COLLISION = 1006,
 

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1989,44 +1989,6 @@ describe('compiler compliance', () => {
 
         expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
       });
-
-      it('should throw error if content queries share a property with inputs', () => {
-        const files = {
-          app: {
-            ...directive,
-            'content_query.ts': `
-            import {Component, ContentChild, Input, NgModule} from '@angular/core';
-
-            @Component({
-              selector: 'content-query-component',
-              template: \`
-                <div><ng-content></ng-content></div>
-              \`
-            })
-            export class ContentQueryComponent {
-              @Input() @ContentChild('foo', {static: false}) foo: any;
-            }
-
-            @Component({
-              selector: 'my-app',
-              template: \`
-                <content-query-component>
-                  <div #foo></div>
-                </content-query-component>
-              \`
-            })
-            export class MyApp { }
-
-            @NgModule({declarations: [ContentQueryComponent, MyApp]})
-            export class MyModule { }
-            `
-          }
-        };
-
-        expect(() => compile(files, angularFiles))
-            .toThrowError(/Cannot combine @Input decorators with query decorators/);
-      });
-
     });
 
     describe('pipes', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
 import {LazyRoute} from '@angular/compiler-cli/src/ngtsc/routing';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -1034,7 +1035,9 @@ describe('ngtsc behavioral tests', () => {
       `);
 
       const errors = env.driveDiagnostics();
-      expect(trim(errors[0].messageText as string))
+      const {code, messageText} = errors[0];
+      expect(code).toBe(ngErrorCode(ErrorCode.DECORATOR_COLLISION));
+      expect(trim(messageText as string))
           .toContain('Cannot combine @Input decorators with query decorators');
     });
 
@@ -1055,7 +1058,9 @@ describe('ngtsc behavioral tests', () => {
       `);
 
       const errors = env.driveDiagnostics();
-      expect(trim(errors[0].messageText as string))
+      const {code, messageText} = errors[0];
+      expect(code).toBe(ngErrorCode(ErrorCode.DECORATOR_COLLISION));
+      expect(trim(messageText as string))
           .toContain('Cannot have multiple query decorators on the same class member');
     });
 
@@ -1075,7 +1080,9 @@ describe('ngtsc behavioral tests', () => {
       `);
 
       const errors = env.driveDiagnostics();
-      expect(trim(errors[0].messageText as string))
+      const {code, messageText} = errors[0];
+      expect(code).toBe(ngErrorCode(ErrorCode.DECORATOR_UNEXPECTED));
+      expect(trim(messageText as string))
           .toContain('Query decorator must go on a property-type member');
     });
   });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1025,12 +1025,10 @@ describe('ngtsc behavioral tests', () => {
         import {Component, ContentChild, Input} from '@angular/core';
 
         @Component({
-          selector: 'content-query-component',
-          template: \`
-            <div><ng-content></ng-content></div>
-          \`
+          selector: 'test-cmp',
+          template: '<ng-content></ng-content>'
         })
-        export class ContentQueryComponent {
+        export class TestCmp {
           @Input() @ContentChild('foo', {static: false}) foo: any;
         }
       `);
@@ -1038,6 +1036,47 @@ describe('ngtsc behavioral tests', () => {
       const errors = env.driveDiagnostics();
       expect(trim(errors[0].messageText as string))
           .toContain('Cannot combine @Input decorators with query decorators');
+    });
+
+    it('should throw error if multiple query decorators are used on the same field', () => {
+      env.tsconfig({});
+      env.write('test.ts', `
+        import {Component, ContentChild} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '...'
+        })
+        export class TestCmp {
+          @ContentChild('bar', {static: true})
+          @ContentChild('foo', {static: false})
+          foo: any;
+        }
+      `);
+
+      const errors = env.driveDiagnostics();
+      expect(trim(errors[0].messageText as string))
+          .toContain('Cannot have multiple query decorators on the same class member');
+    });
+
+    it('should throw error if query decorators are used on non property-type member', () => {
+      env.tsconfig({});
+      env.write('test.ts', `
+        import {Component, ContentChild} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '...'
+        })
+        export class TestCmp {
+          @ContentChild('foo', {static: false})
+          private someFn() {}
+        }
+      `);
+
+      const errors = env.driveDiagnostics();
+      expect(trim(errors[0].messageText as string))
+          .toContain('Query decorator must go on a property-type member');
     });
   });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1018,6 +1018,27 @@ describe('ngtsc behavioral tests', () => {
       expect(trim(errors[0].messageText as string))
           .toContain('Directive TestDir has no selector, please add it!');
     });
+
+    it('should throw error if content queries share a property with inputs', () => {
+      env.tsconfig({});
+      env.write('test.ts', `
+        import {Component, ContentChild, Input} from '@angular/core';
+
+        @Component({
+          selector: 'content-query-component',
+          template: \`
+            <div><ng-content></ng-content></div>
+          \`
+        })
+        export class ContentQueryComponent {
+          @Input() @ContentChild('foo', {static: false}) foo: any;
+        }
+      `);
+
+      const errors = env.driveDiagnostics();
+      expect(trim(errors[0].messageText as string))
+          .toContain('Cannot combine @Input decorators with query decorators');
+    });
   });
 
   describe('multiple decorators on classes', () => {


### PR DESCRIPTION
Prior to this commit, the logic to extract query information from class fields used an instance of regular Error class to throw an error. As a result, some useful information (like reference to a specific field) was missing. Replacing Error class with FatalDiagnosticError one makes the error more verbose that should simplify debugging.

Note: a test that is checking this behavior was moved from `compliance` to `ngtsc` due to the fact that the `compile` function used in compliance tests doesn't have proper instrumentation to work with `FatalDiagnosticError` errors (the error [is intercepted and not thrown](https://github.com/angular/angular/blob/master/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts#L207), thus require additional handling in `compile` function used in compliance tests). Created a separate ticket to provide better support for `FatalDiagnosticError` in compliance tests.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No