### PR TITLE
fix(ivy): DebugNode.query not picking up nodes inserted through Renderer2

### DIFF
--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -517,6 +517,99 @@ class TestCmptWithPropBindings {
       expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
     });
 
+    it('DebugElement.query should work with dynamically created elements', () => {
+      @Directive({
+        selector: '[dir]',
+      })
+      class MyDir {
+        @Input('dir') dir: number|undefined;
+
+        constructor(renderer: Renderer2, element: ElementRef) {
+          const div = renderer.createElement('div');
+          div.classList.add('myclass');
+          renderer.appendChild(element.nativeElement, div);
+        }
+      }
+
+      @Component({
+        selector: 'app-test',
+        template: '<div dir></div>',
+      })
+      class MyComponent {
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
+      const fixture = TestBed.createComponent(MyComponent);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
+    });
+
+    it('DebugElement.query should work with dynamically created descendant elements', () => {
+      @Directive({
+        selector: '[dir]',
+      })
+      class MyDir {
+        @Input('dir') dir: number|undefined;
+
+        constructor(renderer: Renderer2, element: ElementRef) {
+          const outerDiv = renderer.createElement('div');
+          const innerDiv = renderer.createElement('div');
+          const div = renderer.createElement('div');
+
+          div.classList.add('myclass');
+
+          renderer.appendChild(innerDiv, div);
+          renderer.appendChild(outerDiv, innerDiv);
+          renderer.appendChild(element.nativeElement, outerDiv);
+        }
+      }
+
+      @Component({
+        selector: 'app-test',
+        template: '<div dir></div>',
+      })
+      class MyComponent {
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
+      const fixture = TestBed.createComponent(MyComponent);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
+    });
+
+    it('DebugElement.queryAll should pick up both elements inserted via the view and through Renderer2',
+       () => {
+         @Directive({
+           selector: '[dir]',
+         })
+         class MyDir {
+           @Input('dir') dir: number|undefined;
+
+           constructor(renderer: Renderer2, element: ElementRef) {
+             const div = renderer.createElement('div');
+             div.classList.add('myclass');
+             renderer.appendChild(element.nativeElement, div);
+           }
+         }
+
+         @Component({
+           selector: 'app-test',
+           template: '<div dir></div><span class="myclass"></span>',
+         })
+         class MyComponent {
+         }
+
+         TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
+         const fixture = TestBed.createComponent(MyComponent);
+         fixture.detectChanges();
+
+         const results = fixture.debugElement.queryAll(By.css('.myclass'));
+
+         expect(results.map(r => r.nativeElement.nodeName.toLowerCase())).toEqual(['div', 'span']);
+       });
+
     it('should list providerTokens', () => {
       fixture = TestBed.createComponent(ParentComp);
       fixture.detectChanges();


### PR DESCRIPTION
In ViewEngine nodes that were inserted through `Renderer2` would also be picked up by `DebugNode.query` and `DebugNode.queryAll`. This worked because everything in ViewEngine went through `Renderer2` and `DebugRenderer2` in dev mode which was able to keep track of the child nodes as they're being inserted. This no longer works in Ivy, because we don't use `DebugRenderer2` and debug nodes work a little differently. These changes work around the issue by walking the DOM as the logical tree is being walked and looking for matches. Note that this is __not__ optimal, because we're walking similar trees multiple times. ViewEngine could do it more efficiently, because all the insertions go through Renderer2, however that's not the case in Ivy. This approach is being used because:
1. Matching the ViewEngine behavior would mean potentially introducing a depedency from `Renderer2` to Ivy which could bring Ivy code into ViewEngine.
2. We would have to make `Renderer3` "know" about debug nodes.
3. It allows us to capture nodes that were inserted directly via the DOM.
