### PR TITLE
doc(zone.js): update release documentation

### DIFF
--- a/packages/zone.js/DEVELOPER.md
+++ b/packages/zone.js/DEVELOPER.md
@@ -98,7 +98,8 @@ $ yarn gulp changelog:zonejs
 To make a `dry-run`, run the following commands.
 ```
 $ VERSION=<version>
-$ yarn bazel --output_base=$(mktemp -d) run //packages/zone.js:npm_package.pack --workspace_status_command="echo BUILD_SCM_VERSION $VERSION"
+$ TMP=$(mktemp -d)
+$ ./node_modules/.bin/bazel --output_base=$TMP run //packages/zone.js:npm_package.pack --workspace_status_command="echo BUILD_SCM_VERSION $VERSION"
 ```
 
 If everything looks fine, replace `.pack` with `.publish` to push to the npm registry.


### PR DESCRIPTION
Misko observed that interactive prompt from npm publish to get an otp didn't make it to his terminal, I think removing yarn will fix it.
Also pull out the mktemp command, so that you don't do a needless re-build between the pack (dry-run) and publish steps

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
