### PR TITLE
fix(ivy): update ICU placeholders format to match Closure compiler behavior

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -942,25 +942,30 @@ describe('i18n support in the view compiler', () => {
 
     it('should support named interpolations', () => {
       const input = `
-        <div i18n>Some value: {{ valueA // i18n(ph="PH_A") }}</div>
+        <div i18n>
+          Named interpolation: {{ valueA // i18n(ph="PH_A") }}
+          Named interpolation with spaces: {{ valueB // i18n(ph="PH B") }}
+        </div>
       `;
 
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2817319788724342848$$APP_SPEC_TS_0$ = goog.getMsg("Some value: {$phA}", {
-              "phA": "\uFFFD0\uFFFD"
+            const $MSG_EXTERNAL_7597881511811528589$$APP_SPEC_TS_0$ = goog.getMsg(" Named interpolation: {$phA} Named interpolation with spaces: {$phB} ", {
+              "phA": "\uFFFD0\uFFFD",
+              "phB": "\uFFFD1\uFFFD"
             });
-            $I18N_0$ = $MSG_EXTERNAL_2817319788724342848$$APP_SPEC_TS_0$;
+            $I18N_0$ = $MSG_EXTERNAL_7597881511811528589$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $r3$.ɵɵi18nLocalize("Some value: {$phA}", {
-              "phA": "\uFFFD0\uFFFD"
+            $I18N_0$ = $r3$.ɵɵi18nLocalize(" Named interpolation: {$phA} Named interpolation with spaces: {$phB} ", {
+              "phA": "\uFFFD0\uFFFD",
+              "phB": "\uFFFD1\uFFFD"
             });
         }
         …
         consts: 2,
-        vars: 1,
+        vars: 2,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -969,7 +974,7 @@ describe('i18n support in the view compiler', () => {
           }
           if (rf & 2) {
             $r3$.ɵɵselect(1);
-            $r3$.ɵɵi18nExp(ctx.valueA);
+            $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB);
             $r3$.ɵɵi18nApply(1);
           }
         }
@@ -3121,24 +3126,24 @@ describe('i18n support in the view compiler', () => {
           select,
             male {male {{ weight // i18n(ph="PH_A") }}}
             female {female {{ height // i18n(ph="PH_B") }}}
-            other {other {{ age // i18n(ph="PH_C") }}}
+            other {other {{ age // i18n(ph="PH WITH SPACES") }}}
         }</div>
       `;
 
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4853189513362404940$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_C}}}");
-            $I18N_0$ = $MSG_EXTERNAL_4853189513362404940$$APP_SPEC_TS_0$;
+            const $MSG_EXTERNAL_6318060397235942326$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}");
+            $I18N_0$ = $MSG_EXTERNAL_6318060397235942326$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_C}}}");
+            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}");
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
           "VAR_SELECT": "\uFFFD0\uFFFD",
           "PH_A": "\uFFFD1\uFFFD",
           "PH_B": "\uFFFD2\uFFFD",
-          "PH_C": "\uFFFD3\uFFFD"
+          "PH_WITH_SPACES": "\uFFFD3\uFFFD"
         });
         …
         consts: 2,

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -2515,18 +2515,15 @@ describe('i18n support in the view compiler', () => {
         const $_c3$ = ["title", "icu and text"];
         var $I18N_5$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_1922743304863699161$$APP_SPEC_TS__5$ = goog.getMsg("{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{$interpolation} emails}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            const $MSG_EXTERNAL_1922743304863699161$$APP_SPEC_TS__5$ = goog.getMsg("{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{INTERPOLATION} emails}}");
             $I18N_5$ = $MSG_EXTERNAL_1922743304863699161$$APP_SPEC_TS__5$;
         }
         else {
-            $I18N_5$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{$interpolation} emails}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            $I18N_5$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{INTERPOLATION} emails}}");
         }
         $I18N_5$ = $r3$.ɵɵi18nPostprocess($I18N_5$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "INTERPOLATION": "\uFFFD1\uFFFD"
         });
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
@@ -2577,18 +2574,15 @@ describe('i18n support in the view compiler', () => {
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{$interpolation}}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            const $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}");
             $I18N_0$ = $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{$interpolation}}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}");
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "INTERPOLATION": "\uFFFD1\uFFFD"
         });
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -2620,28 +2614,20 @@ describe('i18n support in the view compiler', () => {
       const output = String.raw `
         var $I18N_1$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male - {$startBoldText}male{$closeBoldText}} female {female {$startBoldText}female{$closeBoldText}} other {{$startTagDiv}{$startItalicText}other{$closeItalicText}{$closeTagDiv}}}", {
-              "startBoldText": "<b>",
-              "closeBoldText": "</b>",
-              "startItalicText": "<i>",
-              "closeItalicText": "</i>",
-              "startTagDiv": "<div class=\"other\">",
-              "closeTagDiv": "</div>"
-            });
+            const $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}");
             $I18N_1$ = $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$;
         }
         else {
-            $I18N_1$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male - {$startBoldText}male{$closeBoldText}} female {female {$startBoldText}female{$closeBoldText}} other {{$startTagDiv}{$startItalicText}other{$closeItalicText}{$closeTagDiv}}}", {
-              "startBoldText": "<b>",
-              "closeBoldText": "</b>",
-              "startItalicText": "<i>",
-              "closeItalicText": "</i>",
-              "startTagDiv": "<div class=\"other\">",
-              "closeTagDiv": "</div>"
-            });
+            $I18N_1$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}");
         }
         $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "START_BOLD_TEXT": "<b>",
+          "CLOSE_BOLD_TEXT": "</b>",
+          "START_ITALIC_TEXT": "<i>",
+          "CLOSE_ITALIC_TEXT": "</i>",
+          "START_TAG_DIV": "<div class=\"other\">",
+          "CLOSE_TAG_DIV": "</div>"
         });
         const $_c2$ = [1, "other"];
         var $I18N_0$;
@@ -2701,18 +2687,15 @@ describe('i18n support in the view compiler', () => {
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male of age: {$interpolation}} female {female} other {other}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            const $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}");
             $I18N_0$ = $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male of age: {$interpolation}} female {female} other {other}}", {
-              "interpolation": "\uFFFD1\uFFFD"
-            });
+            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}");
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "INTERPOLATION": "\uFFFD1\uFFFD"
         });
         …
         consts: 2,
@@ -3054,36 +3037,29 @@ describe('i18n support in the view compiler', () => {
       const output = String.raw `
         var $I18N_1$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male {$interpolation}} female {female {$interpolation_1}} other {other}}", {
-              "interpolation": "\uFFFD1\uFFFD",
-              "interpolation_1": "\uFFFD2\uFFFD"
-            });
+            const $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}");
             $I18N_1$ = $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$;
         }
         else {
-            $I18N_1$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {$interpolation}} female {female {$interpolation_1}} other {other}}", {
-              "interpolation": "\uFFFD1\uFFFD",
-              "interpolation_1": "\uFFFD2\uFFFD"
-            });
+            $I18N_1$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}");
         }
         $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "INTERPOLATION": "\uFFFD1\uFFFD",
+          "INTERPOLATION_1": "\uFFFD2\uFFFD"
         });
         const $_c0$ = [${AttributeMarker.Template}, "ngIf"];
         var $I18N_3$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2310343208266678305$$APP_SPEC_TS__3$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {$interpolation}}}", {
-              "interpolation": "\uFFFD1:1\uFFFD"
-            });
+            const $MSG_EXTERNAL_2310343208266678305$$APP_SPEC_TS__3$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {INTERPOLATION}}}");
             $I18N_3$ = $MSG_EXTERNAL_2310343208266678305$$APP_SPEC_TS__3$;
         }
         else {
-            $I18N_3$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {$interpolation}}}", {
-              "interpolation": "\uFFFD1:1\uFFFD"
-            });
+            $I18N_3$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {INTERPOLATION}}}");
         }
         $I18N_3$ = $r3$.ɵɵi18nPostprocess($I18N_3$, {
-          "VAR_SELECT": "\uFFFD0:1\uFFFD"
+          "VAR_SELECT": "\uFFFD0:1\uFFFD",
+          "INTERPOLATION": "\uFFFD1:1\uFFFD"
         });
         var $I18N_0$;
         if (ngI18nClosureMode) {
@@ -3152,22 +3128,17 @@ describe('i18n support in the view compiler', () => {
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4853189513362404940$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {$phA}} female {female {$phB}} other {other {$phC}}}", {
-              "phA": "\uFFFD1\uFFFD",
-              "phB": "\uFFFD2\uFFFD",
-              "phC": "\uFFFD3\uFFFD"
-            });
+            const $MSG_EXTERNAL_4853189513362404940$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_C}}}");
             $I18N_0$ = $MSG_EXTERNAL_4853189513362404940$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {$phA}} female {female {$phB}} other {other {$phC}}}", {
-              "phA": "\uFFFD1\uFFFD",
-              "phB": "\uFFFD2\uFFFD",
-              "phC": "\uFFFD3\uFFFD"
-            });
+            $I18N_0$ = $r3$.ɵɵi18nLocalize("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_C}}}");
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
+          "VAR_SELECT": "\uFFFD0\uFFFD",
+          "PH_A": "\uFFFD1\uFFFD",
+          "PH_B": "\uFFFD2\uFFFD",
+          "PH_C": "\uFFFD3\uFFFD"
         });
         …
         consts: 2,

--- a/packages/compiler/src/render3/view/i18n/serializer.ts
+++ b/packages/compiler/src/render3/view/i18n/serializer.ts
@@ -26,7 +26,8 @@ class SerializerVisitor implements i18n.Visitor {
   private insideIcu = false;
 
   private formatPh(value: string): string {
-    return this.insideIcu ? `{${value}}` : `{$${formatI18nPlaceholderName(value)}}`;
+    const formatted = formatI18nPlaceholderName(value, /* useCamelCase */ !this.insideIcu);
+    return this.insideIcu ? `{${formatted}}` : `{$${formatted}}`;
   }
 
   visitText(text: i18n.Text, context: any): any { return text.value; }

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -220,8 +220,12 @@ export function parseI18nMeta(meta?: string): I18nMeta {
  * @param name The placeholder name that should be formatted
  * @returns Formatted placeholder name
  */
-export function formatI18nPlaceholderName(name: string): string {
-  const chunks = toPublicName(name).split('_');
+export function formatI18nPlaceholderName(name: string, useCamelCase: boolean = true): string {
+  const publicName = toPublicName(name);
+  if (!useCamelCase) {
+    return publicName;
+  }
+  const chunks = publicName.split('_');
   if (chunks.length === 1) {
     // if no "_" found - just lowercase the value
     return name.toLowerCase();

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -249,7 +249,7 @@ describe('Serializer', () => {
       // ICU with nested HTML
       [
         '{age, plural, 10 {<b>ten</b>} other {<div class="A">other</div>}}',
-        '{VAR_PLURAL, plural, 10 {{$startBoldText}ten{$closeBoldText}} other {{$startTagDiv}other{$closeTagDiv}}}'
+        '{VAR_PLURAL, plural, 10 {{START_BOLD_TEXT}ten{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}other{CLOSE_TAG_DIV}}}'
       ]
     ];
 

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -51,6 +51,7 @@ const ROOT_TEMPLATE_ID = 0;
 const PP_MULTI_VALUE_PLACEHOLDERS_REGEXP = /\[(�.+?�?)\]/;
 const PP_PLACEHOLDERS_REGEXP = /\[(�.+?�?)\]|(�\/?\*\d+:\d+�)/g;
 const PP_ICU_VARS_REGEXP = /({\s*)(VAR_(PLURAL|SELECT)(_\d+)?)(\s*,)/g;
+const PP_ICU_PLACEHOLDERS_REGEXP = /{([A-Z0-9_]+)}/g;
 const PP_ICUS_REGEXP = /�I18N_EXP_(ICU(_\d+)?)�/g;
 const PP_CLOSE_TEMPLATE_REGEXP = /\/\*/;
 const PP_TEMPLATE_ID_REGEXP = /\d+\:(\d+)/;
@@ -547,7 +548,8 @@ function appendI18nNode(
  *
  * 1. Resolve all multi-value cases (like [�*1:1��#2:1�|�#4:1�|�5�])
  * 2. Replace all ICU vars (like "VAR_PLURAL")
- * 3. Replace all ICU references with corresponding values (like �ICU_EXP_ICU_1�)
+ * 3. Replace all placeholders used inside ICUs in a form of {PLACEHOLDER}
+ * 4. Replace all ICU references with corresponding values (like �ICU_EXP_ICU_1�)
  *    in case multiple ICUs have the same placeholder name
  *
  * @param message Raw translation string for post processing
@@ -625,7 +627,14 @@ export function ɵɵi18nPostprocess(
   });
 
   /**
-   * Step 3: replace all ICU references with corresponding values (like �ICU_EXP_ICU_1�) in case
+   * Step 3: replace all placeholders used inside ICUs in a form of {PLACEHOLDER}
+   */
+  result = result.replace(PP_ICU_PLACEHOLDERS_REGEXP, (match, key): string => {
+    return replacements.hasOwnProperty(key) ? replacements[key] as string : match;
+  });
+
+  /**
+   * Step 4: replace all ICU references with corresponding values (like �ICU_EXP_ICU_1�) in case
    * multiple ICUs have the same placeholder name
    */
   result = result.replace(PP_ICUS_REGEXP, (match, key): string => {

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -439,8 +439,8 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
     it('multiple', () => {
       ɵi18nConfigureLocalize({
         translations: {
-          '{VAR_PLURAL, plural, =0 {no {$startBoldText}emails{$closeBoldText}!} =1 {one {$startItalicText}email{$closeItalicText}} other {{$interpolation} {$startTagSpan}emails{$closeTagSpan}}}':
-              '{VAR_PLURAL, plural, =0 {aucun {$startBoldText}email{$closeBoldText}!} =1 {un {$startItalicText}email{$closeItalicText}} other {{$interpolation} {$startTagSpan}emails{$closeTagSpan}}}',
+          '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
+              '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
           '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
         }
       });
@@ -485,8 +485,8 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
     it('inside HTML elements', () => {
       ɵi18nConfigureLocalize({
         translations: {
-          '{VAR_PLURAL, plural, =0 {no {$startBoldText}emails{$closeBoldText}!} =1 {one {$startItalicText}email{$closeItalicText}} other {{$interpolation} {$startTagSpan}emails{$closeTagSpan}}}':
-              '{VAR_PLURAL, plural, =0 {aucun {$startBoldText}email{$closeBoldText}!} =1 {un {$startItalicText}email{$closeItalicText}} other {{$interpolation} {$startTagSpan}emails{$closeTagSpan}}}',
+          '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
+              '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
           '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
         }
       });
@@ -568,8 +568,8 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
     it('nested', () => {
       ɵi18nConfigureLocalize({
         translations: {
-          '{VAR_PLURAL, plural, =0 {zero} other {{$interpolation} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}}!}}':
-              '{VAR_PLURAL, plural, =0 {zero} other {{$interpolation} {VAR_SELECT, select, cat {chats} dog {chients} other {animaux}}!}}'
+          '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}}!}}':
+              '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {chats} dog {chients} other {animaux}}!}}'
         }
       });
       const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
@@ -963,8 +963,8 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       translations: {
         'start {$interpolation} middle {$interpolation_1} end':
             'début {$interpolation_1} milieu {$interpolation} fin',
-        '{VAR_PLURAL, plural, =0 {no {$startBoldText}emails{$closeBoldText}!} =1 {one {$startItalicText}email{$closeItalicText}} other {{$interpolation} emails}}':
-            '{VAR_PLURAL, plural, =0 {aucun {$startBoldText}email{$closeBoldText}!} =1 {un {$startItalicText}email{$closeItalicText}} other {{$interpolation} emails}}',
+        '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}':
+            '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}',
         ' trad: {$icu}': ' traduction: {$icu}'
       }
     });


### PR DESCRIPTION
Since `goog.getMsg` does not process ICUs (post-processing is required via goog.i18n.MessageFormat, https://google.github.io/closure-library/api/goog.i18n.MessageFormat.html) and placeholder format used for ICUs and regular messages inside `goog.getMsg` are different, the current implementation (that assumed the same placeholder format) needs to be updated. This commit updates placeholder format used inside ICUs from `{$placeholder}` to `{PLACEHOLDER}` to better align with Closure. ICU placeholders (that were left as is prior to this commit) are now replaced with actual values in post-processing step (inside `i18nPostprocess`).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No