### PR TITLE
fix(ivy): correctly bind `targetToIdentifier` to the TemplateVisitor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -201,7 +201,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
 
     const identifiers = ExpressionVisitor.getIdentifiers(
         attribute.value, expressionSrc, expressionAbsolutePosition, this.boundTemplate,
-        this.targetToIdentifier);
+        this.targetToIdentifier.bind(this));
     identifiers.forEach(id => this.identifiers.add(id));
   }
   visitBoundEvent(attribute: TmplAstBoundEvent) { this.visitExpression(attribute.handler); }

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -124,6 +124,32 @@ runInEachFileSystem(() => {
         });
       });
 
+      it('should discover variables in bound attributes', () => {
+        const template = '<div #div [value]="div.innerText"></div>';
+        const refs = getTemplateIdentifiers(bind(template));
+        const elementReference: ElementIdentifier = {
+          name: 'div',
+          kind: IdentifierKind.Element,
+          span: new AbsoluteSourceSpan(1, 4),
+          attributes: new Set(),
+          usedDirectives: new Set(),
+        };
+        const reference: ReferenceIdentifier = {
+          name: 'div',
+          kind: IdentifierKind.Reference,
+          span: new AbsoluteSourceSpan(6, 9),
+          target: {node: elementReference, directive: null},
+        };
+
+        const refArr = Array.from(refs);
+        expect(refArr).toContain({
+          name: 'div',
+          kind: IdentifierKind.Property,
+          span: new AbsoluteSourceSpan(19, 22),
+          target: reference,
+        });
+      });
+
       it('should discover properties in template expressions', () => {
         const template = '<div [bar]="bar ? bar1 : bar2"></div>';
         const refs = getTemplateIdentifiers(bind(template));


### PR DESCRIPTION
`TemplateVisitor#visitBoundAttribute` currently has to invoke visiting
expressions manually (this is fixed in #31813). Previously, it did not
bind `targetToIdentifier` to the visitor before deferring to the
expression visitor, which breaks the `targetToIdentifier` code. This
fixes that and adds a test to ensure the closure processed correctly.

This change is urgent; without it, many indexing targets in g3 are
broken.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
