### PR TITLE
fix(router): pass state when routerLink is used on non-anchor elements

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -163,6 +163,7 @@ export class RouterLink {
     const extras = {
       skipLocationChange: attrBoolValue(this.skipLocationChange),
       replaceUrl: attrBoolValue(this.replaceUrl),
+      state: this.state,
     };
     this.router.navigateByUrl(this.urlTree, extras);
     return true;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2049,6 +2049,36 @@ describe('Integration', () => {
              .toEqual({foo: 'bar', navigationId: history.length});
        })));
 
+    it('should support history state on non-a tags',
+       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: ButtonLinkWithState},
+             {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
+
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+
+         const native = fixture.nativeElement.querySelector('button');
+         native.click();
+         advance(fixture);
+
+         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+
+         // Check the history entry
+         const history = (location as any)._history;
+
+         expect(history[history.length - 1].state.foo).toBe('bar');
+         expect(history[history.length - 1].state)
+             .toEqual({foo: 'bar', navigationId: history.length});
+       })));
+
     it('should set href on area elements', fakeAsync(() => {
          @Component({
            selector: 'someRoot',
@@ -4923,6 +4953,13 @@ class LinkWithQueryParamsAndFragment {
 class LinkWithState {
 }
 
+@Component({
+  selector: 'link-cmp',
+  template: `<button [routerLink]="['../simple']" [state]="{foo: 'bar'}">button</button>`,
+})
+class ButtonLinkWithState {
+}
+
 @Component({selector: 'simple-cmp', template: `simple`})
 class SimpleCmp {
 }
@@ -5123,6 +5160,7 @@ class LazyComponent {
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
     LinkWithState,
+    ButtonLinkWithState,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,
@@ -5153,6 +5191,7 @@ class LazyComponent {
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
     LinkWithState,
+    ButtonLinkWithState,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,
@@ -5185,6 +5224,7 @@ class LazyComponent {
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
     LinkWithState,
+    ButtonLinkWithState,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,


### PR DESCRIPTION
Closes #28652

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using `routerLink` with `state` does not work in all cases:

```html
<!-- Works -->
<a [routerLink]="route" [state]="{ 'foo':'bar' }">anchor</a>

<!-- Broken -->
<button [routerLink]="route" [state]="{ 'foo':'bar' }">button</button>
```

Live Demo: https://stackblitz.com/edit/angular-routerlink-state

Issue Number: #28652

## What is the new behavior?

`state` is passed along on any usage of `routerLink`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
