### PR TITLE
docs: clarify how to do custom two-way bindings

### DIFF
--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1176,10 +1176,10 @@ Visualize a *banana in a box* to remember that the parentheses go _inside_ the b
 
 </div>
 
-The `[()]` syntax is easy to demonstrate when the element has a settable
-property called `x` and a corresponding event named `xChange`.
-Here's a `SizerComponent` that fits this pattern.
-It has a `size` value property and a companion `sizeChange` event:
+Two-way binding happens when the `[()]` syntax is used **and** the element has a settable
+property (e.g. `x`) with a corresponding event with the same name plus a `Change` suffix
+(e.g. `xChange`). For example, here's a `SizerComponent` that fits this pattern. It has a
+`size` value property and a companion `sizeChange` event:
 
 <code-example path="two-way-binding/src/app/sizer/sizer.component.ts" header="src/app/sizer.component.ts" linenums="false">
 </code-example>


### PR DESCRIPTION
On the "Template Syntax" documentation page, the existing wording doesn't make it clear that the `__Change` syntax is *necessary*, not just an example.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The existing wording doesn't make it clear that the `__Change` syntax is *necessary*, not just an example.

Issue Number: N/A


## What is the new behavior?
It now explicitly states that the `__Change` syntax is what makes the two-way binding happen.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
