### PR TITLE
feat(common): export function to convert to `Date` object

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -12,7 +12,7 @@
  * Entry point for all public APIs of the common package.
  */
 export * from './location/index';
-export {formatDate} from './i18n/format_date';
+export {formatDate, toDate} from './i18n/format_date';
 export {formatCurrency, formatNumber, formatPercent} from './i18n/format_number';
 export {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 export {registerLocaleData} from './i18n/locale_data';

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -12,7 +12,7 @@
  * Entry point for all public APIs of the common package.
  */
 export * from './location/index';
-export {formatDate, toDate} from './i18n/format_date';
+export {formatDate, parseDate} from './i18n/format_date';
 export {formatCurrency, formatNumber, formatPercent} from './i18n/format_number';
 export {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 export {registerLocaleData} from './i18n/locale_data';

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -63,7 +63,7 @@ enum TranslationType {
  */
 export function formatDate(
     value: string | number | Date, format: string, locale: string, timezone?: string): string {
-  let date = toDate(value);
+  let date = parseDate(value);
   const namedFormat = getNamedFormat(locale, format);
   format = namedFormat || format;
 
@@ -662,7 +662,7 @@ function convertTimezoneToLocal(date: Date, timezone: string, reverse: boolean):
  *
  * @publicApi
  */
-export function toDate(value: string | number | Date): Date {
+export function parseDate(value: string | number | Date): Date {
   if (isDate(value)) {
     return value;
   }

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -641,16 +641,26 @@ function convertTimezoneToLocal(date: Date, timezone: string, reverse: boolean):
 }
 
 /**
- * Converts a value to date.
+ * @ngModule CommonModule
+ * @description
  *
- * Supported input formats:
+ * Converts a value to a `Date` object.
+ *
+ * @param value The value to convert from. Supported input formats:
  * - `Date`
  * - number: timestamp
  * - string: numeric (e.g. "1234"), ISO and date strings in a format supported by
  *   [Date.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
  *   Note: ISO strings without time return a date without timeoffset.
  *
+ * @returns the Date object.
+ *
  * Throws if unable to convert to a date.
+ *
+ * @see `formatDate()`
+ * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n)
+ *
+ * @publicApi
  */
 export function toDate(value: string | number | Date): Date {
   if (isDate(value)) {

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -14,35 +14,35 @@ import localeEnExtra from '@angular/common/locales/extra/en';
 import localeHu from '@angular/common/locales/hu';
 import localeSr from '@angular/common/locales/sr';
 import localeTh from '@angular/common/locales/th';
-import {isDate, toDate, formatDate} from '@angular/common/src/i18n/format_date';
+import {isDate, parseDate, formatDate} from '@angular/common/src/i18n/format_date';
 import {ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID} from '@angular/core';
 
 describe('Format date', () => {
   describe('toDate', () => {
-    it('should support date', () => { expect(isDate(toDate(new Date()))).toBeTruthy(); });
+    it('should support date', () => { expect(isDate(parseDate(new Date()))).toBeTruthy(); });
 
-    it('should support int', () => { expect(isDate(toDate(123456789))).toBeTruthy(); });
+    it('should support int', () => { expect(isDate(parseDate(123456789))).toBeTruthy(); });
 
     it('should support numeric strings',
-       () => { expect(isDate(toDate('123456789'))).toBeTruthy(); });
+       () => { expect(isDate(parseDate('123456789'))).toBeTruthy(); });
 
     it('should support decimal strings',
-       () => { expect(isDate(toDate('123456789.11'))).toBeTruthy(); });
+       () => { expect(isDate(parseDate('123456789.11'))).toBeTruthy(); });
 
     it('should support ISO string',
-       () => { expect(isDate(toDate('2015-06-15T21:43:11Z'))).toBeTruthy(); });
+       () => { expect(isDate(parseDate('2015-06-15T21:43:11Z'))).toBeTruthy(); });
 
-    it('should throw for empty string', () => { expect(() => toDate('')).toThrow(); });
+    it('should throw for empty string', () => { expect(() => parseDate('')).toThrow(); });
 
     it('should throw for alpha numeric strings',
-       () => { expect(() => toDate('123456789 hello')).toThrow(); });
+       () => { expect(() => parseDate('123456789 hello')).toThrow(); });
 
-    it('should throw for NaN', () => { expect(() => toDate(Number.NaN)).toThrow(); });
+    it('should throw for NaN', () => { expect(() => parseDate(Number.NaN)).toThrow(); });
 
     it('should support ISO string without time',
-       () => { expect(isDate(toDate('2015-01-01'))).toBeTruthy(); });
+       () => { expect(isDate(parseDate('2015-01-01'))).toBeTruthy(); });
 
-    it('should throw for objects', () => { expect(() => toDate({} as any)).toThrow(); });
+    it('should throw for objects', () => { expect(() => parseDate({} as any)).toThrow(); });
   });
 
   describe('formatDate', () => {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -425,6 +425,8 @@ export declare class TitleCasePipe implements PipeTransform {
     transform(value: string): string;
 }
 
+export declare function toDate(value: string | number | Date): Date;
+
 export declare enum TranslationWidth {
     Narrow = 0,
     Abbreviated = 1,

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -425,7 +425,7 @@ export declare class TitleCasePipe implements PipeTransform {
     transform(value: string): string;
 }
 
-export declare function toDate(value: string | number | Date): Date;
+export declare function parseDate(value: string | number | Date): Date;
 
 export declare enum TranslationWidth {
     Narrow = 0,


### PR DESCRIPTION
The utility function `toDate` used by `formatDate` function to convert its value param to a `Date` is now available to developers who need it.

Fixes #25480

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
CommonModule only exports `formatDate` function from `i18n/format_date`. Some developers would love the `toDate` function to be exportable as well.

Issue Number: #25480 

## What is the new behavior?
- CommonModule now also exports `toDate` function from `i18n/format_date`.
- Also added `toDate` function to the list of publicApi docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No