### PR TITLE
perf(compiler): avoid copying from prototype while cloning an object

### DIFF
--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1464,10 +1464,8 @@ class _ApplySourceSpanTransformer extends AstTransformer {
   constructor(private sourceSpan: ParseSourceSpan) { super(); }
   private _clone(obj: any): any {
     const clone = Object.create(obj.constructor.prototype);
-    for (let prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
-        clone[prop] = obj[prop];
-      }
+    for (let prop of Object.keys(obj)) {
+      clone[prop] = obj[prop];
     }
     return clone;
   }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1465,7 +1465,9 @@ class _ApplySourceSpanTransformer extends AstTransformer {
   private _clone(obj: any): any {
     const clone = Object.create(obj.constructor.prototype);
     for (let prop in obj) {
-      clone[prop] = obj[prop];
+      if (obj.hasOwnProperty(prop)) {
+        clone[prop] = obj[prop];
+      }
     }
     return clone;
   }


### PR DESCRIPTION
This commit updates the `_clone` function of the `_ApplySourceSpanTransformer` class, where the for-in loop was used, resulting in copying from prototype to own properties, thus consuming more memory. Prior to NodeJS 12 (V8 versions before 7.4) there was an optimization that was improving the situation and since that logic was removed in favor of other optimizations, the situation with memory consumption caused by the for-in loop got worse. This commit adds a check to make sure we copy only own properties over to cloned object.

Closes #31627.

## PR Type

What kind of change does this PR introduce?

- [x] Other... Please describe: performance improvement


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No