### PR TITLE
fix(zone.js): Closes #31659, move property patch to legacy

### DIFF
--- a/packages/zone.js/lib/browser/browser-legacy.ts
+++ b/packages/zone.js/lib/browser/browser-legacy.ts
@@ -10,6 +10,7 @@
  * @suppress {missingRequire}
  */
 
+import {propertyPatch} from './define-property';
 import {eventTargetLegacyPatch} from './event-target-legacy';
 import {propertyDescriptorLegacyPatch} from './property-descriptor-legacy';
 import {registerElementPatch} from './register-element';
@@ -17,6 +18,7 @@ import {registerElementPatch} from './register-element';
 (function(_global: any) {
   _global[Zone.__symbol__('legacyPatch')] = function() {
     const Zone = _global['Zone'];
+    Zone.__load_patch('defineProperty', () => { propertyPatch(); });
     Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       registerElementPatch(global, api);
     });

--- a/packages/zone.js/lib/browser/browser.ts
+++ b/packages/zone.js/lib/browser/browser.ts
@@ -15,7 +15,6 @@ import {patchTimer} from '../common/timers';
 import {ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, patchClass, patchMethod, patchPrototype, scheduleMacroTaskWithCurrentZone, zoneSymbol} from '../common/utils';
 
 import {patchCustomElements} from './custom-elements';
-import {propertyPatch} from './define-property';
 import {eventTargetPatch, patchEvent} from './event-target';
 import {propertyDescriptorPatch} from './property-descriptor';
 
@@ -68,7 +67,6 @@ Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate
 
 Zone.__load_patch('on_property', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   propertyDescriptorPatch(api, global);
-  propertyPatch();
 });
 
 Zone.__load_patch('customElements', (global: any, Zone: ZoneType, api: _ZonePrivate) => {

--- a/packages/zone.js/test/browser/define-property.spec.ts
+++ b/packages/zone.js/test/browser/define-property.spec.ts
@@ -13,15 +13,27 @@ describe('defineProperty', function() {
         .not.toThrow();
   });
 
-  it('should not throw error when try to defineProperty with a frozen desc', function() {
+  it('should not be able to change a frozen desc', function() {
     const obj = {};
     const desc = Object.freeze({value: null, writable: true});
     Object.defineProperty(obj, 'prop', desc);
+    let objDesc: any = Object.getOwnPropertyDescriptor(obj, 'prop');
+    expect(objDesc.writable).toBeTruthy();
+    try {
+      Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'test'});
+    } catch (err) {
+    }
+    objDesc = Object.getOwnPropertyDescriptor(obj, 'prop');
+    expect(objDesc.configurable).toBeFalsy();
   });
 
   it('should not throw error when try to defineProperty with a frozen obj', function() {
     const obj = {};
     Object.freeze(obj);
-    Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'value'});
+    try {
+      Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'value'});
+    } catch (err) {
+    }
+    expect((obj as any).prop).toBeFalsy();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31659 

In some browser, monkey-patch `Object.defineProperty` will cause some errors. This patch suppose to resolve some very old browsers (android 4?) issues, so it should be moved to legacy.

## What is the new behavior?
move property patch(`Object.defineProperty` ) to legacy

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No