### PR TITLE
feat(service-worker): fixes/improvements related to entering/recovering from `EXISTING_CLIENTS_ONLY` mode

### DIFF
--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1269,6 +1269,22 @@ import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
         brokenLazyServer.assertNoOtherRequests();
       });
 
+      it('recovers from degraded `EXISTING_CLIENTS_ONLY` mode as soon as there is a valid update',
+         async() => {
+           await driver.initialized;
+           expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+           // Install a broken version.
+           scope.updateServerState(brokenServer);
+           await driver.checkForUpdate();
+           expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
+
+           // Install a good version.
+           scope.updateServerState(serverUpdate);
+           await driver.checkForUpdate();
+           expect(driver.state).toBe(DriverReadyState.NORMAL);
+         });
+
       it('ignores invalid `only-if-cached` requests ', async() => {
         const requestFoo = (cache: RequestCache | 'only-if-cached', mode: RequestMode) =>
             makeRequest(scope, '/foo.txt', undefined, {cache, mode});


### PR DESCRIPTION
Some fixes/improvements related to entering and recovering from the `EXISTING_CLIENTS_ONLY` mode. See individual commints for more details:

- **refactor(service-worker): remove redundant argument to `versionFailed()`**
- **test(service-worker): add helper function for making navigation requests**
- **fix(service-worker): keep serving clients on older versions if latest is invalidated**
- **feat(service-worker): recover from `EXISTING_CLIENTS_ONLY` mode when there is a valid update**

Fixes #31109.