### PR TITLE
ci(docs-infra): re-enable payload size checking for `test_aio_local` and `test_aio_local_ivy`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,8 +314,7 @@ jobs:
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Check the bundle sizes.
-      # Temporary disabled due to a problem with patch branch (8.0.x)
-      # - run: yarn --cwd aio payload-size aio-local
+      - run: yarn --cwd aio payload-size aio-local
 
   test_aio_local_ivy:
     <<: *job_defaults
@@ -334,8 +333,7 @@ jobs:
         # Run PWA-score tests
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Check the bundle sizes.
-      # Temporary disabled due to a problem with patch branch (8.0.x)
-      # - run: yarn --cwd aio payload-size aio-local-ivy
+      - run: yarn --cwd aio payload-size aio-local-ivy
 
   test_aio_tools:
     <<: *job_defaults

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -16,8 +16,8 @@
       "uncompressed": {
         "runtime-es5": 3042,
         "runtime-es2015": 3048,
-        "main-es5": 511036,
-        "main-es2015": 450486,
+        "main-es5": 504845,
+        "main-es2015": 443921,
         "polyfills-es5": 130136,
         "polyfills-es2015": 52931
       }
@@ -28,8 +28,8 @@
       "uncompressed": {
         "runtime-es5": 2932,
         "runtime-es2015": 2938,
-        "main-es5": 565073,
-        "main-es2015": 583108,
+        "main-es5": 563201,
+        "main-es2015": 580852,
         "polyfills-es5": 130136,
         "polyfills-es2015": 52931
       }


### PR DESCRIPTION
Previously, payload size checking for `test_aio_local` and `test_aio_local_ivy` was disabled on the 8.0.x branch (in #31064), because the numbers (which were cherry-picked from master) did not match the actual sizes.

This commit updates the numbers for the 8.0.x branch and re-enables the checks.
