### PR TITLE
feat(bazel): add --config=debug test configuration to bazel schematics .bazelrc

### DIFF
--- a/packages/bazel/src/builders/files/__dot__bazelrc.template
+++ b/packages/bazel/src/builders/files/__dot__bazelrc.template
@@ -25,11 +25,29 @@ test --incompatible_strict_action_env
 
 build --incompatible_bzl_disallow_load_after_statement=false
 
+# Specifies desired output mode for running tests.
+# Valid values are
+#   'summary' to output only test status summary
+#   'errors' to also print test logs for failed tests
+#   'all' to print logs for all tests
+#   'streamed' to output logs for all tests in real time
+#     (this will force tests to be executed locally one at a time regardless of --test_strategy value).
 test --test_output=errors
 
 # Use the Angular 6 compiler
 build --define=compile=legacy
 
-# Turn on managed directories feature in Bazel
-# This allows us to avoid installing a second copy of node_modules
+# Turn on the "Managed Directories" feature.
+# This allows Bazel to share the same node_modules directory with other tools
+# NB: this option was introduced in Bazel 0.26
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_allow_incremental_repository_updates
 common --experimental_allow_incremental_repository_updates
+
+# Support for debugging NodeJS tests
+# Add the Bazel option `--config=debug` to enable this
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+
+# Turn off legacy external runfiles
+# This prevents accidentally depending on this feature, which Bazel will remove.
+run --nolegacy_external_runfiles
+test --nolegacy_external_runfiles


### PR DESCRIPTION
Also adds more verbose comments in the schematics .bazelrc file and adds --nolegacy_external_runfiles flag which is recommended


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No way to put node in debug by passing `--inspect-brk` when running a test with bazel using `--config=debug`.

This is needed to be able to debug rules such a protractor. See https://github.com/angular/angular/pull/30245 as an example.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When using bazel opt-in preview if you leave the bazel files on disk you can put node in debug when running a test with:

`bazel test --config=debug //:test_target`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

