### PR TITLE
fix(zone.js): Closes #31626, zone-mix should import correct browser module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,6 +673,10 @@ jobs:
         # Run zone.js tools tests
       - run: yarn --cwd packages/zone.js promisetest
       - run: yarn --cwd packages/zone.js promisefinallytest
+      - run: yarn bazel build //packages/zone.js:npm_package &&
+             cp dist/bin/packages/zone.js/npm_package/dist/zone-mix.js ./packages/zone.js/test/extra/ &&
+             cp dist/bin/packages/zone.js/npm_package/dist/zone-patch-electron.js ./packages/zone.js/test/extra/ &&
+             yarn --cwd packages/zone.js electrontest
 
 workflows:
   version: 2

--- a/packages/zone.js/lib/mix/rollup-mix.ts
+++ b/packages/zone.js/lib/mix/rollup-mix.ts
@@ -6,8 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../zone';
-import '../common/promise';
-import '../common/to-string';
-import '../browser/browser';
+import '../browser/rollup-main';
 import '../node/node';

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -15,13 +15,16 @@
     "test": "test"
   },
   "devDependencies": {
+    "domino": "2.1.2",
     "mocha": "^3.1.2",
+    "mock-require": "3.0.3",
     "promises-aplus-tests": "^2.1.2",
     "typescript": "~3.4.2"
   },
   "scripts": {
     "promisetest": "tsc -p . && node ./promise-test.js",
-    "promisefinallytest": "tsc -p . && mocha promise.finally.spec.js"
+    "promisefinallytest": "tsc -p . && mocha promise.finally.spec.js",
+    "electrontest": "cd test/extra && node electron.js"
   },
   "repository": {
     "type": "git",

--- a/packages/zone.js/test/extra/electron.js
+++ b/packages/zone.js/test/extra/electron.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+var domino = require('domino');
+var mockRequire = require('mock-require');
+var nativeTimeout = setTimeout;
+require('./zone-mix');
+mockRequire('electron', {
+  desktopCapturer: {getSources: function(callback) { nativeTimeout(callback); }},
+  shell: {openExternal: function(callback) { nativeTimeout(callback); }},
+  ipcRenderer: {on: function(callback) { nativeTimeout(callback); }},
+});
+require('./zone-patch-electron');
+var electron = require('electron');
+var zone = Zone.current.fork({name: 'zone'});
+zone.run(function() {
+  electron.desktopCapturer.getSources(function() {
+    if (Zone.current.name !== 'zone') {
+      process.exit(1);
+    }
+  });
+  electron.shell.openExternal(function() {
+    console.log('shell', Zone.current.name);
+    if (Zone.current.name !== 'zone') {
+      process.exit(1);
+    }
+  });
+  electron.ipcRenderer.on(function() {
+    if (Zone.current.name !== 'zone') {
+      process.exit(1);
+    }
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31626 

import `zone-mix` will cause error when patch `eventTargets`.


## What is the new behavior?
`zone-mix` will work fine.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No