### PR TITLE
ci: enable remote build caching for CI jobs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,3 @@
-################################
-# Settings for Angular team members only
-################################
-# To enable this feature check the "Remote caching" section in docs/BAZEL.md.
-build:angular-team --remote_http_cache=https://storage.googleapis.com/angular-team-cache
-
 ###############################
 # Typescript / Angular / Sass #
 ###############################
@@ -139,9 +133,12 @@ build:remote --platforms=//tools:rbe_ubuntu1604-angular
 build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
 build:remote --project_id=internal-200822
 
-# Do not accept remote cache.
-# We need to understand the security risks of using prior build artifacts.
+# Remote caching
+build:remote --remote_cache=remotebuildexecution.googleapis.com
+# By default, do not accept remote cache, to be set to true for CI based on environment
 build:remote --remote_accept_cached=false
+# By default, do not upload local results to cache, to be set to true for CI based on environment
+build:remote --remote_upload_local_results=false
 
 # Build Event Service Configuration
 build:remote --bes_backend=buildeventservice.googleapis.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,17 @@ var_5: &setup_bazel_remote_execution
       # cause decryption failures based on the openssl version. https://stackoverflow.com/a/39641378/4317734
       openssl aes-256-cbc -d -in .circleci/gcp_token -md md5 -k "$CI_REPO_NAME" -out /home/circleci/.gcp_credentials
       echo "export GOOGLE_APPLICATION_CREDENTIALS=/home/circleci/.gcp_credentials" >> $BASH_ENV
-      sudo bash -c "echo 'build --config=remote' >> /etc/bazel.bazelrc"
+      touch .bazelrc.user
+      sudo bash -c "echo -e 'build --config=remote\n' >> .bazelrc.user"
+      sudo bash -c "echo -e 'build:remote --remote_accept_cached=true\n' >> .bazelrc.user"
+      echo "Reading from remote cache for bazel remote jobs."
+      if [[ "$CI_PULL_REQUEST" == "false" ]]; then
+        sudo bash -c "echo -e 'build:remote --remote_upload_local_results=true\n' >> .bazelrc.user"
+        echo "Uploading local build results to remote cache."
+      else
+        sudo bash -c "echo -e 'build:remote --remote_upload_local_results=false\n' >> .bazelrc.user"
+        echo "Not uploading local build results to remote cache."
+      fi
 
 # Settings common to each job
 var_6: &job_defaults


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
Enables remote caching for CI jobs.

This configuration:
- always reads from build cache on CI 
- only write to build cache for local builds for non-PR CI runs