### PR TITLE
build: correct gulp format error caused by errant matching of zone.js package

### DIFF
--- a/tools/gulp-tasks/format.js
+++ b/tools/gulp-tasks/format.js
@@ -27,6 +27,8 @@ const srcsToFmt = [
   `!${I18N_FOLDER}/locale_en.ts`,
   '!tools/gulp-tasks/cldr/extract.js',
   '!tools/ts-api-guardian/test/fixtures/**',
+  // Ignore packages/zone.js since it matches as a file but is a directory
+  '!packages/zone.js',
 ];
 
 /**


### PR DESCRIPTION
Corrects the gulp format script away from targeting `packages/zone.js` as a file rather than a directory.