### PR TITLE
fix(ivy): include NgModule in incremental compilation if template cha…

### DIFF
--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -180,6 +180,22 @@ runInEachFileSystem(() => {
       expect(written).toContain('/foo_module.js');
     });
 
+    it('should rebuild NgModules where their declared dependencies\' resources have changed',
+       () => {
+         setupFooBarProgram(env);
+
+         // Make a change to the template of FooComponent.
+         env.write('foo_component.html', 'changed');
+         env.driveMain();
+         const written = env.getFilesWrittenSinceLastFlush();
+         expect(written).not.toContain('/bar_directive.js');
+         expect(written).not.toContain('/bar_component.js');
+         expect(written).not.toContain('/bar_module.js');
+         expect(written).toContain('/foo_component.js');
+         expect(written).toContain('/foo_pipe.js');
+         expect(written).toContain('/foo_module.js');
+       });
+
     it('should rebuild components where their NgModule has changed', () => {
       setupFooBarProgram(env);
 
@@ -257,9 +273,10 @@ runInEachFileSystem(() => {
     import {Component} from '@angular/core';
     import {fooSelector} from './foo_selector';
 
-    @Component({selector: fooSelector, template: 'foo'})
+    @Component({selector: fooSelector, templateUrl: './foo_component.html'})
     export class FooCmp {}
   `);
+    env.write('foo_component.html', 'foo');
     env.write('foo_pipe.ts', `
     import {Pipe} from '@angular/core';
 


### PR DESCRIPTION
…nges

Previously if a template changed then we would know to rebuild its component
source file, but we were not noticing that its NgModule needed rebuilding too.

Now we include resource changes as dependencies when computing which
files are unchanged.

Fixes #31654

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
