### PR TITLE
feat(compiler): add support for ::slotted

### DIFF
--- a/aio/content/examples/component-styles/src/app/hero-details.component.css
+++ b/aio/content/examples/component-styles/src/app/hero-details.component.css
@@ -22,6 +22,20 @@
 }
 /* #enddocregion hostcontext */
 
+/* #docregion slotted */
+::slotted(*) {
+  font-weight: bold;
+}
+
+::slotted(h2) {
+  font-weight: bold;
+}
+
+p ::slotted(.hero) {
+  font-weight: bold;
+}
+/* #enddocregion slotted */
+
 /* #docregion deep */
 :host /deep/ h3 {
   font-style: italic;

--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -98,6 +98,26 @@ if some ancestor element has the CSS class `theme-light`.
 
 <code-example path="component-styles/src/app/hero-details.component.css" region="hostcontext" header="src/app/hero-details.component.css"></code-example>
 
+### ::slotted
+
+In order to style elements projected via content projection, the `::slotted()` pseudo-element can be used.
+Note that it is only possible to apply styles to the top-most projected element.
+
+<code-example format="">
+  &lt;hero-details>
+    &lt;h2>Mister Fantastic&lt;/h2> // Can be styled in the hero-details component
+    &lt;hero-team> // Can be styled in the hero-details component
+      &lt;h3>Team&lt;/h3> // CANNOT be styled in the hero-details component
+    &lt;/hero-team>
+  &lt;/hero-detail>
+
+</code-example>
+
+It is possible to use a compound selector (e.g. `span`, `.class`, `[attr]`) to limit
+the selection to specific projected elements. Use an asterisk (`*`) to match any projected element.
+
+<code-example path="component-styles/src/app/hero-details.component.css" region="slotted" header="src/app/hero-details.component.css"></code-example>
+
 ### (deprecated) `/deep/`, `>>>`, and `::ng-deep`
 
 Component styles normally apply only to the HTML in the component's own template.

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -197,6 +197,59 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       });
     });
 
+    describe(('::slotted'), () => {
+      it('should handle standalone ::slotted(*)', () => {
+        expect(s('::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] > *:not([contenta]), [contenta] > *:not([contenta]) {}');
+      });
+
+      it('should handle standalone ::slotted(div.x)', () => {
+        expect(s('::slotted(div.x) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] > div.x:not([contenta]), [contenta] > div.x:not([contenta]) {}');
+      });
+
+      it('should handle nested ::slotted(*)', () => {
+        expect(s('p ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual(
+                'p[contenta] [contenta] > *:not([contenta]), p[contenta] > *:not([contenta]) {}');
+      });
+
+      it('should handle white space around slotted selector', () => {
+        expect(s('::slotted( * ) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] > *:not([contenta]), [contenta] > *:not([contenta]) {}');
+      });
+
+      it('should handle white space in attribute selector', () => {
+        expect(s('::slotted([a="b c"]) {}', 'contenta', 'a-host'))
+            .toEqual(
+                '[a-host] > [a="b c"]:not([contenta]), [contenta] > [a="b c"]:not([contenta]) {}');
+      });
+
+      it('should fail with selectors after ::slotted', () => {
+        expect(s('::slotted(*) .x {}', 'contenta', 'a-host'))
+            .toEqual(
+                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]) {}');
+        expect(s('::slotted(*) .x, .y {}', 'contenta', 'a-host'))
+            .toEqual(
+                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]), .y[contenta] {}');
+      });
+
+      it('should fail with selectors inside ::slotted after first selector', () => {
+        expect(s('::slotted(* span) {}', 'contenta', 'a-host'))
+            .toEqual(
+                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]) {}');
+        expect(s('::slotted(* span), .y {}', 'contenta', 'a-host'))
+            .toEqual(
+                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]), .y[contenta] {}');
+      });
+
+      it('should fail with missing whitespace before ::slotted', () => {
+        expect(s('p::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual(
+                'p[contenta] [contenta] > --invalidslotted:not([contenta]), p[contenta] > --invalidslotted:not([contenta]) {}');
+      });
+    });
+
     it('should support polyfill-next-selector', () => {
       let css = s('polyfill-next-selector {content: \'x > y\'} z {}', 'contenta');
       expect(css).toEqual('x[contenta] > y[contenta]{}');

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -209,9 +209,31 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       });
 
       it('should handle nested ::slotted(*)', () => {
-        expect(s('p ::slotted(*) {}', 'contenta', 'a-host'))
+        expect(s('p ::slotted(*) {}', 'contenta'))
             .toEqual(
                 'p[contenta] [contenta] > *:not([contenta]), p[contenta] > *:not([contenta]) {}');
+      });
+
+      it('should handle child combinator with nested selector before ::slotted(*)', () => {
+        expect(s('p>::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('p[contenta] > *:not([contenta]) {}');
+      });
+
+      it('should handle child combinator with host selector before ::slotted(*)', () => {
+        expect(s(':host>::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] > *:not([contenta]) {}');
+        expect(s(':host(.x) > ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('.x[a-host] > *:not([contenta]) {}');
+      });
+
+      it('should handle adjacent sibling combinator before ::slotted(*)', () => {
+        expect(s('p+::slotted(*) {}', 'contenta')).toEqual('p[contenta] + *:not([contenta]) {}');
+        expect(s('p + ::slotted(*) {}', 'contenta')).toEqual('p[contenta] + *:not([contenta]) {}');
+      });
+
+      it('should handle general sibling combinator before ::slotted(*)', () => {
+        expect(s('p~::slotted(*) {}', 'contenta')).toEqual('p[contenta] ~ *:not([contenta]) {}');
+        expect(s('p ~ ::slotted(*) {}', 'contenta')).toEqual('p[contenta] ~ *:not([contenta]) {}');
       });
 
       it('should handle white space around slotted selector', () => {
@@ -225,28 +247,52 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
                 '[a-host] > [a="b c"]:not([contenta]), [contenta] > [a="b c"]:not([contenta]) {}');
       });
 
+      it('should handle :host-context', () => {
+        expect(s(':host-context(.x) ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual(
+                '.x[a-host] [contenta] > *:not([contenta]), .x[a-host] > *:not([contenta]), .x [a-host] [contenta] > *:not([contenta]), .x [a-host] > *:not([contenta]) {}');
+      });
+
       it('should fail with selectors after ::slotted', () => {
         expect(s('::slotted(*) .x {}', 'contenta', 'a-host'))
             .toEqual(
-                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]) {}');
+                '[a-host] > -invalidslotted:not([contenta]), [contenta] > -invalidslotted:not([contenta]) {}');
         expect(s('::slotted(*) .x, .y {}', 'contenta', 'a-host'))
             .toEqual(
-                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]), .y[contenta] {}');
+                '[a-host] > -invalidslotted:not([contenta]), [contenta] > -invalidslotted:not([contenta]), .y[contenta] {}');
       });
 
       it('should fail with selectors inside ::slotted after first selector', () => {
         expect(s('::slotted(* span) {}', 'contenta', 'a-host'))
             .toEqual(
-                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]) {}');
+                '[a-host] > -invalidslotted:not([contenta]), [contenta] > -invalidslotted:not([contenta]) {}');
         expect(s('::slotted(* span), .y {}', 'contenta', 'a-host'))
             .toEqual(
-                '[a-host] > --invalidslotted:not([contenta]), [contenta] > --invalidslotted:not([contenta]), .y[contenta] {}');
+                '[a-host] > -invalidslotted:not([contenta]), [contenta] > -invalidslotted:not([contenta]), .y[contenta] {}');
       });
 
       it('should fail with missing whitespace before ::slotted', () => {
-        expect(s('p::slotted(*) {}', 'contenta', 'a-host'))
+        expect(s('p::slotted(*) {}', 'contenta'))
             .toEqual(
-                'p[contenta] [contenta] > --invalidslotted:not([contenta]), p[contenta] > --invalidslotted:not([contenta]) {}');
+                'p[contenta] [contenta] > -invalidslotted:not([contenta]), p[contenta] > -invalidslotted:not([contenta]) {}');
+      });
+
+      it('should fail with adjacent sibling combinator with :host', () => {
+        expect(s(':host+::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] + -invalidslotted:not([contenta]) {}');
+        expect(s(':host + ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] + -invalidslotted:not([contenta]) {}');
+        expect(s(':host(.x) + ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('.x[a-host] + -invalidslotted:not([contenta]) {}');
+      });
+
+      it('should fail with general sibling combinator with :host', () => {
+        expect(s(':host~::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] ~ -invalidslotted:not([contenta]) {}');
+        expect(s(':host ~ ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('[a-host] ~ -invalidslotted:not([contenta]) {}');
+        expect(s(':host(.x) ~ ::slotted(*) {}', 'contenta', 'a-host'))
+            .toEqual('.x[a-host] ~ -invalidslotted:not([contenta]) {}');
       });
     });
 


### PR DESCRIPTION
Closes #27614

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there is no support for ::slotted in ViewEncapsulation.Emulated.

Issue Number: #27614


## What is the new behavior?
Support added for ::slotted in ViewEncapsulation.Emulated. 
::slotted is emulated by targeting projected elements with the child selector,
in combination with scope selectors. Invalid configurations will be replaced
with --invalidslotted, which should not match anything.
For example (assuming [x-host] as the host scope and [x-foo] the elements scope):

    ::slotted(*) {
      font-weight: bold;
    }
    p ::slotted(.x) {
      font-size: large;
    }

becomes:

    [x-host] > *:not([x-foo]), [x-foo] > *:not([x-foo]) {
      font-weight: bold;
    }
    p[x-foo] [x-foo] > .x:not([x-foo]), p[x-foo] > .x:not([x-foo]) {
      font-size: large;
    }

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR is intended to gauge reaction, if this feature is something the Angular team wants to support. With ::ng-deep being deprecated and no alternative for ViewEncapsulation.Emulated, this PR attempts to close some of that gap. Looking at #27614, it appears the community is at least interested in a feature like this.

Edit 2019-10-07: Added documentation to aio.