### PR TITLE
build: fix formatting tasks (by downgrading `gulp-clang-format` to 1.0.23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "firefox-profile": "1.0.3",
     "glob": "7.1.2",
     "gulp": "3.9.1",
-    "gulp-clang-format": "1.0.27",
+    "gulp-clang-format": "1.0.23",
     "gulp-connect": "5.0.0",
     "gulp-conventional-changelog": "^2.0.3",
     "gulp-filter": "^5.1.0",

--- a/packages/bazel/src/schematics/ng-new/schema.d.ts
+++ b/packages/bazel/src/schematics/ng-new/schema.d.ts
@@ -95,16 +95,16 @@ export interface CommitObject {
 * The file extension or preprocessor to use for style files.
 */
 export declare enum Style {
-  Css = "css",
-  Sass = "sass",
-  Scss = "scss",
+  Css = 'css',
+  Sass = 'sass',
+  Scss = 'scss',
 }
 /**
 * The view encapsulation strategy to use in the initial project.
 */
 export declare enum ViewEncapsulation {
-  Emulated = "Emulated",
-  Native = "Native",
-  None = "None",
-  ShadowDom = "ShadowDom"
+  Emulated = 'Emulated',
+  Native = 'Native',
+  None = 'None',
+  ShadowDom = 'ShadowDom'
 }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -458,10 +458,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     if (bindings.size) {
       const chainBindings: ChainableBindingInstruction[] = [];
       bindings.forEach(binding => {
-        chainBindings.push({
-          sourceSpan: span,
-          value: () => this.convertPropertyBinding(binding)
-        });
+        chainBindings.push({sourceSpan: span, value: () => this.convertPropertyBinding(binding)});
       });
       this.updateInstructionChain(index, R3.i18nExp, chainBindings);
       this.updateInstruction(index, span, R3.i18nApply, [o.literal(index)]);
@@ -779,8 +776,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             } else {
               // [prop]="value"
               // Collect all the properties so that we can chain into a single function at the end.
-              propertyBindings.push(
-                  {name: attrName, sourceSpan: input.sourceSpan, value: () => this.convertPropertyBinding(value), params});
+              propertyBindings.push({
+                name: attrName,
+                sourceSpan: input.sourceSpan,
+                value: () => this.convertPropertyBinding(value), params
+              });
             }
           } else if (inputType === BindingType.Attribute) {
             if (value instanceof Interpolation && getInterpolationArgsLength(value) > 1) {
@@ -1038,8 +1038,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
         if (value !== undefined) {
           this.allocateBindingSlots(value);
-          propertyBindings.push(
-              {name: input.name, sourceSpan: input.sourceSpan, value: () => this.convertPropertyBinding(value)});
+          propertyBindings.push({
+            name: input.name,
+            sourceSpan: input.sourceSpan,
+            value: () => this.convertPropertyBinding(value)
+          });
         }
       }
     });

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -174,11 +174,13 @@ export interface Directive {
    *
    * @Component({
    *   selector: 'main',
-   *   template: ` {{ bankName }} <child-dir (bankNameChange)="onBankNameChange($event)"></child-dir>`
+   *   template: `
+   *     {{ bankName }} <child-dir (bankNameChange)="onBankNameChange($event)"></child-dir>
+   *   `
    * })
    * class MainComponent {
    *  bankName: string;
-   * 
+   *
    *   onBankNameChange(bankName: string) {
    *     this.bankName = bankName;
    *   }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,16 +7,18 @@
  */
 
 import '../util/ng_i18n_closure_mode';
+
 import {getPluralCase} from '../i18n/localization';
 import {SRCSET_ATTRS, URI_ATTRS, VALID_ATTRS, VALID_ELEMENTS, getTemplateContent} from '../sanitization/html_sanitizer';
 import {InertBodyHelper} from '../sanitization/inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from '../sanitization/url_sanitizer';
 import {addAllToArray} from '../util/array_utils';
 import {assertDataInRange, assertDefined, assertEqual, assertGreaterThan} from '../util/assert';
+
 import {attachPatchData} from './context_discovery';
 import {bind, setDelayProjection, ɵɵload} from './instructions/all';
 import {attachI18nOpCodesDebug} from './instructions/lview_debug';
-import {allocExpando, elementAttributeInternal, elementPropertyInternal, getOrCreateTNode, setInputsForProperty, textBindingInternal, TsickleIssue1009} from './instructions/shared';
+import {TsickleIssue1009, allocExpando, elementAttributeInternal, elementPropertyInternal, getOrCreateTNode, setInputsForProperty, textBindingInternal} from './instructions/shared';
 import {LContainer, NATIVE} from './interfaces/container';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, IcuType, TI18n, TIcu} from './interfaces/i18n';
 import {TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjectionNode} from './interfaces/node';

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -771,8 +771,8 @@ function executeActionOnView(
 }
 
 /**
- * `executeActionOnProjection` performs an operation on the projection specified by `action` (insert,
- * detach, destroy)
+ * `executeActionOnProjection` performs an operation on the projection specified by `action`
+ * (insert, detach, destroy).
  *
  * Inserting a projection requires us to locate the projected nodes from the parent component. The
  * complication is that those nodes themselves could be re-projected from their parent component.
@@ -844,8 +844,8 @@ function executeActionOnContainer(
 
 
 /**
- * `executeActionOnElementContainer` performs an operation on the ng-container node and its child nodes
- * as specified by the `action` (insert, detach, destroy)
+ * `executeActionOnElementContainer` performs an operation on the ng-container node and its child
+ * nodes as specified by the `action` (insert, detach, destroy).
  *
  * @param renderer Renderer to use
  * @param action action to perform (insert, detach, destroy)

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -279,68 +279,68 @@ describe('Zone', function() {
 
           // TODO: JiaLiPassion, need to find out why the test bundle is not `use strict`.
           xit('event handler with null context should use event.target',
-             ifEnvSupports(canPatchOnProperty(Document.prototype, 'onmousedown'), function() {
-               const ieVer = getIEVersion();
-               if (ieVer && ieVer === 9) {
-                 // in ie9, this is window object even we call func.apply(undefined)
-                 return;
-               }
-               const logs: string[] = [];
-               const EventTarget = (window as any)['EventTarget'];
-               let oriAddEventListener = EventTarget && EventTarget.prototype ?
-                   (EventTarget.prototype as any)[zoneSymbol('addEventListener')] :
-                   (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')];
+              ifEnvSupports(canPatchOnProperty(Document.prototype, 'onmousedown'), function() {
+                const ieVer = getIEVersion();
+                if (ieVer && ieVer === 9) {
+                  // in ie9, this is window object even we call func.apply(undefined)
+                  return;
+                }
+                const logs: string[] = [];
+                const EventTarget = (window as any)['EventTarget'];
+                let oriAddEventListener = EventTarget && EventTarget.prototype ?
+                    (EventTarget.prototype as any)[zoneSymbol('addEventListener')] :
+                    (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')];
 
-               if (!oriAddEventListener) {
-                 // no patched addEventListener found
-                 return;
-               }
-               let handler1: Function;
-               let handler2: Function;
+                if (!oriAddEventListener) {
+                  // no patched addEventListener found
+                  return;
+                }
+                let handler1: Function;
+                let handler2: Function;
 
-               const listener = function() { logs.push('listener1'); };
+                const listener = function() { logs.push('listener1'); };
 
-               const listener1 = function() { logs.push('listener2'); };
+                const listener1 = function() { logs.push('listener2'); };
 
-               HTMLSpanElement.prototype.addEventListener = function(
-                   eventName: string, callback: any) {
-                 if (eventName === 'click') {
-                   handler1 = callback;
-                 } else if (eventName === 'mousedown') {
-                   handler2 = callback;
-                 }
-                 return oriAddEventListener.apply(this, arguments);
-               };
+                HTMLSpanElement.prototype.addEventListener = function(
+                    eventName: string, callback: any) {
+                  if (eventName === 'click') {
+                    handler1 = callback;
+                  } else if (eventName === 'mousedown') {
+                    handler2 = callback;
+                  }
+                  return oriAddEventListener.apply(this, arguments);
+                };
 
-               (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')] = null;
+                (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')] = null;
 
-               patchEventTarget(window, [HTMLSpanElement.prototype]);
+                patchEventTarget(window, [HTMLSpanElement.prototype]);
 
-               const span = document.createElement('span');
-               document.body.appendChild(span);
+                const span = document.createElement('span');
+                document.body.appendChild(span);
 
-               zone.run(function() {
-                 span.addEventListener('click', listener);
-                 span.onmousedown = listener1;
-               });
+                zone.run(function() {
+                  span.addEventListener('click', listener);
+                  span.onmousedown = listener1;
+                });
 
-               expect(handler1 !).toBe(handler2 !);
+                expect(handler1 !).toBe(handler2 !);
 
-               handler1 !.apply(null, [{type: 'click', target: span}]);
+                handler1 !.apply(null, [{type: 'click', target: span}]);
 
-               handler2 !.apply(null, [{type: 'mousedown', target: span}]);
+                handler2 !.apply(null, [{type: 'mousedown', target: span}]);
 
-               expect(hookSpy).toHaveBeenCalled();
-               expect(logs).toEqual(['listener1', 'listener2']);
-               document.body.removeChild(span);
-               if (EventTarget) {
-                 (EventTarget.prototype as any)[zoneSymbol('addEventListener')] =
-                     oriAddEventListener;
-               } else {
-                 (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')] =
-                     oriAddEventListener;
-               }
-             }));
+                expect(hookSpy).toHaveBeenCalled();
+                expect(logs).toEqual(['listener1', 'listener2']);
+                document.body.removeChild(span);
+                if (EventTarget) {
+                  (EventTarget.prototype as any)[zoneSymbol('addEventListener')] =
+                      oriAddEventListener;
+                } else {
+                  (HTMLSpanElement.prototype as any)[zoneSymbol('addEventListener')] =
+                      oriAddEventListener;
+                }
+              }));
 
           it('SVGElement onclick should be in zone',
              ifEnvSupports(

--- a/tools/gulp-tasks/format.js
+++ b/tools/gulp-tasks/format.js
@@ -11,22 +11,22 @@ const {I18N_FOLDER, I18N_DATA_FOLDER} = require('./cldr/extract');
 // clang-format entry points
 const srcsToFmt = [
   'packages/**/*.{js,ts}',
+  `!${I18N_DATA_FOLDER}/**/*.{js,ts}`,
+  `!${I18N_FOLDER}/available_locales.ts`,
+  `!${I18N_FOLDER}/currencies.ts`,
+  `!${I18N_FOLDER}/locale_en.ts`,
   'modules/benchmarks/**/*.{js,ts}',
   'modules/e2e_util/**/*.{js,ts}',
   'modules/playground/**/*.{js,ts}',
   'tools/**/*.{js,ts}',
+  '!tools/gulp-tasks/cldr/extract.js',
   '!tools/public_api_guard/**/*.d.ts',
+  '!tools/ts-api-guardian/test/fixtures/**',
   './*.{js,ts}',
   '!**/node_modules/**',
   '!**/dist/**',
   '!**/built/**',
   '!shims_for_IE.js',
-  `!${I18N_DATA_FOLDER}/**/*.{js,ts}`,
-  `!${I18N_FOLDER}/available_locales.ts`,
-  `!${I18N_FOLDER}/currencies.ts`,
-  `!${I18N_FOLDER}/locale_en.ts`,
-  '!tools/gulp-tasks/cldr/extract.js',
-  '!tools/ts-api-guardian/test/fixtures/**',
 ];
 
 /**

--- a/tools/gulp-tasks/format.js
+++ b/tools/gulp-tasks/format.js
@@ -11,6 +11,7 @@ const {I18N_FOLDER, I18N_DATA_FOLDER} = require('./cldr/extract');
 // clang-format entry points
 const srcsToFmt = [
   'packages/**/*.{js,ts}',
+  '!packages/zone.js',  // Ignore the `zone.js/` directory itself. (The contents are still matched.)
   `!${I18N_DATA_FOLDER}/**/*.{js,ts}`,
   `!${I18N_FOLDER}/available_locales.ts`,
   `!${I18N_FOLDER}/currencies.ts`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5034,17 +5034,18 @@ gtoken@^2.3.0:
     mime "^2.2.0"
     pify "^4.0.0"
 
-gulp-clang-format@1.0.27:
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/gulp-clang-format/-/gulp-clang-format-1.0.27.tgz#c89716c26745703356c4ff3f2b0964393c73969e"
-  integrity sha512-Jj4PGuNXKdqVCh9fijvL7wdzma5TQRJz1vv8FjOjnSkfq3s/mvbdE/jq+5HG1c/q+jcYkXTEGkYT3CrdnJOLaQ==
+gulp-clang-format@1.0.23:
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz#fe258586b83998491e632fc0c4fc0ecdfa10c89f"
+  integrity sha1-/iWFhrg5mEkeYy/AxPwOzfoQyJ8=
   dependencies:
     clang-format "^1.0.32"
-    fancy-log "^1.3.2"
     gulp-diff "^1.0.0"
-    plugin-error "^1.0.1"
+    gulp-util "^3.0.4"
+    pkginfo "^0.3.0"
     stream-combiner2 "^1.1.1"
-    through2 "^2.0.3"
+    stream-equal "0.1.6"
+    through2 "^0.6.3"
 
 gulp-connect@5.0.0:
   version "5.0.0"
@@ -5113,7 +5114,7 @@ gulp-tslint@8.1.2:
     map-stream "~0.0.7"
     through "~2.3.8"
 
-gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@~3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.4, gulp-util@^3.0.6, gulp-util@~3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -8576,7 +8577,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pkginfo@0.3.x:
+pkginfo@0.3.x, pkginfo@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
   integrity sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=
@@ -10383,6 +10384,11 @@ stream-each@^1.1.0:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
 
+stream-equal@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/stream-equal/-/stream-equal-0.1.6.tgz#cc522fab38516012e4d4ee47513b147b72359019"
+  integrity sha1-zFIvqzhRYBLk1O5HUTsUe3I1kBk=
+
 stream-events@^1.0.1, stream-events@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
@@ -10752,7 +10758,7 @@ through2@2.0.1:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.1:
+through2@^0.6.1, through2@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=


### PR DESCRIPTION
The `gulp format*` tasks have been broken since 5eb7426. These include the `gulp format:enforce` task, which is what runs on CI to enforce consistent code style. Here is what (I believe) happened:

- I assume formatting was failing in 5eb7426 (moving `zone.js` into `angular/angular`). The reason must have been that [this glob pattern][1] matches `packages/zone.js/` (which is a directory) and passes it to `clang-format` claiming it is a file.
- I further assume that in an attempt to fix the issue, `gulp-clang-format` was updated to the latest version (1.0.27) in 5eb7426.
- `gulp format:enforce` stopped complaining, so everyone thought formatting was fine and moved on.
- Formatting still wasn't fine, but the task completed successfully nevertheless 😱
- The reason is that angular/gulp-clang-format@55b697c (and subsequent commits) changed the way the `done()` callback was called, leaving it to `clang-format` to call it (while previously it was also called when the associated stream ended).
- In the old version of `clang-format` that we are using (1.0.41), there is a bug (which has been fixed in angular/clang-format@4cce2c4):
  The callback is not called [unless the process exits with an error][2].

One can also see that the `gulp format:enforce` task is not completed in `gulp lint`. Example output from [build 374722][3]:

```
yarn gulp lint
...
Starting 'format:enforce'...
Starting 'validate-commit-messages'...
...
Finished 'validate-commit-messages' after 833 ms
Starting 'tools:build'...
Finished 'tools:build' after 1.75 s
Starting 'tslint'...
Finished 'tslint' after 19 s
Done in 21.82s.
```

Notice that all tasks have a corresponding "Finished X` log, except for `format:enforce`.

For reference:
The problem was originally reported by @ocombe on Slack ([discussion][4]).

---
This PR fixes the issues by downgrading `gulp-clang-format` to 1.0.23, ignoring the `zone.js/` directory from the files to format (only the directory itself; not its contents) and formatting all files to fix the linting failures.

[1]: https://github.com/angular/angular/blob/a8f3b317f/tools/gulp-tasks/format.js#L13
[2]: https://github.com/angular/clang-format/blob/b8c7df0b7/index.js#L95
[3]: https://circleci.com/gh/angular/angular/374722
[4]: https://angular-team.slack.com/archives/C042EU9T5/p1561480241191000