### PR TITLE
ci: add josephperrott to `dev-infra` owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@
 #  IgorMinar - Igor Minar
 #  jasonaden - Jason Aden
 #  jenniferfell - Jennifer Fell
+#  josephperrott - Joey Perrott
 #  kara - Kara Erickson
 #  kyliau - Keen Yee Liau
 #  matsko - Matias Niemelä
@@ -346,7 +347,7 @@
 #   - filipesilva
 #   - gkalpak
 #   - IgorMinar
-
+#   - josephperrott
 
 
 


### PR DESCRIPTION
☝️ 
(Joey is already member of the [`fw-dev-infra` GitHub team][1]. This PR just updates `CODEOWNERS` to rflect that.)

[1]: https://github.com/orgs/angular/teams/fw-dev-infra/members