### PR TITLE
fix(service-worker): registration failed on Safari

### DIFF
--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -53,7 +53,9 @@ export class Adapter {
    * Extract the pathname of a URL.
    */
   parseUrl(url: string, relativeTo?: string): {origin: string, path: string, search: string} {
-    const parsed = new URL(url, relativeTo);
+    // Workaround a Safari bug, see
+    // https://github.com/angular/angular/issues/31061#issuecomment-503637978
+    const parsed = !relativeTo ? new URL(url) : new URL(url, relativeTo);
     return {origin: parsed.origin, path: parsed.pathname, search: parsed.search};
   }
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -186,7 +186,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
 
   parseUrl(url: string, relativeTo?: string): {origin: string, path: string, search: string} {
     const parsedUrl: URL = (typeof URL === 'function') ?
-        new URL(url, relativeTo) :
+        (!relativeTo ? new URL(url) : new URL(url, relativeTo)) :
         require('url').parse(require('url').resolve(relativeTo || '', url));
 
     return {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Service worker failed to register on Safari.

## What is the new behavior?

Registered service worker.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It's a regression of Angular v8, it was ok in v7.
Closes #31061
