### PR TITLE
docs: remove prerequisite section in NgModules docs

### DIFF
--- a/aio/content/guide/entry-components.md
+++ b/aio/content/guide/entry-components.md
@@ -1,12 +1,5 @@
 # Entry Components
 
-#### Prerequisites:
-
-A basic understanding of the following concepts:
-* [Bootstrapping](guide/bootstrapping).
-
-<hr />
-
 An entry component is any component that Angular loads imperatively, (which means you’re not referencing it in the template), by type. You specify an entry component by bootstrapping it in an NgModule, or including it in a routing definition.
 
 <div class="alert is-helpful">

--- a/aio/content/guide/feature-modules.md
+++ b/aio/content/guide/feature-modules.md
@@ -1,12 +1,6 @@
 # Feature Modules
 
-Feature modules are NgModules for the purpose of  organizing code.
-
-#### Prerequisites
-A basic understanding of the following:
-* [Bootstrapping](guide/bootstrapping).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-* [Frequently Used Modules](guide/frequent-ngmodules).
+Feature modules are NgModules for the purpose of organizing code.
 
 For the final sample app with a feature module that this page describes,
 see the <live-example></live-example>.

--- a/aio/content/guide/frequent-ngmodules.md
+++ b/aio/content/guide/frequent-ngmodules.md
@@ -1,12 +1,5 @@
 # Frequently Used Modules
 
-#### Prerequisites
-
-A basic understanding of [Bootstrapping](guide/bootstrapping).
-
-
-<hr>
-
 An Angular app needs at least one module that serves as the root module.
 As you add features to your app, you can add them in modules.
 The following are frequently used Angular modules with examples

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -1,22 +1,12 @@
 # Lazy Loading Feature Modules
 
-#### Prerequisites
-A basic understanding of the following:
-* [Feature Modules](guide/feature-modules).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-* [Frequently Used Modules](guide/frequent-ngmodules).
-* [Types of Feature Modules](guide/module-types).
-* [Routing and Navigation](guide/router).
-
-For the final sample app with two lazy loaded modules that this page describes, see the
-<live-example></live-example>.
-
-<hr>
-
 ## High level view
 
 By default, NgModules are eagerly loaded, which means that as soon as the app loads, so do all the NgModules, whether or not they are immediately necessary. For large apps with lots of routes, consider lazy loading&mdash;a design pattern that loads NgModules as needed. Lazy loading helps keep initial
 bundle sizes smaller, which in turn helps decrease load times.
+
+For the final sample app with two lazy loaded modules that this page describes, see the
+<live-example></live-example>.
 
 There are three main steps to setting up a lazy loaded feature module:
 

--- a/aio/content/guide/module-types.md
+++ b/aio/content/guide/module-types.md
@@ -1,15 +1,4 @@
-
-
 # Types of Feature Modules
-
-#### Prerequisites
-
-A basic understanding of the following concepts:
-* [Feature Modules](guide/feature-modules).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-* [Frequently Used Modules](guide/frequent-ngmodules).
-
-<hr>
 
 There are five general categories of feature modules which
 tend to fall into the following groups:

--- a/aio/content/guide/ngmodule-api.md
+++ b/aio/content/guide/ngmodule-api.md
@@ -1,15 +1,5 @@
 # NgModule API
 
-#### Prerequisites
-
-A basic understanding of the following concepts:
-* [Bootstrapping](guide/bootstrapping).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-
-<hr />
-
-## Purpose of `@NgModule`
-
 At a high level, NgModules are a way to organize Angular apps
 and they accomplish this through the metadata in the `@NgModule`
 decorator.

--- a/aio/content/guide/ngmodule-faq.md
+++ b/aio/content/guide/ngmodule-faq.md
@@ -1,13 +1,5 @@
 # NgModule FAQs
 
-
-#### Prerequisites:
-
-A basic understanding of the following concepts:
-* [NgModules](guide/ngmodules).
-
-<hr />
-
 NgModules help organize an application into cohesive blocks of functionality.
 
 This page answers the questions many developers ask about NgModule design and implementation.

--- a/aio/content/guide/ngmodule-vs-jsmodule.md
+++ b/aio/content/guide/ngmodule-vs-jsmodule.md
@@ -1,12 +1,8 @@
 # JavaScript Modules vs. NgModules
 
-#### Prerequisites
-A basic understanding of [JavaScript/ECMAScript modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/).
-
-<hr>
-
 JavaScript and Angular use modules to organize code, and
 though they organize it differently, Angular apps rely on both.
+
 
 ## JavaScript modules
 
@@ -23,6 +19,8 @@ import { AppComponent } from './app.component';
 ```
 
 JavaScript modules help you namespace, preventing accidental global variables.
+
+For more information on JavaScript modules, see [JavaScript/ECMAScript modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/).
 
 ## NgModules
 

--- a/aio/content/guide/ngmodules.md
+++ b/aio/content/guide/ngmodules.md
@@ -1,13 +1,5 @@
 # NgModules
 
-#### Prerequisites
-
-A basic understanding of the following concepts:
-* [Bootstrapping](guide/bootstrapping).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-
-<hr>
-
 **NgModules** configure the injector and the compiler and help organize related things together.
 
 An NgModule is a class marked by the `@NgModule` decorator.

--- a/aio/content/guide/providers.md
+++ b/aio/content/guide/providers.md
@@ -1,15 +1,9 @@
 # Providers
 
-#### Prerequisites:
-* A basic understanding of [Bootstrapping](guide/bootstrapping).
-* Familiarity with [Frequently Used Modules](guide/frequent-ngmodules).
+A provider is an instruction to the DI system on how to obtain a value for a dependency. Most of the time, these dependencies are services that you create and provide.
 
 For the final sample app using the provider that this page describes,
 see the <live-example></live-example>.
-
-<hr>
-
-A provider is an instruction to the DI system on how to obtain a value for a dependency. Most of the time, these dependencies are services that you create and provide.
 
 ## Providing a service
 

--- a/aio/content/guide/sharing-ngmodules.md
+++ b/aio/content/guide/sharing-ngmodules.md
@@ -1,18 +1,5 @@
 # Sharing Modules
 
-#### Prerequisites
-A basic understanding of the following:
-* [Feature Modules](guide/feature-modules).
-* [JavaScript Modules vs. NgModules](guide/ngmodule-vs-jsmodule).
-* [Frequently Used Modules](guide/frequent-ngmodules).
-* [Routing and Navigation](guide/router).
-* [Lazy loading modules](guide/lazy-loading-ngmodules).
-
-
-<!--* Components (#TBD) We don’t have a page just on the concept of components, but I think one would be helpful for beginners.-->
-
-<hr>
-
 Creating shared modules allows you to organize and streamline your code. You can put commonly
 used directives, pipes, and components into one module and then import just that module wherever
 you need it in other parts of your app.
@@ -54,7 +41,7 @@ to import `FormsModule`, `SharedModule` can still export
 way, you can give other modules access to `FormsModule` without
 having to import it directly into the `@NgModule` decorator.
 
-### Using components vs services from other modules.
+### Using components vs services from other modules
 
 There is an important distinction between using another module's component and
 using a service from another module. Import modules when you want to use

--- a/aio/content/guide/singleton-services.md
+++ b/aio/content/guide/singleton-services.md
@@ -1,14 +1,9 @@
 # Singleton services
 
-#### Prerequisites:
-
-* A basic understanding of [Bootstrapping](guide/bootstrapping).
-* Familiarity with [Providers](guide/providers).
+A singleton service is a service for which only once instance exists in an app.
 
 For a sample app using the app-wide singleton service that this page describes, see the
 <live-example name="ngmodules"></live-example> showcasing all the documented features of NgModules.
-
-<hr />
 
 ## Providing a singleton service
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Thereʻs a section at the top of each NgModules page with a list of prerequisites. There have been several issues where readers have been confused by them (either because the nav was not in the same order or because they werenʻt sequential). We also havenʻt continued this formatting in other rewrites of the docs. 

Issue Number: #21531


## What is the new behavior?
Remove this section altogether. It will shorted each document, clear clutter on the page, and allow the reader to find the pertinent information more quickly.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
