### PR TITLE
fix(ivy): attach host element for views created via TestBed.createComponent

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -214,8 +214,9 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
         this.componentType, component,
         createElementRef(viewEngine_ElementRef, tElementNode, rootLView), rootLView, tElementNode);
 
-    if (isInternalRootView) {
-      // The host element of the internal root view is attached to the component's host view node
+    if (isInternalRootView || isIsolated) {
+      // The host element of the internal or isolated root view is attached to the component's host
+      // view node.
       componentRef.hostView._tViewNode !.child = tElementNode;
     }
     return componentRef;

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -1111,7 +1111,7 @@ describe('ViewContainerRef', () => {
            }
          }
 
-         TestBed.configureTestingModule({declarations: [Comp]});
+         TestBed.configureTestingModule({declarations: [Comp, Child]});
 
          const fixture = TestBed.createComponent(Comp);
          fixture.detectChanges();

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -1086,6 +1086,38 @@ describe('ViewContainerRef', () => {
       expect((element.namespaceURI || '').toLowerCase()).not.toContain('svg');
     });
 
+    it('should be compatible with componentRef generated via TestBed.createComponent in component factory',
+       () => {
+         @Component({
+           selector: 'child',
+           template: `Child Component`,
+         })
+         class Child {
+         }
+
+         @Component({
+           selector: 'comp',
+           template: '<ng-template #ref></ng-template>',
+         })
+         class Comp {
+           @ViewChild('ref', {read: ViewContainerRef, static: true})
+           viewContainerRef?: ViewContainerRef;
+
+           ngOnInit() {
+             const makeComponentFactory = (componentType: any) => ({
+               create: () => TestBed.createComponent(componentType).componentRef,
+             });
+             this.viewContainerRef !.createComponent(makeComponentFactory(Child) as any);
+           }
+         }
+
+         TestBed.configureTestingModule({declarations: [Comp]});
+
+         const fixture = TestBed.createComponent(Comp);
+         fixture.detectChanges();
+
+         expect(fixture.debugElement.nativeElement.innerHTML).toContain('Child Component');
+       });
   });
 
   describe('insertion points and declaration points', () => {


### PR DESCRIPTION
Prior to this commit, host element of a view created via TestBed.createComponent was not attached to the component's host, making it problematic to use TestBed.createComponent API in component factories (which might be used for testing purposes - this behavior is observed in google3 app tests). This scenario was supported by VE and this commit aligns Ivy and VE.

This PR resolves FW-1412.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No