### PR TITLE
ci: Add ANGULAR_PACKAGE to snapshot builds

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -70,6 +70,7 @@ function publishRepo {
   fi
   echo `date` > $REPO_DIR/BUILD_INFO
   echo $SHA >> $REPO_DIR/BUILD_INFO
+  echo 'This file is used by the npm/yarn_install rule to detect APF' > $REPO_DIR/ANGULAR_PACKAGE
 
   (
     cd $REPO_DIR && \


### PR DESCRIPTION
Ivy snapshots no longer contain metadata.json which breaks the detection logic for
Angular Package Format (APF) in npm/yarn install.
This PR adds ANGULAR_PACAKGE as a magic file to denote APF.
See https://github.com/bazelbuild/rules_nodejs/issues/927

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
