### PR TITLE
build: Do not generate *.umd.min.js for language service

### DIFF
--- a/packages/language-service/bundles/rollup.bzl
+++ b/packages/language-service/bundles/rollup.bzl
@@ -14,7 +14,7 @@ load(
     "ROLLUP_ATTRS",
     "ROLLUP_DEPS_ASPECTS",
     "run_rollup",
-    "run_terser",
+    # "run_terser",
     "write_rollup_config",
 )
 load("//packages/bazel/src:esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "flatten_esm5")
@@ -25,7 +25,8 @@ load("//packages/bazel/src:esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "f
 # have the path hardcoded in them.
 _ROLLUP_OUTPUTS = {
     "build_umd": "%{name}.umd.js",
-    "build_umd_min": "%{name}.umd.min.js",
+    # min bundle is not used at the moment. Disable to speed up build
+    # "build_umd_min": "%{name}.umd.min.js",
 }
 
 DEPS_ASPECTS = [esm5_outputs_aspect]
@@ -41,8 +42,15 @@ def _ls_rollup_bundle(ctx):
         output_format = "amd",
     )
     run_rollup(ctx, esm5_sources, rollup_config, ctx.outputs.build_umd)
-    source_map = run_terser(ctx, ctx.outputs.build_umd, ctx.outputs.build_umd_min)
-    return DefaultInfo(files = depset([ctx.outputs.build_umd, ctx.outputs.build_umd_min, source_map]))
+
+    # source_map = run_terser(ctx, ctx.outputs.build_umd, ctx.outputs.build_umd_min)
+    return DefaultInfo(
+        files = depset([
+            ctx.outputs.build_umd,
+            # ctx.outputs.build_umd_min,
+            # source_map,
+        ]),
+    )
 
 ls_rollup_bundle = rule(
     implementation = _ls_rollup_bundle,


### PR DESCRIPTION
`language-service.umd.min.js` takes a long time to build (because of
running terser), but it is not used at all.
See https://unpkg.com/browse/@angular/language-service@8.1.3/package.json
where 'main' points to the unminified bundle.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
