### PR TITLE
docs: add "ivy" and "zone.js" to known scopes in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,6 +222,7 @@ The following is the list of supported scopes:
 * **router**
 * **service-worker**
 * **upgrade**
+* **zone.js**
 
 There are currently a few exceptions to the "use package name" rule:
 
@@ -231,6 +232,7 @@ There are currently a few exceptions to the "use package name" rule:
 * **changelog**: used for updating the release notes in CHANGELOG.md
 * **docs-infra**: used for docs-app (angular.io) related changes within the /aio directory of the
   repo
+* **ivy**: used for changes to the [Ivy renderer](https://github.com/angular/angular/issues/21706).
 * none/empty string: useful for `style`, `test` and `refactor` changes that are done across all
   packages (e.g. `style: add missing semicolons`) and for docs changes that are not related to a
   specific package (e.g. `docs: fix typo in tutorial`).


### PR DESCRIPTION
Currently the contributing guide misses entries for the `ivy` and `zone.js`
scopes. This commit adds these to the contributing guide as it is useful
for new contributors to know which scopes are supported.

**Note**: master-only because `zone.js` is not ported into the patch branch. The ivy scope could be added to the patch branch.. and therefore it must be part of a patch-only PR.