### PR TITLE
feat(bazel): allow passing a custom bazel compiler host to ngc compile

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -145,13 +145,15 @@ export function relativeToRootDirs(filePath: string, rootDirs: string[]): string
 }
 
 export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, bazelOpts, files,
-                         inputs, expectedOuts, gatherDiagnostics}: {
+                         inputs, expectedOuts, gatherDiagnostics, bazelHost}: {
   allDepsCompiledWithBazel?: boolean,
   compilerOpts: ng.CompilerOptions,
   tsHost: ts.CompilerHost, inputs?: {[path: string]: string},
   bazelOpts: BazelOptions,
   files: string[],
-  expectedOuts: string[], gatherDiagnostics?: (program: ng.Program) => ng.Diagnostics
+  expectedOuts: string[],
+  gatherDiagnostics?: (program: ng.Program) => ng.Diagnostics,
+  bazelHost?: CompilerHost,
 }): {diagnostics: ng.Diagnostics, program: ng.Program} {
   let fileLoader: FileLoader;
 
@@ -244,8 +246,10 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
         moduleName, containingFile, compilerOptions, generatedFileModuleResolverHost);
   }
 
-  const bazelHost = new CompilerHost(
-      files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
+  if (!bazelHost) {
+    bazelHost = new CompilerHost(
+        files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
+  }
 
   // Also need to disable decorator downleveling in the BazelHost in Ivy mode.
   if (isInIvyMode) {


### PR DESCRIPTION
Enable users to pass a custom Bazel CompilerHost to use for an Angular
compilation. This supports users who must override the TypeScript
compiler host.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Users cannot pass a specialized compiler host to `ngc_wrapped#compile`

Issue Number: N/A


## What is the new behavior?
Users can pass a specialized compiler host to `ngc_wrapped#compile`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
