### PR TITLE
feat(ivy): ngcc - handle top-level helper calls in CommonJS

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
+import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {getDeclaration} from '../../../src/ngtsc/testing';
+import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
+import {MockLogger} from '../helpers/mock_logger';
+import {makeTestBundleProgram} from '../helpers/utils';
+
+runInEachFileSystem(() => {
+  describe('CommonJsReflectionHost [import helper style]', () => {
+    let _: typeof absoluteFrom;
+    let TOPLEVEL_DECORATORS_FILE: TestFile;
+
+    beforeEach(() => {
+      _ = absoluteFrom;
+
+      TOPLEVEL_DECORATORS_FILE = {
+        name: _('/toplevel_decorators.cjs.js'),
+        contents: `
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+  var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+  if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+  else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+  return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var core = require('@angular/core');
+
+var INJECTED_TOKEN = new InjectionToken('injected');
+var ViewContainerRef = {};
+var TemplateRef = {};
+
+var SomeDirective = (function() {
+  function SomeDirective(_viewContainer, _template, injected) {}
+  return SomeDirective;
+}());
+SomeDirective = __decorate([
+  core.Directive({ selector: '[someDirective]' }),
+  __metadata("design:paramtypes", [core.ViewContainerRef, core.TemplateRef])
+], SomeDirective);
+__decorate([
+  core.Input(),
+], SomeDirective.prototype, "input1", void 0);
+__decorate([
+  core.Input(),
+], SomeDirective.prototype, "input2", void 0);
+exports.SomeDirective = SomeDirective;
+
+var OtherDirective = (function() {
+  function OtherDirective(_viewContainer, _template, injected) {}
+  return OtherDirective;
+}());
+OtherDirective = __decorate([
+  core.Directive({ selector: '[OtherDirective]' }),
+  __metadata("design:paramtypes", [core.ViewContainerRef, core.TemplateRef])
+], OtherDirective);
+__decorate([
+  core.Input(),
+], OtherDirective.prototype, "input1", void 0);
+__decorate([
+  core.Input(),
+], OtherDirective.prototype, "input2", void 0);
+exports.OtherDirective = OtherDirective;
+`
+      };
+    });
+
+    describe('getDecoratorsOfDeclaration()', () => {
+      it('should find the decorators on a class at the top level', () => {
+        loadFakeCore(getFileSystem());
+        loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
+        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+        const classNode = getDeclaration(
+            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+        expect(decorators.length).toEqual(1);
+
+        const decorator = decorators[0];
+        expect(decorator.name).toEqual('Directive');
+        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+          '{ selector: \'[someDirective]\' }',
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Some formats of CommonJS put the decorator helper calls
outside the class IIFE as statements on the top level of the
source file.

This commit add support to the `CommonJSReflectionHost`
for this format.
