### PR TITLE
build(docs-infra): display CLI positional option enum values

### DIFF
--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -20,7 +20,7 @@
   <tbody>
   {% for option in arguments %}
   <tr class="cli-option">
-    <td><code class="no-auto-link">&lt;<var>{$ option.name $}</var>&gt;</code></td>
+    <td><code class="cli-option-syntax no-auto-link">&lt;<var>{$ option.name $}</var>&gt;{% if option.enum.length > 0 %}={$ renderValues(option.enum) $}{% endif %}</code></td>
     <td>
       {$ option.description | marked $}
       {% if option.subcommands.length -%}


### PR DESCRIPTION
Previously we on;ly displayed enum values for named options.
Now positional options get equal justice.

Fixes https://github.com/angular/angular-cli/issues/15040
