### PR TITLE
feat(bazel): allow passing and rewriting an old bazel host

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -145,7 +145,7 @@ export function relativeToRootDirs(filePath: string, rootDirs: string[]): string
 }
 
 export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, bazelOpts, files,
-                         inputs, expectedOuts, gatherDiagnostics, bazelHost}: {
+                         inputs, expectedOuts, gatherDiagnostics, oldBazelHost}: {
   allDepsCompiledWithBazel?: boolean,
   compilerOpts: ng.CompilerOptions,
   tsHost: ts.CompilerHost, inputs?: {[path: string]: string},
@@ -153,7 +153,7 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
   files: string[],
   expectedOuts: string[],
   gatherDiagnostics?: (program: ng.Program) => ng.Diagnostics,
-  bazelHost?: CompilerHost,
+  oldBazelHost?: CompilerHost,
 }): {diagnostics: ng.Diagnostics, program: ng.Program} {
   let fileLoader: FileLoader;
 
@@ -246,9 +246,10 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
         moduleName, containingFile, compilerOptions, generatedFileModuleResolverHost);
   }
 
-  if (!bazelHost) {
-    bazelHost = new CompilerHost(
-        files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
+  const bazelHost = new CompilerHost(
+      files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
+  if (oldBazelHost) {
+    Object.assign(bazelHost, oldBazelHost);
   }
 
   // Also need to disable decorator downleveling in the BazelHost in Ivy mode.

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -249,6 +249,8 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
   const bazelHost = new CompilerHost(
       files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
   if (oldBazelHost) {
+    // TODO(ayazhafiz): this kind of patching is hacky. Revisit this after the
+    // indexer consumer of this code is known to be working.
     Object.assign(bazelHost, oldBazelHost);
   }
 


### PR DESCRIPTION
Updates the decision made in #31341; this is for the Angular indexer
inside Google. The indexer currently passes (and ngc-wrapped#compile
accepts) a bazel host to use, but because many methods are overwritten
specially for Angular compilation a better approach is to pass an old
bazel compiler host and siphon methods needed off of it before creating
a new host. This enables the later approach.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
  - n/a
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The indexer currently passes (and ngc-wrapped#compile accepts) a bazel host to use.

## What is the new behavior?
`ngc-wrapped#compile` accepts an old bazel compiler host and siphons methods off of it before creating a new host.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This breaks the Angular indexer inside Google. Is it highly unlikely that anyone is using this API. Migration plan is to change the `bazelHost` property passed to `compile` to `oldBazelHost`.

## Other information

