### PR TITLE
fix(build): Run NGC on upgrade modules

### DIFF
--- a/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
+++ b/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
@@ -19,8 +19,6 @@
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/**/schematics/**",
     "node_modules/@angular/**/testing/**",
-    "node_modules/@angular/compiler-cli/**",
-    "node_modules/@angular/common/upgrade*",
-    "node_modules/@angular/router/upgrade*"
+    "node_modules/@angular/compiler-cli/**"
   ]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you try to use an upgrade modules like LocationUpgradeModule, then NGC will break while running over client code due to NGC not having been over any Upgrade modules as a post install step to npm install.

Issue Number: Fixes #31873


## What is the new behavior?
Runs NGC on all Upgrade modules

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
