### PR TITLE
refactor(ivy): make style application happen automatically

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 13517,
+        "main": 13677,
         "polyfills": 43567
       }
     }

--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵRenderFlags, ɵrenderComponent as renderComponent, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineComponent, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵstyleProp, ɵɵstyling, ɵɵstylingApply, ɵɵtext, ɵɵtextInterpolate1} from '@angular/core';
+import {ɵRenderFlags, ɵrenderComponent as renderComponent, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineComponent, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵstyleProp, ɵɵstyling, ɵɵtext, ɵɵtextInterpolate1} from '@angular/core';
 
 import {bindAction, profile} from '../../util';
 import {createDom, destroyDom, detectChanges} from '../render3/tree';
@@ -48,7 +48,6 @@ export function TreeTpl(rf: ɵRenderFlags, ctx: TreeNode) {
   if (rf & ɵRenderFlags.Update) {
     ɵɵselect(1);
     ɵɵstyleProp('background-color', ctx.depth % 2 ? '' : 'grey');
-    ɵɵstylingApply();
     ɵɵselect(2);
     ɵɵtextInterpolate1(' ', ctx.value, ' ');
     ɵɵcontainerRefreshStart(3);

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Directive, DoCheck, Input, ɵRenderFlags, ɵɵallocHostVars, ɵɵclassMap, ɵɵdefineDirective, ɵɵstyling, ɵɵstylingApply} from '@angular/core';
+import {Directive, DoCheck, Input, ɵRenderFlags, ɵɵallocHostVars, ɵɵclassMap, ɵɵdefineDirective, ɵɵstyling} from '@angular/core';
 
 import {NgClassImpl, NgClassImplProvider} from './ng_class_impl';
 
@@ -40,7 +40,6 @@ export const ngClassDirectiveDef__POST_R3__ = ɵɵdefineDirective({
     }
     if (rf & ɵRenderFlags.Update) {
       ɵɵclassMap(ctx.getValue());
-      ɵɵstylingApply();
     }
   }
 });

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Directive, DoCheck, Input, ɵRenderFlags, ɵɵdefineDirective, ɵɵstyleMap, ɵɵstyling, ɵɵstylingApply} from '@angular/core';
+import {Directive, DoCheck, Input, ɵRenderFlags, ɵɵdefineDirective, ɵɵstyleMap, ɵɵstyling} from '@angular/core';
 
 import {NgStyleImpl, NgStyleImplProvider} from './ng_style_impl';
 
@@ -39,7 +39,6 @@ export const ngStyleDirectiveDef__POST_R3__ = ɵɵdefineDirective({
     }
     if (rf & ɵRenderFlags.Update) {
       ɵɵstyleMap(ctx.getValue());
-      ɵɵstylingApply();
     }
   }
 });

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -493,7 +493,6 @@ describe('compiler compliance', () => {
               if (rf & 2) {
                 $r3$.ɵɵstyleProp("background-color", ctx.color);
                 $r3$.ɵɵclassProp("error", ctx.error);
-                $r3$.ɵɵstylingApply();
               }
             },
             encapsulation: 2

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -389,7 +389,6 @@ describe('compiler compliance: styling', () => {
             if (rf & 2) {
               $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
               $r3$.ɵɵstyleMap($ctx$.myStyleExp);
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -454,7 +453,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵclassMapInterpolate1("foo foo-", $ctx$.fooId, "");
-              $r3$.ɵɵstylingApply();
             }
           }
         …
@@ -468,7 +466,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵclassMapInterpolate2("foo foo-", $ctx$.fooId, "-", $ctx$.fooUsername, "");
-              $r3$.ɵɵstylingApply();
             }
           }
         …
@@ -482,7 +479,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵclassMap($ctx$.exp);
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -540,7 +536,6 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵɵstyleMap($ctx$.myStyleExp);
                   $r3$.ɵɵstyleProp("width", $ctx$.myWidth);
                   $r3$.ɵɵstyleProp("height", $ctx$.myHeight);
-                  $r3$.ɵɵstylingApply();
                   $r3$.ɵɵattribute("style", "border-width: 10px", $r3$.ɵɵsanitizeStyle);
                 }
               },
@@ -591,7 +586,6 @@ describe('compiler compliance: styling', () => {
               if (rf & 2) {
                 $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
                 $r3$.ɵɵstyleProp("background-image", ctx.myImage);
-                $r3$.ɵɵstylingApply();
               }
             },
             encapsulation: 2
@@ -630,7 +624,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵstyleProp("font-size", 12, "px");
-              $r3$.ɵɵstylingApply();
             }
           }
      `;
@@ -694,7 +687,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵclassMap($ctx$.myClassExp);
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -751,7 +743,6 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵɵclassMap($ctx$.myClassExp);
                   $r3$.ɵɵclassProp("apple", $ctx$.yesToApple);
                   $r3$.ɵɵclassProp("orange", $ctx$.yesToOrange);
-                  $r3$.ɵɵstylingApply();
                   $r3$.ɵɵattribute("class", "banana");
                 }
               },
@@ -870,7 +861,6 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
               $r3$.ɵɵstyleMap($ctx$.myStyleExp);
               $r3$.ɵɵclassMap($ctx$.myClassExp);
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -914,7 +904,6 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
               $r3$.ɵɵstyleMap($r3$.ɵɵpipeBind1(1, 2, $ctx$.myStyleExp));
               $r3$.ɵɵclassMap($r3$.ɵɵpipeBind1(2, 4, $ctx$.myClassExp));
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -972,7 +961,6 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵstyleProp("bar", $r3$.ɵɵpipeBind2(2, 9, $ctx$.barExp, 3000));
               $r3$.ɵɵstyleProp("baz", $r3$.ɵɵpipeBind2(3, 12, $ctx$.bazExp, 4000));
               $r3$.ɵɵclassProp("foo", $r3$.ɵɵpipeBind2(4, 15, $ctx$.fooExp, 2000));
-              $r3$.ɵɵstylingApply();
               $r3$.ɵɵselect(5);
               $r3$.ɵɵtextInterpolate1(" ", $ctx$.item, "");
             }
@@ -1017,16 +1005,12 @@ describe('compiler compliance: styling', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵstyleProp("width", $ctx$.w1);
-              $r3$.ɵɵstylingApply();
               $r3$.ɵɵselect(1);
               $r3$.ɵɵstyleProp("height", $ctx$.h1);
-              $r3$.ɵɵstylingApply();
               $r3$.ɵɵselect(2);
               $r3$.ɵɵclassProp("active", $ctx$.a1);
-              $r3$.ɵɵstylingApply();
               $r3$.ɵɵselect(3);
               $r3$.ɵɵclassProp("removed", $ctx$.r1);
-              $r3$.ɵɵstylingApply();
             }
           }
           `;
@@ -1084,7 +1068,6 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵclassMap(ctx.myClass);
               $r3$.ɵɵstyleProp("color", ctx.myColorProp);
               $r3$.ɵɵclassProp("foo", ctx.myFooClass);
-              $r3$.ɵɵstylingApply();
             }
           },
           consts: 0,
@@ -1146,7 +1129,6 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵstyleProp("width", ctx.myWidthProp);
               $r3$.ɵɵclassProp("bar", ctx.myBarClass);
               $r3$.ɵɵclassProp("foo", ctx.myFooClass);
-              $r3$.ɵɵstylingApply();
             }
           },
           consts: 0,
@@ -1207,7 +1189,6 @@ describe('compiler compliance: styling', () => {
                 $r3$.ɵɵclassMap(ctx.myClassExp);
                 $r3$.ɵɵstyleProp("height", ctx.myHeightExp);
                 $r3$.ɵɵclassProp("bar", ctx.myBarClassExp);
-                $r3$.ɵɵstylingApply();
               }
             },
           `;
@@ -1224,7 +1205,6 @@ describe('compiler compliance: styling', () => {
                 $r3$.ɵɵclassMap(ctx.myClassExp);
                 $r3$.ɵɵstyleProp("width", ctx.myWidthExp);
                 $r3$.ɵɵclassProp("foo", ctx.myFooClassExp);
-                $r3$.ɵɵstylingApply();
               }
             },
           `;
@@ -1288,7 +1268,6 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵclassMap(ctx.myClassMap);
-              $r3$.ɵɵstylingApply();
             }
           }
           …
@@ -1300,7 +1279,6 @@ describe('compiler compliance: styling', () => {
             if (rf & 2) {
               $r3$.ɵɵstyleProp("width", ctx.myWidth);
               $r3$.ɵɵclassProp("foo", ctx.myFooClass);
-              $r3$.ɵɵstylingApply();
             }
           }
           …
@@ -1312,7 +1290,6 @@ describe('compiler compliance: styling', () => {
             if (rf & 2) {
               $r3$.ɵɵstyleProp("height", ctx.myHeight);
               $r3$.ɵɵclassProp("bar", ctx.myBarClass);
-              $r3$.ɵɵstylingApply();
             }
           }
           …
@@ -1354,34 +1331,24 @@ describe('compiler compliance: styling', () => {
       …
         if (rf & 2) {
           $r3$.ɵɵclassMapInterpolateV(["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(1);
           $r3$.ɵɵclassMapInterpolate8("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(2);
           $r3$.ɵɵclassMapInterpolate7("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(3);
           $r3$.ɵɵclassMapInterpolate6("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(4);
           $r3$.ɵɵclassMapInterpolate5("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(5);
           $r3$.ɵɵclassMapInterpolate4("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(6);
           $r3$.ɵɵclassMapInterpolate3("a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(7);
           $r3$.ɵɵclassMapInterpolate2("a", ctx.one, "b", ctx.two, "c");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(8);
           $r3$.ɵɵclassMapInterpolate1("a", ctx.one, "b");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(9);
           $r3$.ɵɵclassMap(ctx.one);
-          $r3$.ɵɵstylingApply();
       }
       …
       `;
@@ -1456,34 +1423,24 @@ describe('compiler compliance: styling', () => {
       …
         if (rf & 2) {
           $r3$.ɵɵstylePropInterpolateV("color", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(1);
           $r3$.ɵɵstylePropInterpolate8("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(2);
           $r3$.ɵɵstylePropInterpolate7("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(3);
           $r3$.ɵɵstylePropInterpolate6("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(4);
           $r3$.ɵɵstylePropInterpolate5("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(5);
           $r3$.ɵɵstylePropInterpolate4("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(6);
           $r3$.ɵɵstylePropInterpolate3("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(7);
           $r3$.ɵɵstylePropInterpolate2("color", "a", ctx.one, "b", ctx.two, "c");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(8);
           $r3$.ɵɵstylePropInterpolate1("color", "a", ctx.one, "b");
-          $r3$.ɵɵstylingApply();
           $r3$.ɵɵselect(9);
           $r3$.ɵɵstyleProp("color", ctx.one);
-          $r3$.ɵɵstylingApply();
       }
       …
       `;
@@ -1514,7 +1471,6 @@ describe('compiler compliance: styling', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵstylePropInterpolate2("width", "a", ctx.one, "b", ctx.two, "c", "px");
-              $r3$.ɵɵstylingApply();
             }
             …
           `;
@@ -1545,7 +1501,6 @@ describe('compiler compliance: styling', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵstylePropInterpolate2("width", "a", ctx.one, "b", ctx.two, "c");
-              $r3$.ɵɵstylingApply();
             }
             …
           `;
@@ -1608,7 +1563,6 @@ describe('compiler compliance: styling', () => {
           $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
           $r3$.ɵɵstyleMap(ctx.myStyle);
           $r3$.ɵɵclassMap(ctx.myClass);
-          $r3$.ɵɵstylingApply();
         }
       }
     `;
@@ -1651,7 +1605,6 @@ describe('compiler compliance: styling', () => {
           $r3$.ɵɵhostProperty("id", ctx.id)("title", ctx.title);
           $r3$.ɵɵstyleProp("width", ctx.myWidth);
           $r3$.ɵɵclassProp("foo", ctx.myFooClass);
-          $r3$.ɵɵstylingApply();
         }
       }
     `;
@@ -1687,7 +1640,6 @@ describe('compiler compliance: styling', () => {
           if (rf & 2) {
             $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
             $r3$.ɵɵstyleProp("background-image", ctx.bgExp);
-            $r3$.ɵɵstylingApply();
           }
           …
         }
@@ -1723,7 +1675,6 @@ describe('compiler compliance: styling', () => {
           if (rf & 2) {
             $r3$.ɵɵstyleSanitizer($r3$.ɵɵdefaultStyleSanitizer);
             $r3$.ɵɵstyleMap(ctx.mapExp);
-            $r3$.ɵɵstylingApply();
           }
           …
         }
@@ -1760,7 +1711,6 @@ describe('compiler compliance: styling', () => {
           if (rf & 2) {
             $r3$.ɵɵclassMap(ctx.mapExp);
             $r3$.ɵɵclassProp("name", ctx.nameExp);
-            $r3$.ɵɵstylingApply();
           }
           …
         }
@@ -1823,7 +1773,6 @@ describe('compiler compliance: styling', () => {
                 $r3$.ɵɵpureFunction2(6, _c1, ctx._animValue,
                 $r3$.ɵɵpureFunction2(3, _c0, ctx._animParam1, ctx._animParam2)));
               $r3$.ɵɵclassProp("foo", ctx.foo);
-              $r3$.ɵɵstylingApply();
             }
           }
       `;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1835,7 +1835,6 @@ runInEachFileSystem(os => {
           i0.ɵɵhostProperty("prop", ctx.bar);
           i0.ɵɵattribute("hello", ctx.foo);
           i0.ɵɵclassProp("someclass", ctx.someClass);
-          i0.ɵɵstylingApply();
         }
       }
     `;

--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -68,7 +68,6 @@ interface BoundStylingEntry {
  *   classMap(...)
  *   styleProp(...)
  *   classProp(...)
- *   stylingApply(...)
  * }
  *
  * The creation/update methods within the builder class produce these instructions.
@@ -421,15 +420,6 @@ export class StylingBuilder {
     return [];
   }
 
-  private _buildApplyFn(): StylingInstruction {
-    return {
-      sourceSpan: this._lastStylingInput ? this._lastStylingInput.sourceSpan : null,
-      reference: R3.stylingApply,
-      allocateBindingSlots: 0,
-      params: () => { return []; }
-    };
-  }
-
   private _buildSanitizerFn(): StylingInstruction {
     return {
       sourceSpan: this._firstStylingInput ? this._firstStylingInput.sourceSpan : null,
@@ -459,7 +449,6 @@ export class StylingBuilder {
       }
       instructions.push(...this._buildStyleInputs(valueConverter));
       instructions.push(...this._buildClassInputs(valueConverter));
-      instructions.push(this._buildApplyFn());
     }
     return instructions;
   }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -23,7 +23,7 @@ import {TElementNode, TNode, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {CONTEXT, HEADER_OFFSET, LView, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
-import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState, setActiveHostElement} from './state';
+import {enterView, getPreviousOrParentTNode, incrementActiveDirectiveId, leaveView, resetComponentState, setActiveHostElement} from './state';
 import {publishDefaultGlobalUtils} from './util/global_utils';
 import {defaultScheduler, stringifyForError} from './util/misc_utils';
 import {getRootContext} from './util/view_traversal_utils';
@@ -217,6 +217,7 @@ export function createRootComponent<T>(
   if (tView.firstTemplatePass && componentDef.hostBindings) {
     const elementIndex = rootTNode.index - HEADER_OFFSET;
     setActiveHostElement(elementIndex);
+    incrementActiveDirectiveId();
 
     const expando = tView.expandoInstructions !;
     invokeHostBindingsInCreationMode(

--- a/packages/core/src/render3/instructions/select.ts
+++ b/packages/core/src/render3/instructions/select.ts
@@ -8,7 +8,9 @@
 import {assertGreaterThan, assertLessThan} from '../../util/assert';
 import {executePreOrderHooks} from '../hooks';
 import {HEADER_OFFSET, LView, TVIEW} from '../interfaces/view';
-import {getCheckNoChangesMode, getLView, setSelectedIndex} from '../state';
+import {ActiveElementFlags, executeElementExitFn, getCheckNoChangesMode, getLView, hasActiveElementFlag, resetActiveElementFlags, setSelectedIndex} from '../state';
+import {resetStylingState} from '../styling_next/state';
+
 
 
 /**
@@ -43,6 +45,10 @@ export function ɵɵselect(index: number): void {
 
 
 export function selectInternal(lView: LView, index: number) {
+  if (hasActiveElementFlag(ActiveElementFlags.RunExitFn)) {
+    executeElementExitFn();
+  }
+
   // Flush the initial hooks for elements in the view that have been added up to this point.
   executePreOrderHooks(lView, lView[TVIEW], getCheckNoChangesMode(), index);
 
@@ -51,4 +57,10 @@ export function selectInternal(lView: LView, index: number) {
   // state. If we run `setSelectedIndex` *before* we run the hooks, in some cases the selected index
   // will be altered by the time we leave the `ɵɵselect` instruction.
   setSelectedIndex(index);
+
+  if (hasActiveElementFlag(ActiveElementFlags.ResetStylesOnExit)) {
+    resetStylingState();
+  }
+
+  resetActiveElementFlags();
 }

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -28,8 +28,9 @@ import {isComponent, isComponentDef, isContentQueryHost, isLContainer, isRootVie
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
 import {assertNodeOfPossibleTypes} from '../node_assert';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
-import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, leaveView, namespaceHTMLInternal, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setPreviousOrParentTNode, setSelectedIndex} from '../state';
+import {enterView, executeElementExitFn, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, leaveView, namespaceHTMLInternal, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setPreviousOrParentTNode, setSelectedIndex} from '../state';
 import {renderStylingMap} from '../styling_next/bindings';
+import {resetStylingState} from '../styling_next/state';
 import {NO_CHANGE} from '../tokens';
 import {ANIMATION_PROP_PREFIX, isAnimationProp} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
@@ -85,16 +86,18 @@ export function setHostBindings(tView: TView, viewData: LView): void {
         } else {
           // If it's not a number, it's a host binding function that needs to be executed.
           if (instruction !== null) {
-            viewData[BINDING_INDEX] = bindingRootIndex;
-            const hostCtx = unwrapRNode(viewData[currentDirectiveIndex]);
-            instruction(RenderFlags.Update, hostCtx, currentElementIndex);
-
             // Each directive gets a uniqueId value that is the same for both
             // create and update calls when the hostBindings function is called. The
             // directive uniqueId is not set anywhere--it is just incremented between
             // each hostBindings call and is useful for helping instruction code
             // uniquely determine which directive is currently active when executed.
+            // It is important that this be called first before the actual instructions
+            // are run because this way the first directive ID value is not zero.
             incrementActiveDirectiveId();
+
+            viewData[BINDING_INDEX] = bindingRootIndex;
+            const hostCtx = unwrapRNode(viewData[currentDirectiveIndex]);
+            instruction(RenderFlags.Update, hostCtx, currentElementIndex);
           }
           currentDirectiveIndex++;
         }
@@ -478,7 +481,9 @@ function executeTemplate<T>(
     }
     templateFn(rf, context);
   } finally {
+    executeElementExitFn();
     setSelectedIndex(prevSelectedIndex);
+    resetStylingState();
   }
 }
 
@@ -1104,14 +1109,10 @@ function invokeDirectivesHostBindings(tView: TView, viewData: LView, tNode: TNod
       const def = tView.data[i] as DirectiveDef<any>;
       const directive = viewData[i];
       if (def.hostBindings) {
-        invokeHostBindingsInCreationMode(def, expando, directive, tNode, firstTemplatePass);
-
-        // Each directive gets a uniqueId value that is the same for both
-        // create and update calls when the hostBindings function is called. The
-        // directive uniqueId is not set anywhere--it is just incremented between
-        // each hostBindings call and is useful for helping instruction code
-        // uniquely determine which directive is currently active when executed.
+        // It is important that this be called first before the actual instructions
+        // are run because this way the first directive ID value is not zero.
         incrementActiveDirectiveId();
+        invokeHostBindingsInCreationMode(def, expando, directive, tNode, firstTemplatePass);
       } else if (firstTemplatePass) {
         expando.push(null);
       }

--- a/packages/core/src/render3/styling_next/interfaces.ts
+++ b/packages/core/src/render3/styling_next/interfaces.ts
@@ -173,7 +173,8 @@ import {LView} from '../interfaces/view';
  * Each time a new binding is encountered it is registered into the
  * context. The context then is continually updated until the first
  * styling apply call has been called (this is triggered by the
- * `stylingApply()` instruction for the active element).
+ * `stylingApply()` instruction for the active element---which is
+ * automatically called once an element exits during change detection).
  *
  * # How Styles/Classes are Rendered
  * Each time a styling instruction (e.g. `[class.name]`, `[style.prop]`,

--- a/packages/core/src/render3/styling_next/state.ts
+++ b/packages/core/src/render3/styling_next/state.ts
@@ -84,6 +84,7 @@ export function getStylingState(element: any, readFromMap?: boolean): StylingSta
 export function resetStylingState() {
   _stylingState = null;
   _stylingElement = null;
+  _lastDirectiveIndex = -1;
 }
 
 export function storeStylingState(element: any, state: StylingState) {
@@ -98,4 +99,13 @@ export function deleteStylingStateFromStorage(element: any) {
 export function resetAllStylingState() {
   resetStylingState();
   _stateStorage.clear();
+}
+
+let _lastDirectiveIndex: number = -1;
+export function storeLastDirectiveIndex(index: number) {
+  _lastDirectiveIndex = index;
+}
+
+export function getLastDirectiveIndex() {
+  return _lastDirectiveIndex;
 }

--- a/packages/core/test/acceptance/styling_next_spec.ts
+++ b/packages/core/test/acceptance/styling_next_spec.ts
@@ -939,10 +939,10 @@ describe('new styling integration', () => {
 
             @Component({
               template: `
-            <div class="a" [style.width.px]="w" one></div>
-            <div class="b" [style.height.px]="h" one two></div>
-            <div class="c" [style.color]="c" two></div>
-          `
+                <div class="a" [style.width.px]="w" one></div>
+                <div class="b" [style.height.px]="h" one two></div>
+                <div class="c" [style.color]="c" two></div>
+              `
             })
             class Cmp {
               w = 100;

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -628,7 +628,6 @@ describe('styling', () => {
       expect(childDir.parent).toBeAnInstanceOf(TestDir);
       expect(testDirDiv.classList).not.toContain('with-button');
       expect(fixture.debugElement.nativeElement.textContent).toContain('Hello');
-
     });
   });
 });

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -159,6 +159,9 @@
     "name": "_currentNamespace"
   },
   {
+    "name": "_elementExitFn"
+  },
+  {
     "name": "_global"
   },
   {
@@ -166,6 +169,9 @@
   },
   {
     "name": "_selectedIndex"
+  },
+  {
+    "name": "_selectedIndexFlags"
   },
   {
     "name": "_stateStorage"
@@ -256,6 +262,9 @@
   },
   {
     "name": "executeContentQueries"
+  },
+  {
+    "name": "executeElementExitFn"
   },
   {
     "name": "executeHooks"
@@ -400,6 +409,9 @@
   },
   {
     "name": "getStylingMapArray"
+  },
+  {
+    "name": "hasActiveElementFlag"
   },
   {
     "name": "hasClassInput"
@@ -576,6 +588,9 @@
     "name": "renderView"
   },
   {
+    "name": "resetActiveElementFlags"
+  },
+  {
     "name": "resetAllStylingState"
   },
   {
@@ -667,6 +682,9 @@
   },
   {
     "name": "throwMultipleComponentError"
+  },
+  {
+    "name": "unsetActiveElementFlag"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -138,6 +138,9 @@
     "name": "__window"
   },
   {
+    "name": "_elementExitFn"
+  },
+  {
     "name": "_global"
   },
   {
@@ -145,6 +148,9 @@
   },
   {
     "name": "_selectedIndex"
+  },
+  {
+    "name": "_selectedIndexFlags"
   },
   {
     "name": "_stateStorage"
@@ -211,6 +217,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "executeElementExitFn"
   },
   {
     "name": "executeHooks"
@@ -321,6 +330,9 @@
     "name": "getSelectedIndex"
   },
   {
+    "name": "hasActiveElementFlag"
+  },
+  {
     "name": "hasParentInjector"
   },
   {
@@ -426,6 +438,9 @@
     "name": "renderView"
   },
   {
+    "name": "resetActiveElementFlags"
+  },
+  {
     "name": "resetAllStylingState"
   },
   {
@@ -481,6 +496,9 @@
   },
   {
     "name": "syncViewWithBlueprint"
+  },
+  {
+    "name": "unsetActiveElementFlag"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -114,9 +114,6 @@
     "name": "MAP_BASED_ENTRY_PROP_NAME"
   },
   {
-    "name": "MIN_DIRECTIVE_ID"
-  },
-  {
     "name": "MONKEY_PATCH_KEY_NAME"
   },
   {
@@ -402,13 +399,22 @@
     "name": "_devMode"
   },
   {
+    "name": "_elementExitFn"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_lastDirectiveIndex"
   },
   {
     "name": "_renderCompCount"
   },
   {
     "name": "_selectedIndex"
+  },
+  {
+    "name": "_selectedIndexFlags"
   },
   {
     "name": "_stateStorage"
@@ -463,6 +469,9 @@
   },
   {
     "name": "appendChild"
+  },
+  {
+    "name": "applyAndReset"
   },
   {
     "name": "applyStyling"
@@ -648,6 +657,9 @@
     "name": "executeContentQueries"
   },
   {
+    "name": "executeElementExitFn"
+  },
+  {
     "name": "executeHooks"
   },
   {
@@ -807,6 +819,9 @@
     "name": "getLViewParent"
   },
   {
+    "name": "getLastDirectiveIndex"
+  },
+  {
     "name": "getMapProp"
   },
   {
@@ -925,6 +940,9 @@
   },
   {
     "name": "handleError"
+  },
+  {
+    "name": "hasActiveElementFlag"
   },
   {
     "name": "hasClassInput"
@@ -1116,6 +1134,9 @@
     "name": "markDirtyIfOnPush"
   },
   {
+    "name": "markStylingStateAsDirty"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -1236,6 +1257,9 @@
     "name": "renderView"
   },
   {
+    "name": "resetActiveElementFlags"
+  },
+  {
     "name": "resetAllStylingState"
   },
   {
@@ -1272,6 +1296,9 @@
     "name": "selectInternal"
   },
   {
+    "name": "setActiveElementFlag"
+  },
+  {
     "name": "setActiveHostElement"
   },
   {
@@ -1297,6 +1324,9 @@
   },
   {
     "name": "setDirectiveStylingInput"
+  },
+  {
+    "name": "setElementExitFn"
   },
   {
     "name": "setGuardMask"
@@ -1350,6 +1380,9 @@
     "name": "storeCleanupFn"
   },
   {
+    "name": "storeLastDirectiveIndex"
+  },
+  {
     "name": "storeStylingState"
   },
   {
@@ -1357,6 +1390,9 @@
   },
   {
     "name": "stringifyForError"
+  },
+  {
+    "name": "stylingApplyInternal"
   },
   {
     "name": "stylingMapToString"
@@ -1378,6 +1414,9 @@
   },
   {
     "name": "trackMovedView"
+  },
+  {
+    "name": "unsetActiveElementFlag"
   },
   {
     "name": "unwrapRNode"
@@ -1462,9 +1501,6 @@
   },
   {
     "name": "ɵɵstyling"
-  },
-  {
-    "name": "ɵɵstylingApply"
   },
   {
     "name": "ɵɵtemplate"

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -9,7 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {RenderFlags, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵselect, ɵɵstyleMap, ɵɵstyleProp, ɵɵstyleSanitizer, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
+import {RenderFlags, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵselect, ɵɵstyleMap, ɵɵstyleProp, ɵɵstyleSanitizer, ɵɵstyling, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl, getSanitizationBypassType, unwrapSafeValue} from '../../src/sanitization/bypass';
 import {ɵɵdefaultStyleSanitizer, ɵɵsanitizeHtml, ɵɵsanitizeResourceUrl, ɵɵsanitizeScript, ɵɵsanitizeStyle, ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
@@ -156,7 +156,6 @@ describe('instructions', () => {
       t.update(() => {
         ɵɵstyleSanitizer(ɵɵdefaultStyleSanitizer);
         ɵɵstyleProp('background-image', 'url("http://server")');
-        ɵɵstylingApply();
       });
       // nothing is set because sanitizer suppresses it.
       expect(t.html).toEqual('<div></div>');
@@ -164,7 +163,6 @@ describe('instructions', () => {
       t.update(() => {
         ɵɵstyleSanitizer(ɵɵdefaultStyleSanitizer);
         ɵɵstyleProp('background-image', bypassSanitizationTrustStyle('url("http://server2")'));
-        ɵɵstylingApply();
       });
       expect((t.hostElement.firstChild as HTMLElement).style.getPropertyValue('background-image'))
           .toEqual('url("http://server2")');
@@ -180,10 +178,7 @@ describe('instructions', () => {
 
     it('should add style', () => {
       const fixture = new TemplateFixture(createDivWithStyle, () => {}, 1);
-      fixture.update(() => {
-        ɵɵstyleMap({'background-color': 'red'});
-        ɵɵstylingApply();
-      });
+      fixture.update(() => { ɵɵstyleMap({'background-color': 'red'}); });
       expect(fixture.html).toEqual('<div style="background-color: red; height: 10px;"></div>');
     });
 
@@ -205,7 +200,6 @@ describe('instructions', () => {
           'filter': 'filter',
           'width': 'width'
         });
-        ɵɵstylingApply();
       });
 
       const props = detectedValues.sort();
@@ -224,10 +218,7 @@ describe('instructions', () => {
 
     it('should add class', () => {
       const fixture = new TemplateFixture(createDivWithStyling, () => {}, 1);
-      fixture.update(() => {
-        ɵɵclassMap('multiple classes');
-        ɵɵstylingApply();
-      });
+      fixture.update(() => { ɵɵclassMap('multiple classes'); });
       expect(fixture.html).toEqual('<div class="classes multiple"></div>');
     });
   });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -636,9 +636,6 @@ describe('element discovery', () => {
                ɵɵstyling();
                ɵɵelementEnd();
              }
-             if (rf & RenderFlags.Update) {
-               ɵɵstylingApply();
-             }
            }
          });
        }


### PR DESCRIPTION
This patch removes the need to issue a call to `stylingApply()`
at the end of change detection within a template or host bindings
function. What will happen instead is when the element is exited
(i.e. when `select(n)` is called, when a template exits or when
all host bindings for an element are processed) then styling will
be flushed automatically.