### PR TITLE
build(zone.js): add changelog gulptask for zone.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,7 @@ gulp.task('tools:build', loadTask('tools-build'));
 gulp.task('check-cycle', loadTask('check-cycle'));
 gulp.task('serve', loadTask('serve', 'default'));
 gulp.task('changelog', loadTask('changelog'));
+gulp.task('changelog:zonejs', loadTask('changelog-zonejs'));
 gulp.task('check-env', () => {/* this is a noop because the env test ran already above */});
 gulp.task('cldr:extract', loadTask('cldr', 'extract'));
 gulp.task('cldr:download', loadTask('cldr', 'download'));

--- a/packages/zone.js/CHANGELOG.md
+++ b/packages/zone.js/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="0.10.0"></a>
+# [0.10.0](https://github.com/angular/angular/compare/7b3bcc2...174770e) (2019-07-26)
+
+
+### Bug Fixes
+
+* **zone.js:** __load_patch and __symbol__ should be in zone_extern for closure compiler ([#31350](https://github.com/angular/angular/issues/31350)) ([6b51ed2](https://github.com/angular/angular/commit/6b51ed2))
+* **zone.js:** don't fire unhandledrejection if Zone handled error ([#31718](https://github.com/angular/angular/issues/31718)) ([c7542a1](https://github.com/angular/angular/commit/c7542a1)), closes [#31701](https://github.com/angular/angular/issues/31701)
+* **zone.js:** don't wrap uncaught promise error. ([#31443](https://github.com/angular/angular/issues/31443)) ([2bb9a65](https://github.com/angular/angular/commit/2bb9a65)), closes [#27840](https://github.com/angular/angular/issues/27840)
+* **zone.js:** fix zone for Jasmine 3.3. ([#31497](https://github.com/angular/angular/issues/31497)) ([c4c340a](https://github.com/angular/angular/commit/c4c340a))
+* **zone.js:** handle MSPointer event correctly ([#31722](https://github.com/angular/angular/issues/31722)) ([2c402d5](https://github.com/angular/angular/commit/2c402d5)), closes [#31699](https://github.com/angular/angular/issues/31699)
+* **zone.js:** handle new api of electron 4 ([#31669](https://github.com/angular/angular/issues/31669)) ([a445826](https://github.com/angular/angular/commit/a445826)), closes [#31668](https://github.com/angular/angular/issues/31668)
+* **zone.js:** hook should set correct current zone ([#31642](https://github.com/angular/angular/issues/31642)) ([17b32b5](https://github.com/angular/angular/commit/17b32b5)), closes [#31641](https://github.com/angular/angular/issues/31641)
+* **zone.js:** move property patch to legacy ([#31660](https://github.com/angular/angular/issues/31660)) ([716af10](https://github.com/angular/angular/commit/716af10)), closes [#31659](https://github.com/angular/angular/issues/31659)
+* **zone.js:** patch shadydom ([#31717](https://github.com/angular/angular/issues/31717)) ([35a025f](https://github.com/angular/angular/commit/35a025f)), closes [#31686](https://github.com/angular/angular/issues/31686)
+* **zone.js:** restore definition of global ([#31453](https://github.com/angular/angular/issues/31453)) ([e6f1b04](https://github.com/angular/angular/commit/e6f1b04)), closes [/github.com/angular/zone.js/commit/71b93711806000d7788e79451478e20d6086aa8a#diff-dd469785fca8680a5b33b1e81c5cfd91R1420](https://github.com//github.com/angular/zone.js/commit/71b93711806000d7788e79451478e20d6086aa8a/issues/diff-dd469785fca8680a5b33b1e81c5cfd91R1420)
+* **zone.js:** should remove on symbol property after removeAllListeners ([#31644](https://github.com/angular/angular/issues/31644)) ([a182714](https://github.com/angular/angular/commit/a182714)), closes [#31643](https://github.com/angular/angular/issues/31643)
+* **zone.js:** update dart zone link ([#31646](https://github.com/angular/angular/issues/31646)) ([7f7033b](https://github.com/angular/angular/commit/7f7033b)), closes [#31645](https://github.com/angular/angular/issues/31645)
+* **zone.js:** zone-mix should import correct browser module ([#31628](https://github.com/angular/angular/issues/31628)) ([87ce4e9](https://github.com/angular/angular/commit/87ce4e9)), closes [#31626](https://github.com/angular/angular/issues/31626)
+
 <a name="0.9.1"></a>
 ## [0.9.1](https://github.com/angular/zone.js/compare/v0.9.0...0.9.1) (2019-04-30)
 
@@ -44,7 +64,7 @@
 
 * **env:** change BLACK_LISTED_EVENTS to DISABLE_EVENTS ([9c65d25](https://github.com/angular/zone.js/commit/9c65d25))
 
-### Build 
+### Build
 
 * **build:** build zone-evergreen.js in es2015, add terser minify support ([2ad936b](https://github.com/angular/zone.js/commit/2ad936b))
 * **build:** upgrade to pass jasmine 3.3 test ([82dfd75](https://github.com/angular/zone.js/commit/82dfd75))

--- a/packages/zone.js/DEVELOPER.md
+++ b/packages/zone.js/DEVELOPER.md
@@ -80,10 +80,24 @@ yarn webdriver-sauce-test
 Releasing
 ---------
 
+- create a new tag in `angular` repo.
+
+```
+$ TAG=<TAG>
+$ git tag $TAG
+```
+
+- create a PR to update `changelog` of zone.js
+
+```
+$ yarn gulp changelog:zonejs
+```
+
+- deploy to npm
+
 To make a `dry-run`, run the following commands.
 ```
 $ VERSION=<version>
-$ git tag 'zone.js-$VERSION'
 $ yarn bazel --output_base=$(mktemp -d) run //packages/zone.js:npm_package.pack --workspace_status_command="echo BUILD_SCM_VERSION $VERSION"
 ```
 

--- a/tools/gulp-tasks/changelog-zonejs.js
+++ b/tools/gulp-tasks/changelog-zonejs.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+module.exports = (gulp) => () => {
+  const tag = process.env.ZONE_TAG;
+  const conventionalChangelog = require('gulp-conventional-changelog');
+  return gulp.src('packages/zone.js/CHANGELOG.md')
+      .pipe(conventionalChangelog(
+          {preset: 'angular'}, {
+            currentTag: tag,
+          },
+          {
+            // Ignore commits that have a different scope than `zone.js`.
+            extendedRegexp: true,
+            grep: '^[^(]+\\(zone\\.js\\)',
+          }))
+      .pipe(gulp.dest('./packages/zone.js/'));
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?
1. add gulp task to generate zone.js changelog
2. update zone.js changelog.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Now this process is still not fully automatically, because by default the changelog gulp task will generate something like 

```
+<a name="8.2.0-next.2"></a>
+# [8.2.0-next.2](https://github.com/angular/angular/compare/2.3.0-rc.0...8.2.0-next.2) (2019-07-26)
+
+
+### Bug Fixes
```
So the `tag` will be the `angular repo` version.

And I am not sure whether we should tag `zone.js` (for example: `0.10.0`) for each release, because this tag will also visible for all angular mono repo.
So if we don't make such kind of tags, we have to use the angular tag. which will be something like `8.2.0-next.2`, and in this PR, I modified it to `0.10.0` manually, I am not sure how to deal with this step.

Please review, thanks.