### PR TITLE
refactor(compiler): allow parsing templates with custom leadingTriviaChars

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -29,7 +29,6 @@ import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReferen
 
 const EMPTY_MAP = new Map<string, Expression>();
 const EMPTY_ARRAY: any[] = [];
-const WHITESPACE_LEADING_TRIVIA_CHARS = [' ', '\n', '\r', '\t'];
 
 export interface ComponentHandlerData {
   meta: R3ComponentMetadata;
@@ -600,7 +599,6 @@ export class ComponentDecoratorHandler implements
           preserveWhitespaces,
           interpolationConfig: interpolation,
           range: templateRange, escapedString,
-          leadingTriviaChars: WHITESPACE_LEADING_TRIVIA_CHARS,
         }),
     };
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -29,6 +29,7 @@ import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReferen
 
 const EMPTY_MAP = new Map<string, Expression>();
 const EMPTY_ARRAY: any[] = [];
+const WHITESPACE_LEADING_TRIVIA_CHARS = [' ', '\n', '\r', '\t'];
 
 export interface ComponentHandlerData {
   meta: R3ComponentMetadata;
@@ -598,7 +599,8 @@ export class ComponentDecoratorHandler implements
         interpolation, ...parseTemplate(templateStr, templateUrl, {
           preserveWhitespaces,
           interpolationConfig: interpolation,
-          range: templateRange, escapedString
+          range: templateRange, escapedString,
+          leadingTriviaChars: WHITESPACE_LEADING_TRIVIA_CHARS,
         }),
     };
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -598,7 +598,7 @@ export class ComponentDecoratorHandler implements
         interpolation, ...parseTemplate(templateStr, templateUrl, {
           preserveWhitespaces,
           interpolationConfig: interpolation,
-          range: templateRange, escapedString,
+          range: templateRange, escapedString
         }),
     };
   }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1889,10 +1889,10 @@ export interface ParseTemplateOptions {
    */
   escapedString?: boolean;
   /**
- * An array of characters that should be considered as leading trivia.
- * Leading trivia are characters that are not important to the developer, and so should not be
- * included in source-map segments.  A common example is whitespace.
- */
+   * An array of characters that should be considered as leading trivia.
+   * Leading trivia are characters that are not important to the developer, and so should not be
+   * included in source-map segments.  A common example is whitespace.
+   */
   leadingTriviaChars?: string[];
 }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -50,8 +50,6 @@ const NG_PROJECT_AS_ATTR_NAME = 'ngProjectAs';
 const GLOBAL_TARGET_RESOLVERS = new Map<string, o.ExternalReference>(
     [['window', R3.resolveWindow], ['document', R3.resolveDocument], ['body', R3.resolveBody]]);
 
-const LEADING_TRIVIA_CHARS = [' ', '\n', '\r', '\t'];
-
 //  if (rf & flags) { .. }
 export function renderFlagCheckIfStmt(
     flags: core.RenderFlags, statements: o.Statement[]): o.IfStmt {
@@ -1888,6 +1886,12 @@ export interface ParseTemplateOptions {
    * but the new line should increment the current line for source mapping.
    */
   escapedString?: boolean;
+  /**
+ * An array of characters that should be considered as leading trivia.
+ * Leading trivia are characters that are not important to the developer, and so should not be
+ * included in source-map segments.  A common example is whitespace.
+ */
+  leadingTriviaChars?: string[];
 }
 
 /**
@@ -1903,9 +1907,8 @@ export function parseTemplate(
   const {interpolationConfig, preserveWhitespaces} = options;
   const bindingParser = makeBindingParser(interpolationConfig);
   const htmlParser = new HtmlParser();
-  const parseResult = htmlParser.parse(
-      template, templateUrl,
-      {...options, tokenizeExpansionForms: true, leadingTriviaChars: LEADING_TRIVIA_CHARS});
+  const parseResult =
+      htmlParser.parse(template, templateUrl, {...options, tokenizeExpansionForms: true});
 
   if (parseResult.errors && parseResult.errors.length > 0) {
     return {errors: parseResult.errors, nodes: [], styleUrls: [], styles: []};

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -50,6 +50,8 @@ const NG_PROJECT_AS_ATTR_NAME = 'ngProjectAs';
 const GLOBAL_TARGET_RESOLVERS = new Map<string, o.ExternalReference>(
     [['window', R3.resolveWindow], ['document', R3.resolveDocument], ['body', R3.resolveBody]]);
 
+const LEADING_TRIVIA_CHARS = [' ', '\n', '\r', '\t'];
+
 //  if (rf & flags) { .. }
 export function renderFlagCheckIfStmt(
     flags: core.RenderFlags, statements: o.Statement[]): o.IfStmt {
@@ -1907,8 +1909,9 @@ export function parseTemplate(
   const {interpolationConfig, preserveWhitespaces} = options;
   const bindingParser = makeBindingParser(interpolationConfig);
   const htmlParser = new HtmlParser();
-  const parseResult =
-      htmlParser.parse(template, templateUrl, {...options, tokenizeExpansionForms: true});
+  const parseResult = htmlParser.parse(
+      template, templateUrl,
+      {leadingTriviaChars: LEADING_TRIVIA_CHARS, ...options, tokenizeExpansionForms: true});
 
   if (parseResult.errors && parseResult.errors.length > 0) {
     return {errors: parseResult.errors, nodes: [], styleUrls: [], styles: []};


### PR DESCRIPTION
Move the definition leadingTriviaChars included in parsing a template
to the parameters of parseTemplate. This allows overriding of the
default leadingTriviaChars, which is needed by some pipelines like the
indexing pipeline because leadingTriviaChars may throw off the recorded
span of selectors.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
  - N/A
- [x] Docs have been added / updated (for bug fixes / features)
  - N/A


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Templates are always parsed with the same `leadingTriviaChars` - whitespace characters.

Issue Number: N/A


## What is the new behavior?

Templates are parsed with whitespace `leadingTriviaChars` by default, but this can be overridden. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
