### PR TITLE
fix(ivy): record correct absolute source span for template binding expressions

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -764,7 +764,7 @@ export class _ParseAST {
         const ast = this.parsePipe();
         const source = this.input.substring(start - this.offset, this.inputIndex - this.offset);
         expression =
-            new ASTWithSource(ast, source, this.location, this.absoluteOffset, this.errors);
+            new ASTWithSource(ast, source, this.location, this.absoluteOffset + start, this.errors);
       }
 
       bindings.push(new TemplateBinding(

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -151,10 +151,10 @@ class HtmlAstToIvyAst implements html.Visitor {
         const templateKey = normalizedName.substring(TEMPLATE_ATTR_PREFIX.length);
 
         const parsedVariables: ParsedVariable[] = [];
-        const absoluteOffset = attribute.valueSpan ? attribute.valueSpan.start.offset :
-                                                     attribute.sourceSpan.start.offset;
+        const absoluteValueOffset = attribute.valueSpan ? attribute.valueSpan.start.offset :
+                                                          attribute.sourceSpan.start.offset;
         this.bindingParser.parseInlineTemplateBinding(
-            templateKey, templateValue, attribute.sourceSpan, absoluteOffset, [],
+            templateKey, templateValue, attribute.sourceSpan, absoluteValueOffset, [],
             templateParsedProperties, parsedVariables);
         templateVariables.push(
             ...parsedVariables.map(v => new t.Variable(v.name, v.value, v.sourceSpan)));

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -151,8 +151,12 @@ class HtmlAstToIvyAst implements html.Visitor {
         const templateKey = normalizedName.substring(TEMPLATE_ATTR_PREFIX.length);
 
         const parsedVariables: ParsedVariable[] = [];
-        const absoluteValueOffset = attribute.valueSpan ? attribute.valueSpan.start.offset :
-                                                          attribute.sourceSpan.start.offset;
+        const absoluteValueOffset = attribute.valueSpan ?
+            attribute.valueSpan.start.offset :
+            // If there is no value span the attribute does not have a value, like `attr` in
+            //`<div attr></div>`. In this case, point to one beyond the attribute name.
+            attribute.sourceSpan.start.offset + attribute.name.length;
+
         this.bindingParser.parseInlineTemplateBinding(
             templateKey, templateValue, attribute.sourceSpan, absoluteValueOffset, [],
             templateParsedProperties, parsedVariables);

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -154,7 +154,8 @@ class HtmlAstToIvyAst implements html.Visitor {
         const absoluteValueOffset = attribute.valueSpan ?
             attribute.valueSpan.start.offset :
             // If there is no value span the attribute does not have a value, like `attr` in
-            //`<div attr></div>`. In this case, point to one beyond the attribute name.
+            //`<div attr></div>`. In this case, point to one character beyond the last character of
+            // the attribute name.
             attribute.sourceSpan.start.offset + attribute.name.length;
 
         this.bindingParser.parseInlineTemplateBinding(

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -61,9 +61,7 @@ export class BindingParser {
               boundProps);
         } else {
           this._reportError(
-              `Value of the host property binding "${
-                  propName}" needs to be a string representing an expression but got "${
-                  expression}" (${typeof expression})`,
+              `Value of the host property binding "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -91,9 +89,7 @@ export class BindingParser {
           this.parseEvent(propName, expression, sourceSpan, sourceSpan, [], targetEvents);
         } else {
           this._reportError(
-              `Value of the host listener "${
-                  propName}" needs to be a string representing an expression but got "${
-                  expression}" (${typeof expression})`,
+              `Value of the host listener "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -361,15 +357,13 @@ export class BindingParser {
 
         default:
           this._reportError(
-              `The provided animation output phase value "${phase}" for "@${
-                  eventName}" is not supported (use start or done)`,
+              `The provided animation output phase value "${phase}" for "@${eventName}" is not supported (use start or done)`,
               sourceSpan);
           break;
       }
     } else {
       this._reportError(
-          `The animation trigger output event (@${
-              eventName}) is missing its phase value name (start or done are currently supported)`,
+          `The animation trigger output event (@${eventName}) is missing its phase value name (start or done are currently supported)`,
           sourceSpan);
     }
   }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -61,7 +61,9 @@ export class BindingParser {
               boundProps);
         } else {
           this._reportError(
-              `Value of the host property binding "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
+              `Value of the host property binding "${
+                  propName}" needs to be a string representing an expression but got "${
+                  expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -89,7 +91,9 @@ export class BindingParser {
           this.parseEvent(propName, expression, sourceSpan, sourceSpan, [], targetEvents);
         } else {
           this._reportError(
-              `Value of the host listener "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
+              `Value of the host listener "${
+                  propName}" needs to be a string representing an expression but got "${
+                  expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -115,10 +119,10 @@ export class BindingParser {
 
   // Parse an inline template binding. ie `<tag *tplKey="<tplValue>">`
   parseInlineTemplateBinding(
-      tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan, absoluteOffset: number,
+      tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan, absoluteValueOffset: number,
       targetMatchableAttrs: string[][], targetProps: ParsedProperty[],
       targetVars: ParsedVariable[]) {
-    const bindings = this._parseTemplateBindings(tplKey, tplValue, sourceSpan, absoluteOffset);
+    const bindings = this._parseTemplateBindings(tplKey, tplValue, sourceSpan, absoluteValueOffset);
 
     for (let i = 0; i < bindings.length; i++) {
       const binding = bindings[i];
@@ -131,7 +135,7 @@ export class BindingParser {
       } else {
         targetMatchableAttrs.push([binding.key, '']);
         this.parseLiteralAttr(
-            binding.key, null, sourceSpan, absoluteOffset, undefined, targetMatchableAttrs,
+            binding.key, null, sourceSpan, absoluteValueOffset, undefined, targetMatchableAttrs,
             targetProps);
       }
     }
@@ -139,12 +143,12 @@ export class BindingParser {
 
   private _parseTemplateBindings(
       tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan,
-      absoluteOffset: number): TemplateBinding[] {
+      absoluteValueOffset: number): TemplateBinding[] {
     const sourceInfo = sourceSpan.start.toString();
 
     try {
       const bindingsResult =
-          this._exprParser.parseTemplateBindings(tplKey, tplValue, sourceInfo, absoluteOffset);
+          this._exprParser.parseTemplateBindings(tplKey, tplValue, sourceInfo, absoluteValueOffset);
       this._reportExpressionParserErrors(bindingsResult.errors, sourceSpan);
       bindingsResult.templateBindings.forEach((binding) => {
         if (binding.expression) {
@@ -357,13 +361,15 @@ export class BindingParser {
 
         default:
           this._reportError(
-              `The provided animation output phase value "${phase}" for "@${eventName}" is not supported (use start or done)`,
+              `The provided animation output phase value "${phase}" for "@${
+                  eventName}" is not supported (use start or done)`,
               sourceSpan);
           break;
       }
     } else {
       this._reportError(
-          `The animation trigger output event (@${eventName}) is missing its phase value name (start or done are currently supported)`,
+          `The animation trigger output event (@${
+              eventName}) is missing its phase value name (start or done are currently supported)`,
           sourceSpan);
     }
   }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -113,7 +113,17 @@ export class BindingParser {
     }
   }
 
-  // Parse an inline template binding. ie `<tag *tplKey="<tplValue>">`
+  /**
+   * Parses an inline template binding, e.g.
+   *    <tag *tplKey="<tplValue>">
+   * @param tplKey template binding name
+   * @param tplValue template binding value
+   * @param sourceSpan span of template binding relative to entire the template
+   * @param absoluteValueOffset start of the tplValue relative to the entire template
+   * @param targetMatchableAttrs potential attributes to match in the template
+   * @param targetProps target property bindings in the template
+   * @param targetVars target variables in the template
+   */
   parseInlineTemplateBinding(
       tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan, absoluteValueOffset: number,
       targetMatchableAttrs: string[][], targetProps: ParsedProperty[],
@@ -137,6 +147,14 @@ export class BindingParser {
     }
   }
 
+  /**
+   * Parses the bindings in an inline template binding, e.g.
+   *    <tag *tplKey="let value1 = prop; let value2 = localVar">
+   * @param tplKey template binding name
+   * @param tplValue template binding value
+   * @param sourceSpan span of template binding relative to entire the template
+   * @param absoluteValueOffset start of the tplValue relative to the entire template
+   */
   private _parseTemplateBindings(
       tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan,
       absoluteValueOffset: number): TemplateBinding[] {

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -330,12 +330,10 @@ describe('expression AST absolute source spans', () => {
           .toContain(['items', new AbsoluteSourceSpan(25, 30)]);
     });
 
-    it('should work with multiple bindings',
-       () => {expect(humanizeExpressionSource(
-                         parse('<div *ngFor="let a of As; let b of Bs"></div>').nodes))
-                  .toEqual(jasmine.arrayContaining([
-                    ['As', new AbsoluteSourceSpan(22, 24)],
-                    ['Bs', new AbsoluteSourceSpan(35, 37)]
-                  ]))});
+    it('should work with multiple bindings', () => {
+      expect(humanizeExpressionSource(parse('<div *ngFor="let a of As; let b of Bs"></div>').nodes))
+          .toEqual(jasmine.arrayContaining(
+              [['As', new AbsoluteSourceSpan(22, 24)], ['Bs', new AbsoluteSourceSpan(35, 37)]]));
+    });
   });
 });

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -322,4 +322,20 @@ describe('expression AST absolute source spans', () => {
       'a:b', new AbsoluteSourceSpan(13, 16)
     ]);
   });
+
+  describe('absolute offsets for template expressions', () => {
+    it('should work for simple cases', () => {
+      expect(
+          humanizeExpressionSource(parse('<div *ngFor="let item of items">{{item}}</div>').nodes))
+          .toContain(['items', new AbsoluteSourceSpan(25, 30)]);
+    });
+
+    it('should work with multiple bindings',
+       () => {expect(humanizeExpressionSource(
+                         parse('<div *ngFor="let a of As; let b of Bs"></div>').nodes))
+                  .toEqual(jasmine.arrayContaining([
+                    ['As', new AbsoluteSourceSpan(22, 24)],
+                    ['Bs', new AbsoluteSourceSpan(35, 37)]
+                  ]))});
+  });
 });


### PR DESCRIPTION
Expressions in an inline template binding are improperly recorded as
spaning an offset calculated from the start of the template binding
attribute key, whereas they should be calculated from the start of the
attribute value, which contains the actual binding AST.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
