### PR TITLE
feat(ivy): index information about exporting and imported NgModule

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -338,6 +338,17 @@ export class ComponentDecoratorHandler implements
     const binder = new R3TargetBinder(matcher);
     const boundTemplate = binder.bind({template: template.nodes});
 
+    const ownModule = this.scopeRegistry.getModule(node);
+    let owningModule: ClassDeclaration|undefined = undefined;
+    let importedModules = new Set<ClassDeclaration>();
+    if (ownModule) {
+      const metadata = this.metaReader.getNgModuleMetadata(new Reference(ownModule));
+      if (metadata) {
+        owningModule = metadata.ref.node;
+        importedModules = new Set(metadata.imports.map(ref => ref.node));
+      }
+    }
+
     context.addComponent({
       declaration: node,
       selector,
@@ -346,6 +357,8 @@ export class ComponentDecoratorHandler implements
         isInline: template.isInline,
         file: template.file,
       },
+      owningModule,
+      importedModules,
     });
   }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -79,6 +79,6 @@ export interface IndexedComponent {
     isInline: boolean,
     file: ParseSourceFile;
   };
-  owningModule?: ts.Declaration&{name: ts.Identifier};
+  exportingModule?: ts.Declaration&{name: ts.Identifier};
   importedModules: Set<ts.Declaration&{name: ts.Identifier}>;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -79,4 +79,6 @@ export interface IndexedComponent {
     isInline: boolean,
     file: ParseSourceFile;
   };
+  owningModule?: ts.Declaration&{name: ts.Identifier};
+  importedModules: Set<ts.Declaration&{name: ts.Identifier}>;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -42,6 +42,12 @@ export interface ComponentInfo {
     /** Template file recorded by template parser */
     file: ParseSourceFile;
   };
+
+  /** NgModule owning the component, if any. */
+  owningModule?: ClassDeclaration;
+
+  /** NgModules imported by owningModule, if any. */
+  importedModules: Set<ClassDeclaration>;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -43,8 +43,8 @@ export interface ComponentInfo {
     file: ParseSourceFile;
   };
 
-  /** NgModule owning the component, if any. */
-  owningModule?: ClassDeclaration;
+  /** NgModule exporting the component, if any. */
+  exportingModule?: ClassDeclaration;
 
   /** NgModules imported by owningModule, if any. */
   importedModules: Set<ClassDeclaration>;

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -22,7 +22,7 @@ export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, 
   const analysis = new Map<ts.Declaration, IndexedComponent>();
 
   context.components.forEach(
-      ({declaration, selector, boundTemplate, templateMeta, owningModule, importedModules}) => {
+      ({declaration, selector, boundTemplate, templateMeta, exportingModule, importedModules}) => {
         const name = declaration.name.getText();
 
         const usedComponents = new Set<ts.Declaration>();
@@ -55,7 +55,7 @@ export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, 
             isInline: templateMeta.isInline,
             file: templateFile,
           },
-          owningModule,
+          exportingModule,
           importedModules,
         });
       });

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -21,40 +21,44 @@ import {getTemplateIdentifiers} from './template';
 export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, IndexedComponent> {
   const analysis = new Map<ts.Declaration, IndexedComponent>();
 
-  context.components.forEach(({declaration, selector, boundTemplate, templateMeta}) => {
-    const name = declaration.name.getText();
+  context.components.forEach(
+      ({declaration, selector, boundTemplate, templateMeta, owningModule, importedModules}) => {
+        const name = declaration.name.getText();
 
-    const usedComponents = new Set<ts.Declaration>();
-    const usedDirs = boundTemplate.getUsedDirectives();
-    usedDirs.forEach(dir => {
-      if (dir.isComponent) {
-        usedComponents.add(dir.ref.node);
-      }
-    });
+        const usedComponents = new Set<ts.Declaration>();
+        const usedDirs = boundTemplate.getUsedDirectives();
+        usedDirs.forEach(dir => {
+          if (dir.isComponent) {
+            usedComponents.add(dir.ref.node);
+          }
+        });
 
-    // Get source files for the component and the template. If the template is inline, its source
-    // file is the component's.
-    const componentFile = new ParseSourceFile(
-        declaration.getSourceFile().getFullText(), declaration.getSourceFile().fileName);
-    let templateFile: ParseSourceFile;
-    if (templateMeta.isInline) {
-      templateFile = componentFile;
-    } else {
-      templateFile = templateMeta.file;
-    }
+        // Get source files for the component and the template. If the template is inline, its
+        // source
+        // file is the component's.
+        const componentFile = new ParseSourceFile(
+            declaration.getSourceFile().getFullText(), declaration.getSourceFile().fileName);
+        let templateFile: ParseSourceFile;
+        if (templateMeta.isInline) {
+          templateFile = componentFile;
+        } else {
+          templateFile = templateMeta.file;
+        }
 
-    analysis.set(declaration, {
-      name,
-      selector,
-      file: componentFile,
-      template: {
-        identifiers: getTemplateIdentifiers(boundTemplate),
-        usedComponents,
-        isInline: templateMeta.isInline,
-        file: templateFile,
-      },
-    });
-  });
+        analysis.set(declaration, {
+          name,
+          selector,
+          file: componentFile,
+          template: {
+            identifiers: getTemplateIdentifiers(boundTemplate),
+            usedComponents,
+            isInline: templateMeta.isInline,
+            file: templateFile,
+          },
+          owningModule,
+          importedModules,
+        });
+      });
 
   return analysis;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -15,7 +15,7 @@ runInEachFileSystem(() => {
     it('should store and return information about components', () => {
       const context = new IndexingContext();
       const declaration = util.getClassDeclaration('class C {};', 'C');
-      const owningModule = util.getClassDeclaration('class Owner {};', 'Owner');
+      const exportingModule = util.getClassDeclaration('class Owner {};', 'Owner');
       const importedModules = new Set([util.getClassDeclaration('class Import {};', 'Import')]);
       const boundTemplate = util.getBoundTemplate('<div></div>');
 
@@ -26,7 +26,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
         },
-        owningModule,
+        exportingModule,
         importedModules,
       });
 
@@ -38,7 +38,7 @@ runInEachFileSystem(() => {
             isInline: false,
             file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
           },
-          owningModule,
+          exportingModule,
           importedModules,
         },
       ]));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -14,7 +14,9 @@ runInEachFileSystem(() => {
   describe('ComponentAnalysisContext', () => {
     it('should store and return information about components', () => {
       const context = new IndexingContext();
-      const declaration = util.getComponentDeclaration('class C {};', 'C');
+      const declaration = util.getClassDeclaration('class C {};', 'C');
+      const owningModule = util.getClassDeclaration('class Owner {};', 'Owner');
+      const importedModules = new Set([util.getClassDeclaration('class Import {};', 'Import')]);
       const boundTemplate = util.getBoundTemplate('<div></div>');
 
       context.addComponent({
@@ -24,6 +26,8 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
         },
+        owningModule,
+        importedModules,
       });
 
       expect(context.components).toEqual(new Set([
@@ -34,6 +38,8 @@ runInEachFileSystem(() => {
             isInline: false,
             file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
           },
+          owningModule,
+          importedModules,
         },
       ]));
     });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -233,9 +233,9 @@ runInEachFileSystem(() => {
       });
 
       it('should generate information about used directives', () => {
-        const declA = util.getComponentDeclaration('class A {}', 'A');
-        const declB = util.getComponentDeclaration('class B {}', 'B');
-        const declC = util.getComponentDeclaration('class C {}', 'C');
+        const declA = util.getClassDeclaration('class A {}', 'A');
+        const declB = util.getClassDeclaration('class B {}', 'B');
+        const declC = util.getClassDeclaration('class C {}', 'C');
         const template = '<a-selector b-selector></a-selector>';
         const boundTemplate = util.getBoundTemplate(template, {}, [
           {selector: 'a-selector', declaration: declA},

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -26,7 +26,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile(template, util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
       const analysis = generateAnalysis(context);
@@ -44,7 +44,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile('<div>{{foo}}</div>', util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
     });
@@ -61,7 +61,7 @@ runInEachFileSystem(() => {
           isInline: true,
           file: new ParseSourceFile(decl.getText(), util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
       const analysis = generateAnalysis(context);
@@ -86,7 +86,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile(template, util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
       const analysis = generateAnalysis(context);
@@ -121,7 +121,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile(templateA, util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
       context.addComponent({
@@ -132,7 +132,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile(templateB, util.getTestFilePath()),
         },
-        owningModule: undefined,
+        exportingModule: undefined,
         importedModules: new Set(),
       });
 
@@ -149,7 +149,7 @@ runInEachFileSystem(() => {
       expect(infoB !.template.usedComponents).toEqual(new Set([declA]));
     });
 
-    it('should emit owning and imported NgModule', () => {
+    it('should emit exporting and imported NgModule', () => {
       const context = new IndexingContext();
       const decl = util.getClassDeclaration('class A {}', 'A');
       const owner = util.getClassDeclaration('class Owner {}', 'Owner');
@@ -163,7 +163,7 @@ runInEachFileSystem(() => {
           isInline: false,
           file: new ParseSourceFile('', util.getTestFilePath()),
         },
-        owningModule: owner,
+        exportingModule: owner,
         importedModules: imports,
       });
 
@@ -173,7 +173,7 @@ runInEachFileSystem(() => {
 
       const info = analysis.get(decl);
       expect(info).toBeDefined();
-      expect(info !.owningModule).toEqual(owner);
+      expect(info !.exportingModule).toEqual(owner);
       expect(info !.importedModules).toEqual(imports);
     });
   });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -20,10 +20,13 @@ export function getTestFilePath(): AbsoluteFsPath {
 }
 
 /**
- * Creates a class declaration from a component source code.
+ * Creates a class declaration from a source code.
  */
-export function getComponentDeclaration(componentStr: string, className: string): ClassDeclaration {
-  const program = makeProgram([{name: getTestFilePath(), contents: componentStr}]);
+export function getClassDeclaration(contents: string, className: string): ClassDeclaration {
+  const program = makeProgram([{
+    name: getTestFilePath(),
+    contents,
+  }]);
 
   return getDeclaration(
       program.program, getTestFilePath(), className,

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -173,6 +173,13 @@ export class LocalModuleScopeRegistry implements MetadataRegistry {
   }
 
   /**
+   * Returns the class declaration of the NgModule owning a component, if any.
+   */
+  getModule(declaration: ClassDeclaration): ClassDeclaration|undefined {
+    return this.declarationToModule.get(declaration);
+  }
+
+  /**
    * Implementation of `getScopeOfModule` which accepts a reference to a class and differentiates
    * between:
    *

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -181,7 +181,7 @@ runInEachFileSystem(() => {
         expect(indexed.get(usedComp)).toEqual(testComp);
       });
 
-      it('should generate information about owning and imported modules', () => {
+      it('should generate information about exporting and imported modules', () => {
         env.write(testSourceFile, `
         import {Component, NgModule} from '@angular/core';
 
@@ -230,12 +230,11 @@ runInEachFileSystem(() => {
         const bComp = indexedComps.find(comp => comp.name === 'B');
         expect(aComp).toBeDefined();
         expect(bComp).toBeDefined();
-        expect(aComp !.owningModule).toBeDefined();
-        expect(bComp !.owningModule).toBeDefined();
+        expect(aComp !.exportingModule).toBeDefined();
+        expect(bComp !.exportingModule).toBeUndefined();
 
-        expect(aComp !.owningModule !.name.text).toBe('AModule');
+        expect(aComp !.exportingModule !.name.text).toBe('AModule');
         expect(aComp !.importedModules.size).toBe(0);
-        expect(bComp !.owningModule !.name.text).toBe('BModule');
         expect(Array.from(bComp !.importedModules.values()).map(decl => decl.name.text)).toEqual([
           'AModule'
         ]);


### PR DESCRIPTION
Add a information about the exporting NgModule of a component and the
NgModule that the owner imports to the indexing API.

Matching selectors to class declarations across Angular compilation
units is currently very difficult, if possible at all. Providing
references to the owning and imported NgModules gives a workaround that
will work in many cases, at least for matching element selectors.
Following is an analysis of how this works on an indexer's side.

The idea is because selectors are unique in NgModules, when a selector
on a component is encountered, an indexer implementation may emit the
selector information on the NgModule class declaration. (For example,
in a form like `$MODULE::selector::$SELECTOR`.) When the selector is
later encountered in a template, references to
`$MODULE::selector::$SELECTOR` for each `$MODULE` in the imported
NgModule are optimistically emitted. Hanging references can then be pruned.

This does not resolve issues of reexports and does not work for selectors more
complicated than a tag name.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
See above

Issue Number: N/A


## What is the new behavior?
See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
