### PR TITLE
fix(ivy): ngtsc - NgtscCompilerHost should cope with directories that…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
@@ -58,7 +58,7 @@ export class NgtscCompilerHost implements ts.CompilerHost {
 
   fileExists(fileName: string): boolean {
     const absPath = this.fs.resolve(fileName);
-    return this.fs.exists(absPath);
+    return this.fs.exists(absPath) && this.fs.stat(absPath).isFile();
   }
 
   readFile(fileName: string): string|undefined {

--- a/packages/compiler-cli/src/ngtsc/file_system/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "@npm//typescript",
     ],
 )
 

--- a/packages/compiler-cli/src/ngtsc/file_system/test/compiler_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/compiler_host_spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import {NgtscCompilerHost} from '../src/compiler_host';
+import {absoluteFrom, getFileSystem} from '../src/helpers';
+import {runInEachFileSystem} from '../testing';
+
+runInEachFileSystem(() => {
+  describe('NgtscCompilerHost', () => {
+    describe('fileExists()', () => {
+      it('should return `false` for an existing directory', () => {
+        const directory = absoluteFrom('/a/b/c');
+        const fs = getFileSystem();
+        fs.ensureDir(directory);
+        const host = new NgtscCompilerHost(fs);
+        expect(host.fileExists(directory)).toBe(false);
+      });
+    });
+
+    describe('readFile()', () => {
+      it('should return `undefined` for an existing directory', () => {
+        const directory = absoluteFrom('/a/b/c');
+        const fs = getFileSystem();
+        fs.ensureDir(directory);
+        const host = new NgtscCompilerHost(fs);
+        expect(host.readFile(directory)).toBe(undefined);
+      });
+    });
+
+    describe('getSourceFile()', () => {
+      it('should return `undefined` for an existing directory', () => {
+        const directory = absoluteFrom('/a/b/c');
+        const fs = getFileSystem();
+        fs.ensureDir(directory);
+        const host = new NgtscCompilerHost(fs);
+        expect(host.getSourceFile(directory, ts.ScriptTarget.ES2015)).toBe(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
… look like files

The TS compiler is likely to test paths with extensions and try to
load them as files. Therefore `fileExists()` and methods that rely
on it need to be able to distinguish between real files and directories
that have paths that look like files.

This came up as a bug in ngcc when trying to process `ngx-virtual-scroller`,
which relies upon a library called `@tweenjs/tween.js`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
