### PR TITLE
fix(ivy): correctly associate output bound events with directives

### DIFF
--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -270,28 +270,22 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
 
     // Associate attributes/bindings on the node with directives or with the node itself.
     type BoundNode = BoundAttribute | BoundEvent | TextAttribute;
-    const processAttribute =
-        (attribute: BoundNode, filter: (attribute: BoundNode) => DirectiveT | undefined) => {
-          const dir = filter(attribute);
-          if (dir !== undefined) {
-            this.bindings.set(attribute, dir);
-          } else {
-            this.bindings.set(attribute, node);
-          }
+    const setAttributeBinding =
+        (attribute: BoundNode, ioType: keyof Pick<DirectiveMeta, 'inputs'|'outputs'>) => {
+          const dir = directives.find(dir => dir[ioType].hasOwnProperty(attribute.name));
+          const binding = dir !== undefined ? dir : node;
+          this.bindings.set(attribute, binding);
         };
-    const filterInputs = (attribute: BoundNode) =>
-        directives.find(dir => dir.inputs.hasOwnProperty(attribute.name));
-    const filterOutputs = (attribute: BoundNode) =>
-        directives.find(dir => dir.outputs.hasOwnProperty(attribute.name));
-    // Node attributes, template attributes, and node inputs can be bound to an input on a
-    // directive.
-    node.attributes.forEach(attr => processAttribute(attr, filterInputs));
-    node.inputs.forEach(input => processAttribute(input, filterInputs));
+
+    // Node inputs (bound attributes) and text attributes can be bound to an
+    // input on a directive.
+    node.inputs.forEach(input => setAttributeBinding(input, 'inputs'));
+    node.attributes.forEach(attr => setAttributeBinding(attr, 'inputs'));
     if (node instanceof Template) {
-      node.templateAttrs.forEach(attr => processAttribute(attr, filterInputs));
+      node.templateAttrs.forEach(attr => setAttributeBinding(attr, 'inputs'));
     }
-    // Node outputs can be bound to an output on a directive.
-    node.outputs.forEach(output => processAttribute(output, filterOutputs));
+    // Node outputs (bound events) can be bound to an output on a directive.
+    node.outputs.forEach(output => setAttributeBinding(output, 'outputs'));
 
     // Recurse into the node's children.
     node.children.forEach(child => child.visit(this));

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -31,6 +31,20 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     outputs: {},
     isComponent: false,
   });
+  matcher.addSelectables(CssSelector.parse('[hasOutput]'), {
+    name: 'HasOutput',
+    exportAs: null,
+    inputs: {},
+    outputs: {'outputBinding': 'outputBinding'},
+    isComponent: false,
+  });
+  matcher.addSelectables(CssSelector.parse('[hasInput]'), {
+    name: 'HasInput',
+    exportAs: null,
+    inputs: {'inputBinding': 'inputBinding'},
+    outputs: {},
+    isComponent: false,
+  });
   return matcher;
 }
 
@@ -97,5 +111,51 @@ describe('t2 binding', () => {
     expect(elDirectives).not.toBeNull();
     expect(elDirectives.length).toBe(1);
     expect(elDirectives[0].name).toBe('Dir');
+  });
+
+  describe('matching inputs to consuming directives', () => {
+    it('should work for bound attributes', () => {
+      const template = parseTemplate('<div hasInput [inputBinding]="myValue"></div>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.inputs[0];
+      const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
+      expect(consumer.name).toBe('HasInput');
+    });
+
+    it('should work for text attributes on elements', () => {
+      const template = parseTemplate('<div hasInput inputBinding="{{myValue}}"></div>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.inputs[0];
+      const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
+      expect(consumer.name).toBe('HasInput');
+    });
+
+    it('should work for text attributes on templates', () => {
+      const template =
+          parseTemplate('<ng-template hasInput inputBinding="{{myValue}}"></ng-template>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.inputs[0];
+      const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
+      expect(consumer.name).toBe('HasInput');
+    });
+  });
+
+  describe('matching outputs to consuming directives', () => {
+    it('should work for bound events', () => {
+      const template =
+          parseTemplate('<div hasOutput (outputBinding)="myHandler($event)"></div>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.outputs[0];
+      const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
+      expect(consumer.name).toBe('HasOutput');
+    });
   });
 });

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -125,24 +125,34 @@ describe('t2 binding', () => {
     });
 
     it('should work for text attributes on elements', () => {
-      const template = parseTemplate('<div hasInput inputBinding="{{myValue}}"></div>', '', {});
+      const template = parseTemplate('<div hasInput inputBinding="text"></div>', '', {});
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const res = binder.bind({template: template.nodes});
       const el = template.nodes[0] as a.Element;
-      const attr = el.inputs[0];
+      const attr = el.attributes[1];
       const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
       expect(consumer.name).toBe('HasInput');
     });
 
     it('should work for text attributes on templates', () => {
       const template =
-          parseTemplate('<ng-template hasInput inputBinding="{{myValue}}"></ng-template>', '', {});
+          parseTemplate('<ng-template hasInput inputBinding="text"></ng-template>', '', {});
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const res = binder.bind({template: template.nodes});
       const el = template.nodes[0] as a.Element;
-      const attr = el.inputs[0];
+      const attr = el.attributes[1];
       const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
       expect(consumer.name).toBe('HasInput');
+    });
+
+    it('should bind to then encompassing node when no directive input is matched', () => {
+      const template = parseTemplate('<span dir></span>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.attributes[0];
+      const consumer = res.getConsumerOfBinding(attr);
+      expect(consumer).toEqual(el);
     });
   });
 
@@ -156,6 +166,16 @@ describe('t2 binding', () => {
       const attr = el.outputs[0];
       const consumer = res.getConsumerOfBinding(attr) as DirectiveMeta;
       expect(consumer.name).toBe('HasOutput');
+    });
+
+    it('should bind to the encompassing node when no directive output is matched', () => {
+      const template = parseTemplate('<span dir (fakeOutput)="myHandler($event)"></span>', '', {});
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const res = binder.bind({template: template.nodes});
+      const el = template.nodes[0] as a.Element;
+      const attr = el.outputs[0];
+      const consumer = res.getConsumerOfBinding(attr);
+      expect(consumer).toEqual(el);
     });
   });
 });

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -145,7 +145,7 @@ describe('t2 binding', () => {
       expect(consumer.name).toBe('HasInput');
     });
 
-    it('should bind to then encompassing node when no directive input is matched', () => {
+    it('should bind to the encompassing node when no directive input is matched', () => {
       const template = parseTemplate('<span dir></span>', '', {});
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const res = binder.bind({template: template.nodes});


### PR DESCRIPTION
Previously, bound events were incorrectly bound to directives with
inputs matching the bound event attribute. This fixes that so bound
events can only be bound to directives with matching outputs.

Adds tests for all kinds of directive matching on bound attributes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
