### PR TITLE
build: user bazelrc should be able to overwrite all flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -142,10 +142,6 @@ build:remote --remote_instance_name=projects/internal-200822/instances/default_i
 # We need to understand the security risks of using prior build artifacts.
 build:remote --remote_accept_cached=false
 
-# Load any settings specific to the current user. Needs to be last statement in this
-# config, as the user configuration should be able to overwrite flags from this file.
-try-import .bazelrc.user
-
 ###############################
 # NodeJS rules settings
 # These settings are required for rules_nodejs
@@ -154,3 +150,12 @@ try-import .bazelrc.user
 # Turn on managed directories feature in Bazel
 # This allows us to avoid installing a second copy of node_modules
 common --experimental_allow_incremental_repository_updates
+
+####################################################
+# User bazel configuration
+# NOTE: This needs to be the *last* entry in the config.
+####################################################
+
+# Load any settings which are specific to the current user. Needs to be *last* statement
+# in this config, as the user configuration should be able to overwrite flags from this file.
+try-import .bazelrc.user


### PR DESCRIPTION
After eb00a37eb84fa0002006fd54ef02868f1d55a49d we accidentally regressed due to some recent changes where
more flags were added at the end of the bazelrc. This means that all flags
which were added after the `try-import` can no longer be overwritten easily in the
user project bazelrc file. Technically developers can always overwrite flags though the
command line, but it's a productivity blocker if developers can't permanently overwrite these
flags  through the user config