### PR TITLE
fix(ivy): reuse compilation scope for incremental template changes.

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -75,7 +75,7 @@ export class DecorationAnalyzer {
     new BaseDefDecoratorHandler(this.reflectionHost, this.evaluator, this.isCore),
     new ComponentDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.fullMetaReader,
-        this.scopeRegistry, this.isCore, this.resourceManager, this.rootDirs,
+        this.scopeRegistry, this.scopeRegistry, this.isCore, this.resourceManager, this.rootDirs,
         /* defaultPreserveWhitespaces */ false,
         /* i18nUseExternalIds */ true, this.moduleResolver, this.cycleAnalyzer, this.refEmitter,
         NOOP_DEFAULT_IMPORT_RECORDER),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -18,7 +18,7 @@ import {DirectiveMeta, MetadataReader, MetadataRegistry, extractDirectiveGuards}
 import {flattenInheritedDirectiveMetadata} from '../../metadata/src/inheritance';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
-import {LocalModuleScopeRegistry} from '../../scope';
+import {ComponentScopeReader, LocalModuleScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence, ResolveResult} from '../../transform';
 import {TypeCheckContext} from '../../typecheck';
 import {NoopResourceDependencyRecorder, ResourceDependencyRecorder} from '../../util/src/resource_recorder';
@@ -47,8 +47,8 @@ export class ComponentDecoratorHandler implements
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private metaReader: MetadataReader,
-      private scopeRegistry: LocalModuleScopeRegistry, private isCore: boolean,
-      private resourceLoader: ResourceLoader, private rootDirs: string[],
+      private scopeReader: ComponentScopeReader, private scopeRegistry: LocalModuleScopeRegistry,
+      private isCore: boolean, private resourceLoader: ResourceLoader, private rootDirs: string[],
       private defaultPreserveWhitespaces: boolean, private i18nUseExternalIds: boolean,
       private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
       private refEmitter: ReferenceEmitter, private defaultImportRecorder: DefaultImportRecorder,
@@ -327,7 +327,7 @@ export class ComponentDecoratorHandler implements
       preserveWhitespaces: true,
       leadingTriviaChars: [],
     });
-    const scope = this.scopeRegistry.getScopeForComponent(node);
+    const scope = this.scopeReader.getScopeForComponent(node);
     const selector = analysis.meta.selector;
     const matcher = new SelectorMatcher<DirectiveMeta>();
     if (scope !== null) {
@@ -353,7 +353,7 @@ export class ComponentDecoratorHandler implements
     if (!ts.isClassDeclaration(node)) {
       return;
     }
-    const scope = this.scopeRegistry.getScopeForComponent(node);
+    const scope = this.scopeReader.getScopeForComponent(node);
     const matcher = new SelectorMatcher<DirectiveMeta>();
     if (scope !== null) {
       for (const meta of scope.compilation.directives) {
@@ -377,7 +377,7 @@ export class ComponentDecoratorHandler implements
     const context = node.getSourceFile();
     // Check whether this component was registered with an NgModule. If so, it should be compiled
     // under that module's compilation scope.
-    const scope = this.scopeRegistry.getScopeForComponent(node);
+    const scope = this.scopeReader.getScopeForComponent(node);
     let metadata = analysis.meta;
     if (scope !== null) {
       // Replace the empty components and directives from the analyze() step with a fully expanded

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -60,7 +60,7 @@ runInEachFileSystem(() => {
       const refEmitter = new ReferenceEmitter([]);
 
       const handler = new ComponentDecoratorHandler(
-          reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, false,
+          reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry, false,
           new NoopResourceLoader(), [''], false, true, moduleResolver, cycleAnalyzer, refEmitter,
           NOOP_DEFAULT_IMPORT_RECORDER);
       const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);

--- a/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/scope",
         "//packages/compiler-cli/src/ngtsc/util",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
@@ -12,13 +12,14 @@ import {Reference} from '../../imports';
 import {DirectiveMeta, MetadataReader, MetadataRegistry, NgModuleMeta, PipeMeta} from '../../metadata';
 import {DependencyTracker} from '../../partial_evaluator';
 import {ClassDeclaration} from '../../reflection';
+import {ComponentScopeReader, ComponentScopeRegistry, LocalModuleScope} from '../../scope';
 import {ResourceDependencyRecorder} from '../../util/src/resource_recorder';
 
 /**
  * Accumulates state between compilations.
  */
 export class IncrementalState implements DependencyTracker, MetadataReader, MetadataRegistry,
-    ResourceDependencyRecorder {
+    ResourceDependencyRecorder, ComponentScopeRegistry, ComponentScopeReader {
   private constructor(
       private unchangedFiles: Set<ts.SourceFile>,
       private metadata: Map<ts.SourceFile, FileMetadata>,
@@ -69,32 +70,56 @@ export class IncrementalState implements DependencyTracker, MetadataReader, Meta
   }
 
   getFileDependencies(file: ts.SourceFile): ts.SourceFile[] {
-    const meta = this.metadata.get(file);
-    return meta ? Array.from(meta.fileDependencies) : [];
+    if (!this.metadata.has(file)) {
+      return [];
+    }
+    const meta = this.metadata.get(file) !;
+    return Array.from(meta.fileDependencies);
   }
 
   getNgModuleMetadata(ref: Reference<ClassDeclaration>): NgModuleMeta|null {
-    const metadata = this.metadata.get(ref.node.getSourceFile()) || null;
-    return metadata && metadata.ngModuleMeta.get(ref.node) || null;
+    if (!this.metadata.has(ref.node.getSourceFile())) {
+      return null;
+    }
+    const metadata = this.metadata.get(ref.node.getSourceFile()) !;
+    if (!metadata.ngModuleMeta.has(ref.node)) {
+      return null;
+    }
+    return metadata.ngModuleMeta.get(ref.node) !;
   }
+
   registerNgModuleMetadata(meta: NgModuleMeta): void {
     const metadata = this.ensureMetadata(meta.ref.node.getSourceFile());
     metadata.ngModuleMeta.set(meta.ref.node, meta);
   }
 
   getDirectiveMetadata(ref: Reference<ClassDeclaration>): DirectiveMeta|null {
-    const metadata = this.metadata.get(ref.node.getSourceFile()) || null;
-    return metadata && metadata.directiveMeta.get(ref.node) || null;
+    if (!this.metadata.has(ref.node.getSourceFile())) {
+      return null;
+    }
+    const metadata = this.metadata.get(ref.node.getSourceFile()) !;
+    if (!metadata.directiveMeta.has(ref.node)) {
+      return null;
+    }
+    return metadata.directiveMeta.get(ref.node) !;
   }
+
   registerDirectiveMetadata(meta: DirectiveMeta): void {
     const metadata = this.ensureMetadata(meta.ref.node.getSourceFile());
     metadata.directiveMeta.set(meta.ref.node, meta);
   }
 
   getPipeMetadata(ref: Reference<ClassDeclaration>): PipeMeta|null {
-    const metadata = this.metadata.get(ref.node.getSourceFile()) || null;
-    return metadata && metadata.pipeMeta.get(ref.node) || null;
+    if (!this.metadata.has(ref.node.getSourceFile())) {
+      return null;
+    }
+    const metadata = this.metadata.get(ref.node.getSourceFile()) !;
+    if (!metadata.pipeMeta.has(ref.node)) {
+      return null;
+    }
+    return metadata.pipeMeta.get(ref.node) !;
   }
+
   registerPipeMetadata(meta: PipeMeta): void {
     const metadata = this.ensureMetadata(meta.ref.node.getSourceFile());
     metadata.pipeMeta.set(meta.ref.node, meta);
@@ -103,6 +128,40 @@ export class IncrementalState implements DependencyTracker, MetadataReader, Meta
   recordResourceDependency(file: ts.SourceFile, resourcePath: string): void {
     const metadata = this.ensureMetadata(file);
     metadata.resourcePaths.add(resourcePath);
+  }
+
+  registerComponentScope(clazz: ClassDeclaration, scope: LocalModuleScope): void {
+    const metadata = this.ensureMetadata(clazz.getSourceFile());
+    metadata.componentScope.set(clazz, scope);
+  }
+
+  getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null {
+    if (!this.metadata.has(clazz.getSourceFile())) {
+      return null;
+    }
+    const metadata = this.metadata.get(clazz.getSourceFile()) !;
+    if (!metadata.componentScope.has(clazz)) {
+      return null;
+    }
+    return metadata.componentScope.get(clazz) !;
+  }
+
+  setComponentAsRequiringRemoteScoping(clazz: ClassDeclaration): void {
+    const metadata = this.ensureMetadata(clazz.getSourceFile());
+    metadata.remoteScoping.add(clazz);
+  }
+
+  getRequiresRemoteScope(clazz: ClassDeclaration): boolean|null {
+    // TODO: https://angular-team.atlassian.net/browse/FW-1501
+    // Handle the incremental build case where a component requires remote scoping.
+    // This means that if the the component's template changes, it requires the module to be
+    // re-emitted.
+    // Also, we need to make sure the cycle detector works well across rebuilds.
+    if (!this.metadata.has(clazz.getSourceFile())) {
+      return null;
+    }
+    const metadata = this.metadata.get(clazz.getSourceFile()) !;
+    return metadata.remoteScoping.has(clazz);
   }
 
   private ensureMetadata(sf: ts.SourceFile): FileMetadata {
@@ -131,4 +190,6 @@ class FileMetadata {
   directiveMeta = new Map<ClassDeclaration, DirectiveMeta>();
   ngModuleMeta = new Map<ClassDeclaration, NgModuleMeta>();
   pipeMeta = new Map<ClassDeclaration, PipeMeta>();
+  componentScope = new Map<ClassDeclaration, LocalModuleScope>();
+  remoteScoping = new Set<ClassDeclaration>();
 }

--- a/packages/compiler-cli/src/ngtsc/scope/index.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/index.ts
@@ -7,5 +7,6 @@
  */
 
 export {ExportScope, ScopeData} from './src/api';
+export {ComponentScopeReader, ComponentScopeRegistry, CompoundComponentScopeReader} from './src/component_scope';
 export {DtsModuleScopeResolver, MetadataDtsModuleScopeResolver} from './src/dependency';
 export {LocalModuleScope, LocalModuleScopeRegistry, LocalNgModuleData} from './src/local';

--- a/packages/compiler-cli/src/ngtsc/scope/src/component_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/component_scope.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ClassDeclaration} from '../../reflection';
+import {LocalModuleScope} from './local';
+
+/**
+ * Register information about the compilation scope of components.
+ */
+export interface ComponentScopeRegistry {
+  registerComponentScope(clazz: ClassDeclaration, scope: LocalModuleScope): void;
+  setComponentAsRequiringRemoteScoping(clazz: ClassDeclaration): void;
+}
+
+/**
+ * Read information about the compilation scope of components.
+ */
+export interface ComponentScopeReader {
+  getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null;
+  getRequiresRemoteScope(clazz: ClassDeclaration): boolean|null;
+}
+
+/**
+ * A noop registry that doesn't do anything.
+ *
+ * This can be used in tests and cases where we don't care about the compilation scopes
+ * being registered.
+ */
+export class NoopComponentScopeRegistry implements ComponentScopeRegistry {
+  registerComponentScope(clazz: ClassDeclaration, scope: LocalModuleScope): void {}
+  setComponentAsRequiringRemoteScoping(clazz: ClassDeclaration): void {}
+}
+
+/**
+ * A `ComponentScopeReader` that reads from an ordered set of child readers until it obtains the
+ * requested scope.
+ *
+ * This is used to combine `ComponentScopeReader`s that read from different sources (e.g. from a
+ * registry and from the incremental state).
+ */
+export class CompoundComponentScopeReader implements ComponentScopeReader {
+  constructor(private readers: ComponentScopeReader[]) {}
+
+  getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null {
+    for (const reader of this.readers) {
+      const meta = reader.getScopeForComponent(clazz);
+      if (meta !== null) {
+        return meta;
+      }
+    }
+    return null;
+  }
+
+  getRequiresRemoteScope(clazz: ClassDeclaration): boolean|null {
+    for (const reader of this.readers) {
+      const requiredScoping = reader.getRequiresRemoteScope(clazz);
+      if (requiredScoping !== null) {
+        return requiredScoping;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Previously if only a component template changed then we would know to
rebuild its component source file. But the compilation was incorrect if the
component was part of an NgModule, since we were not capturing the
compilation scope information that had a been acquired from the NgModule
and was not being regenerated since we were not needing to recompile
the NgModule.

Now we register compilation scope information for each component, via the
`ComponentScopeRegistry` interface, so that it is available for incremental
compilation.

The `ComponentDecoratorHandler` now reads the compilation scope from a
`ComponentScopeReader` interface which is implemented as a compound
reader composed of the original `LocalModuleScopeRegistry` and the
`IncrementalState`.

Fixes #31654

