### PR TITLE
build(docs-infra): ignore `__`-prefixed and `ng*Def` members in docs

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -29,6 +29,7 @@ module.exports =
         .processor(require('./processors/processClassLikeMembers'))
         .processor(require('./processors/markBarredODocsAsPrivate'))
         .processor(require('./processors/filterPrivateDocs'))
+        .processor(require('./processors/filterMembers'))
         .processor(require('./processors/computeSearchTitle'))
         .processor(require('./processors/simplifyMemberAnchors'))
         .processor(require('./processors/computeStability'))
@@ -174,6 +175,13 @@ module.exports =
 
         .config(function(filterContainedDocs, API_CONTAINED_DOC_TYPES) {
           filterContainedDocs.docTypes = API_CONTAINED_DOC_TYPES;
+        })
+
+        .config(function(filterMembers) {
+          filterMembers.notAllowedPatterns.push(
+            /^__/,
+            /^ng[A-Z].*Def$/
+          );
         })
 
 

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -179,7 +179,6 @@ module.exports =
 
         .config(function(filterMembers) {
           filterMembers.notAllowedPatterns.push(
-            /^__/,
             /^ng[A-Z].*Def$/
           );
         })

--- a/aio/tools/transforms/angular-api-package/processors/filterMembers.js
+++ b/aio/tools/transforms/angular-api-package/processors/filterMembers.js
@@ -1,0 +1,21 @@
+/**
+ * Filter out members (i.e. static and instance properties and methods) that match specific
+ * patterns. Patterns can be added (as `RegExp`s) to the `notAllowedPatterns` array.
+ *
+ * (By default, no members are excluded.)
+ */
+module.exports = function filterMembers() {
+  return {
+    $runAfter: ['processing-docs'],
+    $runBefore: ['docs-processed'],
+    notAllowedPatterns: [],
+    $process(docs) {
+      const isAllowed = ({name}) => !this.notAllowedPatterns.some(re => re.test(name));
+
+      docs.forEach(doc => {
+        if (doc.statics) doc.statics = doc.statics.filter(isAllowed);
+        if (doc.members) doc.members = doc.members.filter(isAllowed);
+      });
+    },
+  };
+};

--- a/aio/tools/transforms/angular-api-package/processors/filterMembers.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/filterMembers.spec.js
@@ -1,0 +1,102 @@
+const processorFactory = require('./filterMembers');
+const testPackage = require('../../helpers/test-package');
+const Dgeni = require('dgeni');
+
+describe('filterMembers processor', () => {
+
+  it('should be available on the injector', () => {
+    const dgeni = new Dgeni([testPackage('angular-api-package')]);
+    const injector = dgeni.configureInjector();
+    const processor = injector.get('filterMembers');
+    expect(processor.$process).toBeDefined();
+    expect(processor.$runAfter).toEqual(['processing-docs']);
+    expect(processor.$runBefore).toEqual(['docs-processed']);
+  });
+
+  it('should remove members that match one of the not allowed patterns', () => {
+    const processor = processorFactory();
+    processor.notAllowedPatterns = [/^foo/, /bar$/];
+    const docs = [
+      // Doc without members.
+      { },
+
+      // Doc with static members only.
+      {
+        statics: [
+          { name: 'fooStatic' },  // Will be removed.
+          { name: 'FOOStatic' },
+          { name: 'barStatic' },
+          { name: 'statiCbar' },  // Will be removed.
+        ],
+      },
+
+      // Doc with instance members only.
+      {
+        members: [
+          { name: 'fooInstance' },  // Will be removed.
+          { name: 'FOOInstance' },
+          { name: 'barInstance' },
+          { name: 'instancEbar' },  // Will be removed.
+        ],
+      },
+
+      // Doc with both static and instance members.
+      {
+        statics: [
+          { name: 'fooStatic' },  // Will be removed.
+          { name: 'FOOStatic' },
+          { name: 'barStatic' },
+          { name: 'statiCbar' },  // Will be removed.
+        ],
+        members: [
+          { name: 'fooInstance' },  // Will be removed.
+          { name: 'FOOInstance' },
+          { name: 'barInstance' },
+          { name: 'instancEbar' },  // Will be removed.
+        ],
+      },
+    ];
+
+    processor.$process(docs);
+
+    expect(docs).toEqual([
+      { },
+      {
+        statics: [ { name: 'FOOStatic' }, { name: 'barStatic' } ],
+      },
+      {
+        members: [ { name: 'FOOInstance' }, { name: 'barInstance' } ],
+      },
+      {
+        statics: [ { name: 'FOOStatic' }, { name: 'barStatic' } ],
+        members: [ { name: 'FOOInstance' }, { name: 'barInstance' } ],
+      },
+    ]);
+  });
+
+  it('should remove no members by default', () => {
+    const processor = processorFactory();
+    const expectedDocs = [
+      {
+        statics: [
+          { name: '' },
+          { name: 'foo' },
+          { name: '__bar' },
+          { name: 'ngBazDef' },
+        ],
+        members: [
+          { name: '' },
+          { name: 'foo' },
+          { name: '__bar' },
+          { name: 'ngBazDef' },
+        ],
+      },
+    ];
+    const actualDocs = JSON.parse(JSON.stringify(expectedDocs));
+
+    processor.$process(actualDocs);
+
+    expect(processor.notAllowedPatterns).toEqual([]);
+    expect(actualDocs).toEqual(expectedDocs);
+  });
+});

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -62,12 +62,8 @@ import {Subject, Subscription} from 'rxjs';
  * @publicApi
  */
 export class EventEmitter<T extends any> extends Subject<T> {
-  // TODO: mark this as internal once all the facades are gone
-  // we can't mark it as internal now because EventEmitter exported via @angular/core would not
-  // contain this property making it incompatible with all the code that uses EventEmitter via
-  // facades, which are local to the code and do not have this property stripped.
   /**
-   * Internal
+   * @internal
    */
   __isAsync: boolean;  // tslint:disable-line
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -326,7 +326,6 @@ export declare class ErrorHandler {
 }
 
 export declare class EventEmitter<T extends any> extends Subject<T> {
-    __isAsync: boolean;
     constructor(isAsync?: boolean);
     emit(value?: T): void;
     subscribe(generatorOrNext?: any, error?: any, complete?: any): Subscription;


### PR DESCRIPTION
☝️ 