### PR TITLE
build(docs-infra): upgrade cli command docs sources to f99913e9f

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && node scripts/switch-to-ivy",
     "build-with-ivy": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 823731f6e",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js f99913e9f",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#8.1.x](https://github.com/angular/angular/tree/8.1.x) from [cli-builds#8.1.x](https://github.com/angular/cli-builds/tree/8.1.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/823731f6e...f99913e9f):

**Modified**
- help/add.json
- help/analytics.json
- help/build.json
- help/doc.json
- help/e2e.json
- help/generate.json
- help/new.json
- help/serve.json
- help/test.json
- help/update.json
- help/xi18n.json

##