### PR TITLE
docs: fix style issue in aoh that 'nav a' margin-right is missing

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/app.component.css
+++ b/aio/content/examples/toh-pt5/src/app/app.component.css
@@ -11,6 +11,7 @@ h2 {
 nav a {
   padding: 5px 10px;
   text-decoration: none;
+  margin-right: 10px;
   margin-top: 10px;
   display: inline-block;
   background-color: #eee;

--- a/aio/content/examples/toh-pt6/src/app/app.component.css
+++ b/aio/content/examples/toh-pt6/src/app/app.component.css
@@ -11,6 +11,7 @@ h2 {
 nav a {
   padding: 5px 10px;
   text-decoration: none;
+  margin-right: 10px;
   margin-top: 10px;
   display: inline-block;
   background-color: #eee;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
'nav a' elements('Dashboard' and 'Heroes') are closed to each other in code example of below:
https://angular.io/tutorial/toh-pt5#final-code-review
https://angular.io/tutorial/toh-pt6#final-code-review

not same with live example: https://andkdbgekqb.angular.stackblitz.io/dashboard
 
Issue Number: N/A


## What is the new behavior?
'nav a' elements('Dashboard' and 'Heroes') are **NOT** closed to each other with a `margin-right: 10px;`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
