### PR TITLE
fix(docs-infra): fix `search-results` styles

### DIFF
--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -51,6 +51,8 @@ describe('ScrollService', () => {
     spyOn(window, 'scrollBy');
   });
 
+  afterEach(() => scrollService.ngOnDestroy());
+
   it('should debounce `updateScrollPositonInHistory()`', fakeAsync(() => {
     const updateScrollPositionInHistorySpy = spyOn(scrollService, 'updateScrollPositionInHistory');
 
@@ -63,6 +65,25 @@ describe('ScrollService', () => {
     expect(updateScrollPositionInHistorySpy).not.toHaveBeenCalled();
     tick(1);
     expect(updateScrollPositionInHistorySpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should stop updating scroll position once destroyed', fakeAsync(() => {
+    const updateScrollPositionInHistorySpy = spyOn(scrollService, 'updateScrollPositionInHistory');
+
+    window.dispatchEvent(new Event('scroll'));
+    tick(250);
+    expect(updateScrollPositionInHistorySpy).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event('scroll'));
+    tick(250);
+    expect(updateScrollPositionInHistorySpy).toHaveBeenCalledTimes(2);
+
+    updateScrollPositionInHistorySpy.calls.reset();
+    scrollService.ngOnDestroy();
+
+    window.dispatchEvent(new Event('scroll'));
+    tick(250);
+    expect(updateScrollPositionInHistorySpy).not.toHaveBeenCalled();
   }));
 
   it('should set `scrollRestoration` to `manual` if supported', () => {
@@ -111,6 +132,23 @@ describe('ScrollService', () => {
 
       expect(scrollService.topOffset).toBe(100 + topMargin);
       expect(document.querySelector).toHaveBeenCalled();
+    });
+
+    it('should stop updating on resize once destroyed', () => {
+      let clientHeight = 50;
+      (document.querySelector as jasmine.Spy).and.callFake(() => ({clientHeight}));
+
+      expect(scrollService.topOffset).toBe(50 + topMargin);
+
+      clientHeight = 100;
+      window.dispatchEvent(new Event('resize'));
+      expect(scrollService.topOffset).toBe(100 + topMargin);
+
+      scrollService.ngOnDestroy();
+
+      clientHeight = 200;
+      window.dispatchEvent(new Event('resize'));
+      expect(scrollService.topOffset).toBe(100 + topMargin);
     });
   });
 

--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -26,5 +26,5 @@
 </ng-template>
 
 <ng-template #notFound>
-  <p>{{notFoundMessage}}</p>
+  <p class="not-found">{{notFoundMessage}}</p>
 </ng-template>

--- a/aio/src/styles/1-layouts/_not-found.scss
+++ b/aio/src/styles/1-layouts/_not-found.scss
@@ -1,7 +1,3 @@
-#file-not-found {
-    padding: 3rem 3rem 3rem;
-}
-
 .nf-container {
     align-items: center;
     padding: 32px;

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -1,102 +1,101 @@
 aio-search-results {
   z-index: 10;
-}
 
-.search-results {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  overflow: auto;
-  padding: 68px 32px 0;
-  color: $offwhite;
-  width: auto;
-  max-height: 95vh;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 5;
-  background-color: $darkgray;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
-  box-sizing: border-box;
-
-  @media (max-width: 480px) {
-    display: block;
+  .search-results {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    overflow: auto;
+    padding: 68px 32px 0;
+    width: auto;
+    max-height: 95vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 5;
+    background-color: $darkgray;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
+    box-sizing: border-box;
 
     .search-area {
+      display: flex;
+      flex-direction: column;
+      margin: 16px;
+      height: 100%;
+
+      .search-section-header {
+        @include font-size(16);
+        font-weight: 400;
+        margin: 10px 0px 5px;
+        text-transform: uppercase;
+        color: $white;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+
+        li {
+          list-style: none;
+        }
+
+        .search-result-item {
+          @include font-size(14);
+          color: $lightgray;
+          font-weight: normal;
+          &a {
+            text-decoration: none;
+          }
+          &:hover {
+            color: $white;
+          }
+
+          .symbol {
+            margin-right: 8px;
+          }
+        }
+
+        &.priority-pages {
+          padding: 0.5rem 0;
+
+          .search-result-item {
+            font-weight: bold;
+          }
+        }
+      }
+
+      @include bp(tiny) {
+        display: block;
+      }
+    }
+
+    @media (max-width: 480px) {
       display: block;
-      margin: 16px 16px;
-    }
-  }
-}
 
-aio-search-results.embedded .search-results {
-  padding: 0;
-  color: inherit;
-  width: auto;
-  max-height: 100%;
-  position: relative;
-  background-color: inherit;
-  box-shadow: none;
-  box-sizing: border-box;
-
-  .search-area a {
-    color: lighten($darkgray, 10);
-    &:hover {
-      color: $accentblue;
-    }
-  }
-}
-
-.search-area {
-  display: flex;
-  flex-direction: column;
-  margin: 16px 16px;
-  height: 100%;
-
-  .search-section-header {
-    @include font-size(16);
-    font-weight: 400;
-    margin: 10px 0px 5px;
-    text-transform: uppercase;
-    color: $white;
-  }
-
-  ul {
-    margin: 0;
-    padding: 0;
-
-    li {
-      list-style: none;
+      .search-area {
+        display: block;
+      }
     }
   }
 
-  a {
-    @include font-size(14);
-    color: $lightgray;
-    text-decoration: none;
-    font-weight: normal;
-    &:hover {
-      color: $white;
-    }
-    &:visited {
-      text-decoration: none;
-    }
+  &.embedded {
+    .search-results {
+      padding: 0;
+      color: inherit;
+      max-height: 100%;
+      position: relative;
+      background-color: inherit;
+      box-shadow: none;
 
-    span.symbol {
-      margin-right: 8px;
+      .search-area {
+        .search-result-item {
+          color: lighten($darkgray, 10);
+          &:hover {
+            color: $accentblue;
+          }
+        }
+      }
     }
-  }
-
-  .priority-pages {
-    padding: 0.5rem 0;
-
-    a {
-      font-weight: bold;
-    }
-  }
-
-  @include bp(tiny) {
-    display: block;
   }
 }

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -19,8 +19,6 @@ aio-search-results {
     box-sizing: border-box;
 
     .search-area {
-      display: flex;
-      flex-direction: column;
       margin: 16px;
       height: 100%;
 
@@ -64,18 +62,10 @@ aio-search-results {
           }
         }
       }
-
-      @include bp(tiny) {
-        display: block;
-      }
     }
 
     @media (max-width: 480px) {
       display: block;
-
-      .search-area {
-        display: block;
-      }
     }
   }
 

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -64,6 +64,12 @@ aio-search-results {
       }
     }
 
+    .not-found {
+      color: $white;
+      text-align: center;
+      margin: 16px;
+    }
+
     @media (max-width: 600px) {
       display: block;
     }
@@ -85,6 +91,10 @@ aio-search-results {
             color: $accentblue;
           }
         }
+      }
+
+      .not-found {
+        color: $darkgray;
       }
     }
   }

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -1,100 +1,102 @@
 aio-search-results {
-    z-index: 10;
+  z-index: 10;
 }
 
 .search-results {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-    overflow: auto;
-    padding: 68px 32px 0;
-    color: $offwhite;
-    width: auto;
-    max-height: 95vh;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 5;
-    background-color: $darkgray;
-    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
-    box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  overflow: auto;
+  padding: 68px 32px 0;
+  color: $offwhite;
+  width: auto;
+  max-height: 95vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  background-color: $darkgray;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
+  box-sizing: border-box;
 
-    @media (max-width: 480px) {
-        display: block;
-        .search-area {
-            display: block;
-            margin: 16px 16px;
-        }
+  @media (max-width: 480px) {
+    display: block;
+
+    .search-area {
+      display: block;
+      margin: 16px 16px;
     }
+  }
 }
 
 aio-search-results.embedded .search-results {
-    padding: 0;
-    color: inherit;
-    width: auto;
-    max-height: 100%;
-    position: relative;
-    background-color: inherit;
-    box-shadow: none;
-    box-sizing: border-box;
+  padding: 0;
+  color: inherit;
+  width: auto;
+  max-height: 100%;
+  position: relative;
+  background-color: inherit;
+  box-shadow: none;
+  box-sizing: border-box;
 
-    .search-area a {
-        color: lighten($darkgray, 10);
-        &:hover {
-            color: $accentblue;
-        }
+  .search-area a {
+    color: lighten($darkgray, 10);
+    &:hover {
+      color: $accentblue;
     }
+  }
 }
 
 .search-area {
-    display: flex;
-    flex-direction: column;
-    margin: 16px 16px;
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  margin: 16px 16px;
+  height: 100%;
 
-    .search-section-header {
-        @include font-size(16);
-        font-weight: 400;
-        margin: 10px 0px 5px;
-        text-transform: uppercase;
-        color: $white;
+  .search-section-header {
+    @include font-size(16);
+    font-weight: 400;
+    margin: 10px 0px 5px;
+    text-transform: uppercase;
+    color: $white;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+
+    li {
+      list-style: none;
+    }
+  }
+
+  a {
+    @include font-size(14);
+    color: $lightgray;
+    text-decoration: none;
+    font-weight: normal;
+    &:hover {
+      color: $white;
+    }
+    &:visited {
+      text-decoration: none;
     }
 
-    ul {
-        margin: 0;
-        padding: 0;
-
-        li {
-            list-style: none;
-        }
+    span.symbol {
+      margin-right: 8px;
     }
+  }
+
+  .priority-pages {
+    padding: 0.5rem 0;
 
     a {
-        @include font-size(14);
-        color: $lightgray;
-        text-decoration: none;
-        font-weight: normal;
-        &:hover {
-            color: $white;
-        }
-        &:visited {
-          text-decoration: none;
-        }
-
-        span.symbol {
-          margin-right: 8px;
-        }
+      font-weight: bold;
     }
+  }
 
-    .priority-pages {
-        padding: 0.5rem 0;
-        a {
-            font-weight: bold;
-        }
-    }
-
-    @include bp(tiny) {
-        display: block;
-    }
+  @include bp(tiny) {
+    display: block;
+  }
 }

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -42,9 +42,11 @@ aio-search-results {
           @include font-size(14);
           color: $lightgray;
           font-weight: normal;
+
           &a {
             text-decoration: none;
           }
+
           &:hover {
             color: $white;
           }
@@ -85,8 +87,13 @@ aio-search-results {
       box-shadow: none;
 
       .search-area {
+        .search-section-header {
+          color: $darkgray;
+        }
+
         .search-result-item {
           color: lighten($darkgray, 10);
+
           &:hover {
             color: $accentblue;
           }

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -64,7 +64,7 @@ aio-search-results {
       }
     }
 
-    @media (max-width: 480px) {
+    @media (max-width: 600px) {
       display: block;
     }
   }


### PR DESCRIPTION
I started to fix the "No results found" message being hidden, but ended up doing some clean up and other minor fixes (see individual commits for details).

WRT to the main fix ("No results found" being hidden):

**BEFORE**
![search-not-found-before](https://user-images.githubusercontent.com/8604205/60532113-3ae51600-9d05-11e9-8da0-0fdc2817b653.png)

**AFTER**
![search-not-found-after](https://user-images.githubusercontent.com/8604205/60532123-40daf700-9d05-11e9-9890-80301502bbed.png)

##
Both before and after the "No results found" is displayed correctly on the "Page Not Found" page:

![page-not-found-before-and-after](https://user-images.githubusercontent.com/8604205/60532143-4c2e2280-9d05-11e9-9d9a-13791f4230d4.png)

---
**UPDATE:**

This PR also [fixes a bug][1] in `ScrollService` that caused test flakes ([example][2]). No idea why the flakes started appearing on this PR (which was just changing CSS styles 🤷‍♂).

[1]: https://github.com/angular/angular/commit/119dcd146188307f0296132536d8eb311fda96c4
[2]: https://circleci.com/gh/angular/angular/381649