### PR TITLE
build(docs-infra): never show linenums for triple-backticked code blocks

### DIFF
--- a/aio/tools/transforms/remark-package/services/handlers/code.js
+++ b/aio/tools/transforms/remark-package/services/handlers/code.js
@@ -4,7 +4,9 @@
 module.exports = function code(h, node) {
   var value = node.value ? ('\n' + node.value + '\n') : '';
   var lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/);
-  var props = {};
+  var props = {
+    linenums: 'false'
+  };
 
   if (lang) {
     props.language = lang;

--- a/aio/tools/transforms/remark-package/services/renderMarkdown.spec.js
+++ b/aio/tools/transforms/remark-package/services/renderMarkdown.spec.js
@@ -88,7 +88,7 @@ describe('remark: renderMarkdown service', () => {
     '```';
     const output = renderMarkdown(content);
     expect(output).toEqual(
-    '<code-example language="ts">\n' +
+    '<code-example linenums="false" language="ts">\n' +
     '  class MyClass {\n' +
     '    method1() { ... }\n' +
     '  }\n' +


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

