### PR TITLE
docs(router): Compilation error on using matcher option in routes 

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -58,7 +58,7 @@ export type UrlMatchResult = {
  *   return url.length === 1 && url[0].path.endsWith('.html') ? ({consumed: url}) : null;
  * }
  *
- * export const routes = [{ matcher: htmlFiles, component: AnyComponent }];
+ * export const routes = [{ matcher: htmlFiles as UrlMatcher, component: AnyComponent }];
  * ```
  *
  * @publicApi


### PR DESCRIPTION
The given example of using matcher option in Route causes TS compilation error. It expects 
type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult; 

But the provided example shows that 'htmlFiles' function can return UrlMatchResult or null which causes TS compilation error in strict mode.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Using the sample example causes TS compilation error. 

Issue Number: N/A


## What is the new behavior?
Proposes the workaround that works for me. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
