### PR TITLE
fix(ivy): incorrect namespace for root node created through ViewContainerRef

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -30,7 +30,7 @@ import {ComponentDef} from './interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode} from './interfaces/node';
 import {RNode, RendererFactory3, domRendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {LView, LViewFlags, RootContext, TVIEW} from './interfaces/view';
-import {enterView, leaveView} from './state';
+import {enterView, leaveView, namespaceHTMLInternal} from './state';
 import {defaultScheduler} from './util/misc_utils';
 import {getTNode} from './util/view_utils';
 import {createElementRef} from './view_engine_compatibility';
@@ -140,6 +140,9 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
         rootViewInjector.get(RendererFactory2, domRendererFactory3) as RendererFactory3;
     const sanitizer = rootViewInjector.get(Sanitizer, null);
 
+    // Ensure that the namespace for the root node is correct,
+    // otherwise the browser might not render out the element properly.
+    namespaceHTMLInternal();
     const hostRNode = isInternalRootView ?
         elementCreate(this.selector, rendererFactory.createRenderer(null, this.componentDef)) :
         locateHostElement(rendererFactory, rootSelectorOrNode);

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -534,12 +534,20 @@ export function ɵɵnamespaceMathML() {
 }
 
 /**
- * Sets the namespace used to create elements no `null`, which forces element creation to use
+ * Sets the namespace used to create elements to `null`, which forces element creation to use
  * `createElement` rather than `createElementNS`.
  *
  * @codeGenApi
  */
 export function ɵɵnamespaceHTML() {
+  namespaceHTMLInternal();
+}
+
+/**
+ * Sets the namespace used to create elements to `null`, which forces element creation to use
+ * `createElement` rather than `createElementNS`.
+ */
+export function namespaceHTMLInternal() {
   _currentNamespace = null;
 }
 

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -582,6 +582,9 @@
     "name": "matchTemplateAttribute"
   },
   {
+    "name": "namespaceHTMLInternal"
+  },
+  {
     "name": "nativeAppendChild"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -387,6 +387,9 @@
     "name": "locateHostElement"
   },
   {
+    "name": "namespaceHTMLInternal"
+  },
+  {
     "name": "nativeAppendChild"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1245,6 +1245,9 @@
     "name": "matchTemplateAttribute"
   },
   {
+    "name": "namespaceHTMLInternal"
+  },
+  {
     "name": "nativeAppendChild"
   },
   {


### PR DESCRIPTION
Currently in Ivy whenever we encounter a new namespace, we set it in the global state so that all subsequent nodes are created under the same namespace. Next time a template is run the namespace will be reset back to HTML.

This breaks down if the last node that was rendered was under the SVG or MathML namespace and we create a component through `ViewContainerRef.create`, because the next template function hasn't run yet and it hasn't had the chance to update the namespace. The result is that the root node of the new component will retain the wrong namespace and may not end up rendering at all (e.g. if we're trying to show a `div` inside the SVG namespace). This issue has the potential to affect a lot of apps, because all components inserted through the router also go through `ViewContainerRef.create`.
