### PR TITLE
ci: move the `test_saucelabs_bazel` CircleCI job to `default_workflow`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,6 +695,12 @@ workflows:
       - legacy-unit-tests-saucelabs:
           requires:
             - setup
+      - test_saucelabs_bazel:
+          requires:
+            - setup
+          filters:
+            branches:
+              only: master
       - test_aio:
           requires:
             - setup
@@ -756,22 +762,6 @@ workflows:
       - test_zonejs:
           requires:
             - setup
-
-  saucelabs_tests:
-    jobs:
-      - setup
-      - test_saucelabs_bazel:
-          requires:
-            - setup
-    triggers:
-      - schedule:
-          # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs
-          # frequently as the caretaker needs up-to-date results when merging PRs or creating
-          # a new release. Also we primarily moved the Saucelabs job into a cronjob that doesn't
-          # run for PRs, in order to ensure that PRs are not affected by Saucelabs flakiness or
-          # incidents. This is still guaranteed (even if we run the job every hour).
-          cron: "0 * * * *"
-          filters: *publish_branches_filter
 
   aio_monitoring:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -676,31 +676,31 @@ workflows:
       - setup
       - lint:
           requires:
-          - setup
+            - setup
       - test:
           requires:
-          - setup
+            - setup
       - test_ivy_aot:
           requires:
-          - setup
+            - setup
       - build-npm-packages:
           requires:
-          - setup
+            - setup
       - build-ivy-npm-packages:
           requires:
-          - setup
-      - test_aio:
-          requires:
-          - setup
-      - legacy-unit-tests-saucelabs:
-          requires:
-          - setup
-      - deploy_aio:
-          requires:
-            - test_aio
+            - setup
       - legacy-misc-tests:
           requires:
             - build-npm-packages
+      - legacy-unit-tests-saucelabs:
+          requires:
+            - setup
+      - test_aio:
+          requires:
+            - setup
+      - deploy_aio:
+          requires:
+            - test_aio
       - test_aio_local:
           requires:
             - build-npm-packages


### PR DESCRIPTION
Previously, the `test_saucelabs_bazel` job was run as part of the `saucelabs_test` workflow every hour (for every "publish branch"; currently 8.0.x, 8.1.x and master).

Since this job runs a subset of the tests in `legacy-unit-tests-saucelabs` (see [BUILD.bazel][1]) and is just a proof-of-concept for running tests on SauceLabs via bazel, there is little point in running is on all branches. It is also wasteful to run it every hour, even if there were no changes pushed into the branch since the last run.

This commit makes the job part of `default_workflow`, but limits it to only be run on master builds (not on other branches or PRs). Based on its recent history, the job is relatively stable and (since it will only be run on master builds) it is not expected to affect our dev workflow.

[1]: https://github.com/angular/angular/blob/ef44f51d5/BUILD.bazel#L66-L92