### PR TITLE
fix(ivy): pass real source spans where they are empty

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, EMPTY_SOURCE_SPAN, Expression, Identifiers, ParseError, ParsedHostBindings, R3DependencyMetadata, R3DirectiveMetadata, R3FactoryTarget, R3QueryMetadata, Statement, WrappedNodeExpr, compileDirectiveFromMetadata, makeBindingParser, parseHostBindings, verifyHostBindings} from '@angular/compiler';
+import {ConstantPool, Expression, Identifiers, ParseError, ParsedHostBindings, R3DependencyMetadata, R3DirectiveMetadata, R3FactoryTarget, R3QueryMetadata, Statement, WrappedNodeExpr, compileDirectiveFromMetadata, makeBindingParser, parseHostBindings, verifyHostBindings} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -21,7 +21,7 @@ import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFl
 import {getDirectiveDiagnostics, getProviderDiagnostics} from './diagnostics';
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getConstructorDependencies, isAngularDecorator, readBaseClass, resolveProvidersRequiringFactory, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference} from './util';
+import {createSourceSpan, findAngularDecorator, getConstructorDependencies, isAngularDecorator, readBaseClass, resolveProvidersRequiringFactory, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference} from './util';
 
 const EMPTY_OBJECT: {[key: string]: string} = {};
 const FIELD_DECORATORS = [
@@ -320,7 +320,7 @@ export function extractDirectiveMetadata(
     outputs: {...outputsFromMeta, ...outputsFromFields}, queries, viewQueries, selector,
     fullInheritance: !!(flags & HandlerFlags.FULL_INHERITANCE), type, internalType,
     typeArgumentCount: reflector.getGenericArityOfClass(clazz) || 0,
-    typeSourceSpan: EMPTY_SOURCE_SPAN, usesInheritance, exportAs, providers
+    typeSourceSpan: createSourceSpan(clazz.name), usesInheritance, exportAs, providers
   };
   return {decorator: directive, metadata};
 }
@@ -583,7 +583,7 @@ type StringMap<T> = {
 export function extractHostBindings(
     members: ClassMember[], evaluator: PartialEvaluator, coreModule: string | undefined,
     metadata?: Map<string, ts.Expression>): ParsedHostBindings {
-  let hostMetadata: StringMap<string|Expression> = {};
+  let bindings: ParsedHostBindings = parseHostBindings({});
   if (metadata && metadata.has('host')) {
     const expr = metadata.get('host') !;
     const hostMetaMap = evaluator.evaluate(expr);
@@ -591,6 +591,7 @@ export function extractHostBindings(
       throw new FatalDiagnosticError(
           ErrorCode.VALUE_HAS_WRONG_TYPE, expr, `Decorator host metadata must be an object`);
     }
+    const hostMetadata: StringMap<string|Expression> = {};
     hostMetaMap.forEach((value, key) => {
       // Resolve Enum references to their declared value.
       if (value instanceof EnumValue) {
@@ -613,19 +614,17 @@ export function extractHostBindings(
             `Decorator host metadata must be a string -> string object, but found unparseable value`);
       }
     });
-  }
 
-  const bindings = parseHostBindings(hostMetadata);
+    bindings = parseHostBindings(hostMetadata);
 
-  // TODO: create and provide proper sourceSpan to make error message more descriptive (FW-995)
-  // For now, pass an incorrect (empty) but valid sourceSpan.
-  const errors = verifyHostBindings(bindings, EMPTY_SOURCE_SPAN);
-  if (errors.length > 0) {
-    throw new FatalDiagnosticError(
-        // TODO: provide more granular diagnostic and output specific host expression that triggered
-        // an error instead of the whole host object
-        ErrorCode.HOST_BINDING_PARSE_ERROR, metadata !.get('host') !,
-        errors.map((error: ParseError) => error.msg).join('\n'));
+    const errors = verifyHostBindings(bindings, createSourceSpan(expr));
+    if (errors.length > 0) {
+      throw new FatalDiagnosticError(
+          // TODO: provide more granular diagnostic and output specific host expression that
+          // triggered an error instead of the whole host object.
+          ErrorCode.HOST_BINDING_PARSE_ERROR, metadata !.get('host') !,
+          errors.map((error: ParseError) => error.msg).join('\n'));
+    }
   }
 
   filterToMembersWithDecorator(members, 'HostBinding', coreModule).forEach(({member, decorators}) => {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -479,11 +479,10 @@ export function wrapTypeReference(reflector: ReflectionHost, clazz: ClassDeclara
 /** Creates a ParseSourceSpan for a TypeScript node. */
 export function createSourceSpan(node: ts.Node): ParseSourceSpan {
   const sf = node.getSourceFile();
-  const [startOffset, endOffset] = [node.getStart(), node.end];
+  const [startOffset, endOffset] = [node.getStart(), node.getEnd()];
   const {line: startLine, character: startCol} = sf.getLineAndCharacterOfPosition(startOffset);
   const {line: endLine, character: endCol} = sf.getLineAndCharacterOfPosition(endOffset);
-  const parseSf =
-      new ParseSourceFile(node.getSourceFile().getFullText(), node.getSourceFile().fileName);
+  const parseSf = new ParseSourceFile(sf.getFullText(), sf.fileName);
 
   // +1 because values are zero-indexed.
   return new ParseSourceSpan(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, ExternalExpr, LiteralExpr, R3DependencyMetadata, R3Reference, R3ResolvedDependencyType, WrappedNodeExpr} from '@angular/compiler';
+import {Expression, ExternalExpr, LiteralExpr, ParseLocation, ParseSourceFile, ParseSourceSpan, R3DependencyMetadata, R3Reference, R3ResolvedDependencyType, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../diagnostics';
@@ -474,4 +474,19 @@ export function wrapTypeReference(reflector: ReflectionHost, clazz: ClassDeclara
       new WrappedNodeExpr(dtsClass.name) :
       value;
   return {value, type};
+}
+
+/** Creates a ParseSourceSpan for a TypeScript node. */
+export function createSourceSpan(node: ts.Node): ParseSourceSpan {
+  const sf = node.getSourceFile();
+  const [startOffset, endOffset] = [node.getStart(), node.end];
+  const {line: startLine, character: startCol} = sf.getLineAndCharacterOfPosition(startOffset);
+  const {line: endLine, character: endCol} = sf.getLineAndCharacterOfPosition(endOffset);
+  const parseSf =
+      new ParseSourceFile(node.getSourceFile().getFullText(), node.getSourceFile().fileName);
+
+  // +1 because values are zero-indexed.
+  return new ParseSourceSpan(
+      new ParseLocation(parseSf, startOffset, startLine + 1, startCol + 1),
+      new ParseLocation(parseSf, endOffset, endLine + 1, endCol + 1));
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -77,15 +77,13 @@ runInEachFileSystem(() => {
   // Helpers
   function analyzeDirective(program: ts.Program, dirName: string, hasBaseClass: boolean = false) {
     class TestReflectionHost extends TypeScriptReflectionHost {
-      constructor(checker: ts.TypeChecker, private hasBaseClassReturnValue: boolean) {
-        super(checker);
-      }
+      constructor(checker: ts.TypeChecker) { super(checker); }
 
-      hasBaseClass(_class: ClassDeclaration): boolean { return this.hasBaseClassReturnValue; }
+      hasBaseClass(_class: ClassDeclaration): boolean { return hasBaseClass; }
     }
 
     const checker = program.getTypeChecker();
-    const reflectionHost = new TestReflectionHost(checker, hasBaseClass);
+    const reflectionHost = new TestReflectionHost(checker);
     const evaluator = new PartialEvaluator(reflectionHost, checker, /*dependencyTracker*/ null);
     const metaReader = new LocalMetadataRegistry();
     const dtsReader = new DtsMetadataReader(checker, reflectionHost);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as ts from 'typescript';
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
@@ -16,8 +17,9 @@ import {getDeclaration, makeProgram} from '../../testing';
 import {DirectiveDecoratorHandler} from '../src/directive';
 
 runInEachFileSystem(() => {
+  let _: typeof absoluteFrom;
+
   describe('DirectiveDecoratorHandler', () => {
-    let _: typeof absoluteFrom;
     beforeEach(() => _ = absoluteFrom);
 
     it('should use the `ReflectionHost` to detect class inheritance', () => {
@@ -40,53 +42,81 @@ runInEachFileSystem(() => {
         },
       ]);
 
-      const checker = program.getTypeChecker();
-      const reflectionHost = new TestReflectionHost(checker);
-      const evaluator = new PartialEvaluator(reflectionHost, checker, /* dependencyTracker */ null);
-      const metaReader = new LocalMetadataRegistry();
-      const dtsReader = new DtsMetadataReader(checker, reflectionHost);
-      const scopeRegistry = new LocalModuleScopeRegistry(
-          metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
-          null);
-      const injectableRegistry = new InjectableClassRegistry(reflectionHost);
-      const handler = new DirectiveDecoratorHandler(
-          reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader,
-          NOOP_DEFAULT_IMPORT_RECORDER, injectableRegistry,
-          /* isCore */ false, /* annotateForClosureCompiler */ false);
-
-      const analyzeDirective = (dirName: string) => {
-        const DirNode = getDeclaration(program, _('/entry.ts'), dirName, isNamedClassDeclaration);
-
-        const detected =
-            handler.detect(DirNode, reflectionHost.getDecoratorsOfDeclaration(DirNode));
-        if (detected === undefined) {
-          throw new Error(`Failed to recognize @Directive (${dirName}).`);
-        }
-
-        const {analysis} = handler.analyze(DirNode, detected.metadata);
-        if (analysis === undefined) {
-          throw new Error(`Failed to analyze @Directive (${dirName}).`);
-        }
-
-        return analysis;
-      };
-
       // By default, `TestReflectionHost#hasBaseClass()` returns `false`.
-      const analysis1 = analyzeDirective('TestDir1');
+      const analysis1 = analyzeDirective(program, 'TestDir1');
       expect(analysis1.meta.usesInheritance).toBe(false);
 
       // Tweak `TestReflectionHost#hasBaseClass()` to return true.
-      reflectionHost.hasBaseClassReturnValue = true;
+      TestReflectionHost.hasBaseClassReturnValue = true;
 
-      const analysis2 = analyzeDirective('TestDir2');
+      const analysis2 = analyzeDirective(program, 'TestDir2');
       expect(analysis2.meta.usesInheritance).toBe(true);
+
+      TestReflectionHost.hasBaseClassReturnValue = false;
+    });
+
+    it('should record the source span of a Directive class type', () => {
+      const src = `
+        import {Directive} from '@angular/core';
+
+        @Directive({selector: 'test-dir'})
+        export class TestDir {}
+      `;
+      const {program} = makeProgram([
+        {
+          name: _('/node_modules/@angular/core/index.d.ts'),
+          contents: 'export const Directive: any;',
+        },
+        {
+          name: _('/entry.ts'),
+          contents: src,
+        },
+      ]);
+
+      const analysis = analyzeDirective(program, 'TestDir');
+      const span = analysis.meta.typeSourceSpan;
+      expect(span.toString()).toBe('TestDir');
+      expect(span.start.toString()).toContain('/entry.ts@5:22');
+      expect(span.end.toString()).toContain('/entry.ts@5:29');
     });
   });
 
   // Helpers
   class TestReflectionHost extends TypeScriptReflectionHost {
-    hasBaseClassReturnValue = false;
+    static hasBaseClassReturnValue = false;
 
-    hasBaseClass(clazz: ClassDeclaration): boolean { return this.hasBaseClassReturnValue; }
+    hasBaseClass(_clazz: ClassDeclaration): boolean {
+      return TestReflectionHost.hasBaseClassReturnValue;
+    }
+  }
+
+  function analyzeDirective(program: ts.Program, dirName: string) {
+    const checker = program.getTypeChecker();
+    const reflectionHost = new TestReflectionHost(checker);
+    const evaluator = new PartialEvaluator(reflectionHost, checker, /*dependencyTracker*/ null);
+    const metaReader = new LocalMetadataRegistry();
+    const dtsReader = new DtsMetadataReader(checker, reflectionHost);
+    const scopeRegistry = new LocalModuleScopeRegistry(
+        metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
+        null);
+    const injectableRegistry = new InjectableClassRegistry(reflectionHost);
+    const handler = new DirectiveDecoratorHandler(
+        reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader,
+        NOOP_DEFAULT_IMPORT_RECORDER, injectableRegistry, /*isCore*/ false,
+        /*annotateForClosureCompiler*/ false);
+
+    const DirNode = getDeclaration(program, _('/entry.ts'), dirName, isNamedClassDeclaration);
+
+    const detected = handler.detect(DirNode, reflectionHost.getDecoratorsOfDeclaration(DirNode));
+    if (detected === undefined) {
+      throw new Error(`Failed to recognize @Directive (${dirName}).`);
+    }
+
+    const {analysis} = handler.analyze(DirNode, detected.metadata);
+    if (analysis === undefined) {
+      throw new Error(`Failed to analyze @Directive (${dirName}).`);
+    }
+
+    return analysis;
   }
 });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2897,6 +2897,25 @@ runInEachFileSystem(os => {
               `Unexpected global target 'UnknownTarget' defined for 'click' event. Supported list of global targets: window,document,body.`);
     });
 
+    it('should provide error location for invalid host properties', () => {
+      const compSrc = `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '...',
+          host: {
+            '(click)': 'act() | pipe',
+          }
+        })
+        class FooCmp {}`;
+
+      env.write(`test.ts`, compSrc);
+      const errors = env.driveDiagnostics();
+      expect(errors[0].start).toBe(143);
+      expect(trim(errors[0].messageText as string)).toContain('/test.ts@7:17');
+    });
+
     it('should throw in case pipes are used in host listeners', () => {
       env.write(`test.ts`, `
         import {Component} from '@angular/core';

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2916,7 +2916,9 @@ runInEachFileSystem(os => {
       `);
 
       const errors = env.driveDiagnostics();
-      expect(getDiagnosticSourceCode(errors[0])).toBe('FooCmp');
+      expect(getDiagnosticSourceCode(errors[0])).toBe(`{
+            '(click)': 'act() | pipe',
+          }`);
       expect(errors[0].messageText).toContain('/test.ts@7:17');
     });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -37,6 +37,10 @@ const setClassMetadataRegExp = (expectedType: string): RegExp =>
 
 const testFiles = loadStandardTestFiles();
 
+function getDiagnosticSourceCode(diag: ts.Diagnostic): string {
+  return diag.file !.text.substr(diag.start !, diag.length !);
+}
+
 runInEachFileSystem(os => {
   describe('ngtsc behavioral tests', () => {
     let env !: NgtscTestEnvironment;
@@ -2898,7 +2902,7 @@ runInEachFileSystem(os => {
     });
 
     it('should provide error location for invalid host properties', () => {
-      const compSrc = `
+      env.write('test.ts', `
         import {Component} from '@angular/core';
 
         @Component({
@@ -2908,12 +2912,12 @@ runInEachFileSystem(os => {
             '(click)': 'act() | pipe',
           }
         })
-        class FooCmp {}`;
+        class FooCmp {}
+      `);
 
-      env.write(`test.ts`, compSrc);
       const errors = env.driveDiagnostics();
-      expect(errors[0].start).toBe(143);
-      expect(trim(errors[0].messageText as string)).toContain('/test.ts@7:17');
+      expect(getDiagnosticSourceCode(errors[0])).toBe('FooCmp');
+      expect(errors[0].messageText).toContain('/test.ts@7:17');
     });
 
     it('should throw in case pipes are used in host listeners', () => {

--- a/packages/compiler/src/parse_util.ts
+++ b/packages/compiler/src/parse_util.ts
@@ -7,7 +7,6 @@
  */
 import * as chars from './chars';
 import {CompileIdentifierMetadata, identifierModuleUrl, identifierName} from './compile_metadata';
-import {error} from './util';
 
 export class ParseLocation {
   constructor(
@@ -108,9 +107,6 @@ export class ParseSourceSpan {
     return this.start.file.content.substring(this.start.offset, this.end.offset);
   }
 }
-
-export const EMPTY_PARSE_LOCATION = new ParseLocation(new ParseSourceFile('', ''), 0, 0, 0);
-export const EMPTY_SOURCE_SPAN = new ParseSourceSpan(EMPTY_PARSE_LOCATION, EMPTY_PARSE_LOCATION);
 
 export enum ParseErrorLevel {
   WARNING,


### PR DESCRIPTION
Some consumers of functions that take `ParseSourceSpan`s currently pass
empty and incorrect source spans. This fixes those cases.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
