### PR TITLE
docs: add missing return to example storage.service.ts

### DIFF
--- a/aio/content/examples/dependency-injection-in-action/src/app/storage.service.ts
+++ b/aio/content/examples/dependency-injection-in-action/src/app/storage.service.ts
@@ -16,7 +16,7 @@ export class BrowserStorageService {
   constructor(@Inject(BROWSER_STORAGE) public storage: Storage) {}
 
   get(key: string) {
-    this.storage.getItem(key);
+    return this.storage.getItem(key);
   }
 
   set(key: string, value: string) {


### PR DESCRIPTION
While JavaScript does support implicit returns, it seems TypeScript will not infer the function return type from the implicit return of the last statement (at least not in TS 3.4.3). So, when the `return` is missing from the `get` function the implicit type of the function is `void`. So for the `get` function to be usable it needs to an explicit return.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
