### PR TITLE
build(compiler-cli): remove unused dependencies (`shelljs`, `@types/source-map`)

### DIFF
--- a/integration/bazel/package.json
+++ b/integration/bazel/package.json
@@ -27,7 +27,6 @@
     "@bazel/karma": "0.32.2",
     "@bazel/typescript": "0.32.2",
     "@types/jasmine": "2.8.8",
-    "@types/source-map": "0.5.1",
     "protractor": "5.1.2",
     "typescript": "3.4.2"
   },

--- a/integration/bazel/yarn.lock
+++ b/integration/bazel/yarn.lock
@@ -47,6 +47,15 @@
     shelljs "0.8.2"
     tsickle "^0.35.0"
 
+"@angular/cdk@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-8.0.1.tgz#106872aa7fac0c55144ed5dd60df9af7e24b436a"
+  integrity sha512-Ul7rVU/rr4qGHs1w24P/6MHEosYp8AHRxBHrp/yJ50eHbHVS31FyfO8gKfNqPc1bnL1YoYYCs0hIBwNDaz8uDg==
+  dependencies:
+    tslib "^1.7.1"
+  optionalDependencies:
+    parse5 "^5.0.0"
+
 "@angular/common@file:../../dist/packages-dist/common":
   version "8.1.0-next.3"
   dependencies:
@@ -62,7 +71,6 @@
     magic-string "^0.25.0"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
-    shelljs "^0.8.1"
     source-map "^0.6.1"
     tslib "^1.9.0"
     yargs "13.1.0"
@@ -76,6 +84,18 @@
   version "8.1.0-next.3"
   dependencies:
     tslib "^1.9.0"
+
+"@angular/forms@file:../../dist/packages-dist/forms":
+  version "8.1.0-next.3"
+  dependencies:
+    tslib "^1.9.0"
+
+"@angular/material@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-8.0.1.tgz#cbb3f7776d2405a1d75b6e7eb6675fd80a8a5cf5"
+  integrity sha512-BozIS+9yiqFTfXBoZfhFUibY8meDUcv/e+CxhSHyv3vZw9XVTNTbiaX7tX/FX0Ai+1VKnwRTGrKvPKGFSqynCA==
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "8.1.0-next.3"
@@ -321,11 +341,6 @@
   version "2.53.43"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz#2de3d718819bc20165754c4a59afb7e9833f6707"
   integrity sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==
-
-"@types/source-map@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.1.tgz#7e74db5d06ab373a712356eebfaea2fad0ea2367"
-  integrity sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA==
 
 "@types/z-schema@3.16.31":
   version "3.16.31"
@@ -2364,6 +2379,11 @@ pako@~1.0.2:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
+parse5@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
 parseqs@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
@@ -2873,15 +2893,6 @@ shelljs@0.8.2:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -3223,7 +3234,7 @@ tslib@1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/node": "^10.9.4",
     "@types/selenium-webdriver": "3.0.7",
     "@types/shelljs": "^0.7.8",
-    "@types/source-map": "^0.5.1",
     "@types/systemjs": "0.19.32",
     "@types/yargs": "^11.1.1",
     "@webcomponents/custom-elements": "^1.0.4",

--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -26,7 +26,6 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/util",
         "@npm//@types/convert-source-map",
         "@npm//@types/node",
-        "@npm//@types/source-map",
         "@npm//@types/yargs",
         "@npm//canonical-path",
         "@npm//dependency-graph",

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -17,7 +17,6 @@
     "convert-source-map": "^1.5.1",
     "dependency-graph": "^0.7.2",
     "magic-string": "^0.25.0",
-    "shelljs": "^0.8.1",
     "source-map": "^0.6.1",
     "tslib": "^1.9.0",
     "yargs": "13.1.0"

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -15,7 +15,6 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/util",
         "//packages/compiler-cli/test:test_utils",
         "//packages/compiler-cli/test/helpers",
-        "@npm//@types/source-map",
         "@npm//source-map",
         "@npm//typescript",
     ],

--- a/tools/size-tracking/BUILD.bazel
+++ b/tools/size-tracking/BUILD.bazel
@@ -11,7 +11,6 @@ ts_library(
     tsconfig = "//tools:tsconfig.json",
     deps = [
         "@npm//@types/node",
-        "@npm//@types/source-map",
         "@npm//chalk",
         "@npm//source-map",
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,13 +699,6 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/source-map@^0.5.1":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.7.tgz#165eeb583c1ef00196fe4ef4da5d7832b03b275b"
-  integrity sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==
-  dependencies:
-    source-map "*"
-
 "@types/systemjs@0.19.32":
   version "0.19.32"
   resolved "https://registry.yarnpkg.com/@types/systemjs/-/systemjs-0.19.32.tgz#e9204c4cdbc8e275d645c00e6150e68fc5615a24"
@@ -10154,11 +10147,6 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@*, source-map@0.7.3, source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
 source-map@0.1.31:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.31.tgz#9f704d0d69d9e138a81badf6ebb4fde33d151c61"
@@ -10170,6 +10158,11 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
   integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
+source-map@0.7.3, source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"


### PR DESCRIPTION
- **build(compiler-cli): remove unused dependency (`shelljs`)**
    Since, 7186f9c `compiler-cli` is no longer depending on `shelljs` for production code. (We still use it in tests and infrastructure/tooling.)
    Incidentally, this should also help with #29460.

- **build: remove redundant `@types/source-map` dependency**
    In version 0.6.1 that we are using, `source-map` ships with [its own typings][1], so there is no need to use `@types/source-map`. The types were even removed from `DefinitelyTyped` in DefinitelyTyped/DefinitelyTyped@1792bfa.

##
BTW, `shelljs` is also a [dependency of `@angular/bazel` (https://github.com/angular/angular/blob/6aaca21c27f0e220e2ec59b7ea46d20e1a70a597/packages/bazel/package.json#L36), because it is used in [src/ng_package/packager.ts](https://github.com/angular/angular/blob/6aaca21c27f0e220e2ec59b7ea46d20e1a70a597/packages/bazel/src/ng_package/packager.ts#L11).


[1]: https://github.com/mozilla/source-map/blob/0.6.1/package.json#L72