### PR TITLE
fix(core): handle `undefined` meta in `injectArgs`

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -64,7 +64,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
       // migration, but this can be revisited.
       if (typeof paramTypes === 'undefined') {
         result[i] = [];
-      } else if (paramTypes[i] != Object) {
+      } else if (paramTypes[i] && paramTypes[i] != Object) {
         result[i] = [paramTypes[i]];
       } else {
         result[i] = [];

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -109,6 +109,16 @@ class TestObj {
         class ForwardDep {}
         expect(reflector.parameters(Forward)).toEqual([[ForwardDep]]);
       });
+
+      it('should not return undefined types for downleveled types', () => {
+        class Dep {}
+
+        class TestService {
+          constructor() {}
+          static ctorParameters = () => [{type: undefined, decorators: []}, {type: Dep}];
+        }
+        expect(reflector.parameters(TestService)).toEqual([[], [Dep]]);
+      });
     });
 
     describe('propMetadata', () => {


### PR DESCRIPTION
In the recent versions of the CLI we introduced a ctor downlevel for VE JIT build based on the one found in tsickle, to fix the TDZ issue of `forwardRef`.

However this caused a regression as the injector is not handling that a position paramType can be undefined. Which is bubbled down to https://github.com/angular/angular/blob/c6b29f4c6d23b1510db3434cb030203d5bdea119/packages/core/src/di/injector_compatibility.ts#L162 and will crash https://github.com/angular/angular/blob/c6b29f4c6d23b1510db3434cb030203d5bdea119/packages/core/src/di/injector_compatibility.ts#L174-L186

Fixes https://github.com/angular/angular-cli/issues/14888

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
