### PR TITLE
fix(ivy): ngcc emits static fields before extra statements

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -29,7 +29,7 @@
         "runtime-es5": 2932,
         "runtime-es2015": 2938,
         "main-es5": 560811,
-        "main-es2015": 572938,
+        "main-es2015": 499846,
         "polyfills-es5": 129161,
         "polyfills-es2015": 53295
       }

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -165,14 +165,12 @@ export function renderDefinitions(
       translateStatement(stmt, imports, NOOP_DEFAULT_IMPORT_RECORDER);
   const print = (stmt: Statement) =>
       printer.printNode(ts.EmitHint.Unspecified, translate(stmt), sourceFile);
-  const definitions = compiledClass.compilation
-                          .map(
-                              c => [createAssignmentStatement(name, c.name, c.initializer)]
-                                       .concat(c.statements)
-                                       .map(print)
-                                       .join('\n'))
-                          .join('\n');
-  return definitions;
+  const statements: Statement[] =
+      compiledClass.compilation.map(c => createAssignmentStatement(name, c.name, c.initializer));
+  for (const c of compiledClass.compilation) {
+    statements.push(...c.statements);
+  }
+  return statements.map(print).join('\n');
 }
 
 /**


### PR DESCRIPTION
This commit changes the emit order of ngcc when a class has multiple static
fields being assigned. Previously, ngcc would emit each static field
followed immediately by any extra statements specified for that field. This
causes issues with downstream tooling such as build optimizer, which expects
all of the static fields for a class to be grouped together. ngtsc already
groups static fields and additional statements. This commit changes ngcc's
ordering to match.
