### PR TITLE
fix(ivy): pass `schemas` field to nested views

### DIFF
--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -76,7 +76,8 @@ export function ɵɵtemplate(
     resolveDirectives(tView, lView, tContainerNode, localRefs || null);
 
     const embeddedTView = tContainerNode.tViews = createTView(
-        -1, templateFn, consts, vars, tView.directiveRegistry, tView.pipeRegistry, null, null);
+        -1, templateFn, consts, vars, tView.directiveRegistry, tView.pipeRegistry, null,
+        tView.schemas);
     if (tView.queries !== null) {
       tView.queries.template(tView, tContainerNode);
       embeddedTView.queries = tView.queries.embeddedTView(tContainerNode);

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {Component, NO_ERRORS_SCHEMA, NgModule} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('NgModule', () => {
@@ -70,6 +71,65 @@ describe('NgModule', () => {
       expect(() => {
         TestBed.createComponent(TestCmp);
         TestBed.createComponent(TestCmp2);
+      }).not.toThrow();
+    });
+  });
+
+  describe('schemas', () => {
+    it('should throw on unknown props if NO_ERRORS_SCHEMA is absent', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `
+          <ng-container *ngIf="condition">
+            <div [unknown-prop]="true"></div>
+          </ng-container>
+        `,
+      })
+      class MyComp {
+        condition = true;
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [MyComp],
+      })
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
+      }).toThrowError(/Can't bind to 'unknown-prop' since it isn't a known property of 'div'/);
+    });
+
+    it('should not throw on unknown props if NO_ERRORS_SCHEMA is present', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `
+          <ng-container *ngIf="condition">
+            <div [unknown-prop]="true"></div>
+          </ng-container>
+        `,
+      })
+      class MyComp {
+        condition = true;
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        schemas: [NO_ERRORS_SCHEMA],
+        declarations: [MyComp],
+      })
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
       }).not.toThrow();
     });
   });


### PR DESCRIPTION
Prior to this commit, the `schemas` configuration was applied to top-level view only. That leads to problems when using unknown props with elements inside nested views (for example generated as a result of *ngIf). This commit passes `schemas` information down to nested views to make sure that all the checks are consistent.

This PR resolves FW-1492.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No