### PR TITLE
fix(zone.js): move MutationObserver/FileReader to different module

### DIFF
--- a/packages/zone.js/MODULE.md
+++ b/packages/zone.js/MODULE.md
@@ -36,6 +36,10 @@ Below is the full list of currently supported modules.
 |requestAnimationFrame|requestAnimationFrame will be patched as Zone MacroTask|__Zone_disable_requestAnimationFrame = true|
 |blocking|alert/prompt/confirm will be patched as Zone.run|__Zone_disable_blocking = true|
 |EventTarget|target.addEventListener will be patched as Zone aware EventTask|__Zone_disable_EventTarget = true|
+|MutationObserver|MutationObserver will be patched as Zone aware operation|__Zone_disable_MutationObserver = true|
+|IntersectionObserver|Intersection will be patched as Zone aware operation|__Zone_disable_Intersection = true|
+|FileReader|FileReader will be patched as Zone aware operation|__Zone_disable_FileReader = true|
+|canvas|HTMLCanvasElement.toBlob will be patched as Zone aware operation|__Zone_disable_canvas = true|
 |IE BrowserTools check|in IE, browser tool will not use zone patched eventListener|__Zone_disable_IE_check = true|
 |CrossContext check|in webdriver, enable check event listener is cross context|__Zone_enable_cross_context_check = true|
 |XHR|XMLHttpRequest will be patched as Zone aware MacroTask|__Zone_disable_XHR = true|

--- a/packages/zone.js/lib/browser/browser.ts
+++ b/packages/zone.js/lib/browser/browser.ts
@@ -12,7 +12,7 @@
 
 import {findEventTasks} from '../common/events';
 import {patchTimer} from '../common/timers';
-import {patchClass, patchMethod, patchPrototype, scheduleMacroTaskWithCurrentZone, ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, zoneSymbol} from '../common/utils';
+import {patchClass, patchMethod, patchPrototype, scheduleMacroTaskWithCurrentZone, ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, zoneSymbol,} from '../common/utils';
 
 import {patchCustomElements} from './custom-elements';
 import {eventTargetPatch, patchEvent} from './event-target';
@@ -59,9 +59,18 @@ Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate
   if (XMLHttpRequestEventTarget && XMLHttpRequestEventTarget.prototype) {
     api.patchEventTarget(global, [XMLHttpRequestEventTarget.prototype]);
   }
+});
+
+Zone.__load_patch('MutationObserver', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   patchClass('MutationObserver');
   patchClass('WebKitMutationObserver');
+});
+
+Zone.__load_patch('IntersectionObserver', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   patchClass('IntersectionObserver');
+});
+
+Zone.__load_patch('FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   patchClass('FileReader');
 });
 

--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -326,6 +326,21 @@ interface ZoneGlobalConfigurations {
   __Zone_disable_EventTarget?: boolean;
 
   /**
+   * Disable the monkey patch of the browser `FileReader` APIs.
+   */
+  __Zone_disable_FileReader?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `MutationObserver` APIs.
+   */
+  __Zone_disable_MutationObserver?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `IntersectionObserver` APIs.
+   */
+  __Zone_disable_IntersectionObserver?: boolean;
+
+  /**
    * Disable the monkey patch of the browser onProperty APIs(such as onclick).
    *
    * By default, `zone.js` monkey patches onXXX properties (such as onclick). The callbacks of onXXX


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Separate `MutationObserver` and `FileReader` to separated module, so they can be disabled separately. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Close #36460