### PR TITLE
fix(ivy): handle empty bindings in template type checker

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '@angular/compiler';
+import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {TypeCheckingConfig} from './api';
@@ -58,6 +58,11 @@ class AstTranslator implements AstVisitor {
     // which would prevent any custom resolution through `maybeResolve` for that node.
     if (ast instanceof ASTWithSource) {
       ast = ast.ast;
+    }
+
+    // The `EmptyExpr` doesn't have a dedicated method on `AstVisitor`, so it's special cased here.
+    if (ast instanceof EmptyExpr) {
+      return UNDEFINED;
     }
 
     // First attempt to let any custom resolution logic provide a translation for the given node.

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -39,6 +39,16 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('_t1.htmlFor = ("test");');
   });
 
+  it('should handle empty bindings', () => {
+    const TEMPLATE = `<input [type]="">`;
+    expect(tcb(TEMPLATE)).toContain('_t1.type = undefined;');
+  });
+
+  it('should handle bindings without value', () => {
+    const TEMPLATE = `<input [type]>`;
+    expect(tcb(TEMPLATE)).toContain('_t1.type = undefined;');
+  });
+
   it('should handle implicit vars on ng-template', () => {
     const TEMPLATE = `<ng-template let-a></ng-template>`;
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -41,12 +41,12 @@ describe('type check blocks', () => {
 
   it('should handle empty bindings', () => {
     const TEMPLATE = `<input [type]="">`;
-    expect(tcb(TEMPLATE)).toContain('_t1.type = undefined;');
+    expect(tcb(TEMPLATE)).toContain('_t1.type = (undefined);');
   });
 
   it('should handle bindings without value', () => {
     const TEMPLATE = `<input [type]>`;
-    expect(tcb(TEMPLATE)).toContain('_t1.type = undefined;');
+    expect(tcb(TEMPLATE)).toContain('_t1.type = (undefined);');
   });
 
   it('should handle implicit vars on ng-template', () => {


### PR DESCRIPTION
When a template contains a binding without a value, the template parser
creates an `EmptyExpr` node. This would previously be translated into
an `undefined` value, which would cause a crash downstream as `undefined`
is not included in the allowed type, so it was not handled properly.

This commit prevents the crash by returning an actual expression for empty
bindings.

Fixes #30076
Fixes #30929

---

This is a new PR for #30938 without the breaking changes regarding the `AstVisitor`.