### PR TITLE
build: allow "zone.js" as scope for commit messages

### DIFF
--- a/tools/gulp-tasks/changelog.js
+++ b/tools/gulp-tasks/changelog.js
@@ -12,6 +12,7 @@ module.exports = (gulp) => () => {
     'aio',
     'docs-infra',
     'ivy',
+    'zone.js',
   ];
 
   return gulp.src('CHANGELOG.md')

--- a/tools/validate-commit-message/commit-message.json
+++ b/tools/validate-commit-message/commit-message.json
@@ -36,6 +36,7 @@
     "service-worker",
     "upgrade",
     "packaging",
-    "changelog"
+    "changelog",
+    "zone.js"
   ]
 }


### PR DESCRIPTION
Adds `zone.js` as valid scope for commit messages. This
is necessary because the `zone.js` repository has been
moved into the mono-repo and future changes should be
categorized properly through commit messages.

Currently the pre-commit git hook or CircleCI will fail when
`zone.js` is used as commit scope.