### PR TITLE
feat(forms): support a generic type for ControlValueAccessor

### DIFF
--- a/packages/forms/src/directives/checkbox_value_accessor.ts
+++ b/packages/forms/src/directives/checkbox_value_accessor.ts
@@ -75,7 +75,7 @@ export class CheckboxControlValueAccessor implements ControlValueAccessor {
    *
    * @param fn The callback function
    */
-  registerOnChange(fn: (_: any) => {}): void {
+  registerOnChange(fn: (_: any) => void): void {
     this.onChange = fn;
   }
 
@@ -85,7 +85,7 @@ export class CheckboxControlValueAccessor implements ControlValueAccessor {
    *
    * @param fn The callback function
    */
-  registerOnTouched(fn: () => {}): void {
+  registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
   }
 

--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -20,7 +20,7 @@ import {InjectionToken} from '@angular/core';
  *
  * @publicApi
  */
-export interface ControlValueAccessor {
+export interface ControlValueAccessor<T = any> {
   /**
    * @description
    * Writes a new value to the element.
@@ -39,9 +39,9 @@ export interface ControlValueAccessor {
    * }
    * ```
    *
-   * @param obj The new value for the element
+   * @param value The new value for the element
    */
-  writeValue(obj: any): void;
+  writeValue(value: T): void;
 
   /**
    * @description
@@ -60,7 +60,7 @@ export interface ControlValueAccessor {
    * The following example stores the provided function as an internal method.
    *
    * ```ts
-   * registerOnChange(fn: (_: any) => void): void {
+   * registerOnChange(fn: (value: any) => void): void {
    *   this._onChange = fn;
    * }
    * ```
@@ -76,7 +76,7 @@ export interface ControlValueAccessor {
    *
    * @param fn The callback function to register
    */
-  registerOnChange(fn: any): void;
+  registerOnChange(fn: (value: T) => void): void;
 
   /**
    * @description
@@ -93,7 +93,7 @@ export interface ControlValueAccessor {
    * The following example stores the provided function as an internal method.
    *
    * ```ts
-   * registerOnTouched(fn: any): void {
+   * registerOnTouched(fn: () => void): void {
    *   this._onTouched = fn;
    * }
    * ```
@@ -109,7 +109,7 @@ export interface ControlValueAccessor {
    *
    * @param fn The callback function to register
    */
-  registerOnTouched(fn: any): void;
+  registerOnTouched(fn: () => void): void;
 
   /**
    * @description

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -176,7 +176,7 @@ export class RadioControlValueAccessor implements ControlValueAccessor, OnDestro
    *
    * @param fn The callback function
    */
-  registerOnChange(fn: (_: any) => {}): void {
+  registerOnChange(fn: (_: any) => void): void {
     this._fn = fn;
     this.onChange = () => {
       fn(this.value);
@@ -199,7 +199,7 @@ export class RadioControlValueAccessor implements ControlValueAccessor, OnDestro
    *
    * @param fn The callback function
    */
-  registerOnTouched(fn: () => {}): void {
+  registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
ControlValueAccessor has no support for a generic type, meaning that when implemented all methods assume a type of `any`.

## What is the new behavior?
ControlValueAccessor now accepts an optional generic type so that all methods that are implemented from this interface receive the appropriate type.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR is related to the following issues and requests:
- #19329 - Issue regarding missing types for `registerOnChange` and `registerOnTouched` (recommend closing after merge).
- #19340 - PR for aforementioned issue, stale and not passing CI (recommend closing after merge).
- #13721 - General issue for strongly typing Reactive forms, for which this is a small step forward.
