### PR TITLE
feat(ivy): support types narrowing for template context of NgIf

### DIFF
--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -149,14 +149,14 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  * @publicApi
  */
 @Directive({selector: '[ngIf]'})
-export class NgIf {
-  private _context: NgIfContext = new NgIfContext();
-  private _thenTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _elseTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _thenViewRef: EmbeddedViewRef<NgIfContext>|null = null;
-  private _elseViewRef: EmbeddedViewRef<NgIfContext>|null = null;
+export class NgIf<T = any> {
+  private _context: NgIfContext<T> = new NgIfContext<T>(null !, null !);
+  private _thenTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _elseTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _thenViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
+  private _elseViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
 
-  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>) {
+  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>) {
     this._thenTemplateRef = templateRef;
   }
 
@@ -164,7 +164,7 @@ export class NgIf {
    * The Boolean expression to evaluate as the condition for showing a template.
    */
   @Input()
-  set ngIf(condition: any) {
+  set ngIf(condition: T) {
     this._context.$implicit = this._context.ngIf = condition;
     this._updateView();
   }
@@ -173,7 +173,7 @@ export class NgIf {
    * A template to show if the condition expression evaluates to true.
    */
   @Input()
-  set ngIfThen(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfThen(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfThen', templateRef);
     this._thenTemplateRef = templateRef;
     this._thenViewRef = null;  // clear previous view if any.
@@ -184,7 +184,7 @@ export class NgIf {
    * A template to show if the condition expression evaluates to false.
    */
   @Input()
-  set ngIfElse(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfElse(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfElse', templateRef);
     this._elseTemplateRef = templateRef;
     this._elseViewRef = null;  // clear previous view if any.
@@ -225,14 +225,21 @@ export class NgIf {
    * narrow its type, which allows the strictNullChecks feature of TypeScript to work with `NgIf`.
    */
   static ngTemplateGuard_ngIf: 'binding';
+
+  /**
+  * Asserts the correct type of the context for the template that `NgIf` will render.
+  *
+  * The presence of this method is a signal to the Ivy template type-check compiler that the
+  * `NgIf` structural directive renders its template with a specific context type.
+  */
+  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T> { return true; }
 }
 
 /**
  * @publicApi
  */
-export class NgIfContext {
-  public $implicit: any = null;
-  public ngIf: any = null;
+export class NgIfContext<T = any> {
+  constructor(public $implicit: T, public ngIf: T) {}
 }
 
 function assertTemplate(property: string, templateRef: TemplateRef<any>| null): void {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -129,6 +129,23 @@ describe('type check blocks', () => {
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('if (ctx.person !== null)');
     });
+
+    it('should combine two kinds of guards if provided', () => {
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'NgIf',
+        selector: '[ngIf]',
+        inputs: {'ngIf': 'ngIf'},
+        ngTemplateGuards: [{
+          inputName: 'ngIf',
+          type: 'binding',
+        }],
+        hasNgTemplateContextGuard: true
+      }];
+      const TEMPLATE = `<div *ngIf="person"></div>`;
+      const block = tcb(TEMPLATE, DIRECTIVES);
+      expect(block).toContain('if (NgIf.ngTemplateContextGuard(_t1, _t2) && ctx.person)');
+    });
   });
 
   describe('config', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -36,6 +36,11 @@ export declare class NgForOfContext<T> {
   readonly odd: boolean;
 }
 
+export declare class NgIfContext<T> {
+  $implicit: T;
+  ngIf: T;
+}
+
 export declare class IndexPipe {
   transform<T>(value: T[], index: number): T;
 
@@ -48,9 +53,10 @@ export declare class NgForOf<T> {
   static ngDirectiveDef: i0.ɵɵDirectiveDefWithMeta<NgForOf<any>, '[ngFor][ngForOf]', never, {'ngForOf': 'ngForOf'}, {}, never>;
 }
 
-export declare class NgIf {
-  ngIf: any;
+export declare class NgIf<T = any> {
+  ngIf: T;
   static ngTemplateGuard_ngIf: 'binding';
+  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T>;
   static ngDirectiveDef: i0.ɵɵDirectiveDefWithMeta<NgForOf<any>, '[ngIf]', never, {'ngIf': 'ngIf'}, {}, never>;
 }
 
@@ -123,6 +129,31 @@ export declare class CommonModule {
     `);
 
       env.driveMain();
+    });
+
+    it('should constrain the template rendering context of NgIf', () => {
+      env.write('test.ts', `
+    import {CommonModule} from '@angular/common';
+    import {Component, Input, NgModule} from '@angular/core';
+
+    @Component({
+      selector: 'test',
+      template: '<div *ngIf="user; let u">{{u.does_not_exist}}</div>',
+    })
+    class TestCmp {
+      @Input() user: {name: string};
+    }
+
+    @NgModule({
+      declarations: [TestCmp],
+      imports: [CommonModule],
+    })
+    class Module {}
+    `);
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toContain('does_not_exist');
     });
 
     it('should check basic usage of NgFor', () => {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -258,17 +258,18 @@ export declare class NgForOfContext<T> {
     constructor($implicit: T, ngForOf: NgIterable<T>, index: number, count: number);
 }
 
-export declare class NgIf {
+export declare class NgIf<T = any> {
     ngIf: any;
-    ngIfElse: TemplateRef<NgIfContext> | null;
-    ngIfThen: TemplateRef<NgIfContext> | null;
-    constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>);
+    ngIfElse: TemplateRef<NgIfContext<T>> | null;
+    ngIfThen: TemplateRef<NgIfContext<T>> | null;
+    constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>);
     static ngTemplateGuard_ngIf: 'binding';
+    static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T>;
 }
 
-export declare class NgIfContext {
-    $implicit: any;
-    ngIf: any;
+export declare class NgIfContext<T> {
+    $implicit: T;
+    ngIf: T;
 }
 
 export declare class NgLocaleLocalization extends NgLocalization {


### PR DESCRIPTION
This commits adds the `ngTemplateContextGuard` static method to the `NgIf`
directive.
The function of this static method is to narrow the template rendering
context variable `ctx` within generated type checking code for consumers of the directive.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Previously, the ngIf only supported `ngTemplateGuard_ngIf` guard which
narrows the expression passed to an @Input of the directive. For more details see https://github.com/angular/angular/pull/30248.
It can't narrow types for template reference variable.

## What is the new behavior?

The new behaviour is to constrain a `NgIf` template reference variable so that for the following template:

```html
<div *ngIf="{ foo: 'bar' }; let x">
  {{ x.unknown }}
</div>
```
the compiler will generate the type-check block (TCB):

```typescript
if (NgIf.ngTemplateContextGuard(_t1, _t2) && { "foo": "bar" }) {
  var _t3 = _t2.$implicit;
  var _t4 = document.createElement("div");
  "" + _t3.unknown;
}
```
and it will fail to compile with the error `Property 'unknown' does not
exist on type '{ "foo": string; }'`

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

As part of the changes, the `NgIf` directive and `NgIfContext` class
become generic with default type `any`. 

Before:

```
@Directive({selector: '[ngIf]'})
export class NgIf {
  private _context: NgIfContext = new NgIfContext();
  ...
}

export class NgIfContext {
  public $implicit: any = null;
  public ngIf: any = null;
}
```
After:

```
@Directive({selector: '[ngIf]'})
export class NgIf<T = any> {
  private _context: NgIfContext<T> = new NgIfContext<T>(null !, null !);
  ...
}

export class NgIfContext<T = any> {
  constructor(public $implicit: T, public ngIf: T) {}
}
```
Since the `any` default type is used I can't predict exactly which impact it will have on end users.

## Other information

Fix #31556