### PR TITLE
ci: target default pool for linux RBE executions

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -22,5 +22,9 @@ platform(
             name: "dockerAddCapabilities"
             value: "SYS_ADMIN"
         }
+        properties: {
+            name: "Pool"
+            value: "default"
+        }
         """,
 )


### PR DESCRIPTION
As part of setting up configuration for windows RBE, our current RBE setup must target the linux pool directly, which is current named `default`. 