### PR TITLE
fix(zone.js): fix #27840, don't wrap uncaught promise error.

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -176,20 +176,25 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         }
         if (queue.length == 0 && state == REJECTED) {
           (promise as any)[symbolState] = REJECTED_NO_CATCH;
-          try {
-            // try to print more readable error log
-            throw new Error(
-                'Uncaught (in promise): ' + readableObjectToString(value) +
-                (value && value.stack ? '\n' + value.stack : ''));
-          } catch (err) {
-            const error: UncaughtPromiseError = err;
-            error.rejection = value;
-            error.promise = promise;
-            error.zone = Zone.current;
-            error.task = Zone.currentTask !;
-            _uncaughtPromiseErrors.push(error);
-            api.scheduleMicroTask();  // to make sure that it is running
+          let uncaughtPromiseError: any;
+          if (value instanceof Error || (value && value.message)) {
+            uncaughtPromiseError = value;
+          } else {
+            try {
+              // try to print more readable error log
+              throw new Error(
+                  'Uncaught (in promise): ' + readableObjectToString(value) +
+                  (value && value.stack ? '\n' + value.stack : ''));
+            } catch (err) {
+              uncaughtPromiseError = err;
+            }
           }
+          uncaughtPromiseError.rejection = value;
+          uncaughtPromiseError.promise = promise;
+          uncaughtPromiseError.zone = Zone.current;
+          uncaughtPromiseError.task = Zone.currentTask !;
+          _uncaughtPromiseErrors.push(uncaughtPromiseError);
+          api.scheduleMicroTask();  // to make sure that it is running
         }
       }
     }

--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -345,11 +345,8 @@ describe(
                 });
             setTimeout((): any => null);
             setTimeout(() => {
-              expect(promiseError !.message)
-                  .toBe(
-                      'Uncaught (in promise): ' + error +
-                      (error !.stack ? '\n' + error !.stack : ''));
               expect((promiseError as any)['rejection']).toBe(error);
+              expect(promiseError).toBe(error);
               expect((promiseError as any)['zone']).toBe(zone);
               expect((promiseError as any)['task']).toBe(task);
               done();
@@ -388,6 +385,39 @@ describe(
             });
           });
         });
+
+        it('should print original information when throw a not error object with a message property',
+           (done) => {
+             let promiseError: Error|null = null;
+             let zone: Zone|null = null;
+             let task: Task|null = null;
+             let rejectObj: TestRejection;
+             queueZone
+                 .fork({
+                   name: 'promise-error',
+                   onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any):
+                                      boolean => {
+                                        promiseError = error;
+                                        delegate.handleError(target, error);
+                                        return false;
+                                      }
+                 })
+                 .run(() => {
+                   zone = Zone.current;
+                   task = Zone.currentTask;
+                   rejectObj = new TestRejection();
+                   rejectObj.prop1 = 'value1';
+                   rejectObj.prop2 = 'value2';
+                   (rejectObj as any).message = 'rejectMessage';
+                   Promise.reject(rejectObj);
+                   expect(promiseError).toBe(null);
+                 });
+             setTimeout((): any => null);
+             setTimeout(() => {
+               expect(promiseError).toEqual(rejectObj as any);
+               done();
+             });
+           });
 
         describe('Promise.race', () => {
           it('should reject the value', () => {

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -84,9 +84,7 @@ describe('FakeAsyncTestZoneSpec', () => {
        () => {
          fakeAsyncTestZone.run(() => {
            Promise.resolve(null).then((_) => { throw new Error('async'); });
-           expect(() => {
-             testZoneSpec.flushMicrotasks();
-           }).toThrowError(/Uncaught \(in promise\): Error: async/);
+           expect(() => { testZoneSpec.flushMicrotasks(); }).toThrowError(/async/);
          });
        });
 
@@ -1171,7 +1169,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
             resolvedPromise.then((_) => { throw new Error('async'); });
             flushMicrotasks();
           })();
-        }).toThrowError(/Uncaught \(in promise\): Error: async/);
+        }).toThrowError(/async/);
       });
 
       it('should complain if a test throws an exception', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27840 

`zone.js` will catch `uncaught promise rejection`, such as this case.

```
Promise.reject(new Error('test'));
```

And when `zone onHandleError` catch the error, the error will look like

```
{
  message: 'Uncaught (in promise): test',
  reason: Error('test')
}
```

because `zone.js` wrap the original error into a new Error with the reason property equals to the original error. It will make developer hard to use, because developer expect the original error will be caught in error handler.


## What is the new behavior?
If the `uncaught Promise rejection` is `instanceof Error or has a message property`. 
To keep the backward compatibility, I also set the `reason` property to the `error`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
