### PR TITLE
fix(ivy): ngcc - several dependency related fixes

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -81,7 +81,7 @@ export class DependencyResolver {
 
     let sortedEntryPointNodes: string[];
     if (target) {
-      if (target.compiledByAngular) {
+      if (target.compiledByAngular && graph.hasNode(target.path)) {
         sortedEntryPointNodes = graph.dependenciesOf(target.path);
         sortedEntryPointNodes.push(target.path);
       } else {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -192,6 +192,13 @@ function getTargetedEntryPoints(
   const finder = new TargetedEntryPointFinder(
       fs, config, logger, resolver, basePath, absoluteTargetEntryPointPath, pathMappings);
   const entryPointInfo = finder.findEntryPoints();
+  const invalidTarget = entryPointInfo.invalidEntryPoints.find(
+      i => i.entryPoint.path === absoluteTargetEntryPointPath);
+  if (invalidTarget !== undefined) {
+    throw new Error(
+        `The target entry-point "${invalidTarget.entryPoint.name}" has missing dependencies:\n` +
+        invalidTarget.missingDependencies.map(dep => ` - ${dep}\n`));
+  }
   if (entryPointInfo.entryPoints.length === 0) {
     markNonAngularPackageAsProcessed(fs, absoluteTargetEntryPointPath, propertiesToConsider);
   }

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -190,6 +190,19 @@ runInEachFileSystem(() => {
         expect(sorted.entryPoints).toEqual([]);
       });
 
+      it('should not consider builtin NodeJS modules as missing dependency', () => {
+        spyOn(host, 'findDependencies').and.callFake(createFakeComputeDependencies({
+          [_('/first/index.js')]: {resolved: [], missing: ['fs']},
+        }));
+        const entryPoints = [first];
+        let sorted: SortedEntryPointsInfo;
+
+        sorted = resolver.sortEntryPointsByDependency(entryPoints, first);
+        expect(sorted.entryPoints).toEqual([first]);
+        expect(sorted.invalidEntryPoints).toEqual([]);
+        expect(sorted.ignoredDependencies).toEqual([]);
+      });
+
       it('should use the appropriate DependencyHost for each entry-point', () => {
         const esm5Host = new EsmDependencyHost(fs, moduleResolver);
         const esm2015Host = new EsmDependencyHost(fs, moduleResolver);

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -179,6 +179,17 @@ runInEachFileSystem(() => {
         expect(sorted.entryPoints).toEqual([fifth]);
       });
 
+      it('should not process the provided target if its marked as ignored', () => {
+        spyOn(host, 'findDependencies').and.callFake(createFakeComputeDependencies({
+          [_('/first/index.js')]: {resolved: [], missing: ['/missing']},
+        }));
+        const entryPoints = [first];
+        let sorted: SortedEntryPointsInfo;
+
+        sorted = resolver.sortEntryPointsByDependency(entryPoints, first);
+        expect(sorted.entryPoints).toEqual([]);
+      });
+
       it('should use the appropriate DependencyHost for each entry-point', () => {
         const esm5Host = new EsmDependencyHost(fs, moduleResolver);
         const esm2015Host = new EsmDependencyHost(fs, moduleResolver);

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -179,7 +179,7 @@ runInEachFileSystem(() => {
         expect(sorted.entryPoints).toEqual([fifth]);
       });
 
-      it('should not process the provided target if its marked as ignored', () => {
+      it('should not process the provided target if it has missing dependencies', () => {
         spyOn(host, 'findDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.js')]: {resolved: [], missing: ['/missing']},
         }));
@@ -188,6 +188,8 @@ runInEachFileSystem(() => {
 
         sorted = resolver.sortEntryPointsByDependency(entryPoints, first);
         expect(sorted.entryPoints).toEqual([]);
+        expect(sorted.invalidEntryPoints[0].entryPoint).toEqual(first);
+        expect(sorted.invalidEntryPoints[0].missingDependencies).toEqual(['/missing']);
       });
 
       it('should not consider builtin NodeJS modules as missing dependency', () => {

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -92,6 +92,14 @@ runInEachFileSystem(() => {
         // was not processed.
         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toBeUndefined();
       });
+
+      it('should report an error if a dependency of the target does not exist', () => {
+        expect(() => {
+          mainNgcc({basePath: '/node_modules', targetEntryPointPath: 'invalid-package'});
+        })
+            .toThrowError(
+                'The target entry-point "invalid-package" has missing dependencies:\n - @angular/missing\n');
+      });
     });
 
     describe('early skipping of target entry-point', () => {
@@ -481,6 +489,30 @@ runInEachFileSystem(() => {
           name: _('/dist/local-package/index.d.ts'),
           contents: `export declare class AppComponent {};`
         },
+      ]);
+
+      // An Angular package that has a missing dependency
+      loadTestFiles([
+        {
+          name: _('/node_modules/invalid-package/package.json'),
+          contents: '{"name": "invalid-package", "es2015": "./index.js", "typings": "./index.d.ts"}'
+        },
+        {
+          name: _('/node_modules/invalid-package/index.js'),
+          contents: `
+          import {AppModule} from "@angular/missing";
+          import {Component} from '@angular/core';
+          export class AppComponent {};
+          AppComponent.decorators = [
+            { type: Component, args: [{selector: 'app', template: '<h2>Hello</h2>'}] }
+          ];
+          `
+        },
+        {
+          name: _('/node_modules/invalid-package/index.d.ts'),
+          contents: `export declare class AppComponent {}`
+        },
+        {name: _('/node_modules/invalid-package/index.metadata.json'), contents: 'DUMMY DATA'},
       ]);
     }
   });


### PR DESCRIPTION
**fix(ivy): ngcc - prevent crash when analyzed target is ignored**

ngcc analyzes the dependency structure of the entrypoints it needs to
process, as the compilation of entrypoints is ordering sensitive: any
dependent upon entrypoint must be compiled before its dependees. As part
of the analysis of the dependency graph, it is detected when a
dependency of entrypoint is not installed, in which case that entrypoint
will be marked as ignored.

When a target entrypoint to compile is provided, it could occur that
given target is considered ignored because one of its dependencies might
be missing. This situation was not dealt with currently, instead
resulting in a crash of ngcc.

This commit prevents the crash by taking the above scenario into account.

---

**fix(ivy): ngcc - do not consider builtin NodeJS modules as missing**

ngcc analyzes the dependency structure of the entrypoints it needs to
process, as the compilation of entrypoints is ordering sensitive: any
dependent upon entrypoint must be compiled before its dependees. As part
of the analysis of the dependency graph, it is detected when a
dependency of entrypoint is not installed, in which case that entrypoint
will be marked as ignored.

For libraries that work with Angular Universal to run in NodeJS, imports
into builtin NodeJS modules can be present. ngcc's dependency analyzer
can only resolve imports within the TypeScript compilation, which
builtin modules are not part of. Therefore, such imports would
erroneously cause the entrypoint be become ignored.

This commit fixes the problem by taking the NodeJS builtins into account
when dealing with missing imports.

Fixes #31522