### PR TITLE
fix(router): fix error when calling ParamMap.get function

### DIFF
--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -74,7 +74,7 @@ class ParamsAsMap implements ParamMap {
   }
 
   has(name: string): boolean {
-    return this.params.hasOwnProperty(name);
+    return Object.prototype.hasOwnProperty.call(this.params, name);
   }
 
   get(name: string): string|null {

--- a/packages/router/test/shared.spec.ts
+++ b/packages/router/test/shared.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {convertToParamMap, ParamMap} from '../src/shared';
+import {convertToParamMap, ParamMap, Params} from '../src/shared';
 
 describe('ParamsMap', () => {
   it('should returns whether a parameter is present', () => {
@@ -42,4 +42,14 @@ describe('ParamsMap', () => {
     const map = convertToParamMap({});
     expect(map.getAll('name')).toEqual([]);
   });
+
+  it('should not error when trying to call ParamMap.get function using an object created with Object.create() function',
+     () => {
+       const objectToMap: Params = Object.create(null);
+       objectToMap['single'] = 's';
+       objectToMap['multiple'] = ['m1', 'm2'];
+       const paramMaps: ParamMap = convertToParamMap(objectToMap);
+       expect(() => paramMaps.get('single')).not.toThrow();
+       expect(paramMaps.get('single')).toEqual('s');
+     });
 });


### PR DESCRIPTION
fix this.params.hasOwnProperty is not a function in case of creating an object using Object.create()

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


Error this.params.hasOwnProperty is not a function when calling ParamMap.get function for an object created with Object.create() function


Issue Number: #29816 


## What is the new behavior?

Calling ParamMap.get does not produce error when calling ParamMap.get function for an object created with Object.create() function

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
