### PR TITLE
fix(ivy): handle modifiedResourceFiles being null on incremental compilation

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -26,7 +26,7 @@ export function main(
     config?: NgcParsedConfiguration, customTransformers?: api.CustomTransformers, programReuse?: {
       program: api.Program | undefined,
     },
-    modifiedResourceFiles?: Set<string>): number {
+    modifiedResourceFiles?: Set<string>| null): number {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {

--- a/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
@@ -112,7 +112,7 @@ export class IncrementalState implements DependencyTracker, MetadataReader, Meta
   }
 
   private hasChangedResourceDependencies(sf: ts.SourceFile): boolean {
-    if (this.modifiedResourceFiles === undefined || !this.metadata.has(sf)) {
+    if (this.modifiedResourceFiles === null || !this.metadata.has(sf)) {
       return false;
     }
     const resourceDeps = this.metadata.get(sf) !.resourcePaths;

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -224,7 +224,7 @@ export function exitCodeFromResult(diags: Diagnostics | undefined): number {
 export function performCompilation(
     {rootNames, options, host, oldProgram, emitCallback, mergeEmitResultsCallback,
      gatherDiagnostics = defaultGatherDiagnostics, customTransformers,
-     emitFlags = api.EmitFlags.Default, modifiedResourceFiles}: {
+     emitFlags = api.EmitFlags.Default, modifiedResourceFiles = null}: {
       rootNames: string[],
       options: api.CompilerOptions,
       host?: api.CompilerHost,
@@ -234,7 +234,7 @@ export function performCompilation(
       gatherDiagnostics?: (program: api.Program) => Diagnostics,
       customTransformers?: api.CustomTransformers,
       emitFlags?: api.EmitFlags,
-      modifiedResourceFiles?: Set<string>,
+      modifiedResourceFiles?: Set<string>| null,
     }): PerformCompilationResult {
   let program: api.Program|undefined;
   let emitResult: ts.EmitResult|undefined;

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -26,7 +26,7 @@ import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 export class NgtscTestEnvironment {
   private multiCompileHostExt: MultiCompileHostExt|null = null;
   private oldProgram: Program|null = null;
-  private changedResources: Set<string>|undefined = undefined;
+  private changedResources: Set<string>|null = null;
 
   private constructor(
       private fs: FileSystem, readonly outDir: AbsoluteFsPath, readonly basePath: AbsoluteFsPath) {}
@@ -106,6 +106,12 @@ export class NgtscTestEnvironment {
     this.changedResources !.clear();
     this.multiCompileHostExt.flushWrittenFileTracking();
   }
+
+  /**
+   * Older versions of the CLI do not provide the `CompilerHost.getModifiedResourceFiles()` method.
+   * This results in the `changedResources` set being `null`.
+   */
+  simulateLegacyCLICompilerHost() { this.changedResources = null; }
 
   getFilesWrittenSinceLastFlush(): Set<string> {
     if (this.multiCompileHostExt === null) {

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -23,6 +23,23 @@ runInEachFileSystem(() => {
       env.tsconfig();
     });
 
+    it('should not crash if CLI does not provide getModifiedResourceFiles()', () => {
+      env.write('component1.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({selector: 'cmp', templateUrl: './component1.template.html'})
+      export class Cmp1 {}
+    `);
+      env.write('component1.template.html', 'cmp1');
+      env.driveMain();
+
+      // Simulate a change to `component1.html`
+      env.flushWrittenFileTracking();
+      env.invalidateCachedFile('component1.html');
+      env.simulateLegacyCLICompilerHost();
+      env.driveMain();
+    });
+
     it('should skip unchanged services', () => {
       env.write('service.ts', `
       import {Injectable} from '@angular/core';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Incremental compilation fails with ivy:
```
ERROR in Cannot read property 'has' of null
ℹ ｢wdm｣: Failed to compile.
/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/incremental/src/state.js:120
                .some(function (resourcePath) { return _this.modifiedResourceFiles.has(resourcePath); });
                                                                                   ^

TypeError: Cannot read property 'has' of null
    at /Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/incremental/src/state.js:120:84
    at Array.some (<anonymous>)
    at IncrementalState.hasChangedResourceDependencies (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/incremental/src/state.js:120:18)
    at IncrementalState.safeToSkip (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/incremental/src/state.js:70:57)
    at IvyCompilation.analyze (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/transform/src/compilation.js:156:39)
    at IvyCompilation.analyzeSync (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/transform/src/compilation.js:71:76)
    at /Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/program.js:257:39
    at Array.forEach (<anonymous>)
    at NgtscProgram.ensureAnalyzed (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/program.js:255:22)
    at NgtscProgram.getNgSemanticDiagnostics (/Users/mattlewis/Code/clickup/frontend/node_modules/@angular/compiler-cli/src/ngtsc/program.js:167:36)
```


## What is the new behavior?
Incremental compilation works

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I applied this patch locally and everything worked smoothly after! 😄 