### PR TITLE
feat(ivy): index template elements

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -15,13 +15,8 @@ import * as ts from 'typescript';
 export enum IdentifierKind {
   Property,
   Method,
-}
-
-/**
- * Describes the absolute byte offsets of a text anchor in a source code.
- */
-export class AbsoluteSourceSpan {
-  constructor(public start: number, public end: number) {}
+  Element,
+  Attribute,
 }
 
 /**
@@ -34,6 +29,43 @@ export interface TemplateIdentifier {
   kind: IdentifierKind;
 }
 
+/** Describes a property accessed in a template. */
+export interface PropertyIdentifier extends TemplateIdentifier { kind: IdentifierKind.Property; }
+
+/** Describes a method accessed in a template. */
+export interface MethodIdentifier extends TemplateIdentifier { kind: IdentifierKind.Method; }
+
+/** Describes an element attribute in a template. */
+export interface AttributeIdentifier extends TemplateIdentifier { kind: IdentifierKind.Attribute; }
+
+/**
+ * Describes an indexed element in a template. The name of an `ElementIdentifier` is the entire
+ * element tag, which can be parsed by an indexer to determine where used directives should be
+ * referenced.
+ */
+export interface ElementIdentifier extends TemplateIdentifier {
+  kind: IdentifierKind.Element;
+
+  /** Attributes on an element. */
+  attributes: Set<AttributeIdentifier>;
+
+  /** Directives applied to an element. */
+  usedDirectives: Set<ts.Declaration>;
+}
+
+/**
+ * Identifiers recorded at the top level of the template, without any context about the HTML nodes
+ * they were discovered in.
+ */
+export type TopLevelIdentifier = PropertyIdentifier | MethodIdentifier | ElementIdentifier;
+
+/**
+ * Describes the absolute byte offsets of a text anchor in a source code.
+ */
+export class AbsoluteSourceSpan {
+  constructor(public start: number, public end: number) {}
+}
+
 /**
  * Describes an analyzed, indexed component and its template.
  */
@@ -42,7 +74,7 @@ export interface IndexedComponent {
   selector: string|null;
   file: ParseSourceFile;
   template: {
-    identifiers: Set<TemplateIdentifier>,
+    identifiers: Set<TopLevelIdentifier>,
     usedComponents: Set<ts.Declaration>,
     isInline: boolean,
     file: ParseSourceFile;

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -74,8 +74,8 @@ class ExpressionVisitor extends RecursiveAstVisitor {
    * @param ast expression AST the identifier is in
    * @param kind identifier kind
    */
-  private visitIdentifier<Id extends ExpressionIdentifier>(
-      ast: AST&{name: string, receiver: AST}, kind: Id['kind']) {
+  private visitIdentifier(
+      ast: AST&{name: string, receiver: AST}, kind: ExpressionIdentifier['kind']) {
     // The definition of a non-top-level property such as `bar` in `{{foo.bar}}` is currently
     // impossible to determine by an indexer and unsupported by the indexing module.
     // The indexing module also does not currently support references to identifiers declared in the
@@ -100,7 +100,7 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     const absoluteStart = this.absoluteOffset + identifierStart;
     const span = new AbsoluteSourceSpan(absoluteStart, absoluteStart + ast.name.length);
 
-    this.identifiers.push({ name: ast.name, span, kind, } as Id);
+    this.identifiers.push({ name: ast.name, span, kind, } as ExpressionIdentifier);
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteSourceSpan, IdentifierKind} from '..';
+import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind} from '..';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getTemplateIdentifiers} from '../src/template';
 import * as util from './util';
@@ -20,8 +20,8 @@ function bind(template: string) {
 
 runInEachFileSystem(() => {
   describe('getTemplateIdentifiers', () => {
-    it('should generate nothing in HTML-only template', () => {
-      const refs = getTemplateIdentifiers(bind('<div></div>'));
+    it('should generate nothing in empty template', () => {
+      const refs = getTemplateIdentifiers(bind(''));
 
       expect(refs.size).toBe(0);
     });
@@ -33,14 +33,14 @@ runInEachFileSystem(() => {
     });
 
     it('should handle arbitrary whitespace', () => {
-      const template = '<div>\n\n   {{foo}}</div>';
+      const template = '\n\n   {{foo}}';
       const refs = getTemplateIdentifiers(bind(template));
 
       const [ref] = Array.from(refs);
       expect(ref).toEqual({
         name: 'foo',
         kind: IdentifierKind.Property,
-        span: new AbsoluteSourceSpan(12, 15),
+        span: new AbsoluteSourceSpan(7, 10),
       });
     });
 
@@ -75,11 +75,11 @@ runInEachFileSystem(() => {
         const refs = getTemplateIdentifiers(bind(template));
 
         const refArr = Array.from(refs);
-        expect(refArr).toEqual(jasmine.arrayContaining([{
+        expect(refArr).toContain({
           name: 'foo',
           kind: IdentifierKind.Property,
           span: new AbsoluteSourceSpan(13, 16),
-        }]));
+        });
       });
 
       it('should ignore identifiers that are not implicitly received by the template', () => {
@@ -111,11 +111,11 @@ runInEachFileSystem(() => {
         const refs = getTemplateIdentifiers(bind(template));
 
         const refArr = Array.from(refs);
-        expect(refArr).toEqual(jasmine.arrayContaining([{
+        expect(refArr).toContain({
           name: 'foo',
           kind: IdentifierKind.Method,
           span: new AbsoluteSourceSpan(13, 16),
-        }]));
+        });
       });
 
       it('should ignore identifiers that are not implicitly received by the template', () => {
@@ -125,6 +125,128 @@ runInEachFileSystem(() => {
 
         const [ref] = Array.from(refs);
         expect(ref.name).toBe('foo');
+      });
+    });
+
+    describe('generates identifiers for elements', () => {
+      it('should record elements as ElementIdentifiers', () => {
+        const template = '<test-selector>';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref.kind).toBe(IdentifierKind.Element);
+      });
+
+      it('should record element names as their selector', () => {
+        const template = '<test-selector>';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref as ElementIdentifier).toEqual({
+          name: 'test-selector',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(1, 14),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        });
+      });
+
+      it('should discover selectors in self-closing elements', () => {
+        const template = '<img />';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref as ElementIdentifier).toEqual({
+          name: 'img',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(1, 4),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        });
+      });
+
+      it('should discover selectors in elements with adjacent open and close tags', () => {
+        const template = '<test-selector></test-selector>';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref as ElementIdentifier).toEqual({
+          name: 'test-selector',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(1, 14),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        });
+      });
+
+      it('should discover selectors in elements with non-adjacent open and close tags', () => {
+        const template = '<test-selector> text </test-selector>';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref as ElementIdentifier).toEqual({
+          name: 'test-selector',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(1, 14),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        });
+      });
+
+      it('should discover nested selectors', () => {
+        const template = '<div><span></span></div>';
+        const refs = getTemplateIdentifiers(bind(template));
+
+        const refArr = Array.from(refs);
+        expect(refArr).toContain({
+          name: 'span',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(6, 10),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        });
+      });
+
+      it('should generate information about attributes', () => {
+        const template = '<div attrA attrB="val"></div>';
+        const refs = getTemplateIdentifiers(bind(template));
+
+        const [ref] = Array.from(refs);
+        const attrs = (ref as ElementIdentifier).attributes;
+        expect(attrs).toEqual(new Set<AttributeIdentifier>([
+          {
+            name: 'attrA',
+            kind: IdentifierKind.Attribute,
+            span: new AbsoluteSourceSpan(5, 10),
+          },
+          {
+            name: 'attrB',
+            kind: IdentifierKind.Attribute,
+            span: new AbsoluteSourceSpan(11, 22),
+          }
+        ]));
+      });
+
+      it('should generate information about used directives', () => {
+        const declA = util.getComponentDeclaration('class A {}', 'A');
+        const declB = util.getComponentDeclaration('class B {}', 'B');
+        const declC = util.getComponentDeclaration('class C {}', 'C');
+        const template = '<a-selector b-selector></a-selector>';
+        const boundTemplate = util.getBoundTemplate(template, {}, [
+          {selector: 'a-selector', declaration: declA},
+          {selector: '[b-selector]', declaration: declB},
+          {selector: ':not(never-selector)', declaration: declC},
+        ]);
+
+        const refs = getTemplateIdentifiers(boundTemplate);
+        const [ref] = Array.from(refs);
+        const usedDirectives = (ref as ElementIdentifier).usedDirectives;
+        expect(usedDirectives).toEqual(new Set([declA, declB, declC]));
       });
     });
   });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -7,9 +7,8 @@
  */
 import {BoundTarget, ParseSourceFile} from '@angular/compiler';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
-import {IndexingContext} from '../src/context';
+import {ComponentMeta, IndexingContext} from '../src/context';
 import {getTemplateIdentifiers} from '../src/template';
 import {generateAnalysis} from '../src/transform';
 import * as util from './util';
@@ -19,7 +18,7 @@ import * as util from './util';
  */
 function populateContext(
     context: IndexingContext, component: ClassDeclaration, selector: string, template: string,
-    boundTemplate: BoundTarget<DirectiveMeta>, isInline: boolean = false) {
+    boundTemplate: BoundTarget<ComponentMeta>, isInline: boolean = false) {
   context.addComponent({
     declaration: component,
     selector,

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -10,9 +10,9 @@ import {BoundTarget, CssSelector, ParseTemplateOptions, R3TargetBinder, Selector
 import * as ts from 'typescript';
 import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
 import {Reference} from '../../imports';
-import {DirectiveMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
+import {ComponentMeta} from '../src/context';
 
 /** Dummy file URL */
 export function getTestFilePath(): AbsoluteFsPath {
@@ -41,16 +41,12 @@ export function getComponentDeclaration(componentStr: string, className: string)
 export function getBoundTemplate(
     template: string, options: ParseTemplateOptions = {},
     components: Array<{selector: string, declaration: ClassDeclaration}> =
-        []): BoundTarget<DirectiveMeta> {
-  const matcher = new SelectorMatcher<DirectiveMeta>();
+        []): BoundTarget<ComponentMeta> {
+  const matcher = new SelectorMatcher<ComponentMeta>();
   components.forEach(({selector, declaration}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
       ref: new Reference(declaration),
       selector,
-      queries: [],
-      ngTemplateGuards: [],
-      hasNgTemplateContextGuard: false,
-      baseClass: null,
       name: declaration.name.getText(),
       isComponent: true,
       inputs: {},

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -7,7 +7,7 @@
  */
 import {AbsoluteFsPath, resolve} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {AbsoluteSourceSpan, IdentifierKind} from '@angular/compiler-cli/src/ngtsc/indexer';
+import {AbsoluteSourceSpan, IdentifierKind, TopLevelIdentifier} from '@angular/compiler-cli/src/ngtsc/indexer';
 import {ParseSourceFile} from '@angular/compiler/src/compiler';
 
 import {NgtscTestEnvironment} from './env';
@@ -66,7 +66,7 @@ runInEachFileSystem(() => {
         const template = indexedComp.template;
 
         expect(template).toEqual({
-          identifiers: new Set([{
+          identifiers: new Set<TopLevelIdentifier>([{
             name: 'foo',
             kind: IdentifierKind.Property,
             span: new AbsoluteSourceSpan(127, 130),
@@ -93,7 +93,7 @@ runInEachFileSystem(() => {
         const template = indexedComp.template;
 
         expect(template).toEqual({
-          identifiers: new Set([{
+          identifiers: new Set<TopLevelIdentifier>([{
             name: 'foo',
             kind: IdentifierKind.Property,
             span: new AbsoluteSourceSpan(2, 5),
@@ -118,20 +118,20 @@ runInEachFileSystem(() => {
         })
         export class TestCmp { foo = 0; }
       `);
-        env.write(testTemplateFile, '<div>  \n  {{foo}}</div>');
+        env.write(testTemplateFile, '  \n  {{foo}}');
         const indexed = env.driveIndexer();
         const [[_, indexedComp]] = Array.from(indexed.entries());
         const template = indexedComp.template;
 
         expect(template).toEqual({
-          identifiers: new Set([{
+          identifiers: new Set<TopLevelIdentifier>([{
             name: 'foo',
             kind: IdentifierKind.Property,
-            span: new AbsoluteSourceSpan(12, 15),
+            span: new AbsoluteSourceSpan(7, 10),
           }]),
           usedComponents: new Set(),
           isInline: false,
-          file: new ParseSourceFile('<div>  \n  {{foo}}</div>', testTemplateFile),
+          file: new ParseSourceFile('  \n  {{foo}}', testTemplateFile),
         });
       });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Indexer module does not index the location of element selectors.

Issue Number: #31299

## What is the new behavior?
Index the location of element selectors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Closes #31299