### PR TITLE
docs: add links to web.dev/angular guides

### DIFF
--- a/aio/content/guide/accessibility.md
+++ b/aio/content/guide/accessibility.md
@@ -179,3 +179,8 @@ Books
 * "A Web for Everyone: Designing Accessible User Experiences", Sarah Horton and Whitney Quesenbery
 
 * "Inclusive Design Patterns", Heydon Pickering
+
+## More on accessibility
+
+You may also be interested in the following:
+* [Audit your Angular app's accessibility with codelyzer](https://web.dev/accessible-angular-with-codelyzer/).

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -217,3 +217,6 @@ You may also be interested in the following:
 * [Routing and Navigation](guide/router).
 * [Providers](guide/providers).
 * [Types of Feature Modules](guide/module-types).
+* [Route-level code-splitting in Angular](https://web.dev/route-level-code-splitting-in-angular/)
+* [Route preloading strategies in Angular](https://web.dev/route-preloading-in-angular/)
+

--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -631,6 +631,12 @@
             "rev": true,
             "title": "Loiane Training (Português)",
             "url": "https://loiane.training/course/angular/"
+          },
+          "web-dev-angular": {
+            "desc": "Build performant and progressive Angular applications.",
+            "rev": true,
+            "title": "web.dev/angular",
+            "url": "https://web.dev/angular"
           }
         }
       },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

This PR adds the following links to web.dev/angular:

1. Link to the guides in the resource section under "Online Training"
2. Links to code-splitting & preloading in the lazy-loading guide

// cc @robdodson @housseindjirdeh @igorminar