### PR TITLE
ci: move the `test_saucelabs_bazel` CircleCI job to `default_workflow`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,31 +656,31 @@ workflows:
       - setup
       - lint:
           requires:
-          - setup
+            - setup
       - test:
           requires:
-          - setup
+            - setup
       - test_ivy_aot:
           requires:
-          - setup
+            - setup
       - build-npm-packages:
           requires:
-          - setup
+            - setup
       - build-ivy-npm-packages:
           requires:
-          - setup
-      - test_aio:
-          requires:
-          - setup
-      - legacy-unit-tests-saucelabs:
-          requires:
-          - setup
-      - deploy_aio:
-          requires:
-            - test_aio
+            - setup
       - legacy-misc-tests:
           requires:
             - build-npm-packages
+      - legacy-unit-tests-saucelabs:
+          requires:
+            - setup
+      - test_aio:
+          requires:
+            - setup
+      - deploy_aio:
+          requires:
+            - test_aio
       - test_aio_local:
           requires:
             - build-npm-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,6 +675,12 @@ workflows:
       - legacy-unit-tests-saucelabs:
           requires:
             - setup
+      - test_saucelabs_bazel:
+          requires:
+            - setup
+          filters:
+            branches:
+              only: master
       - test_aio:
           requires:
             - setup
@@ -733,22 +739,6 @@ workflows:
       - material-unit-tests:
           requires:
             - build-ivy-npm-packages
-
-  saucelabs_tests:
-    jobs:
-      - setup
-      - test_saucelabs_bazel:
-          requires:
-            - setup
-    triggers:
-      - schedule:
-          # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs
-          # frequently as the caretaker needs up-to-date results when merging PRs or creating
-          # a new release. Also we primarily moved the Saucelabs job into a cronjob that doesn't
-          # run for PRs, in order to ensure that PRs are not affected by Saucelabs flakiness or
-          # incidents. This is still guaranteed (even if we run the job every hour).
-          cron: "0 * * * *"
-          filters: *publish_branches_filter
 
   aio_monitoring:
     jobs:


### PR DESCRIPTION
This is a backport of #31636 to 8.0.x.
(We need this in order for the changes to take effect on the 8.0.x branch, because CircleCI reads the config from each branch.)