### PR TITLE
refactor(ivy): remove instruction usage from other instructions

### DIFF
--- a/packages/core/src/render3/instructions/class_map_interpolation.ts
+++ b/packages/core/src/render3/instructions/class_map_interpolation.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getLView} from '../state';
+import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
-import {ɵɵclassMap} from './styling';
+import {classMapInternal, getActiveDirectiveStylingIndex} from './styling';
 
 
 /**
@@ -35,10 +35,11 @@ import {ɵɵclassMap} from './styling';
  * @codeGenApi
  */
 export function ɵɵclassMapInterpolate1(prefix: string, v0: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolation1(getLView(), prefix, v0, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -67,10 +68,11 @@ export function ɵɵclassMapInterpolate1(prefix: string, v0: any, suffix: string
  */
 export function ɵɵclassMapInterpolate2(
     prefix: string, v0: any, i0: string, v1: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolation2(getLView(), prefix, v0, i0, v1, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -102,10 +104,11 @@ export function ɵɵclassMapInterpolate2(
  */
 export function ɵɵclassMapInterpolate3(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolation3(getLView(), prefix, v0, i0, v1, i1, v2, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -140,10 +143,11 @@ export function ɵɵclassMapInterpolate3(
 export function ɵɵclassMapInterpolate4(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolation4(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -180,11 +184,12 @@ export function ɵɵclassMapInterpolate4(
 export function ɵɵclassMapInterpolate5(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
+  const lView = getLView();
   const interpolatedValue =
-      interpolation5(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
+      interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -223,11 +228,12 @@ export function ɵɵclassMapInterpolate5(
 export function ɵɵclassMapInterpolate6(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
+  const lView = getLView();
   const interpolatedValue =
-      interpolation6(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
+      interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -268,11 +274,12 @@ export function ɵɵclassMapInterpolate6(
 export function ɵɵclassMapInterpolate7(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolation7(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
+  const lView = getLView();
+  const interpolatedValue =
+      interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -316,11 +323,12 @@ export function ɵɵclassMapInterpolate8(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
+  const lView = getLView();
   const interpolatedValue = interpolation8(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
+      lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }
 
@@ -348,9 +356,10 @@ export function ɵɵclassMapInterpolate8(
  * @codeGenApi
  */
 export function ɵɵclassMapInterpolateV(values: any[]): void {
-  // TODO(FW-1340): Refactor to remove the use of other instructions here.
-  const interpolatedValue = interpolationV(getLView(), values);
+  const lView = getLView();
+  const interpolatedValue = interpolationV(lView, values);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵclassMap(interpolatedValue);
+    classMapInternal(
+        lView, getSelectedIndex(), getActiveDirectiveStylingIndex(), interpolatedValue);
   }
 }

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -59,7 +59,7 @@ export function ɵɵlistener(
  *
  * @codeGenApi
 */
-export function ɵɵcomponentHostSyntheticListener<T>(
+export function ɵɵcomponentHostSyntheticListener(
     eventName: string, listenerFn: (e?: any) => any, useCapture = false,
     eventTargetResolver?: GlobalTargetResolver): void {
   listenerInternal(eventName, listenerFn, useCapture, eventTargetResolver, loadComponentRenderer);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -30,7 +30,7 @@ import {StylingContext} from '../interfaces/styling';
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from '../node_assert';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
-import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, isCreationMode, leaveView, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode, setSelectedIndex, ɵɵnamespaceHTML} from '../state';
+import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, isCreationMode, leaveView, namespaceHTMLInternal, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode, setSelectedIndex} from '../state';
 import {initializeStaticContext as initializeStaticStylingContext} from '../styling/class_and_style_bindings';
 import {ANIMATION_PROP_PREFIX, isAnimationProp} from '../styling/util';
 import {NO_CHANGE} from '../tokens';
@@ -38,8 +38,10 @@ import {attrsStylingIndexOf} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
 import {getLViewParent, getRootContext} from '../util/view_traversal_utils';
 import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isComponent, isComponentDef, isContentQueryHost, isLContainer, isRootView, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
+
 import {LCleanup, LViewBlueprint, MatchesArray, TCleanup, TNodeInitialData, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor, attachLContainerDebug, attachLViewDebug, cloneToLView, cloneToTViewData} from './lview_debug';
 import {selectInternal} from './select';
+
 
 
 /**
@@ -458,7 +460,7 @@ export function renderComponentOrTemplate<T>(
 
 function executeTemplate<T>(
     lView: LView, templateFn: ComponentTemplate<T>, rf: RenderFlags, context: T) {
-  ɵɵnamespaceHTML();
+  namespaceHTMLInternal();
   const prevSelectedIndex = getSelectedIndex();
   try {
     setActiveHostElement(null);

--- a/packages/core/src/render3/instructions/style_prop_interpolation.ts
+++ b/packages/core/src/render3/instructions/style_prop_interpolation.ts
@@ -5,12 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {getLView} from '../state';
+import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
 import {TsickleIssue1009} from './shared';
-import {ɵɵstyleProp} from './styling';
+import {getActiveDirectiveStylingIndex, stylePropInternal} from './styling';
 
 
 
@@ -44,9 +44,12 @@ import {ɵɵstyleProp} from './styling';
 export function ɵɵstylePropInterpolate1(
     styleIndex: number, prefix: string, v0: any, suffix: string, valueSuffix?: string | null,
     forceOverride?: boolean): TsickleIssue1009 {
-  const interpolatedValue = interpolation1(getLView(), prefix, v0, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate1;
 }
@@ -83,9 +86,12 @@ export function ɵɵstylePropInterpolate1(
 export function ɵɵstylePropInterpolate2(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, suffix: string,
     valueSuffix?: string | null, forceOverride?: boolean): TsickleIssue1009 {
-  const interpolatedValue = interpolation2(getLView(), prefix, v0, i0, v1, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate2;
 }
@@ -124,9 +130,12 @@ export function ɵɵstylePropInterpolate2(
 export function ɵɵstylePropInterpolate3(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string, valueSuffix?: string | null, forceOverride?: boolean): TsickleIssue1009 {
-  const interpolatedValue = interpolation3(getLView(), prefix, v0, i0, v1, i1, v2, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate3;
 }
@@ -168,9 +177,12 @@ export function ɵɵstylePropInterpolate4(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     i2: string, v3: any, suffix: string, valueSuffix?: string | null,
     forceOverride?: boolean): TsickleIssue1009 {
-  const interpolatedValue = interpolation4(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate4;
 }
@@ -214,10 +226,13 @@ export function ɵɵstylePropInterpolate5(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     i2: string, v3: any, i3: string, v4: any, suffix: string, valueSuffix?: string | null,
     forceOverride?: boolean): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue =
-      interpolation5(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
+      interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate5;
 }
@@ -263,10 +278,13 @@ export function ɵɵstylePropInterpolate6(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     i2: string, v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string,
     valueSuffix?: string | null, forceOverride?: boolean): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue =
-      interpolation6(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
+      interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate6;
 }
@@ -315,10 +333,13 @@ export function ɵɵstylePropInterpolate7(
     styleIndex: number, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     i2: string, v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any,
     suffix: string, valueSuffix?: string | null, forceOverride?: boolean): TsickleIssue1009 {
-  const interpolatedValue = interpolation7(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
+  const lView = getLView();
+  const interpolatedValue =
+      interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate7;
 }
@@ -370,10 +391,13 @@ export function ɵɵstylePropInterpolate8(
     i2: string, v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string,
     v7: any, suffix: string, valueSuffix?: string | null,
     forceOverride?: boolean): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue = interpolation8(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
+      lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolatedValue as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolatedValue as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolate8;
 }
@@ -412,9 +436,12 @@ export function ɵɵstylePropInterpolate8(
 export function ɵɵstylePropInterpolateV(
     styleIndex: number, values: any[], valueSuffix?: string | null,
     forceOverride?: boolean): TsickleIssue1009 {
-  const interpolated = interpolationV(getLView(), values);
+  const lView = getLView();
+  const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
-    ɵɵstyleProp(styleIndex, interpolated as string, valueSuffix, forceOverride);
+    stylePropInternal(
+        lView, getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(),
+        interpolated as string, valueSuffix, forceOverride);
   }
   return ɵɵstylePropInterpolateV;
 }

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -146,10 +146,17 @@ function initStyling(
 export function ɵɵstyleProp(
     styleIndex: number, value: string | number | String | PlayerFactory | null,
     suffix?: string | null, forceOverride?: boolean): void {
-  const index = getSelectedIndex();
+  stylePropInternal(
+      getLView(), getSelectedIndex(), styleIndex, getActiveDirectiveStylingIndex(), value, suffix,
+      forceOverride);
+}
+
+export function stylePropInternal(
+    lView: LView, selectedIndex: number, styleIndex: number, directiveStylingIndex: number,
+    value: string | number | String | PlayerFactory | null, suffix?: string | null,
+    forceOverride?: boolean): void {
   const valueToAdd = resolveStylePropValue(value, suffix);
-  const stylingContext = getStylingContext(index, getLView());
-  const directiveStylingIndex = getActiveDirectiveStylingIndex();
+  const stylingContext = getStylingContext(selectedIndex, lView);
   if (directiveStylingIndex) {
     const args: ParamsOf<typeof updatestyleProp> =
         [stylingContext, styleIndex, valueToAdd, directiveStylingIndex, forceOverride];
@@ -311,15 +318,18 @@ export function ɵɵstyleMap(styles: {[styleName: string]: any} | NO_CHANGE | nu
  * @codeGenApi
  */
 export function ɵɵclassMap(classes: {[styleName: string]: any} | string | null): void {
-  const index = getSelectedIndex();
-  const lView = getLView();
-  const stylingContext = getStylingContext(index, lView);
-  const directiveStylingIndex = getActiveDirectiveStylingIndex();
+  classMapInternal(getLView(), getSelectedIndex(), getActiveDirectiveStylingIndex(), classes);
+}
+
+export function classMapInternal(
+    lView: LView, selectedIndex: number, directiveStylingIndex: number,
+    classes: {[styleName: string]: any} | string | null) {
+  const stylingContext = getStylingContext(selectedIndex, lView);
   if (directiveStylingIndex) {
     const args: ParamsOf<typeof updateClassMap> = [stylingContext, classes, directiveStylingIndex];
     enqueueHostInstruction(stylingContext, directiveStylingIndex, updateClassMap, args);
   } else {
-    const tNode = getTNode(index, lView);
+    const tNode = getTNode(selectedIndex, lView);
     // inputs are only evaluated from a template binding into a directive, therefore,
     // there should not be a situation where a directive host bindings function
     // evaluates the inputs (this should only happen in the template function)

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -786,9 +786,6 @@
     "name": "ɵɵelementStart"
   },
   {
-    "name": "ɵɵnamespaceHTML"
-  },
-  {
     "name": "ɵɵsetComponentScope"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -522,9 +522,6 @@
     "name": "ɵɵdefineInjectable"
   },
   {
-    "name": "ɵɵnamespaceHTML"
-  },
-  {
     "name": "ɵɵtext"
   }
 ]

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1626,9 +1626,6 @@
     "name": "ɵɵlistener"
   },
   {
-    "name": "ɵɵnamespaceHTML"
-  },
-  {
     "name": "ɵɵnextContext"
   },
   {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -744,7 +744,7 @@ export declare type ɵɵComponentDefWithMeta<T, Selector extends String, ExportA
     [key: string]: string;
 }, QueryFields extends string[]> = ComponentDef<T>;
 
-export declare function ɵɵcomponentHostSyntheticListener<T>(eventName: string, listenerFn: (e?: any) => any, useCapture?: boolean, eventTargetResolver?: GlobalTargetResolver): void;
+export declare function ɵɵcomponentHostSyntheticListener(eventName: string, listenerFn: (e?: any) => any, useCapture?: boolean, eventTargetResolver?: GlobalTargetResolver): void;
 
 export declare function ɵɵcontainer(index: number): void;
 


### PR DESCRIPTION
Removes direct calls from one instruction into another, moves the shared logic into a separate function and removes the state getters from the shared function.

This PR resolves FW-1340.