### PR TITLE
feat(ivy): error in ivy when inheriting a ctor from an undecorated base

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -106,8 +106,8 @@ export class DecorationAnalyzer {
         /* i18nUseExternalIds */ true, this.moduleResolver, this.cycleAnalyzer, this.refEmitter,
         NOOP_DEFAULT_IMPORT_RECORDER),
     new DirectiveDecoratorHandler(
-        this.reflectionHost, this.evaluator, this.fullRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
-        this.isCore),
+        this.reflectionHost, this.evaluator, this.fullMetaReader, this.fullRegistry,
+        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore),
     new InjectableDecoratorHandler(
         this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
         /* strictCtorDeps */ false),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -25,6 +25,7 @@ import {NoopResourceDependencyRecorder, ResourceDependencyRecorder} from '../../
 import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 
 import {ResourceLoader} from './api';
+import {getDirectiveDiagnostics} from './diagnostics';
 import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReference, readBaseClass, unwrapExpression} from './util';
@@ -467,7 +468,11 @@ export class ComponentDecoratorHandler implements
         this.scopeRegistry.setComponentAsRequiringRemoteScoping(node);
       }
     }
-    return {};
+
+    const diagnostics = getDirectiveDiagnostics(node, this.metaReader, this.evaluator);
+    return {
+      diagnostics: diagnostics !== null ? diagnostics : undefined,
+    };
   }
 
   compile(node: ClassDeclaration, analysis: ComponentHandlerData, pool: ConstantPool):

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {ErrorCode, makeDiagnostic} from '../../diagnostics';
+import {Reference} from '../../imports';
+import {MetadataReader} from '../../metadata';
+import {PartialEvaluator} from '../../partial_evaluator';
+import {ClassDeclaration, ReflectionHost, isNamedClassDeclaration} from '../../reflection';
+
+export function getDirectiveDiagnostics(
+    node: ClassDeclaration, reader: MetadataReader, evaluator: PartialEvaluator): ts.Diagnostic[]|
+    null {
+  let diagnostics: ts.Diagnostic[]|null = [];
+
+  const addDiagnostics = (more: ts.Diagnostic | ts.Diagnostic[] | null) => {
+    if (more === null) {
+      return;
+    } else if (diagnostics === null) {
+      diagnostics = Array.isArray(more) ? more : [more];
+    } else if (Array.isArray(more)) {
+      diagnostics.push(...more);
+    } else {
+      diagnostics.push(more);
+    }
+  };
+
+  addDiagnostics(checkInheritanceOfDirective(node, reader, evaluator));
+  return diagnostics;
+}
+
+export function checkInheritanceOfDirective(
+    node: ClassDeclaration, reader: MetadataReader, evaluator: PartialEvaluator): ts.Diagnostic|
+    null {
+  if (!ts.isClassDeclaration(node) || node.heritageClauses === undefined) {
+    return null;
+  }
+
+  const extendsClause =
+      node.heritageClauses.find(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
+  if (extendsClause === undefined) {
+    return null;
+  }
+
+  if (node.members.find(member => ts.isConstructorDeclaration(member)) !== undefined) {
+    // If a constructor exists, then no base class definition is required on the runtime side -
+    // it's legal to inherit from any class.
+    return null;
+  }
+
+
+  // The extends clause is an expression which can be as dynamic as the user wants. Try to
+  // evaluate
+  // it, but fall back on ignoring the clause if it can't be understood. This is a View Engine
+  // compatibility hack: View Engine ignores 'extends' expressions that it cannot understand.
+  const type = extendsClause.types[0];
+  const baseClass = evaluator.evaluate(type.expression);
+  if (!(baseClass instanceof Reference) || !isNamedClassDeclaration(baseClass.node)) {
+    return null;
+  }
+
+  const baseClassMeta = reader.getDirectiveMetadata(baseClass as Reference<ClassDeclaration>);
+  if (baseClassMeta !== null) {
+    return null;
+  }
+
+  const subclassMeta = reader.getDirectiveMetadata(new Reference(node)) !;
+
+  const dirOrComp = subclassMeta.isComponent ? 'Component' : 'Directive';
+
+  return makeDiagnostic(
+      ErrorCode.DIRECTIVE_INHERITS_UNDECORATED_CTOR, type,
+      `The ${dirOrComp.toLowerCase()} ${node.name.text} inherits its constructor from ${baseClass.debugName}, ` +
+          `but the latter does not have an Angular decorator of its own. Dependency injection will not be able to ` +
+          `resolve the parameters of ${baseClass.debugName}'s constructor. Either add an @Directive annotation ` +
+          `to ${baseClass.debugName}, or add an explicit constructor to ${node.name.text}.`);
+}

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -49,7 +49,8 @@ runInEachFileSystem(() => {
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
       const handler = new DirectiveDecoratorHandler(
-          reflectionHost, evaluator, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER, false);
+          reflectionHost, evaluator, metaReader, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+          false);
 
       const analyzeDirective = (dirName: string) => {
         const DirNode = getDeclaration(program, _('/entry.ts'), dirName, isNamedClassDeclaration);

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -56,6 +56,12 @@ export enum ErrorCode {
    * otherwise imported.
    */
   NGMODULE_INVALID_REEXPORT = 6004,
+
+  /**
+   * Raised when a Directive inherits its constructor from a base class without an Angular
+   * decorator.
+   */
+  DIRECTIVE_INHERITS_UNDECORATED_CTOR = 7001,
 }
 
 export function ngErrorCode(code: ErrorCode): number {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -30,6 +30,10 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
     return this.pipes.has(ref.node) ? this.pipes.get(ref.node) ! : null;
   }
 
+  forEachDirective(fn: (dir: ClassDeclaration, meta: DirectiveMeta) => void): void {
+    this.directives.forEach((meta, dir) => fn(dir, meta));
+  }
+
   registerDirectiveMetadata(meta: DirectiveMeta): void { this.directives.set(meta.ref.node, meta); }
   registerNgModuleMetadata(meta: NgModuleMeta): void { this.ngModules.set(meta.ref.node, meta); }
   registerPipeMetadata(meta: PipeMeta): void { this.pipes.set(meta.ref.node, meta); }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -507,7 +507,8 @@ export class NgtscProgram implements api.Program {
           this.options.i18nUseExternalIds !== false, this.moduleResolver, this.cycleAnalyzer,
           this.refEmitter, this.defaultImportTracker, this.incrementalState),
       new DirectiveDecoratorHandler(
-          this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore),
+          this.reflector, evaluator, this.metaReader, metaRegistry, this.defaultImportTracker,
+          this.isCore),
       new InjectableDecoratorHandler(
           this.reflector, this.defaultImportTracker, this.isCore,
           this.options.strictInjectionParameters || false),

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2374,6 +2374,9 @@ runInEachFileSystem(os => {
       env.write(`test.ts`, `
         import {Directive} from '@angular/core';
 
+        @Directive({
+          selector: '[base]',
+        })
         class Base {}
 
         @Directive({
@@ -4160,6 +4163,128 @@ export const Foo = Foo__PRE_R3__;
             .toContain(
                 'export { TestDir as \u0275ng$root$other___test$$TestDir } from "root/other._$test";');
       });
+    });
+
+    describe('inherited directives', () => {
+      beforeEach(() => {
+        env.write('local.ts', `
+          import {Component, Directive} from '@angular/core';
+  
+          export class BasePlain {}
+          
+          @Component({
+            selector: 'base-cmp',
+            template: 'BaseCmp',
+          })
+          export class BaseCmp {}
+  
+          @Directive({
+            selector: '[base]',
+          })
+          export class BaseDir {}
+        `);
+
+        env.write('lib.d.ts', `
+          import {ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta} from '@angular/core';
+  
+          export declare class BasePlain {}
+    
+          export declare class BaseCmp {
+            static ngComponentDef: ɵɵComponentDefWithMeta<BaseCmp, "base-cmp", never, {}, {}, never>
+          }
+  
+          export declare class BaseDir {
+            static ngDirectiveDef: ɵɵDirectiveDefWithMeta<BaseDir, '[base]', never, never, never, never>;
+          }
+        `);
+      });
+
+      it('should not error when inheriting a constructor from a decorated directive class', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+        import {Directive, Component} from '@angular/core';
+        import {BaseDir, BaseCmp} from './local';
+  
+        @Directive({
+          selector: '[dir]',
+        })
+        export class Dir extends BaseDir {}
+  
+        @Component({
+          selector: 'test-cmp',
+          template: 'TestCmp',
+        })
+        export class Cmp extends BaseCmp {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should error when inheriting a constructor from an undecorated class', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {Directive, Component} from '@angular/core';
+          import {BasePlain} from './local';
+  
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir extends BasePlain {}
+  
+          @Component({
+            selector: 'test-cmp',
+            template: 'TestCmp',
+          })
+          export class Cmp extends BasePlain {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText).toContain('Dir');
+        expect(diags[0].messageText).toContain('BasePlain');
+        expect(diags[1].messageText).toContain('Cmp');
+        expect(diags[1].messageText).toContain('BasePlain');
+      });
+
+      it('should not error when inheriting a constructor from decorated directive or component classes in a .d.ts file',
+         () => {
+           env.tsconfig();
+           env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+              import {BaseDir, BaseCmp} from './lib';
+  
+              @Directive({
+                selector: '[dir]',
+              })
+              export class Dir extends BaseDir {}
+  
+              @Component({
+                selector: 'test-cmp',
+                template: 'TestCmp',
+              })
+              export class Cmp extends BaseCmp {}
+           `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(0);
+         });
+
+      it('should error when inheriting a constructor from an undecorated class in a .d.ts file',
+         () => {
+           env.tsconfig();
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+  
+              import {BasePlain} from './lib';
+  
+              @Directive({
+                selector: '[dir]',
+              })
+              export class Dir extends BasePlain {}
+            `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText).toContain('Dir');
+           expect(diags[0].messageText).toContain('Base');
+         });
     });
 
     describe('inline resources', () => {


### PR DESCRIPTION
Angular View Engine uses global knowledge to compile the following code:

```typescript
export class Base {
  constructor(private vcr: ViewContainerRef) {}
}

@Directive({...})
export class Dir extends Base {
  // constructor inherited from base
}
```

Here, `Dir` extends `Base` and inherits its constructor. To create a `Dir`
the arguments to this inherited constructor must be obtained via dependency
injection. View Engine is able to generate a correct factory for `Dir` to do
this because via metadata it knows the arguments of `Base`'s constructor,
even if `Base` is declared in a different library.

In Ivy, DI is entirely a runtime concept. Currently `Dir` is compiled with
an ngDirectiveDef field that delegates its factory to `getInheritedFactory`.
This looks for some kind of factory function on `Base`, which comes up
empty. This case looks identical to an inheritance chain with no
constructors, which works today in Ivy.

Both of these cases will now become an error in this commit. If a decorated
class inherits from an undecorated base class, a diagnostic is produced
informing the user of the need to either explicitly declare a constructor or
to decorate the base class.