### PR TITLE
refactor(language-service): ReflectorHost should infer context from scripts

### DIFF
--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -7,12 +7,10 @@
  */
 
 import {StaticSymbol} from '@angular/compiler';
-import {CompilerHost} from '@angular/compiler-cli';
 import {ReflectorHost} from '@angular/language-service/src/reflector_host';
 import * as ts from 'typescript';
 
-import {getExpressionDiagnostics, getTemplateExpressionDiagnostics} from '../../src/diagnostics/expression_diagnostics';
-import {CompilerOptions} from '../../src/transformers/api';
+import {getTemplateExpressionDiagnostics} from '../../src/diagnostics/expression_diagnostics';
 import {Directory} from '../mocks';
 
 import {DiagnosticContext, MockLanguageServiceHost, getDiagnosticTemplateInfo} from './mocks';
@@ -31,10 +29,7 @@ describe('expression diagnostics', () => {
     service = ts.createLanguageService(host, registry);
     const program = service.getProgram() !;
     const checker = program.getTypeChecker();
-    const options: CompilerOptions = Object.create(host.getCompilationSettings());
-    options.genDir = '/dist';
-    options.basePath = '/src';
-    const symbolResolverHost = new ReflectorHost(() => program !, host, options);
+    const symbolResolverHost = new ReflectorHost(() => program !, host);
     context = new DiagnosticContext(service, program !, checker, symbolResolverHost);
     type = context.getStaticSymbol('app/app.component.ts', 'AppComponent');
   });

--- a/packages/compiler-cli/test/diagnostics/typescript_symbols_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/typescript_symbols_spec.ts
@@ -6,15 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {StaticSymbol} from '@angular/compiler';
-import {CompilerHost} from '@angular/compiler-cli';
-import {EmittingCompilerHost, MockAotCompilerHost, MockCompilerHost, MockData, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, arrayToMockMap, isSource, settings, setup, toMockFileArray} from '@angular/compiler/test/aot/test_util';
 import {ReflectorHost} from '@angular/language-service/src/reflector_host';
 import * as ts from 'typescript';
 
 import {BuiltinType, Symbol, SymbolQuery, SymbolTable} from '../../src/diagnostics/symbols';
 import {getSymbolQuery, toSymbolTableFactory} from '../../src/diagnostics/typescript_symbols';
-import {CompilerOptions} from '../../src/transformers/api';
 import {Directory} from '../mocks';
 
 import {DiagnosticContext, MockLanguageServiceHost} from './mocks';
@@ -42,10 +38,7 @@ describe('symbol query', () => {
     program = service.getProgram() !;
     checker = program.getTypeChecker();
     sourceFile = program.getSourceFile('/quickstart/app/app.component.ts') !;
-    const options: CompilerOptions = Object.create(host.getCompilationSettings());
-    options.genDir = '/dist';
-    options.basePath = '/quickstart';
-    const symbolResolverHost = new ReflectorHost(() => program, host, options);
+    const symbolResolverHost = new ReflectorHost(() => program, host);
     context = new DiagnosticContext(service, program, checker, symbolResolverHost);
     query = getSymbolQuery(program, checker, sourceFile, emptyPipes);
   });

--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -26,7 +26,7 @@ describe('reflector_host_spec', () => {
           posix:
               {...path.posix, join: (...args: string[]) => originalPosixJoin.apply(path, args)}
         });
-    const reflectorHost = new ReflectorHost(() => undefined as any, mockHost, {basePath: '\\app'});
+    const reflectorHost = new ReflectorHost(() => undefined as any, mockHost);
 
     if (process.platform !== 'win32') {
       // If we call this in Windows it will cause a 'Maximum call stack size exceeded error'


### PR DESCRIPTION

Instead of passing a `baseDir` to `ReflectorHost`, the Host should always
use the `ts.LanguageServiceHost` to find a suitable context to resolve
absolute imports.

This refactoring is necessary so that the Host is stable, i.e. it could
be reused throughout the lifetime of the language service. This will be
addressed in subsequent refactorings.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
