### PR TITLE
test(ivy): fix broken testcase in Windows

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {Diagnostic} from '../src/diagnostics';
 
-import {NGFOR_DECLARATION, TestDeclaration, ngForDts, typecheck} from './test_utils';
+import {TestDeclaration, ngForDeclaration, ngForDts, typecheck} from './test_utils';
 
 runInEachFileSystem(() => {
   describe('template diagnostics', () => {
@@ -46,7 +46,7 @@ runInEachFileSystem(() => {
           
           render(input: string): string { return input; }
         }`,
-          [NGFOR_DECLARATION], [ngForDts()]);
+          [ngForDeclaration()], [ngForDts()]);
 
       expect(messages).toEqual([
         `synthetic.html(61, 64): Argument of type 'number' is not assignable to parameter of type 'string'.`,
@@ -61,7 +61,7 @@ runInEachFileSystem(() => {
           
           render(input: string): string { return input; }
         }`,
-          [NGFOR_DECLARATION], [ngForDts()]);
+          [ngForDeclaration()], [ngForDts()]);
 
       expect(messages).toEqual([]);
     });
@@ -127,7 +127,7 @@ runInEachFileSystem(() => {
             name: string;
           }[];
         }`,
-          [NGFOR_DECLARATION], [ngForDts()]);
+          [ngForDeclaration()], [ngForDts()]);
 
       expect(messages).toEqual([
         `synthetic.html(39, 52): Property 'namme' does not exist on type '{ name: string; }'. Did you mean 'name'?`,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -77,14 +77,16 @@ export function angularCoreDts(): TestFile {
   };
 }
 
-export const NGFOR_DECLARATION: TestDeclaration = {
-  type: 'directive',
-  file: 'ngfor.d.ts',
-  selector: '[ngForOf]',
-  name: 'NgForOf',
-  inputs: {ngForOf: 'ngForOf'},
-  hasNgTemplateContextGuard: true,
-};
+export function ngForDeclaration(): TestDeclaration {
+  return {
+    type: 'directive',
+    file: absoluteFrom('/ngfor.d.ts'),
+    selector: '[ngForOf]',
+    name: 'NgForOf',
+    inputs: {ngForOf: 'ngForOf'},
+    hasNgTemplateContextGuard: true,
+  };
+}
 
 export function ngForDts(): TestFile {
   return {
@@ -124,10 +126,10 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
 export type TestDirective =
     Partial<Pick<TypeCheckableDirectiveMeta, Exclude<keyof TypeCheckableDirectiveMeta, 'ref'>>>&
-    {selector: string, name: string, file?: string, type: 'directive'};
+    {selector: string, name: string, file?: AbsoluteFsPath, type: 'directive'};
 export type TestPipe = {
   name: string,
-  file?: string,
+  file?: AbsoluteFsPath,
   pipeName: string,
   type: 'pipe',
 };
@@ -185,7 +187,7 @@ export function typecheck(
     ...additionalSources,
   ];
   const {program, host, options} = makeProgram(files, {strictNullChecks: true}, undefined, false);
-  const sf = program.getSourceFile('main.ts') !;
+  const sf = program.getSourceFile(absoluteFrom('/main.ts')) !;
   const checker = program.getTypeChecker();
   const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
   const emitter = new ReferenceEmitter([


### PR DESCRIPTION
In #30181, several testcases were added that were failing in Windows.
The reason was that a recent rebase missed a required change to interact
with the compiler's virtualized filesystems. This commit introduces the
required usage of the VFS layer to fix the testcase.
