### PR TITLE
feat(docs-infra): improve small screen experience for docs cards layout

### DIFF
--- a/aio/src/styles/1-layouts/_content-layout.scss
+++ b/aio/src/styles/1-layouts/_content-layout.scss
@@ -1,33 +1,35 @@
-aio-shell.page-docs {
-  .sidenav-content {
-    // padding: 6rem 3rem 3rem 3rem; // THIS CAUSES THE TOP NAV TOOLBAR TO JUMP BETWEEN DOCS AND OTHER PAGES
-    margin: auto;
-  }
-}
-
-.sidenav-content {
-  min-height: 100vh;
-  padding: 80px 3rem 2rem;
-}
-
-@media (max-width: 600px) {
-  aio-menu {
-    display: none;
-  }
-
-  .sidenav-content {
-    min-height: 450px;
-    padding: 80px 1rem 1rem;
-  }
-}
-
 .sidenav-container {
   width: 100%;
   height: 100vh;
 }
 
-.sidenav-content button {
-  min-width: 24px;
+.sidenav-content {
+  min-height: 100vh;
+  padding: 80px 3rem 2rem;
+
+  @media screen and (max-width: 600px) {
+    min-height: 450px;
+    padding: 80px 2rem 1rem;
+  }
+
+  @media screen and (max-width: 480px) {
+    padding: 80px 1rem 1rem;
+  }
+
+  aio-shell.page-docs & {
+    // padding: 6rem 3rem 3rem 3rem; // THIS CAUSES THE TOP NAV TOOLBAR TO JUMP BETWEEN DOCS AND OTHER PAGES
+    margin: auto;
+  }
+
+  button {
+    min-width: 24px;
+  }
+}
+
+aio-menu {
+  @media (max-width: 600px) {
+    display: none;
+  }
 }
 
 #guide-change-log h2::before {

--- a/aio/src/styles/2-modules/_card.scss
+++ b/aio/src/styles/2-modules/_card.scss
@@ -2,76 +2,82 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    margin: 24px 0;
-}
+    margin: 16px 0;
 
-.docs-card {
-  @include card(194px, 30%);
-  max-width: 340px;
-  min-width: 262px;
-  margin: 24px 8px;
-  padding-bottom: 48px;
-  position: relative;
+    .docs-card {
+      @include card(194px, 30%);
+      max-width: 340px;
+      min-width: 262px;
+      margin: 24px 8px;
+      padding-bottom: 48px;
+      position: relative;
 
-  &:hover {
-    text-decoration: none;
+      @media screen and (max-width: 600px) {
+        width: 100%;
+        margin: 8px auto;
+        max-width: none;
+      }
 
-    section {
-      color: $blue;
+      &:hover {
+        text-decoration: none;
+
+        section {
+          color: $blue;
+        }
+
+        p {
+          color: $darkgray;
+          padding: 0 16px;
+        }
+
+        .card-footer {
+          @include line-height(32);
+          padding: 8px 16px;
+          background-color: rgba($blue, 0.1);
+          color: $blue;
+        }
+      }
+
+      section {
+        color: $deepgray;
+        @include font-size(20);
+        @include line-height(24);
+        margin: 0;
+        padding: 32px 0 24px;
+        text-transform: none;
+        text-align: center;
+      }
+
+      p {
+        color: $darkgray;
+        @include font-size(13);
+        @include line-height(24);
+        padding: 0 16px;
+        margin: 0;
+        text-align: center;
+      }
+
+      .card-footer {
+        bottom: 0;
+        border-top: 0.5px solid $lightgray;
+        box-sizing: border-box;
+        @include line-height(48);
+        left: 0;
+        position: absolute;
+        right: 0;
+        text-align: right;
+        color: $mediumgray;
+
+        a {
+          color: $mediumgray;
+          @include font-size(13);
+        }
+      }
+
+      .card-footer.center {
+        text-align: center;
+      }
     }
-
-    p {
-      color: $darkgray;
-      padding: 0 16px;
-    }
-
-    .card-footer {
-      @include line-height(32);
-      padding: 8px 16px;
-      background-color: rgba($blue, 0.1);
-      color: $blue;
-    }
-  }
-
-
-  section {
-    color: $deepgray;
-    @include font-size(20);
-    @include line-height(24);
-    margin: 0;
-    padding: 32px 0 24px;
-    text-transform: none;
-    text-align: center;
-  }
-
-  p {
-    color: $darkgray;
-    @include font-size(13);
-    @include line-height(24);
-    padding: 0 16px;
-    margin: 0;
-    text-align: center;
-  }
-
-  .card-footer {
-    bottom: 0;
-    border-top: 0.5px solid $lightgray;
-    box-sizing: border-box;
-    @include line-height(48);
-    left: 0;
-    position: absolute;
-    right: 0;
-    text-align: right;
-    color: $mediumgray;
-
-    a {
-      color: $mediumgray;
-      @include font-size(13);
-    }
-  }
-  .card-footer.center {
-    text-align: center;
-  }
 }
 
 .card-section {
@@ -87,11 +93,18 @@
     box-shadow: 0 2px 2px rgba($black, 0.24), 0 0 2px rgba($black, 0.12);
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin: 8px 0;
   }
 
-  a, .button, button {
+  a,
+  .button,
+  button {
     text-align: center;
   }
 


### PR DESCRIPTION
Make docs cards expand to full width in smaller screen sizes.
Reduce spacing around card container to match general spacing patterns seen in AIO.
Includes SCSS formatting.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Docs cards are currently awkwardly spaced.
<img width="291" alt="Screen Shot 2019-07-15 at 2 44 59 PM" src="https://user-images.githubusercontent.com/2958442/61251493-745b4f80-a70f-11e9-9820-3caffe9d794b.png">

## What is the new behavior?
Docs cards expand to full width in smaller screen sizes.
<img width="288" alt="Screen Shot 2019-07-15 at 2 45 11 PM" src="https://user-images.githubusercontent.com/2958442/61251497-77564000-a70f-11e9-86d8-5c9171da6457.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No