### PR TITLE
fix(ivy): incorrect ChangeDetectorRef injected into pipes used in component inputs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -49,13 +49,6 @@ export function getConstructorDependencies(
     let token = valueReferenceToExpression(param.typeValueReference, defaultImportRecorder);
     let optional = false, self = false, skipSelf = false, host = false;
     let resolved = R3ResolvedDependencyType.Token;
-    const typeValueReference = param.typeValueReference;
-
-    if (typeValueReference && !typeValueReference.local &&
-        typeValueReference.name === 'ChangeDetectorRef' &&
-        typeValueReference.moduleName === '@angular/core') {
-      resolved = R3ResolvedDependencyType.ChangeDetectorRef;
-    }
 
     (param.decorators || []).filter(dec => isCore || isAngularCore(dec)).forEach(dec => {
       const name = isCore || dec.import === null ? dec.name : dec.import !.name;
@@ -87,6 +80,11 @@ export function getConstructorDependencies(
             ErrorCode.DECORATOR_UNEXPECTED, dec.node, `Unexpected decorator ${name} on parameter.`);
       }
     });
+
+    if (token instanceof ExternalExpr && token.value.name === 'ChangeDetectorRef' &&
+        token.value.moduleName === '@angular/core') {
+      resolved = R3ResolvedDependencyType.ChangeDetectorRef;
+    }
     if (token === null) {
       errors.push({
         index: idx,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -49,6 +49,14 @@ export function getConstructorDependencies(
     let token = valueReferenceToExpression(param.typeValueReference, defaultImportRecorder);
     let optional = false, self = false, skipSelf = false, host = false;
     let resolved = R3ResolvedDependencyType.Token;
+    const typeValueReference = param.typeValueReference;
+
+    if (typeValueReference && !typeValueReference.local &&
+        typeValueReference.name === 'ChangeDetectorRef' &&
+        typeValueReference.moduleName === '@angular/core') {
+      resolved = R3ResolvedDependencyType.ChangeDetectorRef;
+    }
+
     (param.decorators || []).filter(dec => isCore || isAngularCore(dec)).forEach(dec => {
       const name = isCore || dec.import === null ? dec.name : dec.import !.name;
       if (name === 'Inject') {

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -65,6 +65,7 @@ export type Provider = any;
 export enum R3ResolvedDependencyType {
   Token = 0,
   Attribute = 1,
+  ChangeDetectorRef = 2,
 }
 
 export interface R3DependencyMetadataFacade {

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -97,6 +97,11 @@ export enum R3ResolvedDependencyType {
    * The token expression is a string representing the attribute name.
    */
   Attribute = 1,
+
+  /**
+   * Injecting the `ChangeDetectorRef` token. Needs special handling when injected into a pipe.
+   */
+  ChangeDetectorRef = 2,
 }
 
 /**
@@ -138,8 +143,8 @@ export interface R3DependencyMetadata {
 /**
  * Construct a factory function expression for the given `R3FactoryMetadata`.
  */
-export function compileFactoryFunction(meta: R3FactoryMetadata):
-    {factory: o.Expression, statements: o.Statement[]} {
+export function compileFactoryFunction(
+    meta: R3FactoryMetadata, isPipe = false): {factory: o.Expression, statements: o.Statement[]} {
   const t = o.variable('t');
   const statements: o.Statement[] = [];
 
@@ -155,7 +160,8 @@ export function compileFactoryFunction(meta: R3FactoryMetadata):
   if (meta.deps !== null) {
     // There is a constructor (either explicitly or implicitly defined).
     if (meta.deps !== 'invalid') {
-      ctorExpr = new o.InstantiateExpr(typeForCtor, injectDependencies(meta.deps, meta.injectFn));
+      ctorExpr =
+          new o.InstantiateExpr(typeForCtor, injectDependencies(meta.deps, meta.injectFn, isPipe));
     }
   } else {
     const baseFactory = o.variable(`ɵ${meta.name}_BaseFactory`);
@@ -203,7 +209,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata):
   } else if (isDelegatedMetadata(meta)) {
     // This type is created with a delegated factory. If a type parameter is not specified, call
     // the factory instead.
-    const delegateArgs = injectDependencies(meta.delegateDeps, meta.injectFn);
+    const delegateArgs = injectDependencies(meta.delegateDeps, meta.injectFn, isPipe);
     // Either call `new delegate(...)` or `delegate(...)` depending on meta.useNewForDelegate.
     const factoryExpr = new (
         meta.delegateType === R3FactoryDelegateType.Class ?
@@ -232,30 +238,38 @@ export function compileFactoryFunction(meta: R3FactoryMetadata):
 }
 
 function injectDependencies(
-    deps: R3DependencyMetadata[], injectFn: o.ExternalReference): o.Expression[] {
-  return deps.map(dep => compileInjectDependency(dep, injectFn));
+    deps: R3DependencyMetadata[], injectFn: o.ExternalReference, isPipe: boolean): o.Expression[] {
+  return deps.map(dep => compileInjectDependency(dep, injectFn, isPipe));
 }
 
 function compileInjectDependency(
-    dep: R3DependencyMetadata, injectFn: o.ExternalReference): o.Expression {
+    dep: R3DependencyMetadata, injectFn: o.ExternalReference, isPipe: boolean): o.Expression {
   // Interpret the dependency according to its resolved type.
   switch (dep.resolved) {
-    case R3ResolvedDependencyType.Token: {
+    case R3ResolvedDependencyType.Token:
+    case R3ResolvedDependencyType.ChangeDetectorRef:
       // Build up the injection flags according to the metadata.
       const flags = InjectFlags.Default | (dep.self ? InjectFlags.Self : 0) |
           (dep.skipSelf ? InjectFlags.SkipSelf : 0) | (dep.host ? InjectFlags.Host : 0) |
           (dep.optional ? InjectFlags.Optional : 0);
 
-      // Build up the arguments to the injectFn call.
-      const injectArgs = [dep.token];
       // If this dependency is optional or otherwise has non-default flags, then additional
       // parameters describing how to inject the dependency must be passed to the inject function
       // that's being used.
-      if (flags !== InjectFlags.Default || dep.optional) {
-        injectArgs.push(o.literal(flags));
+      let flagsParam: o.LiteralExpr|null =
+          (flags !== InjectFlags.Default || dep.optional) ? o.literal(flags) : null;
+
+      // We have a separate instruction for injecting ChangeDetectorRef into a pipe.
+      if (isPipe && dep.resolved === R3ResolvedDependencyType.ChangeDetectorRef) {
+        return o.importExpr(R3.injectPipeChangeDetectorRef).callFn(flagsParam ? [flagsParam] : []);
+      }
+
+      // Build up the arguments to the injectFn call.
+      const injectArgs = [dep.token];
+      if (flagsParam) {
+        injectArgs.push(flagsParam);
       }
       return o.importExpr(injectFn).callFn(injectArgs);
-    }
     case R3ResolvedDependencyType.Attribute:
       // In the case of attributes, the attribute name in question is given as the token.
       return o.importExpr(R3.injectAttribute).callFn([dep.token]);

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -215,6 +215,9 @@ export class Identifiers {
 
   static injectAttribute: o.ExternalReference = {name: 'ɵɵinjectAttribute', moduleName: CORE};
 
+  static injectPipeChangeDetectorRef:
+      o.ExternalReference = {name: 'ɵɵinjectPipeChangeDetectorRef', moduleName: CORE};
+
   static directiveInject: o.ExternalReference = {name: 'ɵɵdirectiveInject', moduleName: CORE};
 
   static templateRefExtractor:

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -57,12 +57,14 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata) {
   // e.g. `type: MyPipe`
   definitionMapValues.push({key: 'type', value: metadata.type, quoted: false});
 
-  const templateFactory = compileFactoryFunction({
-    name: metadata.name,
-    type: metadata.type,
-    deps: metadata.deps,
-    injectFn: R3.directiveInject,
-  });
+  const templateFactory = compileFactoryFunction(
+      {
+        name: metadata.name,
+        type: metadata.type,
+        deps: metadata.deps,
+        injectFn: R3.directiveInject,
+      },
+      true);
   definitionMapValues.push({key: 'factory', value: templateFactory.factory, quoted: false});
 
   // e.g. `pure: true`

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -65,6 +65,7 @@ export type Provider = any;
 export enum R3ResolvedDependencyType {
   Token = 0,
   Attribute = 1,
+  ChangeDetectorRef = 2,
 }
 
 export interface R3DependencyMetadataFacade {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -33,6 +33,7 @@ export {
   RenderFlags as ɵRenderFlags,
   ɵɵdirectiveInject,
   ɵɵinjectAttribute,
+  ɵɵinjectPipeChangeDetectorRef,
   ɵɵgetFactoryOf,
   ɵɵgetInheritedFactory,
   ɵɵsetComponentScope,

--- a/packages/core/src/di/jit/util.ts
+++ b/packages/core/src/di/jit/util.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ChangeDetectorRef} from '../../change_detection/change_detector_ref';
 import {CompilerFacade, R3DependencyMetadataFacade, getCompilerFacade} from '../../compiler/compiler_facade';
 import {Type} from '../../interface/type';
 import {ReflectionCapabilities} from '../../reflection/reflection_capabilities';
@@ -66,6 +67,9 @@ function reflectDependency(compiler: CompilerFacade, dep: any | any[]): R3Depend
         }
         meta.token = param.attributeName;
         meta.resolved = compiler.R3ResolvedDependencyType.Attribute;
+      } else if (param === ChangeDetectorRef) {
+        meta.token = param;
+        meta.resolved = compiler.R3ResolvedDependencyType.ChangeDetectorRef;
       } else {
         setTokenAndResolvedType(param);
       }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectFlags, InjectionToken} from '../di';
+import {InjectionToken} from '../di/injection_token';
 import {Injector} from '../di/injector';
 import {injectRootLimpMode, setInjectImplementation} from '../di/injector_compatibility';
 import {getInjectableDef, getInjectorDef} from '../di/interface/defs';
+import {InjectFlags} from '../di/interface/injector';
 import {Type} from '../interface/type';
 import {assertDefined, assertEqual} from '../util/assert';
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -70,7 +70,6 @@ export {
 
   ɵɵgetCurrentView,
   ɵɵinjectAttribute,
-  ɵɵinjectPipeChangeDetectorRef,
 
   ɵɵlistener,
   ɵɵload,
@@ -199,7 +198,7 @@ export {
   ɵɵpureFunctionV,
 } from './pure_function';
 
-export {ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
+export {ɵɵtemplateRefExtractor, ɵɵinjectPipeChangeDetectorRef} from './view_engine_compatibility_prebound';
 
 export {ɵɵresolveWindow, ɵɵresolveDocument, ɵɵresolveBody} from './util/misc_utils';
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -70,6 +70,7 @@ export {
 
   ɵɵgetCurrentView,
   ɵɵinjectAttribute,
+  ɵɵinjectPipeChangeDetectorRef,
 
   ɵɵlistener,
   ɵɵload,

--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -5,12 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ChangeDetectorRef} from '../../change_detection/change_detection';
 import {InjectFlags, InjectionToken, resolveForwardRef} from '../../di';
 import {ɵɵinject} from '../../di/injector_compatibility';
 import {Type} from '../../interface/type';
 import {getOrCreateInjectable, injectAttributeImpl} from '../di';
 import {TContainerNode, TElementContainerNode, TElementNode} from '../interfaces/node';
 import {getLView, getPreviousOrParentTNode} from '../state';
+import {injectChangeDetectorRef} from '../view_engine_compatibility';
 
 /**
  * Returns the value associated to the given token from the injectors.
@@ -58,4 +60,18 @@ export function ɵɵdirectiveInject<T>(
  */
 export function ɵɵinjectAttribute(attrNameToInject: string): string|null {
   return injectAttributeImpl(getPreviousOrParentTNode(), attrNameToInject);
+}
+
+/**
+ * Returns the appropriate `ChangeDetectorRef` for a pipe.
+ *
+ * @codeGenApi
+ */
+export function ɵɵinjectPipeChangeDetectorRef(flags = InjectFlags.Default): ChangeDetectorRef|null {
+  const value = injectChangeDetectorRef(true);
+  if (value == null && !(flags & InjectFlags.Optional)) {
+    throw new Error(`No provider for ChangeDetectorRef!`);
+  } else {
+    return value;
+  }
 }

--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -5,14 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ChangeDetectorRef} from '../../change_detection/change_detection';
 import {InjectFlags, InjectionToken, resolveForwardRef} from '../../di';
 import {ɵɵinject} from '../../di/injector_compatibility';
 import {Type} from '../../interface/type';
 import {getOrCreateInjectable, injectAttributeImpl} from '../di';
 import {TContainerNode, TElementContainerNode, TElementNode} from '../interfaces/node';
 import {getLView, getPreviousOrParentTNode} from '../state';
-import {injectChangeDetectorRef} from '../view_engine_compatibility';
 
 /**
  * Returns the value associated to the given token from the injectors.
@@ -60,18 +58,4 @@ export function ɵɵdirectiveInject<T>(
  */
 export function ɵɵinjectAttribute(attrNameToInject: string): string|null {
   return injectAttributeImpl(getPreviousOrParentTNode(), attrNameToInject);
-}
-
-/**
- * Returns the appropriate `ChangeDetectorRef` for a pipe.
- *
- * @codeGenApi
- */
-export function ɵɵinjectPipeChangeDetectorRef(flags = InjectFlags.Default): ChangeDetectorRef|null {
-  const value = injectChangeDetectorRef(true);
-  if (value == null && !(flags & InjectFlags.Optional)) {
-    throw new Error(`No provider for ChangeDetectorRef!`);
-  } else {
-    return value;
-  }
 }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -42,6 +42,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵgetInheritedFactory': r3.ɵɵgetInheritedFactory,
        'ɵɵinject': ɵɵinject,
        'ɵɵinjectAttribute': r3.ɵɵinjectAttribute,
+       'ɵɵinjectPipeChangeDetectorRef': r3.ɵɵinjectPipeChangeDetectorRef,
        'ɵɵtemplateRefExtractor': r3.ɵɵtemplateRefExtractor,
        'ɵɵNgOnChangesFeature': r3.ɵɵNgOnChangesFeature,
        'ɵɵProvidersFeature': r3.ɵɵProvidersFeature,

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -368,8 +368,8 @@ export function injectChangeDetectorRef(isPipe = false): ViewEngine_ChangeDetect
  * Creates a ViewRef and stores it on the injector as ChangeDetectorRef (public alias).
  *
  * @param hostTNode The node that is requesting a ChangeDetectorRef
- * @param hostTNodeIsParent Whether the `hostTNode` is a parent node
  * @param hostView The view to which the node belongs
+ * @param isPipe Whether the view is being injected into a pipe.
  * @returns The ChangeDetectorRef to use
  */
 function createViewRef(

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -360,24 +360,24 @@ export function createContainerRef(
 
 
 /** Returns a ChangeDetectorRef (a.k.a. a ViewRef) */
-export function injectChangeDetectorRef(): ViewEngine_ChangeDetectorRef {
-  return createViewRef(getPreviousOrParentTNode(), getLView(), null);
+export function injectChangeDetectorRef(isPipe = false): ViewEngine_ChangeDetectorRef {
+  return createViewRef(getPreviousOrParentTNode(), getLView(), isPipe);
 }
 
 /**
  * Creates a ViewRef and stores it on the injector as ChangeDetectorRef (public alias).
  *
  * @param hostTNode The node that is requesting a ChangeDetectorRef
+ * @param hostTNodeIsParent Whether the `hostTNode` is a parent node
  * @param hostView The view to which the node belongs
- * @param context The context for this change detector ref
  * @returns The ChangeDetectorRef to use
  */
-export function createViewRef(
-    hostTNode: TNode, hostView: LView, context: any): ViewEngine_ChangeDetectorRef {
-  if (isComponent(hostTNode)) {
+function createViewRef(
+    hostTNode: TNode, hostView: LView, isPipe: boolean): ViewEngine_ChangeDetectorRef {
+  if (isComponent(hostTNode) && !isPipe) {
     const componentIndex = hostTNode.directiveStart;
     const componentView = getComponentViewByIndex(hostTNode.index, hostView);
-    return new ViewRef(componentView, context, componentIndex);
+    return new ViewRef(componentView, null, componentIndex);
   } else if (
       hostTNode.type === TNodeType.Element || hostTNode.type === TNodeType.Container ||
       hostTNode.type === TNodeType.ElementContainer) {

--- a/packages/core/src/render3/view_engine_compatibility_prebound.ts
+++ b/packages/core/src/render3/view_engine_compatibility_prebound.ts
@@ -7,12 +7,14 @@
  */
 
 
+import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
+import {InjectFlags} from '../di/interface/injector';
 import {ElementRef as ViewEngine_ElementRef} from '../linker/element_ref';
 import {TemplateRef as ViewEngine_TemplateRef} from '../linker/template_ref';
 
 import {TNode} from './interfaces/node';
 import {LView} from './interfaces/view';
-import {createTemplateRef} from './view_engine_compatibility';
+import {createTemplateRef, injectChangeDetectorRef} from './view_engine_compatibility';
 
 
 
@@ -24,4 +26,19 @@ import {createTemplateRef} from './view_engine_compatibility';
  */
 export function ɵɵtemplateRefExtractor(tNode: TNode, currentView: LView) {
   return createTemplateRef(ViewEngine_TemplateRef, ViewEngine_ElementRef, tNode, currentView);
+}
+
+
+/**
+ * Returns the appropriate `ChangeDetectorRef` for a pipe.
+ *
+ * @codeGenApi
+ */
+export function ɵɵinjectPipeChangeDetectorRef(flags = InjectFlags.Default): ChangeDetectorRef|null {
+  const value = injectChangeDetectorRef(true);
+  if (value == null && !(flags & InjectFlags.Optional)) {
+    throw new Error(`No provider for ChangeDetectorRef!`);
+  } else {
+    return value;
+  }
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -920,6 +920,8 @@ export interface ɵɵInjectorDef<T> {
     providers: (Type<any> | ValueProvider | ExistingProvider | FactoryProvider | ConstructorProvider | StaticClassProvider | ClassProvider | any[])[];
 }
 
+export declare function ɵɵinjectPipeChangeDetectorRef(flags?: InjectFlags): ChangeDetectorRef | null;
+
 export declare function ɵɵlistener(eventName: string, listenerFn: (e?: any) => any, useCapture?: boolean, eventTargetResolver?: GlobalTargetResolver): void;
 
 export declare function ɵɵload<T>(index: number): T;


### PR DESCRIPTION
When injecting a `ChangeDetectorRef` into a pipe, the expected result is that the ref will be tied to the component in which the pipe is being used. This works for most cases, however when a pipe is used inside a property binding of a component (see test case as an example), the current `TNode` is pointing to component's host so we end up injecting the inner component's view. These changes fix the issue by only looking up the component view of the `TNode` if the `TNode` is a parent.

This PR resolves FW-1419.