### PR TITLE
feat(upgrade): support $element in upgraded component template/templateUrl functions

### DIFF
--- a/packages/upgrade/src/common/src/upgrade_helper.ts
+++ b/packages/upgrade/src/common/src/upgrade_helper.ts
@@ -71,13 +71,13 @@ export class UpgradeHelper {
   }
 
   static getTemplate(
-      $injector: IInjectorService, directive: IDirective, fetchRemoteTemplate = false): string
-      |Promise<string> {
+      $injector: IInjectorService, directive: IDirective, fetchRemoteTemplate = false,
+      $element?: IAugmentedJQuery): string|Promise<string> {
     if (directive.template !== undefined) {
-      return getOrCall<string>(directive.template);
+      return getOrCall<string>(directive.template, $element);
     } else if (directive.templateUrl) {
       const $templateCache = $injector.get($TEMPLATE_CACHE) as ITemplateCacheService;
-      const url = getOrCall<string>(directive.templateUrl);
+      const url = getOrCall<string>(directive.templateUrl, $element);
       const template = $templateCache.get(url);
 
       if (template !== undefined) {
@@ -114,7 +114,8 @@ export class UpgradeHelper {
 
   compileTemplate(template?: string): ILinkFn {
     if (template === undefined) {
-      template = UpgradeHelper.getTemplate(this.$injector, this.directive) as string;
+      template =
+          UpgradeHelper.getTemplate(this.$injector, this.directive, false, this.$element) as string;
     }
 
     return this.compileHtml(template);
@@ -304,8 +305,8 @@ export class UpgradeHelper {
   }
 }
 
-function getOrCall<T>(property: T | Function): T {
-  return isFunction(property) ? property() : property;
+function getOrCall<T>(property: T | Function, ...args: any[]): T {
+  return isFunction(property) ? property(...args) : property;
 }
 
 // NOTE: Only works for `typeof T !== 'object'`.

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -106,12 +106,12 @@ withEachNg1Version(() => {
            });
          }));
 
-      it('should support not pass any arguments to `template` function', async(() => {
+      it('should pass $element to `template` function and not $attrs', async(() => {
            // Define `ng1Component`
            const ng1Component: angular.IComponent = {
              template: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
                expect($attrs).toBeUndefined();
-               expect($element).toBeUndefined();
+               expect($element).toBeDefined();
 
                return 'Hello, Angular!';
              }
@@ -241,12 +241,12 @@ withEachNg1Version(() => {
            });
          }));
 
-      it('should support not pass any arguments to `templateUrl` function', async(() => {
+      it('should pass $element to `templateUrl` function and not $attrs', async(() => {
            // Define `ng1Component`
            const ng1Component: angular.IComponent = {
              templateUrl: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
                expect($attrs).toBeUndefined();
-               expect($element).toBeUndefined();
+               expect($element).toBeDefined();
 
                return 'ng1.component.html';
              }


### PR DESCRIPTION
Template functions on upgraded components will receive $element

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
  - I modified an existing one that verified that both `$element` and `$attrs` were undefined; it now verifies that `$element` is defined and `$attrs` is undefined
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31565


## What is the new behavior?
`template` and `templateUrl` functions on upgraded components will receive `$element` via `UpgradeHelper.compileTemplate`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
