### PR TITLE
feat(docs-infra): add prominent archive mode banner styling

### DIFF
--- a/aio/src/app/layout/mode-banner/mode-banner.component.ts
+++ b/aio/src/app/layout/mode-banner/mode-banner.component.ts
@@ -4,9 +4,9 @@ import { VersionInfo } from 'app/navigation/navigation.service';
 @Component({
   selector: 'aio-mode-banner',
   template: `
-  <div *ngIf="mode == 'archive'" class="mode-banner">
-    This is the <strong>archived documentation for Angular v{{version?.major}}.</strong>
-    Please visit <a href="https://angular.io/">angular.io</a> to see documentation for the current version of Angular.
+  <div *ngIf="mode == 'archive'" class="mode-banner alert archive-warning">
+    <p>This is the <strong>archived documentation for Angular v{{version?.major}}.</strong>
+    Please visit <a href="https://angular.io/">angular.io</a> to see documentation for the current version of Angular.</p>
   </div>
   `
 })

--- a/aio/src/styles/2-modules/_alert.scss
+++ b/aio/src/styles/2-modules/_alert.scss
@@ -38,6 +38,26 @@
         }
     }
 
+    &.archive-warning {
+      background-color: $darkred;
+      border-radius: 4px;
+      margin-bottom: 1rem;
+
+      * {
+        color: $white;
+      }
+
+      a {
+        color: $white;
+        font-weight: bold;
+        text-decoration: underline;
+
+        &:hover {
+          opacity: 0.9;
+        }
+      }
+    }
+
     > * {
         margin: 8px 16px;
     }

--- a/aio/src/styles/2-modules/_modules-dir.scss
+++ b/aio/src/styles/2-modules/_modules-dir.scss
@@ -12,6 +12,7 @@
    @import 'code';
    @import 'contribute';
    @import 'contributor';
+   @import 'deploy-theme';
    @import 'details';
    @import 'edit-page-cta';
    @import 'features';
@@ -19,14 +20,13 @@
    @import 'heading-anchors';
    @import 'hr';
    @import 'images';
+   @import 'label';
+   @import 'notification';
    @import 'progress-bar';
-   @import 'table';
    @import 'presskit';
    @import 'resources';
    @import 'scrollbar';
    @import 'search-results';
-   @import 'toc';
    @import 'select-menu';
-   @import 'deploy-theme';
-   @import 'notification';
-   @import 'label';
+   @import 'table';
+   @import 'toc';


### PR DESCRIPTION
Used existing `alert` class styling for consistency with modifications to make more prominent.

To consider: If this mode-banner is going to show up on every page, we might want a full page banner (such as below the toolbar, or above it as a sticky banner). If the mode-banner is only for certain pages, then the alert-style visual makes more sense.

After:
<img width="1418" alt="Screen Shot 2019-06-24 at 1 39 01 PM" src="https://user-images.githubusercontent.com/2958442/60050450-7fc5d880-9685-11e9-81f5-9ca312687b71.png">

Before:
<img width="1419" alt="Screen Shot 2019-06-24 at 1 39 21 PM" src="https://user-images.githubusercontent.com/2958442/60050453-82283280-9685-11e9-95c7-cc5eb6bf3299.png">

<hr>
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #25968


## What is the new behavior?
More prominent style for archived documentation mode banner

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
