### PR TITLE
docs(observable): backoff that propagates error

### DIFF
--- a/aio/content/examples/practical-observable-usage/src/backoff.ts
+++ b/aio/content/examples/practical-observable-usage/src/backoff.ts
@@ -1,23 +1,30 @@
 
-import { pipe, range, timer, zip } from 'rxjs';
+import { iif, of, pipe, throwError } from 'rxjs';
 import { ajax } from 'rxjs/ajax';
-import { retryWhen, map, mergeMap } from 'rxjs/operators';
+import { concatMap, delay, retryWhen } from 'rxjs/operators';
 
 function backoff(maxTries, ms) {
- return pipe(
-   retryWhen(attempts => zip(range(1, maxTries), attempts)
-     .pipe(
-       map(([i]) => i * i),
-       mergeMap(i =>  timer(i * ms))
-     )
-   )
- );
+  return pipe(
+    retryWhen(errors => errors.pipe(
+      // retry in order
+      concatMap((err, n) => iif(
+        () => n < maxTries,
+        // add delay to error with random jitter
+        of(err).pipe(delay((2 + Math.random()) ** n * ms)),
+        throwError(err)
+      ))
+    ))
+  );
 }
 
 ajax('/api/endpoint')
   .pipe(backoff(3, 250))
-  .subscribe(data => handleData(data));
+  .subscribe(data => handleData(data), err => handleError(err));
 
 function handleData(data) {
+  // ...
+}
+
+function handleError(data) {
   // ...
 }


### PR DESCRIPTION
- propagate error from backoff to allow error handling
- add random jitter to avoid thundering herd problem

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The example shown does not propagates error back to the subscriber.

Issue Number: N/A


## What is the new behavior?

Error will be propagated if all retries failed. In addition, random jitter are added to the delay.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
