### PR TITLE
docs(core): fix typo in event-binding code example

### DIFF
--- a/aio/content/examples/event-binding/src/app/app.component.ts
+++ b/aio/content/examples/event-binding/src/app/app.component.ts
@@ -18,7 +18,7 @@ export class AppComponent {
   }
 
   deleteItem(item: Item) {
-    alert(`Delete the ${item}.`);
+    alert(`Delete the ${item.name}.`);
   }
 
   onClickMe(event?: KeyboardEvent) {


### PR DESCRIPTION
`item` is an object, so it is stringified to `[object Object]`. Using its `name` property produces a more meaningful message.
