### PR TITLE
feat(language-service): add Angular pseudo elements into completions

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,7 +28,7 @@ const hiddenHtmlElements = {
   link: true,
 };
 
-const angularPseudoElements = ['ng-container', 'ng-content', 'ng-template'];
+const ANGULAR_PSEUDO_ELEMENTS = ['ng-container', 'ng-content', 'ng-template'] as const;
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {
@@ -244,7 +244,7 @@ function elementCompletions(info: AstResult, path: AstPath<HtmlAst>): ts.Complet
       sortText: name,
     };
   });
-  const pseudoElements = angularPseudoElements.map(name => {
+  const pseudoElements = ANGULAR_PSEUDO_ELEMENTS.map(name => {
     return {
       name,
       // Need to cast to unknown because Angular's CompletionKind includes HTML

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,7 +28,7 @@ const hiddenHtmlElements = {
   link: true,
 };
 
-const ANGULAR_PSEUDO_ELEMENTS = ['ng-container', 'ng-content', 'ng-template'] as const;
+const ANGULAR_PSEUDO_ELEMENTS = ['ng-container', 'ng-content', 'ng-template'] as const ;
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {
@@ -249,7 +249,7 @@ function elementCompletions(info: AstResult, path: AstPath<HtmlAst>): ts.Complet
       name,
       // Need to cast to unknown because Angular's CompletionKind includes HTML
       // entites.
-      kind: CompletionKind.COMPONENT as unknown as ts.ScriptElementKind,
+      kind: CompletionKind.PSEUDO_ELEMENT as unknown as ts.ScriptElementKind,
       sortText: name,
     };
   });

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,8 +28,7 @@ const hiddenHtmlElements = {
   link: true,
 };
 
-const ANGULAR_ELEMENTS: ReadonlyArray<string> =
-    ['ng-container', 'ng-content', 'ng-template'] ;
+const ANGULAR_ELEMENTS: ReadonlyArray<string> = ['ng-container', 'ng-content', 'ng-template'];
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,6 +28,8 @@ const hiddenHtmlElements = {
   link: true,
 };
 
+const angularPseudoElements = ['ng-container', 'ng-content', 'ng-template'];
+
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {
   let result: ts.CompletionEntry[] = [];
@@ -242,9 +244,18 @@ function elementCompletions(info: AstResult, path: AstPath<HtmlAst>): ts.Complet
       sortText: name,
     };
   });
+  const pseudoElements = angularPseudoElements.map(name => {
+    return {
+      name,
+      // Need to cast to unknown because Angular's CompletionKind includes HTML
+      // entites.
+      kind: CompletionKind.COMPONENT as unknown as ts.ScriptElementKind,
+      sortText: name,
+    };
+  });
 
   // Return components and html elements
-  return uniqueByName(htmlElements.concat(components));
+  return uniqueByName([...htmlElements, ...components, ...pseudoElements]);
 }
 
 /**

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,7 +28,7 @@ const hiddenHtmlElements = {
   link: true,
 };
 
-const ANGULAR_PSEUDO_ELEMENTS = ['ng-container', 'ng-content', 'ng-template'] as const ;
+const ANGULAR_ELEMENTS: ReadonlyArray<string> = ['ng-container', 'ng-content', 'ng-template'] as const ;
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {
@@ -244,18 +244,18 @@ function elementCompletions(info: AstResult, path: AstPath<HtmlAst>): ts.Complet
       sortText: name,
     };
   });
-  const pseudoElements = ANGULAR_PSEUDO_ELEMENTS.map(name => {
+  const angularElements = ANGULAR_ELEMENTS.map(name => {
     return {
       name,
       // Need to cast to unknown because Angular's CompletionKind includes HTML
       // entites.
-      kind: CompletionKind.PSEUDO_ELEMENT as unknown as ts.ScriptElementKind,
+      kind: CompletionKind.ANGULAR_ELEMENT as unknown as ts.ScriptElementKind,
       sortText: name,
     };
   });
 
   // Return components and html elements
-  return uniqueByName([...htmlElements, ...components, ...pseudoElements]);
+  return uniqueByName([...htmlElements, ...components, ...angularElements]);
 }
 
 /**

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -28,7 +28,8 @@ const hiddenHtmlElements = {
   link: true,
 };
 
-const ANGULAR_ELEMENTS: ReadonlyArray<string> = ['ng-container', 'ng-content', 'ng-template'] as const ;
+const ANGULAR_ELEMENTS: ReadonlyArray<string> =
+    ['ng-container', 'ng-content', 'ng-template'] as const ;
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -29,7 +29,7 @@ const hiddenHtmlElements = {
 };
 
 const ANGULAR_ELEMENTS: ReadonlyArray<string> =
-    ['ng-container', 'ng-content', 'ng-template'] as const ;
+    ['ng-container', 'ng-content', 'ng-template'] ;
 
 export function getTemplateCompletions(
     templateInfo: AstResult, position: number): ts.CompletionEntry[] {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -274,7 +274,7 @@ export enum CompletionKind {
   REFERENCE = 'reference',
   TYPE = 'type',
   VARIABLE = 'variable',
-  PSEUDO_ELEMENT = 'pseudo element'
+  ANGULAR_ELEMENT = 'angular element'
 }
 
 /**

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -262,6 +262,7 @@ export enum DirectiveKind {
  * ScriptElementKind for completion.
  */
 export enum CompletionKind {
+  ANGULAR_ELEMENT = 'angular element',
   ATTRIBUTE = 'attribute',
   COMPONENT = 'component',
   ELEMENT = 'element',
@@ -274,7 +275,6 @@ export enum CompletionKind {
   REFERENCE = 'reference',
   TYPE = 'type',
   VARIABLE = 'variable',
-  ANGULAR_ELEMENT = 'angular element'
 }
 
 /**

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -274,6 +274,7 @@ export enum CompletionKind {
   REFERENCE = 'reference',
   TYPE = 'type',
   VARIABLE = 'variable',
+  PSEUDO_ELEMENT = 'pseudo element'
 }
 
 /**

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -51,6 +51,16 @@ describe('completions', () => {
     ]);
   });
 
+  it('should be able to return angular pseudo elements', () => {
+    const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'empty');
+    const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);
+    expectContain(completions, CompletionKind.ANGULAR_ELEMENT, [
+      'ng-container',
+      'ng-content',
+      'ng-template',
+    ]);
+  });
+
   it('should be able to return h1 attributes', () => {
     const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'h1-after-space');
     const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Angular pseudo elements such as `ng-container`, `ng-content` and `ng-template` are not in the completion list. They are not suggested by IDEs.

## What is the new behavior?

Added into the completion list. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I don't know how can I test language-service in VSCode locally...
