### PR TITLE
feat(ivy): integrate indexing pipeline with NgtscProgram

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -329,22 +329,24 @@ export class ComponentDecoratorHandler implements
     });
     const scope = this.scopeRegistry.getScopeForComponent(node);
     const selector = analysis.meta.selector;
-    let boundTemplate = null;
+    const matcher = new SelectorMatcher<DirectiveMeta>();
     if (scope !== null) {
-      const matcher = new SelectorMatcher<DirectiveMeta>();
       for (const directive of scope.compilation.directives) {
         const {selector} = directive;
         matcher.addSelectables(CssSelector.parse(selector), directive);
       }
-      const binder = new R3TargetBinder(matcher);
-      boundTemplate = binder.bind({template: template.nodes});
     }
+    const binder = new R3TargetBinder(matcher);
+    const boundTemplate = binder.bind({template: template.nodes});
 
     context.addComponent({
       declaration: node,
       selector,
-      template,
-      scope: boundTemplate,
+      boundTemplate,
+      templateMeta: {
+        isInline: template.isInline,
+        file: template.file,
+      },
     });
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, R3ComponentMetadata, R3TargetBinder, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
-import {ParseTemplateOptions} from '@angular/compiler/src/render3/view/template';
+import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3TargetBinder, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -37,7 +36,7 @@ export interface ComponentHandlerData {
   meta: R3ComponentMetadata;
   parsedTemplate: TmplAstNode[];
   metadataStmt: Statement|null;
-  parseTemplate(options?: ParseTemplateOptions): ParsedTemplate;
+  parseTemplate: (options?: ParseTemplateOptions) => ParsedTemplate;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -332,8 +332,7 @@ export class ComponentDecoratorHandler implements
     const matcher = new SelectorMatcher<DirectiveMeta>();
     if (scope !== null) {
       for (const directive of scope.compilation.directives) {
-        const {selector} = directive;
-        matcher.addSelectables(CssSelector.parse(selector), directive);
+        matcher.addSelectables(CssSelector.parse(directive.selector), directive);
       }
     }
     const binder = new R3TargetBinder(matcher);

--- a/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/BUILD.bazel
@@ -9,6 +9,9 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InterpolationConfig, ParseSourceFile} from '@angular/compiler';
-import {ParseTemplateOptions} from '@angular/compiler/src/render3/view/template';
+import {ParseSourceFile} from '@angular/compiler';
 import * as ts from 'typescript';
 
 /**
@@ -46,17 +45,6 @@ export interface IndexedComponent {
   content: string;
   template: {
     identifiers: Set<TemplateIdentifier>,
-    usedComponents: Set<ts.ClassDeclaration>,
+    usedComponents: Set<ts.Declaration>,
   };
-}
-
-/**
- * Options for restoring a parsed template. See `template.ts#restoreTemplate`.
- */
-export interface RestoreTemplateOptions extends ParseTemplateOptions {
-  /**
-   * The interpolation configuration of the template is lost after it already
-   * parsed, so it must be respecified.
-   */
-  interpolationConfig: InterpolationConfig;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -32,7 +32,6 @@ export interface TemplateIdentifier {
   name: string;
   span: AbsoluteSourceSpan;
   kind: IdentifierKind;
-  file: ParseSourceFile;
 }
 
 /**
@@ -41,10 +40,11 @@ export interface TemplateIdentifier {
 export interface IndexedComponent {
   name: string;
   selector: string|null;
-  sourceFile: string;
-  content: string;
+  file: ParseSourceFile;
   template: {
     identifiers: Set<TemplateIdentifier>,
     usedComponents: Set<ts.Declaration>,
+    isInline: boolean,
+    file: ParseSourceFile;
   };
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, DirectiveMeta, ParseSourceFile, TmplAstNode} from '@angular/compiler';
+import {BoundTarget, DirectiveMeta, ParseSourceFile} from '@angular/compiler';
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
@@ -28,24 +28,20 @@ export interface ComponentInfo {
   /** Component template selector if it exists, otherwise null. */
   selector: string|null;
 
-  /** Parsed component template */
-  template: {
-    /** Template nodes */
-    nodes: TmplAstNode[];
+  /**
+   * BoundTarget containing the parsed template. Can also be used to query for directives used in
+   * the template.
+   */
+  boundTemplate: BoundTarget<ComponentMeta>;
 
+  /** Metadata about the template */
+  templateMeta: {
     /** Whether the component template is inline */
     isInline: boolean;
 
     /** Template file recorded by template parser */
     file: ParseSourceFile;
   };
-
-  /**
-   * BoundTarget containing the parsed template. Can be used to query for directives used in the
-   * template.
-   * Null if there is no registry of the component by the decorator handler.
-   */
-  scope: BoundTarget<ComponentMeta>|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,8 +6,48 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BoundTarget, DirectiveMeta, TmplAstNode} from '@angular/compiler';
+import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {Reference} from '../../imports';
+import {ClassDeclaration} from '../../reflection';
+
+export interface ComponentMeta extends DirectiveMeta {
+  ref: Reference<ClassDeclaration>;
+  /**
+   * Unparsed selector of the directive.
+   */
+  selector: string;
+}
+
+/**
+ * An intermediate representation of a component.
+ */
+export interface ComponentInfo {
+  /** Component TypeScript class declaration */
+  declaration: ClassDeclaration;
+
+  /** Component template selector */
+  selector: string|null;
+
+  /** Parsed component template */
+  template: TmplAstNode[];
+
+  /**
+   * BoundTarget containing the parsed template. Can be used to query for directives used in the
+   * template.
+   */
+  scope: BoundTarget<ComponentMeta>|null;
+}
+
 /**
  * Stores analysis information about components in a compilation for and provides methods for
- * querying information about components to be used in indexing.
+ * querying information about components.
  */
-export class IndexingContext {}
+export class IndexingContext {
+  readonly components = new Set<ComponentInfo>();
+
+  /**
+   * Adds a component to the context.
+   */
+  addComponent(info: ComponentInfo) { this.components.add(info); }
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -25,7 +25,7 @@ export interface ComponentInfo {
   /** Component TypeScript class declaration */
   declaration: ClassDeclaration;
 
-  /** Component template selector */
+  /** Component template selector if it exists, otherwise null. */
   selector: string|null;
 
   /** Parsed component template */
@@ -43,13 +43,16 @@ export interface ComponentInfo {
   /**
    * BoundTarget containing the parsed template. Can be used to query for directives used in the
    * template.
+   * Null if there is no registry of the component by the decorator handler.
    */
   scope: BoundTarget<ComponentMeta>|null;
 }
 
 /**
- * Stores analysis information about components in a compilation for and provides methods for
- * querying information about components.
+ * A context for storing indexing infromation about components of a program.
+ *
+ * An `IndexingContext` collects component and template analysis information from
+ * `DecoratorHandler`s and exposes them to be indexed.
  */
 export class IndexingContext {
   readonly components = new Set<ComponentInfo>();

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, DirectiveMeta, TmplAstNode} from '@angular/compiler';
-import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {BoundTarget, DirectiveMeta, ParseSourceFile, TmplAstNode} from '@angular/compiler';
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
@@ -30,7 +29,16 @@ export interface ComponentInfo {
   selector: string|null;
 
   /** Parsed component template */
-  template: TmplAstNode[];
+  template: {
+    /** Template nodes */
+    nodes: TmplAstNode[];
+
+    /** Whether the component template is inline */
+    isInline: boolean;
+
+    /** Template file recorded by template parser */
+    file: ParseSourceFile;
+  }
 
   /**
    * BoundTarget containing the parsed template. Can be used to query for directives used in the

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -38,7 +38,7 @@ export interface ComponentInfo {
 
     /** Template file recorded by template parser */
     file: ParseSourceFile;
-  }
+  };
 
   /**
    * BoundTarget containing the parsed template. Can be used to query for directives used in the

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -55,16 +55,21 @@ class ExpressionVisitor extends RecursiveAstVisitor {
   visit(ast: AST) { ast.visit(this); }
 
   visitMethodCall(ast: MethodCall, context: {}) {
-    this.addIdentifier(ast, IdentifierKind.Method);
+    this.visitIdentifier(ast, IdentifierKind.Method);
     super.visitMethodCall(ast, context);
   }
 
   visitPropertyRead(ast: PropertyRead, context: {}) {
-    this.addIdentifier(ast, IdentifierKind.Property);
+    this.visitIdentifier(ast, IdentifierKind.Property);
     super.visitPropertyRead(ast, context);
   }
 
-  private addIdentifier(ast: AST&{name: string, receiver: AST}, kind: IdentifierKind) {
+  /**
+   * Visits an identifier, adding it to the identifier store if it is useful for indexing.
+   * @param ast expression AST the identifier is in
+   * @param kind identifier kind
+   */
+  private visitIdentifier(ast: AST&{name: string, receiver: AST}, kind: IdentifierKind) {
     // The definition of a non-top-level property such as `bar` in `{{foo.bar}}` is currently
     // impossible to determine by an indexer and unsupported by the indexing module.
     // The indexing module also does not currently support references to identifiers declared in the

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -6,12 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, HtmlParser, Lexer, MethodCall, ParseSourceFile, PropertyRead, RecursiveAstVisitor, TmplAstNode, TokenType, visitAll} from '@angular/compiler';
+import {AST, MethodCall, PropertyRead, RecursiveAstVisitor, TmplAstNode} from '@angular/compiler';
+import {ImplicitReceiver} from '@angular/compiler/src/compiler';
 import {BoundText, Element, Node, RecursiveVisitor as RecursiveTemplateVisitor, Template} from '@angular/compiler/src/render3/r3_ast';
-import {htmlAstToRender3Ast} from '@angular/compiler/src/render3/r3_template_transform';
-import {I18nMetaVisitor} from '@angular/compiler/src/render3/view/i18n/meta';
-import {makeBindingParser} from '@angular/compiler/src/render3/view/template';
-import {AbsoluteSourceSpan, IdentifierKind, RestoreTemplateOptions, TemplateIdentifier} from './api';
+import {AbsoluteSourceSpan, IdentifierKind, TemplateIdentifier} from './api';
 
 /**
  * A parsed node in a template, which may have a name (if it is a selector) or
@@ -20,46 +18,6 @@ import {AbsoluteSourceSpan, IdentifierKind, RestoreTemplateOptions, TemplateIden
 interface HTMLNode extends Node {
   tagName?: string;
   name?: string;
-}
-
-/**
- * Updates the location of an identifier to its real anchor in a source code.
- *
- * The compiler's expression parser records the location of some expressions in a manner not
- * useful to the indexer. For example, a `MethodCall` `foo(a, b)` will record the span of the
- * entire method call, but the indexer is interested only in the method identifier.
- *
- * To remedy all this, the visitor tokenizes the template node the expression was discovered in,
- * and updates the locations of entities found during expression traversal with those of the
- * tokens.
- *
- * TODO(ayazhafiz): Think about how to handle `PropertyRead`s in `BoundAttribute`s. The Lexer
- * tokenizes the attribute as a string and ignores quotes.
- *
- * @param entities entities to update
- * @param currentNode node expression was in
- */
-function updateIdentifierSpans(identifiers: TemplateIdentifier[], currentNode: Node) {
-  const localSpan = currentNode.sourceSpan;
-  const localExpression = localSpan.toString();
-
-  const lexedIdentifiers =
-      new Lexer().tokenize(localExpression).filter(token => token.type === TokenType.Identifier);
-
-  // Join the relative position of the expression within a node with the absolute position of the
-  // node to get the absolute position of the expression in the source code.
-  const absoluteOffset = currentNode.sourceSpan.start.offset;
-  identifiers.forEach((id, index) => {
-    const lexedId = lexedIdentifiers[index];
-    if (id.name !== lexedId.strValue) {
-      throw new Error(
-          'Impossible state: lexed and parsed expression should contain the same tokens.');
-    }
-
-    const start = absoluteOffset + lexedId.index;
-    const absoluteSpan = new AbsoluteSourceSpan(start, start + lexedId.strValue.length);
-    id.span = absoluteSpan;
-  });
 }
 
 /**
@@ -72,22 +30,19 @@ function updateIdentifierSpans(identifiers: TemplateIdentifier[], currentNode: N
  * 11}}]`.
  */
 class ExpressionVisitor extends RecursiveAstVisitor {
-  private readonly file: ParseSourceFile;
+  readonly identifiers: TemplateIdentifier[] = [];
 
-  private constructor(context: Node, readonly identifiers: TemplateIdentifier[] = []) {
+  private constructor(
+      context: Node, private readonly expressionStr = context.sourceSpan.toString(),
+      private readonly absoluteOffset = context.sourceSpan.start.offset,
+      private readonly file = context.sourceSpan.start.file, ) {
     super();
-
-    this.file = context.sourceSpan.start.file;
   }
 
   static getIdentifiers(ast: AST, context: Node): TemplateIdentifier[] {
     const visitor = new ExpressionVisitor(context);
     visitor.visit(ast);
-    const identifiers = visitor.identifiers;
-
-    updateIdentifierSpans(identifiers, context);
-
-    return identifiers;
+    return visitor.identifiers;
   }
 
   visit(ast: AST) { ast.visit(this); }
@@ -102,12 +57,27 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     super.visitPropertyRead(ast, context);
   }
 
-  private addIdentifier(ast: AST&{name: string}, kind: IdentifierKind) {
-    this.identifiers.push({
-      name: ast.name,
-      span: ast.span, kind,
-      file: this.file,
-    });
+  private addIdentifier(ast: AST&{name: string, receiver: AST}, kind: IdentifierKind) {
+    if (ast.receiver instanceof ImplicitReceiver) {
+      // Get the location of the identifier of real interest.
+      // The compiler's expression parser records the location of some expressions in a manner not
+      // useful to the indexer. For example, a `MethodCall` `foo(a, b)` will record the span of the
+      // entire method call, but the indexer is interested only in the method identifier.
+      const localExpression = this.expressionStr.substr(ast.span.start, ast.span.end);
+      const identifierStart = ast.span.start + localExpression.indexOf(ast.name);
+
+      // Join the relative position of the expression within a node with the absolute position
+      // of the node to get the absolute position of the expression in the source code.
+      const absoluteStart = this.absoluteOffset + identifierStart;
+      const span = new AbsoluteSourceSpan(absoluteStart, absoluteStart + ast.name.length);
+
+      this.identifiers.push({
+        name: ast.name,
+        span,
+        kind,
+        file: this.file,
+      });
+    }
   }
 }
 
@@ -152,58 +122,13 @@ class TemplateVisitor extends RecursiveTemplateVisitor {
 }
 
 /**
- * Unwraps and reparses a template, preserving whitespace and with no leading trivial characters.
- *
- * A template may previously have been parsed without preserving whitespace, and was definitely
- * parsed with leading trivial characters (see `parseTemplate` from the compiler package API).
- * Both of these are detrimental for indexing as they result in a manipulated AST not representing
- * the template source code.
- *
- * TODO(ayazhafiz): Remove once issues with `leadingTriviaChars` and `parseTemplate` are resolved.
- */
-function restoreTemplate(template: TmplAstNode[], options: RestoreTemplateOptions): TmplAstNode[] {
-  // try to recapture the template content and URL
-  // if there was nothing in the template to begin with, this is just a no-op
-  if (template.length === 0) {
-    return [];
-  }
-  const {content: templateStr, url: templateUrl} = template[0].sourceSpan.start.file;
-
-  options.preserveWhitespaces = true;
-  const {interpolationConfig, preserveWhitespaces} = options;
-
-  const bindingParser = makeBindingParser(interpolationConfig);
-  const htmlParser = new HtmlParser();
-  const parseResult = htmlParser.parse(templateStr, templateUrl, {
-    ...options,
-    tokenizeExpansionForms: true,
-  });
-
-  if (parseResult.errors && parseResult.errors.length > 0) {
-    throw new Error('Impossible state: template must have been successfully parsed previously.');
-  }
-
-  const rootNodes = visitAll(
-      new I18nMetaVisitor(interpolationConfig, !preserveWhitespaces), parseResult.rootNodes);
-
-  const {nodes, errors} = htmlAstToRender3Ast(rootNodes, bindingParser);
-  if (errors && errors.length > 0) {
-    throw new Error('Impossible state: template must have been successfully parsed previously.');
-  }
-
-  return nodes;
-}
-
-/**
  * Traverses a template AST and builds identifiers discovered in it.
  * @param template template to extract indentifiers from
  * @param options options for restoring the parsed template to a indexable state
  * @return identifiers in template
  */
-export function getTemplateIdentifiers(
-    template: TmplAstNode[], options: RestoreTemplateOptions): Set<TemplateIdentifier> {
-  const restoredTemplate = restoreTemplate(template, options);
+export function getTemplateIdentifiers(template: TmplAstNode[]): Set<TemplateIdentifier> {
   const visitor = new TemplateVisitor();
-  visitor.visitAll(restoredTemplate);
+  visitor.visitAll(template);
   return visitor.identifiers;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BoundTarget, DirectiveMeta, ImplicitReceiver, MethodCall, PropertyRead, R3TargetBinder, RecursiveAstVisitor, SelectorMatcher, TmplAstNode} from '@angular/compiler';
+import {AST, BoundTarget, DirectiveMeta, ImplicitReceiver, MethodCall, PropertyRead, RecursiveAstVisitor} from '@angular/compiler';
 import {BoundText, Element, Node, RecursiveVisitor as RecursiveTemplateVisitor, Template} from '@angular/compiler/src/render3/r3_ast';
 import {AbsoluteSourceSpan, IdentifierKind, TemplateIdentifier} from './api';
 
@@ -40,6 +40,7 @@ class ExpressionVisitor extends RecursiveAstVisitor {
 
   /**
    * Returns identifiers discovered in an expression.
+   *
    * @param ast expression AST to visit
    * @param context HTML node expression is defined in
    * @param boundTemplate bound target of the entire template, which can be used to query for the
@@ -66,6 +67,7 @@ class ExpressionVisitor extends RecursiveAstVisitor {
 
   /**
    * Visits an identifier, adding it to the identifier store if it is useful for indexing.
+   *
    * @param ast expression AST the identifier is in
    * @param kind identifier kind
    */
@@ -110,12 +112,14 @@ class TemplateVisitor extends RecursiveTemplateVisitor {
   /**
    * Creates a template visitor for a bound template target. The bound target can be used when
    * deferred to the expression visitor to get information about the target of an expression.
+   *
    * @param boundTemplate bound template target
    */
   constructor(private boundTemplate: BoundTarget<DirectiveMeta>) { super(); }
 
   /**
    * Visits a node in the template.
+   *
    * @param node node to visit
    */
   visit(node: HTMLNode) { node.visit(this); }
@@ -137,6 +141,7 @@ class TemplateVisitor extends RecursiveTemplateVisitor {
 
   /**
    * Visits a node's expression and adds its identifiers, if any, to the visitor's state.
+   *
    * @param curretNode node whose expression to visit
    */
   private visitExpression(node: Node&{value: AST}) {
@@ -147,13 +152,15 @@ class TemplateVisitor extends RecursiveTemplateVisitor {
 
 /**
  * Traverses a template AST and builds identifiers discovered in it.
- * @param template template to extract indentifiers from
- * @param options options for restoring the parsed template to a indexable state
+ *
+ * @param boundTemplate bound template target, which can be used for querying expression targets.
  * @return identifiers in template
  */
-export function getTemplateIdentifiers(template: TmplAstNode[]): Set<TemplateIdentifier> {
-  const boundTemplate = new R3TargetBinder(new SelectorMatcher()).bind({template});
+export function getTemplateIdentifiers(boundTemplate: BoundTarget<DirectiveMeta>):
+    Set<TemplateIdentifier> {
   const visitor = new TemplateVisitor(boundTemplate);
-  visitor.visitAll(template);
+  if (boundTemplate.target.template !== undefined) {
+    visitor.visitAll(boundTemplate.target.template);
+  }
   return visitor.identifiers;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -34,8 +34,7 @@ class ExpressionVisitor extends RecursiveAstVisitor {
 
   private constructor(
       context: Node, private readonly expressionStr = context.sourceSpan.toString(),
-      private readonly absoluteOffset = context.sourceSpan.start.offset,
-      private readonly file = context.sourceSpan.start.file, ) {
+      private readonly absoluteOffset = context.sourceSpan.start.offset) {
     super();
   }
 
@@ -75,7 +74,6 @@ class ExpressionVisitor extends RecursiveAstVisitor {
         name: ast.name,
         span,
         kind,
-        file: this.file,
       });
     }
   }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -30,7 +30,7 @@ export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, 
         if (dir.isComponent) {
           usedComponents.add(dir.ref.node);
         }
-      })
+      });
     }
 
     analysis.set(declaration, {

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -21,28 +21,26 @@ import {getTemplateIdentifiers} from './template';
 export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, IndexedComponent> {
   const analysis = new Map<ts.Declaration, IndexedComponent>();
 
-  context.components.forEach(({declaration, selector, scope, template}) => {
+  context.components.forEach(({declaration, selector, boundTemplate, templateMeta}) => {
     const name = declaration.name.getText();
 
     const usedComponents = new Set<ts.Declaration>();
-    if (scope) {
-      const usedDirs = scope.getUsedDirectives();
-      usedDirs.forEach(dir => {
-        if (dir.isComponent) {
-          usedComponents.add(dir.ref.node);
-        }
-      });
-    }
+    const usedDirs = boundTemplate.getUsedDirectives();
+    usedDirs.forEach(dir => {
+      if (dir.isComponent) {
+        usedComponents.add(dir.ref.node);
+      }
+    });
 
     // Get source files for the component and the template. If the template is inline, its source
     // file is the component's.
     const componentFile = new ParseSourceFile(
         declaration.getSourceFile().getFullText(), declaration.getSourceFile().fileName);
     let templateFile: ParseSourceFile;
-    if (template.isInline) {
+    if (templateMeta.isInline) {
       templateFile = componentFile;
     } else {
-      templateFile = template.file;
+      templateFile = templateMeta.file;
     }
 
     analysis.set(declaration, {
@@ -50,9 +48,9 @@ export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, 
       selector,
       file: componentFile,
       template: {
-        identifiers: getTemplateIdentifiers(template.nodes),
+        identifiers: getTemplateIdentifiers(boundTemplate),
         usedComponents,
-        isInline: template.isInline,
+        isInline: templateMeta.isInline,
         file: templateFile,
       },
     });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/BUILD.bazel
@@ -10,7 +10,11 @@ ts_library(
     ]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/indexer",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/testing",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -7,10 +7,8 @@
  */
 
 import {ParseSourceFile, R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
-
 import {DirectiveMeta} from '../../metadata';
 import {IndexingContext} from '../src/context';
-
 import * as util from './util';
 
 describe('ComponentAnalysisContext', () => {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {IndexingContext} from '../src/context';
+import * as util from './util';
+
+describe('ComponentAnalysisContext', () => {
+  it('should store and return information about components', () => {
+    const context = new IndexingContext();
+    const declaration = util.getComponentDeclaration('class C {};', 'C');
+    const template = util.getParsedTemplate('<div></div>');
+    const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
+    const scope = binder.bind({template});
+
+    context.addComponent({
+      declaration,
+      selector: 'c-selector', template, scope,
+    });
+    context.addComponent({
+      declaration,
+      selector: null,
+      template: [],
+      scope: null,
+    });
+
+    expect(context.components).toEqual(new Set([
+      {
+        declaration,
+        selector: 'c-selector', template, scope,
+      },
+      {
+        declaration,
+        selector: null,
+        template: [],
+        scope: null,
+      },
+    ]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseSourceFile, R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+import {ParseSourceFile, R3TargetBinder, SelectorMatcher} from '@angular/compiler';
 import {DirectiveMeta} from '../../metadata';
 import {IndexingContext} from '../src/context';
 import * as util from './util';

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -6,39 +6,61 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+import {ParseSourceFile, R3TargetBinder, SelectorMatcher} from '@angular/compiler/src/compiler';
+
 import {DirectiveMeta} from '../../metadata';
 import {IndexingContext} from '../src/context';
+
 import * as util from './util';
 
 describe('ComponentAnalysisContext', () => {
   it('should store and return information about components', () => {
     const context = new IndexingContext();
     const declaration = util.getComponentDeclaration('class C {};', 'C');
-    const template = util.getParsedTemplate('<div></div>');
+    const templateNodes = util.getParsedTemplate('<div></div>');
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
-    const scope = binder.bind({template});
+    const scope = binder.bind({template: templateNodes});
 
     context.addComponent({
       declaration,
-      selector: 'c-selector', template, scope,
+      selector: 'c-selector',
+      template: {
+        nodes: templateNodes,
+        isInline: false,
+        file: new ParseSourceFile('<div></div>', util.TESTFILE),
+      },
+      scope,
     });
     context.addComponent({
       declaration,
       selector: null,
-      template: [],
+      template: {
+        nodes: [],
+        isInline: false,
+        file: new ParseSourceFile('', util.TESTFILE),
+      },
       scope: null,
     });
 
     expect(context.components).toEqual(new Set([
       {
         declaration,
-        selector: 'c-selector', template, scope,
+        selector: 'c-selector',
+        template: {
+          nodes: templateNodes,
+          isInline: false,
+          file: new ParseSourceFile('<div></div>', util.TESTFILE),
+        },
+        scope,
       },
       {
         declaration,
         selector: null,
-        template: [],
+        template: {
+          nodes: [],
+          isInline: false,
+          file: new ParseSourceFile('', util.TESTFILE),
+        },
         scope: null,
       },
     ]));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseSourceFile, R3TargetBinder, SelectorMatcher} from '@angular/compiler';
-import {DirectiveMeta} from '../../metadata';
+import {ParseSourceFile} from '@angular/compiler';
 import {IndexingContext} from '../src/context';
 import * as util from './util';
 
@@ -15,51 +14,25 @@ describe('ComponentAnalysisContext', () => {
   it('should store and return information about components', () => {
     const context = new IndexingContext();
     const declaration = util.getComponentDeclaration('class C {};', 'C');
-    const templateNodes = util.getParsedTemplate('<div></div>');
-    const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
-    const scope = binder.bind({template: templateNodes});
+    const boundTemplate = util.getBoundTemplate('<div></div>');
 
     context.addComponent({
       declaration,
-      selector: 'c-selector',
-      template: {
-        nodes: templateNodes,
+      selector: 'c-selector', boundTemplate,
+      templateMeta: {
         isInline: false,
         file: new ParseSourceFile('<div></div>', util.TESTFILE),
       },
-      scope,
-    });
-    context.addComponent({
-      declaration,
-      selector: null,
-      template: {
-        nodes: [],
-        isInline: false,
-        file: new ParseSourceFile('', util.TESTFILE),
-      },
-      scope: null,
     });
 
     expect(context.components).toEqual(new Set([
       {
         declaration,
-        selector: 'c-selector',
-        template: {
-          nodes: templateNodes,
+        selector: 'c-selector', boundTemplate,
+        templateMeta: {
           isInline: false,
           file: new ParseSourceFile('<div></div>', util.TESTFILE),
         },
-        scope,
-      },
-      {
-        declaration,
-        selector: null,
-        template: {
-          nodes: [],
-          isInline: false,
-          file: new ParseSourceFile('', util.TESTFILE),
-        },
-        scope: null,
       },
     ]));
   });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -7,52 +7,49 @@
  */
 
 import {InterpolationConfig, ParseSourceFile, TmplAstNode, parseTemplate} from '@angular/compiler';
-import {AbsoluteSourceSpan, IdentifierKind, RestoreTemplateOptions} from '..';
+import {AbsoluteSourceSpan, IdentifierKind} from '..';
 import {getTemplateIdentifiers} from '../src/template';
 
 const TEST_FILE = 'TEST';
 
 function parse(template: string): TmplAstNode[] {
-  return parseTemplate(template, TEST_FILE).nodes;
+  return parseTemplate(template, TEST_FILE, {
+           preserveWhitespaces: true,
+           leadingTriviaChars: [],
+         })
+      .nodes;
 }
 
 describe('getTemplateIdentifiers', () => {
-  const DEFAULT_RESTORE_OPTIONS:
-      RestoreTemplateOptions = {interpolationConfig: new InterpolationConfig('{{', '}}')};
-
   it('should generate nothing in HTML-only template', () => {
-    const refs = getTemplateIdentifiers(parse('<div></div>'), DEFAULT_RESTORE_OPTIONS);
+    const refs = getTemplateIdentifiers(parse('<div></div>'));
 
     expect(refs.size).toBe(0);
   });
 
   it('should ignore comments', () => {
-    const refs = getTemplateIdentifiers(
-        parse(`
+    const refs = getTemplateIdentifiers(parse(`
     <!-- {{my_module}} -->
     <div><!-- {{goodbye}} --></div>
-    `),
-        DEFAULT_RESTORE_OPTIONS);
+    `));
 
     expect(refs.size).toBe(0);
   });
 
-  it('should use any interpolation config', () => {
-    const template = '<div>((foo))</div>';
-    const refs = getTemplateIdentifiers(
-        parse(template), {interpolationConfig: new InterpolationConfig('((', '))')});
-
-    const [ref] = Array.from(refs);
-    expect(ref.name).toBe('foo');
-    expect(ref.kind).toBe(IdentifierKind.Property);
-    expect(ref.span).toEqual(new AbsoluteSourceSpan(7, 10));
-    expect(ref.file).toEqual(new ParseSourceFile(template, TEST_FILE));
-  });
-
   describe('generates identifiers for PropertyReads', () => {
+    it('should ignore identifiers that are not implicitly received by the template', () => {
+      const template = '<div>{{foo.bar.baz}} {{m().p}}</div>';
+      const refs = getTemplateIdentifiers(parse(template));
+      expect(refs.size).toBe(2);
+
+      const [foo, m] = Array.from(refs);
+      expect(foo.name).toBe('foo');
+      expect(m.name).toBe('m');
+    });
+
     it('should discover component properties', () => {
       const template = '<div>{{foo}}</div>';
-      const refs = getTemplateIdentifiers(parse(template), DEFAULT_RESTORE_OPTIONS);
+      const refs = getTemplateIdentifiers(parse(template));
       expect(refs.size).toBe(1);
 
       const [ref] = Array.from(refs);
@@ -64,7 +61,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should discover component method calls', () => {
       const template = '<div>{{foo()}}</div>';
-      const refs = getTemplateIdentifiers(parse(template), DEFAULT_RESTORE_OPTIONS);
+      const refs = getTemplateIdentifiers(parse(template));
 
       const [ref] = Array.from(refs);
       expect(ref.name).toBe('foo');
@@ -75,7 +72,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should handle arbitrary whitespace', () => {
       const template = '<div>\n\n   {{foo}}</div>';
-      const refs = getTemplateIdentifiers(parse(template), DEFAULT_RESTORE_OPTIONS);
+      const refs = getTemplateIdentifiers(parse(template));
 
       const [ref] = Array.from(refs);
       expect(ref.name).toBe('foo');
@@ -86,7 +83,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should handle nested scopes', () => {
       const template = '<div><span>{{foo}}</span></div>';
-      const refs = getTemplateIdentifiers(parse(template), DEFAULT_RESTORE_OPTIONS);
+      const refs = getTemplateIdentifiers(parse(template));
 
       const [ref] = Array.from(refs);
       expect(ref.name).toBe('foo');

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -44,6 +44,18 @@ describe('getTemplateIdentifiers', () => {
     });
   });
 
+  it('should ignore identifiers defined in the template', () => {
+    const template = `
+      <input #model />
+      {{model.valid}}
+    `;
+    const refs = getTemplateIdentifiers(parse(template));
+
+    const refArr = Array.from(refs);
+    const modelId = refArr.find(ref => ref.name === 'model');
+    expect(modelId).toBeUndefined();
+  });
+
   describe('generates identifiers for PropertyReads', () => {
     it('should discover component properties', () => {
       const template = '{{foo}}';

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -6,35 +6,33 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TmplAstNode, parseTemplate} from '@angular/compiler';
 import {AbsoluteSourceSpan, IdentifierKind} from '..';
 import {getTemplateIdentifiers} from '../src/template';
-import {TESTFILE} from './util';
+import * as util from './util';
 
-function parse(template: string): TmplAstNode[] {
-  return parseTemplate(template, TESTFILE, {
-           preserveWhitespaces: true,
-           leadingTriviaChars: [],
-         })
-      .nodes;
+function bind(template: string) {
+  return util.getBoundTemplate(template, {
+    preserveWhitespaces: true,
+    leadingTriviaChars: [],
+  });
 }
 
 describe('getTemplateIdentifiers', () => {
   it('should generate nothing in HTML-only template', () => {
-    const refs = getTemplateIdentifiers(parse('<div></div>'));
+    const refs = getTemplateIdentifiers(bind('<div></div>'));
 
     expect(refs.size).toBe(0);
   });
 
   it('should ignore comments', () => {
-    const refs = getTemplateIdentifiers(parse('<!-- {{comment}} -->'));
+    const refs = getTemplateIdentifiers(bind('<!-- {{comment}} -->'));
 
     expect(refs.size).toBe(0);
   });
 
   it('should handle arbitrary whitespace', () => {
     const template = '<div>\n\n   {{foo}}</div>';
-    const refs = getTemplateIdentifiers(parse(template));
+    const refs = getTemplateIdentifiers(bind(template));
 
     const [ref] = Array.from(refs);
     expect(ref).toEqual({
@@ -49,7 +47,7 @@ describe('getTemplateIdentifiers', () => {
       <input #model />
       {{model.valid}}
     `;
-    const refs = getTemplateIdentifiers(parse(template));
+    const refs = getTemplateIdentifiers(bind(template));
 
     const refArr = Array.from(refs);
     const modelId = refArr.find(ref => ref.name === 'model');
@@ -59,7 +57,7 @@ describe('getTemplateIdentifiers', () => {
   describe('generates identifiers for PropertyReads', () => {
     it('should discover component properties', () => {
       const template = '{{foo}}';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
       expect(refs.size).toBe(1);
 
       const [ref] = Array.from(refs);
@@ -72,7 +70,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should discover nested properties', () => {
       const template = '<div><span>{{foo}}</span></div>';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
 
       const refArr = Array.from(refs);
       expect(refArr).toEqual(jasmine.arrayContaining([{
@@ -84,7 +82,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should ignore identifiers that are not implicitly received by the template', () => {
       const template = '{{foo.bar.baz}}';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
       expect(refs.size).toBe(1);
 
       const [ref] = Array.from(refs);
@@ -95,7 +93,7 @@ describe('getTemplateIdentifiers', () => {
   describe('generates identifiers for MethodCalls', () => {
     it('should discover component method calls', () => {
       const template = '{{foo()}}';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
       expect(refs.size).toBe(1);
 
       const [ref] = Array.from(refs);
@@ -108,7 +106,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should discover nested properties', () => {
       const template = '<div><span>{{foo()}}</span></div>';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
 
       const refArr = Array.from(refs);
       expect(refArr).toEqual(jasmine.arrayContaining([{
@@ -120,7 +118,7 @@ describe('getTemplateIdentifiers', () => {
 
     it('should ignore identifiers that are not implicitly received by the template', () => {
       const template = '{{foo().bar().baz()}}';
-      const refs = getTemplateIdentifiers(parse(template));
+      const refs = getTemplateIdentifiers(bind(template));
       expect(refs.size).toBe(1);
 
       const [ref] = Array.from(refs);

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BoundTarget} from '@angular/compiler';
+import {InterpolationConfig} from '@angular/compiler/src/compiler';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+import {IndexingContext} from '../src/context';
+import {getTemplateIdentifiers} from '../src/template';
+import {generateAnalysis} from '../src/transform';
+
+import * as util from './util';
+
+/**
+ * Adds information about a component to a context.
+ */
+function populateContext(
+    context: IndexingContext, component: ClassDeclaration, selector: string, template: string,
+    scope: BoundTarget<DirectiveMeta>| null) {
+  const parsedTemplate = util.getParsedTemplate(template);
+  context.addComponent({
+    declaration: component,
+    template: parsedTemplate, selector, scope,
+  });
+}
+
+describe('generateAnalysis', () => {
+  it('should emit analysis information', () => {
+    const context = new IndexingContext();
+    const decl = util.getComponentDeclaration('class C {}', 'C');
+    populateContext(context, decl, 'c-selector', '<div>{{foo}}</div>', null);
+    const analysis = generateAnalysis(context);
+
+    expect(analysis.size).toBe(1);
+
+    const info = analysis.get(decl);
+    expect(info).toEqual({
+      content: 'class C {}',
+      name: 'C',
+      selector: 'c-selector',
+      sourceFile: util.TESTFILE,
+      template: {
+        identifiers: getTemplateIdentifiers(util.getParsedTemplate('<div>{{foo}}</div>')),
+        usedComponents: new Set(),
+      }
+    });
+  });
+
+  it('should emit used components', () => {
+    const context = new IndexingContext();
+
+    const templateA = '<b-selector></b-selector>';
+    const declA = util.getComponentDeclaration('class A {}', 'A');
+
+    const templateB = '<a-selector></a-selector>';
+    const declB = util.getComponentDeclaration('class B {}', 'B');
+
+    const scopeA = util.bindTemplate(templateA, [{selector: 'b-selector', declaration: declB}]);
+    const scopeB = util.bindTemplate(templateB, [{selector: 'a-selector', declaration: declA}]);
+
+    populateContext(context, declA, 'a-selector', templateA, scopeA);
+    populateContext(context, declB, 'b-selector', templateB, scopeB);
+
+    const analysis = generateAnalysis(context);
+
+    expect(analysis.size).toBe(2);
+
+    const infoA = analysis.get(declA);
+    expect(infoA).toBeDefined();
+    expect(infoA !.template.usedComponents).toEqual(new Set([declB]));
+
+    const infoB = analysis.get(declB);
+    expect(infoB).toBeDefined();
+    expect(infoB !.template.usedComponents).toEqual(new Set([declA]));
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -6,14 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget} from '@angular/compiler';
-import {ParseSourceFile} from '@angular/compiler/src/compiler';
+import {BoundTarget, ParseSourceFile} from '@angular/compiler';
 import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 import {IndexingContext} from '../src/context';
 import {getTemplateIdentifiers} from '../src/template';
 import {generateAnalysis} from '../src/transform';
-
 import * as util from './util';
 
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -70,7 +70,7 @@ describe('generateAnalysis', () => {
     const info = analysis.get(decl);
     expect(info).toBeDefined();
     expect(info !.template.file).toEqual(new ParseSourceFile('class C {}', util.TESTFILE));
-  })
+  });
 
   it('should give external templates their own source file', () => {
     const context = new IndexingContext();

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -81,7 +81,7 @@ describe('generateAnalysis', () => {
     const info = analysis.get(decl);
     expect(info).toBeDefined();
     expect(info !.template.file).toEqual(new ParseSourceFile('<div>{{foo}}</div>', util.TESTFILE));
-  })
+  });
 
   it('should emit used components', () => {
     const context = new IndexingContext();

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BoundTarget, CssSelector, R3TargetBinder, SelectorMatcher, TmplAstNode, parseTemplate} from '@angular/compiler/src/compiler';
+import * as ts from 'typescript';
+import {Reference} from '../../imports';
+import {DirectiveMeta} from '../../metadata';
+import {ClassDeclaration} from '../../reflection';
+import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
+
+/** Dummy file URL */
+export const TESTFILE = '/TESTFILE.ts';
+
+/**
+ * Creates a class declaration from a component source code.
+ */
+export function getComponentDeclaration(componentStr: string, className: string): ClassDeclaration {
+  const program = makeProgram([{name: TESTFILE, contents: componentStr}]);
+
+  return getDeclaration(
+      program.program, TESTFILE, className,
+      (value: ts.Declaration): value is ClassDeclaration => ts.isClassDeclaration(value));
+}
+
+/**
+ * Parses a template source code.
+ */
+export function getParsedTemplate(template: string): TmplAstNode[] {
+  return parseTemplate(template, TESTFILE).nodes;
+}
+
+/**
+ * Binds information about a component on a template (a target). The BoundTarget
+ * describes the scope of the template and can be queried for directives the
+ * template uses.
+ */
+export function bindTemplate(
+    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
+    BoundTarget<DirectiveMeta> {
+  const matcher = new SelectorMatcher<DirectiveMeta>();
+  components.forEach(({selector, declaration}) => {
+    matcher.addSelectables(CssSelector.parse(selector), {
+      ref: new Reference(declaration),
+      selector,
+      queries: [],
+      ngTemplateGuards: [],
+      hasNgTemplateContextGuard: false,
+      baseClass: null,
+      name: declaration.name.getText(),
+      isComponent: true,
+      inputs: {},
+      outputs: {},
+      exportAs: null,
+    });
+  });
+  const binder = new R3TargetBinder(matcher);
+
+  return binder.bind({template: getParsedTemplate(template)});
+}

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, CssSelector, R3TargetBinder, SelectorMatcher, TmplAstNode, parseTemplate} from '@angular/compiler/src/compiler';
+import {BoundTarget, CssSelector, ParseTemplateOptions, R3TargetBinder, SelectorMatcher, parseTemplate} from '@angular/compiler';
 import * as ts from 'typescript';
 import {Reference} from '../../imports';
 import {DirectiveMeta} from '../../metadata';
@@ -28,20 +28,17 @@ export function getComponentDeclaration(componentStr: string, className: string)
 }
 
 /**
- * Parses a template source code.
+ * Parses a template source code and returns a template-bound target, optionally with information
+ * about used components.
+ *
+ * @param template template to parse
+ * @param options extra template parsing options
+ * @param components components to bind to the template target
  */
-export function getParsedTemplate(template: string): TmplAstNode[] {
-  return parseTemplate(template, TESTFILE).nodes;
-}
-
-/**
- * Binds information about a component on a template (a target). The BoundTarget
- * describes the scope of the template and can be queried for directives the
- * template uses.
- */
-export function bindTemplate(
-    template: string, components: Array<{selector: string, declaration: ClassDeclaration}>):
-    BoundTarget<DirectiveMeta> {
+export function getBoundTemplate(
+    template: string, options: ParseTemplateOptions = {},
+    components: Array<{selector: string, declaration: ClassDeclaration}> =
+        []): BoundTarget<DirectiveMeta> {
   const matcher = new SelectorMatcher<DirectiveMeta>();
   components.forEach(({selector, declaration}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
@@ -60,5 +57,5 @@ export function bindTemplate(
   });
   const binder = new R3TargetBinder(matcher);
 
-  return binder.bind({template: getParsedTemplate(template)});
+  return binder.bind({template: parseTemplate(template, TESTFILE, options).nodes});
 }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -19,7 +19,8 @@ import {ErrorCode, ngErrorCode} from './diagnostics';
 import {FlatIndexGenerator, ReferenceGraph, checkForPrivateExports, findFlatIndexEntryPoint} from './entry_point';
 import {AbsoluteModuleStrategy, AliasGenerator, AliasStrategy, DefaultImportTracker, FileToModuleHost, FileToModuleStrategy, ImportRewriter, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NoopImportRewriter, R3SymbolsImportRewriter, Reference, ReferenceEmitter} from './imports';
 import {IncrementalState} from './incremental';
-import {IndexedComponent} from './indexer';
+import {IndexedComponent, IndexingContext} from './indexer';
+import {generateAnalysis} from './indexer/src/transform';
 import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, LocalMetadataRegistry, MetadataReader} from './metadata';
 import {PartialEvaluator} from './partial_evaluator';
 import {AbsoluteFsPath, LogicalFileSystem} from './path';
@@ -268,10 +269,6 @@ export class NgtscProgram implements api.Program {
     return this.routeAnalyzer !.listLazyRoutes(entryRoute);
   }
 
-  getIndexedComponents(): Map<ts.Declaration, IndexedComponent> {
-    throw new Error('Method not implemented.');
-  }
-
   getLibrarySummaries(): Map<string, api.LibrarySummary> {
     throw new Error('Method not implemented.');
   }
@@ -432,6 +429,13 @@ export class NgtscProgram implements api.Program {
     this.reuseTsProgram = program;
 
     return diagnostics;
+  }
+
+  getIndexedComponents(): Map<ts.Declaration, IndexedComponent> {
+    const compilation = this.ensureAnalyzed();
+    const context = new IndexingContext();
+    compilation.index(context);
+    return generateAnalysis(context);
   }
 
   private makeCompilation(): IvyCompilation {

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -82,7 +82,7 @@ export interface DecoratorHandler<A, M> {
    * `IndexingContext`, which stores information about components discovered in the
    * program.
    */
-  index?(context: IndexingContext, node: ClassDeclaration, metadata: M): void;
+  index?(context: IndexingContext, node: ClassDeclaration, metadata: A): void;
 
   /**
    * Perform resolution on the given decorator along with the result of analysis.

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -254,7 +254,16 @@ export class IvyCompilation {
   /**
    * Feeds components discovered in the compilation to a context for indexing.
    */
-  index(context: IndexingContext) { throw new Error('Method not implemented.'); }
+  index(context: IndexingContext) {
+    this.ivyClasses.forEach((ivyClass, declaration) => {
+      for (const match of ivyClass.matchedHandlers) {
+        if (match.handler.index !== undefined && match.analyzed !== null &&
+            match.analyzed.analysis !== undefined) {
+          match.handler.index(context, declaration, match.analyzed.analysis);
+        }
+      }
+    });
+  }
 
   resolve(): void {
     const resolveSpan = this.perf.start('resolve');

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/path",
         "//packages/compiler-cli/src/ngtsc/routing",
         "//packages/compiler-cli/src/ngtsc/util",

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -115,7 +115,7 @@ describe('ngtsc component indexing', () => {
         })
         export class TestCmp { foo = 0; }
       `);
-      env.write('test.html', '<div>{{foo}}</div>');
+      env.write('test.html', '<div>  \n  {{foo}}</div>');
       const indexed = env.driveIndexer();
       const [[_, indexedComp]] = Array.from(indexed.entries());
       const template = indexedComp.template;
@@ -127,8 +127,8 @@ describe('ngtsc component indexing', () => {
       expect(identifier).toEqual(jasmine.objectContaining({
         name: 'foo',
         kind: IdentifierKind.Property,
-        span: new AbsoluteSourceSpan(7, 10),
-        file: new ParseSourceFile('<div>{{foo}}</div>', testPath('test.html')),
+        span: new AbsoluteSourceSpan(12, 15),
+        file: new ParseSourceFile('<div>  \n  {{foo}}</div>', testPath('test.html')),
       }));
     });
 

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -36,7 +36,7 @@ describe('ngtsc component indexing', () => {
       const indexed = env.driveIndexer();
       expect(indexed.size).toBe(1);
 
-      const [[decl, indexedComp]] = indexed.entries();
+      const [[decl, indexedComp]] = Array.from(indexed.entries());
 
       expect(decl.getText()).toContain('export class TestCmp {}');
       expect(indexedComp).toEqual(jasmine.objectContaining({
@@ -59,12 +59,12 @@ describe('ngtsc component indexing', () => {
       `;
       env.write('test.ts', componentContent);
       const indexed = env.driveIndexer();
-      const [[_, indexedComp]] = indexed.entries();
+      const [[_, indexedComp]] = Array.from(indexed.entries());
       const template = indexedComp.template;
 
       expect(template.identifiers.size).toBe(1);
       expect(template.usedComponents.size).toBe(0);
-      const [identifier] = template.identifiers.values();
+      const [identifier] = Array.from(template.identifiers.values());
 
       expect(identifier).toEqual(jasmine.objectContaining({
         name: 'foo',
@@ -86,12 +86,12 @@ describe('ngtsc component indexing', () => {
       `);
       env.write('test.html', '<div>{{foo}}</div>');
       const indexed = env.driveIndexer();
-      const [[_, indexedComp]] = indexed.entries();
+      const [[_, indexedComp]] = Array.from(indexed.entries());
       const template = indexedComp.template;
 
       expect(template.identifiers.size).toBe(1);
       expect(template.usedComponents.size).toBe(0);
-      const [identifier] = template.identifiers.values();
+      const [identifier] = Array.from(template.identifiers.values());
 
       expect(identifier).toEqual(jasmine.objectContaining({
         name: 'foo',
@@ -117,12 +117,12 @@ describe('ngtsc component indexing', () => {
       `);
       env.write('test.html', '<div>{{foo}}</div>');
       const indexed = env.driveIndexer();
-      const [[_, indexedComp]] = indexed.entries();
+      const [[_, indexedComp]] = Array.from(indexed.entries());
       const template = indexedComp.template;
 
       expect(template.identifiers.size).toBe(1);
       expect(template.usedComponents.size).toBe(0);
-      const [identifier] = template.identifiers.values();
+      const [identifier] = Array.from(template.identifiers.values());
 
       expect(identifier).toEqual(jasmine.objectContaining({
         name: 'foo',
@@ -174,7 +174,7 @@ describe('ngtsc component indexing', () => {
       expect(testComp !.template.usedComponents.size).toBe(0);
       expect(testImportComp !.template.usedComponents.size).toBe(1);
 
-      const [usedComp] = testImportComp !.template.usedComponents;
+      const [usedComp] = Array.from(testImportComp !.template.usedComponents);
       expect(indexed.get(usedComp)).toEqual(testComp);
     });
   });

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AbsoluteSourceSpan, IdentifierKind} from '@angular/compiler-cli/src/ngtsc/indexer';
+import {ParseSourceFile} from '@angular/compiler/src/compiler';
+import * as path from 'path';
+import {NgtscTestEnvironment} from './env';
+
+describe('ngtsc component indexing', () => {
+  let env !: NgtscTestEnvironment;
+
+  function testPath(testFile: string): string { return path.posix.join(env.basePath, testFile); }
+
+  beforeEach(() => {
+    env = NgtscTestEnvironment.setup();
+    env.tsconfig();
+  });
+
+  describe('indexing metadata', () => {
+    it('should generate component metadata', () => {
+      const componentContent = `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '<div></div>',
+        })
+        export class TestCmp {}
+    `;
+      env.write('test.ts', componentContent);
+      const indexed = env.driveIndexer();
+      expect(indexed.size).toBe(1);
+
+      const [[decl, indexedComp]] = indexed.entries();
+
+      expect(decl.getText()).toContain('export class TestCmp {}');
+      expect(indexedComp).toEqual(jasmine.objectContaining({
+        name: 'TestCmp',
+        selector: 'test-cmp',
+        content: componentContent,
+        sourceFile: testPath('test.ts'),
+      }));
+    });
+
+    it('should index inline templates', () => {
+      const componentContent = `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '<div>{{foo}}</div>',
+        })
+        export class TestCmp { foo = 0; }
+      `;
+      env.write('test.ts', componentContent);
+      const indexed = env.driveIndexer();
+      const [[_, indexedComp]] = indexed.entries();
+      const template = indexedComp.template;
+
+      expect(template.identifiers.size).toBe(1);
+      expect(template.usedComponents.size).toBe(0);
+      const [identifier] = template.identifiers.values();
+
+      expect(identifier).toEqual(jasmine.objectContaining({
+        name: 'foo',
+        kind: IdentifierKind.Property,
+        span: new AbsoluteSourceSpan(132, 135),
+        file: new ParseSourceFile(componentContent, 'test.ts'),
+      }));
+    });
+
+    it('should index external templates', () => {
+      env.write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          templateUrl: './test.html',
+        })
+        export class TestCmp { foo = 0; }
+      `);
+      env.write('test.html', '<div>{{foo}}</div>');
+      const indexed = env.driveIndexer();
+      const [[_, indexedComp]] = indexed.entries();
+      const template = indexedComp.template;
+
+      expect(template.identifiers.size).toBe(1);
+      expect(template.usedComponents.size).toBe(0);
+      const [identifier] = template.identifiers.values();
+
+      expect(identifier).toEqual(jasmine.objectContaining({
+        name: 'foo',
+        kind: IdentifierKind.Property,
+        span: new AbsoluteSourceSpan(7, 10),
+        file: new ParseSourceFile('<div>{{foo}}</div>', testPath('test.html')),
+      }));
+    });
+
+    it('should index templates compiled without preserving whitespace', () => {
+      env.tsconfig({
+        preserveWhitespaces: false,
+      });
+
+      env.write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          templateUrl: './test.html',
+        })
+        export class TestCmp { foo = 0; }
+      `);
+      env.write('test.html', '<div>{{foo}}</div>');
+      const indexed = env.driveIndexer();
+      const [[_, indexedComp]] = indexed.entries();
+      const template = indexedComp.template;
+
+      expect(template.identifiers.size).toBe(1);
+      expect(template.usedComponents.size).toBe(0);
+      const [identifier] = template.identifiers.values();
+
+      expect(identifier).toEqual(jasmine.objectContaining({
+        name: 'foo',
+        kind: IdentifierKind.Property,
+        span: new AbsoluteSourceSpan(7, 10),
+        file: new ParseSourceFile('<div>{{foo}}</div>', testPath('test.html')),
+      }));
+    });
+
+    it('should generated information about used components', () => {
+      env.write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          templateUrl: './test.html',
+        })
+        export class TestCmp {}
+      `);
+      env.write('test.html', '<div></div>');
+      env.write('test_import.ts', `
+        import {Component, NgModule} from '@angular/core';
+        import {TestCmp} from './test';
+
+        @Component({
+          templateUrl: './test_import.html',
+        })
+        export class TestImportCmp {}
+
+        @NgModule({
+          declarations: [
+            TestCmp,
+            TestImportCmp,
+          ],
+          bootstrap: [TestImportCmp]
+        })
+        export class TestModule {}
+      `);
+      env.write('test_import.html', '<test-cmp></test-cmp>');
+      const indexed = env.driveIndexer();
+      expect(indexed.size).toBe(2);
+
+      const indexedComps = Array.from(indexed.values());
+      const testComp = indexedComps.find(comp => comp.name === 'TestCmp');
+      const testImportComp = indexedComps.find(cmp => cmp.name === 'TestImportCmp');
+      expect(testComp).toBeDefined();
+      expect(testImportComp).toBeDefined();
+
+      expect(testComp !.template.usedComponents.size).toBe(0);
+      expect(testImportComp !.template.usedComponents.size).toBe(1);
+
+      const [usedComp] = testImportComp !.template.usedComponents;
+      expect(indexed.get(usedComp)).toEqual(testComp);
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -7,6 +7,8 @@
  */
 
 import {CustomTransformers, Program} from '@angular/compiler-cli';
+import {IndexedComponent} from '@angular/compiler-cli/src/ngtsc/indexer';
+import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
 import {setWrapHostForTest} from '@angular/compiler-cli/src/transformers/compiler_host';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -202,6 +204,13 @@ export class NgtscTestEnvironment {
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
     return program.listLazyRoutes(entryPoint);
+  }
+
+  driveIndexer(): Map<ts.Declaration, IndexedComponent> {
+    const {rootNames, options} = readNgcCommandLineAndConfiguration(['-p', this.basePath]);
+    const host = createCompilerHost({options});
+    const program = createProgram({rootNames, host, options});
+    return (program as NgtscProgram).getIndexedComponents();
   }
 }
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -97,7 +97,7 @@ export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
 export {R3DependencyMetadata, R3FactoryMetadata, R3ResolvedDependencyType} from './render3/r3_factory';
 export {compileInjector, compileNgModule, R3InjectorMetadata, R3NgModuleMetadata} from './render3/r3_module_compiler';
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
-export {makeBindingParser, parseTemplate} from './render3/view/template';
+export {makeBindingParser, parseTemplate, ParseTemplateOptions} from './render3/view/template';
 export {R3Reference} from './render3/util';
 export {compileBaseDefFromMetadata, R3BaseRefMetaData, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, ParsedHostBindings, verifyHostBindings} from './render3/view/compiler';
 export {publishFacade} from './jit_compiler_facade';


### PR DESCRIPTION
Add an IndexingContext class to store indexing information and a
transformer module to generate indexing analysis. Integrate the indexing
module with the rest of NgtscProgram and add integration tests.

Closes #30959

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  - N/A, limited compiler API


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Indexing module is standalone, not integrated with the compiler.

Issue Number: #30959 


## What is the new behavior?

Integrates the indexing module with all of `NgtscProgram`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
