### PR TITLE
Revert "fix(zone.js): don't wrap uncaught promise error. (#31443)"

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -176,25 +176,20 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         }
         if (queue.length == 0 && state == REJECTED) {
           (promise as any)[symbolState] = REJECTED_NO_CATCH;
-          let uncaughtPromiseError: any;
-          if (value instanceof Error || (value && value.message)) {
-            uncaughtPromiseError = value;
-          } else {
-            try {
-              // try to print more readable error log
-              throw new Error(
-                  'Uncaught (in promise): ' + readableObjectToString(value) +
-                  (value && value.stack ? '\n' + value.stack : ''));
-            } catch (err) {
-              uncaughtPromiseError = err;
-            }
+          try {
+            // try to print more readable error log
+            throw new Error(
+                'Uncaught (in promise): ' + readableObjectToString(value) +
+                (value && value.stack ? '\n' + value.stack : ''));
+          } catch (err) {
+            const error: UncaughtPromiseError = err;
+            error.rejection = value;
+            error.promise = promise;
+            error.zone = Zone.current;
+            error.task = Zone.currentTask !;
+            _uncaughtPromiseErrors.push(error);
+            api.scheduleMicroTask();  // to make sure that it is running
           }
-          uncaughtPromiseError.rejection = value;
-          uncaughtPromiseError.promise = promise;
-          uncaughtPromiseError.zone = Zone.current;
-          uncaughtPromiseError.task = Zone.currentTask !;
-          _uncaughtPromiseErrors.push(uncaughtPromiseError);
-          api.scheduleMicroTask();  // to make sure that it is running
         }
       }
     }

--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -345,8 +345,11 @@ describe(
                 });
             setTimeout((): any => null);
             setTimeout(() => {
+              expect(promiseError !.message)
+                  .toBe(
+                      'Uncaught (in promise): ' + error +
+                      (error !.stack ? '\n' + error !.stack : ''));
               expect((promiseError as any)['rejection']).toBe(error);
-              expect(promiseError).toBe(error);
               expect((promiseError as any)['zone']).toBe(zone);
               expect((promiseError as any)['task']).toBe(task);
               done();
@@ -385,39 +388,6 @@ describe(
             });
           });
         });
-
-        it('should print original information when throw a not error object with a message property',
-           (done) => {
-             let promiseError: Error|null = null;
-             let zone: Zone|null = null;
-             let task: Task|null = null;
-             let rejectObj: TestRejection;
-             queueZone
-                 .fork({
-                   name: 'promise-error',
-                   onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any):
-                                      boolean => {
-                                        promiseError = error;
-                                        delegate.handleError(target, error);
-                                        return false;
-                                      }
-                 })
-                 .run(() => {
-                   zone = Zone.current;
-                   task = Zone.currentTask;
-                   rejectObj = new TestRejection();
-                   rejectObj.prop1 = 'value1';
-                   rejectObj.prop2 = 'value2';
-                   (rejectObj as any).message = 'rejectMessage';
-                   Promise.reject(rejectObj);
-                   expect(promiseError).toBe(null);
-                 });
-             setTimeout((): any => null);
-             setTimeout(() => {
-               expect(promiseError).toEqual(rejectObj as any);
-               done();
-             });
-           });
 
         describe('Promise.race', () => {
           it('should reject the value', () => {

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -84,7 +84,9 @@ describe('FakeAsyncTestZoneSpec', () => {
        () => {
          fakeAsyncTestZone.run(() => {
            Promise.resolve(null).then((_) => { throw new Error('async'); });
-           expect(() => { testZoneSpec.flushMicrotasks(); }).toThrowError(/async/);
+           expect(() => {
+             testZoneSpec.flushMicrotasks();
+           }).toThrowError(/Uncaught \(in promise\): Error: async/);
          });
        });
 
@@ -1169,7 +1171,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
             resolvedPromise.then((_) => { throw new Error('async'); });
             flushMicrotasks();
           })();
-        }).toThrowError(/async/);
+        }).toThrowError(/Uncaught \(in promise\): Error: async/);
       });
 
       it('should complain if a test throws an exception', () => {


### PR DESCRIPTION
This reverts commit 2bb9a6535115ad8ba3c56781a4fe4141936cefe6.

It breaks tests in google3 which rely on the error handling behavior.

After google3 is syncing from this code location we can roll forward with flags as needed.