### PR TITLE
feat(bazel): compile targets used for indexing by Kythe with Ivy

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -42,6 +42,11 @@ def compile_strategy(ctx):
     if "compile" in ctx.var:
         strategy = ctx.var["compile"]
 
+    # Enable Angular targets extracted by Kythe Angular indexer to be compiled with the Ivy compiler architecture.
+    # TODO(ayazhafiz): remove once Ivy has landed as the default in g3.
+    if ctx.var.get("GROK_ELLIPSIS_BUILD", None) != None:
+        strategy = "aot"
+
     if strategy not in ["legacy", "aot"]:
         fail("Unknown --define=compile value '%s'" % strategy)
 


### PR DESCRIPTION
This switches all Angular targets to be built with the same Angular compiler architecture (c.n. Ivy) that the Angular indexer uses. This eliminates issues with cross-references to transitive dependencies not being generated because of the way such dependencies are loaded by the legacy compiler arch.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
