### PR TITLE
Minor ivy refactorings

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -185,7 +185,7 @@ export function createRootComponentView(
       rootView[HEADER_OFFSET], tNode, rendererFactory, renderer, sanitizer);
 
   if (tView.firstTemplatePass) {
-    diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), rootView, def.type);
+    diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), tView, def.type);
     tNode.flags = TNodeFlags.isComponent;
     initNodeFlags(tNode, rootView.length, 1);
     queueComponentIndexForCheck(tNode);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -230,8 +230,8 @@ export function getParentInjectorLocation(tNode: TNode, view: LView): RelativeIn
  * @param token The type or the injection token to be made public
  */
 export function diPublicInInjector(
-    injectorIndex: number, view: LView, token: InjectionToken<any>| Type<any>): void {
-  bloomAdd(injectorIndex, view[TVIEW], token);
+    injectorIndex: number, tView: TView, token: InjectionToken<any>| Type<any>): void {
+  bloomAdd(injectorIndex, tView, token);
 }
 
 /**

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -72,6 +72,7 @@ function resolveProvider(
     }
   } else {
     const lView = getLView();
+    const tView = lView[TVIEW];
     let token: any = isTypeProvider(provider) ? provider : resolveForwardRef(provider.provide);
     let providerFactory: () => any = providerToFactory(provider);
 
@@ -86,7 +87,6 @@ function resolveProvider(
       const ngOnDestroy = prototype.ngOnDestroy;
 
       if (ngOnDestroy) {
-        const tView = lView[TVIEW];
         (tView.destroyHooks || (tView.destroyHooks = [])).push(tInjectables.length, ngOnDestroy);
       }
     }
@@ -101,7 +101,7 @@ function resolveProvider(
         diPublicInInjector(
             getOrCreateNodeInjectorForNode(
                 tNode as TElementNode | TContainerNode | TElementContainerNode, lView),
-            lView, token);
+            tView, token);
         tInjectables.push(token);
         tNode.directiveStart++;
         tNode.directiveEnd++;
@@ -151,7 +151,7 @@ function resolveProvider(
         diPublicInInjector(
             getOrCreateNodeInjectorForNode(
                 tNode as TElementNode | TContainerNode | TElementContainerNode, lView),
-            lView, token);
+            tView, token);
         const factory = multiFactory(
             isViewProvider ? multiViewProvidersFactoryResolver : multiProvidersFactoryResolver,
             lInjectablesBlueprint.length, isViewProvider, isComponent, providerFactory);

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -75,7 +75,7 @@ export function ɵɵtemplate(
         -1, templateFn, consts, vars, tView.directiveRegistry, tView.pipeRegistry, null, null);
   }
 
-  createDirectivesAndLocals(tView, lView, localRefs, localRefExtractor);
+  createDirectivesAndLocals(tView, lView, tContainerNode, localRefs, localRefExtractor);
   addTContainerToQueries(lView, tContainerNode);
   attachPatchData(getNativeByTNode(tContainerNode, lView), lView);
   registerPostOrderHooks(tView, tContainerNode);

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -85,7 +85,7 @@ export function ɵɵelementStart(
   }
 
   appendChild(native, tNode, lView);
-  createDirectivesAndLocals(tView, lView, localRefs);
+  createDirectivesAndLocals(tView, lView, tNode, localRefs);
 
   // any immediate children of a component or template container must be pre-emptively
   // monkey-patched with the component view data so that the element can be inspected

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -59,7 +59,7 @@ export function ɵɵelementContainerStart(
   }
 
   appendChild(native, tNode, lView);
-  createDirectivesAndLocals(tView, lView, localRefs);
+  createDirectivesAndLocals(tView, lView, tNode, localRefs);
   attachPatchData(native, lView);
 
   const currentQueries = lView[QUERIES];

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1206,7 +1206,7 @@ function findDirectiveMatches(tView: TView, viewData: LView, tNode: TNode): Dire
             getOrCreateNodeInjectorForNode(
                 getPreviousOrParentTNode() as TElementNode | TContainerNode | TElementContainerNode,
                 viewData),
-            viewData, def.type);
+            tView, def.type);
 
         if (isComponentDef(def)) {
           if (tNode.flags & TNodeFlags.isComponent) throwMultipleComponentError(tNode);


### PR DESCRIPTION
This PR have 2 small changes that:
* passes `TView` as an argument (instead of `LView`) where only `TView` is needed
* limits usage of global state

Those were discovered on TQuery refactor