### PR TITLE
docs(core): update code sample for "outputs" attribute

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -163,18 +163,25 @@ export interface Directive {
    * ### Example
    *
    * ```typescript
-   * @Directive({
+   * @Component({
    *   selector: 'child-dir',
-   *   exportAs: 'child'
+   *   outputs: [ 'bankNameChange' ]
+   *   template: `<input (input)="bankNameChange.emit($event.target.value)" />`
    * })
    * class ChildDir {
+   *  bankNameChange: EventEmitter<string> = new EventEmitter<string>();
    * }
    *
    * @Component({
    *   selector: 'main',
-   *   template: `<child-dir #c="child"></child-dir>`
+   *   template: ` {{ bankName }} <child-dir (bankNameChange)="onBankNameChange($event)"></child-dir>`
    * })
    * class MainComponent {
+   *  bankName: string;
+   * 
+   *   onBankNameChange(bankName: string) {
+   *     this.bankName = bankName;
+   *   }
    * }
    * ```
    *


### PR DESCRIPTION
The current code sample for (directive) "outputs" attribute is incorrect as it does not provide the usage of "outputs" attribute rather it provides the usage of "exportAs" attribute. This PR updates the code sample by correcting the code sample with correct usage of "outputs" attribute.

Related work https://github.com/angular/angular/pull/30014

This PR continues from the unfinished (https://github.com/angular/angular/pull/30014#issuecomment-485419124, https://github.com/angular/angular/issues/29523#issuecomment-497333146) work.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number Fixes https://github.com/angular/angular/issues/29523

## What is the new behavior?

N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A