### PR TITLE
perf(ivy): avoid extra parameter in query instructions

### DIFF
--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -280,7 +280,7 @@ runInEachFileSystem(() => {
           expect(addDefinitionsSpy.calls.first().args[2])
               .toEqual(
                   `UndecoratedBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ viewQuery: function (rf, ctx) { if (rf & 1) {
-        ɵngcc0.ɵɵstaticViewQuery(_c0, true, null);
+        ɵngcc0.ɵɵstaticViewQuery(_c0, true);
     } if (rf & 2) {
         var _t;
         ɵngcc0.ɵɵqueryRefresh(_t = ɵngcc0.ɵɵloadViewQuery()) && (ctx.test = _t.first);

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1530,8 +1530,8 @@ describe('compiler compliance', () => {
             factory: function ViewQueryComponent_Factory(t) { return new (t || ViewQueryComponent)(); },
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
-                $r3$.ɵɵviewQuery(SomeDirective, true, null);
-                $r3$.ɵɵviewQuery(SomeDirective, true, null);
+                $r3$.ɵɵviewQuery(SomeDirective, true);
+                $r3$.ɵɵviewQuery(SomeDirective, true);
               }
               if (rf & 2) {
                 var $tmp$;
@@ -1588,8 +1588,8 @@ describe('compiler compliance', () => {
             …
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
-                $r3$.ɵɵviewQuery($e0_attrs$, true, null);
-                $r3$.ɵɵviewQuery($e1_attrs$, true, null);
+                $r3$.ɵɵviewQuery($e0_attrs$, true);
+                $r3$.ɵɵviewQuery($e1_attrs$, true);
               }
               if (rf & 2) {
                 var $tmp$;
@@ -1641,8 +1641,8 @@ describe('compiler compliance', () => {
             factory: function ViewQueryComponent_Factory(t) { return new (t || ViewQueryComponent)(); },
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
-                $r3$.ɵɵstaticViewQuery(SomeDirective, true, null);
-                $r3$.ɵɵviewQuery($refs$, true, null);
+                $r3$.ɵɵstaticViewQuery(SomeDirective, true);
+                $r3$.ɵɵviewQuery($refs$, true);
               }
               if (rf & 2) {
                 var $tmp$;
@@ -1770,8 +1770,8 @@ describe('compiler compliance', () => {
             },
             contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
               if (rf & 1) {
-              $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, true, null);
-              $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false, null);
+              $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, true);
+              $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false);
               }
               if (rf & 2) {
               var $tmp$;
@@ -1830,8 +1830,8 @@ describe('compiler compliance', () => {
             …
             contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
               if (rf & 1) {
-              $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, true, null);
-              $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, false, null);
+              $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, true);
+              $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, false);
               }
               if (rf & 2) {
               var $tmp$;
@@ -1892,8 +1892,8 @@ describe('compiler compliance', () => {
             },
             contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
               if (rf & 1) {
-              $r3$.ɵɵstaticContentQuery(dirIndex, SomeDirective, true, null);
-              $r3$.ɵɵcontentQuery(dirIndex, $ref0$, true, null);
+              $r3$.ɵɵstaticContentQuery(dirIndex, SomeDirective, true);
+              $r3$.ɵɵcontentQuery(dirIndex, $ref0$, true);
               }
               if (rf & 2) {
               var $tmp$;
@@ -3140,7 +3140,7 @@ describe('compiler compliance', () => {
       BaseClass.ngBaseDef = i0.ɵɵdefineBase({
         viewQuery: function (rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵviewQuery($e0_attrs$, true, null);
+            $r3$.ɵɵviewQuery($e0_attrs$, true);
           }
           if (rf & 2) {
             var $tmp$;
@@ -3185,7 +3185,7 @@ describe('compiler compliance', () => {
       BaseClass.ngBaseDef = i0.ɵɵdefineBase({
         viewQuery: function (rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵviewQuery(SomeDirective, true, null);
+            $r3$.ɵɵviewQuery(SomeDirective, true);
           }
           if (rf & 2) {
             var $tmp$;
@@ -3228,7 +3228,7 @@ describe('compiler compliance', () => {
       BaseClass.ngBaseDef = i0.ɵɵdefineBase({
         contentQueries: function (rf, ctx, dirIndex) {
           if (rf & 1) {
-            $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, true, null);
+            $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, true);
           }
           if (rf & 2) {
             var $tmp$;
@@ -3273,7 +3273,7 @@ describe('compiler compliance', () => {
       BaseClass.ngBaseDef = i0.ɵɵdefineBase({
         contentQueries: function (rf, ctx, dirIndex) {
           if (rf & 1) {
-            $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false, null);
+            $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false);
           }
           if (rf & 2) {
             var $tmp$;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -22,13 +22,13 @@ const trim = (input: string): string => input.replace(/\s+/g, ' ').trim();
 const varRegExp = (name: string): RegExp => new RegExp(`var \\w+ = \\[\"${name}\"\\];`);
 
 const viewQueryRegExp = (descend: boolean, ref?: string): RegExp => {
-  const maybeRef = ref ? `${ref}` : `null`;
-  return new RegExp(`i0\\.ɵɵviewQuery\\(\\w+, ${descend}, ${maybeRef}\\)`);
+  const maybeRef = ref ? `, ${ref}` : ``;
+  return new RegExp(`i0\\.ɵɵviewQuery\\(\\w+, ${descend}${maybeRef}\\)`);
 };
 
 const contentQueryRegExp = (predicate: string, descend: boolean, ref?: string): RegExp => {
-  const maybeRef = ref ? `${ref}` : `null`;
-  return new RegExp(`i0\\.ɵɵcontentQuery\\(dirIndex, ${predicate}, ${descend}, ${maybeRef}\\)`);
+  const maybeRef = ref ? `, ${ref}` : ``;
+  return new RegExp(`i0\\.ɵɵcontentQuery\\(dirIndex, ${predicate}, ${descend}${maybeRef}\\)`);
 };
 
 const setClassMetadataRegExp = (expectedType: string): RegExp =>
@@ -1654,7 +1654,7 @@ runInEachFileSystem(os => {
       // match `i0.ɵɵcontentQuery(dirIndex, _c1, true, TemplateRef)`
       expect(jsContents).toMatch(contentQueryRegExp('\\w+', true, 'TemplateRef'));
 
-      // match `i0.ɵɵviewQuery(_c2, true, null)`
+      // match `i0.ɵɵviewQuery(_c2, true)`
       // Note that while ViewQuery doesn't necessarily make sense on a directive, because it doesn't
       // have a view, we still need to handle it because a component could extend the directive.
       expect(jsContents).toMatch(viewQueryRegExp(true));

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -80,8 +80,8 @@ class LQueries_ implements LQueries {
 
 class TQueryMetadata_ implements TQueryMetadata {
   constructor(
-      public predicate: Type<any>|string[], public descendants: boolean, public read: any,
-      public isStatic: boolean) {}
+      public predicate: Type<any>|string[], public descendants: boolean, public isStatic: boolean,
+      public read: any = null) {}
 }
 
 class TQueries_ implements TQueries {
@@ -417,7 +417,7 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
  * @codeGenApi
  */
 export function ɵɵstaticViewQuery<T>(
-    predicate: Type<any>| string[], descend: boolean, read: any): void {
+    predicate: Type<any>| string[], descend: boolean, read?: any): void {
   viewQueryInternal(getLView(), predicate, descend, read, true);
 }
 
@@ -430,7 +430,7 @@ export function ɵɵstaticViewQuery<T>(
  *
  * @codeGenApi
  */
-export function ɵɵviewQuery<T>(predicate: Type<any>| string[], descend: boolean, read: any): void {
+export function ɵɵviewQuery<T>(predicate: Type<any>| string[], descend: boolean, read?: any): void {
   viewQueryInternal(getLView(), predicate, descend, read, false);
 }
 
@@ -439,7 +439,7 @@ function viewQueryInternal<T>(
     isStatic: boolean): void {
   const tView = lView[TVIEW];
   if (tView.firstTemplatePass) {
-    createTQuery(tView, new TQueryMetadata_(predicate, descend, read, isStatic), -1);
+    createTQuery(tView, new TQueryMetadata_(predicate, descend, isStatic, read), -1);
     if (isStatic) {
       tView.staticViewQueries = true;
     }
@@ -469,7 +469,7 @@ export function ɵɵloadViewQuery<T>(): QueryList<T> {
  * @codeGenApi
  */
 export function ɵɵcontentQuery<T>(
-    directiveIndex: number, predicate: Type<any>| string[], descend: boolean, read: any): void {
+    directiveIndex: number, predicate: Type<any>| string[], descend: boolean, read?: any): void {
   contentQueryInternal(
       getLView(), predicate, descend, read, false, getPreviousOrParentTNode(), directiveIndex);
 }
@@ -487,7 +487,7 @@ export function ɵɵcontentQuery<T>(
  * @codeGenApi
  */
 export function ɵɵstaticContentQuery<T>(
-    directiveIndex: number, predicate: Type<any>| string[], descend: boolean, read: any): void {
+    directiveIndex: number, predicate: Type<any>| string[], descend: boolean, read?: any): void {
   contentQueryInternal(
       getLView(), predicate, descend, read, true, getPreviousOrParentTNode(), directiveIndex);
 }
@@ -497,7 +497,7 @@ function contentQueryInternal<T>(
     tNode: TNode, directiveIndex: number): void {
   const tView = lView[TVIEW];
   if (tView.firstTemplatePass) {
-    createTQuery(tView, new TQueryMetadata_(predicate, descend, read, isStatic), tNode.index);
+    createTQuery(tView, new TQueryMetadata_(predicate, descend, isStatic, read), tNode.index);
     saveContentQueryAndDirectiveIndex(tView, directiveIndex);
     if (isStatic) {
       tView.staticContentQueries = true;

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -80,8 +80,8 @@ describe('query', () => {
         2, 0, [Child], [],
         function(rf: RenderFlags, ctx: any) {
           if (rf & RenderFlags.Create) {
-            ɵɵviewQuery(Child, false, null);
-            ɵɵviewQuery(Child, true, null);
+            ɵɵviewQuery(Child, false);
+            ɵɵviewQuery(Child, true);
           }
           if (rf & RenderFlags.Update) {
             let tmp: any;
@@ -258,9 +258,9 @@ describe('query', () => {
             },
             viewQuery: function(rf: RenderFlags, ctx: App) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(MyDirective, false, null);
-                ɵɵviewQuery(Service, false, null);
-                ɵɵviewQuery(Alias, false, null);
+                ɵɵviewQuery(MyDirective, false);
+                ɵɵviewQuery(Service, false);
+                ɵɵviewQuery(Alias, false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -347,7 +347,7 @@ describe('query', () => {
             3, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], false, null);
+                ɵɵviewQuery(['foo'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -385,8 +385,8 @@ describe('query', () => {
             4, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], false, null);
-                ɵɵviewQuery(['bar'], false, null);
+                ɵɵviewQuery(['foo'], false);
+                ɵɵviewQuery(['bar'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -434,7 +434,7 @@ describe('query', () => {
             5, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo', 'bar'], false, null);
+                ɵɵviewQuery(['foo', 'bar'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -472,7 +472,7 @@ describe('query', () => {
             3, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], false, null);
+                ɵɵviewQuery(['foo'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -545,7 +545,7 @@ describe('query', () => {
             2, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], true, null);
+                ɵɵviewQuery(['foo'], true);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -746,7 +746,7 @@ describe('query', () => {
             2, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], false, null);
+                ɵɵviewQuery(['foo'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -817,7 +817,7 @@ describe('query', () => {
             2, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], true, null);
+                ɵɵviewQuery(['foo'], true);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -863,7 +863,7 @@ describe('query', () => {
             2, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], true, null);
+                ɵɵviewQuery(['foo'], true);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -902,7 +902,7 @@ describe('query', () => {
                2, 0, [Child], [],
                function(rf: RenderFlags, ctx: any) {
                  if (rf & RenderFlags.Create) {
-                   ɵɵviewQuery(['foo'], true, null);
+                   ɵɵviewQuery(['foo'], true);
                  }
                  if (rf & RenderFlags.Update) {
                    let tmp: any;
@@ -943,7 +943,7 @@ describe('query', () => {
             3, 0, [Child1, Child2], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo', 'bar'], true, null);
+                ɵɵviewQuery(['foo', 'bar'], true);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -983,8 +983,8 @@ describe('query', () => {
             3, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo'], true, null);
-                ɵɵviewQuery(['bar'], true, null);
+                ɵɵviewQuery(['foo'], true);
+                ɵɵviewQuery(['bar'], true);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -1066,7 +1066,7 @@ describe('query', () => {
             3, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(['foo', 'bar'], false, null);
+                ɵɵviewQuery(['foo', 'bar'], false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -1267,7 +1267,7 @@ describe('query', () => {
             1, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(TemplateRef as any, false, null);
+                ɵɵviewQuery(TemplateRef as any, false);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;
@@ -1316,7 +1316,7 @@ describe('query', () => {
             6, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                ɵɵviewQuery(TemplateRef as any, false, null);
+                ɵɵviewQuery(TemplateRef as any, false);
                 ɵɵviewQuery(TemplateRef as any, false, ElementRef);
               }
               if (rf & RenderFlags.Update) {
@@ -1358,7 +1358,7 @@ describe('query', () => {
           2, 0, [], [],
           function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
-              ɵɵviewQuery(['foo'], false, null);
+              ɵɵviewQuery(['foo'], false);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1440,7 +1440,7 @@ describe('query', () => {
         3, 0, [SomeDir], [],
         function(rf: RenderFlags, ctx: any) {
           if (rf & RenderFlags.Create) {
-            ɵɵviewQuery(['foo'], true, null);
+            ɵɵviewQuery(['foo'], true);
           }
           if (rf & RenderFlags.Update) {
             let tmp: any;
@@ -1476,7 +1476,7 @@ describe('query', () => {
         factory: () => withContentInstance = new WithContentDirective(),
         contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
           if (rf & RenderFlags.Create) {
-            ɵɵcontentQuery(dirIndex, ['foo'], true, null);
+            ɵɵcontentQuery(dirIndex, ['foo'], true);
           }
           if (rf & RenderFlags.Update) {
             let tmp: any;
@@ -1600,7 +1600,7 @@ describe('query', () => {
           5, 0, [WithContentDirective], [],
           function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
-              ɵɵviewQuery(['foo', 'bar'], true, null);
+              ɵɵviewQuery(['foo', 'bar'], true);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1641,7 +1641,7 @@ describe('query', () => {
           5, 0, [WithContentDirective], [],
           function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
-              ɵɵviewQuery(['bar'], true, null);
+              ɵɵviewQuery(['bar'], true);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1667,7 +1667,7 @@ describe('query', () => {
             // @ContentChildren('foo, bar, baz', {descendants: true})
             // fooBars: QueryList<ElementRef>;
             if (rf & RenderFlags.Create) {
-              ɵɵcontentQuery(dirIndex, ['foo', 'bar', 'baz'], true, null);
+              ɵɵcontentQuery(dirIndex, ['foo', 'bar', 'baz'], true);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1731,7 +1731,7 @@ describe('query', () => {
             // @ContentChildren('foo', {descendants: true})
             // fooBars: QueryList<ElementRef>;
             if (rf & RenderFlags.Create) {
-              ɵɵcontentQuery(dirIndex, ['foo'], false, null);
+              ɵɵcontentQuery(dirIndex, ['foo'], false);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1787,7 +1787,7 @@ describe('query', () => {
             // @ContentChildren('foo', {descendants: true})
             // fooBars: QueryList<ElementRef>;
             if (rf & RenderFlags.Create) {
-              ɵɵcontentQuery(dirIndex, ['foo'], false, null);
+              ɵɵcontentQuery(dirIndex, ['foo'], false);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -1847,7 +1847,7 @@ describe('query', () => {
                // @ContentChildren('foo', {descendants: false})
                // foos: QueryList<ElementRef>;
                if (rf & RenderFlags.Create) {
-                 ɵɵcontentQuery(dirIndex, ['foo'], false, null);
+                 ɵɵcontentQuery(dirIndex, ['foo'], false);
                }
                if (rf & RenderFlags.Update) {
                  let tmp: any;
@@ -1868,7 +1868,7 @@ describe('query', () => {
                // @ContentChildren('foo', {descendants: true})
                // foos: QueryList<ElementRef>;
                if (rf & RenderFlags.Create) {
-                 ɵɵcontentQuery(dirIndex, ['foo'], true, null);
+                 ɵɵcontentQuery(dirIndex, ['foo'], true);
                }
                if (rf & RenderFlags.Update) {
                  let tmp: any;
@@ -1944,7 +1944,7 @@ describe('query', () => {
             // @ContentChildren(TextDirective, {descendants: true})
             // texts: QueryList<TextDirective>;
             if (rf & RenderFlags.Create) {
-              ɵɵcontentQuery(dirIndex, TextDirective, true, null);
+              ɵɵcontentQuery(dirIndex, TextDirective, true);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;
@@ -2024,7 +2024,7 @@ describe('query', () => {
           viewQuery: function(rf: RenderFlags, ctx: ViewQueryComponent) {
             let tmp: any;
             if (rf & RenderFlags.Create) {
-              ɵɵviewQuery(TextDirective, true, null);
+              ɵɵviewQuery(TextDirective, true);
             }
             if (rf & RenderFlags.Update) {
               ɵɵqueryRefresh(tmp = ɵɵloadViewQuery<QueryList<TextDirective>>()) &&

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -439,7 +439,7 @@ describe('ViewContainerRef', () => {
           },
           viewQuery: function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
-              ɵɵviewQuery(['foo'], true, null);
+              ɵɵviewQuery(['foo'], true);
             }
             if (rf & RenderFlags.Update) {
               let tmp: any;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -752,7 +752,7 @@ export declare function ɵɵcontainerRefreshEnd(): void;
 
 export declare function ɵɵcontainerRefreshStart(index: number): void;
 
-export declare function ɵɵcontentQuery<T>(directiveIndex: number, predicate: Type<any> | string[], descend: boolean, read: any): void;
+export declare function ɵɵcontentQuery<T>(directiveIndex: number, predicate: Type<any> | string[], descend: boolean, read?: any): void;
 
 export declare const ɵɵdefaultStyleSanitizer: StyleSanitizeFn;
 
@@ -1053,9 +1053,9 @@ export declare function ɵɵsetNgModuleScope(type: any, scope: {
     exports?: Type<any>[] | (() => Type<any>[]);
 }): void;
 
-export declare function ɵɵstaticContentQuery<T>(directiveIndex: number, predicate: Type<any> | string[], descend: boolean, read: any): void;
+export declare function ɵɵstaticContentQuery<T>(directiveIndex: number, predicate: Type<any> | string[], descend: boolean, read?: any): void;
 
-export declare function ɵɵstaticViewQuery<T>(predicate: Type<any> | string[], descend: boolean, read: any): void;
+export declare function ɵɵstaticViewQuery<T>(predicate: Type<any> | string[], descend: boolean, read?: any): void;
 
 export declare function ɵɵstyleMap(styles: {
     [styleName: string]: any;
@@ -1117,7 +1117,7 @@ export declare function ɵɵtextInterpolateV(values: any[]): TsickleIssue1009;
 
 export declare function ɵɵupdateSyntheticHostBinding<T>(propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null): TsickleIssue1009;
 
-export declare function ɵɵviewQuery<T>(predicate: Type<any> | string[], descend: boolean, read: any): void;
+export declare function ɵɵviewQuery<T>(predicate: Type<any> | string[], descend: boolean, read?: any): void;
 
 export declare const PACKAGE_ROOT_URL: InjectionToken<string>;
 


### PR DESCRIPTION
Currently we always generate the `read` parameter for the view and content query instructions, however since most of the time the `read` parameter won't be set, we'll end up generating `null` which adds 5 bytes for each query when minified. These changes make it so that the `read` parameter only gets generated if it has a value.
