### PR TITLE
feat(ivy): provide indexing information for attributes consumed by directives

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -21,6 +21,7 @@ export enum IdentifierKind {
   Attribute,
   Reference,
   Variable,
+  ConsumedBinding,
 }
 
 /**
@@ -99,11 +100,31 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
 export interface VariableIdentifier extends TemplateIdentifier { kind: IdentifierKind.Variable; }
 
 /**
+ * Describes a bound attribute, bound event, or text attribute that is consumed as a binding to a
+ * directive. For example, in a template code like
+ *   <used-component [bound]="value"></used-component>
+ * `bound` is consumed by `boundValue` in
+ *   @Component({
+ *     selector: 'used-component',
+ *     template: './uc.html',
+ *   })
+ *   class UsedComponent {
+ *     @Input('bound') boundValue: BoundValue;
+ *   }
+ */
+export interface ConsumedBindingIdentifier extends TemplateIdentifier {
+  kind: IdentifierKind.ConsumedBinding;
+
+  /** Directive consuming the binding. */
+  consumer: ClassDeclaration;
+}
+
+/**
  * Identifiers recorded at the top level of the template, without any context about the HTML nodes
  * they were discovered in.
  */
 export type TopLevelIdentifier = PropertyIdentifier | MethodIdentifier | ElementIdentifier |
-    TemplateNodeIdentifier | ReferenceIdentifier | VariableIdentifier;
+    TemplateNodeIdentifier | ReferenceIdentifier | VariableIdentifier | ConsumedBindingIdentifier;
 
 /**
  * Describes the absolute byte offsets of a text anchor in a source code.

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -757,4 +757,76 @@ runInEachFileSystem(() => {
       ]));
     });
   });
+
+  describe('generates identifiers for consumed bindings', () => {
+    it('should discover consumed bindings for bound attributes', () => {
+      const declConsumer = util.getComponentDeclaration('class Consumer {}', 'Consumer');
+      const template = '<consumer [bound]="value"></consumer>';
+      const boundTemplate = util.getBoundTemplate(template, {}, [
+        {
+          selector: 'consumer',
+          declaration: declConsumer,
+          inputs: {
+            'bound': 'boundValue',
+          }
+        },
+      ]);
+      const refs = getTemplateIdentifiers(boundTemplate);
+
+      const refArray = Array.from(refs);
+      expect(refArray).toContain({
+        name: 'bound',
+        kind: IdentifierKind.ConsumedBinding,
+        span: new AbsoluteSourceSpan(11, 16),
+        consumer: declConsumer,
+      });
+    });
+
+    it('should discover consumed bindings for bound events', () => {
+      const declConsumer = util.getComponentDeclaration('class Consumer {}', 'Consumer');
+      const template = '<consumer (bound)="value"></consumer>';
+      const boundTemplate = util.getBoundTemplate(template, {}, [
+        {
+          selector: 'consumer',
+          declaration: declConsumer,
+          inputs: {
+            'bound': 'boundValue',
+          }
+        },
+      ]);
+      const refs = getTemplateIdentifiers(boundTemplate);
+
+      const refArray = Array.from(refs);
+      expect(refArray).toContain({
+        name: 'bound',
+        kind: IdentifierKind.ConsumedBinding,
+        span: new AbsoluteSourceSpan(11, 16),
+        consumer: declConsumer,
+      });
+    });
+
+    it('should discover consumed bindings for text attributes', () => {
+      const declConsumer = util.getComponentDeclaration('class Consumer {}', 'Consumer');
+      const template = '<consumer bound="{{value}}"></consumer>';
+      const boundTemplate = util.getBoundTemplate(template, {}, [
+        {
+          selector: 'consumer',
+          declaration: declConsumer,
+          inputs: {
+            'bound': 'boundValue',
+          }
+        },
+      ]);
+      const refs = getTemplateIdentifiers(boundTemplate);
+      debugger;
+
+      const refArray = Array.from(refs);
+      expect(refArray).toContain({
+        name: 'bound',
+        kind: IdentifierKind.ConsumedBinding,
+        span: new AbsoluteSourceSpan(10, 15),
+        consumer: declConsumer,
+      });
+    });
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -818,7 +818,6 @@ runInEachFileSystem(() => {
         },
       ]);
       const refs = getTemplateIdentifiers(boundTemplate);
-      debugger;
 
       const refArray = Array.from(refs);
       expect(refArray).toContain({

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -789,7 +789,7 @@ runInEachFileSystem(() => {
         {
           selector: 'consumer',
           declaration: declConsumer,
-          inputs: {
+          outputs: {
             'bound': 'boundValue',
           }
         },

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -40,19 +40,18 @@ export function getComponentDeclaration(componentStr: string, className: string)
  */
 export function getBoundTemplate(
     template: string, options: ParseTemplateOptions = {},
-    components: Array<
-        {selector: string, declaration: ClassDeclaration, inputs?: {[property: string]: string}}> =
+    components: Array<Partial<ComponentMeta>&{selector: string, declaration: ClassDeclaration}> =
         []): BoundTarget<ComponentMeta> {
   const matcher = new SelectorMatcher<ComponentMeta>();
-  components.forEach(({selector, declaration, inputs}) => {
+  components.forEach(({selector, declaration, isComponent, inputs, outputs, exportAs}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
       ref: new Reference(declaration),
       selector,
       name: declaration.name.getText(),
-      isComponent: true,
+      isComponent: isComponent || true,
       inputs: inputs || {},
-      outputs: {},
-      exportAs: null,
+      outputs: outputs || {},
+      exportAs: exportAs || null,
     });
   });
   const binder = new R3TargetBinder(matcher);

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -40,16 +40,17 @@ export function getComponentDeclaration(componentStr: string, className: string)
  */
 export function getBoundTemplate(
     template: string, options: ParseTemplateOptions = {},
-    components: Array<{selector: string, declaration: ClassDeclaration}> =
+    components: Array<
+        {selector: string, declaration: ClassDeclaration, inputs?: {[property: string]: string}}> =
         []): BoundTarget<ComponentMeta> {
   const matcher = new SelectorMatcher<ComponentMeta>();
-  components.forEach(({selector, declaration}) => {
+  components.forEach(({selector, declaration, inputs}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
       ref: new Reference(declaration),
       selector,
       name: declaration.name.getText(),
       isComponent: true,
-      inputs: {},
+      inputs: inputs || {},
       outputs: {},
       exportAs: null,
     });


### PR DESCRIPTION
Bound attributes, bound events, and text attributes can be consumed by
other directives (most commonly as inputs). Introduce a new
`ConsumedBindingIdentifier` in the indexing API that represents an
consumed attribute and provides the class declaration of the directive
consuming the binding.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No