### PR TITLE
docs(core): clarify @ContentChild(ren) behavior

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -132,6 +132,9 @@ export interface ContentChildrenDecorator {
    *
    * Content queries are set before the `ngAfterContentInit` callback is called.
    *
+   * Does not retrieve elements or directives that are in other components' templates,
+   * since a component's template is always a black box to its ancestors.
+   *
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
@@ -193,6 +196,9 @@ export interface ContentChildDecorator {
    * the property will be updated.
    *
    * Content queries are set before the `ngAfterContentInit` callback is called.
+   *
+   * Does not retrieve elements or directives that are in other components' templates,
+   * since a component's template is always a black box to its ancestors.
    *
    * **Metadata Properties**:
    *


### PR DESCRIPTION
Describe that @ContentChild(ren) doesn't search within other component templates (doesn't go across "component boundaries").

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
