### PR TITLE
feat(ivy): expose ClassDeclaration as a public interface

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -9,6 +9,7 @@
 import {ParseSourceFile} from '@angular/compiler';
 import * as ts from 'typescript';
 import {ClassDeclaration} from '../../reflection';
+export {ClassDeclaration} from '../../reflection';
 
 /**
  * Describes the kind of identifier found in a template.

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -8,8 +8,11 @@
 
 import {ParseSourceFile} from '@angular/compiler';
 import * as ts from 'typescript';
-import {ClassDeclaration} from '../../reflection';
-export {ClassDeclaration} from '../../reflection';
+
+/**
+ * A TypeScript declaration that is guaranteed to have a name.
+ */
+export type NamedDeclaration = ts.Declaration & {name: ts.Identifier};
 
 /**
  * Describes the kind of identifier found in a template.
@@ -54,7 +57,7 @@ export interface AttributeIdentifier extends TemplateIdentifier { kind: Identifi
 
 /** A reference to a directive node and its selector. */
 interface DirectiveReference {
-  node: ClassDeclaration;
+  node: NamedDeclaration;
   selector: string;
 }
 /** A base interface for element and template identifiers. */

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -8,10 +8,10 @@
 
 import {BoundTarget, DirectiveMeta, ParseSourceFile} from '@angular/compiler';
 import {Reference} from '../../imports';
-import {ClassDeclaration} from '../../reflection';
+import {NamedDeclaration} from './api';
 
 export interface ComponentMeta extends DirectiveMeta {
-  ref: Reference<ClassDeclaration>;
+  ref: Reference<NamedDeclaration>;
   /**
    * Unparsed selector of the directive.
    */
@@ -23,7 +23,7 @@ export interface ComponentMeta extends DirectiveMeta {
  */
 export interface ComponentInfo {
   /** Component TypeScript class declaration */
-  declaration: ClassDeclaration;
+  declaration: NamedDeclaration;
 
   /** Component template selector if it exists, otherwise null. */
   selector: string|null;


### PR DESCRIPTION
The indexing module uses ClassDeclaration as a type on the public API
surface but does not reexport the ClassDeclaration type. Do so here.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
