### PR TITLE
build(core): add missing tsconfig-build.json dependency

### DIFF
--- a/packages/core/test/strict_types/BUILD.bazel
+++ b/packages/core/test/strict_types/BUILD.bazel
@@ -7,6 +7,7 @@ ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
     deps = [
+        "//packages:tsconfig-build.json",
         "//packages:tsconfig-test",
     ],
 )


### PR DESCRIPTION
For some reason (on OS/X) this transitive dependency is not being passed
through to the final TS builds that rely on this rule, so the build fails
with a missing file error:

```
The specified path does not exist:
'/.../sandbox/darwin-sandbox/451/execroot/angular/packages/tsconfig-build.json'.
```
