### PR TITLE
fix(router): Allow question marks in query param values

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -520,7 +520,7 @@ function matchQueryParams(str: string): string {
   return match ? match[0] : '';
 }
 
-const QUERY_PARAM_VALUE_RE = /^[^?&#]+/;
+const QUERY_PARAM_VALUE_RE = /^[^&#]+/;
 // Return the value of the query param at the start of the string or an empty string
 function matchUrlQueryParamValue(str: string): string {
   const match = str.match(QUERY_PARAM_VALUE_RE);

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -26,6 +26,11 @@ describe('UrlTree', () => {
         'k/(a;b)': 'c',
       });
     });
+
+    it('should allow question marks in query param values', () => {
+      const tree = serializer.parse('/path/to?first=http://foo/bar?baz=true&second=123');
+      expect(tree.queryParams).toEqual({'first': 'http://foo/bar?baz=true', 'second': '123'});
+    });
   });
 
   describe('containsTree', () => {


### PR DESCRIPTION
According to the URI spec, question mark characters are valid in query data, so these should accepted by the param parsing.

Fixes #31116

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Don't think this needs to be mentioned in docs?

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #31116

Question mark characters were not accepted as part of a query parameter value, despite them being valid according to the URI spec. This was particularly a problem for including a URL (such as a redirect) as a query param.

## What is the new behavior?

The query param value regex has been relaxed to allow question marks. I have left the query param key regex unchanged, as there seems to be less reason for having question marks as part of a query param key, and this might be more likely to cause problems.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

I'm not 100% sure. I suppose theoretically there could applications that rely, knowingly or unknowingly, on the previous behaviour. E.g. an app that is loaded with URLs or other question-mark-containing strings as query string params and relies on this behaviour to strip out the "?" and everything after it in order to product strings that are valid for the app's purposes.

## Other information
