### PR TITLE
refactor(ivy): make `bind` an internal-only function

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -90,8 +90,6 @@ export class Identifiers {
 
   static textBinding: o.ExternalReference = {name: 'ɵɵtextBinding', moduleName: CORE};
 
-  static bind: o.ExternalReference = {name: 'ɵɵbind', moduleName: CORE};
-
   static enableBindings: o.ExternalReference = {name: 'ɵɵenableBindings', moduleName: CORE};
 
   static disableBindings: o.ExternalReference = {name: 'ɵɵdisableBindings', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -69,7 +69,6 @@ export {
   ɵɵtextInterpolateV,
   ɵɵembeddedViewStart,
   ɵɵprojection,
-  ɵɵbind,
   ɵɵinterpolation1,
   ɵɵinterpolation2,
   ɵɵinterpolation3,

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,16 +7,14 @@
  */
 
 import '../util/ng_i18n_closure_mode';
-
 import {getPluralCase} from '../i18n/localization';
 import {SRCSET_ATTRS, URI_ATTRS, VALID_ATTRS, VALID_ELEMENTS, getTemplateContent} from '../sanitization/html_sanitizer';
 import {InertBodyHelper} from '../sanitization/inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from '../sanitization/url_sanitizer';
 import {addAllToArray} from '../util/array_utils';
 import {assertDataInRange, assertDefined, assertEqual, assertGreaterThan} from '../util/assert';
-
 import {attachPatchData} from './context_discovery';
-import {setDelayProjection, ɵɵbind, ɵɵload} from './instructions/all';
+import {bind, setDelayProjection, ɵɵload} from './instructions/all';
 import {attachI18nOpCodesDebug} from './instructions/lview_debug';
 import {allocExpando, elementAttributeInternal, elementPropertyInternal, getOrCreateTNode, setInputsForProperty, textBindingInternal} from './instructions/shared';
 import {LContainer, NATIVE} from './interfaces/container';
@@ -1018,7 +1016,8 @@ let shiftsCounter = 0;
  * @codeGenApi
  */
 export function ɵɵi18nExp<T>(value: T): void {
-  const expression = ɵɵbind(value);
+  const lView = getLView();
+  const expression = bind(lView, value);
   if (expression !== NO_CHANGE) {
     changeMask = changeMask | (1 << shiftsCounter);
   }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -35,7 +35,6 @@ export {
   ɵɵattributeInterpolate8,
   ɵɵattributeInterpolateV,
 
-  ɵɵbind,
   ɵɵclassMap,
   ɵɵclassProp,
   ɵɵcomponentHostSyntheticListener,

--- a/packages/core/src/render3/instructions/attribute.ts
+++ b/packages/core/src/render3/instructions/attribute.ts
@@ -9,7 +9,7 @@ import {SanitizerFn} from '../interfaces/sanitization';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
-import {ɵɵbind} from './property';
+import {bind} from './property';
 import {elementAttributeInternal} from './shared';
 
 
@@ -32,7 +32,7 @@ export function ɵɵattribute(
   const index = getSelectedIndex();
   const lView = getLView();
   // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const bound = ɵɵbind(value);
+  const bound = bind(lView, value);
   if (bound !== NO_CHANGE) {
     return elementAttributeInternal(index, name, bound, lView, sanitizer, namespace);
   }

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -8,7 +8,7 @@
 import {assertNotEqual} from '../../util/assert';
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX} from '../interfaces/view';
+import {BINDING_INDEX, LView} from '../interfaces/view';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
@@ -40,7 +40,8 @@ export function ɵɵproperty<T>(
     nativeOnly?: boolean): TsickleIssue1009 {
   const index = getSelectedIndex();
   ngDevMode && assertNotEqual(index, -1, 'selected index cannot be -1');
-  const bindReconciledValue = ɵɵbind(value);
+  const lView = getLView();
+  const bindReconciledValue = bind(lView, value);
   if (bindReconciledValue !== NO_CHANGE) {
     elementPropertyInternal(index, propName, bindReconciledValue, sanitizer, nativeOnly);
   }
@@ -50,12 +51,10 @@ export function ɵɵproperty<T>(
 /**
  * Creates a single value binding.
  *
+ * @param lView Current view
  * @param value Value to diff
- *
- * @codeGenApi
  */
-export function ɵɵbind<T>(value: T): T|NO_CHANGE {
-  const lView = getLView();
+export function bind<T>(lView: LView, value: T): T|NO_CHANGE {
   const bindingIndex = lView[BINDING_INDEX]++;
   storeBindingMetadata(lView);
   return bindingUpdated(lView, bindingIndex, value) ? value : NO_CHANGE;
@@ -87,8 +86,9 @@ export function ɵɵbind<T>(value: T): T|NO_CHANGE {
 export function ɵɵupdateSyntheticHostBinding<T>(
     propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null, nativeOnly?: boolean) {
   const index = getSelectedIndex();
+  const lView = getLView();
   // TODO(benlesh): remove bind call here.
-  const bound = ɵɵbind(value);
+  const bound = bind(lView, value);
   if (bound !== NO_CHANGE) {
     elementPropertyInternal(index, propName, bound, sanitizer, nativeOnly, loadComponentRenderer);
   }

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -15,7 +15,7 @@ import {NO_CHANGE} from '../tokens';
 import {renderStringify} from '../util/misc_utils';
 import {getNativeByIndex} from '../util/view_utils';
 
-import {ɵɵbind} from './property';
+import {bind} from './property';
 import {getOrCreateTNode, textBindingInternal} from './shared';
 
 
@@ -55,7 +55,7 @@ export function ɵɵtext(index: number, value?: any): void {
 export function ɵɵtextBinding<T>(value: T | NO_CHANGE): void {
   const lView = getLView();
   const index = getSelectedIndex();
-  const bound = ɵɵbind(value);
+  const bound = bind(lView, value);
   if (bound !== NO_CHANGE) {
     textBindingInternal(lView, index, renderStringify(bound));
   }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -46,7 +46,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵNgOnChangesFeature': r3.ɵɵNgOnChangesFeature,
        'ɵɵProvidersFeature': r3.ɵɵProvidersFeature,
        'ɵɵInheritDefinitionFeature': r3.ɵɵInheritDefinitionFeature,
-       'ɵɵbind': r3.ɵɵbind,
        'ɵɵcontainer': r3.ɵɵcontainer,
        'ɵɵnextContext': r3.ɵɵnextContext,
        'ɵɵcontainerRefreshStart': r3.ɵɵcontainerRefreshStart,

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -507,6 +507,9 @@
     "name": "baseResolveDirective"
   },
   {
+    "name": "bind"
+  },
+  {
     "name": "bindingUpdated"
   },
   {
@@ -1573,9 +1576,6 @@
   },
   {
     "name": "wrapListener"
-  },
-  {
-    "name": "ɵɵbind"
   },
   {
     "name": "ɵɵclassProp"

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -9,7 +9,7 @@
 import {ViewEncapsulation, ɵɵdefineInjectable, ɵɵdefineInjector} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
 import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
-import {tick, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {tick, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {ComponentDef, RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -415,7 +415,7 @@ describe('recursive components', () => {
           ɵɵselect(0);
           ɵɵtextBinding(ctx.data.value);
           ɵɵselect(1);
-          ɵɵproperty('ngIf', ɵɵbind(ctx.data.left));
+          ɵɵproperty('ngIf', ctx.data.left);
           ɵɵselect(2);
           ɵɵproperty('ngIf', ctx.data.right);
         }

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -7,9 +7,8 @@
  */
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-
 import {ComponentFixture, TemplateFixture, createComponent} from './render_util';
 
 describe('JS control flow', () => {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -12,7 +12,7 @@ import {RenderFlags} from '@angular/core/src/render3/interfaces/definition';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHasToken, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation2, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding, ɵɵtextInterpolate2} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation2, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding, ɵɵtextInterpolate2} from '../../src/render3/index';
 import {TNODE} from '../../src/render3/interfaces/injector';
 import {TNodeType} from '../../src/render3/interfaces/node';
 import {isProceduralRenderer} from '../../src/render3/interfaces/renderer';

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-
 import {ComponentFixture, createComponent} from './render_util';
 
 describe('exports', () => {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -9,7 +9,7 @@
 import {RendererType2} from '../../src/render/api';
 import {getLContext} from '../../src/render3/context_discovery';
 import {AttributeMarker, ɵɵattribute, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
-import {ɵɵallocHostVars, ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵallocHostVars, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {MONKEY_PATCH_KEY_NAME} from '../../src/render3/interfaces/context';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -17,7 +17,6 @@ import {StylingIndex} from '../../src/render3/interfaces/styling';
 import {CONTEXT, HEADER_OFFSET} from '../../src/render3/interfaces/view';
 import {ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
 import {Sanitizer, SecurityContext} from '../../src/sanitization/security';
-
 import {NgIf} from './common_with_def';
 import {ComponentFixture, MockRendererFactory, renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {OnDestroy} from '../../src/core';
-import {AttributeMarker, ComponentTemplate, ɵɵNgOnChangesFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {ComponentTemplate, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-
 import {NgIf} from './common_with_def';
 import {ComponentFixture, createComponent} from './render_util';
 

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -8,12 +8,11 @@
 
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 
-import {markDirty, ɵɵbind, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵreference, ɵɵresolveBody, ɵɵresolveDocument, ɵɵselect, ɵɵtextBinding} from '../../src/render3/index';
+import {markDirty, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵreference, ɵɵresolveBody, ɵɵresolveDocument, ɵɵselect, ɵɵtextBinding} from '../../src/render3/index';
 import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵgetCurrentView, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {GlobalTargetResolver} from '../../src/render3/interfaces/renderer';
 import {ɵɵrestoreView} from '../../src/render3/state';
-
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, TemplateFixture, containerEl, createComponent, getDirectiveOnNode, renderToHtml, requestAnimationFrame} from './render_util';
 

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -10,11 +10,10 @@ import {Component as _Component, ComponentFactoryResolver, ElementRef, InjectFla
 import {forwardRef} from '../../src/di/forward_ref';
 import {createInjector} from '../../src/di/r3_injector';
 import {injectComponentFactoryResolver, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵselect, ɵɵtextInterpolate1} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵinterpolation1, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {NgModuleFactory} from '../../src/render3/ng_module_ref';
 import {getInjector} from '../../src/render3/util/discovery_utils';
-
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture} from './render_util';
 

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵɵdefineComponent, ɵɵproperty, ɵɵselect} from '../../src/render3/index';
-import {ɵɵbind, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵpureFunction2} from '../../src/render3/pure_function';
 import {getDirectiveOnNode, renderToHtml} from '../../test/render3/render_util';

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -696,8 +696,6 @@ export interface ɵɵBaseDef<T> {
     viewQuery: ViewQueriesFunction<T> | null;
 }
 
-export declare function ɵɵbind<T>(value: T): T | NO_CHANGE;
-
 export declare function ɵɵclassMap(classes: {
     [styleName: string]: any;
 } | NO_CHANGE | string | null): void;


### PR DESCRIPTION
The function `bind` should no longer be a public instruction because it has been internalized wherever it was needed. This PR makes sure that it is no longer publicly exported.