### PR TITLE
fix(zone.js): Closes #31643, should remove on symbol property after removeAllListeners

### DIFF
--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -540,6 +540,13 @@ export function patchEventTarget(
               // remove globalZoneAwareCallback and remove the task cache from target
               (existingTask as any).allRemoved = true;
               target[symbolEventName] = null;
+              // in the target, we have an event listener which is added by on_property
+              // such as target.onclick = function() {}, so we need to clear this internal
+              // property too if all delegates all removed
+              if (typeof eventName === 'string') {
+                const onPropertySymbol = ZONE_SYMBOL_PREFIX + 'ON_PROPERTY' + eventName;
+                target[onPropertySymbol] = null;
+              }
             }
             existingTask.zone.cancelTask(existingTask);
             if (returnTarget) {

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -245,7 +245,7 @@ describe('Zone', function() {
             Zone.current.fork({name: 'test1'}).run(() => { testTarget.dispatchEvent('prop3'); });
           });
 
-          it('window onclick should be in zone',
+          it('window onmousedown should be in zone',
              ifEnvSupports(canPatchOnProperty(window, 'onmousedown'), function() {
                zone.run(function() { window.onmousedown = eventListenerSpy; });
 
@@ -254,6 +254,10 @@ describe('Zone', function() {
                expect(hookSpy).toHaveBeenCalled();
                expect(eventListenerSpy).toHaveBeenCalled();
                window.removeEventListener('mousedown', eventListenerSpy);
+               expect((window as any)[zoneSymbol('ON_PROPERTYmousedown')])
+                   .toEqual(eventListenerSpy);
+               window.onmousedown = null;
+               expect(!!(window as any)[zoneSymbol('ON_PROPERTYmousedown')]).toBeFalsy();
              }));
 
           it('window onresize should be patched',
@@ -264,9 +268,12 @@ describe('Zone', function() {
                innerResizeProp();
                expect(eventListenerSpy).toHaveBeenCalled();
                window.removeEventListener('resize', eventListenerSpy);
+               expect((window as any)[zoneSymbol('ON_PROPERTYresize')]).toEqual(eventListenerSpy);
+               window.onresize = null;
+               expect(!!(window as any)[zoneSymbol('ON_PROPERTYresize')]).toBeFalsy();
              }));
 
-          it('document onclick should be in zone',
+          it('document onmousedown should be in zone',
              ifEnvSupports(canPatchOnProperty(Document.prototype, 'onmousedown'), function() {
                zone.run(function() { document.onmousedown = eventListenerSpy; });
 
@@ -275,6 +282,10 @@ describe('Zone', function() {
                expect(hookSpy).toHaveBeenCalled();
                expect(eventListenerSpy).toHaveBeenCalled();
                document.removeEventListener('mousedown', eventListenerSpy);
+               expect((document as any)[zoneSymbol('ON_PROPERTYmousedown')])
+                   .toEqual(eventListenerSpy);
+               document.onmousedown = null;
+               expect(!!(document as any)[zoneSymbol('ON_PROPERTYmousedown')]).toBeFalsy();
              }));
 
           // TODO: JiaLiPassion, need to find out why the test bundle is not `use strict`.
@@ -342,7 +353,7 @@ describe('Zone', function() {
                 }
               }));
 
-          it('SVGElement onclick should be in zone',
+          it('SVGElement onmousedown should be in zone',
              ifEnvSupports(
                  canPatchOnProperty(SVGElement && SVGElement.prototype, 'onmousedown'), function() {
                    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -1921,15 +1932,20 @@ describe('Zone', function() {
         const listener2 = function() { logs.push('listener2'); };
         const listener3 = {handleEvent: function(event: Event) { logs.push('listener3'); }};
         const listener4 = function() { logs.push('listener4'); };
+        const listener5 = function() { logs.push('listener5'); };
 
         button.addEventListener('mouseover', listener1);
         button.addEventListener('mouseover', listener2);
         button.addEventListener('mouseover', listener3);
         button.addEventListener('click', listener4);
+        button.onmouseover = listener5;
+        expect((button as any)[Zone.__symbol__('ON_PROPERTYmouseover')]).toEqual(listener5);
 
         (button as any).removeAllListeners('mouseover');
-        const listeners = (button as any).eventListeners('mouseove');
+        const listeners = (button as any).eventListeners('mouseover');
         expect(listeners.length).toBe(0);
+        expect((button as any)[Zone.__symbol__('ON_PROPERTYmouseover')]).toBeNull();
+        expect(!!button.onmouseover).toBeFalsy();
 
         const mouseEvent = document.createEvent('Event');
         mouseEvent.initEvent('mouseover', true, true);
@@ -1957,7 +1973,7 @@ describe('Zone', function() {
            button.addEventListener('click', listener4, true);
 
            (button as any).removeAllListeners('mouseover');
-           const listeners = (button as any).eventListeners('mouseove');
+           const listeners = (button as any).eventListeners('mouseover');
            expect(listeners.length).toBe(0);
 
            const mouseEvent = document.createEvent('Event');
@@ -2007,15 +2023,20 @@ describe('Zone', function() {
         const listener2 = function() { logs.push('listener2'); };
         const listener3 = {handleEvent: function(event: Event) { logs.push('listener3'); }};
         const listener4 = function() { logs.push('listener4'); };
+        const listener5 = function() { logs.push('listener5'); };
 
         button.addEventListener('mouseover', listener1);
         button.addEventListener('mouseover', listener2);
         button.addEventListener('mouseover', listener3);
         button.addEventListener('click', listener4);
+        button.onmouseover = listener5;
+        expect((button as any)[Zone.__symbol__('ON_PROPERTYmouseover')]).toEqual(listener5);
 
         (button as any).removeAllListeners();
         const listeners = (button as any).eventListeners('mouseover');
         expect(listeners.length).toBe(0);
+        expect((button as any)[Zone.__symbol__('ON_PROPERTYmouseover')]).toBeNull();
+        expect(!!button.onmouseover).toBeFalsy();
 
         const mouseEvent = document.createEvent('Event');
         mouseEvent.initEvent('mouseover', true, true);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31643
```
document.onclick = () => console.log('click');

// After calling this, the listener above is removed, and clicking on
// the document does nothing.
document.removeAllListeners();

// The 'onclick' property still contains the old event listener.
console.log(document.onclick);
console.log(document[Zone.__symbol__('ON_PROPERTYclick')]);
```

after `removeAllListeners`, the document.onclick should be null.

## What is the new behavior?

after `removeAllListeners`, the document.onclick will be null.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
