### PR TITLE
fix(zone.js): Closes #31641, hook should set correct current zone

### DIFF
--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -1016,47 +1016,49 @@ const Zone: ZoneType = (function(global: any) {
       this._forkZS =
           zoneSpec && (zoneSpec && zoneSpec.onFork ? zoneSpec : parentDelegate !._forkZS);
       this._forkDlgt = zoneSpec && (zoneSpec.onFork ? parentDelegate : parentDelegate !._forkDlgt);
-      this._forkCurrZone = zoneSpec && (zoneSpec.onFork ? this.zone : parentDelegate !.zone);
+      this._forkCurrZone =
+          zoneSpec && (zoneSpec.onFork ? this.zone : parentDelegate !._forkCurrZone);
 
       this._interceptZS =
           zoneSpec && (zoneSpec.onIntercept ? zoneSpec : parentDelegate !._interceptZS);
       this._interceptDlgt =
           zoneSpec && (zoneSpec.onIntercept ? parentDelegate : parentDelegate !._interceptDlgt);
       this._interceptCurrZone =
-          zoneSpec && (zoneSpec.onIntercept ? this.zone : parentDelegate !.zone);
+          zoneSpec && (zoneSpec.onIntercept ? this.zone : parentDelegate !._interceptCurrZone);
 
       this._invokeZS = zoneSpec && (zoneSpec.onInvoke ? zoneSpec : parentDelegate !._invokeZS);
       this._invokeDlgt =
           zoneSpec && (zoneSpec.onInvoke ? parentDelegate ! : parentDelegate !._invokeDlgt);
-      this._invokeCurrZone = zoneSpec && (zoneSpec.onInvoke ? this.zone : parentDelegate !.zone);
+      this._invokeCurrZone =
+          zoneSpec && (zoneSpec.onInvoke ? this.zone : parentDelegate !._invokeCurrZone);
 
       this._handleErrorZS =
           zoneSpec && (zoneSpec.onHandleError ? zoneSpec : parentDelegate !._handleErrorZS);
       this._handleErrorDlgt = zoneSpec &&
           (zoneSpec.onHandleError ? parentDelegate ! : parentDelegate !._handleErrorDlgt);
       this._handleErrorCurrZone =
-          zoneSpec && (zoneSpec.onHandleError ? this.zone : parentDelegate !.zone);
+          zoneSpec && (zoneSpec.onHandleError ? this.zone : parentDelegate !._handleErrorCurrZone);
 
       this._scheduleTaskZS =
           zoneSpec && (zoneSpec.onScheduleTask ? zoneSpec : parentDelegate !._scheduleTaskZS);
       this._scheduleTaskDlgt = zoneSpec &&
           (zoneSpec.onScheduleTask ? parentDelegate ! : parentDelegate !._scheduleTaskDlgt);
-      this._scheduleTaskCurrZone =
-          zoneSpec && (zoneSpec.onScheduleTask ? this.zone : parentDelegate !.zone);
+      this._scheduleTaskCurrZone = zoneSpec &&
+          (zoneSpec.onScheduleTask ? this.zone : parentDelegate !._scheduleTaskCurrZone);
 
       this._invokeTaskZS =
           zoneSpec && (zoneSpec.onInvokeTask ? zoneSpec : parentDelegate !._invokeTaskZS);
       this._invokeTaskDlgt =
           zoneSpec && (zoneSpec.onInvokeTask ? parentDelegate ! : parentDelegate !._invokeTaskDlgt);
       this._invokeTaskCurrZone =
-          zoneSpec && (zoneSpec.onInvokeTask ? this.zone : parentDelegate !.zone);
+          zoneSpec && (zoneSpec.onInvokeTask ? this.zone : parentDelegate !._invokeTaskCurrZone);
 
       this._cancelTaskZS =
           zoneSpec && (zoneSpec.onCancelTask ? zoneSpec : parentDelegate !._cancelTaskZS);
       this._cancelTaskDlgt =
           zoneSpec && (zoneSpec.onCancelTask ? parentDelegate ! : parentDelegate !._cancelTaskDlgt);
       this._cancelTaskCurrZone =
-          zoneSpec && (zoneSpec.onCancelTask ? this.zone : parentDelegate !.zone);
+          zoneSpec && (zoneSpec.onCancelTask ? this.zone : parentDelegate !._cancelTaskCurrZone);
 
       this._hasTaskZS = null;
       this._hasTaskDlgt = null;

--- a/packages/zone.js/test/common/zone.spec.ts
+++ b/packages/zone.js/test/common/zone.spec.ts
@@ -49,6 +49,22 @@ describe('Zone', function() {
       const zoneC = zoneB.fork({name: 'C'});
       zoneC.run(function() {});
     });
+
+    it('should send correct currentZone in hook method when in nested zone with empty implementation',
+       function() {
+         const zone = Zone.current;
+         const zoneA = zone.fork({
+           name: 'A',
+           onInvoke: function(
+               parentDelegate, currentZone, targetZone, callback, applyThis, applyArgs, source) {
+             expect(currentZone.name).toEqual('A');
+             return parentDelegate.invoke(targetZone, callback, applyThis, applyArgs, source);
+           }
+         });
+         const zoneB = zoneA.fork({name: 'B'});
+         const zoneC = zoneB.fork({name: 'C'});
+         zoneC.run(function() {});
+       });
   });
 
   it('should allow zones to be run from within another zone', function() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31641 
The case like this will print wrong current zone.

```
const zone = Zone.current;
const zoneA = zone.fork({
  name: 'A',
  onInvoke: function(
    parentDelegate, currentZone, targetZone, callback, applyThis, applyArgs, source) {
    expect(currentZone.name).toEqual('A');
    return parentDelegate.invoke(targetZone, callback, applyThis, applyArgs, source);
  }
});
const zoneB = zoneA.fork({
  name: 'B'
});
const zoneC = zoneB.fork({name: 'C'});
zoneC.run(function() {});
```

expect current zone to be `A`, but the result is `B`.


## What is the new behavior?
the current zone will be `A`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No