### PR TITLE
docs: allow custom package version for example zip file dependencies

### DIFF
--- a/aio/README.md
+++ b/aio/README.md
@@ -32,6 +32,7 @@ Here are the most important tasks you might need to use:
 * `yarn docs-test` - run the unit tests for the doc generation code.
 
 * `yarn boilerplate:add` - generate all the boilerplate code for the examples, so that they can be run locally. Add the option `--local` to use your local version of Angular contained in the "dist" folder.
+* `yarn boilerplate:add:ivy` - performs the same task as `yarn boilerplate:add` but with an additional step to run `ngcc` over the shared example `node_modules` and enables Ivy mode for the example apps.
 * `yarn boilerplate:remove` - remove all the boilerplate code that was added via `yarn boilerplate:add`.
 * `yarn generate-stackblitz` - generate the stackblitz files that are used by the `live-example` tags in the docs.
 * `yarn generate-zips` - generate the zip files from the examples. Zip available via the `live-example` tags in the docs.
@@ -40,6 +41,7 @@ Here are the most important tasks you might need to use:
   - `yarn example-e2e --setup` - force webdriver update & other setup, then run tests
   - `yarn example-e2e --filter=foo` - limit e2e tests to those containing the word "foo"
   - `yarn example-e2e --setup --local` - run e2e tests with the local version of Angular contained in the "dist" folder
+  - `yarn example-e2e --setup --local --ivy` - run e2e tests using Ivy with the local version of Angular contained in the "dist" folder
 
 
 ## Using ServiceWorker locally

--- a/aio/tools/example-zipper/customizer/package-json/base.json
+++ b/aio/tools/example-zipper/customizer/package-json/base.json
@@ -12,7 +12,7 @@
     "@angular/platform-browser-dynamic",
     "@angular/router",
     "@angular/upgrade",
-    "angular-in-memory-web-api",
+    { "name": "angular-in-memory-web-api", "version": "^0.8.0" },
     "core-js",
     "rxjs",
     "zone.js"

--- a/aio/tools/example-zipper/customizer/package-json/packageJsonCustomizer.js
+++ b/aio/tools/example-zipper/customizer/package-json/packageJsonCustomizer.js
@@ -28,13 +28,23 @@ class PackageJsonCustomizer {
       packageJson.scripts[finalName] = finalScript;
     });
 
-    rules.dependencies.forEach((name) => {
-      const version = this.dependenciesPackageJson.dependencies[name];
+    rules.dependencies.forEach((pkg) => {
+      const name = pkg.name || pkg;
+      // If the package has a custom version, use it instead
+      // This is a workaround for angular-in-memory-web-api being broken with Ivy
+      // Until then, we don't want users to download the workaround build
+      const version = pkg.version || this.dependenciesPackageJson.dependencies[name];
+
       packageJson.dependencies[name] = version;
     });
 
-    rules.devDependencies.forEach((name) => {
-      const version = this.dependenciesPackageJson.devDependencies[name];
+    rules.devDependencies.forEach((pkg) => {
+      const name = pkg.name || pkg;
+      // If the package has a custom version, use it instead
+      // This is a workaround for angular-in-memory-web-api being broken with Ivy
+      // Until then, we don't want users to download the workaround build
+      const version = pkg.version || this.dependenciesPackageJson.devDependencies[name];
+
       packageJson.devDependencies[name] = version;
     });
 

--- a/aio/tools/examples/README.md
+++ b/aio/tools/examples/README.md
@@ -104,3 +104,8 @@ With every major release, we update the examples to be on the latest version. Th
 * In the `shared` folder, run `yarn` to update the dependencies for the shared `node_modules` and the `yarn.lock` file.
 * In the `boilerplate` folder, go through each sub-folder and update the `package.json` dependencies if one is present.
 * Follow the [update guide](./shared/boilerplate/UPDATING_CLI.md) to update the common files used in the examples based on project type.
+
+### Ivy Notes
+
+In the `shared/package.json` folder, the `angular-in-memory-web-api` dependency used for the examples is using a custom build as a workaround. This
+is due to in incompatibility of the published npm version with ngcc for usage with Ivy. After the compatibility support is added, the version should be changed back to the published npm version.

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -32,7 +32,7 @@
     "@nguniversal/common": "^8.0.0-rc.1",
     "@nguniversal/express-engine": "^8.0.0-rc.1",
     "@nguniversal/module-map-ngfactory-loader": "^8.0.0-rc.1",
-    "angular-in-memory-web-api": "github:brandonroberts/in-memory-web-api-bazel#50a34d8",
+    "angular-in-memory-web-api": "github:brandonroberts/in-memory-web-api-bazel#240ca24",
     "core-js": "^2.5.4",
     "express": "^4.14.1",
     "rxjs": "^6.5.1",

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -795,9 +795,9 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-"angular-in-memory-web-api@github:brandonroberts/in-memory-web-api-bazel#50a34d8":
+"angular-in-memory-web-api@github:brandonroberts/in-memory-web-api-bazel#240ca24":
   version "0.8.0"
-  resolved "https://codeload.github.com/brandonroberts/in-memory-web-api-bazel/tar.gz/50a34d84b627ec88816242dec77603d6dcb9c880"
+  resolved "https://codeload.github.com/brandonroberts/in-memory-web-api-bazel/tar.gz/240ca247c1c421dc8e3cff801ddef4eeb1c5c35f"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This change allows you to specify a version that is included in the zip
files that users download from the guides. This is a temporary workaround
due to the incompatibility of angular-in-memory-web-api with Ivy.

The decision is to leave angular-in-memory-web-api as-is until the
compatibility issue is resolved. This allows users to use the npm
version instead of the custom build we use for Ivy support with the examples.

Also adds notes on how to run the E2E tests for the docs examples with Ivy.

Fixes #28603

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
