### PR TITLE
ci: re-enable payload size tracking

### DIFF
--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -136,17 +136,15 @@ trackPayloadSize() {
   # Save the file sizes to be retrieved from `payload-size.js`.
   echo "$(payloadToJson)" > /tmp/current.log
 
-  # TODO: Temporarily disabled until we get back `CIRCLE_COMPARE_URL` or another way to get the
-  #       commit range. Re-enable once the issue is resolved.
   # If this is a non-PR build, upload the data to firebase.
-  # if [[ "$CI_PULL_REQUEST" == "false" ]]; then
-  #   if [[ $trackChangeType = true ]]; then
-  #     addChangeType $CI_COMMIT_RANGE
-  #   fi
-  #   addTimestamp
-  #   addMessage $CI_COMMIT_RANGE
-  #   uploadData $name
-  # fi
+  if [[ "$CI_PULL_REQUEST" == "false" ]]; then
+    if [[ $trackChangeType = true ]]; then
+      addChangeType $CI_COMMIT_RANGE
+    fi
+    addTimestamp
+    addMessage $CI_COMMIT_RANGE
+    uploadData $name
+  fi
 
   # Check the file sizes against the specified limits.
   if [[ $checkSize = true ]]; then


### PR DESCRIPTION
Payload size tracking was temporarily disabled in #31057, due to `CIRCLE_COMPARE_URL` stopping being available. It turned out this was related to turning on the new [Pipelines][1] feature, which was required for testing Windows on CircleCI.

Since then, we have turned `Pipelines` off and got `CIRCLE_COMPARE_URL` back (e.g. see [build 362971][2]). According to CircleCI, failing to populate `CIRCLE_COMPARE_URL` with `Pipelines` on is a bug and they are working on fixing it.

[1]: https://circleci.com/docs/2.0/build-processing/
[2]: https://circleci.com/gh/angular/angular/362971

Fixes #31121
