### PR TITLE
fix(ivy): quote dots in directive inputs and outputs

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2721,8 +2721,8 @@ describe('ngtsc behavioral tests', () => {
 
       @Directive({
         selector: '[somedir]',
-        inputs: ['track-type', 'track-name', 'inputTrackName'],
-        outputs: ['output-track-type', 'output-track-name', 'outputTrackName']
+        inputs: ['track-type', 'track-name', 'inputTrackName', 'src.xl'],
+        outputs: ['output-track-type', 'output-track-name', 'outputTrackName', 'output.event']
       })
       export class SomeDir {
         @Input('track-type') trackType: string;
@@ -2737,13 +2737,15 @@ describe('ngtsc behavioral tests', () => {
         "track-type": "track-type",
         "track-name": "track-name",
         inputTrackName: "inputTrackName",
+        "src.xl": "src.xl",
         trackType: ["track-type", "trackType"],
         trackName: ["track-name", "trackName"]
       },
       outputs: {
         "output-track-type": "output-track-type",
         "output-track-name": "output-track-name",
-        outputTrackName: "outputTrackName"
+        outputTrackName: "outputTrackName",
+        "output.event": "output.event"
       }
     `;
     expect(trim(jsContents)).toContain(trim(inputsAndOutputs));

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -21,7 +21,7 @@ import {isI18nAttribute} from './i18n/util';
  * TODO(FW-1136): this is a temporary solution, we need to come up with a better way of working with
  * inputs that contain potentially unsafe chars.
  */
-const UNSAFE_OBJECT_KEY_NAME_REGEXP = /-/;
+const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
 
 /** Name of the temporary to use during data binding */
 export const TEMPORARY_NAME = '_t';


### PR DESCRIPTION
A temporary check is in place to determine whether a key in an object
literal needs to be quoted during emit. Previously, only the presence of
a dash caused a key to become quoted, this however is not sufficient for
@angular/flex-layout to compile properly as it has dots in its inputs.

This commit extends the check to also use quotes when a dot is present.

Fixes #30114