### PR TITLE
build: create Bazel setup for aio example cli apps

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,7 +1,6 @@
 .git
 node_modules
 dist
-aio/content
 aio/node_modules
 aio/tools/examples/shared/node_modules
 integration/bazel

--- a/aio/content/examples/BUILD.bazel
+++ b/aio/content/examples/BUILD.bazel
@@ -1,0 +1,5 @@
+exports_files([
+    "tsconfig-example.json",
+    "tsconfig-e2e.json",
+    "start-e2e-server.js",
+])

--- a/aio/content/examples/ajs-quick-reference/BUILD.bazel
+++ b/aio/content/examples/ajs-quick-reference/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//aio/tools:aio_example.bzl", "aio_example", "aio_example_e2e")
+
+aio_example(
+    name = "example",
+    srcs = glob(
+        ["src/**/*.ts"],
+        exclude = ["src/app/app.module.1.ts"],
+    ),
+    assets = glob([
+        "src/**/*.html",
+        "src/**/*.css",
+    ]),
+    entry_module = "angular/aio/content/examples/ajs-quick-reference/src/main",
+    server_assets = glob(["src/assets/**/*.png"]),
+    # Needed because the CLI project normally loads assets relatively to the "src" directory.
+    server_root_paths = ["angular/aio/content/examples/ajs-quick-reference/src"],
+    deps = [
+        "//packages/core",
+        "//packages/forms",
+        "//packages/platform-browser",
+        "//packages/platform-browser-dynamic",
+        "//packages/router",
+    ],
+)
+
+aio_example_e2e(
+    name = "e2e_tests",
+    srcs = glob(["e2e/**/*.ts"]),
+    server = ":example_devserver",
+)

--- a/aio/content/examples/start-e2e-server.js
+++ b/aio/content/examples/start-e2e-server.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const protractorUtils = require('@angular/bazel/protractor-utils');
+const protractor = require('protractor');
+
+module.exports = async function(config) {
+  const {port} = await protractorUtils.runServer(config.workspace, config.server, '-port', []);
+  const serverUrl = `http://localhost:${port}`;
+
+  protractor.browser.baseUrl = serverUrl;
+};

--- a/aio/content/examples/tsconfig-e2e.json
+++ b/aio/content/examples/tsconfig-e2e.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "es2015"
+    ],
+    "types": [
+      "node",
+      "jasminewd2"
+    ]
+  }
+}

--- a/aio/content/examples/tsconfig-example.json
+++ b/aio/content/examples/tsconfig-example.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "types": []
+  }
+}

--- a/aio/tools/BUILD.bazel
+++ b/aio/tools/BUILD.bazel
@@ -1,0 +1,1 @@
+# Empty bazel BUILD file to allow for aio_example.bzl to be loaded.

--- a/aio/tools/aio_example.bzl
+++ b/aio/tools/aio_example.bzl
@@ -1,0 +1,76 @@
+load("//packages/bazel:index.bzl", "protractor_web_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ts_library")
+load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
+
+# Macro rule for creating the ng_module and ts_devserver rules for an aio example.
+def aio_example(
+        name,
+        srcs,
+        entry_module,
+        assets = [],
+        deps = [],
+        server_assets = [],
+        server_root_paths = [],
+        server_index_html = "src/index.html"):
+    ng_module(
+        name = "%s" % name,
+        srcs = [":%s_environment_file" % name] + srcs,
+        assets = assets,
+        # TODO: FW-1004 Type checking is currently not complete.
+        type_check = False,
+        deps = deps,
+        tsconfig = "//aio/content/examples:tsconfig-example.json",
+    )
+
+    native.genrule(
+        name = "%s_environment_file" % name,
+        outs = ["src/environments/environment.ts"],
+        cmd = "echo 'export const environment = {production: false};' > $@",
+    )
+
+    ts_devserver(
+        name = "%s_devserver" % name,
+        entry_module = entry_module,
+        index_html = server_index_html,
+        port = 4200,
+        scripts = [
+            "//tools/rxjs:rxjs_umd_modules",
+            "@npm//:node_modules/tslib/tslib.js",
+        ],
+        static_files = [
+            "@npm//:node_modules/zone.js/dist/zone.js",
+            # Needed because the examples can be bootstrapped in JIT mode.
+            "@npm//:node_modules/reflect-metadata/Reflect.js",
+        ],
+        additional_root_paths = server_root_paths,
+        deps = [":%s" % name],
+        data = server_assets,
+    )
+
+# Macro rule for creating the e2e testing target for an aio example.
+def aio_example_e2e(name, srcs, server, deps = []):
+    ts_library(
+        name = "%s_lib" % name,
+        testonly = True,
+        srcs = srcs,
+        tsconfig = "//aio/content/examples:tsconfig-e2e.json",
+        deps = [
+            "//packages/private/testing",
+            "@npm//@types/jasminewd2",
+            "@npm//@types/selenium-webdriver",
+            "@npm//selenium-webdriver",
+            "@npm//protractor",
+        ] + deps,
+    )
+
+    protractor_web_test_suite(
+        name = "%s" % name,
+        data = ["//packages/bazel/src/protractor/utils"],
+        on_prepare = "//aio/content/examples:start-e2e-server.js",
+        server = server,
+        deps = [
+            ":%s_lib" % name,
+            "@npm//protractor",
+            "@npm//selenium-webdriver",
+        ],
+    )

--- a/packages/private/testing/BUILD.bazel
+++ b/packages/private/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 package(default_visibility = [
+    "//aio:__subpackages__",
     "//modules/playground:__subpackages__",
     "//packages:__subpackages__",
 ])


### PR DESCRIPTION
Written based on work  by @devversion

This PR creates a couple Bazel rules for AIO example apps to use, one defining how to spin up the devserver and another to run the apps e2e tests.

These e2e tests will automatically be included in our CI runs in our `test_ivy_aot` and `test` jobs.