### PR TITLE
feat(ivy): record the value of a template reference in indexing API

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -52,7 +52,11 @@ export interface MethodIdentifier extends ExpressionIdentifier { kind: Identifie
 /** Describes an element attribute in a template. */
 export interface AttributeIdentifier extends TemplateIdentifier { kind: IdentifierKind.Attribute; }
 
-/** Describes a value of a template reference. */
+/**
+ * Describes a text value of an attribute-like identifier. A template code
+ *   <div #ref="value"></div>
+ * has a value identifier for the text "value".
+ */
 export interface ValueIdentifier extends TemplateIdentifier { kind: IdentifierKind.Value; }
 
 /** A reference to a directive node and its selector. */
@@ -98,7 +102,11 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
     directive: ClassDeclaration | null;
   }|null;
 
-  /** The value of the reference. If the value is empty, this is `null`. */
+  /**
+   * The text value of the reference, e.g. `value` in
+   *   <div #ref="value"></div>
+   * If the value is empty, this is `null`.
+   */
   value: ValueIdentifier|null;
 }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -21,6 +21,7 @@ export enum IdentifierKind {
   Attribute,
   Reference,
   Variable,
+  Value,
 }
 
 /**
@@ -50,6 +51,9 @@ export interface MethodIdentifier extends ExpressionIdentifier { kind: Identifie
 
 /** Describes an element attribute in a template. */
 export interface AttributeIdentifier extends TemplateIdentifier { kind: IdentifierKind.Attribute; }
+
+/** Describes a value of a template reference. */
+export interface ValueIdentifier extends TemplateIdentifier { kind: IdentifierKind.Value; }
 
 /** A reference to a directive node and its selector. */
 interface DirectiveReference {
@@ -93,6 +97,9 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
      */
     directive: ClassDeclaration | null;
   }|null;
+
+  /** The value of the reference. If the value is empty, this is `null`. */
+  value: ValueIdentifier|null;
 }
 
 /** Describes a template variable like "foo" in `<div *ngFor="let foo of foos"></div>`. */

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from '..';
+import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, ValueIdentifier, VariableIdentifier} from '..';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getTemplateIdentifiers} from '../src/template';
 import * as util from './util';
@@ -319,6 +319,7 @@ runInEachFileSystem(() => {
         kind: IdentifierKind.Reference,
         span: new AbsoluteSourceSpan(6, 9),
         target: {node: elementReference, directive: null},
+        value: null,
       }] as TopLevelIdentifier[]));
     });
 
@@ -339,6 +340,7 @@ runInEachFileSystem(() => {
         kind: IdentifierKind.Reference,
         span: new AbsoluteSourceSpan(12, 15),
         target: {node: elementReference, directive: null},
+        value: null,
       }] as TopLevelIdentifier[]));
     });
 
@@ -357,6 +359,7 @@ runInEachFileSystem(() => {
         kind: IdentifierKind.Reference,
         span: new AbsoluteSourceSpan(6, 9),
         target: {node: elementIdentifier, directive: null},
+        value: null,
       };
 
       const refArr = Array.from(refs);
@@ -385,6 +388,7 @@ runInEachFileSystem(() => {
         kind: IdentifierKind.Reference,
         span: new AbsoluteSourceSpan(13, 16),
         target: {node: elementIdentifier, directive: null},
+        value: null,
       };
 
       const refArr = Array.from(refs);
@@ -419,6 +423,27 @@ runInEachFileSystem(() => {
       expect(fooRef.target !.directive).toEqual(declB);
     });
 
+    it('should generate information reference values', () => {
+      const declB = util.getComponentDeclaration('class B {}', 'B');
+      const template = '<div #foo="b-sel" b-selector>';
+      const boundTemplate = util.getBoundTemplate(template, {}, [
+        {selector: '[b-selector]', declaration: declB, exportAs: ['b-sel']},
+      ]);
+
+      const refs = getTemplateIdentifiers(boundTemplate);
+      const refArr = Array.from(refs);
+      let fooRef = refArr.find(id => id.name === 'foo');
+      expect(fooRef).toBeDefined();
+      expect(fooRef !.kind).toBe(IdentifierKind.Reference);
+
+      fooRef = fooRef as ReferenceIdentifier;
+      expect(fooRef.value).toEqual({
+        name: 'b-sel',
+        kind: IdentifierKind.Value,
+        span: new AbsoluteSourceSpan(11, 16),
+      });
+    });
+
     it('should discover references to references', () => {
       const template = `<div #foo (ngSubmit)="do(foo)"></div>`;
       const refs = getTemplateIdentifiers(bind(template));
@@ -434,6 +459,7 @@ runInEachFileSystem(() => {
         kind: IdentifierKind.Reference,
         span: new AbsoluteSourceSpan(6, 9),
         target: {node: elementIdentifier, directive: null},
+        value: null,
       };
 
       const refArr = Array.from(refs);

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -40,10 +40,10 @@ export function getComponentDeclaration(componentStr: string, className: string)
  */
 export function getBoundTemplate(
     template: string, options: ParseTemplateOptions = {},
-    components: Array<{selector: string, declaration: ClassDeclaration}> =
+    components: Array<{selector: string, declaration: ClassDeclaration, exportAs?: string[]}> =
         []): BoundTarget<ComponentMeta> {
   const matcher = new SelectorMatcher<ComponentMeta>();
-  components.forEach(({selector, declaration}) => {
+  components.forEach(({selector, declaration, exportAs}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
       ref: new Reference(declaration),
       selector,
@@ -51,7 +51,7 @@ export function getBoundTemplate(
       isComponent: true,
       inputs: {},
       outputs: {},
-      exportAs: null,
+      exportAs: exportAs || null,
     });
   });
   const binder = new R3TargetBinder(matcher);


### PR DESCRIPTION
An indexer can use the value of a template to cross-reference to the
directive that the reference targets, if any. This enables extraction of
reference value information by adding a new `ValueIdentifier` that is
only used on a new `value` field on `ReferenceIdentifier`s.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
