### PR TITLE
feat(ivy): support undefined and null in static interpreter

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -100,6 +100,8 @@ export class StaticInterpreter {
       return true;
     } else if (node.kind === ts.SyntaxKind.FalseKeyword) {
       return false;
+    } else if (node.kind === ts.SyntaxKind.NullKeyword) {
+      return null;
     } else if (ts.isStringLiteral(node)) {
       return node.text;
     } else if (ts.isNoSubstitutionTemplateLiteral(node)) {
@@ -215,7 +217,11 @@ export class StaticInterpreter {
   private visitIdentifier(node: ts.Identifier, context: Context): ResolvedValue {
     const decl = this.host.getDeclarationOfIdentifier(node);
     if (decl === null) {
-      return DynamicValue.fromUnknownIdentifier(node);
+      if (node.originalKeywordKind === ts.SyntaxKind.UndefinedKeyword) {
+        return undefined;
+      } else {
+        return DynamicValue.fromUnknownIdentifier(node);
+      }
     }
     const result =
         this.visitDeclaration(decl.node, {...context, ...joinModuleContext(context, node, decl)});

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -172,6 +172,21 @@ runInEachFileSystem(() => {
       expect(evaluate(`const x = 3;`, '!!x')).toEqual(true);
     });
 
+    it('supports boolean literals', () => {
+      expect(evaluate('const a = true;', 'a')).toEqual(true);
+      expect(evaluate('const a = false;', 'a')).toEqual(false);
+    });
+
+    it('supports undefined',
+       () => { expect(evaluate('const a = undefined;', 'a')).toEqual(undefined); });
+
+    it('supports null', () => { expect(evaluate('const a = null;', 'a')).toEqual(null); });
+
+    it('negation works', () => {
+      expect(evaluate(`const x = 3;`, '!x')).toEqual(false);
+      expect(evaluate(`const x = 3;`, '!!x')).toEqual(true);
+    });
+
     it('resolves access from external variable declarations as dynamic value', () => {
       const value = evaluate('declare const window: any;', 'window.location');
       if (!(value instanceof DynamicValue)) {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -182,11 +182,6 @@ runInEachFileSystem(() => {
 
     it('supports null', () => { expect(evaluate('const a = null;', 'a')).toEqual(null); });
 
-    it('negation works', () => {
-      expect(evaluate(`const x = 3;`, '!x')).toEqual(false);
-      expect(evaluate(`const x = 3;`, '!!x')).toEqual(true);
-    });
-
     it('resolves access from external variable declarations as dynamic value', () => {
       const value = evaluate('declare const window: any;', 'window.location');
       if (!(value instanceof DynamicValue)) {


### PR DESCRIPTION
Previously, the usage of `null` and `undefined` keywords in code that is
statically interpreted by ngtsc resulted in a `DynamicValue`, as they were
not recognized as special entities. This commit adds support to interpret
these keywords.
