### PR TITLE
fix(ivy): DebugElement.triggerEventHandler not picking up events registered via Renderer2

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -28,7 +28,7 @@
       "uncompressed": {
         "runtime-es5": 2932,
         "runtime-es2015": 2938,
-        "main-es5": 555102,
+        "main-es5": 560811,
         "main-es2015": 572938,
         "polyfills-es5": 129161,
         "polyfills-es2015": 53295

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -235,7 +235,13 @@ function wrapListener(
     wrapWithPreventDefault: boolean): EventListener {
   // Note: we are performing most of the work in the listener function itself
   // to optimize listener registration.
-  return function wrapListenerIn_markDirtyAndPreventDefault(e: Event) {
+  return function wrapListenerIn_markDirtyAndPreventDefault(e: any) {
+    // Ivy uses `Function` as a special token that allows us to unwrap the function
+    // so that it can be invoked programmatically by `DebugNode.triggerEventHandler`.
+    if (e === Function) {
+      return listenerFn;
+    }
+
     // In order to be backwards compatible with View Engine, events on component host nodes
     // must also mark the component view itself dirty (i.e. the view that it owns).
     const startView =

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -49,12 +49,20 @@ export function flattenStyles(
 
 function decoratePreventDefault(eventHandler: Function): Function {
   return (event: any) => {
+    // Ivy uses `Function` as a special token that allows us to unwrap the function
+    // so that it can be invoked programmatically by `DebugNode.triggerEventHandler`.
+    if (event === Function) {
+      return eventHandler;
+    }
+
     const allowDefaultBehavior = eventHandler(event);
     if (allowDefaultBehavior === false) {
       // TODO(tbosch): move preventDefault into event plugins...
       event.preventDefault();
       event.returnValue = false;
     }
+
+    return undefined;
   };
 }
 

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -182,6 +182,12 @@ class DefaultServerRenderer2 implements Renderer2 {
 
   private decoratePreventDefault(eventHandler: Function): Function {
     return (event: any) => {
+      // Ivy uses `Function` as a special token that allows us to unwrap the function
+      // so that it can be invoked programmatically by `DebugNode.triggerEventHandler`.
+      if (event === Function) {
+        return eventHandler;
+      }
+
       // Run the event handler inside the ngZone because event handlers are not patched
       // by Zone on the server. This is required only for tests.
       const allowDefaultBehavior = this.ngZone.runGuarded(() => eventHandler(event));
@@ -189,6 +195,8 @@ class DefaultServerRenderer2 implements Renderer2 {
         event.preventDefault();
         event.returnValue = false;
       }
+
+      return undefined;
     };
   }
 }


### PR DESCRIPTION
Fixes Ivy's `DebugElement.triggerEventHandler` to picking up events that have been registered through a `Renderer2`, unlike ViewEngine.

This PR resolves FW-1480.
