### PR TITLE
fix(zone.js): restore definition of global

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
+    patch_args = ["-p1"],
+    # Patch https://github.com/bazelbuild/rules_nodejs/pull/903
+    patches = ["//tools:rollup_bundle_commonjs_ignoreGlobal.patch"],
     sha256 = "6d4edbf28ff6720aedf5f97f9b9a7679401bf7fca9d14a0fff80f644a99992b4",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.32.2/rules_nodejs-0.32.2.tar.gz"],
 )

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -299,4 +299,4 @@
     };
     return ZoneQueueRunner;
   })(QueueRunner);
-})(global);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/packages/zone.js/lib/mocha/mocha.ts
+++ b/packages/zone.js/lib/mocha/mocha.ts
@@ -158,4 +158,4 @@
       return originalRun.call(this, fn);
     };
   })(Mocha.Runner.prototype.runTest, Mocha.Runner.prototype.run);
-})(global);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/packages/zone.js/lib/zone-spec/async-test.ts
+++ b/packages/zone.js/lib/zone-spec/async-test.ts
@@ -146,4 +146,4 @@
   // Export the class so that new instances can be created with proper
   // constructor params.
   (Zone as any)['AsyncTestZoneSpec'] = AsyncTestZoneSpec;
-})(global);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -557,4 +557,4 @@
   // Export the class so that new instances can be created with proper
   // constructor params.
   (Zone as any)['FakeAsyncTestZoneSpec'] = FakeAsyncTestZoneSpec;
-})(global);
+})(typeof window === 'object' && window || typeof self === 'object' && self || global);

--- a/packages/zone.js/lib/zone-spec/wtf.ts
+++ b/packages/zone.js/lib/zone-spec/wtf.ts
@@ -158,4 +158,4 @@
   }
 
   (Zone as any)['wtfZoneSpec'] = !wtfEnabled ? null : new WtfZoneSpec();
-})(global);
+})(typeof window === 'object' && window || typeof self === 'object' && self || global);

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -1401,4 +1401,4 @@ const Zone: ZoneType = (function(global: any) {
 
   performanceMeasure('Zone', 'Zone');
   return global['Zone'] = Zone;
-})(global);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/tools/rollup_bundle_commonjs_ignoreGlobal.patch
+++ b/tools/rollup_bundle_commonjs_ignoreGlobal.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/rollup/rollup.config.js b/internal/rollup/rollup.config.js
+index 720b5f6..cbfa99c 100644
+--- a/internal/rollup/rollup.config.js
++++ b/internal/rollup/rollup.config.js
+@@ -189,7 +189,9 @@ const config = {
+       // with the amd plugin.
+       include: /\.ngfactory\.js$/i,
+     }),
+-    commonjs(),
++    commonjs({
++      ignoreGlobal: true,
++    }),
+     {
+       name: 'notResolved',
+       resolveId: notResolved,


### PR DESCRIPTION
This partially reverts some changes from https://github.com/angular/zone.js/commit/71b93711806000d7788e79451478e20d6086aa8a#diff-dd469785fca8680a5b33b1e81c5cfd91R1420
These broke the g3sync of zone.js because we use the output of the TypeScript compiler directly, rather than rely on the rollup commonjs plugin to define the global symbol
