### PR TITLE
fix(compiler): fix Elements not making a new ParseSourceSpan

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -72,7 +72,7 @@ export class Element implements Node {
       public endSourceSpan: ParseSourceSpan|null, public i18n?: I18nAST) {
     // If the element is empty then the source span should include any closing tag
     if (children.length === 0 && startSourceSpan && endSourceSpan) {
-      this.sourceSpan = {...sourceSpan, end: endSourceSpan.end};
+      this.sourceSpan = new ParseSourceSpan(sourceSpan.start, endSourceSpan.end);
     }
   }
   visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitElement(this); }

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -95,7 +95,17 @@ function expectFromR3Nodes(nodes: t.Node[]) {
   return expect(humanizer.result);
 }
 
+function expectSpanFromHtml(html: string) {
+  const {nodes} = parse(html);
+  return expect(nodes[0] !.sourceSpan.toString());
+}
+
 describe('R3 template transform', () => {
+  describe('ParseSpan on nodes toString', () => {
+    it('should create valid text span on Element with adjacent start and end tags',
+       () => { expectSpanFromHtml('<div></div>').toBe('<div></div>'); });
+  });
+
   describe('Nodes without binding', () => {
     it('should parse text nodes', () => {
       expectFromHtml('a').toEqual([


### PR DESCRIPTION
Change the Element constructor in r3_ast to create a new ParseSourceSpan when regenerating it rather than extending an object, which does not contain the overloaded toString().

Same as #31153. Retrying here because tests on the other PR failed, I think because it was a patch on the master repo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Parsing a template that has an element with adjacent start and end tags creates an object to represent the element `ParseSourceSpan` rather than a new instance of a `ParseSourceSpan`, which does not make the overloaded `ParseSourceSpan.toString` accessible.

## What is the new behavior?

Create a new `ParseSourceSpan` instance.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
