### PR TITLE
feat(ivy): pass information about used directive selectors on elements

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -8,6 +8,7 @@
 
 import {ParseSourceFile} from '@angular/compiler';
 import * as ts from 'typescript';
+import {ClassDeclaration} from '../../reflection';
 
 /**
  * Describes the kind of identifier found in a template.
@@ -40,7 +41,7 @@ export interface AttributeIdentifier extends TemplateIdentifier { kind: Identifi
 
 /** A reference to a directive node and its selector. */
 interface DirectiveReference {
-  node: ts.Declaration;
+  node: ClassDeclaration;
   selector: string;
 }
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -38,6 +38,11 @@ export interface MethodIdentifier extends TemplateIdentifier { kind: IdentifierK
 /** Describes an element attribute in a template. */
 export interface AttributeIdentifier extends TemplateIdentifier { kind: IdentifierKind.Attribute; }
 
+/** A reference to a directive node and its selector. */
+interface DirectiveReference {
+  node: ts.Declaration;
+  selector: string;
+}
 /**
  * Describes an indexed element in a template. The name of an `ElementIdentifier` is the entire
  * element tag, which can be parsed by an indexer to determine where used directives should be
@@ -50,7 +55,7 @@ export interface ElementIdentifier extends TemplateIdentifier {
   attributes: Set<AttributeIdentifier>;
 
   /** Directives applied to an element. */
-  usedDirectives: Set<ts.Declaration>;
+  usedDirectives: Set<DirectiveReference>;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -157,7 +157,12 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       span: new AbsoluteSourceSpan(start, start + name.length),
       kind: IdentifierKind.Element,
       attributes: new Set(attributes),
-      usedDirectives: new Set(usedDirectives.map(dir => dir.ref.node)),
+      usedDirectives: new Set(usedDirectives.map(dir => {
+        return {
+          node: dir.ref.node,
+          selector: dir.selector,
+        };
+      })),
     };
     this.identifiers.add(elId);
 

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -246,7 +246,20 @@ runInEachFileSystem(() => {
         const refs = getTemplateIdentifiers(boundTemplate);
         const [ref] = Array.from(refs);
         const usedDirectives = (ref as ElementIdentifier).usedDirectives;
-        expect(usedDirectives).toEqual(new Set([declA, declB, declC]));
+        expect(usedDirectives).toEqual(new Set([
+          {
+            node: declA,
+            selector: 'a-selector',
+          },
+          {
+            node: declB,
+            selector: '[b-selector]',
+          },
+          {
+            node: declC,
+            selector: ':not(never-selector)',
+          }
+        ]));
       });
     });
   });


### PR DESCRIPTION
Extend indexing API interface to provide information about used
directives' selectors on template elements. This enables an indexer to
xref element attributes to the directives that match them.

The current way this matching is done is by mapping selectors to indexed
directives. However, this fails in cases where the directive is not
indexed by the indexer API, like for transitive dependencies. This
solution is much more general.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Affects only Angular indexer in g3.

## Other information
