### PR TITLE
fix(ivy): use goog.LOCALE for Closure Compiler to define default LOCALE_ID

### DIFF
--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -30,7 +30,13 @@ export function _keyValueDiffersFactory() {
 }
 
 export function _localeFactory(locale?: string): string {
-  return locale || 'en-US';
+  if (locale) {
+    return locale;
+  }
+  if (ngI18nClosureMode) {
+    return goog.LOCALE;
+  }
+  return 'en-US';
 }
 
 /**

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -33,7 +33,10 @@ export function _localeFactory(locale?: string): string {
   if (locale) {
     return locale;
   }
-  if (ngI18nClosureMode) {
+  // Use `goog.LOCALE` as default value for `LOCALE_ID` token for Closure Compiler.
+  // Note: default `goog.LOCALE` value is `en`, when Angular used `en-US`. In order to preserve
+  // backwards compatibility, we use Angular default value over Closure Compiler's one.
+  if (ngI18nClosureMode && typeof goog !== 'undefined' && goog.LOCALE !== 'en') {
     return goog.LOCALE;
   }
   return 'en-US';

--- a/packages/goog.d.ts
+++ b/packages/goog.d.ts
@@ -16,6 +16,7 @@ declare namespace goog {
    * as it is sometimes true.
    */
   export const DEBUG: boolean;
+  export const LOCALE: string;
   export const getMsg: (input: string, placeholders?: {[key: string]: string}) => string;
 }
 


### PR DESCRIPTION
Prior to this commit, default value for `LOCALE_ID` was not setup for Closure Compiler in Ivy. In Closure Compiler, we can use `goog.LOCALE` as a default value, which will be replaced at build time with current locale.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No