### PR TITLE
fix(zone.js): __load_patch and __symbol__ should be in zone_extern for closure compiler

### DIFF
--- a/packages/zone.js/lib/closure/zone_externs.js
+++ b/packages/zone.js/lib/closure/zone_externs.js
@@ -27,6 +27,10 @@ Zone.prototype.name;
 
 Zone.assertZonePatched = function() {};
 
+Zone.__symbol__ = function(name) {};
+
+Zone.__load_patch = function(name, fn) {};
+
 /**
  * @type {!Zone} Returns the current [Zone]. Returns the current zone. The only way to change
  * the current zone is by invoking a run() method, which will update the current zone for the

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -309,10 +309,15 @@ interface ZoneType {
    */
   root: Zone;
 
-  /** @internal */
+  /**
+  * load patch for specified native module, allow user to
+  * define their own patch, user can use this API after loading zone.js
+  */
   __load_patch(name: string, fn: _PatchFn): void;
 
-  /** Was @ internal but this prevents compiling tests as separate unit */
+  /**
+   * Zone symbol API to generate a string with __zone_symbol__ prefix
+   */
   __symbol__(name: string): string;
 }
 

--- a/packages/zone.js/test/closure/zone.closure.ts
+++ b/packages/zone.js/test/closure/zone.closure.ts
@@ -52,6 +52,9 @@ const testClosureFunction = () => {
     }
   };
 
+  Zone.__load_patch('test_closure_load_patch', function() {});
+  Zone.__symbol__('test_symbol');
+
   const testZone: Zone = Zone.current.fork(testZoneSpec);
   testZone.runGuarded(() => {
     testZone.run(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #30533 
If we use `Zone.__symbol__` in application or angular code, after closure compiler, the `__symbol__` will be gone, because this API is internal and not exist in extern declaration file `zone_extern.js`. We need to add those APIs (__symbol__ and __load_patch) because they are also public APIs.

## What is the new behavior?

`__symbol__ and __load_patch` becomes public APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#30533 need this PR to work.
