### PR TITLE
ci: send more failure notifications to Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,11 +535,15 @@ jobs:
           name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE
       - run:
-          name: Notify caretaker about failure
-          # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
-          # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
-          command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $SLACK_CARETAKER_WEBHOOK_URL'
           when: on_fail
+          name: Notify caretaker and dev-infra about failure
+          # `$SLACK_CARETAKER_WEBHOOK_URL` and `$SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK` are secret env
+          # vars defined in CircleCI project settings.
+          # The URLs come from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+          command: |
+            notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
+            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_CARETAKER_WEBHOOK_URL
+            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL
 
   aio_monitoring_next:
     <<: *job_defaults
@@ -554,11 +558,15 @@ jobs:
           name: Run tests against https://next.angular.io/
           command: ./aio/scripts/test-production.sh https://next.angular.io/ $CI_AIO_MIN_PWA_SCORE
       - run:
-          name: Notify caretaker about failure
-          # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
-          # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
-          command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $SLACK_CARETAKER_WEBHOOK_URL'
           when: on_fail
+          name: Notify caretaker and dev-infra about failure
+          # `$SLACK_CARETAKER_WEBHOOK_URL` and `$SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL` are secret env
+          # vars defined in CircleCI project settings.
+          # The URLs come from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+          command: |
+            notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
+            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_CARETAKER_WEBHOOK_URL
+            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL
 
   legacy-unit-tests-saucelabs:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,7 @@ jobs:
         # //packages/forms/test:web_test_sauce TIMEOUT in 315.0s
       - run: yarn bazel test --config=saucelabs //:test_web_all
       - run: ./scripts/saucelabs/stop-tunnel.sh
+      - *notify_dev_infra_on_fail
 
   test_aio:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ var_10: &restore_cache
 
 # Branch filter that can be specified for jobs that should only run on publish branches
 # (e.g. master or the patch branch)
-var_12: &publish_branches_filter
+var_11: &publish_branches_filter
   branches:
     only:
       - master
@@ -117,9 +117,29 @@ var_12: &publish_branches_filter
 # `build-npm-packages`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/
-var_13: &attach_workspace
+var_12: &attach_workspace
   attach_workspace:
     at: ~/
+
+var_13: &notify_caretaker_on_fail
+  run:
+    when: on_fail
+    name: Notify caretaker about failure
+    # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
+    # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+    command: |
+      notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
+      curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_CARETAKER_WEBHOOK_URL
+
+var_14: &notify_dev_infra_on_fail
+  run:
+    when: on_fail
+    name: Notify dev-infra about failure
+    # `$SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
+    # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+    command: |
+      notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
+      curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL
 
 version: 2
 jobs:
@@ -534,16 +554,8 @@ jobs:
       - run:
           name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE
-      - run:
-          when: on_fail
-          name: Notify caretaker and dev-infra about failure
-          # `$SLACK_CARETAKER_WEBHOOK_URL` and `$SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK` are secret env
-          # vars defined in CircleCI project settings.
-          # The URLs come from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
-          command: |
-            notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
-            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_CARETAKER_WEBHOOK_URL
-            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL
+      - *notify_caretaker_on_fail
+      - *notify_dev_infra_on_fail
 
   aio_monitoring_next:
     <<: *job_defaults
@@ -557,16 +569,8 @@ jobs:
       - run:
           name: Run tests against https://next.angular.io/
           command: ./aio/scripts/test-production.sh https://next.angular.io/ $CI_AIO_MIN_PWA_SCORE
-      - run:
-          when: on_fail
-          name: Notify caretaker and dev-infra about failure
-          # `$SLACK_CARETAKER_WEBHOOK_URL` and `$SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL` are secret env
-          # vars defined in CircleCI project settings.
-          # The URLs come from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
-          command: |
-            notificationJson="{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}"
-            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_CARETAKER_WEBHOOK_URL
-            curl --request POST --header "Content-Type: application/json" --data "$notificationJson" $SLACK_DEV_INFRA_CI_FAILURES_WEBHOOK_URL
+      - *notify_caretaker_on_fail
+      - *notify_dev_infra_on_fail
 
   legacy-unit-tests-saucelabs:
     <<: *job_defaults


### PR DESCRIPTION
Currently, we are sending failure notifications from the `aio_monitoring` jobs (executed once per day) to the `#fw-caretaker` Slack channel.

This PR configures CircleCI to also send failure notifications to the `#dev-infra-ci-failures` Slack channel for both `aio_monitoring` and `saucelabs_tests` (executed every hour).