### PR TITLE
perf(ivy): chain multiple attribute instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -812,8 +812,7 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵɵelement(0, "div", $e0_attrs$);
                 }
                 if (rf & 2) {
-                  $r3$.ɵɵattribute("class", "round");
-                  $r3$.ɵɵattribute("style", "height:100px", $r3$.ɵɵsanitizeStyle);
+                  $r3$.ɵɵattribute("class", "round")("style", "height:100px", $r3$.ɵɵsanitizeStyle);
                 }
               },
               encapsulation: 2

--- a/packages/core/src/render3/instructions/attribute.ts
+++ b/packages/core/src/render3/instructions/attribute.ts
@@ -10,7 +10,7 @@ import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {bind} from './property';
-import {elementAttributeInternal} from './shared';
+import {TsickleIssue1009, elementAttributeInternal} from './shared';
 
 
 
@@ -28,12 +28,14 @@ import {elementAttributeInternal} from './shared';
  * @codeGenApi
  */
 export function ɵɵattribute(
-    name: string, value: any, sanitizer?: SanitizerFn | null, namespace?: string) {
+    name: string, value: any, sanitizer?: SanitizerFn | null,
+    namespace?: string): TsickleIssue1009 {
   const index = getSelectedIndex();
   const lView = getLView();
   // TODO(FW-1340): Refactor to remove the use of other instructions here.
   const bound = bind(lView, value);
   if (bound !== NO_CHANGE) {
-    return elementAttributeInternal(index, name, bound, lView, sanitizer, namespace);
+    elementAttributeInternal(index, name, bound, lView, sanitizer, namespace);
   }
+  return ɵɵattribute;
 }

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -73,6 +73,104 @@ describe('attribute binding', () => {
     expect(a.href).toEqual('https://angular.io/robots.txt');
   });
 
+  it('should be able to bind multiple attribute values per element', () => {
+    @Component({
+      template: `<a [attr.id]="id" [attr.href]="url" [attr.tabindex]="'-1'"></a>`,
+    })
+    class Comp {
+      url = 'https://angular.io/robots.txt';
+      id = 'my-link';
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+
+    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    // NOTE: different browsers will add `//` into the URI.
+    expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
+    expect(a.getAttribute('id')).toBe('my-link');
+    expect(a.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('should be able to bind multiple attributes in the presence of other bindings', () => {
+    @Component({
+      template: `<a [id]="id" [attr.href]="url" [title]="'hello'"></a>`,
+    })
+    class Comp {
+      url = 'https://angular.io/robots.txt';
+      id = 'my-link';
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+
+    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    // NOTE: different browsers will add `//` into the URI.
+    expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
+    expect(a.id).toBe('my-link');
+    expect(a.getAttribute('title')).toBe('hello');
+  });
+
+  it('should be able to bind attributes with interpolations', () => {
+    @Component({
+      template: `
+        <button
+          attr.id="my-{{id}}-button"
+          [attr.title]="title"
+          attr.tabindex="{{1 + 3 + 7}}"></button>`,
+    })
+    class Comp {
+      title = 'hello';
+      id = 'custom';
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+
+    expect(button.getAttribute('id')).toBe('my-custom-button');
+    expect(button.getAttribute('tabindex')).toBe('11');
+    expect(button.getAttribute('title')).toBe('hello');
+  });
+
+
+  it('should be able to bind attributes both to parent and child nodes', () => {
+    @Component({
+      template: `
+        <button
+          attr.id="my-{{id}}-button"
+          [attr.title]="title"
+          attr.tabindex="{{1 + 3 + 7}}">
+
+          <span attr.title="span-{{title}}" id="custom-span" [attr.tabindex]="-1"></span>
+        </button>
+      `,
+    })
+    class Comp {
+      title = 'hello';
+      id = 'custom';
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const span = fixture.debugElement.query(By.css('span')).nativeElement;
+
+    expect(button.getAttribute('id')).toBe('my-custom-button');
+    expect(button.getAttribute('tabindex')).toBe('11');
+    expect(button.getAttribute('title')).toBe('hello');
+
+    expect(span.getAttribute('id')).toBe('custom-span');
+    expect(span.getAttribute('tabindex')).toBe('-1');
+    expect(span.getAttribute('title')).toBe('span-hello');
+  });
+
   it('should sanitize attribute values', () => {
     @Component({
       template: `<a [attr.href]="badUrl"></a>`,

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -665,7 +665,7 @@ export interface OutputDecorator {
 
 export declare function ɵɵallocHostVars(count: number): void;
 
-export declare function ɵɵattribute(name: string, value: any, sanitizer?: SanitizerFn | null, namespace?: string): void;
+export declare function ɵɵattribute(name: string, value: any, sanitizer?: SanitizerFn | null, namespace?: string): TsickleIssue1009;
 
 export declare function ɵɵattributeInterpolate1(attrName: string, prefix: string, v0: any, suffix: string, sanitizer?: SanitizerFn, namespace?: string): TsickleIssue1009;
 


### PR DESCRIPTION
Similarly to what we did in #31078, these changes implement chaining for the `attribute` instruction.

This PR resolves FW-1390.