### PR TITLE
build(docs-infra): upgrade cli command docs sources to 6b6b8f828

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && node scripts/switch-to-ivy",
     "build-with-ivy": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js a8fe15cb6",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 6b6b8f828",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#8.2.x](https://github.com/angular/angular/tree/8.2.x) from [cli-builds#8.1.x](https://github.com/angular/cli-builds/tree/8.1.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/a8fe15cb6...6b6b8f828):

**Modified**
- help/build.json

##