### PR TITLE
fix(ivy): ngcc - don't crash if entry-points have multiple invalid dependencies

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -130,12 +130,13 @@ export class DependencyResolver {
         removeNodes(entryPoint, Array.from(missing));
       } else {
         dependencies.forEach(dependencyPath => {
-          if (graph.hasNode(dependencyPath)) {
-            if (graph.hasNode(entryPoint.path)) {
-              // The entry-point is still valid (i.e. has no missing dependencies) and
-              // the dependency maps to an entry point that exists in the graph so add it
-              graph.addDependency(entryPoint.path, dependencyPath);
-            }
+          if (!graph.hasNode(entryPoint.path)) {
+            // The entry-point has already been identified as invalid so we don't need
+            // to do any further work on it.
+          } else if (graph.hasNode(dependencyPath)) {
+            // The entry-point is still valid (i.e. has no missing dependencies) and
+            // the dependency maps to an entry point that exists in the graph so add it
+            graph.addDependency(entryPoint.path, dependencyPath);
           } else if (invalidEntryPoints.some(i => i.entryPoint.path === dependencyPath)) {
             // The dependency path maps to an entry-point that was previously removed
             // from the graph, so remove this entry-point as well.


### PR DESCRIPTION
If an entry-point has missing dependencies then it cannot be
processed and is marked as invalid. Similarly, if an entry-point
has dependencies that have been marked as invalid then that
entry-point too is invalid. In all these cases, ngcc should quietly
ignore these entry-points and continue processing what it can.

Previously, if an entry-point had more than one entry-point that
was transitively invalid then ngcc was crashing rather than
ignoring the entry-point.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
