### PR TITLE
fix(bazel): pass custom bazel compiler host rather than rewriting one

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -145,7 +145,7 @@ export function relativeToRootDirs(filePath: string, rootDirs: string[]): string
 }
 
 export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, bazelOpts, files,
-                         inputs, expectedOuts, gatherDiagnostics, oldBazelHost}: {
+                         inputs, expectedOuts, gatherDiagnostics, bazelHost}: {
   allDepsCompiledWithBazel?: boolean,
   compilerOpts: ng.CompilerOptions,
   tsHost: ts.CompilerHost, inputs?: {[path: string]: string},
@@ -153,7 +153,7 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
   files: string[],
   expectedOuts: string[],
   gatherDiagnostics?: (program: ng.Program) => ng.Diagnostics,
-  oldBazelHost?: CompilerHost,
+  bazelHost?: CompilerHost,
 }): {diagnostics: ng.Diagnostics, program: ng.Program} {
   let fileLoader: FileLoader;
 
@@ -246,12 +246,9 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
         moduleName, containingFile, compilerOptions, generatedFileModuleResolverHost);
   }
 
-  const bazelHost = new CompilerHost(
-      files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
-  if (oldBazelHost) {
-    // TODO(ayazhafiz): this kind of patching is hacky. Revisit this after the
-    // indexer consumer of this code is known to be working.
-    Object.assign(bazelHost, oldBazelHost);
+  if (!bazelHost) {
+    bazelHost = new CompilerHost(
+        files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
   }
 
   // Also need to disable decorator downleveling in the BazelHost in Ivy mode.


### PR DESCRIPTION
Switch back to passing a custom bazel host instead of rewriting one that
is passed to `compile` now that the Angular indexer is stable.

Revert "feat(bazel): allow passing and rewriting an old bazel host"

This reverts commit 0a4c1c8f803a65f5c156af90e67f7d7d68ebc7f8.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Rewrites an old bazel host.

Issue Number: N/A


## What is the new behavior?
User has to define their own bazel host

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Should only impact the Angular indexer inside Google. This change is has not been documented and announced publicly.