### PR TITLE
feat(language-service): Introduce 'angularOnly' flag

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -279,7 +279,7 @@ function voidElementAttributeCompletions(info: TemplateInfo, path: AstPath<HtmlA
 
 class ExpressionVisitor extends NullTemplateVisitor {
   private getExpressionScope: () => SymbolTable;
-  result: Completions;
+  result: Completion[]|undefined;
 
   constructor(
       private info: TemplateInfo, private position: number, private attr?: Attribute,

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as tss from 'typescript/lib/tsserverlibrary'
+import * as tss from 'typescript/lib/tsserverlibrary';
 
 import {TemplateInfo} from './common';
 import {locateSymbol} from './locate_symbol';

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -6,11 +6,28 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as tss from 'typescript/lib/tsserverlibrary'
+
 import {TemplateInfo} from './common';
 import {locateSymbol} from './locate_symbol';
-import {Definition} from './types';
+import {Location} from './types';
 
-export function getDefinition(info: TemplateInfo): Definition {
+export function getDefinition(info: TemplateInfo): Location[]|undefined {
   const result = locateSymbol(info);
   return result && result.symbol.definition;
+}
+
+export function ngLocationToTsDefinitionInfo(loc: Location): tss.DefinitionInfo {
+  return {
+    fileName: loc.fileName,
+    textSpan: {
+      start: loc.span.start,
+      length: loc.span.end - loc.span.start,
+    },
+    // TODO(kyliau): Provide more useful info for name, kind and containerKind
+    name: '',  // should be name of symbol but we don't have enough information here.
+    kind: tss.ScriptElementKind.unknown,
+    containerName: loc.fileName,
+    containerKind: tss.ScriptElementKind.unknown,
+  };
 }

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -243,9 +243,9 @@ export interface Completion {
 /**
  * A sequence of completions.
  *
- * @publicApi
+ * @deprecated
  */
-export type Completions = Completion[] | undefined;
+export type Completions = Completion[];
 
 /**
  * A file and span.
@@ -312,7 +312,7 @@ export interface Diagnostic {
 /**
  * A sequence of diagnostic message.
  *
- * @publicApi
+ * @deprecated
  */
 export type Diagnostics = Diagnostic[];
 
@@ -384,17 +384,17 @@ export interface LanguageService {
   /**
    * Returns a list of all error for all templates in the given file.
    */
-  getDiagnostics(fileName: string): Diagnostics|undefined;
+  getDiagnostics(fileName: string): Diagnostic[];
 
   /**
    * Return the completions at the given position.
    */
-  getCompletionsAt(fileName: string, position: number): Completions|undefined;
+  getCompletionsAt(fileName: string, position: number): Completion[]|undefined;
 
   /**
    * Return the definition location for the symbol at position.
    */
-  getDefinitionAt(fileName: string, position: number): Definition|undefined;
+  getDefinitionAt(fileName: string, position: number): Location[]|undefined;
 
   /**
    * Return the hover information for the symbol at position.

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -10,7 +10,7 @@ import 'reflect-metadata';
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions} from '../src/types';
+import {Completion} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
@@ -228,7 +228,8 @@ export class MyComponent {
 });
 
 
-function expectEntries(locationMarker: string, completions: Completions, ...names: string[]) {
+function expectEntries(
+    locationMarker: string, completions: Completion[] | undefined, ...names: string[]) {
   let entries: {[name: string]: boolean} = {};
   if (!completions) {
     throw new Error(


### PR DESCRIPTION
This PR changes the language service to work in two different modes:

1. TS + Angular
   Plugin augments TS language service to provide additonal Angular
   information. This only works with inline template and is meant to be
   used as a local plugin (configured via tsconfig.json).
2. Angular only
   Plugin only provides information on Angular templates, no TS info at
   all. This effectively disables native TS features and is meant for
   internal use only.

Default mode is `angularOnly = false` so that we don't break any users
already using Angular LS as local plugin.

As part of the refactoring, `undefined` is removed from type aliases
because it is considered bad practice.

go/tsstyle#nullableundefined-type-aliases
```
Type aliases must not include |null or |undefined in a union type.
Nullable aliases typically indicate that null values are being passed
around through too many layers of an application, and this clouds the
source of the original issue that resulted in null. They also make it
unclear when specific values on a class or interface might be absent.
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
