### PR TITLE
build(zone.js): remove sourceMappingUrl from bundle

### DIFF
--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -100,6 +100,8 @@ genrule(
         ],
         cmd = " && ".join([
             "mkdir -p $(@D)",
+            # remove the last line '//# sourceMappingURL=b[0].umd.js.map' because we don't release
+            # source map for now
             "sed '$$d' $(@D)/" + b[0].replace("-", "_") + "_rollup.es5umd.js > $(@D)/" + b[0] + ".js",
             "cp $(@D)/" + b[0].replace("-", "_") + "_rollup.min.es5umd.js $(@D)/" + b[0] + ".min.js",
         ]),
@@ -174,6 +176,8 @@ genrule(
         ],
         cmd = " && ".join([
             "mkdir -p $(@D)",
+            # remove the last line '//# sourceMappingURL=b[0].umd.js.map' because we don't release
+            # source map for now
             "sed '$$d' $(@D)/" + b.replace("-", "_") + "_rollup.umd.js > $(@D)/" + b + ".js",
             "cp $(@D)/" + b.replace("-", "_") + "_rollup.min.umd.js $(@D)/" + b + ".min.js",
         ]),

--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -100,7 +100,7 @@ genrule(
         ],
         cmd = " && ".join([
             "mkdir -p $(@D)",
-            "cp $(@D)/" + b[0].replace("-", "_") + "_rollup.es5umd.js $(@D)/" + b[0] + ".js",
+            "sed '$$d' $(@D)/" + b[0].replace("-", "_") + "_rollup.es5umd.js > $(@D)/" + b[0] + ".js",
             "cp $(@D)/" + b[0].replace("-", "_") + "_rollup.min.es5umd.js $(@D)/" + b[0] + ".min.js",
         ]),
     )
@@ -174,7 +174,7 @@ genrule(
         ],
         cmd = " && ".join([
             "mkdir -p $(@D)",
-            "cp $(@D)/" + b.replace("-", "_") + "_rollup.umd.js $(@D)/" + b + ".js",
+            "sed '$$d' $(@D)/" + b.replace("-", "_") + "_rollup.umd.js > $(@D)/" + b + ".js",
             "cp $(@D)/" + b.replace("-", "_") + "_rollup.min.umd.js $(@D)/" + b + ".min.js",
         ]),
     )

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -49,11 +49,16 @@ describe('Zone.js npm_package', () => {
     describe('es5', () => {
       it('zone.js(es5) should not contain es6 spread code',
          () => { expect(shx.cat('zone.js')).not.toContain('let value of values'); });
+
+      it('zone.js(es5) should not contain source map comment',
+         () => { expect(shx.cat('zone.js')).not.toContain('sourceMappingURL'); });
     });
 
     describe('es2015', () => {
       it('zone-evergreen.js(es2015) should contain es6 code',
          () => { expect(shx.cat('zone-evergreen.js')).toContain('let value of values'); });
+      it('zone.js(es5) should not contain source map comment',
+         () => { expect(shx.cat('zone-evergreen.js')).not.toContain('sourceMappingURL'); });
     });
 
     describe('dist file list', () => {


### PR DESCRIPTION
Close #31883

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31883 
`zone.js` bundle has an additional line for `sourceMappingUrl`, and the source map file not exists.


## What is the new behavior?
remove the `sourceMappingUrl` line from bundle.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
