### PR TITLE
refactor: early compatibility with TypeScript 3.5

### DIFF
--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -418,8 +418,9 @@ export class MetadataCollector {
             const maybeFunc = maybeGetSimpleFunction(functionDeclaration);
             if (name) {
               if (!metadata) metadata = {};
-              metadata[name] =
-                  maybeFunc ? recordEntry(maybeFunc.func, node) : {__symbolic: 'function'};
+              // TODO(alxhub): The literal here is not valid FunctionMetadata.
+              metadata[name] = maybeFunc ? recordEntry(maybeFunc.func, node) :
+                                           ({ __symbolic: 'function' } as any);
             }
           }
           break;
@@ -448,13 +449,15 @@ export class MetadataCollector {
               if (typeof enumValue === 'number') {
                 nextDefaultValue = enumValue + 1;
               } else if (name) {
+                // TODO(alxhub): 'left' here has a name propery which is not valid for
+                // MetadataSymbolicSelectExpression.
                 nextDefaultValue = {
                   __symbolic: 'binary',
                   operator: '+',
                   left: {
                     __symbolic: 'select',
                     expression: recordEntry({__symbolic: 'reference', name: enumName}, node), name
-                  }
+                  } as any,
                 };
               } else {
                 nextDefaultValue =

--- a/packages/compiler-cli/src/metadata/evaluator.ts
+++ b/packages/compiler-cli/src/metadata/evaluator.ts
@@ -555,7 +555,7 @@ export class Evaluator {
               return !operand;
           }
         }
-        let operatorText: string;
+        let operatorText: '+'|'-'|'~'|'!';
         switch (prefixUnaryExpression.operator) {
           case ts.SyntaxKind.PlusToken:
             operatorText = '+';

--- a/packages/compiler/src/metadata_resolver.ts
+++ b/packages/compiler/src/metadata_resolver.ts
@@ -907,7 +907,7 @@ export class CompileMetadataResolver {
       let isOptional = false;
       let token: any = null;
       if (Array.isArray(param)) {
-        param.forEach((paramEntry) => {
+        param.forEach((paramEntry: any) => {
           if (createHost.isTypeOf(paramEntry)) {
             isHost = true;
           } else if (createSelf.isTypeOf(paramEntry)) {
@@ -918,11 +918,12 @@ export class CompileMetadataResolver {
             isOptional = true;
           } else if (createAttribute.isTypeOf(paramEntry)) {
             isAttribute = true;
-            token = paramEntry.attributeName;
+            token = (paramEntry as any).attributeName;
           } else if (createInject.isTypeOf(paramEntry)) {
-            token = paramEntry.token;
+            token = (paramEntry as any).token;
           } else if (
-              createInjectionToken.isTypeOf(paramEntry) || paramEntry instanceof StaticSymbol) {
+              createInjectionToken.isTypeOf(paramEntry) ||
+              (paramEntry as any) instanceof StaticSymbol) {
             token = paramEntry;
           } else if (isValidType(paramEntry) && token == null) {
             token = paramEntry;


### PR DESCRIPTION
This commit fixes a couple of issues with TS 3.5 compatibility in order to
unblock migration of g3. Mostly 'any's are added, and there are no behavior
changes.
