### PR TITLE
 fix(docs-infra): separate vendor-specific CSS selectors

### DIFF
--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -97,10 +97,6 @@ mat-sidenav-container div.mat-sidenav-content {
 
   //icons _within_ nav
   .mat-icon {
-    // position: absolute;
-    // top: 8px;
-    // right: 8px;
-    // margin: 0;
     height: 24px;
     width: 24px;
   }
@@ -161,11 +157,13 @@ button.vertical-menu-item {
   transition: background-color 0.2s;
   text-transform: uppercase;
 
-  &.expanded .mat-icon, .level-2.expanded .mat-icon {
+  &.expanded .mat-icon,
+  .level-2.expanded .mat-icon {
     @include rotate(90deg);
   }
 
-  &:not(.expanded) .mat-icon, .level-2:not(.expanded) .mat-icon {
+  &:not(.expanded) .mat-icon,
+  .level-2:not(.expanded) .mat-icon {
     @include rotate(0deg);
   }
 

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -8,24 +8,24 @@
 /* API LIST STYLES */
 
 aio-api-list {
-    div.form-search i.material-icons {
-        width: 20px;
-        pointer-events: none;
-    }
+  div.form-search i.material-icons {
+    width: 20px;
+    pointer-events: none;
+  }
 
-    .form-search input {
-        width: 182px;
-    }
+  .form-search input {
+    width: 182px;
+  }
 
-    .api-list-container {
-      display: flex;
-      flex-direction: column;
-      margin: 0 auto;
+  .api-list-container {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
 
-      h2 {
-        margin-top: 16px;
-      }
+    h2 {
+      margin-top: 16px;
     }
+  }
 }
 
 .api-filter {
@@ -33,12 +33,12 @@ aio-api-list {
   margin: 0 auto;
 
   @media (max-width: 600px) {
-      flex-direction: column;
-      margin: 16px auto;
+    flex-direction: column;
+    margin: 16px auto;
   }
 
   .form-select-menu, .form-search {
-      margin: 8px;
+    margin: 8px;
   }
 }
 
@@ -162,8 +162,8 @@ aio-api-list {
   overflow: hidden;
 
   @media screen and (max-width: 600px) {
-        margin: 0 0 0 -8px;
-    }
+    margin: 0 0 0 -8px;
+  }
 
   li {
     @include font-size(14);
@@ -180,6 +180,7 @@ aio-api-list {
     .symbol {
       margin-right: 8px;
     }
+
     a {
       color: $blue-grey-600;
       display: inline-block;
@@ -226,7 +227,6 @@ aio-api-list {
 }
 
 p {
-
   &.selector {
     margin: 0;
   }

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -78,15 +78,21 @@ aio-api-list {
     transition: all .2s;
 
     // PLACEHOLDER TEXT
-    &::-webkit-input-placeholder,
-    &::-moz-placeholder,
-    &::-ms-input-placeholder,
-    &:-moz-placeholder {
-      /* Chrome/Opera/Safari */
-      /* Firefox 19+ */
-      /* IE 10+ */
-      /* Firefox 18- */
-
+    // NOTE: Vendor-prefixed selectors must be on separate blocks, because one invalid/unknown
+    //       selector will invalidate the whole block.
+    &::placeholder {  // Chrome/Firefox/Safari
+      color: $blue-grey-100;
+      @include font-size(14);
+    }
+    &::-webkit-input-placeholder {  // QQ Browser
+      color: $blue-grey-100;
+      @include font-size(14);
+    }
+    &::-ms-input-placeholder {  // Edge
+      color: $blue-grey-100;
+      @include font-size(14);
+    }
+    &:-ms-input-placeholder {  // IE
       color: $blue-grey-100;
       @include font-size(14);
     }


### PR DESCRIPTION
In #31118, some vendor-specific selectors were combined in one rule-set. As pointed out in [this comment][1], this would result in the whole rule-set being ignored by all browsers, since one invalid/unrecognized selector invalidates the declaration block.

This commit fixes it by defining a separate rule-set per selector. The list of vendor-specific selectors is also adjusted to better target the currently supported browsers.

[1]: https://github.com/angular/angular/pull/31118/files#r296923652