### PR TITLE
fix(ivy): speed up ngtsc if project has no templates to check

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -59,6 +59,11 @@ export class TypeCheckFile extends Environment {
       source += printer.printNode(ts.EmitHint.Unspecified, stmt, this.contextFile) + '\n';
     }
 
+    // Ensure the template type-checking file is an ES module. Otherwise, it's interpreted as some
+    // kind of global namespace in TS, which forces a full re-typecheck of the user's program that
+    // is somehow more expensive than the initial parse.
+    source += '\nexport const IS_A_MODULE = true;\n';
+
     return ts.createSourceFile(
         this.fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   }


### PR DESCRIPTION
If a project being built with ngtsc has no templates to check, then ngtsc
previously generated an empty typecheck file. This seems to trigger some
pathological behavior in TS where the entire user program is re-checked,
which is extremely expensive. This likely has to do with the fact that the
empty file is not considered an ES module, meaning the module structure of
the program has changed.

This commit causes an export to be produced in the typecheck file regardless
of its other contents, which guarantees that it will be an ES module. The
pathological behavior is avoided and template type-checking is fast once
again.