### PR TITLE
fix(ivy): handle namespaced imports correctly

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -12,7 +12,7 @@ import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ng
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {ClassMemberKind, Import, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
-import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {loadFakeCore, loadTestFiles, loadTsLib} from '../../../test/helpers';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
 import {MockLogger} from '../helpers/mock_logger';
 import {convertToDirectTsLibImport, makeTestBundleProgram} from '../helpers/utils';
@@ -122,6 +122,7 @@ runInEachFileSystem(() => {
       describe(`[${label}]`, () => {
         beforeEach(() => {
           const fs = getFileSystem();
+          loadTsLib(fs);
           loadFakeCore(fs);
           loadTestFiles(FILES[label]);
         });

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -11,7 +11,7 @@ import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ng
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {ClassMemberKind, Import, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
-import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {loadFakeCore, loadTestFiles, loadTsLib} from '../../../test/helpers';
 import {Esm5ReflectionHost} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
 import {convertToDirectTsLibImport, makeTestBundleProgram} from '../helpers/utils';
@@ -143,6 +143,7 @@ export { SomeDirective };
       describe(`[${label}]`, () => {
         beforeEach(() => {
           const fs = getFileSystem();
+          loadTsLib(fs);
           loadFakeCore(fs);
           loadTestFiles(FILES[label]);
         });

--- a/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
+++ b/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
@@ -31,9 +31,7 @@ export function loadStandardTestFiles(
       tmpFs, resolveNpmTreeArtifact('typescript'),
       tmpFs.resolve(basePath, 'node_modules/typescript'));
 
-  loadTestDirectory(
-      tmpFs, resolveNpmTreeArtifact('tslib'), tmpFs.resolve(basePath, 'node_modules/tslib'));
-
+  loadTsLib(tmpFs, basePath);
 
   if (fakeCore) {
     loadFakeCore(tmpFs, basePath);
@@ -49,6 +47,11 @@ export function loadStandardTestFiles(
   }
 
   return tmpFs.dump();
+}
+
+export function loadTsLib(fs: FileSystem, basePath: string = '/') {
+  loadTestDirectory(
+      fs, resolveNpmTreeArtifact('tslib'), fs.resolve(basePath, 'node_modules/tslib'));
 }
 
 export function loadFakeCore(fs: FileSystem, basePath: string = '/') {


### PR DESCRIPTION
The ngcc tool adds namespaced imports to files when compiling. The ngtsc
tooling was not processing types correctly when they were imported via
such namespaces. For example:

```
export declare class SomeModule {
    static withOptions(...): ModuleWithProviders<ɵngcc1.BaseModule>;
```

In this case the `BaseModule` was being incorrectly attributed to coming
from the current module rather than the imported module, represented by
`ɵngcc1`.

Fixes #31342

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
