### PR TITLE
refactor(ivy): move directive, component and pipe factories to ngFactory

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 13411,
+        "main": 13266,
         "polyfills": 45340
       }
     }

--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -18,6 +18,9 @@ export class TreeFunction {
   data: TreeNode = emptyTree;
 
   /** @nocollapse */
+  static ngFactoryFn = () => new TreeFunction;
+
+  /** @nocollapse */
   static ngComponentDef = ɵɵdefineComponent({
     type: TreeFunction,
     selectors: [['tree']],
@@ -29,9 +32,6 @@ export class TreeFunction {
     },
     inputs: {data: 'data'}
   });
-
-  /** @nocollapse */
-  static ngFactoryFn = () => new TreeFunction;
 }
 
 export function TreeTpl(rf: ɵRenderFlags, ctx: TreeNode) {

--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -27,9 +27,11 @@ export class TreeFunction {
       // bit of a hack
       TreeTpl(rf, ctx.data);
     },
-    factory: () => new TreeFunction,
     inputs: {data: 'data'}
   });
+
+  /** @nocollapse */
+  static ngFactoryFn = () => new TreeFunction;
 }
 
 export function TreeTpl(rf: ɵRenderFlags, ctx: TreeNode) {

--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -18,7 +18,7 @@ export class TreeFunction {
   data: TreeNode = emptyTree;
 
   /** @nocollapse */
-  static ngFactoryFn = () => new TreeFunction;
+  static ngFactoryDef = () => new TreeFunction;
 
   /** @nocollapse */
   static ngComponentDef = ɵɵdefineComponent({

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -29,5 +29,5 @@ export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from '
 
 export {NgClassImplProvider__POST_R3__ as ɵNgClassImplProvider__POST_R3__, NgClassR2Impl as ɵNgClassR2Impl, NgClassImpl as ɵNgClassImpl} from './directives/ng_class_impl';
 export {NgStyleImplProvider__POST_R3__ as ɵNgStyleImplProvider__POST_R3__, NgStyleR2Impl as ɵNgStyleR2Impl, NgStyleImpl as ɵNgStyleImpl} from './directives/ng_style_impl';
-export {ngStyleDirectiveDef__POST_R3__ as ɵngStyleDirectiveDef__POST_R3__} from './directives/ng_style';
-export {ngClassDirectiveDef__POST_R3__ as ɵngClassDirectiveDef__POST_R3__} from './directives/ng_class';
+export {ngStyleDirectiveDef__POST_R3__ as ɵngStyleDirectiveDef__POST_R3__, ngStyleFactoryFn__POST_R3__ as ɵngStyleFactoryFn__POST_R3__} from './directives/ng_style';
+export {ngClassDirectiveDef__POST_R3__ as ɵngClassDirectiveDef__POST_R3__, ngClassFactoryFn__POST_R3__ as ɵngClassFactoryFn__POST_R3__} from './directives/ng_class';

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -29,5 +29,5 @@ export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from '
 
 export {NgClassImplProvider__POST_R3__ as ɵNgClassImplProvider__POST_R3__, NgClassR2Impl as ɵNgClassR2Impl, NgClassImpl as ɵNgClassImpl} from './directives/ng_class_impl';
 export {NgStyleImplProvider__POST_R3__ as ɵNgStyleImplProvider__POST_R3__, NgStyleR2Impl as ɵNgStyleR2Impl, NgStyleImpl as ɵNgStyleImpl} from './directives/ng_style_impl';
-export {ngStyleDirectiveDef__POST_R3__ as ɵngStyleDirectiveDef__POST_R3__, ngStyleFactoryFn__POST_R3__ as ɵngStyleFactoryFn__POST_R3__} from './directives/ng_style';
-export {ngClassDirectiveDef__POST_R3__ as ɵngClassDirectiveDef__POST_R3__, ngClassFactoryFn__POST_R3__ as ɵngClassFactoryFn__POST_R3__} from './directives/ng_class';
+export {ngStyleDirectiveDef__POST_R3__ as ɵngStyleDirectiveDef__POST_R3__, ngStyleFactoryDef__POST_R3__ as ɵngStyleFactoryDef__POST_R3__} from './directives/ng_style';
+export {ngClassDirectiveDef__POST_R3__ as ɵngClassDirectiveDef__POST_R3__, ngClassFactoryDef__POST_R3__ as ɵngClassFactoryDef__POST_R3__} from './directives/ng_class';

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -46,9 +46,9 @@ export const ngClassDirectiveDef__POST_R3__ = ɵɵdefineDirective({
 
 export const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
 
-export const ngClassFactoryFn__PRE_R3__ = undefined;
-export const ngClassFactoryFn__POST_R3__ = function() {};
-export const ngClassFactoryFn = ngClassFactoryFn__PRE_R3__;
+export const ngClassFactoryDef__PRE_R3__ = undefined;
+export const ngClassFactoryDef__POST_R3__ = function() {};
+export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgClass.
@@ -66,7 +66,7 @@ export const ngClassFactoryFn = ngClassFactoryFn__PRE_R3__;
  */
 export class NgClassBase {
   static ngDirectiveDef: any = ngClassDirectiveDef;
-  static ngFactoryFn: any = ngClassFactoryFn;
+  static ngFactoryDef: any = ngClassFactoryDef;
 
   constructor(protected _delegate: NgClassImpl) {}
 

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -32,7 +32,6 @@ export const ngClassDirectiveDef__PRE_R3__ = undefined;
 export const ngClassDirectiveDef__POST_R3__ = ɵɵdefineDirective({
   type: function() {} as any,
   selectors: null as any,
-  factory: () => {},
   hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
     if (rf & ɵRenderFlags.Create) {
       ɵɵallocHostVars(1);
@@ -46,6 +45,10 @@ export const ngClassDirectiveDef__POST_R3__ = ɵɵdefineDirective({
 });
 
 export const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
+
+export const ngClassFactoryFn__PRE_R3__ = undefined;
+export const ngClassFactoryFn__POST_R3__ = function() {};
+export const ngClassFactoryFn = ngClassFactoryFn__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgClass.
@@ -63,6 +66,7 @@ export const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
  */
 export class NgClassBase {
   static ngDirectiveDef: any = ngClassDirectiveDef;
+  static ngFactoryFn: any = ngClassFactoryFn;
 
   constructor(protected _delegate: NgClassImpl) {}
 

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -25,6 +25,7 @@ import {NgStyleImpl, NgStyleImplProvider} from './ng_style_impl';
 
 // used when the VE is present
 export const ngStyleDirectiveDef__PRE_R3__ = undefined;
+export const ngStyleFactoryFn__PRE_R3__ = undefined;
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
@@ -32,7 +33,6 @@ export const ngStyleDirectiveDef__PRE_R3__ = undefined;
 export const ngStyleDirectiveDef__POST_R3__ = ɵɵdefineDirective({
   type: function() {} as any,
   selectors: null as any,
-  factory: () => {},
   hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
     if (rf & ɵRenderFlags.Create) {
       ɵɵstyling();
@@ -44,7 +44,10 @@ export const ngStyleDirectiveDef__POST_R3__ = ɵɵdefineDirective({
   }
 });
 
+export const ngStyleFactoryFn__POST_R3__ = function() {};
+
 export const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
+export const ngStyleFactoryFn = ngStyleDirectiveDef__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgStyle.
@@ -62,6 +65,7 @@ export const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
  */
 export class NgStyleBase {
   static ngDirectiveDef: any = ngStyleDirectiveDef;
+  static ngFactoryFn: any = ngStyleFactoryFn;
 
   constructor(protected _delegate: NgStyleImpl) {}
 

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -25,7 +25,7 @@ import {NgStyleImpl, NgStyleImplProvider} from './ng_style_impl';
 
 // used when the VE is present
 export const ngStyleDirectiveDef__PRE_R3__ = undefined;
-export const ngStyleFactoryFn__PRE_R3__ = undefined;
+export const ngStyleFactoryDef__PRE_R3__ = undefined;
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
@@ -44,10 +44,10 @@ export const ngStyleDirectiveDef__POST_R3__ = ɵɵdefineDirective({
   }
 });
 
-export const ngStyleFactoryFn__POST_R3__ = function() {};
+export const ngStyleFactoryDef__POST_R3__ = function() {};
 
 export const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
-export const ngStyleFactoryFn = ngStyleDirectiveDef__PRE_R3__;
+export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgStyle.
@@ -65,7 +65,7 @@ export const ngStyleFactoryFn = ngStyleDirectiveDef__PRE_R3__;
  */
 export class NgStyleBase {
   static ngDirectiveDef: any = ngStyleDirectiveDef;
-  static ngFactoryFn: any = ngStyleFactoryFn;
+  static ngFactory: any = ngStyleFactoryDef;
 
   constructor(protected _delegate: NgStyleImpl) {}
 

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -119,7 +119,7 @@ runInEachFileSystem(() => {
       const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
       expect(typingsFile.contents)
           .toContain(
-              'foo(x: number): number;\n    static ngDirectiveDef: ɵngcc0.ɵɵDirectiveDefWithMeta');
+              'foo(x: number): number;\n    static ngFactoryFn: ɵngcc0.ɵɵFactoryFn<A>;\n    static ngDirectiveDef: ɵngcc0.ɵɵDirectiveDefWithMeta');
     });
 
     it('should render imports into typings files', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -119,7 +119,7 @@ runInEachFileSystem(() => {
       const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
       expect(typingsFile.contents)
           .toContain(
-              'foo(x: number): number;\n    static ngFactoryFn: ɵngcc0.ɵɵFactoryFn<A>;\n    static ngDirectiveDef: ɵngcc0.ɵɵDirectiveDefWithMeta');
+              'foo(x: number): number;\n    static ngFactoryDef: ɵngcc0.ɵɵFactoryDef<A>;\n    static ngDirectiveDef: ɵngcc0.ɵɵDirectiveDefWithMeta');
     });
 
     it('should render imports into typings files', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -188,13 +188,12 @@ runInEachFileSystem(() => {
             decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
         const addDefinitionsSpy = testFormatter.addDefinitions as jasmine.Spy;
         expect(addDefinitionsSpy.calls.first().args[2])
-            .toEqual(
-                `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
+            .toEqual(`A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
+A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
     } if (rf & 2) {
         ɵngcc0.ɵɵtextInterpolate(ctx.person.name);
     } }, encapsulation: 2 });
-A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Component,
         args: [{ selector: 'a', template: '{{ person!.name }}' }]
@@ -228,10 +227,10 @@ A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
                name: 'A',
                decorators: [jasmine.objectContaining({name: 'Directive'})]
              }));
+
              expect(addDefinitionsSpy.calls.first().args[2])
-                 .toEqual(
-                     `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
-A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
+                 .toEqual(`A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
+A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Directive,
         args: [{ selector: '[a]' }]

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -189,11 +189,12 @@ runInEachFileSystem(() => {
         const addDefinitionsSpy = testFormatter.addDefinitions as jasmine.Spy;
         expect(addDefinitionsSpy.calls.first().args[2])
             .toEqual(
-                `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
+                `A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
     } if (rf & 2) {
         ɵngcc0.ɵɵtextInterpolate(ctx.person.name);
     } }, encapsulation: 2 });
+A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Component,
         args: [{ selector: 'a', template: '{{ person!.name }}' }]
@@ -229,7 +230,8 @@ runInEachFileSystem(() => {
              }));
              expect(addDefinitionsSpy.calls.first().args[2])
                  .toEqual(
-                     `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); } });
+                     `A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
+A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Directive,
         args: [{ selector: '[a]' }]

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -188,7 +188,7 @@ runInEachFileSystem(() => {
             decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
         const addDefinitionsSpy = testFormatter.addDefinitions as jasmine.Spy;
         expect(addDefinitionsSpy.calls.first().args[2])
-            .toEqual(`A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
+            .toEqual(`A.ngFactoryDef = function A_Factory(t) { return new (t || A)(); };
 A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
     } if (rf & 2) {
@@ -229,7 +229,7 @@ A.ngComponentDef = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], co
              }));
 
              expect(addDefinitionsSpy.calls.first().args[2])
-                 .toEqual(`A.ngFactoryFn = function A_Factory(t) { return new (t || A)(); };
+                 .toEqual(`A.ngFactoryDef = function A_Factory(t) { return new (t || A)(); };
 A.ngDirectiveDef = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Directive,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -26,7 +26,7 @@ import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 
 import {ResourceLoader} from './api';
 import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
-import {getNgFactoryFnCompileResult} from './factory';
+import {compileNgFactoryField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReference, readBaseClass, unwrapExpression} from './util';
 
@@ -519,8 +519,12 @@ export class ComponentDecoratorHandler implements
 
   compile(node: ClassDeclaration, analysis: ComponentHandlerData, pool: ConstantPool):
       CompileResult[] {
-    const res = compileComponentFromMetadata(analysis.meta, pool, makeBindingParser());
-    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt);
+    const meta = analysis.meta;
+    const res = compileComponentFromMetadata(meta, pool, makeBindingParser());
+    const factoryRes = compileNgFactoryField(meta);
+    if (analysis.metadataStmt !== null) {
+      factoryRes.statements.push(analysis.metadataStmt);
+    }
     return [
       factoryRes, {
         name: 'ngComponentDef',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -517,18 +517,21 @@ export class ComponentDecoratorHandler implements
   }
 
   compile(node: ClassDeclaration, analysis: ComponentHandlerData, pool: ConstantPool):
-      CompileResult {
+      CompileResult[] {
     const res = compileComponentFromMetadata(analysis.meta, pool, makeBindingParser());
 
     const statements = res.statements;
     if (analysis.metadataStmt !== null) {
       statements.push(analysis.metadataStmt);
     }
-    return {
-      name: 'ngComponentDef',
-      initializer: res.expression, statements,
-      type: res.type,
-    };
+    return [
+      {
+        name: 'ngComponentDef',
+        initializer: res.expression, statements,
+        type: res.type,
+      },
+      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+    ];
   }
 
   private _resolveLiteral(decorator: Decorator): ts.ObjectLiteralExpression {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -26,6 +26,7 @@ import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 
 import {ResourceLoader} from './api';
 import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
+import {getNgFactoryFnCompileResult} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReference, readBaseClass, unwrapExpression} from './util';
 
@@ -519,18 +520,14 @@ export class ComponentDecoratorHandler implements
   compile(node: ClassDeclaration, analysis: ComponentHandlerData, pool: ConstantPool):
       CompileResult[] {
     const res = compileComponentFromMetadata(analysis.meta, pool, makeBindingParser());
-
-    const statements = res.statements;
-    if (analysis.metadataStmt !== null) {
-      statements.push(analysis.metadataStmt);
-    }
+    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt);
     return [
-      {
+      factoryRes, {
         name: 'ngComponentDef',
-        initializer: res.expression, statements,
+        initializer: res.expression,
+        statements: [],
         type: res.type,
-      },
-      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+      }
     ];
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -26,7 +26,7 @@ import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 
 import {ResourceLoader} from './api';
 import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
-import {compileNgFactoryField} from './factory';
+import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReference, readBaseClass, unwrapExpression} from './util';
 
@@ -521,7 +521,7 @@ export class ComponentDecoratorHandler implements
       CompileResult[] {
     const meta = analysis.meta;
     const res = compileComponentFromMetadata(meta, pool, makeBindingParser());
-    const factoryRes = compileNgFactoryField(meta);
+    const factoryRes = compileNgFactoryDefField(meta);
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -17,7 +17,7 @@ import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost, filterToMembersWithDecorator, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
-import {compileNgFactoryField} from './factory';
+import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, readBaseClass, unwrapExpression, unwrapForwardRef} from './util';
 
@@ -94,7 +94,7 @@ export class DirectiveDecoratorHandler implements
       CompileResult[] {
     const meta = analysis.meta;
     const res = compileDirectiveFromMetadata(meta, pool, makeBindingParser());
-    const factoryRes = compileNgFactoryField(meta);
+    const factoryRes = compileNgFactoryDefField(meta);
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -90,18 +90,21 @@ export class DirectiveDecoratorHandler implements
   }
 
   compile(node: ClassDeclaration, analysis: DirectiveHandlerData, pool: ConstantPool):
-      CompileResult {
+      CompileResult[] {
     const res = compileDirectiveFromMetadata(analysis.meta, pool, makeBindingParser());
     const statements = res.statements;
     if (analysis.metadataStmt !== null) {
       statements.push(analysis.metadataStmt);
     }
-    return {
-      name: 'ngDirectiveDef',
-      initializer: res.expression,
-      statements: statements,
-      type: res.type,
-    };
+    return [
+      {
+        name: 'ngDirectiveDef',
+        initializer: res.expression,
+        statements: statements,
+        type: res.type,
+      },
+      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+    ];
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -17,7 +17,7 @@ import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost, filterToMembersWithDecorator, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
-import {getNgFactoryFnCompileResult} from './factory';
+import {compileNgFactoryField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, readBaseClass, unwrapExpression, unwrapForwardRef} from './util';
 
@@ -92,8 +92,12 @@ export class DirectiveDecoratorHandler implements
 
   compile(node: ClassDeclaration, analysis: DirectiveHandlerData, pool: ConstantPool):
       CompileResult[] {
-    const res = compileDirectiveFromMetadata(analysis.meta, pool, makeBindingParser());
-    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt);
+    const meta = analysis.meta;
+    const res = compileDirectiveFromMetadata(meta, pool, makeBindingParser());
+    const factoryRes = compileNgFactoryField(meta);
+    if (analysis.metadataStmt !== null) {
+      factoryRes.statements.push(analysis.metadataStmt);
+    }
     return [
       factoryRes, {
         name: 'ngDirectiveDef',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -17,6 +17,7 @@ import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost, filterToMembersWithDecorator, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
+import {getNgFactoryFnCompileResult} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, readBaseClass, unwrapExpression, unwrapForwardRef} from './util';
 
@@ -92,18 +93,14 @@ export class DirectiveDecoratorHandler implements
   compile(node: ClassDeclaration, analysis: DirectiveHandlerData, pool: ConstantPool):
       CompileResult[] {
     const res = compileDirectiveFromMetadata(analysis.meta, pool, makeBindingParser());
-    const statements = res.statements;
-    if (analysis.metadataStmt !== null) {
-      statements.push(analysis.metadataStmt);
-    }
+    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt);
     return [
-      {
+      factoryRes, {
         name: 'ngDirectiveDef',
         initializer: res.expression,
-        statements: statements,
+        statements: [],
         type: res.type,
-      },
-      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+      }
     ];
   }
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {R3FactoryFnMetadata, Statement, compileFactoryFromMetadata} from '@angular/compiler';
+
+import {CompileResult} from '../../transform';
+
+export function getNgFactoryFnCompileResult(
+    metadata: R3FactoryFnMetadata, metadataStatement: Statement | null,
+    isPipe = false): CompileResult {
+  const res = compileFactoryFromMetadata(metadata, isPipe);
+  if (metadataStatement !== null) {
+    res.statements.push(metadataStatement);
+  }
+  return {
+    name: 'ngFactoryFn',
+    initializer: res.factory,
+    statements: res.statements,
+    type: res.type
+  };
+}

--- a/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
@@ -6,17 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3FactoryFnMetadata, Statement, compileFactoryFromMetadata} from '@angular/compiler';
+import {R3FactoryFnMetadata, compileFactoryFromMetadata} from '@angular/compiler';
 
 import {CompileResult} from '../../transform';
 
-export function getNgFactoryFnCompileResult(
-    metadata: R3FactoryFnMetadata, metadataStatement: Statement | null,
-    isPipe = false): CompileResult {
-  const res = compileFactoryFromMetadata(metadata, isPipe);
-  if (metadataStatement !== null) {
-    res.statements.push(metadataStatement);
-  }
+export function compileNgFactoryField(metadata: R3FactoryFnMetadata): CompileResult {
+  const res = compileFactoryFromMetadata(metadata);
   return {
     name: 'ngFactoryFn',
     initializer: res.factory,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3FactoryFnMetadata, compileFactoryFromMetadata} from '@angular/compiler';
+import {R3FactoryDefMetadata, compileFactoryFromMetadata} from '@angular/compiler';
 
 import {CompileResult} from '../../transform';
 
-export function compileNgFactoryField(metadata: R3FactoryFnMetadata): CompileResult {
+export function compileNgFactoryDefField(metadata: R3FactoryDefMetadata): CompileResult {
   const res = compileFactoryFromMetadata(metadata);
   return {
-    name: 'ngFactoryFn',
+    name: 'ngFactoryDef',
     initializer: res.factory,
     statements: res.statements,
     type: res.type

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -16,6 +16,7 @@ import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
+import {getNgFactoryFnCompileResult} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, unwrapExpression} from './util';
 
@@ -107,17 +108,14 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
 
   compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult[] {
     const res = compilePipeFromMetadata(analysis.meta);
-    const statements = res.statements;
-    if (analysis.metadataStmt !== null) {
-      statements.push(analysis.metadataStmt);
-    }
+    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt, true);
     return [
-      {
+      factoryRes, {
         name: 'ngPipeDef',
-        initializer: res.expression, statements,
+        initializer: res.expression,
+        statements: [],
         type: res.type,
-      },
-      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+      }
     ];
   }
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -16,7 +16,7 @@ import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
-import {getNgFactoryFnCompileResult} from './factory';
+import {compileNgFactoryField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, unwrapExpression} from './util';
 
@@ -107,8 +107,12 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
   }
 
   compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult[] {
-    const res = compilePipeFromMetadata(analysis.meta);
-    const factoryRes = getNgFactoryFnCompileResult(analysis.meta, analysis.metadataStmt, true);
+    const meta = analysis.meta;
+    const res = compilePipeFromMetadata(meta);
+    const factoryRes = compileNgFactoryField({...meta, isPipe: true});
+    if (analysis.metadataStmt !== null) {
+      factoryRes.statements.push(analysis.metadataStmt);
+    }
     return [
       factoryRes, {
         name: 'ngPipeDef',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -16,7 +16,7 @@ import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
-import {compileNgFactoryField} from './factory';
+import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, unwrapExpression} from './util';
 
@@ -109,7 +109,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
   compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult[] {
     const meta = analysis.meta;
     const res = compilePipeFromMetadata(meta);
-    const factoryRes = compileNgFactoryField({...meta, isPipe: true});
+    const factoryRes = compileNgFactoryDefField({...meta, isPipe: true});
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -105,16 +105,19 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
     };
   }
 
-  compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult {
+  compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult[] {
     const res = compilePipeFromMetadata(analysis.meta);
     const statements = res.statements;
     if (analysis.metadataStmt !== null) {
       statements.push(analysis.metadataStmt);
     }
-    return {
-      name: 'ngPipeDef',
-      initializer: res.expression, statements,
-      type: res.type,
-    };
+    return [
+      {
+        name: 'ngPipeDef',
+        initializer: res.expression, statements,
+        type: res.type,
+      },
+      {name: 'ngFactoryFn', initializer: res.factory, statements: [], type: res.type}
+    ];
   }
 }

--- a/packages/compiler-cli/src/transformers/nocollapse_hack.ts
+++ b/packages/compiler-cli/src/transformers/nocollapse_hack.ts
@@ -26,6 +26,7 @@ const R3_DEF_NAME_PATTERN = [
   'ngInjectorDef',
   'ngModuleDef',
   'ngPipeDef',
+  'ngFactoryFn',
 ].join('|');
 
 // Pattern matching `Identifier.property` where property is a Render3 property.

--- a/packages/compiler-cli/src/transformers/nocollapse_hack.ts
+++ b/packages/compiler-cli/src/transformers/nocollapse_hack.ts
@@ -26,7 +26,7 @@ const R3_DEF_NAME_PATTERN = [
   'ngInjectorDef',
   'ngModuleDef',
   'ngPipeDef',
-  'ngFactoryFn',
+  'ngFactoryDef',
 ].join('|');
 
 // Pattern matching `Identifier.property` where property is a Render3 property.

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -44,7 +44,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -94,7 +94,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -142,7 +142,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -190,7 +190,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -306,7 +306,7 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         const $e0_attrs$ = [${AttributeMarker.Bindings}, "id"];
         …
@@ -361,7 +361,7 @@ describe('compiler compliance', () => {
       ///////////////
 
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -476,7 +476,7 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         MyComponent.ngComponentDef = i0.ɵɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
             consts: 1,
@@ -544,7 +544,7 @@ describe('compiler compliance', () => {
         });`;
 
       const ChildComponentFactory =
-          `ChildComponent.ngFactoryFn = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
+          `ChildComponent.ngFactoryDef = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
 
       // SomeDirective definition should be:
       const SomeDirectiveDefinition = `
@@ -555,7 +555,7 @@ describe('compiler compliance', () => {
       `;
 
       const SomeDirectiveFactory =
-          `SomeDirective.ngFactoryFn = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+          `SomeDirective.ngFactoryDef = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // MyComponent definition should be:
       const MyComponentDefinition = `
@@ -578,17 +578,17 @@ describe('compiler compliance', () => {
       `;
 
       const MyComponentFactory =
-          `MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+          `MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, ChildComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
-      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
+      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ngDirectiveDef');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryFn');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryDef');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponentDefinition.ngComponentDef');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ngFactoryFn');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ngFactoryDef');
     });
 
     it('should support complex selectors', () => {
@@ -618,7 +618,7 @@ describe('compiler compliance', () => {
       `;
 
       const SomeDirectiveFactory =
-          `SomeDirective.ngFactoryFn = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+          `SomeDirective.ngFactoryDef = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // OtherDirective definition should be:
       const OtherDirectiveDefinition = `
@@ -629,15 +629,15 @@ describe('compiler compliance', () => {
       `;
 
       const OtherDirectiveFactory =
-          `OtherDirective.ngFactoryFn = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
+          `OtherDirective.ngFactoryDef = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ngDirectiveDef');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryFn');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryDef');
       expectEmit(source, OtherDirectiveDefinition, 'Incorrect OtherDirective.ngDirectiveDef');
-      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ngFactoryFn');
+      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ngFactoryDef');
     });
 
     it('should support components without selector', () => {
@@ -673,14 +673,15 @@ describe('compiler compliance', () => {
       `;
 
       const EmptyOutletComponentFactory =
-          `EmptyOutletComponent.ngFactoryFn = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
+          `EmptyOutletComponent.ngFactoryDef = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(
           source, EmptyOutletComponentDefinition, 'Incorrect EmptyOutletComponent.ngComponentDef');
-      expectEmit(source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ngFactoryFn');
+      expectEmit(
+          source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ngFactoryDef');
     });
 
     it('should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting',
@@ -715,7 +716,7 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-         const MyComponentFactory = `MyComponent.ngFactoryFn = function MyComponent_Factory(t) {
+         const MyComponentFactory = `MyComponent.ngFactoryDef = function MyComponent_Factory(t) {
             return new (t || MyComponent)(
               $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
               $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
@@ -725,7 +726,7 @@ describe('compiler compliance', () => {
          const source = result.source;
 
          expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
-         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryFn');
+         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
        });
 
     it('should support structural directives', () => {
@@ -759,7 +760,7 @@ describe('compiler compliance', () => {
           selectors: [["", "if", ""]]
         });`;
       const IfDirectiveFactory =
-          `IfDirective.ngFactoryFn = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
+          `IfDirective.ngFactoryDef = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
 
       const MyComponentDefinition = `
         const $c1$ = ["foo", ""];
@@ -795,15 +796,15 @@ describe('compiler compliance', () => {
         });`;
 
       const MyComponentFactory =
-          `MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+          `MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, IfDirectiveDefinition, 'Incorrect IfDirective.ngDirectiveDef');
-      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ngFactoryFn');
+      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ngFactoryDef');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryFn');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
     });
 
     describe('value composition', () => {
@@ -1993,8 +1994,8 @@ describe('compiler compliance', () => {
             });
         `;
 
-        const MyPipeNgFactoryFn = `
-          MyPipe.ngFactoryFn = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
+        const MyPipengFactoryDef = `
+          MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
         `;
 
         const MyPurePipeDefinition = `
@@ -2004,8 +2005,8 @@ describe('compiler compliance', () => {
               pure: true
             });`;
 
-        const MyPurePipeNgFactoryFn = `
-          MyPurePipe.ngFactoryFn = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
+        const MyPurePipengFactoryDef = `
+          MyPurePipe.ngFactoryDef = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
         `;
 
         const MyAppDefinition = `
@@ -2043,9 +2044,9 @@ describe('compiler compliance', () => {
         const source = result.source;
 
         expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
-        expectEmit(source, MyPipeNgFactoryFn, 'Invalid pipe factory function');
+        expectEmit(source, MyPipengFactoryDef, 'Invalid pipe factory function');
         expectEmit(source, MyPurePipeDefinition, 'Invalid pure pipe definition');
-        expectEmit(source, MyPurePipeNgFactoryFn, 'Invalid pure pipe factory function');
+        expectEmit(source, MyPurePipengFactoryDef, 'Invalid pure pipe factory function');
         expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
       });
 
@@ -2159,8 +2160,8 @@ describe('compiler compliance', () => {
               });
             `;
 
-           const MyPipeFactoryFn = `
-              MyPipe.ngFactoryFn = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
+           const MyPipeFactory = `
+              MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
             `;
 
            const MyOtherPipeDefinition = `
@@ -2170,17 +2171,17 @@ describe('compiler compliance', () => {
                 pure: true
               });`;
 
-           const MyOtherPipeFactoryFn = `
-              MyOtherPipe.ngFactoryFn = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
+           const MyOtherPipeFactory = `
+              MyOtherPipe.ngFactoryDef = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
             `;
 
            const result = compile(files, angularFiles);
            const source = result.source;
 
            expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
-           expectEmit(source, MyPipeFactoryFn, 'Invalid pipe factory function');
+           expectEmit(source, MyPipeFactory, 'Invalid pipe factory function');
            expectEmit(source, MyOtherPipeDefinition, 'Invalid alternate pipe definition');
-           expectEmit(source, MyOtherPipeFactoryFn, 'Invalid alternate pipe factory function');
+           expectEmit(source, MyOtherPipeFactory, 'Invalid alternate pipe factory function');
          });
 
     });
@@ -2573,7 +2574,7 @@ describe('compiler compliance', () => {
             `;
 
         const ForDirectiveFactory =
-            `ForOfDirective.ngFactoryFn = function ForOfDirective_Factory(t) {
+            `ForOfDirective.ngFactoryDef = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };`;
 
@@ -2654,7 +2655,7 @@ describe('compiler compliance', () => {
         `;
 
         const ForDirectiveFactory = `
-          ForOfDirective.ngFactoryFn = function ForOfDirective_Factory(t) {
+          ForOfDirective.ngFactoryDef = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };
         `;

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -44,7 +44,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -94,7 +94,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -142,7 +142,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -190,7 +190,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -306,7 +306,7 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         const $e0_attrs$ = [${AttributeMarker.Bindings}, "id"];
         …
@@ -361,7 +361,7 @@ describe('compiler compliance', () => {
       ///////////////
 
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -476,12 +476,9 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         MyComponent.ngComponentDef = i0.ɵɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
-            factory: function MyComponent_Factory(t){
-              return new (t || MyComponent)();
-            },
             consts: 1,
             vars: 2,
             template: function MyComponent_Template(rf,ctx){
@@ -536,7 +533,6 @@ describe('compiler compliance', () => {
         ChildComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: ChildComponent,
           selectors: [["child"]],
-          factory: function ChildComponent_Factory(t) { return new (t || ChildComponent)(); },
           consts: 1,
           vars: 0,
           template:  function ChildComponent_Template(rf, ctx) {
@@ -547,14 +543,19 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
+      const ChildComponentFactory =
+          `ChildComponent.ngFactoryFn = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
+
       // SomeDirective definition should be:
       const SomeDirectiveDefinition = `
         SomeDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
-          selectors: [["", "some-directive", ""]],
-          factory: function SomeDirective_Factory(t) {return new (t || SomeDirective)(); }
+          selectors: [["", "some-directive", ""]]
         });
       `;
+
+      const SomeDirectiveFactory =
+          `SomeDirective.ngFactoryFn = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // MyComponent definition should be:
       const MyComponentDefinition = `
@@ -563,7 +564,6 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           consts: 2,
           vars: 0,
           template:  function MyComponent_Template(rf, ctx) {
@@ -577,13 +577,18 @@ describe('compiler compliance', () => {
         });
       `;
 
+      const MyComponentFactory =
+          `MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, ChildComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
+      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ngDirectiveDef');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryFn');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponentDefinition.ngComponentDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ngFactoryFn');
     });
 
     it('should support complex selectors', () => {
@@ -608,25 +613,31 @@ describe('compiler compliance', () => {
       const SomeDirectiveDefinition = `
         SomeDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
-          selectors: [["div", "some-directive", "", 8, "foo", 3, "title", "", 9, "baz"]],
-          factory: function SomeDirective_Factory(t) {return new (t || SomeDirective)(); }
+          selectors: [["div", "some-directive", "", 8, "foo", 3, "title", "", 9, "baz"]]
         });
       `;
+
+      const SomeDirectiveFactory =
+          `SomeDirective.ngFactoryFn = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // OtherDirective definition should be:
       const OtherDirectiveDefinition = `
         OtherDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: OtherDirective,
-          selectors: [["", 5, "span", "title", "", 9, "baz"]],
-          factory: function OtherDirective_Factory(t) {return new (t || OtherDirective)(); }
+          selectors: [["", 5, "span", "title", "", 9, "baz"]]
         });
       `;
+
+      const OtherDirectiveFactory =
+          `OtherDirective.ngFactoryFn = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ngDirectiveDef');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryFn');
       expectEmit(source, OtherDirectiveDefinition, 'Incorrect OtherDirective.ngDirectiveDef');
+      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ngFactoryFn');
     });
 
     it('should support components without selector', () => {
@@ -650,7 +661,6 @@ describe('compiler compliance', () => {
         EmptyOutletComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: EmptyOutletComponent,
           selectors: [["ng-component"]],
-          factory: function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); },
           consts: 1,
           vars: 0,
           template: function EmptyOutletComponent_Template(rf, ctx) {
@@ -662,11 +672,15 @@ describe('compiler compliance', () => {
         });
       `;
 
+      const EmptyOutletComponentFactory =
+          `EmptyOutletComponent.ngFactoryFn = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
+
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(
           source, EmptyOutletComponentDefinition, 'Incorrect EmptyOutletComponent.ngComponentDef');
+      expectEmit(source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ngFactoryFn');
     });
 
     it('should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting',
@@ -695,21 +709,23 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) {
-             return new (t || MyComponent)(
-                $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
-                $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
-          },
           consts: 0,
           vars: 0,
           template:  function MyComponent_Template(rf, ctx) {},
           encapsulation: 2
         });`;
 
+         const MyComponentFactory = `MyComponent.ngFactoryFn = function MyComponent_Factory(t) {
+            return new (t || MyComponent)(
+              $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
+              $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
+          };`;
+
          const result = compile(files, angularFiles);
          const source = result.source;
 
          expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
+         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryFn');
        });
 
     it('should support structural directives', () => {
@@ -740,9 +756,11 @@ describe('compiler compliance', () => {
       const IfDirectiveDefinition = `
         IfDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: IfDirective,
-          selectors: [["", "if", ""]],
-          factory: function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); }
+          selectors: [["", "if", ""]]
         });`;
+      const IfDirectiveFactory =
+          `IfDirective.ngFactoryFn = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
+
       const MyComponentDefinition = `
         const $c1$ = ["foo", ""];
         const $c2$ = [${AttributeMarker.Template}, "if"];
@@ -763,7 +781,6 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           consts: 3,
           vars: 0,
           template:  function MyComponent_Template(rf, ctx) {
@@ -777,11 +794,16 @@ describe('compiler compliance', () => {
            encapsulation: 2
         });`;
 
+      const MyComponentFactory =
+          `MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, IfDirectiveDefinition, 'Incorrect IfDirective.ngDirectiveDef');
+      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ngFactoryFn');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryFn');
     });
 
     describe('value composition', () => {
@@ -826,7 +848,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             consts: 1,
             vars: 3,
             template:  function MyApp_Template(rf, ctx) {
@@ -908,7 +929,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             consts: 1,
             vars: 11,
             template:  function MyApp_Template(rf, ctx) {
@@ -971,7 +991,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             consts: 1,
             vars: 3,
             template:  function MyApp_Template(rf, ctx) {
@@ -1039,7 +1058,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             consts: 1,
             vars: 8,
             template:  function MyApp_Template(rf, ctx) {
@@ -1100,7 +1118,6 @@ describe('compiler compliance', () => {
           SimpleComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: SimpleComponent,
             selectors: [["simple"]],
-            factory: function SimpleComponent_Factory(t) { return new (t || SimpleComponent)(); },
             ngContentSelectors: $c0$,
             consts: 2,
             vars: 0,
@@ -1123,7 +1140,6 @@ describe('compiler compliance', () => {
           ComplexComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: ComplexComponent,
             selectors: [["complex"]],
-            factory: function ComplexComponent_Factory(t) { return new (t || ComplexComponent)(); },
             ngContentSelectors: _c4,
             consts: 4,
             vars: 0,
@@ -1179,7 +1195,6 @@ describe('compiler compliance', () => {
           Cmp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: Cmp,
             selectors: [["ng-component"]],
-            factory: function Cmp_Factory(t) { return new (t || Cmp)(); },
             ngContentSelectors: $c1$,
             consts: 3,
             vars: 0,
@@ -1368,9 +1383,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) {
-                return new(t || MyApp)();
-            },
             consts: 2,
             vars: 0,
             template: function MyApp_Template(rf, ctx) {
@@ -1423,9 +1435,6 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory(t) {
-                return new(t || MyApp)();
-            },
             consts: 2,
             vars: 0,
             template: function MyApp_Template(rf, ctx) {
@@ -1489,7 +1498,6 @@ describe('compiler compliance', () => {
           ViewQueryComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: ViewQueryComponent,
             selectors: [["view-query-component"]],
-            factory: function ViewQueryComponent_Factory(t) { return new (t || ViewQueryComponent)(); },
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵviewQuery(SomeDirective, true);
@@ -1600,7 +1608,6 @@ describe('compiler compliance', () => {
           ViewQueryComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: ViewQueryComponent,
             selectors: [["view-query-component"]],
-            factory: function ViewQueryComponent_Factory(t) { return new (t || ViewQueryComponent)(); },
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵstaticViewQuery(SomeDirective, true);
@@ -1727,9 +1734,6 @@ describe('compiler compliance', () => {
           ContentQueryComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: ContentQueryComponent,
             selectors: [["content-query-component"]],
-            factory: function ContentQueryComponent_Factory(t) {
-              return new (t || ContentQueryComponent)();
-            },
             contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
               if (rf & 1) {
               $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, true);
@@ -1849,9 +1853,6 @@ describe('compiler compliance', () => {
           ContentQueryComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: ContentQueryComponent,
             selectors: [["content-query-component"]],
-            factory: function ContentQueryComponent_Factory(t) {
-              return new (t || ContentQueryComponent)();
-            },
             contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
               if (rf & 1) {
               $r3$.ɵɵstaticContentQuery(dirIndex, SomeDirective, true);
@@ -1988,18 +1989,24 @@ describe('compiler compliance', () => {
             MyPipe.ngPipeDef = $r3$.ɵɵdefinePipe({
               name: "myPipe",
               type: MyPipe,
-              factory: function MyPipe_Factory(t) { return new (t || MyPipe)(); },
               pure: false
             });
+        `;
+
+        const MyPipeNgFactoryFn = `
+          MyPipe.ngFactoryFn = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
         `;
 
         const MyPurePipeDefinition = `
             MyPurePipe.ngPipeDef = $r3$.ɵɵdefinePipe({
               name: "myPurePipe",
               type: MyPurePipe,
-              factory: function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); },
               pure: true
             });`;
+
+        const MyPurePipeNgFactoryFn = `
+          MyPurePipe.ngFactoryFn = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
+        `;
 
         const MyAppDefinition = `
             const $c0$ = function ($a0$) {
@@ -2009,7 +2016,6 @@ describe('compiler compliance', () => {
             MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
               type: MyApp,
               selectors: [["my-app"]],
-              factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
               consts: 7,
               vars: 20,
               template:  function MyApp_Template(rf, ctx) {
@@ -2037,7 +2043,9 @@ describe('compiler compliance', () => {
         const source = result.source;
 
         expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
+        expectEmit(source, MyPipeNgFactoryFn, 'Invalid pipe factory function');
         expectEmit(source, MyPurePipeDefinition, 'Invalid pure pipe definition');
+        expectEmit(source, MyPurePipeNgFactoryFn, 'Invalid pure pipe factory function');
         expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
       });
 
@@ -2075,7 +2083,6 @@ describe('compiler compliance', () => {
             MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
               type: MyApp,
               selectors: [["my-app"]],
-              factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
               consts: 6,
               vars: 27,
               template:  function MyApp_Template(rf, ctx) {
@@ -2148,24 +2155,32 @@ describe('compiler compliance', () => {
               MyPipe.ngPipeDef = $r3$.ɵɵdefinePipe({
                 name: "myPipe",
                 type: MyPipe,
-                factory: function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); },
                 pure: true
               });
+            `;
+
+           const MyPipeFactoryFn = `
+              MyPipe.ngFactoryFn = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
             `;
 
            const MyOtherPipeDefinition = `
               MyOtherPipe.ngPipeDef = $r3$.ɵɵdefinePipe({
                 name: "myOtherPipe",
                 type: MyOtherPipe,
-                factory: function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); },
                 pure: true
               });`;
+
+           const MyOtherPipeFactoryFn = `
+              MyOtherPipe.ngFactoryFn = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
+            `;
 
            const result = compile(files, angularFiles);
            const source = result.source;
 
            expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
+           expectEmit(source, MyPipeFactoryFn, 'Invalid pipe factory function');
            expectEmit(source, MyOtherPipeDefinition, 'Invalid alternate pipe definition');
+           expectEmit(source, MyOtherPipeFactoryFn, 'Invalid alternate pipe factory function');
          });
 
     });
@@ -2191,7 +2206,6 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           consts: 3,
           vars: 1,
           template:  function MyComponent_Template(rf, ctx) {
@@ -2288,7 +2302,6 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           consts: 6,
           vars: 1,
           template:  function MyComponent_Template(rf, ctx) {
@@ -2434,7 +2447,6 @@ describe('compiler compliance', () => {
           LifecycleComp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: LifecycleComp,
             selectors: [["lifecycle-comp"]],
-            factory: function LifecycleComp_Factory(t) { return new (t || LifecycleComp)(); },
             inputs: {nameMin: ["name", "nameMin"]},
             features: [$r3$.ɵɵNgOnChangesFeature()],
             consts: 0,
@@ -2447,7 +2459,6 @@ describe('compiler compliance', () => {
           SimpleLayout.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: SimpleLayout,
             selectors: [["simple-layout"]],
-            factory: function SimpleLayout_Factory(t) { return new (t || SimpleLayout)(); },
             consts: 2,
             vars: 2,
             template:  function SimpleLayout_Template(rf, ctx) {
@@ -2556,13 +2567,15 @@ describe('compiler compliance', () => {
               ForOfDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
                 type: ForOfDirective,
                 selectors: [["", "forOf", ""]],
-                factory: function ForOfDirective_Factory(t) {
-                  return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
-                },
                 features: [$r3$.ɵɵNgOnChangesFeature()],
                 inputs: {forOf: "forOf"}
               });
             `;
+
+        const ForDirectiveFactory =
+            `ForOfDirective.ngFactoryFn = function ForOfDirective_Factory(t) {
+            return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
+          };`;
 
         const MyComponentDefinition = `
               const $t1_attrs$ = [${AttributeMarker.Template}, "for", "forOf"];
@@ -2578,7 +2591,6 @@ describe('compiler compliance', () => {
               MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
-                factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
                 consts: 2,
                 vars: 1,
                 template:  function MyComponent_Template(rf, ctx){
@@ -2603,6 +2615,7 @@ describe('compiler compliance', () => {
 
         // TODO(benlesh): Enforce this when the directives are specified
         // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
+        // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
         expectEmit(source, MyComponentDefinition, 'Invalid component definition');
       });
 
@@ -2635,12 +2648,15 @@ describe('compiler compliance', () => {
           ForOfDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
             type: ForOfDirective,
             selectors: [["", "forOf", ""]],
-            factory: function ForOfDirective_Factory(t) {
-              return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
-            },
             features: [$r3$.ɵɵNgOnChangesFeature()],
             inputs: {forOf: "forOf"}
           });
+        `;
+
+        const ForDirectiveFactory = `
+          ForOfDirective.ngFactoryFn = function ForOfDirective_Factory(t) {
+            return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
+          };
         `;
 
         const MyComponentDefinition = `
@@ -2661,7 +2677,6 @@ describe('compiler compliance', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
             consts: 2,
             vars: 1,
             template:  function MyComponent_Template(rf, ctx) {
@@ -2685,6 +2700,7 @@ describe('compiler compliance', () => {
 
         // TODO(chuckj): Enforce this when the directives are specified
         // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
+        // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
         expectEmit(source, MyComponentDefinition, 'Invalid component definition');
       });
 
@@ -2765,7 +2781,6 @@ describe('compiler compliance', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
             consts: 2,
             vars: 1,
             template:  function MyComponent_Template(rf, ctx) {
@@ -2883,7 +2898,6 @@ describe('compiler compliance', () => {
         SomeDirective.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
           selectors: [["", "some-directive", ""]],
-          factory: function SomeDirective_Factory(t) {return new (t || SomeDirective)(); },
           exportAs: ["someDir", "otherDir"]
         });
       `;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -671,7 +671,6 @@ describe('compiler compliance: bindings', () => {
         HostBindingDir.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: HostBindingDir,
           selectors: [["", "hostBindingDir", ""]],
-          factory: function HostBindingDir_Factory(t) { return new (t || HostBindingDir)(); },
           hostBindings: function HostBindingDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵallocHostVars(1);
@@ -718,7 +717,6 @@ describe('compiler compliance: bindings', () => {
         HostBindingComp.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: HostBindingComp,
           selectors: [["host-binding-comp"]],
-          factory: function HostBindingComp_Factory(t) { return new (t || HostBindingComp)(); },
           hostBindings: function HostBindingComp_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵallocHostVars(3);
@@ -766,7 +764,6 @@ describe('compiler compliance: bindings', () => {
         HostAttributeDir.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
-          factory: function HostAttributeDir_Factory(t) { return new (t || HostAttributeDir)(); },
           hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵallocHostVars(1);
@@ -811,7 +808,6 @@ describe('compiler compliance: bindings', () => {
         HostAttributeDir.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
-          factory: function HostAttributeDir_Factory(t) { return new (t || HostAttributeDir)(); },
           hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵelementHostAttrs($c0$);
@@ -869,7 +865,6 @@ describe('compiler compliance: bindings', () => {
         HostAttributeComp.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: HostAttributeComp,
           selectors: [["my-host-attribute-component"]],
-          factory: function HostAttributeComp_Factory(t) { return new (t || HostAttributeComp)(); },
           hostBindings: function HostAttributeComp_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵelementHostAttrs($c0$);
@@ -881,7 +876,6 @@ describe('compiler compliance: bindings', () => {
         HostAttributeDir.ngDirectiveDef = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
-          factory: function HostAttributeDir_Factory(t) { return new (t || HostAttributeDir)(); },
           hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵɵallocHostVars(2);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -48,7 +48,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      MyComponent.ngFactoryFn = function MyComponent_Factory(t) {
+      MyComponent.ngFactoryDef = function MyComponent_Factory(t) {
         return new (t || MyComponent)(
           $r3$.ɵɵinjectAttribute('name'),
           $r3$.ɵɵdirectiveInject(MyService),

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -48,7 +48,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      factory: function MyComponent_Factory(t) {
+      MyComponent.ngFactoryFn = function MyComponent_Factory(t) {
         return new (t || MyComponent)(
           $r3$.ɵɵinjectAttribute('name'),
           $r3$.ɵɵdirectiveInject(MyService),

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -41,7 +41,6 @@ describe('compiler compliance: directives', () => {
             MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
-                factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
                 consts: 1,
                 vars: 0,
                 template: function MyComponent_Template(rf, ctx) {
@@ -53,10 +52,15 @@ describe('compiler compliance: directives', () => {
             });
         `;
 
+      const MyComponentFactory = `
+        MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+      `;
+
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
     });
 
     it('should not match directives on i18n-prefixed attributes', () => {
@@ -87,7 +91,6 @@ describe('compiler compliance: directives', () => {
             MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
-                factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
                 consts: 1,
                 vars: 0,
                 template: function MyComponent_Template(rf, ctx) {
@@ -99,10 +102,15 @@ describe('compiler compliance: directives', () => {
             });
         `;
 
+      const MyComponentFactory = `
+        MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+      `;
+
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
     });
 
     it('should match directives on element bindings', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -53,14 +53,14 @@ describe('compiler compliance: directives', () => {
         `;
 
       const MyComponentFactory = `
-        MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+        MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
     });
 
     it('should not match directives on i18n-prefixed attributes', () => {
@@ -103,14 +103,14 @@ describe('compiler compliance: directives', () => {
         `;
 
       const MyComponentFactory = `
-        MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+        MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ngComponentDef');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryFn');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
     });
 
     it('should match directives on element bindings', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -221,15 +221,15 @@ describe('compiler compliance: listen()', () => {
         });
       `;
 
-    const MyComponentFactoryFn = `
-      MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+    const MyComponentFactory = `
+      MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     `;
 
     const result = compile(files, angularFiles);
     const source = result.source;
 
     expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
-    expectEmit(source, MyComponentFactoryFn, 'Incorrect MyComponent.ngFactoryFn');
+    expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
   });
 
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -201,7 +201,6 @@ describe('compiler compliance: listen()', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           consts: 4,
           vars: 0,
           template:  function MyComponent_Template(rf, ctx) {
@@ -222,10 +221,15 @@ describe('compiler compliance: listen()', () => {
         });
       `;
 
+    const MyComponentFactoryFn = `
+      MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+    `;
+
     const result = compile(files, angularFiles);
     const source = result.source;
 
     expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
+    expectEmit(source, MyComponentFactoryFn, 'Incorrect MyComponent.ngFactoryFn');
   });
 
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -144,7 +144,7 @@ describe('compiler compliance: providers', () => {
         result.source, `
     export class MyComponent {
     }
-    MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+    MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     MyComponent.ngComponentDef = i0.ɵɵdefineComponent({
       type: MyComponent,
       selectors: [["my-component"]],

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -144,6 +144,7 @@ describe('compiler compliance: providers', () => {
         result.source, `
     export class MyComponent {
     }
+    MyComponent.ngFactoryFn = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     MyComponent.ngComponentDef = i0.ɵɵdefineComponent({
       type: MyComponent,
       selectors: [["my-component"]],

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -147,7 +147,6 @@ describe('compiler compliance: providers', () => {
     MyComponent.ngComponentDef = i0.ɵɵdefineComponent({
       type: MyComponent,
       selectors: [["my-component"]],
-      factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
       consts: 1,
       vars: 0,
       template: function MyComponent_Template(rf, ctx) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -131,9 +131,6 @@ describe('compiler compliance: styling', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors:[["my-component"]],
-          factory:function MyComponent_Factory(t){
-            return new (t || MyComponent)();
-          },
           consts: 0,
           vars: 0,
           template:  function MyComponent_Template(rf, $ctx$) {
@@ -173,9 +170,6 @@ describe('compiler compliance: styling', () => {
         MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors:[["my-component"]],
-          factory:function MyComponent_Factory(t){
-            return new (t || MyComponent)();
-          },
           consts: 0,
           vars: 0,
           template:  function MyComponent_Template(rf, $ctx$) {
@@ -524,9 +518,6 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(t){
-                return new (t || MyComponent)();
-              },
               consts: 1,
               vars: 4,
               template:  function MyComponent_Template(rf, $ctx$) {
@@ -577,9 +568,6 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory(t) {
-              return new (t || MyComponent)();
-            },
             consts: 1,
             vars: 1,
             template:  function MyComponent_Template(rf, ctx) {
@@ -736,9 +724,6 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(t){
-                return new (t || MyComponent)();
-              },
               consts: 1,
               vars: 4,
               template:  function MyComponent_Template(rf, $ctx$) {
@@ -791,9 +776,6 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(t){
-                return new (t || MyComponent)();
-              },
               consts: 1,
               vars: 2,
               template:  function MyComponent_Template(rf, $ctx$) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -880,8 +880,10 @@ runInEachFileSystem(os => {
 
       expect(jsContents)
           .toContain(
-              'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
-              'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: false })');
+              'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: false })');
+      expect(jsContents)
+          .toContain(
+              'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
     });
@@ -903,8 +905,10 @@ runInEachFileSystem(os => {
 
       expect(jsContents)
           .toContain(
-              'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
-              'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: true })');
+              'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: true })');
+      expect(jsContents)
+          .toContain(
+              'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
     });
@@ -1615,7 +1619,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents)
           .toContain(
-              `factory: function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
+              `FooCmp.ngFactoryFn = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
     });
 
     it('should generate queries for components', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -197,12 +197,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
+      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
     });
 
     it('should compile Components (dynamic inline template) without errors', () => {
@@ -220,12 +222,15 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
+      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
+
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
     });
 
     it('should compile Components (function call inline template) without errors', () => {
@@ -246,12 +251,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
+      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
     });
 
     it('should compile Components (external template) without errors', () => {
@@ -886,6 +893,7 @@ runInEachFileSystem(os => {
               'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe>;');
     });
 
     it('should compile pure Pipes without errors', () => {
@@ -911,6 +919,7 @@ runInEachFileSystem(os => {
               'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe>;');
     });
 
     it('should compile Pipes with dependencies', () => {
@@ -951,6 +960,7 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe<any>, "test-pipe">;');
+      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe<any>>;');
     });
 
     it('should include @Pipes in @NgModule scopes', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -197,14 +197,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
+      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (dynamic inline template) without errors', () => {
@@ -222,7 +222,7 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
+      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
@@ -230,7 +230,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (function call inline template) without errors', () => {
@@ -251,14 +251,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ngComponentDef = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryFn = function');
+      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ngComponentDef: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestCmp>');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (external template) without errors', () => {
@@ -890,10 +890,10 @@ runInEachFileSystem(os => {
               'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: false })');
       expect(jsContents)
           .toContain(
-              'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
+              'TestPipe.ngFactoryDef = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe>;');
     });
 
     it('should compile pure Pipes without errors', () => {
@@ -916,10 +916,10 @@ runInEachFileSystem(os => {
               'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: true })');
       expect(jsContents)
           .toContain(
-              'TestPipe.ngFactoryFn = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
+              'TestPipe.ngFactoryDef = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe>;');
     });
 
     it('should compile Pipes with dependencies', () => {
@@ -960,7 +960,7 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe<any>, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryFn: i0.ɵɵFactoryFn<TestPipe<any>>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe<any>>;');
     });
 
     it('should include @Pipes in @NgModule scopes', () => {
@@ -1629,7 +1629,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents)
           .toContain(
-              `FooCmp.ngFactoryFn = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
+              `FooCmp.ngFactoryDef = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
     });
 
     it('should generate queries for components', () => {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -95,7 +95,7 @@ export {BoundAttribute as TmplAstBoundAttribute, BoundEvent as TmplAstBoundEvent
 export * from './render3/view/t2_api';
 export * from './render3/view/t2_binder';
 export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
-export {R3DependencyMetadata, R3FactoryMetadata, R3ResolvedDependencyType} from './render3/r3_factory';
+export {R3DependencyMetadata, R3FactoryMetadata, R3ResolvedDependencyType, compileFactoryFromMetadata, R3FactoryFnMetadata} from './render3/r3_factory';
 export {compileInjector, compileNgModule, R3InjectorMetadata, R3NgModuleMetadata} from './render3/r3_module_compiler';
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 export {makeBindingParser, parseTemplate, ParseTemplateOptions} from './render3/view/template';

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -95,7 +95,7 @@ export {BoundAttribute as TmplAstBoundAttribute, BoundEvent as TmplAstBoundEvent
 export * from './render3/view/t2_api';
 export * from './render3/view/t2_binder';
 export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
-export {R3DependencyMetadata, R3FactoryMetadata, R3ResolvedDependencyType, compileFactoryFromMetadata, R3FactoryFnMetadata} from './render3/r3_factory';
+export {R3DependencyMetadata, R3FactoryDefMetadata, R3ResolvedDependencyType, compileFactoryFromMetadata, R3FactoryMetadata} from './render3/r3_factory';
 export {compileInjector, compileNgModule, R3InjectorMetadata, R3NgModuleMetadata} from './render3/r3_module_compiler';
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 export {makeBindingParser, parseTemplate, ParseTemplateOptions} from './render3/view/template';

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -39,6 +39,10 @@ export interface CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
+  compileFactory(
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
+      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -37,6 +37,7 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
   const factoryMeta = {
     name: meta.name,
     type: meta.type,
+    typeArgumentCount: meta.typeArgumentCount,
     deps: meta.ctorDeps,
     injectFn: Identifiers.inject,
   };

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -44,11 +44,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       pure: facade.pure,
     };
     const res = compilePipeFromMetadata(metadata);
-    const factoryRes = compileFactoryFromMetadata(metadata, true);
-    return [
-      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []),
-      this.jitExpression(factoryRes.factory, angularCoreEnv, '', factoryRes.statements)
-    ];
+    return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []);
   }
 
   compileInjectable(
@@ -110,12 +106,8 @@ export class CompilerFacadeImpl implements CompilerFacade {
 
     const meta: R3DirectiveMetadata = convertDirectiveFacadeToMetadata(facade);
     const res = compileDirectiveFromMetadata(meta, constantPool, bindingParser);
-    const factoryRes = compileFactoryFromMetadata(meta);
-
-    return [
-      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, constantPool.statements),
-      this.jitExpression(factoryRes.factory, angularCoreEnv, '', factoryRes.statements)
-    ];
+    return this.jitExpression(
+        res.expression, angularCoreEnv, sourceMapUrl, constantPool.statements);
   }
 
   compileComponent(
@@ -156,14 +148,23 @@ export class CompilerFacadeImpl implements CompilerFacade {
     };
     const res = compileComponentFromMetadata(
         metadata, constantPool, makeBindingParser(interpolationConfig));
-    const factoryRes = compileFactoryFromMetadata(metadata);
     const jitExpressionSourceMap = `ng:///${facade.name}.js`;
-    return [
-      this.jitExpression(
-          res.expression, angularCoreEnv, jitExpressionSourceMap, constantPool.statements),
-      this.jitExpression(
-          factoryRes.factory, angularCoreEnv, jitExpressionSourceMap, factoryRes.statements)
-    ];
+    return this.jitExpression(
+        res.expression, angularCoreEnv, jitExpressionSourceMap, constantPool.statements);
+  }
+
+  compileFactory(
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
+      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      isPipe = false) {
+    const factoryRes = compileFactoryFromMetadata({
+      name: meta.name,
+      type: new WrappedNodeExpr(meta.type),
+      typeArgumentCount: meta.typeArgumentCount,
+      deps: convertR3DependencyMetadataArray(meta.deps), isPipe
+    });
+    return this.jitExpression(
+        factoryRes.factory, angularCoreEnv, sourceMapUrl, factoryRes.statements);
   }
 
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3BaseMetadataFacade):

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -15,7 +15,7 @@ import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/int
 import {DeclareVarStmt, Expression, LiteralExpr, Statement, StmtModifier, WrappedNodeExpr} from './output/output_ast';
 import {JitEvaluator} from './output/output_jit';
 import {ParseError, ParseSourceSpan, r3JitTypeSourceSpan} from './parse_util';
-import {R3DependencyMetadata, R3ResolvedDependencyType} from './render3/r3_factory';
+import {R3DependencyMetadata, R3ResolvedDependencyType, compileFactoryFromMetadata} from './render3/r3_factory';
 import {R3JitReflector} from './render3/r3_jit';
 import {R3InjectorMetadata, R3NgModuleMetadata, compileInjector, compileNgModule} from './render3/r3_module_compiler';
 import {compilePipeFromMetadata} from './render3/r3_pipe_compiler';
@@ -35,17 +35,19 @@ export class CompilerFacadeImpl implements CompilerFacade {
 
   compilePipe(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3PipeMetadataFacade):
       any {
-    const res = compilePipeFromMetadata({
+    const metadata = {
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
       typeArgumentCount: facade.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(facade.deps),
       pipeName: facade.pipeName,
       pure: facade.pure,
-    });
+    };
+    const res = compilePipeFromMetadata(metadata);
+    const factoryRes = compileFactoryFromMetadata(metadata, true);
     return [
-      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, res.statements),
-      this.jitExpression(res.factory, angularCoreEnv, '', [])
+      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []),
+      this.jitExpression(factoryRes.factory, angularCoreEnv, '', factoryRes.statements)
     ];
   }
 
@@ -108,11 +110,11 @@ export class CompilerFacadeImpl implements CompilerFacade {
 
     const meta: R3DirectiveMetadata = convertDirectiveFacadeToMetadata(facade);
     const res = compileDirectiveFromMetadata(meta, constantPool, bindingParser);
-    const preStatements = [...constantPool.statements, ...res.statements];
+    const factoryRes = compileFactoryFromMetadata(meta);
 
     return [
-      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, preStatements),
-      this.jitExpression(res.factory, angularCoreEnv, '', [])
+      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, constantPool.statements),
+      this.jitExpression(factoryRes.factory, angularCoreEnv, '', factoryRes.statements)
     ];
   }
 
@@ -136,29 +138,31 @@ export class CompilerFacadeImpl implements CompilerFacade {
 
     // Compile the component metadata, including template, into an expression.
     // TODO(alxhub): implement inputs, outputs, queries, etc.
+    const metadata = {
+      ...facade as R3ComponentMetadataFacadeNoPropAndWhitespace,
+      ...convertDirectiveFacadeToMetadata(facade),
+      selector: facade.selector || this.elementSchemaRegistry.getDefaultComponentElementName(),
+      template,
+      wrapDirectivesAndPipesInClosure: false,
+      styles: facade.styles || [],
+      encapsulation: facade.encapsulation as any,
+      interpolation: interpolationConfig,
+      changeDetection: facade.changeDetection,
+      animations: facade.animations != null ? new WrappedNodeExpr(facade.animations) : null,
+      viewProviders: facade.viewProviders != null ? new WrappedNodeExpr(facade.viewProviders) :
+                                                    null,
+      relativeContextFilePath: '',
+      i18nUseExternalIds: true,
+    };
     const res = compileComponentFromMetadata(
-        {
-          ...facade as R3ComponentMetadataFacadeNoPropAndWhitespace,
-          ...convertDirectiveFacadeToMetadata(facade),
-          selector: facade.selector || this.elementSchemaRegistry.getDefaultComponentElementName(),
-          template,
-          wrapDirectivesAndPipesInClosure: false,
-          styles: facade.styles || [],
-          encapsulation: facade.encapsulation as any,
-          interpolation: interpolationConfig,
-          changeDetection: facade.changeDetection,
-          animations: facade.animations != null ? new WrappedNodeExpr(facade.animations) : null,
-          viewProviders: facade.viewProviders != null ? new WrappedNodeExpr(facade.viewProviders) :
-                                                        null,
-          relativeContextFilePath: '',
-          i18nUseExternalIds: true,
-        },
-        constantPool, makeBindingParser(interpolationConfig));
-    const preStatements = [...constantPool.statements, ...res.statements];
-
+        metadata, constantPool, makeBindingParser(interpolationConfig));
+    const factoryRes = compileFactoryFromMetadata(metadata);
+    const jitExpressionSourceMap = `ng:///${facade.name}.js`;
     return [
-      this.jitExpression(res.expression, angularCoreEnv, `ng:///${facade.name}.js`, preStatements),
-      this.jitExpression(res.factory, angularCoreEnv, sourceMapUrl, [])
+      this.jitExpression(
+          res.expression, angularCoreEnv, jitExpressionSourceMap, constantPool.statements),
+      this.jitExpression(
+          factoryRes.factory, angularCoreEnv, jitExpressionSourceMap, factoryRes.statements)
     ];
   }
 

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -43,7 +43,10 @@ export class CompilerFacadeImpl implements CompilerFacade {
       pipeName: facade.pipeName,
       pure: facade.pure,
     });
-    return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, res.statements);
+    return [
+      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, res.statements),
+      this.jitExpression(res.factory, angularCoreEnv, '', [])
+    ];
   }
 
   compileInjectable(
@@ -106,7 +109,11 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const meta: R3DirectiveMetadata = convertDirectiveFacadeToMetadata(facade);
     const res = compileDirectiveFromMetadata(meta, constantPool, bindingParser);
     const preStatements = [...constantPool.statements, ...res.statements];
-    return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, preStatements);
+
+    return [
+      this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, preStatements),
+      this.jitExpression(res.factory, angularCoreEnv, '', [])
+    ];
   }
 
   compileComponent(
@@ -148,8 +155,11 @@ export class CompilerFacadeImpl implements CompilerFacade {
         },
         constantPool, makeBindingParser(interpolationConfig));
     const preStatements = [...constantPool.statements, ...res.statements];
-    return this.jitExpression(
-        res.expression, angularCoreEnv, `ng:///${facade.name}.js`, preStatements);
+
+    return [
+      this.jitExpression(res.expression, angularCoreEnv, `ng:///${facade.name}.js`, preStatements),
+      this.jitExpression(res.factory, angularCoreEnv, sourceMapUrl, [])
+    ];
   }
 
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3BaseMetadataFacade):

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -87,6 +87,7 @@ export interface R3FactoryFnMetadata {
   type: o.Expression;
   typeArgumentCount: number;
   deps: R3DependencyMetadata[]|null;
+  isPipe?: boolean;
 }
 
 /**
@@ -152,11 +153,16 @@ export interface R3DependencyMetadata {
   skipSelf: boolean;
 }
 
+export interface R3FactoryFn {
+  factory: o.Expression;
+  statements: o.Statement[];
+  type: o.ExpressionType;
+}
+
 /**
  * Construct a factory function expression for the given `R3FactoryMetadata`.
  */
-export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false):
-    {factory: o.Expression, statements: o.Statement[], type: o.ExpressionType} {
+export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false): R3FactoryFn {
   const t = o.variable('t');
   const statements: o.Statement[] = [];
 
@@ -254,7 +260,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false):
 /**
  * Constructs the `ngFactoryFn` from directive/component/pipe metadata.
  */
-export function compileFactoryFromMetadata(meta: R3FactoryFnMetadata, isPipe = false) {
+export function compileFactoryFromMetadata(meta: R3FactoryFnMetadata): R3FactoryFn {
   return compileFactoryFunction(
       {
         name: meta.name,
@@ -264,7 +270,7 @@ export function compileFactoryFromMetadata(meta: R3FactoryFnMetadata, isPipe = f
         // TODO(crisbeto): this should be refactored once we start using it for injectables.
         injectFn: R3.directiveInject,
       },
-      isPipe);
+      meta.isPipe);
 }
 
 function injectDependencies(

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -15,7 +15,9 @@ import * as o from '../output/output_ast';
 import {Identifiers as R3} from '../render3/r3_identifiers';
 import {OutputContext} from '../util';
 
+import {typeWithParameters} from './util';
 import {unsupported} from './view/util';
+
 
 
 /**
@@ -35,6 +37,9 @@ export interface R3ConstructorFactoryMetadata {
    * `useNew` property determines whether it will be called as a constructor or not.
    */
   type: o.Expression;
+
+  /** Number of arguments for the `type`. */
+  typeArgumentCount: number;
 
   /**
    * Regardless of whether `fnOrClass` is a constructor function or a user-defined factory, it
@@ -76,6 +81,13 @@ export interface R3ExpressionFactoryMetadata extends R3ConstructorFactoryMetadat
 
 export type R3FactoryMetadata = R3ConstructorFactoryMetadata | R3DelegatedFactoryMetadata |
     R3DelegatedFnOrClassMetadata | R3ExpressionFactoryMetadata;
+
+export interface R3FactoryFnMetadata {
+  name: string;
+  type: o.Expression;
+  typeArgumentCount: number;
+  deps: R3DependencyMetadata[]|null;
+}
 
 /**
  * Resolved type of a dependency.
@@ -143,8 +155,8 @@ export interface R3DependencyMetadata {
 /**
  * Construct a factory function expression for the given `R3FactoryMetadata`.
  */
-export function compileFactoryFunction(
-    meta: R3FactoryMetadata, isPipe = false): {factory: o.Expression, statements: o.Statement[]} {
+export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false):
+    {factory: o.Expression, statements: o.Statement[], type: o.ExpressionType} {
   const t = o.variable('t');
   const statements: o.Statement[] = [];
 
@@ -234,7 +246,25 @@ export function compileFactoryFunction(
         [new o.FnParam('t', o.DYNAMIC_TYPE)], body, o.INFERRED_TYPE, undefined,
         `${meta.name}_Factory`),
     statements,
+    type: o.expressionType(
+        o.importExpr(R3.FactoryFn, [typeWithParameters(meta.type, meta.typeArgumentCount)]))
   };
+}
+
+/**
+ * Constructs the `ngFactoryFn` from directive/component/pipe metadata.
+ */
+export function compileFactoryFromMetadata(meta: R3FactoryFnMetadata, isPipe = false) {
+  return compileFactoryFunction(
+      {
+        name: meta.name,
+        type: meta.type,
+        deps: meta.deps,
+        typeArgumentCount: meta.typeArgumentCount,
+        // TODO(crisbeto): this should be refactored once we start using it for injectables.
+        injectFn: R3.directiveInject,
+      },
+      isPipe);
 }
 
 function injectDependencies(

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -82,7 +82,7 @@ export interface R3ExpressionFactoryMetadata extends R3ConstructorFactoryMetadat
 export type R3FactoryMetadata = R3ConstructorFactoryMetadata | R3DelegatedFactoryMetadata |
     R3DelegatedFnOrClassMetadata | R3ExpressionFactoryMetadata;
 
-export interface R3FactoryFnMetadata {
+export interface R3FactoryDefMetadata {
   name: string;
   type: o.Expression;
   typeArgumentCount: number;
@@ -253,14 +253,14 @@ export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false):
         `${meta.name}_Factory`),
     statements,
     type: o.expressionType(
-        o.importExpr(R3.FactoryFn, [typeWithParameters(meta.type, meta.typeArgumentCount)]))
+        o.importExpr(R3.FactoryDef, [typeWithParameters(meta.type, meta.typeArgumentCount)]))
   };
 }
 
 /**
- * Constructs the `ngFactoryFn` from directive/component/pipe metadata.
+ * Constructs the `ngFactoryDef` from directive/component/pipe metadata.
  */
-export function compileFactoryFromMetadata(meta: R3FactoryFnMetadata): R3FactoryFn {
+export function compileFactoryFromMetadata(meta: R3FactoryDefMetadata): R3FactoryFn {
   return compileFactoryFunction(
       {
         name: meta.name,

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -241,8 +241,8 @@ export class Identifiers {
     moduleName: CORE,
   };
 
-  static FactoryFn: o.ExternalReference = {
-    name: 'ɵɵFactoryFn',
+  static FactoryDef: o.ExternalReference = {
+    name: 'ɵɵFactoryDef',
     moduleName: CORE,
   };
 

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -241,6 +241,11 @@ export class Identifiers {
     moduleName: CORE,
   };
 
+  static FactoryFn: o.ExternalReference = {
+    name: 'ɵɵFactoryFn',
+    moduleName: CORE,
+  };
+
   static defineDirective: o.ExternalReference = {
     name: 'ɵɵdefineDirective',
     moduleName: CORE,

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -207,6 +207,7 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
   const result = compileFactoryFunction({
     name: meta.name,
     type: meta.type,
+    typeArgumentCount: 0,
     deps: meta.deps,
     injectFn: R3.inject,
   });

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -88,9 +88,8 @@ export function compilePipeFromRender2(
     deps: dependenciesFromGlobalMetadata(pipe.type, outputCtx, reflector),
     pure: pipe.pure,
   };
-
   const res = compilePipeFromMetadata(metadata);
-  const factoryRes = compileFactoryFromMetadata(metadata, true);
+  const factoryRes = compileFactoryFromMetadata({...metadata, isPipe: true});
   const definitionField = outputCtx.constantPool.propertyNameOf(DefinitionKind.Pipe);
   const ngFactoryFnStatement = new o.ClassStmt(
       /* name */ name,

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -91,12 +91,12 @@ export function compilePipeFromRender2(
   const res = compilePipeFromMetadata(metadata);
   const factoryRes = compileFactoryFromMetadata({...metadata, isPipe: true});
   const definitionField = outputCtx.constantPool.propertyNameOf(DefinitionKind.Pipe);
-  const ngFactoryFnStatement = new o.ClassStmt(
+  const ngFactoryDefStatement = new o.ClassStmt(
       /* name */ name,
       /* parent */ null,
       /* fields */
       [new o.ClassField(
-          /* name */ 'ngFactoryFn',
+          /* name */ 'ngFactoryDef',
           /* type */ o.INFERRED_TYPE,
           /* modifiers */[o.StmtModifier.Static],
           /* initializer */ factoryRes.factory)],
@@ -115,5 +115,5 @@ export function compilePipeFromRender2(
       /* constructorMethod */ new o.ClassMethod(null, [], []),
       /* methods */[]);
 
-  outputCtx.statements.push(ngFactoryFnStatement, pipeDefStatement);
+  outputCtx.statements.push(ngFactoryDefStatement, pipeDefStatement);
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -238,6 +238,7 @@ export interface R3DirectiveDef {
   expression: o.Expression;
   type: o.Type;
   statements: o.Statement[];
+  factory: o.Expression;
 }
 
 /**
@@ -247,6 +248,7 @@ export interface R3ComponentDef {
   expression: o.Expression;
   type: o.Type;
   statements: o.Statement[];
+  factory: o.Expression;
 }
 
 /**

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -237,8 +237,6 @@ export interface R3QueryMetadata {
 export interface R3DirectiveDef {
   expression: o.Expression;
   type: o.Type;
-  statements: o.Statement[];
-  factory: o.Expression;
 }
 
 /**
@@ -247,8 +245,6 @@ export interface R3DirectiveDef {
 export interface R3ComponentDef {
   expression: o.Expression;
   type: o.Type;
-  statements: o.Statement[];
-  factory: o.Expression;
 }
 
 /**

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -326,9 +326,10 @@ export function compileDirectiveFromRender2(
   const meta = directiveMetadataFromGlobalMetadata(directive, outputCtx, reflector);
   const res = compileDirectiveFromMetadata(meta, outputCtx.constantPool, bindingParser);
   const factoryRes = compileFactoryFromMetadata(meta);
-  const ngFactoryFnStatement = new o.ClassStmt(
-      name, null, [new o.ClassField(
-                      'ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
+  const ngFactoryDefStatement = new o.ClassStmt(
+      name, null,
+      [new o.ClassField(
+          'ngFactoryDef', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
       [], new o.ClassMethod(null, [], []), []);
   const directiveDefStatement = new o.ClassStmt(
       name, null,
@@ -336,7 +337,7 @@ export function compileDirectiveFromRender2(
       [], new o.ClassMethod(null, [], []), []);
 
   // Create the partial class to be merged with the actual class.
-  outputCtx.statements.push(ngFactoryFnStatement, directiveDefStatement);
+  outputCtx.statements.push(ngFactoryDefStatement, directiveDefStatement);
 }
 
 /**
@@ -378,9 +379,10 @@ export function compileComponentFromRender2(
   };
   const res = compileComponentFromMetadata(meta, outputCtx.constantPool, bindingParser);
   const factoryRes = compileFactoryFromMetadata(meta);
-  const ngFactoryFnStatement = new o.ClassStmt(
-      name, null, [new o.ClassField(
-                      'ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
+  const ngFactoryDefStatement = new o.ClassStmt(
+      name, null,
+      [new o.ClassField(
+          'ngFactoryDef', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
       [], new o.ClassMethod(null, [], []), []);
   const componentDefStatement = new o.ClassStmt(
       name, null,
@@ -388,7 +390,7 @@ export function compileComponentFromRender2(
       [], new o.ClassMethod(null, [], []), []);
 
   // Create the partial class to be merged with the actual class.
-  outputCtx.statements.push(ngFactoryFnStatement, componentDefStatement);
+  outputCtx.statements.push(ngFactoryDefStatement, componentDefStatement);
 }
 
 /**

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -326,7 +326,6 @@ export function compileDirectiveFromRender2(
   const meta = directiveMetadataFromGlobalMetadata(directive, outputCtx, reflector);
   const res = compileDirectiveFromMetadata(meta, outputCtx.constantPool, bindingParser);
   const factoryRes = compileFactoryFromMetadata(meta);
-
   const ngFactoryFnStatement = new o.ClassStmt(
       name, null, [new o.ClassField(
                       'ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
@@ -379,7 +378,6 @@ export function compileComponentFromRender2(
   };
   const res = compileComponentFromMetadata(meta, outputCtx.constantPool, bindingParser);
   const factoryRes = compileFactoryFromMetadata(meta);
-
   const ngFactoryFnStatement = new o.ClassStmt(
       name, null, [new o.ClassField(
                       'ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -43,8 +43,8 @@ function getStylingPrefix(name: string): string {
 }
 
 function baseDirectiveFields(
-    meta: R3DirectiveMetadata, constantPool: ConstantPool,
-    bindingParser: BindingParser): {definitionMap: DefinitionMap, statements: o.Statement[]} {
+    meta: R3DirectiveMetadata, constantPool: ConstantPool, bindingParser: BindingParser):
+    {definitionMap: DefinitionMap, statements: o.Statement[], factory: o.Expression} {
   const definitionMap = new DefinitionMap();
 
   // e.g. `type: MyDirective`
@@ -53,7 +53,6 @@ function baseDirectiveFields(
   // e.g. `selectors: [['', 'someDir', '']]`
   definitionMap.set('selectors', createDirectiveSelector(meta.selector));
 
-
   // e.g. `factory: () => new MyApp(directiveInject(ElementRef))`
   const result = compileFactoryFunction({
     name: meta.name,
@@ -61,7 +60,6 @@ function baseDirectiveFields(
     deps: meta.deps,
     injectFn: R3.directiveInject,
   });
-  definitionMap.set('factory', result.factory);
 
   if (meta.queries.length > 0) {
     // e.g. `contentQueries: (rf, ctx, dirIndex) => { ... }
@@ -90,7 +88,7 @@ function baseDirectiveFields(
     definitionMap.set('exportAs', o.literalArr(meta.exportAs.map(e => o.literal(e))));
   }
 
-  return {definitionMap, statements: result.statements};
+  return {definitionMap, statements: result.statements, factory: result.factory};
 }
 
 /**
@@ -128,12 +126,13 @@ function addFeatures(
 export function compileDirectiveFromMetadata(
     meta: R3DirectiveMetadata, constantPool: ConstantPool,
     bindingParser: BindingParser): R3DirectiveDef {
-  const {definitionMap, statements} = baseDirectiveFields(meta, constantPool, bindingParser);
+  const {definitionMap, statements, factory} =
+      baseDirectiveFields(meta, constantPool, bindingParser);
   addFeatures(definitionMap, meta);
   const expression = o.importExpr(R3.defineDirective).callFn([definitionMap.toLiteralMap()]);
 
   const type = createTypeForDef(meta, R3.DirectiveDefWithMeta);
-  return {expression, type, statements};
+  return {expression, type, statements, factory};
 }
 
 export interface R3BaseRefMetaData {
@@ -197,7 +196,8 @@ export function compileBaseDefFromMetadata(
 export function compileComponentFromMetadata(
     meta: R3ComponentMetadata, constantPool: ConstantPool,
     bindingParser: BindingParser): R3ComponentDef {
-  const {definitionMap, statements} = baseDirectiveFields(meta, constantPool, bindingParser);
+  const {definitionMap, statements, factory} =
+      baseDirectiveFields(meta, constantPool, bindingParser);
   addFeatures(definitionMap, meta);
 
   const selector = meta.selector && CssSelector.parse(meta.selector);
@@ -315,7 +315,7 @@ export function compileComponentFromMetadata(
   const expression = o.importExpr(R3.defineComponent).callFn([definitionMap.toLiteralMap()]);
   const type = createTypeForDef(meta, R3.ComponentDefWithMeta);
 
-  return {expression, type, statements};
+  return {expression, type, statements, factory};
 }
 
 /**
@@ -336,11 +336,17 @@ export function compileDirectiveFromRender2(
   const meta = directiveMetadataFromGlobalMetadata(directive, outputCtx, reflector);
   const res = compileDirectiveFromMetadata(meta, outputCtx.constantPool, bindingParser);
 
-  // Create the partial class to be merged with the actual class.
-  outputCtx.statements.push(new o.ClassStmt(
+  const directiveDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(definitionField, o.INFERRED_TYPE, [o.StmtModifier.Static], res.expression)],
-      [], new o.ClassMethod(null, [], []), []));
+      [], new o.ClassMethod(null, [], []), []);
+  const ngFactoryFnStatement = new o.ClassStmt(
+      name, null,
+      [new o.ClassField('ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], res.factory)], [],
+      new o.ClassMethod(null, [], []), []);
+
+  // Create the partial class to be merged with the actual class.
+  outputCtx.statements.push(directiveDefStatement, ngFactoryFnStatement);
 }
 
 /**
@@ -382,11 +388,17 @@ export function compileComponentFromRender2(
   };
   const res = compileComponentFromMetadata(meta, outputCtx.constantPool, bindingParser);
 
-  // Create the partial class to be merged with the actual class.
-  outputCtx.statements.push(new o.ClassStmt(
+  const componentDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(definitionField, o.INFERRED_TYPE, [o.StmtModifier.Static], res.expression)],
-      [], new o.ClassMethod(null, [], []), []));
+      [], new o.ClassMethod(null, [], []), []);
+  const ngFactoryFnStatement = new o.ClassStmt(
+      name, null,
+      [new o.ClassField('ngFactoryFn', o.INFERRED_TYPE, [o.StmtModifier.Static], res.factory)], [],
+      new o.ClassMethod(null, [], []), []);
+
+  // Create the partial class to be merged with the actual class.
+  outputCtx.statements.push(componentDefStatement, ngFactoryFnStatement);
 }
 
 /**

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -39,6 +39,10 @@ export interface CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
+  compileFactory(
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
+      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -156,7 +156,7 @@ export {
   ɵɵBaseDef,
   ComponentDef as ɵComponentDef,
   ɵɵComponentDefWithMeta,
-  ɵɵFactoryFn,
+  ɵɵFactoryDef,
   DirectiveDef as ɵDirectiveDef,
   ɵɵDirectiveDefWithMeta,
   PipeDef as ɵPipeDef,

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -156,6 +156,7 @@ export {
   ɵɵBaseDef,
   ComponentDef as ɵComponentDef,
   ɵɵComponentDefWithMeta,
+  ɵɵFactoryFn,
   DirectiveDef as ɵDirectiveDef,
   ɵɵDirectiveDefWithMeta,
   PipeDef as ɵPipeDef,

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -10,6 +10,7 @@ import '../util/ng_dev_mode';
 
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
+import {getFactoryFn} from '../render3/definition';
 import {throwCyclicDependencyError, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors';
 import {deepForEach, newArray} from '../util/array_utils';
 import {stringify} from '../util/stringify';
@@ -398,8 +399,10 @@ export class R3Injector {
 function injectableDefOrInjectorDefFactory(token: Type<any>| InjectionToken<any>): () => any {
   // Most tokens will have an ngInjectableDef directly on them, which specifies a factory directly.
   const injectableDef = getInjectableDef(token);
-  if (injectableDef !== null) {
-    return injectableDef.factory;
+  const factory = injectableDef !== null ? injectableDef.factory : getFactoryFn(token);
+
+  if (factory !== null) {
+    return factory;
   }
 
   // If the token is an NgModule, it's also injectable but the factory is on its ngInjectorDef.

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -10,7 +10,7 @@ import '../util/ng_dev_mode';
 
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
-import {getFactoryFn} from '../render3/definition';
+import {getFactoryDef} from '../render3/definition';
 import {throwCyclicDependencyError, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors';
 import {deepForEach, newArray} from '../util/array_utils';
 import {stringify} from '../util/stringify';
@@ -399,7 +399,7 @@ export class R3Injector {
 function injectableDefOrInjectorDefFactory(token: Type<any>| InjectionToken<any>): () => any {
   // Most tokens will have an ngInjectableDef directly on them, which specifies a factory directly.
   const injectableDef = getInjectableDef(token);
-  const factory = injectableDef !== null ? injectableDef.factory : getFactoryFn(token);
+  const factory = injectableDef !== null ? injectableDef.factory : getFactoryDef(token);
 
   if (factory !== null) {
     return factory;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -248,6 +248,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
     providersResolver: null,
     consts: componentDefinition.consts,
     vars: componentDefinition.vars,
+    factory: null,
     template: componentDefinition.template || null !,
     ngContentSelectors: componentDefinition.ngContentSelectors,
     hostBindings: componentDefinition.hostBindings || null,
@@ -719,6 +720,7 @@ export function ɵɵdefinePipe<T>(pipeDef: {
   return (<PipeDef<T>>{
     type: pipeDef.type,
     name: pipeDef.name,
+    factory: null,
     pure: pipeDef.pure !== false,
     onDestroy: pipeDef.type.prototype.ngOnDestroy || null
   }) as never;
@@ -750,7 +752,7 @@ export function getFactoryFn<T>(type: any, throwNotFound: true): FactoryFn<T>;
 export function getFactoryFn<T>(type: any): FactoryFn<T>|null;
 export function getFactoryFn<T>(type: any, throwNotFound?: boolean): FactoryFn<T>|null {
   const factoryFn = type[NG_FACTORY_FN] || null;
-  if (!factoryFn && throwNotFound === true) {
+  if (!factoryFn && throwNotFound === true && ngDevMode) {
     throw new Error(`Type ${stringify(type)} does not have 'ngFactoryFn' property.`);
   }
   return factoryFn;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -18,7 +18,7 @@ import {noSideEffects} from '../util/closure';
 import {stringify} from '../util/stringify';
 
 import {EMPTY_ARRAY, EMPTY_OBJ} from './empty';
-import {NG_BASE_DEF, NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_FACTORY_FN, NG_LOCALE_ID_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
+import {NG_BASE_DEF, NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_FACTORY_DEF, NG_LOCALE_ID_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
 import {ComponentDef, ComponentDefFeature, ComponentTemplate, ComponentType, ContentQueriesFunction, DirectiveDef, DirectiveDefFeature, DirectiveType, DirectiveTypesOrFactory, FactoryFn, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory, ViewQueriesFunction, ɵɵBaseDef} from './interfaces/definition';
 // while SelectorFlags is unused here, it's required so that types don't get resolved lazily
 // see: https://github.com/Microsoft/web-build-tools/issues/1050
@@ -748,12 +748,12 @@ export function getBaseDef<T>(type: any): ɵɵBaseDef<T>|null {
   return type[NG_BASE_DEF] || null;
 }
 
-export function getFactoryFn<T>(type: any, throwNotFound: true): FactoryFn<T>;
-export function getFactoryFn<T>(type: any): FactoryFn<T>|null;
-export function getFactoryFn<T>(type: any, throwNotFound?: boolean): FactoryFn<T>|null {
-  const factoryFn = type[NG_FACTORY_FN] || null;
+export function getFactoryDef<T>(type: any, throwNotFound: true): FactoryFn<T>;
+export function getFactoryDef<T>(type: any): FactoryFn<T>|null;
+export function getFactoryDef<T>(type: any, throwNotFound?: boolean): FactoryFn<T>|null {
+  const factoryFn = type[NG_FACTORY_DEF] || null;
   if (!factoryFn && throwNotFound === true && ngDevMode) {
-    throw new Error(`Type ${stringify(type)} does not have 'ngFactoryFn' property.`);
+    throw new Error(`Type ${stringify(type)} does not have 'ngFactoryDef' property.`);
   }
   return factoryFn;
 }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -642,6 +642,7 @@ export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
     }) as any;
   }
 
+  // TODO(crisbeto): unify injectable factories with getFactoryFn.
   const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
   const factory = def && def.factory || getFactoryFn<T>(typeAny);
   return factory || null;

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -15,7 +15,7 @@ import {InjectFlags} from '../di/interface/injector';
 import {Type} from '../interface/type';
 import {assertDefined, assertEqual} from '../util/assert';
 
-import {getComponentDef, getDirectiveDef, getPipeDef} from './definition';
+import {getComponentDef, getDirectiveDef, getFactoryFn, getPipeDef} from './definition';
 import {NG_ELEMENT_ID} from './fields';
 import {DirectiveDef, FactoryFn} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
@@ -642,12 +642,9 @@ export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
     }) as any;
   }
 
-  const def = getComponentDef<T>(typeAny) || getDirectiveDef<T>(typeAny) ||
-      getPipeDef<T>(typeAny) || getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
-  if (!def || def.factory === undefined) {
-    return null;
-  }
-  return def.factory;
+  const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
+  const factory = def && def.factory || getFactoryFn<T>(typeAny);
+  return factory || null;
 }
 
 /**

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -15,7 +15,7 @@ import {InjectFlags} from '../di/interface/injector';
 import {Type} from '../interface/type';
 import {assertDefined, assertEqual} from '../util/assert';
 
-import {getComponentDef, getDirectiveDef, getFactoryFn, getPipeDef} from './definition';
+import {getFactoryDef} from './definition';
 import {NG_ELEMENT_ID} from './fields';
 import {DirectiveDef, FactoryFn} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
@@ -642,9 +642,9 @@ export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
     }) as any;
   }
 
-  // TODO(crisbeto): unify injectable factories with getFactoryFn.
+  // TODO(crisbeto): unify injectable factories with getFactory.
   const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
-  const factory = def && def.factory || getFactoryFn<T>(typeAny);
+  const factory = def && def.factory || getFactoryDef<T>(typeAny);
   return factory || null;
 }
 

--- a/packages/core/src/render3/fields.ts
+++ b/packages/core/src/render3/fields.ts
@@ -14,7 +14,7 @@ export const NG_PIPE_DEF = getClosureSafeProperty({ngPipeDef: getClosureSafeProp
 export const NG_MODULE_DEF = getClosureSafeProperty({ngModuleDef: getClosureSafeProperty});
 export const NG_LOCALE_ID_DEF = getClosureSafeProperty({ngLocaleIdDef: getClosureSafeProperty});
 export const NG_BASE_DEF = getClosureSafeProperty({ngBaseDef: getClosureSafeProperty});
-export const NG_FACTORY_FN = getClosureSafeProperty({ngFactoryFn: getClosureSafeProperty});
+export const NG_FACTORY_DEF = getClosureSafeProperty({ngFactoryDef: getClosureSafeProperty});
 
 /**
  * If a directive is diPublic, bloomAdd sets a property on the type with this constant as

--- a/packages/core/src/render3/fields.ts
+++ b/packages/core/src/render3/fields.ts
@@ -14,6 +14,7 @@ export const NG_PIPE_DEF = getClosureSafeProperty({ngPipeDef: getClosureSafeProp
 export const NG_MODULE_DEF = getClosureSafeProperty({ngModuleDef: getClosureSafeProperty});
 export const NG_LOCALE_ID_DEF = getClosureSafeProperty({ngLocaleIdDef: getClosureSafeProperty});
 export const NG_BASE_DEF = getClosureSafeProperty({ngBaseDef: getClosureSafeProperty});
+export const NG_FACTORY_FN = getClosureSafeProperty({ngFactoryFn: getClosureSafeProperty});
 
 /**
  * If a directive is diPublic, bloomAdd sets a property on the type with this constant as

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -10,7 +10,7 @@ import {ɵɵdefineBase, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefineNgMo
 import {ɵɵInheritDefinitionFeature} from './features/inherit_definition_feature';
 import {ɵɵNgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ɵɵProvidersFeature} from './features/providers_feature';
-import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef, ɵɵBaseDef, ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta, ɵɵFactoryFn, ɵɵPipeDefWithMeta} from './interfaces/definition';
+import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef, ɵɵBaseDef, ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta, ɵɵFactoryDef, ɵɵPipeDefWithMeta} from './interfaces/definition';
 import {getComponent, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
 
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef, injectComponentFactoryResolver} from './component_ref';
@@ -206,7 +206,7 @@ export {
   ɵɵBaseDef,
   ComponentDef,
   ɵɵComponentDefWithMeta,
-  ɵɵFactoryFn,
+  ɵɵFactoryDef,
   ComponentTemplate,
   ComponentType,
   DirectiveDef,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -10,11 +10,12 @@ import {ɵɵdefineBase, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefineNgMo
 import {ɵɵInheritDefinitionFeature} from './features/inherit_definition_feature';
 import {ɵɵNgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ɵɵProvidersFeature} from './features/providers_feature';
-import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef, ɵɵBaseDef, ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta, ɵɵPipeDefWithMeta} from './interfaces/definition';
+import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef, ɵɵBaseDef, ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta, ɵɵFactoryFn, ɵɵPipeDefWithMeta} from './interfaces/definition';
 import {getComponent, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
 
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef, injectComponentFactoryResolver} from './component_ref';
 export {ɵɵgetFactoryOf, ɵɵgetInheritedFactory} from './di';
+
 // clang-format off
 export {
   detectChanges,
@@ -205,6 +206,7 @@ export {
   ɵɵBaseDef,
   ComponentDef,
   ɵɵComponentDefWithMeta,
+  ɵɵFactoryFn,
   ComponentTemplate,
   ComponentType,
   DirectiveDef,

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -15,6 +15,7 @@ import {createNamedArrayType} from '../../util/named_array_type';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
 import {assertFirstTemplatePass, assertLView} from '../assert';
 import {attachPatchData, getComponentViewByInstance} from '../context_discovery';
+import {getFactoryFn} from '../definition';
 import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
 import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags, registerPreOrderHooks} from '../hooks';
@@ -1028,7 +1029,7 @@ export function instantiateRootComponent<T>(
   if (tView.firstTemplatePass) {
     if (def.providersResolver) def.providersResolver(def);
     generateExpandoInstructionBlock(tView, rootTNode, 1);
-    baseResolveDirective(tView, viewData, def, def.factory);
+    baseResolveDirective(tView, viewData, def);
   }
   const directive =
       getNodeInjectable(tView.data, viewData, viewData.length - 1, rootTNode as TElementNode);
@@ -1072,7 +1073,7 @@ export function resolveDirectives(
       const def = directives[i] as DirectiveDef<any>;
 
       const directiveDefIdx = tView.data.length;
-      baseResolveDirective(tView, lView, def, def.factory);
+      baseResolveDirective(tView, lView, def);
 
       saveNameToExportMap(tView.data !.length - 1, def, exportsMap);
 
@@ -1311,9 +1312,9 @@ export function initNodeFlags(tNode: TNode, index: number, numberOfDirectives: n
   tNode.providerIndexes = index;
 }
 
-function baseResolveDirective<T>(
-    tView: TView, viewData: LView, def: DirectiveDef<T>, directiveFactory: FactoryFn<T>) {
+function baseResolveDirective<T>(tView: TView, viewData: LView, def: DirectiveDef<T>) {
   tView.data.push(def);
+  const directiveFactory = getFactoryFn(def.type, true);
   const nodeInjectorFactory = new NodeInjectorFactory(directiveFactory, isComponentDef(def), null);
   tView.blueprint.push(nodeInjectorFactory);
   viewData.push(nodeInjectorFactory);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -15,7 +15,7 @@ import {createNamedArrayType} from '../../util/named_array_type';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
 import {assertFirstTemplatePass, assertLView} from '../assert';
 import {attachPatchData, getComponentViewByInstance} from '../context_discovery';
-import {getFactoryFn} from '../definition';
+import {getFactoryDef} from '../definition';
 import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
 import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags, registerPreOrderHooks} from '../hooks';
@@ -1314,7 +1314,7 @@ export function initNodeFlags(tNode: TNode, index: number, numberOfDirectives: n
 
 function baseResolveDirective<T>(tView: TView, viewData: LView, def: DirectiveDef<T>) {
   tView.data.push(def);
-  const directiveFactory = def.factory || (def.factory = getFactoryFn(def.type, true));
+  const directiveFactory = def.factory || (def.factory = getFactoryDef(def.type, true));
   const nodeInjectorFactory = new NodeInjectorFactory(directiveFactory, isComponentDef(def), null);
   tView.blueprint.push(nodeInjectorFactory);
   viewData.push(nodeInjectorFactory);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1314,7 +1314,7 @@ export function initNodeFlags(tNode: TNode, index: number, numberOfDirectives: n
 
 function baseResolveDirective<T>(tView: TView, viewData: LView, def: DirectiveDef<T>) {
   tView.data.push(def);
-  const directiveFactory = getFactoryFn(def.type, true);
+  const directiveFactory = def.factory || (def.factory = getFactoryFn(def.type, true));
   const nodeInjectorFactory = new NodeInjectorFactory(directiveFactory, isComponentDef(def), null);
   tView.blueprint.push(nodeInjectorFactory);
   viewData.push(nodeInjectorFactory);

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -177,6 +177,12 @@ export interface DirectiveDef<T> extends ɵɵBaseDef<T> {
    */
   readonly exportAs: string[]|null;
 
+  /**
+   * Factory function used to create a new directive instance. Will be null initially.
+   * Populated when the factory is first requested by directive instantiation logic.
+   */
+  factory: FactoryFn<T>|null;
+
   /* The following are lifecycle hooks for this component */
   onChanges: (() => void)|null;
   onInit: (() => void)|null;
@@ -204,6 +210,11 @@ export interface DirectiveDef<T> extends ɵɵBaseDef<T> {
 export type ɵɵComponentDefWithMeta<
     T, Selector extends String, ExportAs extends string[], InputMap extends{[key: string]: string},
     OutputMap extends{[key: string]: string}, QueryFields extends string[]> = ComponentDef<T>;
+
+/**
+ * @codeGenApi
+ */
+export type ɵɵFactoryFn<T> = () => T;
 
 /**
  * Runtime link information for Components.
@@ -336,6 +347,12 @@ export interface PipeDef<T> {
    * Used to resolve pipe in templates.
    */
   readonly name: string;
+
+  /**
+   * Factory function used to create a new pipe instance. Will be null initially.
+   * Populated when the factory is first requested by pipe instantiation logic.
+   */
+  factory: FactoryFn<T>|null;
 
   /**
    * Whether or not the pipe is pure.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -78,7 +78,7 @@ export interface ComponentType<T> extends Type<T> { ngComponentDef: never; }
  */
 export interface DirectiveType<T> extends Type<T> {
   ngDirectiveDef: never;
-  ngFactoryFn: () => T;
+  ngFactoryDef: () => T;
 }
 
 export const enum DirectiveDefFlags {ContentQuery = 0b10}
@@ -214,7 +214,7 @@ export type ɵɵComponentDefWithMeta<
 /**
  * @codeGenApi
  */
-export type ɵɵFactoryFn<T> = () => T;
+export type ɵɵFactoryDef<T> = () => T;
 
 /**
  * Runtime link information for Components.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -76,7 +76,10 @@ export interface ComponentType<T> extends Type<T> { ngComponentDef: never; }
  * A subclass of `Type` which has a static `ngDirectiveDef`:`DirectiveDef` field making it
  * consumable for rendering.
  */
-export interface DirectiveType<T> extends Type<T> { ngDirectiveDef: never; }
+export interface DirectiveType<T> extends Type<T> {
+  ngDirectiveDef: never;
+  ngFactoryFn: () => T;
+}
 
 export const enum DirectiveDefFlags {ContentQuery = 0b10}
 
@@ -173,11 +176,6 @@ export interface DirectiveDef<T> extends ɵɵBaseDef<T> {
    * Name under which the directive is exported (for use with local references in template)
    */
   readonly exportAs: string[]|null;
-
-  /**
-   * Factory function used to create a new directive instance.
-   */
-  factory: FactoryFn<T>;
 
   /* The following are lifecycle hooks for this component */
   onChanges: (() => void)|null;
@@ -329,17 +327,15 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
  * See: {@link definePipe}
  */
 export interface PipeDef<T> {
+  /** Token representing the pipe. */
+  type: Type<T>;
+
   /**
    * Pipe name.
    *
    * Used to resolve pipe in templates.
    */
   readonly name: string;
-
-  /**
-   * Factory function used to create a new pipe instance.
-   */
-  factory: FactoryFn<T>;
 
   /**
    * Whether or not the pipe is pure.

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -42,6 +42,18 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
 
   // Metadata may have resources which need to be resolved.
   maybeQueueResolutionOfComponentResources(type, metadata);
+
+  Object.defineProperty(type, NG_FACTORY_FN, {
+    get: () => {
+      if (ngFactoryFn === null) {
+        [ngComponentDef, ngFactoryFn] = getComponentCompilerOutput(type, metadata);
+      }
+      return ngFactoryFn;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
+
   Object.defineProperty(type, NG_COMPONENT_DEF, {
     get: () => {
       if (ngComponentDef === null) {
@@ -64,17 +76,6 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
         }
       }
       return ngComponentDef;
-    },
-    // Make the property configurable in dev mode to allow overriding in tests
-    configurable: !!ngDevMode,
-  });
-
-  Object.defineProperty(type, NG_FACTORY_FN, {
-    get: () => {
-      if (ngFactoryFn === null) {
-        [ngComponentDef, ngFactoryFn] = getComponentCompilerOutput(type, metadata);
-      }
-      return ngFactoryFn;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
@@ -138,20 +139,6 @@ export function compileDirective(type: Type<any>, directive: Directive | null): 
   let ngDirectiveDef: any = null;
   let ngFactoryFn: any = null;
 
-  Object.defineProperty(type, NG_DIRECTIVE_DEF, {
-    get: () => {
-      if (ngDirectiveDef === null) {
-        // `directive` can be null in the case of abstract directives as a base class
-        // that use `@Directive()` with no selector. In that case, pass empty object to the
-        // `directiveMetadata` function instead of null.
-        [ngDirectiveDef, ngFactoryFn] = getDirectiveCompilerOutput(type, directive || {});
-      }
-      return ngDirectiveDef;
-    },
-    // Make the property configurable in dev mode to allow overriding in tests
-    configurable: !!ngDevMode,
-  });
-
   Object.defineProperty(type, NG_FACTORY_FN, {
     get: () => {
       if (ngFactoryFn === null) {
@@ -161,6 +148,20 @@ export function compileDirective(type: Type<any>, directive: Directive | null): 
         [ngDirectiveDef, ngFactoryFn] = getDirectiveCompilerOutput(type, directive || {});
       }
       return ngFactoryFn;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
+
+  Object.defineProperty(type, NG_DIRECTIVE_DEF, {
+    get: () => {
+      if (ngDirectiveDef === null) {
+        // `directive` can be null in the case of abstract directives as a base class
+        // that use `@Directive()` with no selector. In that case, pass empty object to the
+        // `directiveMetadata` function instead of null.
+        [ngDirectiveDef, ngFactoryFn] = getDirectiveCompilerOutput(type, directive || {});
+      }
+      return ngDirectiveDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -18,7 +18,7 @@ import {componentNeedsResolution, maybeQueueResolutionOfComponentResources} from
 import {ViewEncapsulation} from '../../metadata/view';
 import {getBaseDef, getComponentDef, getDirectiveDef} from '../definition';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
-import {NG_BASE_DEF, NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_FACTORY_FN} from '../fields';
+import {NG_BASE_DEF, NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_FACTORY_DEF} from '../fields';
 import {ComponentType} from '../interfaces/definition';
 import {stringifyForError} from '../util/misc_utils';
 
@@ -38,20 +38,20 @@ import {flushModuleScopingQueueAsMuchAsPossible, patchComponentDefWithScope, tra
  */
 export function compileComponent(type: Type<any>, metadata: Component): void {
   let ngComponentDef: any = null;
-  let ngFactoryFn: any = null;
+  let ngFactoryDef: any = null;
 
   // Metadata may have resources which need to be resolved.
   maybeQueueResolutionOfComponentResources(type, metadata);
 
-  Object.defineProperty(type, NG_FACTORY_FN, {
+  Object.defineProperty(type, NG_FACTORY_DEF, {
     get: () => {
-      if (ngFactoryFn === null) {
+      if (ngFactoryDef === null) {
         const compiler = getCompilerFacade();
         const meta = getComponentMetadata(compiler, type, metadata);
-        ngFactoryFn = compiler.compileFactory(
-            angularCoreEnv, `ng:///${type.name}/ngFactoryFn.js`, meta.metadata);
+        ngFactoryDef = compiler.compileFactory(
+            angularCoreEnv, `ng:///${type.name}/ngFactory.js`, meta.metadata);
       }
-      return ngFactoryFn;
+      return ngFactoryDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
@@ -140,19 +140,19 @@ function hasSelectorScope<T>(component: Type<T>): component is Type<T>&
  */
 export function compileDirective(type: Type<any>, directive: Directive | null): void {
   let ngDirectiveDef: any = null;
-  let ngFactoryFn: any = null;
+  let ngFactoryDef: any = null;
 
-  Object.defineProperty(type, NG_FACTORY_FN, {
+  Object.defineProperty(type, NG_FACTORY_DEF, {
     get: () => {
-      if (ngFactoryFn === null) {
+      if (ngFactoryDef === null) {
         // `directive` can be null in the case of abstract directives as a base class
         // that use `@Directive()` with no selector. In that case, pass empty object to the
         // `directiveMetadata` function instead of null.
         const meta = getDirectiveMetadata(type, directive || {});
-        ngFactoryFn = getCompilerFacade().compileFactory(
-            angularCoreEnv, `ng:///${type.name}/ngFactoryFn.js`, meta.metadata);
+        ngFactoryDef = getCompilerFacade().compileFactory(
+            angularCoreEnv, `ng:///${type.name}/ngFactory.js`, meta.metadata);
       }
-      return ngFactoryFn;
+      return ngFactoryDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -10,22 +10,22 @@ import {getCompilerFacade} from '../../compiler/compiler_facade';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {Pipe} from '../../metadata/directives';
-import {NG_FACTORY_FN, NG_PIPE_DEF} from '../fields';
+import {NG_FACTORY_DEF, NG_PIPE_DEF} from '../fields';
 
 import {angularCoreEnv} from './environment';
 
 export function compilePipe(type: Type<any>, meta: Pipe): void {
   let ngPipeDef: any = null;
-  let ngFactoryFn: any = null;
+  let ngFactoryDef: any = null;
 
-  Object.defineProperty(type, NG_FACTORY_FN, {
+  Object.defineProperty(type, NG_FACTORY_DEF, {
     get: () => {
-      if (ngFactoryFn === null) {
+      if (ngFactoryDef === null) {
         const metadata = getPipeMetadata(type, meta);
-        ngFactoryFn = getCompilerFacade().compileFactory(
-            angularCoreEnv, `ng:///${metadata.name}/ngFactoryFn.js`, metadata, true);
+        ngFactoryDef = getCompilerFacade().compileFactory(
+            angularCoreEnv, `ng:///${metadata.name}/ngFactory.js`, metadata, true);
       }
-      return ngFactoryFn;
+      return ngFactoryDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -21,7 +21,9 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
   Object.defineProperty(type, NG_FACTORY_FN, {
     get: () => {
       if (ngFactoryFn === null) {
-        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
+        const metadata = getPipeMetadata(type, meta);
+        ngFactoryFn = getCompilerFacade().compileFactory(
+            angularCoreEnv, `ng:///${metadata.name}/ngFactoryFn.js`, metadata, true);
       }
       return ngFactoryFn;
     },
@@ -32,7 +34,9 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
   Object.defineProperty(type, NG_PIPE_DEF, {
     get: () => {
       if (ngPipeDef === null) {
-        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
+        const metadata = getPipeMetadata(type, meta);
+        ngPipeDef = getCompilerFacade().compilePipe(
+            angularCoreEnv, `ng:///${metadata.name}/ngPipeDef.js`, metadata);
       }
       return ngPipeDef;
     },
@@ -41,15 +45,13 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
   });
 }
 
-function getPipeCompilerOutput(type: Type<any>, meta: Pipe) {
-  const typeName = type.name;
-
-  return getCompilerFacade().compilePipe(angularCoreEnv, `ng:///${typeName}/ngPipeDef.js`, {
+function getPipeMetadata(type: Type<any>, meta: Pipe) {
+  return {
     type: type,
     typeArgumentCount: 0,
-    name: typeName,
+    name: type.name,
     deps: reflectDependencies(type),
     pipeName: meta.name,
     pure: meta.pure !== undefined ? meta.pure : true
-  });
+  };
 }

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -10,29 +10,46 @@ import {getCompilerFacade} from '../../compiler/compiler_facade';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {Pipe} from '../../metadata/directives';
-import {NG_PIPE_DEF} from '../fields';
+import {NG_FACTORY_FN, NG_PIPE_DEF} from '../fields';
 
 import {angularCoreEnv} from './environment';
 
 export function compilePipe(type: Type<any>, meta: Pipe): void {
   let ngPipeDef: any = null;
+  let ngFactoryFn: any = null;
+
   Object.defineProperty(type, NG_PIPE_DEF, {
     get: () => {
       if (ngPipeDef === null) {
-        const typeName = type.name;
-        ngPipeDef =
-            getCompilerFacade().compilePipe(angularCoreEnv, `ng:///${typeName}/ngPipeDef.js`, {
-              type: type,
-              typeArgumentCount: 0,
-              name: typeName,
-              deps: reflectDependencies(type),
-              pipeName: meta.name,
-              pure: meta.pure !== undefined ? meta.pure : true
-            });
+        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
       }
       return ngPipeDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
+  });
+
+  Object.defineProperty(type, NG_FACTORY_FN, {
+    get: () => {
+      if (ngFactoryFn === null) {
+        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
+      }
+      return ngFactoryFn;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
+}
+
+function getPipeCompilerOutput(type: Type<any>, meta: Pipe) {
+  const typeName = type.name;
+
+  return getCompilerFacade().compilePipe(angularCoreEnv, `ng:///${typeName}/ngPipeDef.js`, {
+    type: type,
+    typeArgumentCount: 0,
+    name: typeName,
+    deps: reflectDependencies(type),
+    pipeName: meta.name,
+    pure: meta.pure !== undefined ? meta.pure : true
   });
 }

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -18,23 +18,23 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
   let ngPipeDef: any = null;
   let ngFactoryFn: any = null;
 
-  Object.defineProperty(type, NG_PIPE_DEF, {
-    get: () => {
-      if (ngPipeDef === null) {
-        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
-      }
-      return ngPipeDef;
-    },
-    // Make the property configurable in dev mode to allow overriding in tests
-    configurable: !!ngDevMode,
-  });
-
   Object.defineProperty(type, NG_FACTORY_FN, {
     get: () => {
       if (ngFactoryFn === null) {
         [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
       }
       return ngFactoryFn;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
+
+  Object.defineProperty(type, NG_PIPE_DEF, {
+    get: () => {
+      if (ngPipeDef === null) {
+        [ngPipeDef, ngFactoryFn] = getPipeCompilerOutput(type, meta);
+      }
+      return ngPipeDef;
     },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -44,7 +44,7 @@ export function ɵɵpipe(index: number, pipeName: string): any {
     pipeDef = tView.data[adjustedIndex] as PipeDef<any>;
   }
 
-  const pipeFactory = getFactoryFn(pipeDef.type, true);
+  const pipeFactory = pipeDef.factory || (pipeDef.factory = getFactoryFn(pipeDef.type, true));
   const pipeInstance = pipeFactory();
   store(index, pipeInstance);
   return pipeInstance;

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -9,6 +9,7 @@
 import {WrappedValue} from '../change_detection/change_detection_util';
 import {PipeTransform} from '../change_detection/pipe_transform';
 
+import {getFactoryFn} from './definition';
 import {store} from './instructions/all';
 import {PipeDef, PipeDefList} from './interfaces/definition';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
@@ -43,7 +44,8 @@ export function ɵɵpipe(index: number, pipeName: string): any {
     pipeDef = tView.data[adjustedIndex] as PipeDef<any>;
   }
 
-  const pipeInstance = pipeDef.factory();
+  const pipeFactory = getFactoryFn(pipeDef.type, true);
+  const pipeInstance = pipeFactory();
   store(index, pipeInstance);
   return pipeInstance;
 }

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -9,7 +9,7 @@
 import {WrappedValue} from '../change_detection/change_detection_util';
 import {PipeTransform} from '../change_detection/pipe_transform';
 
-import {getFactoryFn} from './definition';
+import {getFactoryDef} from './definition';
 import {store} from './instructions/all';
 import {PipeDef, PipeDefList} from './interfaces/definition';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
@@ -44,7 +44,7 @@ export function ɵɵpipe(index: number, pipeName: string): any {
     pipeDef = tView.data[adjustedIndex] as PipeDef<any>;
   }
 
-  const pipeFactory = pipeDef.factory || (pipeDef.factory = getFactoryFn(pipeDef.type, true));
+  const pipeFactory = pipeDef.factory || (pipeDef.factory = getFactoryDef(pipeDef.type, true));
   const pipeInstance = pipeFactory();
   store(index, pipeInstance);
   return pipeInstance;

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -312,6 +312,9 @@
     "name": "getElementDepthCount"
   },
   {
+    "name": "getFactoryFn"
+  },
+  {
     "name": "getHostNative"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -81,7 +81,7 @@
     "name": "NG_ELEMENT_ID"
   },
   {
-    "name": "NG_FACTORY_FN"
+    "name": "NG_FACTORY_DEF"
   },
   {
     "name": "NG_PIPE_DEF"
@@ -312,7 +312,7 @@
     "name": "getElementDepthCount"
   },
   {
-    "name": "getFactoryFn"
+    "name": "getFactoryDef"
   },
   {
     "name": "getHostNative"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -651,9 +651,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "stringify"
-  },
-  {
     "name": "stringifyForError"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -81,7 +81,7 @@
     "name": "NG_ELEMENT_ID"
   },
   {
-    "name": "NG_INJECTABLE_DEF"
+    "name": "NG_FACTORY_FN"
   },
   {
     "name": "NG_PIPE_DEF"
@@ -651,6 +651,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "stringify"
+  },
+  {
     "name": "stringifyForError"
   },
   {
@@ -673,9 +676,6 @@
   },
   {
     "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
   },
   {
     "name": "ɵɵdefineInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -72,7 +72,7 @@
     "name": "NG_ELEMENT_ID"
   },
   {
-    "name": "NG_INJECTABLE_DEF"
+    "name": "NG_FACTORY_FN"
   },
   {
     "name": "NG_PIPE_DEF"
@@ -471,6 +471,9 @@
     "name": "setTNodeAndViewData"
   },
   {
+    "name": "stringify"
+  },
+  {
     "name": "stringifyForError"
   },
   {
@@ -484,9 +487,6 @@
   },
   {
     "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
   },
   {
     "name": "ɵɵtext"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -249,6 +249,9 @@
     "name": "getDirectiveDef"
   },
   {
+    "name": "getFactoryFn"
+  },
+  {
     "name": "getHostNative"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -72,7 +72,7 @@
     "name": "NG_ELEMENT_ID"
   },
   {
-    "name": "NG_FACTORY_FN"
+    "name": "NG_FACTORY_DEF"
   },
   {
     "name": "NG_PIPE_DEF"
@@ -249,7 +249,7 @@
     "name": "getDirectiveDef"
   },
   {
-    "name": "getFactoryFn"
+    "name": "getFactoryDef"
   },
   {
     "name": "getHostNative"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -471,9 +471,6 @@
     "name": "setTNodeAndViewData"
   },
   {
-    "name": "stringify"
-  },
-  {
     "name": "stringifyForError"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "NEW_LINE"
   },
   {
+    "name": "NG_FACTORY_FN"
+  },
+  {
     "name": "NG_INJECTABLE_DEF"
   },
   {
@@ -115,6 +118,9 @@
   },
   {
     "name": "getClosureSafeProperty"
+  },
+  {
+    "name": "getFactoryFn"
   },
   {
     "name": "getInheritedInjectableDef"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -27,7 +27,7 @@
     "name": "NEW_LINE"
   },
   {
-    "name": "NG_FACTORY_FN"
+    "name": "NG_FACTORY_DEF"
   },
   {
     "name": "NG_INJECTABLE_DEF"
@@ -120,7 +120,7 @@
     "name": "getClosureSafeProperty"
   },
   {
-    "name": "getFactoryFn"
+    "name": "getFactoryDef"
   },
   {
     "name": "getInheritedInjectableDef"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -135,7 +135,7 @@
     "name": "NG_ELEMENT_ID"
   },
   {
-    "name": "NG_FACTORY_FN"
+    "name": "NG_FACTORY_DEF"
   },
   {
     "name": "NG_INJECTABLE_DEF"
@@ -762,7 +762,7 @@
     "name": "getErrorLogger"
   },
   {
-    "name": "getFactoryFn"
+    "name": "getFactoryDef"
   },
   {
     "name": "getGuardMask"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -135,6 +135,9 @@
     "name": "NG_ELEMENT_ID"
   },
   {
+    "name": "NG_FACTORY_FN"
+  },
+  {
     "name": "NG_INJECTABLE_DEF"
   },
   {
@@ -757,6 +760,9 @@
   },
   {
     "name": "getErrorLogger"
+  },
+  {
+    "name": "getFactoryFn"
   },
   {
     "name": "getGuardMask"

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -59,9 +59,9 @@ describe('iv perf test', () => {
                 }
                 ɵɵcontainerRefreshEnd();
               }
-            },
-            factory: () => new Component
+            }
           });
+          static ngFactoryFn = () => new Component;
         }
 
         const start = new Date().getTime();

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -33,6 +33,7 @@ describe('iv perf test', () => {
 
       it(`${iteration}. create ${count} divs in Render3`, () => {
         class Component {
+          static ngFactoryFn = () => new Component;
           static ngComponentDef = ɵɵdefineComponent({
             type: Component,
             selectors: [['div']],
@@ -61,7 +62,6 @@ describe('iv perf test', () => {
               }
             }
           });
-          static ngFactoryFn = () => new Component;
         }
 
         const start = new Date().getTime();

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -33,7 +33,7 @@ describe('iv perf test', () => {
 
       it(`${iteration}. create ${count} divs in Render3`, () => {
         class Component {
-          static ngFactoryFn = () => new Component;
+          static ngFactoryDef = () => new Component;
           static ngComponentDef = ɵɵdefineComponent({
             type: Component,
             selectors: [['div']],

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -28,7 +28,6 @@ describe('change detection', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
-        factory: () => new MyComponent(),
         consts: 2,
         vars: 1,
         template: (rf: RenderFlags, ctx: MyComponent) => {
@@ -43,6 +42,7 @@ describe('change detection', () => {
           }
         }
       });
+      static ngFactoryFn = () => new MyComponent();
     }
 
     it('should mark a component dirty and schedule change detection', withBody('my-comp', () => {
@@ -104,7 +104,6 @@ describe('change detection', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
-        factory: () => comp = new MyComponent(),
         consts: 2,
         vars: 2,
         /**
@@ -128,6 +127,7 @@ describe('change detection', () => {
         changeDetection: ChangeDetectionStrategy.OnPush,
         inputs: {name: 'name'}
       });
+      static ngFactoryFn = () => comp = new MyComponent();
     }
 
     describe('Manual mode', () => {
@@ -143,7 +143,6 @@ describe('change detection', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualComponent,
           selectors: [['manual-comp']],
-          factory: () => comp = new ManualComponent(),
           consts: 2,
           vars: 2,
           /**
@@ -172,6 +171,7 @@ describe('change detection', () => {
           changeDetection: ChangeDetectionStrategy.OnPush,
           inputs: {name: 'name'}
         });
+        static ngFactoryFn = () => comp = new ManualComponent();
       }
 
       class ManualApp {
@@ -180,7 +180,6 @@ describe('change detection', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualApp,
           selectors: [['manual-app']],
-          factory: () => new ManualApp(),
           consts: 1,
           vars: 1,
           /** <manual-comp [name]="name"></manual-comp> */
@@ -196,6 +195,7 @@ describe('change detection', () => {
           },
           directives: () => [ManualComponent]
         });
+        static ngFactoryFn = () => new ManualApp();
       }
 
 
@@ -236,7 +236,6 @@ describe('change detection', () => {
              static ngComponentDef = ɵɵdefineComponent({
                type: ButtonParent,
                selectors: [['button-parent']],
-               factory: () => parent = new ButtonParent(),
                consts: 2,
                vars: 1,
                /** {{ doCheckCount }} - <manual-comp></manual-comp> */
@@ -253,6 +252,7 @@ describe('change detection', () => {
                directives: () => [ManualComponent],
                changeDetection: ChangeDetectionStrategy.OnPush
              });
+             static ngFactoryFn = () => parent = new ButtonParent();
            }
 
            const MyButtonApp = createComponent('my-button-app', function(rf: RenderFlags) {
@@ -314,7 +314,6 @@ describe('change detection', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
-        factory: () => new MyComponent(),
         consts: 1,
         vars: 1,
         template: (rf: RenderFlags, ctx: MyComponent) => {
@@ -327,6 +326,7 @@ describe('change detection', () => {
           }
         }
       });
+      static ngFactoryFn = () => new MyComponent();
     }
 
     const myComp = renderComponent(MyComponent, {rendererFactory: testRendererFactory});

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -25,6 +25,7 @@ describe('change detection', () => {
       doCheckCount = 0;
       ngDoCheck(): void { this.doCheckCount++; }
 
+      static ngFactoryFn = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -42,7 +43,6 @@ describe('change detection', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComponent();
     }
 
     it('should mark a component dirty and schedule change detection', withBody('my-comp', () => {
@@ -101,6 +101,7 @@ describe('change detection', () => {
 
       onClick() {}
 
+      static ngFactoryFn = () => comp = new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -127,7 +128,6 @@ describe('change detection', () => {
         changeDetection: ChangeDetectionStrategy.OnPush,
         inputs: {name: 'name'}
       });
-      static ngFactoryFn = () => comp = new MyComponent();
     }
 
     describe('Manual mode', () => {
@@ -140,6 +140,7 @@ describe('change detection', () => {
 
         onClick() {}
 
+        static ngFactoryFn = () => comp = new ManualComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualComponent,
           selectors: [['manual-comp']],
@@ -171,12 +172,12 @@ describe('change detection', () => {
           changeDetection: ChangeDetectionStrategy.OnPush,
           inputs: {name: 'name'}
         });
-        static ngFactoryFn = () => comp = new ManualComponent();
       }
 
       class ManualApp {
         name: string = 'Nancy';
 
+        static ngFactoryFn = () => new ManualApp();
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualApp,
           selectors: [['manual-app']],
@@ -195,7 +196,6 @@ describe('change detection', () => {
           },
           directives: () => [ManualComponent]
         });
-        static ngFactoryFn = () => new ManualApp();
       }
 
 
@@ -233,6 +233,7 @@ describe('change detection', () => {
              doCheckCount = 0;
              ngDoCheck(): void { this.doCheckCount++; }
 
+             static ngFactoryFn = () => parent = new ButtonParent();
              static ngComponentDef = ɵɵdefineComponent({
                type: ButtonParent,
                selectors: [['button-parent']],
@@ -252,7 +253,6 @@ describe('change detection', () => {
                directives: () => [ManualComponent],
                changeDetection: ChangeDetectionStrategy.OnPush
              });
-             static ngFactoryFn = () => parent = new ButtonParent();
            }
 
            const MyButtonApp = createComponent('my-button-app', function(rf: RenderFlags) {
@@ -311,6 +311,7 @@ describe('change detection', () => {
         return 'works';
       }
 
+      static ngFactoryFn = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -326,7 +327,6 @@ describe('change detection', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComponent();
     }
 
     const myComp = renderComponent(MyComponent, {rendererFactory: testRendererFactory});

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -25,7 +25,7 @@ describe('change detection', () => {
       doCheckCount = 0;
       ngDoCheck(): void { this.doCheckCount++; }
 
-      static ngFactoryFn = () => new MyComponent();
+      static ngFactoryDef = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -101,7 +101,7 @@ describe('change detection', () => {
 
       onClick() {}
 
-      static ngFactoryFn = () => comp = new MyComponent();
+      static ngFactoryDef = () => comp = new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -140,7 +140,7 @@ describe('change detection', () => {
 
         onClick() {}
 
-        static ngFactoryFn = () => comp = new ManualComponent();
+        static ngFactoryDef = () => comp = new ManualComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualComponent,
           selectors: [['manual-comp']],
@@ -177,7 +177,7 @@ describe('change detection', () => {
       class ManualApp {
         name: string = 'Nancy';
 
-        static ngFactoryFn = () => new ManualApp();
+        static ngFactoryDef = () => new ManualApp();
         static ngComponentDef = ɵɵdefineComponent({
           type: ManualApp,
           selectors: [['manual-app']],
@@ -233,7 +233,7 @@ describe('change detection', () => {
              doCheckCount = 0;
              ngDoCheck(): void { this.doCheckCount++; }
 
-             static ngFactoryFn = () => parent = new ButtonParent();
+             static ngFactoryDef = () => parent = new ButtonParent();
              static ngComponentDef = ɵɵdefineComponent({
                type: ButtonParent,
                selectors: [['button-parent']],
@@ -311,7 +311,7 @@ describe('change detection', () => {
         return 'works';
       }
 
-      static ngFactoryFn = () => new MyComponent();
+      static ngFactoryDef = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -18,9 +18,6 @@ export const NgTemplateOutlet: DirectiveType<NgTemplateOutletDef> = NgTemplateOu
 NgForOf.ngDirectiveDef = ɵɵdefineDirective({
   type: NgForOfDef,
   selectors: [['', 'ngForOf', '']],
-  factory: () => new NgForOfDef(
-               ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any),
-               ɵɵdirectiveInject(IterableDiffers)),
   inputs: {
     ngForOf: 'ngForOf',
     ngForTrackBy: 'ngForTrackBy',
@@ -28,19 +25,26 @@ NgForOf.ngDirectiveDef = ɵɵdefineDirective({
   }
 });
 
-(NgIf as any).ngDirectiveDef = ɵɵdefineDirective({
+NgForOf.ngFactoryFn = () => new NgForOfDef(
+    ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any),
+    ɵɵdirectiveInject(IterableDiffers));
+
+NgIf.ngDirectiveDef = ɵɵdefineDirective({
   type: NgIfDef,
   selectors: [['', 'ngIf', '']],
-  factory: () => new NgIfDef(
-               ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any)),
   inputs: {ngIf: 'ngIf', ngIfThen: 'ngIfThen', ngIfElse: 'ngIfElse'}
 });
 
-(NgTemplateOutlet as any).ngDirectiveDef = ɵɵdefineDirective({
+NgIf.ngFactoryFn = () =>
+    new NgIfDef(ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any));
+
+NgTemplateOutlet.ngDirectiveDef = ɵɵdefineDirective({
   type: NgTemplateOutletDef,
   selectors: [['', 'ngTemplateOutlet', '']],
-  factory: () => new NgTemplateOutletDef(ɵɵdirectiveInject(ViewContainerRef as any)),
   features: [ɵɵNgOnChangesFeature()],
   inputs:
       {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}
 });
+
+NgTemplateOutlet.ngFactoryFn = () =>
+    new NgTemplateOutletDef(ɵɵdirectiveInject(ViewContainerRef as any));

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -25,7 +25,7 @@ NgForOf.ngDirectiveDef = ɵɵdefineDirective({
   }
 });
 
-NgForOf.ngFactoryFn = () => new NgForOfDef(
+NgForOf.ngFactoryDef = () => new NgForOfDef(
     ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any),
     ɵɵdirectiveInject(IterableDiffers));
 
@@ -35,7 +35,7 @@ NgIf.ngDirectiveDef = ɵɵdefineDirective({
   inputs: {ngIf: 'ngIf', ngIfThen: 'ngIfThen', ngIfElse: 'ngIfElse'}
 });
 
-NgIf.ngFactoryFn = () =>
+NgIf.ngFactoryDef = () =>
     new NgIfDef(ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any));
 
 NgTemplateOutlet.ngDirectiveDef = ɵɵdefineDirective({
@@ -46,5 +46,5 @@ NgTemplateOutlet.ngDirectiveDef = ɵɵdefineDirective({
       {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}
 });
 
-NgTemplateOutlet.ngFactoryFn = () =>
+NgTemplateOutlet.ngFactoryDef = () =>
     new NgTemplateOutletDef(ɵɵdirectiveInject(ViewContainerRef as any));

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -26,8 +26,8 @@ describe('ComponentFactory', () => {
           consts: 0,
           vars: 0,
           template: () => undefined,
-          factory: () => new TestComponent(),
         });
+        static ngFactoryFn = () => new TestComponent();
       }
 
       const cf = cfr.resolveComponentFactory(TestComponent);
@@ -49,7 +49,6 @@ describe('ComponentFactory', () => {
           vars: 0,
           template: () => undefined,
           ngContentSelectors: ['*', 'a', 'b'],
-          factory: () => new TestComponent(),
           inputs: {
             in1: 'in1',
             in2: ['input-attr-2', 'in2'],
@@ -59,6 +58,7 @@ describe('ComponentFactory', () => {
             out2: 'output-attr-2',
           },
         });
+        static ngFactoryFn = () => new TestComponent();
       }
 
       const cf = cfr.resolveComponentFactory(TestComponent);
@@ -96,8 +96,8 @@ describe('ComponentFactory', () => {
           consts: 0,
           vars: 0,
           template: () => undefined,
-          factory: () => new TestComponent(),
         });
+        static ngFactoryFn = () => new TestComponent();
       }
 
       cf = cfr.resolveComponentFactory(TestComponent);

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -20,6 +20,7 @@ describe('ComponentFactory', () => {
   describe('constructor()', () => {
     it('should correctly populate default properties', () => {
       class TestComponent {
+        static ngFactoryFn = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           selectors: [['test', 'foo'], ['bar']],
@@ -27,7 +28,6 @@ describe('ComponentFactory', () => {
           vars: 0,
           template: () => undefined,
         });
-        static ngFactoryFn = () => new TestComponent();
       }
 
       const cf = cfr.resolveComponentFactory(TestComponent);
@@ -41,6 +41,7 @@ describe('ComponentFactory', () => {
 
     it('should correctly populate defined properties', () => {
       class TestComponent {
+        static ngFactoryFn = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,
@@ -58,7 +59,6 @@ describe('ComponentFactory', () => {
             out2: 'output-attr-2',
           },
         });
-        static ngFactoryFn = () => new TestComponent();
       }
 
       const cf = cfr.resolveComponentFactory(TestComponent);
@@ -89,6 +89,7 @@ describe('ComponentFactory', () => {
       createRenderer3Spy = spyOn(domRendererFactory3, 'createRenderer').and.callThrough();
 
       class TestComponent {
+        static ngFactoryFn = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,
@@ -97,7 +98,6 @@ describe('ComponentFactory', () => {
           vars: 0,
           template: () => undefined,
         });
-        static ngFactoryFn = () => new TestComponent();
       }
 
       cf = cfr.resolveComponentFactory(TestComponent);

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -20,7 +20,7 @@ describe('ComponentFactory', () => {
   describe('constructor()', () => {
     it('should correctly populate default properties', () => {
       class TestComponent {
-        static ngFactoryFn = () => new TestComponent();
+        static ngFactoryDef = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           selectors: [['test', 'foo'], ['bar']],
@@ -41,7 +41,7 @@ describe('ComponentFactory', () => {
 
     it('should correctly populate defined properties', () => {
       class TestComponent {
-        static ngFactoryFn = () => new TestComponent();
+        static ngFactoryDef = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,
@@ -89,7 +89,7 @@ describe('ComponentFactory', () => {
       createRenderer3Spy = spyOn(domRendererFactory3, 'createRenderer').and.callThrough();
 
       class TestComponent {
-        static ngFactoryFn = () => new TestComponent();
+        static ngFactoryDef = () => new TestComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -21,6 +21,7 @@ describe('component', () => {
 
     increment() { this.count++; }
 
+    static ngFactoryFn = () => new CounterComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: CounterComponent,
       encapsulation: ViewEncapsulation.None,
@@ -38,7 +39,6 @@ describe('component', () => {
       },
       inputs: {count: 'count'},
     });
-    static ngFactoryFn = () => new CounterComponent;
   }
 
   describe('renderComponent', () => {
@@ -72,6 +72,7 @@ describe('component', () => {
     }
     class MyComponent {
       constructor(public myService: MyService) {}
+      static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(MyService));
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         encapsulation: ViewEncapsulation.None,
@@ -88,7 +89,6 @@ describe('component', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(MyService));
     }
 
     class MyModule {
@@ -117,6 +117,7 @@ describe('component', () => {
       // @Input
       name = '';
 
+      static ngFactoryFn = () => new Comp();
       static ngComponentDef = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
@@ -133,7 +134,6 @@ describe('component', () => {
         },
         inputs: {name: 'name'}
       });
-      static ngFactoryFn = () => new Comp();
     }
 
     // Artificially inflating the slot IDs of this app component to mimic an app
@@ -172,6 +172,12 @@ it('should not invoke renderer destroy method for embedded views', () => {
   class Comp {
     visible = true;
 
+    static ngFactoryFn =
+        () => {
+          comp = new Comp();
+          return comp;
+        }
+
     static ngComponentDef = ɵɵdefineComponent({
       type: Comp,
       selectors: [['comp']],
@@ -196,10 +202,6 @@ it('should not invoke renderer destroy method for embedded views', () => {
         }
       }
     });
-    static ngFactoryFn = () => {
-      comp = new Comp();
-      return comp;
-    }
   }
 
   const rendererFactory = new MockRendererFactory(['destroy']);
@@ -248,6 +250,7 @@ describe('component with a container', () => {
   class WrapperComponent {
     // TODO(issue/24571): remove '!'.
     items !: string[];
+    static ngFactoryFn = () => new WrapperComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: WrapperComponent,
       encapsulation: ViewEncapsulation.None,
@@ -270,7 +273,6 @@ describe('component with a container', () => {
       },
       inputs: {items: 'items'}
     });
-    static ngFactoryFn = () => new WrapperComponent;
   }
 
   function template(rf: RenderFlags, ctx: {items: string[]}) {
@@ -326,6 +328,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
+    static ngFactoryFn = () => new TreeComponent();
     static ngComponentDef = ɵɵdefineComponent({
       type: TreeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -375,7 +378,6 @@ describe('recursive components', () => {
       },
       inputs: {data: 'data'}
     });
-    static ngFactoryFn = () => new TreeComponent();
   }
 
   (TreeComponent.ngComponentDef as ComponentDef<TreeComponent>).directiveDefs =
@@ -393,6 +395,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
+    static ngFactoryFn = () => new NgIfTree();
     static ngComponentDef = ɵɵdefineComponent({
       type: NgIfTree,
       encapsulation: ViewEncapsulation.None,
@@ -422,7 +425,6 @@ describe('recursive components', () => {
       },
       inputs: {data: 'data'},
     });
-    static ngFactoryFn = () => new NgIfTree();
   }
 
   function IfTemplate(rf: RenderFlags, left: any) {
@@ -543,6 +545,7 @@ describe('recursive components', () => {
     class TestInputsComponent {
       // TODO(issue/24571): remove '!'.
       minifiedName !: string;
+      static ngFactoryFn = () => new TestInputsComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: TestInputsComponent,
         encapsulation: ViewEncapsulation.None,
@@ -554,7 +557,6 @@ describe('recursive components', () => {
           // Template not needed for this test
         }
       });
-      static ngFactoryFn = () => new TestInputsComponent();
     }
 
     const testInputsComponentFactory = new ComponentFactory(TestInputsComponent.ngComponentDef);

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -21,7 +21,7 @@ describe('component', () => {
 
     increment() { this.count++; }
 
-    static ngFactoryFn = () => new CounterComponent;
+    static ngFactoryDef = () => new CounterComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: CounterComponent,
       encapsulation: ViewEncapsulation.None,
@@ -72,7 +72,7 @@ describe('component', () => {
     }
     class MyComponent {
       constructor(public myService: MyService) {}
-      static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(MyService));
+      static ngFactoryDef = () => new MyComponent(ɵɵdirectiveInject(MyService));
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         encapsulation: ViewEncapsulation.None,
@@ -117,7 +117,7 @@ describe('component', () => {
       // @Input
       name = '';
 
-      static ngFactoryFn = () => new Comp();
+      static ngFactoryDef = () => new Comp();
       static ngComponentDef = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
@@ -172,7 +172,7 @@ it('should not invoke renderer destroy method for embedded views', () => {
   class Comp {
     visible = true;
 
-    static ngFactoryFn =
+    static ngFactoryDef =
         () => {
           comp = new Comp();
           return comp;
@@ -250,7 +250,7 @@ describe('component with a container', () => {
   class WrapperComponent {
     // TODO(issue/24571): remove '!'.
     items !: string[];
-    static ngFactoryFn = () => new WrapperComponent;
+    static ngFactoryDef = () => new WrapperComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: WrapperComponent,
       encapsulation: ViewEncapsulation.None,
@@ -328,7 +328,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
-    static ngFactoryFn = () => new TreeComponent();
+    static ngFactoryDef = () => new TreeComponent();
     static ngComponentDef = ɵɵdefineComponent({
       type: TreeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -395,7 +395,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
-    static ngFactoryFn = () => new NgIfTree();
+    static ngFactoryDef = () => new NgIfTree();
     static ngComponentDef = ɵɵdefineComponent({
       type: NgIfTree,
       encapsulation: ViewEncapsulation.None,
@@ -545,7 +545,7 @@ describe('recursive components', () => {
     class TestInputsComponent {
       // TODO(issue/24571): remove '!'.
       minifiedName !: string;
-      static ngFactoryFn = () => new TestInputsComponent();
+      static ngFactoryDef = () => new TestInputsComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: TestInputsComponent,
         encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -36,9 +36,9 @@ describe('component', () => {
           ɵɵtextBinding(ctx.count);
         }
       },
-      factory: () => new CounterComponent,
       inputs: {count: 'count'},
     });
+    static ngFactoryFn = () => new CounterComponent;
   }
 
   describe('renderComponent', () => {
@@ -76,7 +76,6 @@ describe('component', () => {
         type: MyComponent,
         encapsulation: ViewEncapsulation.None,
         selectors: [['my-component']],
-        factory: () => new MyComponent(ɵɵdirectiveInject(MyService)),
         consts: 1,
         vars: 1,
         template: function(fs: RenderFlags, ctx: MyComponent) {
@@ -89,6 +88,7 @@ describe('component', () => {
           }
         }
       });
+      static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(MyService));
     }
 
     class MyModule {
@@ -120,7 +120,6 @@ describe('component', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
-        factory: () => new Comp(),
         consts: 1,
         vars: 1,
         template: (rf: RenderFlags, ctx: Comp) => {
@@ -134,6 +133,7 @@ describe('component', () => {
         },
         inputs: {name: 'name'}
       });
+      static ngFactoryFn = () => new Comp();
     }
 
     // Artificially inflating the slot IDs of this app component to mimic an app
@@ -177,10 +177,6 @@ it('should not invoke renderer destroy method for embedded views', () => {
       selectors: [['comp']],
       consts: 3,
       vars: 1,
-      factory: () => {
-        comp = new Comp();
-        return comp;
-      },
       directives: [NgIf],
       /**
        *  <div>Root view</div>
@@ -200,6 +196,10 @@ it('should not invoke renderer destroy method for embedded views', () => {
         }
       }
     });
+    static ngFactoryFn = () => {
+      comp = new Comp();
+      return comp;
+    }
   }
 
   const rendererFactory = new MockRendererFactory(['destroy']);
@@ -268,9 +268,9 @@ describe('component with a container', () => {
           ɵɵcontainerRefreshEnd();
         }
       },
-      factory: () => new WrapperComponent,
       inputs: {items: 'items'}
     });
+    static ngFactoryFn = () => new WrapperComponent;
   }
 
   function template(rf: RenderFlags, ctx: {items: string[]}) {
@@ -330,7 +330,6 @@ describe('recursive components', () => {
       type: TreeComponent,
       encapsulation: ViewEncapsulation.None,
       selectors: [['tree-comp']],
-      factory: () => new TreeComponent(),
       consts: 3,
       vars: 1,
       template: (rf: RenderFlags, ctx: TreeComponent) => {
@@ -376,6 +375,7 @@ describe('recursive components', () => {
       },
       inputs: {data: 'data'}
     });
+    static ngFactoryFn = () => new TreeComponent();
   }
 
   (TreeComponent.ngComponentDef as ComponentDef<TreeComponent>).directiveDefs =
@@ -397,7 +397,6 @@ describe('recursive components', () => {
       type: NgIfTree,
       encapsulation: ViewEncapsulation.None,
       selectors: [['ng-if-tree']],
-      factory: () => new NgIfTree(),
       consts: 3,
       vars: 3,
       template: (rf: RenderFlags, ctx: NgIfTree) => {
@@ -423,6 +422,7 @@ describe('recursive components', () => {
       },
       inputs: {data: 'data'},
     });
+    static ngFactoryFn = () => new NgIfTree();
   }
 
   function IfTemplate(rf: RenderFlags, left: any) {
@@ -550,11 +550,11 @@ describe('recursive components', () => {
         inputs: {minifiedName: 'unminifiedName'},
         consts: 0,
         vars: 0,
-        factory: () => new TestInputsComponent(),
         template: function(rf: RenderFlags, ctx: TestInputsComponent): void {
           // Template not needed for this test
         }
       });
+      static ngFactoryFn = () => new TestInputsComponent();
     }
 
     const testInputsComponentFactory = new ComponentFactory(TestInputsComponent.ngComponentDef);

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -692,6 +692,12 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates in test below so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
+      static ngFactoryFn =
+          () => {
+            log.push('comp!');
+            return new Comp();
+          }
+
       static ngComponentDef = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
@@ -699,16 +705,13 @@ describe('JS control flow', () => {
         vars: 0,
         template: function(rf: RenderFlags, ctx: Comp) {}
       });
-      static ngFactoryFn = () => {
-        log.push('comp!');
-        return new Comp();
-      }
     }
 
     class App {
       condition = true;
       condition2 = true;
 
+      static ngFactoryFn = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
@@ -747,7 +750,6 @@ describe('JS control flow', () => {
         },
         directives: () => [Comp]
       });
-      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);
@@ -760,6 +762,12 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates from above so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
+      static ngFactoryFn =
+          () => {
+            log.push('comp!');
+            return new Comp();
+          }
+
       static ngComponentDef = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
@@ -767,16 +775,13 @@ describe('JS control flow', () => {
         vars: 0,
         template: function(rf: RenderFlags, ctx: Comp) {}
       });
-      static ngFactoryFn = () => {
-        log.push('comp!');
-        return new Comp();
-      }
     }
 
     class App {
       condition = false;
       condition2 = true;
 
+      static ngFactoryFn = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
@@ -815,7 +820,6 @@ describe('JS control flow', () => {
         },
         directives: () => [Comp]
       });
-      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -697,12 +697,12 @@ describe('JS control flow', () => {
         selectors: [['comp']],
         consts: 0,
         vars: 0,
-        factory: () => {
-          log.push('comp!');
-          return new Comp();
-        },
         template: function(rf: RenderFlags, ctx: Comp) {}
       });
+      static ngFactoryFn = () => {
+        log.push('comp!');
+        return new Comp();
+      }
     }
 
     class App {
@@ -712,7 +712,6 @@ describe('JS control flow', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
-        factory: () => new App(),
         consts: 3,
         vars: 0,
         template: function(rf: RenderFlags, ctx: any) {
@@ -748,6 +747,7 @@ describe('JS control flow', () => {
         },
         directives: () => [Comp]
       });
+      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);
@@ -765,12 +765,12 @@ describe('JS control flow', () => {
         selectors: [['comp']],
         consts: 0,
         vars: 0,
-        factory: () => {
-          log.push('comp!');
-          return new Comp();
-        },
         template: function(rf: RenderFlags, ctx: Comp) {}
       });
+      static ngFactoryFn = () => {
+        log.push('comp!');
+        return new Comp();
+      }
     }
 
     class App {
@@ -780,7 +780,6 @@ describe('JS control flow', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
-        factory: () => new App(),
         consts: 3,
         vars: 0,
         template: function(rf: RenderFlags, ctx: any) {
@@ -816,6 +815,7 @@ describe('JS control flow', () => {
         },
         directives: () => [Comp]
       });
+      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -692,7 +692,7 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates in test below so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
-      static ngFactoryFn =
+      static ngFactoryDef =
           () => {
             log.push('comp!');
             return new Comp();
@@ -711,7 +711,7 @@ describe('JS control flow', () => {
       condition = true;
       condition2 = true;
 
-      static ngFactoryFn = () => new App();
+      static ngFactoryDef = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
@@ -762,7 +762,7 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates from above so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
-      static ngFactoryFn =
+      static ngFactoryDef =
           () => {
             log.push('comp!');
             return new Comp();
@@ -781,7 +781,7 @@ describe('JS control flow', () => {
       condition = false;
       condition2 = true;
 
-      static ngFactoryFn = () => new App();
+      static ngFactoryDef = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],

--- a/packages/core/test/render3/debug_spec.ts
+++ b/packages/core/test/render3/debug_spec.ts
@@ -15,7 +15,7 @@ import {ComponentFixture} from './render_util';
 describe('Debug Representation', () => {
   it('should generate a human readable version', () => {
     class MyComponent {
-      static ngFactoryFn = () => new MyComponent();
+      static ngFactoryDef = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],

--- a/packages/core/test/render3/debug_spec.ts
+++ b/packages/core/test/render3/debug_spec.ts
@@ -20,7 +20,6 @@ describe('Debug Representation', () => {
         selectors: [['my-comp']],
         vars: 0,
         consts: 2,
-        factory: () => new MyComponent(),
         template: function(rf: RenderFlags, ctx: MyComponent) {
           if (rf == RenderFlags.Create) {
             ɵɵelementStart(0, 'div', ['id', '123']);
@@ -29,6 +28,7 @@ describe('Debug Representation', () => {
           }
         }
       });
+      static ngFactoryFn = () => new MyComponent();
     }
 
     const fixture = new ComponentFixture(MyComponent);

--- a/packages/core/test/render3/debug_spec.ts
+++ b/packages/core/test/render3/debug_spec.ts
@@ -15,6 +15,7 @@ import {ComponentFixture} from './render_util';
 describe('Debug Representation', () => {
   it('should generate a human readable version', () => {
     class MyComponent {
+      static ngFactoryFn = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -28,7 +29,6 @@ describe('Debug Representation', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComponent();
     }
 
     const fixture = new ComponentFixture(MyComponent);

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -31,12 +31,9 @@ describe('di', () => {
       value = 'DirB';
       constructor() { log.push(this.value); }
 
-      static ngDirectiveDef = ɵɵdefineDirective({
-        selectors: [['', 'dirB', '']],
-        type: DirB,
-        factory: () => new DirB(),
-        inputs: {value: 'value'}
-      });
+      static ngDirectiveDef =
+          ɵɵdefineDirective({selectors: [['', 'dirB', '']], type: DirB, inputs: {value: 'value'}});
+      static ngFactoryFn = () => new DirB();
     }
 
     beforeEach(() => log = []);
@@ -49,11 +46,8 @@ describe('di', () => {
       class DirA {
         constructor(dir: DirB) { log.push(`DirA (dep: ${dir.value})`); }
 
-        static ngDirectiveDef = ɵɵdefineDirective({
-          selectors: [['', 'dirA', '']],
-          type: DirA,
-          factory: () => new DirA(ɵɵdirectiveInject(DirB))
-        });
+        static ngDirectiveDef = ɵɵdefineDirective({selectors: [['', 'dirA', '']], type: DirA});
+        static ngFactoryFn = () => new DirA(ɵɵdirectiveInject(DirB));
       }
 
       /**
@@ -92,13 +86,10 @@ describe('di', () => {
           this.injector = vcr.injector;
         }
 
-        static ngDirectiveDef = ɵɵdefineDirective({
-          type: DirA,
-          selectors: [['', 'dirA', '']],
-          factory:
-              () => new DirA(ɵɵdirectiveInject(DirB), ɵɵdirectiveInject(ViewContainerRef as any)),
-          exportAs: ['dirA']
-        });
+        static ngDirectiveDef =
+            ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']], exportAs: ['dirA']});
+        static ngFactoryFn = () =>
+            new DirA(ɵɵdirectiveInject(DirB), ɵɵdirectiveInject(ViewContainerRef as any))
       }
 
       /**
@@ -171,12 +162,9 @@ describe('di', () => {
         // TODO(issue/24571): remove '!'.
         value !: string;
 
-        static ngDirectiveDef = ɵɵdefineDirective({
-          type: DirB,
-          selectors: [['', 'dirB', '']],
-          factory: () => new DirB(),
-          inputs: {value: 'dirB'}
-        });
+        static ngDirectiveDef =
+            ɵɵdefineDirective({type: DirB, selectors: [['', 'dirB', '']], inputs: {value: 'dirB'}});
+        static ngFactoryFn = () => new DirB();
       }
 
       describe('Optional', () => {
@@ -185,11 +173,8 @@ describe('di', () => {
         class DirA {
           constructor(@Optional() public dirB: DirB|null) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({
-            type: DirA,
-            selectors: [['', 'dirA', '']],
-            factory: () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional))
-          });
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
+          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional));
         }
 
         beforeEach(() => dirA = null);
@@ -214,11 +199,8 @@ describe('di', () => {
         class DirA {
           constructor(@Self() public dirB: DirB) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({
-            type: DirA,
-            selectors: [['', 'dirA', '']],
-            factory: () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self))
-          });
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
+          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
         }
 
         const DirC = createDirective('dirC');
@@ -251,11 +233,8 @@ describe('di', () => {
         class DirA {
           constructor(@Host() public dirB: DirB) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({
-            type: DirA,
-            selectors: [['', 'dirA', '']],
-            factory: () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Host))
-          });
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
+          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Host));
         }
 
         /**
@@ -322,7 +301,6 @@ describe('di', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComp,
           selectors: [['my-comp']],
-          factory: () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any)),
           consts: 1,
           vars: 0,
           template: function(rf: RenderFlags, ctx: MyComp) {
@@ -332,6 +310,7 @@ describe('di', () => {
             }
           }
         });
+        static ngFactoryFn = () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any));
       }
 
       class Directive {
@@ -339,23 +318,18 @@ describe('di', () => {
 
         constructor(public cdr: ChangeDetectorRef) { this.value = (cdr.constructor as any).name; }
 
-        static ngDirectiveDef = ɵɵdefineDirective({
-          type: Directive,
-          selectors: [['', 'dir', '']],
-          factory: () => dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any)),
-          exportAs: ['dir']
-        });
+        static ngDirectiveDef =
+            ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']], exportAs: ['dir']});
+        static ngFactoryFn = () => dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any));
       }
 
       class DirectiveSameInstance {
         constructor(public cdr: ChangeDetectorRef) {}
 
-        static ngDirectiveDef = ɵɵdefineDirective({
-          type: DirectiveSameInstance,
-          selectors: [['', 'dirSame', '']],
-          factory: () => dirSameInstance =
-                       new DirectiveSameInstance(ɵɵdirectiveInject(ChangeDetectorRef as any))
-        });
+        static ngDirectiveDef =
+            ɵɵdefineDirective({type: DirectiveSameInstance, selectors: [['', 'dirSame', '']]});
+        static ngFactoryFn = () => dirSameInstance =
+            new DirectiveSameInstance(ɵɵdirectiveInject(ChangeDetectorRef as any))
       }
 
       const directives = [MyComp, Directive, DirectiveSameInstance];
@@ -374,7 +348,6 @@ describe('di', () => {
           static ngComponentDef = ɵɵdefineComponent({
             type: MyApp,
             selectors: [['my-app']],
-            factory: () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any)),
             consts: 1,
             vars: 0,
             /**
@@ -409,6 +382,7 @@ describe('di', () => {
             },
             directives: directives
           });
+          static ngFactoryFn = () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any));
         }
 
         const app = renderComponent(MyApp);
@@ -429,7 +403,6 @@ describe('di', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['my-comp']],
-        factory: () => new MyComp(ɵɵdirectiveInject(Renderer2 as any)),
         consts: 1,
         vars: 0,
         template: function(rf: RenderFlags, ctx: MyComp) {
@@ -438,6 +411,7 @@ describe('di', () => {
           }
         }
       });
+      static ngFactoryFn = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
     }
 
     it('should inject the Renderer2 used by the application', () => {
@@ -537,24 +511,18 @@ describe('di', () => {
       class ChildDirective {
         value: string;
         constructor(public parent: any) { this.value = (parent.constructor as any).name; }
-        static ngDirectiveDef = ɵɵdefineDirective({
-          type: ChildDirective,
-          selectors: [['', 'childDir', '']],
-          factory: () => new ChildDirective(ɵɵdirectiveInject(ParentDirective)),
-          exportAs: ['childDir']
-        });
+        static ngDirectiveDef = ɵɵdefineDirective(
+            {type: ChildDirective, selectors: [['', 'childDir', '']], exportAs: ['childDir']});
+        static ngFactoryFn = () => new ChildDirective(ɵɵdirectiveInject(ParentDirective));
       }
 
       class Child2Directive {
         value: boolean;
         constructor(parent: any, child: ChildDirective) { this.value = parent === child.parent; }
-        static ngDirectiveDef = ɵɵdefineDirective({
-          selectors: [['', 'child2Dir', '']],
-          type: Child2Directive,
-          factory: () => new Child2Directive(
-                       ɵɵdirectiveInject(ParentDirective), ɵɵdirectiveInject(ChildDirective)),
-          exportAs: ['child2Dir']
-        });
+        static ngDirectiveDef = ɵɵdefineDirective(
+            {selectors: [['', 'child2Dir', '']], type: Child2Directive, exportAs: ['child2Dir']});
+        static ngFactoryFn = () => new Child2Directive(
+            ɵɵdirectiveInject(ParentDirective), ɵɵdirectiveInject(ChildDirective))
       }
 
       /**

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -31,7 +31,7 @@ describe('di', () => {
       value = 'DirB';
       constructor() { log.push(this.value); }
 
-      static ngFactoryFn = () => new DirB();
+      static ngFactoryDef = () => new DirB();
       static ngDirectiveDef =
           ɵɵdefineDirective({selectors: [['', 'dirB', '']], type: DirB, inputs: {value: 'value'}});
     }
@@ -46,7 +46,7 @@ describe('di', () => {
       class DirA {
         constructor(dir: DirB) { log.push(`DirA (dep: ${dir.value})`); }
 
-        static ngFactoryFn = () => new DirA(ɵɵdirectiveInject(DirB));
+        static ngFactoryDef = () => new DirA(ɵɵdirectiveInject(DirB));
         static ngDirectiveDef = ɵɵdefineDirective({selectors: [['', 'dirA', '']], type: DirA});
       }
 
@@ -86,7 +86,7 @@ describe('di', () => {
           this.injector = vcr.injector;
         }
 
-        static ngFactoryFn = () => new DirA(
+        static ngFactoryDef = () => new DirA(
             ɵɵdirectiveInject(DirB), ɵɵdirectiveInject(ViewContainerRef as any))
 
             static ngDirectiveDef =
@@ -163,7 +163,7 @@ describe('di', () => {
         // TODO(issue/24571): remove '!'.
         value !: string;
 
-        static ngFactoryFn = () => new DirB();
+        static ngFactoryDef = () => new DirB();
         static ngDirectiveDef =
             ɵɵdefineDirective({type: DirB, selectors: [['', 'dirB', '']], inputs: {value: 'dirB'}});
       }
@@ -174,7 +174,12 @@ describe('di', () => {
         class DirA {
           constructor(@Optional() public dirB: DirB|null) {}
 
-          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional));
+          static ngFactoryDef =
+              () => {
+                dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional));
+                return dirA;
+              }
+
           static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
@@ -200,7 +205,7 @@ describe('di', () => {
         class DirA {
           constructor(@Self() public dirB: DirB) {}
 
-          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
+          static ngFactoryDef = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
           static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
@@ -234,7 +239,7 @@ describe('di', () => {
         class DirA {
           constructor(@Host() public dirB: DirB) {}
 
-          static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Host));
+          static ngFactoryDef = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Host));
           static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
@@ -299,7 +304,7 @@ describe('di', () => {
       class MyComp {
         constructor(public cdr: ChangeDetectorRef) {}
 
-        static ngFactoryFn = () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any));
+        static ngFactoryDef = () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any));
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComp,
           selectors: [['my-comp']],
@@ -319,7 +324,12 @@ describe('di', () => {
 
         constructor(public cdr: ChangeDetectorRef) { this.value = (cdr.constructor as any).name; }
 
-        static ngFactoryFn = () => dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any));
+        static ngFactoryDef =
+            () => {
+              dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any));
+              return dir;
+            }
+
         static ngDirectiveDef =
             ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']], exportAs: ['dir']});
       }
@@ -327,7 +337,7 @@ describe('di', () => {
       class DirectiveSameInstance {
         constructor(public cdr: ChangeDetectorRef) {}
 
-        static ngFactoryFn = () => dirSameInstance =
+        static ngFactoryDef = () => dirSameInstance =
             new DirectiveSameInstance(ɵɵdirectiveInject(ChangeDetectorRef as any))
 
                 static ngDirectiveDef = ɵɵdefineDirective(
@@ -347,7 +357,7 @@ describe('di', () => {
 
           constructor(public cdr: ChangeDetectorRef) {}
 
-          static ngFactoryFn = () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any));
+          static ngFactoryDef = () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any));
           static ngComponentDef = ɵɵdefineComponent({
             type: MyApp,
             selectors: [['my-app']],
@@ -402,7 +412,7 @@ describe('di', () => {
     class MyComp {
       constructor(public renderer: Renderer2) {}
 
-      static ngFactoryFn = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
+      static ngFactoryDef = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['my-comp']],
@@ -513,7 +523,7 @@ describe('di', () => {
       class ChildDirective {
         value: string;
         constructor(public parent: any) { this.value = (parent.constructor as any).name; }
-        static ngFactoryFn = () => new ChildDirective(ɵɵdirectiveInject(ParentDirective));
+        static ngFactoryDef = () => new ChildDirective(ɵɵdirectiveInject(ParentDirective));
         static ngDirectiveDef = ɵɵdefineDirective(
             {type: ChildDirective, selectors: [['', 'childDir', '']], exportAs: ['childDir']});
       }
@@ -521,7 +531,7 @@ describe('di', () => {
       class Child2Directive {
         value: boolean;
         constructor(parent: any, child: ChildDirective) { this.value = parent === child.parent; }
-        static ngFactoryFn = () => new Child2Directive(
+        static ngFactoryDef = () => new Child2Directive(
             ɵɵdirectiveInject(ParentDirective), ɵɵdirectiveInject(ChildDirective))
 
             static ngDirectiveDef = ɵɵdefineDirective({

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -31,9 +31,9 @@ describe('di', () => {
       value = 'DirB';
       constructor() { log.push(this.value); }
 
+      static ngFactoryFn = () => new DirB();
       static ngDirectiveDef =
           ɵɵdefineDirective({selectors: [['', 'dirB', '']], type: DirB, inputs: {value: 'value'}});
-      static ngFactoryFn = () => new DirB();
     }
 
     beforeEach(() => log = []);
@@ -46,8 +46,8 @@ describe('di', () => {
       class DirA {
         constructor(dir: DirB) { log.push(`DirA (dep: ${dir.value})`); }
 
-        static ngDirectiveDef = ɵɵdefineDirective({selectors: [['', 'dirA', '']], type: DirA});
         static ngFactoryFn = () => new DirA(ɵɵdirectiveInject(DirB));
+        static ngDirectiveDef = ɵɵdefineDirective({selectors: [['', 'dirA', '']], type: DirA});
       }
 
       /**
@@ -86,10 +86,11 @@ describe('di', () => {
           this.injector = vcr.injector;
         }
 
-        static ngDirectiveDef =
-            ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']], exportAs: ['dirA']});
-        static ngFactoryFn = () =>
-            new DirA(ɵɵdirectiveInject(DirB), ɵɵdirectiveInject(ViewContainerRef as any))
+        static ngFactoryFn = () => new DirA(
+            ɵɵdirectiveInject(DirB), ɵɵdirectiveInject(ViewContainerRef as any))
+
+            static ngDirectiveDef =
+                ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']], exportAs: ['dirA']});
       }
 
       /**
@@ -162,9 +163,9 @@ describe('di', () => {
         // TODO(issue/24571): remove '!'.
         value !: string;
 
+        static ngFactoryFn = () => new DirB();
         static ngDirectiveDef =
             ɵɵdefineDirective({type: DirB, selectors: [['', 'dirB', '']], inputs: {value: 'dirB'}});
-        static ngFactoryFn = () => new DirB();
       }
 
       describe('Optional', () => {
@@ -173,8 +174,8 @@ describe('di', () => {
         class DirA {
           constructor(@Optional() public dirB: DirB|null) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
           static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional));
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
         beforeEach(() => dirA = null);
@@ -199,8 +200,8 @@ describe('di', () => {
         class DirA {
           constructor(@Self() public dirB: DirB) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
           static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
         const DirC = createDirective('dirC');
@@ -233,8 +234,8 @@ describe('di', () => {
         class DirA {
           constructor(@Host() public dirB: DirB) {}
 
-          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
           static ngFactoryFn = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Host));
+          static ngDirectiveDef = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
         /**
@@ -298,6 +299,7 @@ describe('di', () => {
       class MyComp {
         constructor(public cdr: ChangeDetectorRef) {}
 
+        static ngFactoryFn = () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any));
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComp,
           selectors: [['my-comp']],
@@ -310,7 +312,6 @@ describe('di', () => {
             }
           }
         });
-        static ngFactoryFn = () => comp = new MyComp(ɵɵdirectiveInject(ChangeDetectorRef as any));
       }
 
       class Directive {
@@ -318,18 +319,19 @@ describe('di', () => {
 
         constructor(public cdr: ChangeDetectorRef) { this.value = (cdr.constructor as any).name; }
 
+        static ngFactoryFn = () => dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any));
         static ngDirectiveDef =
             ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']], exportAs: ['dir']});
-        static ngFactoryFn = () => dir = new Directive(ɵɵdirectiveInject(ChangeDetectorRef as any));
       }
 
       class DirectiveSameInstance {
         constructor(public cdr: ChangeDetectorRef) {}
 
-        static ngDirectiveDef =
-            ɵɵdefineDirective({type: DirectiveSameInstance, selectors: [['', 'dirSame', '']]});
         static ngFactoryFn = () => dirSameInstance =
             new DirectiveSameInstance(ɵɵdirectiveInject(ChangeDetectorRef as any))
+
+                static ngDirectiveDef = ɵɵdefineDirective(
+                    {type: DirectiveSameInstance, selectors: [['', 'dirSame', '']]});
       }
 
       const directives = [MyComp, Directive, DirectiveSameInstance];
@@ -345,6 +347,7 @@ describe('di', () => {
 
           constructor(public cdr: ChangeDetectorRef) {}
 
+          static ngFactoryFn = () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any));
           static ngComponentDef = ɵɵdefineComponent({
             type: MyApp,
             selectors: [['my-app']],
@@ -382,7 +385,6 @@ describe('di', () => {
             },
             directives: directives
           });
-          static ngFactoryFn = () => new MyApp(ɵɵdirectiveInject(ChangeDetectorRef as any));
         }
 
         const app = renderComponent(MyApp);
@@ -400,6 +402,7 @@ describe('di', () => {
     class MyComp {
       constructor(public renderer: Renderer2) {}
 
+      static ngFactoryFn = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['my-comp']],
@@ -411,7 +414,6 @@ describe('di', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
     }
 
     it('should inject the Renderer2 used by the application', () => {
@@ -511,18 +513,22 @@ describe('di', () => {
       class ChildDirective {
         value: string;
         constructor(public parent: any) { this.value = (parent.constructor as any).name; }
+        static ngFactoryFn = () => new ChildDirective(ɵɵdirectiveInject(ParentDirective));
         static ngDirectiveDef = ɵɵdefineDirective(
             {type: ChildDirective, selectors: [['', 'childDir', '']], exportAs: ['childDir']});
-        static ngFactoryFn = () => new ChildDirective(ɵɵdirectiveInject(ParentDirective));
       }
 
       class Child2Directive {
         value: boolean;
         constructor(parent: any, child: ChildDirective) { this.value = parent === child.parent; }
-        static ngDirectiveDef = ɵɵdefineDirective(
-            {selectors: [['', 'child2Dir', '']], type: Child2Directive, exportAs: ['child2Dir']});
         static ngFactoryFn = () => new Child2Directive(
             ɵɵdirectiveInject(ParentDirective), ɵɵdirectiveInject(ChildDirective))
+
+            static ngDirectiveDef = ɵɵdefineDirective({
+              selectors: [['', 'child2Dir', '']],
+              type: Child2Directive,
+              exportAs: ['child2Dir']
+            });
       }
 
       /**

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -272,7 +272,7 @@ describe('instructions', () => {
       class NestedLoops {
         rows = [['a', 'b'], ['A', 'B'], ['a', 'b'], ['A', 'B']];
 
-        static ngFactoryFn = function ToDoAppComponent_Factory() { return new NestedLoops(); };
+        static ngFactoryDef = function ToDoAppComponent_Factory() { return new NestedLoops(); };
         static ngComponentDef = ɵɵdefineComponent({
           type: NestedLoops,
           selectors: [['nested-loops']],

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -272,6 +272,7 @@ describe('instructions', () => {
       class NestedLoops {
         rows = [['a', 'b'], ['A', 'B'], ['a', 'b'], ['A', 'B']];
 
+        static ngFactoryFn = function ToDoAppComponent_Factory() { return new NestedLoops(); };
         static ngComponentDef = ɵɵdefineComponent({
           type: NestedLoops,
           selectors: [['nested-loops']],
@@ -287,7 +288,6 @@ describe('instructions', () => {
           },
           directives: [NgForOf]
         });
-        static ngFactoryFn = function ToDoAppComponent_Factory() { return new NestedLoops(); };
       }
       const fixture = new ComponentFixture(NestedLoops);
       expect(ngDevMode).toHaveProperties({

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -275,7 +275,6 @@ describe('instructions', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: NestedLoops,
           selectors: [['nested-loops']],
-          factory: function ToDoAppComponent_Factory() { return new NestedLoops(); },
           consts: 1,
           vars: 1,
           template: function ToDoAppComponent_Template(rf: RenderFlags, ctx: NestedLoops) {
@@ -288,6 +287,7 @@ describe('instructions', () => {
           },
           directives: [NgForOf]
         });
+        static ngFactoryFn = function ToDoAppComponent_Factory() { return new NestedLoops(); };
       }
       const fixture = new ComponentFixture(NestedLoops);
       expect(ngDevMode).toHaveProperties({

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -147,9 +147,9 @@ describe('render3 integration test', () => {
             ɵɵcontainerRefreshEnd();
           }
         },
-        factory: () => new ChildComponent,
         inputs: {beforeTree: 'beforeTree', afterTree: 'afterTree'}
       });
+      static ngFactoryFn = () => new ChildComponent;
     }
 
     function parentTemplate(rf: RenderFlags, ctx: ParentCtx) {
@@ -207,13 +207,13 @@ describe('component styles', () => {
         vars: 0,
         encapsulation: 100,
         selectors: [['foo']],
-        factory: () => new StyledComp(),
         template: (rf: RenderFlags, ctx: StyledComp) => {
           if (rf & RenderFlags.Create) {
             ɵɵelement(0, 'div');
           }
         }
       });
+      static ngFactoryFn = () => new StyledComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(StyledComp, {rendererFactory});
@@ -239,9 +239,9 @@ describe('component animations', () => {
           ],
         },
         selectors: [['foo']],
-        factory: () => new AnimComp(),
         template: (rf: RenderFlags, ctx: AnimComp) => {}
       });
+      static ngFactoryFn = () => new AnimComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(AnimComp, {rendererFactory});
@@ -263,9 +263,9 @@ describe('component animations', () => {
           animation: [],
         },
         selectors: [['foo']],
-        factory: () => new AnimComp(),
         template: (rf: RenderFlags, ctx: AnimComp) => {}
       });
+      static ngFactoryFn = () => new AnimComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(AnimComp, {rendererFactory});
@@ -280,7 +280,6 @@ describe('component animations', () => {
         consts: 1,
         vars: 1,
         selectors: [['foo']],
-        factory: () => new AnimComp(),
         template: (rf: RenderFlags, ctx: AnimComp) => {
           if (rf & RenderFlags.Create) {
             ɵɵelement(0, 'div', [AttributeMarker.Bindings, '@fooAnimation']);
@@ -291,6 +290,7 @@ describe('component animations', () => {
           }
         }
       });
+      static ngFactoryFn = () => new AnimComp();
 
       animationValue = '123';
     }
@@ -317,13 +317,13 @@ describe('component animations', () => {
            consts: 1,
            vars: 1,
            selectors: [['foo']],
-           factory: () => new AnimComp(),
            template: (rf: RenderFlags, ctx: AnimComp) => {
              if (rf & RenderFlags.Create) {
                ɵɵelement(0, 'div', ['@fooAnimation', '']);
              }
            }
          });
+         static ngFactoryFn = () => new AnimComp();
        }
 
        const rendererFactory = new MockRendererFactory(['setProperty']);
@@ -347,7 +347,6 @@ describe('component animations', () => {
   //     class ChildCompWithAnim {
   //       static ngDirectiveDef = ɵɵdefineDirective({
   //         type: ChildCompWithAnim,
-  //         factory: () => new ChildCompWithAnim(),
   //         selectors: [['child-comp-with-anim']],
   //         hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
   //           if (rf & RenderFlags.Update) {
@@ -355,6 +354,7 @@ describe('component animations', () => {
   //           }
   //         },
   //       });
+  //       static ngFactoryFn = () => new ChildCompWithAnim();
 
   //       exp = 'go';
   //     }
@@ -365,7 +365,6 @@ describe('component animations', () => {
   //         consts: 1,
   //         vars: 1,
   //         selectors: [['foo']],
-  //         factory: () => new ParentComp(),
   //         template: (rf: RenderFlags, ctx: ParentComp) => {
   //           if (rf & RenderFlags.Create) {
   //             ɵɵelement(0, 'child-comp-with-anim');
@@ -373,6 +372,7 @@ describe('component animations', () => {
   //         },
   //         directives: [ChildCompWithAnim]
   //       });
+  //       static ngFactoryFn = () => new ParentComp();
   //     }
 
   //     const rendererFactory = new MockRendererFactory(['setProperty']);
@@ -393,7 +393,6 @@ describe('element discovery', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
-        factory: () => new StructuredComp(),
         consts: 2,
         vars: 0,
         template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -407,6 +406,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -425,7 +425,6 @@ describe('element discovery', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: ChildComp,
         selectors: [['child-comp']],
-        factory: () => new ChildComp(),
         consts: 3,
         vars: 0,
         template: (rf: RenderFlags, ctx: ChildComp) => {
@@ -436,6 +435,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new ChildComp();
     }
 
     class ParentComp {
@@ -443,7 +443,6 @@ describe('element discovery', () => {
         type: ParentComp,
         selectors: [['parent-comp']],
         directives: [ChildComp],
-        factory: () => new ParentComp(),
         consts: 2,
         vars: 0,
         template: (rf: RenderFlags, ctx: ParentComp) => {
@@ -455,6 +454,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new ParentComp();
     }
 
     const fixture = new ComponentFixture(ParentComp);
@@ -476,7 +476,6 @@ describe('element discovery', () => {
         type: StructuredComp,
         selectors: [['structured-comp']],
         directives: [NgIf],
-        factory: () => new StructuredComp(),
         consts: 2,
         vars: 1,
         template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -498,6 +497,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -525,7 +525,6 @@ describe('element discovery', () => {
         type: StructuredComp,
         selectors: [['structured-comp']],
         directives: [NgIf],
-        factory: () => new StructuredComp(),
         consts: 2,
         vars: 0,
         template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -535,6 +534,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -562,7 +562,6 @@ describe('element discovery', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
-        factory: () => new StructuredComp(),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -571,6 +570,7 @@ describe('element discovery', () => {
           }
         }
       });
+      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -594,7 +594,6 @@ describe('element discovery', () => {
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
-           factory: () => new StructuredComp(),
            consts: 2,
            vars: 0,
            template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -605,6 +604,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -627,7 +627,6 @@ describe('element discovery', () => {
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
-           factory: () => new StructuredComp(),
            consts: 1,
            vars: 0,
            template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -641,6 +640,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -680,7 +680,6 @@ describe('element discovery', () => {
          static ngComponentDef = ɵɵdefineComponent({
            type: ProjectorComp,
            selectors: [['projector-comp']],
-           factory: () => new ProjectorComp(),
            consts: 4,
            vars: 0,
            template: (rf: RenderFlags, ctx: ProjectorComp) => {
@@ -697,6 +696,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new ProjectorComp();
        }
 
        class ParentComp {
@@ -704,7 +704,6 @@ describe('element discovery', () => {
            type: ParentComp,
            selectors: [['parent-comp']],
            directives: [ProjectorComp],
-           factory: () => new ParentComp(),
            consts: 5,
            vars: 0,
            template: (rf: RenderFlags, ctx: ParentComp) => {
@@ -720,6 +719,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -777,7 +777,6 @@ describe('element discovery', () => {
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
-           factory: () => new StructuredComp(),
            consts: 1,
            vars: 0,
            template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -786,6 +785,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -804,11 +804,11 @@ describe('element discovery', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
-        factory: () => new StructuredComp(),
         consts: 0,
         vars: 0,
         template: (rf: RenderFlags, ctx: StructuredComp) => {}
       });
+      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -840,27 +840,21 @@ describe('element discovery', () => {
        let myDir3Instance: MyDir2|null = null;
 
        class MyDir1 {
-         static ngDirectiveDef = ɵɵdefineDirective({
-           type: MyDir1,
-           selectors: [['', 'my-dir-1', '']],
-           factory: () => myDir1Instance = new MyDir1()
-         });
+         static ngDirectiveDef =
+             ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
+         static ngFactoryFn = () => myDir1Instance = new MyDir1();
        }
 
        class MyDir2 {
-         static ngDirectiveDef = ɵɵdefineDirective({
-           type: MyDir2,
-           selectors: [['', 'my-dir-2', '']],
-           factory: () => myDir2Instance = new MyDir2()
-         });
+         static ngDirectiveDef =
+             ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
+         static ngFactoryFn = () => myDir2Instance = new MyDir2();
        }
 
        class MyDir3 {
-         static ngDirectiveDef = ɵɵdefineDirective({
-           type: MyDir3,
-           selectors: [['', 'my-dir-3', '']],
-           factory: () => myDir3Instance = new MyDir2()
-         });
+         static ngDirectiveDef =
+             ɵɵdefineDirective({type: MyDir3, selectors: [['', 'my-dir-3', '']]});
+         static ngFactoryFn = () => myDir3Instance = new MyDir2();
        }
 
        class StructuredComp {
@@ -868,7 +862,6 @@ describe('element discovery', () => {
            type: StructuredComp,
            selectors: [['structured-comp']],
            directives: [MyDir1, MyDir2, MyDir3],
-           factory: () => new StructuredComp(),
            consts: 2,
            vars: 0,
            template: (rf: RenderFlags, ctx: StructuredComp) => {
@@ -878,6 +871,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -929,26 +923,21 @@ describe('element discovery', () => {
        let childComponentInstance: ChildComp|null = null;
 
        class MyDir1 {
-         static ngDirectiveDef = ɵɵdefineDirective({
-           type: MyDir1,
-           selectors: [['', 'my-dir-1', '']],
-           factory: () => myDir1Instance = new MyDir1()
-         });
+         static ngDirectiveDef =
+             ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
+         static ngFactoryFn = () => myDir1Instance = new MyDir1();
        }
 
        class MyDir2 {
-         static ngDirectiveDef = ɵɵdefineDirective({
-           type: MyDir2,
-           selectors: [['', 'my-dir-2', '']],
-           factory: () => myDir2Instance = new MyDir2()
-         });
+         static ngDirectiveDef =
+             ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
+         static ngFactoryFn = () => myDir2Instance = new MyDir2();
        }
 
        class ChildComp {
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
-           factory: () => childComponentInstance = new ChildComp(),
            consts: 1,
            vars: 0,
            template: (rf: RenderFlags, ctx: ChildComp) => {
@@ -957,6 +946,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => childComponentInstance = new ChildComp();
        }
 
        class ParentComp {
@@ -964,7 +954,6 @@ describe('element discovery', () => {
            type: ParentComp,
            selectors: [['parent-comp']],
            directives: [ChildComp, MyDir1, MyDir2],
-           factory: () => new ParentComp(),
            consts: 1,
            vars: 0,
            template: (rf: RenderFlags, ctx: ParentComp) => {
@@ -973,6 +962,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -1025,7 +1015,6 @@ describe('element discovery', () => {
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
-           factory: () => new ChildComp(),
            consts: 3,
            vars: 0,
            template: (rf: RenderFlags, ctx: ChildComp) => {
@@ -1036,6 +1025,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new ChildComp();
        }
 
        class ParentComp {
@@ -1043,7 +1033,6 @@ describe('element discovery', () => {
            type: ParentComp,
            selectors: [['parent-comp']],
            directives: [ChildComp],
-           factory: () => new ParentComp(),
            consts: 2,
            vars: 0,
            template: (rf: RenderFlags, ctx: ParentComp) => {
@@ -1055,6 +1044,7 @@ describe('element discovery', () => {
              }
            }
          });
+         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -1086,7 +1076,6 @@ describe('sanitization', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: SanitizationComp,
         selectors: [['sanitize-this']],
-        factory: () => new SanitizationComp(),
         consts: 1,
         vars: 1,
         template: (rf: RenderFlags, ctx: SanitizationComp) => {
@@ -1099,6 +1088,7 @@ describe('sanitization', () => {
           }
         }
       });
+      static ngFactoryFn = () => new SanitizationComp();
 
       private href = '';
 
@@ -1129,7 +1119,6 @@ describe('sanitization', () => {
       static ngDirectiveDef = ɵɵdefineDirective({
         type: UnsafeUrlHostBindingDir,
         selectors: [['', 'unsafeUrlHostBindingDir', '']],
-        factory: () => hostBindingDir = new UnsafeUrlHostBindingDir(),
         hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
           if (rf & RenderFlags.Create) {
             ɵɵallocHostVars(1);
@@ -1140,13 +1129,13 @@ describe('sanitization', () => {
           }
         }
       });
+      static ngFactoryFn = () => hostBindingDir = new UnsafeUrlHostBindingDir();
     }
 
     class SimpleComp {
       static ngComponentDef = ɵɵdefineComponent({
         type: SimpleComp,
         selectors: [['sanitize-this']],
-        factory: () => new SimpleComp(),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, ctx: SimpleComp) => {
@@ -1156,6 +1145,7 @@ describe('sanitization', () => {
         },
         directives: [UnsafeUrlHostBindingDir]
       });
+      static ngFactoryFn = () => new SimpleComp();
     }
 
     const sanitizer = new LocalSanitizer((value) => 'http://bar');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -117,6 +117,8 @@ describe('render3 integration test', () => {
       beforeTree !: Tree;
       // TODO(issue/24571): remove '!'.
       afterTree !: Tree;
+
+      static ngFactoryFn = () => new ChildComponent;
       static ngComponentDef = ɵɵdefineComponent({
         selectors: [['child']],
         type: ChildComponent,
@@ -149,7 +151,6 @@ describe('render3 integration test', () => {
         },
         inputs: {beforeTree: 'beforeTree', afterTree: 'afterTree'}
       });
-      static ngFactoryFn = () => new ChildComponent;
     }
 
     function parentTemplate(rf: RenderFlags, ctx: ParentCtx) {
@@ -200,6 +201,7 @@ describe('render3 integration test', () => {
 describe('component styles', () => {
   it('should pass in the component styles directly into the underlying renderer', () => {
     class StyledComp {
+      static ngFactoryFn = () => new StyledComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StyledComp,
         styles: ['div { color: red; }'],
@@ -213,7 +215,6 @@ describe('component styles', () => {
           }
         }
       });
-      static ngFactoryFn = () => new StyledComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(StyledComp, {rendererFactory});
@@ -228,6 +229,7 @@ describe('component animations', () => {
     const animB = {name: 'b'};
 
     class AnimComp {
+      static ngFactoryFn = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 0,
@@ -241,7 +243,6 @@ describe('component animations', () => {
         selectors: [['foo']],
         template: (rf: RenderFlags, ctx: AnimComp) => {}
       });
-      static ngFactoryFn = () => new AnimComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(AnimComp, {rendererFactory});
@@ -255,6 +256,7 @@ describe('component animations', () => {
 
   it('should include animations in the renderType data array even if the array is empty', () => {
     class AnimComp {
+      static ngFactoryFn = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 0,
@@ -265,7 +267,6 @@ describe('component animations', () => {
         selectors: [['foo']],
         template: (rf: RenderFlags, ctx: AnimComp) => {}
       });
-      static ngFactoryFn = () => new AnimComp();
     }
     const rendererFactory = new ProxyRenderer3Factory();
     new ComponentFixture(AnimComp, {rendererFactory});
@@ -275,6 +276,7 @@ describe('component animations', () => {
 
   it('should allow [@trigger] bindings to be picked up by the underlying renderer', () => {
     class AnimComp {
+      static ngFactoryFn = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 1,
@@ -290,7 +292,6 @@ describe('component animations', () => {
           }
         }
       });
-      static ngFactoryFn = () => new AnimComp();
 
       animationValue = '123';
     }
@@ -312,6 +313,7 @@ describe('component animations', () => {
   it('should allow creation-level [@trigger] properties to be picked up by the underlying renderer',
      () => {
        class AnimComp {
+         static ngFactoryFn = () => new AnimComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: AnimComp,
            consts: 1,
@@ -323,7 +325,6 @@ describe('component animations', () => {
              }
            }
          });
-         static ngFactoryFn = () => new AnimComp();
        }
 
        const rendererFactory = new MockRendererFactory(['setProperty']);
@@ -345,6 +346,7 @@ describe('component animations', () => {
 
   //   it('should allow host binding animations to be picked up and rendered', () => {
   //     class ChildCompWithAnim {
+  //       static ngFactoryFn = () => new ChildCompWithAnim();
   //       static ngDirectiveDef = ɵɵdefineDirective({
   //         type: ChildCompWithAnim,
   //         selectors: [['child-comp-with-anim']],
@@ -354,12 +356,12 @@ describe('component animations', () => {
   //           }
   //         },
   //       });
-  //       static ngFactoryFn = () => new ChildCompWithAnim();
 
   //       exp = 'go';
   //     }
 
   //     class ParentComp {
+  //       static ngFactoryFn = () => new ParentComp();
   //       static ngComponentDef = ɵɵdefineComponent({
   //         type: ParentComp,
   //         consts: 1,
@@ -372,7 +374,6 @@ describe('component animations', () => {
   //         },
   //         directives: [ChildCompWithAnim]
   //       });
-  //       static ngFactoryFn = () => new ParentComp();
   //     }
 
   //     const rendererFactory = new MockRendererFactory(['setProperty']);
@@ -390,6 +391,7 @@ describe('component animations', () => {
 describe('element discovery', () => {
   it('should only monkey-patch immediate child nodes in a component', () => {
     class StructuredComp {
+      static ngFactoryFn = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -406,7 +408,6 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -422,6 +423,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in a sub component', () => {
     class ChildComp {
+      static ngFactoryFn = () => new ChildComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: ChildComp,
         selectors: [['child-comp']],
@@ -435,10 +437,10 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new ChildComp();
     }
 
     class ParentComp {
+      static ngFactoryFn = () => new ParentComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: ParentComp,
         selectors: [['parent-comp']],
@@ -454,7 +456,6 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new ParentComp();
     }
 
     const fixture = new ComponentFixture(ParentComp);
@@ -472,6 +473,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in an embedded template container', () => {
     class StructuredComp {
+      static ngFactoryFn = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -497,7 +499,6 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -521,6 +522,7 @@ describe('element discovery', () => {
 
   it('should return a context object from a given dom node', () => {
     class StructuredComp {
+      static ngFactoryFn = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -534,7 +536,6 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -559,6 +560,7 @@ describe('element discovery', () => {
 
   it('should cache the element context on a element was pre-emptively monkey-patched', () => {
     class StructuredComp {
+      static ngFactoryFn = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -570,7 +572,6 @@ describe('element discovery', () => {
           }
         }
       });
-      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -591,6 +592,7 @@ describe('element discovery', () => {
   it('should cache the element context on an intermediate element that isn\'t pre-emptively monkey-patched',
      () => {
        class StructuredComp {
+         static ngFactoryFn = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -604,7 +606,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -624,6 +625,7 @@ describe('element discovery', () => {
   it('should be able to pull in element context data even if the element is decorated using styling',
      () => {
        class StructuredComp {
+         static ngFactoryFn = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -640,7 +642,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -677,6 +678,7 @@ describe('element discovery', () => {
          </section>
        */
        class ProjectorComp {
+         static ngFactoryFn = () => new ProjectorComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ProjectorComp,
            selectors: [['projector-comp']],
@@ -696,10 +698,10 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new ProjectorComp();
        }
 
        class ParentComp {
+         static ngFactoryFn = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -719,7 +721,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -774,6 +775,7 @@ describe('element discovery', () => {
   it('should return `null` when an element context is retrieved that is a DOM node that was not created by Angular',
      () => {
        class StructuredComp {
+         static ngFactoryFn = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -785,7 +787,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -801,6 +802,7 @@ describe('element discovery', () => {
 
   it('should by default monkey-patch the bootstrap component with context details', () => {
     class StructuredComp {
+      static ngFactoryFn = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -808,7 +810,6 @@ describe('element discovery', () => {
         vars: 0,
         template: (rf: RenderFlags, ctx: StructuredComp) => {}
       });
-      static ngFactoryFn = () => new StructuredComp();
     }
 
     const fixture = new ComponentFixture(StructuredComp);
@@ -840,24 +841,25 @@ describe('element discovery', () => {
        let myDir3Instance: MyDir2|null = null;
 
        class MyDir1 {
+         static ngFactoryFn = () => myDir1Instance = new MyDir1();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
-         static ngFactoryFn = () => myDir1Instance = new MyDir1();
        }
 
        class MyDir2 {
+         static ngFactoryFn = () => myDir2Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
-         static ngFactoryFn = () => myDir2Instance = new MyDir2();
        }
 
        class MyDir3 {
+         static ngFactoryFn = () => myDir3Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir3, selectors: [['', 'my-dir-3', '']]});
-         static ngFactoryFn = () => myDir3Instance = new MyDir2();
        }
 
        class StructuredComp {
+         static ngFactoryFn = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -871,7 +873,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new StructuredComp();
        }
 
        const fixture = new ComponentFixture(StructuredComp);
@@ -923,18 +924,19 @@ describe('element discovery', () => {
        let childComponentInstance: ChildComp|null = null;
 
        class MyDir1 {
+         static ngFactoryFn = () => myDir1Instance = new MyDir1();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
-         static ngFactoryFn = () => myDir1Instance = new MyDir1();
        }
 
        class MyDir2 {
+         static ngFactoryFn = () => myDir2Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
-         static ngFactoryFn = () => myDir2Instance = new MyDir2();
        }
 
        class ChildComp {
+         static ngFactoryFn = () => childComponentInstance = new ChildComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -946,10 +948,10 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => childComponentInstance = new ChildComp();
        }
 
        class ParentComp {
+         static ngFactoryFn = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -962,7 +964,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -1012,6 +1013,7 @@ describe('element discovery', () => {
   it('should monkey-patch sub components with the view data and then replace them with the context result once a lookup occurs',
      () => {
        class ChildComp {
+         static ngFactoryFn = () => new ChildComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -1025,10 +1027,10 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new ChildComp();
        }
 
        class ParentComp {
+         static ngFactoryFn = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -1044,7 +1046,6 @@ describe('element discovery', () => {
              }
            }
          });
-         static ngFactoryFn = () => new ParentComp();
        }
 
        const fixture = new ComponentFixture(ParentComp);
@@ -1073,6 +1074,7 @@ describe('element discovery', () => {
 describe('sanitization', () => {
   it('should sanitize data using the provided sanitization interface', () => {
     class SanitizationComp {
+      static ngFactoryFn = () => new SanitizationComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: SanitizationComp,
         selectors: [['sanitize-this']],
@@ -1088,7 +1090,6 @@ describe('sanitization', () => {
           }
         }
       });
-      static ngFactoryFn = () => new SanitizationComp();
 
       private href = '';
 
@@ -1116,6 +1117,7 @@ describe('sanitization', () => {
       // @HostBinding()
       cite: any = 'http://cite-dir-value';
 
+      static ngFactoryFn = () => hostBindingDir = new UnsafeUrlHostBindingDir();
       static ngDirectiveDef = ɵɵdefineDirective({
         type: UnsafeUrlHostBindingDir,
         selectors: [['', 'unsafeUrlHostBindingDir', '']],
@@ -1129,10 +1131,10 @@ describe('sanitization', () => {
           }
         }
       });
-      static ngFactoryFn = () => hostBindingDir = new UnsafeUrlHostBindingDir();
     }
 
     class SimpleComp {
+      static ngFactoryFn = () => new SimpleComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: SimpleComp,
         selectors: [['sanitize-this']],
@@ -1145,7 +1147,6 @@ describe('sanitization', () => {
         },
         directives: [UnsafeUrlHostBindingDir]
       });
-      static ngFactoryFn = () => new SimpleComp();
     }
 
     const sanitizer = new LocalSanitizer((value) => 'http://bar');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -118,7 +118,7 @@ describe('render3 integration test', () => {
       // TODO(issue/24571): remove '!'.
       afterTree !: Tree;
 
-      static ngFactoryFn = () => new ChildComponent;
+      static ngFactoryDef = () => new ChildComponent;
       static ngComponentDef = ɵɵdefineComponent({
         selectors: [['child']],
         type: ChildComponent,
@@ -201,7 +201,7 @@ describe('render3 integration test', () => {
 describe('component styles', () => {
   it('should pass in the component styles directly into the underlying renderer', () => {
     class StyledComp {
-      static ngFactoryFn = () => new StyledComp();
+      static ngFactoryDef = () => new StyledComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StyledComp,
         styles: ['div { color: red; }'],
@@ -229,7 +229,7 @@ describe('component animations', () => {
     const animB = {name: 'b'};
 
     class AnimComp {
-      static ngFactoryFn = () => new AnimComp();
+      static ngFactoryDef = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 0,
@@ -256,7 +256,7 @@ describe('component animations', () => {
 
   it('should include animations in the renderType data array even if the array is empty', () => {
     class AnimComp {
-      static ngFactoryFn = () => new AnimComp();
+      static ngFactoryDef = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 0,
@@ -276,7 +276,7 @@ describe('component animations', () => {
 
   it('should allow [@trigger] bindings to be picked up by the underlying renderer', () => {
     class AnimComp {
-      static ngFactoryFn = () => new AnimComp();
+      static ngFactoryDef = () => new AnimComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AnimComp,
         consts: 1,
@@ -313,7 +313,7 @@ describe('component animations', () => {
   it('should allow creation-level [@trigger] properties to be picked up by the underlying renderer',
      () => {
        class AnimComp {
-         static ngFactoryFn = () => new AnimComp();
+         static ngFactoryDef = () => new AnimComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: AnimComp,
            consts: 1,
@@ -346,7 +346,7 @@ describe('component animations', () => {
 
   //   it('should allow host binding animations to be picked up and rendered', () => {
   //     class ChildCompWithAnim {
-  //       static ngFactoryFn = () => new ChildCompWithAnim();
+  //       static ngFactoryDef = () => new ChildCompWithAnim();
   //       static ngDirectiveDef = ɵɵdefineDirective({
   //         type: ChildCompWithAnim,
   //         selectors: [['child-comp-with-anim']],
@@ -361,7 +361,7 @@ describe('component animations', () => {
   //     }
 
   //     class ParentComp {
-  //       static ngFactoryFn = () => new ParentComp();
+  //       static ngFactoryDef = () => new ParentComp();
   //       static ngComponentDef = ɵɵdefineComponent({
   //         type: ParentComp,
   //         consts: 1,
@@ -391,7 +391,7 @@ describe('component animations', () => {
 describe('element discovery', () => {
   it('should only monkey-patch immediate child nodes in a component', () => {
     class StructuredComp {
-      static ngFactoryFn = () => new StructuredComp();
+      static ngFactoryDef = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -423,7 +423,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in a sub component', () => {
     class ChildComp {
-      static ngFactoryFn = () => new ChildComp();
+      static ngFactoryDef = () => new ChildComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: ChildComp,
         selectors: [['child-comp']],
@@ -440,7 +440,7 @@ describe('element discovery', () => {
     }
 
     class ParentComp {
-      static ngFactoryFn = () => new ParentComp();
+      static ngFactoryDef = () => new ParentComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: ParentComp,
         selectors: [['parent-comp']],
@@ -473,7 +473,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in an embedded template container', () => {
     class StructuredComp {
-      static ngFactoryFn = () => new StructuredComp();
+      static ngFactoryDef = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -522,7 +522,7 @@ describe('element discovery', () => {
 
   it('should return a context object from a given dom node', () => {
     class StructuredComp {
-      static ngFactoryFn = () => new StructuredComp();
+      static ngFactoryDef = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -560,7 +560,7 @@ describe('element discovery', () => {
 
   it('should cache the element context on a element was pre-emptively monkey-patched', () => {
     class StructuredComp {
-      static ngFactoryFn = () => new StructuredComp();
+      static ngFactoryDef = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -592,7 +592,7 @@ describe('element discovery', () => {
   it('should cache the element context on an intermediate element that isn\'t pre-emptively monkey-patched',
      () => {
        class StructuredComp {
-         static ngFactoryFn = () => new StructuredComp();
+         static ngFactoryDef = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -625,7 +625,7 @@ describe('element discovery', () => {
   it('should be able to pull in element context data even if the element is decorated using styling',
      () => {
        class StructuredComp {
-         static ngFactoryFn = () => new StructuredComp();
+         static ngFactoryDef = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -678,7 +678,7 @@ describe('element discovery', () => {
          </section>
        */
        class ProjectorComp {
-         static ngFactoryFn = () => new ProjectorComp();
+         static ngFactoryDef = () => new ProjectorComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ProjectorComp,
            selectors: [['projector-comp']],
@@ -701,7 +701,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryFn = () => new ParentComp();
+         static ngFactoryDef = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -775,7 +775,7 @@ describe('element discovery', () => {
   it('should return `null` when an element context is retrieved that is a DOM node that was not created by Angular',
      () => {
        class StructuredComp {
-         static ngFactoryFn = () => new StructuredComp();
+         static ngFactoryDef = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -802,7 +802,7 @@ describe('element discovery', () => {
 
   it('should by default monkey-patch the bootstrap component with context details', () => {
     class StructuredComp {
-      static ngFactoryFn = () => new StructuredComp();
+      static ngFactoryDef = () => new StructuredComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -841,25 +841,25 @@ describe('element discovery', () => {
        let myDir3Instance: MyDir2|null = null;
 
        class MyDir1 {
-         static ngFactoryFn = () => myDir1Instance = new MyDir1();
+         static ngFactoryDef = () => myDir1Instance = new MyDir1();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
        }
 
        class MyDir2 {
-         static ngFactoryFn = () => myDir2Instance = new MyDir2();
+         static ngFactoryDef = () => myDir2Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
        }
 
        class MyDir3 {
-         static ngFactoryFn = () => myDir3Instance = new MyDir2();
+         static ngFactoryDef = () => myDir3Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir3, selectors: [['', 'my-dir-3', '']]});
        }
 
        class StructuredComp {
-         static ngFactoryFn = () => new StructuredComp();
+         static ngFactoryDef = () => new StructuredComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -924,19 +924,19 @@ describe('element discovery', () => {
        let childComponentInstance: ChildComp|null = null;
 
        class MyDir1 {
-         static ngFactoryFn = () => myDir1Instance = new MyDir1();
+         static ngFactoryDef = () => myDir1Instance = new MyDir1();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
        }
 
        class MyDir2 {
-         static ngFactoryFn = () => myDir2Instance = new MyDir2();
+         static ngFactoryDef = () => myDir2Instance = new MyDir2();
          static ngDirectiveDef =
              ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
        }
 
        class ChildComp {
-         static ngFactoryFn = () => childComponentInstance = new ChildComp();
+         static ngFactoryDef = () => childComponentInstance = new ChildComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -951,7 +951,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryFn = () => new ParentComp();
+         static ngFactoryDef = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -1013,7 +1013,7 @@ describe('element discovery', () => {
   it('should monkey-patch sub components with the view data and then replace them with the context result once a lookup occurs',
      () => {
        class ChildComp {
-         static ngFactoryFn = () => new ChildComp();
+         static ngFactoryDef = () => new ChildComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -1030,7 +1030,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryFn = () => new ParentComp();
+         static ngFactoryDef = () => new ParentComp();
          static ngComponentDef = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -1074,7 +1074,7 @@ describe('element discovery', () => {
 describe('sanitization', () => {
   it('should sanitize data using the provided sanitization interface', () => {
     class SanitizationComp {
-      static ngFactoryFn = () => new SanitizationComp();
+      static ngFactoryDef = () => new SanitizationComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: SanitizationComp,
         selectors: [['sanitize-this']],
@@ -1117,7 +1117,7 @@ describe('sanitization', () => {
       // @HostBinding()
       cite: any = 'http://cite-dir-value';
 
-      static ngFactoryFn = () => hostBindingDir = new UnsafeUrlHostBindingDir();
+      static ngFactoryDef = () => hostBindingDir = new UnsafeUrlHostBindingDir();
       static ngDirectiveDef = ɵɵdefineDirective({
         type: UnsafeUrlHostBindingDir,
         selectors: [['', 'unsafeUrlHostBindingDir', '']],
@@ -1134,7 +1134,7 @@ describe('sanitization', () => {
     }
 
     class SimpleComp {
-      static ngFactoryFn = () => new SimpleComp();
+      static ngFactoryDef = () => new SimpleComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: SimpleComp,
         selectors: [['sanitize-this']],

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -15,7 +15,7 @@ import {ivyEnabled} from '@angular/core/src/ivy_switch';
 import {ContentChild, ContentChildren, ViewChild, ViewChildren} from '@angular/core/src/metadata/di';
 import {Component, Directive, HostBinding, HostListener, Input, Output, Pipe} from '@angular/core/src/metadata/directives';
 import {NgModule, NgModuleDef} from '@angular/core/src/metadata/ng_module';
-import {ComponentDef, PipeDef} from '@angular/core/src/render3/interfaces/definition';
+import {ComponentDef, FactoryFn, PipeDef} from '@angular/core/src/render3/interfaces/definition';
 
 
 ivyEnabled && describe('render3 jit', () => {
@@ -34,7 +34,7 @@ ivyEnabled && describe('render3 jit', () => {
     const SomeCmpAny = SomeCmp as any;
 
     expect(SomeCmpAny.ngComponentDef).toBeDefined();
-    expect(SomeCmpAny.ngComponentDef.factory() instanceof SomeCmp).toBe(true);
+    expect(SomeCmpAny.ngFactoryFn() instanceof SomeCmp).toBe(true);
   });
 
   it('compiles an injectable with a type provider', () => {
@@ -242,9 +242,10 @@ ivyEnabled && describe('render3 jit', () => {
     }
 
     const pipeDef = (P as any).ngPipeDef as PipeDef<P>;
+    const pipeFactory = (P as any).ngFactoryFn as FactoryFn<P>;
     expect(pipeDef.name).toBe('test-pipe');
     expect(pipeDef.pure).toBe(false, 'pipe should not be pure');
-    expect(pipeDef.factory() instanceof P)
+    expect(pipeFactory() instanceof P)
         .toBe(true, 'factory() should create an instance of the pipe');
   });
 

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -34,7 +34,7 @@ ivyEnabled && describe('render3 jit', () => {
     const SomeCmpAny = SomeCmp as any;
 
     expect(SomeCmpAny.ngComponentDef).toBeDefined();
-    expect(SomeCmpAny.ngFactoryFn() instanceof SomeCmp).toBe(true);
+    expect(SomeCmpAny.ngFactoryDef() instanceof SomeCmp).toBe(true);
   });
 
   it('compiles an injectable with a type provider', () => {
@@ -242,7 +242,7 @@ ivyEnabled && describe('render3 jit', () => {
     }
 
     const pipeDef = (P as any).ngPipeDef as PipeDef<P>;
-    const pipeFactory = (P as any).ngFactoryFn as FactoryFn<P>;
+    const pipeFactory = (P as any).ngFactoryDef as FactoryFn<P>;
     expect(pipeDef.name).toBe('test-pipe');
     expect(pipeDef.pure).toBe(false, 'pipe should not be pure');
     expect(pipeFactory() instanceof P)

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -18,7 +18,7 @@ const INTERFACE_EXCEPTIONS = new Set<string>([
   'ɵɵInjectorDef',
   'ɵɵNgModuleDefWithMeta',
   'ɵɵPipeDefWithMeta',
-  'ɵɵFactoryFn',
+  'ɵɵFactoryDef',
 ]);
 
 describe('r3 jit environment', () => {

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -18,6 +18,7 @@ const INTERFACE_EXCEPTIONS = new Set<string>([
   'ɵɵInjectorDef',
   'ɵɵNgModuleDefWithMeta',
   'ɵɵPipeDefWithMeta',
+  'ɵɵFactoryFn',
 ]);
 
 describe('r3 jit environment', () => {

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -61,18 +61,18 @@ describe('lifecycles', () => {
           selectors: [[name]],
           consts: consts,
           vars: vars,
-          factory: () => new Component(),
           inputs: {val: 'val'}, template,
           directives: directives
         });
+        static ngFactoryFn = () => new Component();
       };
     }
 
     class Directive {
       ngOnInit() { events.push('dir'); }
 
-      static ngDirectiveDef = ɵɵdefineDirective(
-          {type: Directive, selectors: [['', 'dir', '']], factory: () => new Directive()});
+      static ngDirectiveDef = ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']]});
+      static ngFactoryFn = () => new Directive();
     }
 
     const directives = [Comp, Parent, ProjectedComp, Directive, NgIf];

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -56,7 +56,7 @@ describe('lifecycles', () => {
           events.push(`${name}${this.val}`);
         }
 
-        static ngFactoryFn = () => new Component();
+        static ngFactoryDef = () => new Component();
         static ngComponentDef = ɵɵdefineComponent({
           type: Component,
           selectors: [[name]],
@@ -71,7 +71,7 @@ describe('lifecycles', () => {
     class Directive {
       ngOnInit() { events.push('dir'); }
 
-      static ngFactoryFn = () => new Directive();
+      static ngFactoryDef = () => new Directive();
       static ngDirectiveDef = ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']]});
     }
 

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -56,6 +56,7 @@ describe('lifecycles', () => {
           events.push(`${name}${this.val}`);
         }
 
+        static ngFactoryFn = () => new Component();
         static ngComponentDef = ɵɵdefineComponent({
           type: Component,
           selectors: [[name]],
@@ -64,15 +65,14 @@ describe('lifecycles', () => {
           inputs: {val: 'val'}, template,
           directives: directives
         });
-        static ngFactoryFn = () => new Component();
       };
     }
 
     class Directive {
       ngOnInit() { events.push('dir'); }
 
-      static ngDirectiveDef = ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']]});
       static ngFactoryFn = () => new Directive();
+      static ngDirectiveDef = ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']]});
     }
 
     const directives = [Comp, Parent, ProjectedComp, Directive, NgIf];

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -27,6 +27,13 @@ describe('event listeners', () => {
 
     onClick() { this.counter++; }
 
+    static ngFactoryFn =
+        () => {
+          let comp = new MyComp();
+          comps.push(comp);
+          return comp;
+        }
+
     static ngComponentDef = ɵɵdefineComponent({
       type: MyComp,
       selectors: [['comp']],
@@ -44,11 +51,6 @@ describe('event listeners', () => {
         }
       }
     });
-    static ngFactoryFn = () => {
-      let comp = new MyComp();
-      comps.push(comp);
-      return comp;
-    }
   }
 
   class MyCompWithGlobalListeners {
@@ -57,6 +59,13 @@ describe('event listeners', () => {
 
     /* @HostListener('body:click') */
     onBodyClick() { events.push('component - body:click'); }
+
+    static ngFactoryFn =
+        () => {
+          let comp = new MyCompWithGlobalListeners();
+          comps.push(comp);
+          return comp;
+        }
 
     static ngComponentDef = ɵɵdefineComponent({
       type: MyCompWithGlobalListeners,
@@ -80,11 +89,6 @@ describe('event listeners', () => {
         }
       }
     });
-    static ngFactoryFn = () => {
-      let comp = new MyCompWithGlobalListeners();
-      comps.push(comp);
-      return comp;
-    }
   }
 
   class GlobalHostListenerDir {
@@ -94,6 +98,7 @@ describe('event listeners', () => {
     /* @HostListener('body:click') */
     onBodyClick() { events.push('directive - body:click'); }
 
+    static ngFactoryFn = function HostListenerDir_Factory() { return new GlobalHostListenerDir(); };
     static ngDirectiveDef = ɵɵdefineDirective({
       type: GlobalHostListenerDir,
       selectors: [['', 'hostListenerDir', '']],
@@ -109,7 +114,6 @@ describe('event listeners', () => {
         }
       }
     });
-    static ngFactoryFn = function HostListenerDir_Factory() { return new GlobalHostListenerDir(); };
   }
 
   class PreventDefaultComp {
@@ -128,6 +132,7 @@ describe('event listeners', () => {
       return this.handlerReturnValue;
     }
 
+    static ngFactoryFn = () => new PreventDefaultComp();
     static ngComponentDef = ɵɵdefineComponent({
       type: PreventDefaultComp,
       selectors: [['prevent-default-comp']],
@@ -145,7 +150,6 @@ describe('event listeners', () => {
         }
       }
     });
-    static ngFactoryFn = () => new PreventDefaultComp();
   }
 
   beforeEach(() => {
@@ -319,6 +323,7 @@ describe('event listeners', () => {
 
       onClick() { this.counter++; }
 
+      static ngFactoryFn = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -347,7 +352,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp, {rendererFactory: getRendererFactory2(document)});
@@ -380,6 +384,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
+      static ngFactoryFn = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -408,7 +413,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp);
@@ -444,6 +448,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
+      static ngFactoryFn = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -480,7 +485,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp, {rendererFactory: getRendererFactory2(document)});
@@ -523,6 +527,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
+      static ngFactoryFn = () => { return new MyComp(); };
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -540,7 +545,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = () => { return new MyComp(); };
     }
 
     const fixture = new ComponentFixture(MyComp);
@@ -574,6 +578,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
+      static ngFactoryFn = function HostListenerDir_Factory() { return new HostListenerDir(); };
       static ngDirectiveDef = ɵɵdefineDirective({
         type: HostListenerDir,
         selectors: [['', 'hostListenerDir', '']],
@@ -584,7 +589,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = function HostListenerDir_Factory() { return new HostListenerDir(); };
     }
 
     const fixture = new TemplateFixture(() => {
@@ -626,6 +630,7 @@ describe('event listeners', () => {
 
       onClick(a: any, b: any) { this.counter += a + b; }
 
+      static ngFactoryFn = () => new MyComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -643,7 +648,6 @@ describe('event listeners', () => {
           }
         }
       });
-      static ngFactoryFn = () => new MyComp();
     }
 
     const fixture = new ComponentFixture(MyComp);
@@ -907,6 +911,7 @@ describe('event listeners', () => {
 
       onClick(comp: any) { this.comp = comp; }
 
+      static ngFactoryFn = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
@@ -932,7 +937,6 @@ describe('event listeners', () => {
         },
         directives: [Comp]
       });
-      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -42,13 +42,13 @@ describe('event listeners', () => {
           }
           ɵɵelementEnd();
         }
-      },
-      factory: () => {
-        let comp = new MyComp();
-        comps.push(comp);
-        return comp;
       }
     });
+    static ngFactoryFn = () => {
+      let comp = new MyComp();
+      comps.push(comp);
+      return comp;
+    }
   }
 
   class MyCompWithGlobalListeners {
@@ -68,11 +68,6 @@ describe('event listeners', () => {
           ɵɵtext(0, 'Some text');
         }
       },
-      factory: () => {
-        let comp = new MyCompWithGlobalListeners();
-        comps.push(comp);
-        return comp;
-      },
       hostBindings: function HostListenerDir_HostBindings(
           rf: RenderFlags, ctx: any, elIndex: number) {
         if (rf & RenderFlags.Create) {
@@ -85,6 +80,11 @@ describe('event listeners', () => {
         }
       }
     });
+    static ngFactoryFn = () => {
+      let comp = new MyCompWithGlobalListeners();
+      comps.push(comp);
+      return comp;
+    }
   }
 
   class GlobalHostListenerDir {
@@ -97,7 +97,6 @@ describe('event listeners', () => {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: GlobalHostListenerDir,
       selectors: [['', 'hostListenerDir', '']],
-      factory: function HostListenerDir_Factory() { return new GlobalHostListenerDir(); },
       hostBindings: function HostListenerDir_HostBindings(
           rf: RenderFlags, ctx: any, elIndex: number) {
         if (rf & RenderFlags.Create) {
@@ -110,6 +109,7 @@ describe('event listeners', () => {
         }
       }
     });
+    static ngFactoryFn = function HostListenerDir_Factory() { return new GlobalHostListenerDir(); };
   }
 
   class PreventDefaultComp {
@@ -131,7 +131,6 @@ describe('event listeners', () => {
     static ngComponentDef = ɵɵdefineComponent({
       type: PreventDefaultComp,
       selectors: [['prevent-default-comp']],
-      factory: () => new PreventDefaultComp(),
       consts: 2,
       vars: 0,
       /** <button (click)="onClick($event)">Click</button> */
@@ -146,6 +145,7 @@ describe('event listeners', () => {
         }
       }
     });
+    static ngFactoryFn = () => new PreventDefaultComp();
   }
 
   beforeEach(() => {
@@ -322,7 +322,6 @@ describe('event listeners', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
-        factory: () => new AppComp(),
         consts: 1,
         vars: 0,
         template: function(rf: RenderFlags, ctx: any) {
@@ -348,6 +347,7 @@ describe('event listeners', () => {
           }
         }
       });
+      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp, {rendererFactory: getRendererFactory2(document)});
@@ -383,7 +383,6 @@ describe('event listeners', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
-        factory: () => new AppComp(),
         consts: 1,
         vars: 0,
         template: function(rf: RenderFlags, ctx: any) {
@@ -409,6 +408,7 @@ describe('event listeners', () => {
           }
         }
       });
+      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp);
@@ -447,7 +447,6 @@ describe('event listeners', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
-        factory: () => new AppComp(),
         consts: 1,
         vars: 0,
         template: function(rf: RenderFlags, ctx: any) {
@@ -481,6 +480,7 @@ describe('event listeners', () => {
           }
         }
       });
+      static ngFactoryFn = () => new AppComp();
     }
 
     const fixture = new ComponentFixture(AppComp, {rendererFactory: getRendererFactory2(document)});
@@ -533,7 +533,6 @@ describe('event listeners', () => {
             ɵɵtext(0, 'Some text');
           }
         },
-        factory: () => { return new MyComp(); },
         hostBindings: function HostListenerDir_HostBindings(
             rf: RenderFlags, ctx: any, elIndex: number) {
           if (rf & RenderFlags.Create) {
@@ -541,6 +540,7 @@ describe('event listeners', () => {
           }
         }
       });
+      static ngFactoryFn = () => { return new MyComp(); };
     }
 
     const fixture = new ComponentFixture(MyComp);
@@ -577,7 +577,6 @@ describe('event listeners', () => {
       static ngDirectiveDef = ɵɵdefineDirective({
         type: HostListenerDir,
         selectors: [['', 'hostListenerDir', '']],
-        factory: function HostListenerDir_Factory() { return new HostListenerDir(); },
         hostBindings: function HostListenerDir_HostBindings(
             rf: RenderFlags, ctx: any, elIndex: number) {
           if (rf & RenderFlags.Create) {
@@ -585,6 +584,7 @@ describe('event listeners', () => {
           }
         }
       });
+      static ngFactoryFn = function HostListenerDir_Factory() { return new HostListenerDir(); };
     }
 
     const fixture = new TemplateFixture(() => {
@@ -641,9 +641,9 @@ describe('event listeners', () => {
             }
             ɵɵelementEnd();
           }
-        },
-        factory: () => new MyComp()
+        }
       });
+      static ngFactoryFn = () => new MyComp();
     }
 
     const fixture = new ComponentFixture(MyComp);
@@ -910,7 +910,6 @@ describe('event listeners', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
-        factory: () => new App(),
         consts: 3,
         vars: 0,
         template: (rf: RenderFlags, ctx: App) => {
@@ -933,6 +932,7 @@ describe('event listeners', () => {
         },
         directives: [Comp]
       });
+      static ngFactoryFn = () => new App();
     }
 
     const fixture = new ComponentFixture(App);

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -27,7 +27,7 @@ describe('event listeners', () => {
 
     onClick() { this.counter++; }
 
-    static ngFactoryFn =
+    static ngFactoryDef =
         () => {
           let comp = new MyComp();
           comps.push(comp);
@@ -60,7 +60,7 @@ describe('event listeners', () => {
     /* @HostListener('body:click') */
     onBodyClick() { events.push('component - body:click'); }
 
-    static ngFactoryFn =
+    static ngFactoryDef =
         () => {
           let comp = new MyCompWithGlobalListeners();
           comps.push(comp);
@@ -98,7 +98,9 @@ describe('event listeners', () => {
     /* @HostListener('body:click') */
     onBodyClick() { events.push('directive - body:click'); }
 
-    static ngFactoryFn = function HostListenerDir_Factory() { return new GlobalHostListenerDir(); };
+    static ngFactoryDef = function HostListenerDir_Factory() {
+      return new GlobalHostListenerDir();
+    };
     static ngDirectiveDef = ɵɵdefineDirective({
       type: GlobalHostListenerDir,
       selectors: [['', 'hostListenerDir', '']],
@@ -132,7 +134,7 @@ describe('event listeners', () => {
       return this.handlerReturnValue;
     }
 
-    static ngFactoryFn = () => new PreventDefaultComp();
+    static ngFactoryDef = () => new PreventDefaultComp();
     static ngComponentDef = ɵɵdefineComponent({
       type: PreventDefaultComp,
       selectors: [['prevent-default-comp']],
@@ -323,7 +325,7 @@ describe('event listeners', () => {
 
       onClick() { this.counter++; }
 
-      static ngFactoryFn = () => new AppComp();
+      static ngFactoryDef = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -384,7 +386,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
-      static ngFactoryFn = () => new AppComp();
+      static ngFactoryDef = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -448,7 +450,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
-      static ngFactoryFn = () => new AppComp();
+      static ngFactoryDef = () => new AppComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -527,7 +529,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
-      static ngFactoryFn = () => { return new MyComp(); };
+      static ngFactoryDef = () => { return new MyComp(); };
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -578,7 +580,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
-      static ngFactoryFn = function HostListenerDir_Factory() { return new HostListenerDir(); };
+      static ngFactoryDef = function HostListenerDir_Factory() { return new HostListenerDir(); };
       static ngDirectiveDef = ɵɵdefineDirective({
         type: HostListenerDir,
         selectors: [['', 'hostListenerDir', '']],
@@ -630,7 +632,7 @@ describe('event listeners', () => {
 
       onClick(a: any, b: any) { this.counter += a + b; }
 
-      static ngFactoryFn = () => new MyComp();
+      static ngFactoryDef = () => new MyComp();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -911,7 +913,7 @@ describe('event listeners', () => {
 
       onClick(comp: any) { this.comp = comp; }
 
-      static ngFactoryFn = () => new App();
+      static ngFactoryDef = () => new App();
       static ngComponentDef = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -21,6 +21,7 @@ describe('outputs', () => {
     change = new EventEmitter();
     resetStream = new EventEmitter();
 
+    static ngFactoryFn = () => buttonToggle = new ButtonToggle();
     static ngComponentDef = ɵɵdefineComponent({
       type: ButtonToggle,
       selectors: [['button-toggle']],
@@ -29,7 +30,6 @@ describe('outputs', () => {
       vars: 0,
       outputs: {change: 'change', resetStream: 'reset'}
     });
-    static ngFactoryFn = () => buttonToggle = new ButtonToggle();
   }
 
   let otherDir: OtherDir;
@@ -37,9 +37,9 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
+    static ngFactoryFn = () => otherDir = new OtherDir;
     static ngDirectiveDef = ɵɵdefineDirective(
         {type: OtherDir, selectors: [['', 'otherDir', '']], outputs: {changeStream: 'change'}});
-    static ngFactoryFn = () => otherDir = new OtherDir;
   }
 
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -27,9 +27,9 @@ describe('outputs', () => {
       template: function(rf: RenderFlags, ctx: any) {},
       consts: 0,
       vars: 0,
-      factory: () => buttonToggle = new ButtonToggle(),
       outputs: {change: 'change', resetStream: 'reset'}
     });
+    static ngFactoryFn = () => buttonToggle = new ButtonToggle();
   }
 
   let otherDir: OtherDir;
@@ -37,12 +37,9 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
-    static ngDirectiveDef = ɵɵdefineDirective({
-      type: OtherDir,
-      selectors: [['', 'otherDir', '']],
-      factory: () => otherDir = new OtherDir,
-      outputs: {changeStream: 'change'}
-    });
+    static ngDirectiveDef = ɵɵdefineDirective(
+        {type: OtherDir, selectors: [['', 'otherDir', '']], outputs: {changeStream: 'change'}});
+    static ngFactoryFn = () => otherDir = new OtherDir;
   }
 
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -21,7 +21,7 @@ describe('outputs', () => {
     change = new EventEmitter();
     resetStream = new EventEmitter();
 
-    static ngFactoryFn = () => buttonToggle = new ButtonToggle();
+    static ngFactoryDef = () => buttonToggle = new ButtonToggle();
     static ngComponentDef = ɵɵdefineComponent({
       type: ButtonToggle,
       selectors: [['button-toggle']],
@@ -37,7 +37,7 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
-    static ngFactoryFn = () => otherDir = new OtherDir;
+    static ngFactoryDef = () => otherDir = new OtherDir;
     static ngDirectiveDef = ɵɵdefineDirective(
         {type: OtherDir, selectors: [['', 'otherDir', '']], outputs: {changeStream: 'change'}});
   }

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -29,8 +29,8 @@ describe('pipe', () => {
     class WrappingPipe implements PipeTransform {
       transform(value: any) { return new WrappedValue('Bar'); }
 
-      static ngPipeDef = ɵɵdefinePipe({name: 'wrappingPipe', type: WrappingPipe, pure: false});
       static ngFactoryFn = function WrappingPipe_Factory() { return new WrappingPipe(); };
+      static ngPipeDef = ɵɵdefinePipe({name: 'wrappingPipe', type: WrappingPipe, pure: false});
     }
 
     function createTemplate() {

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -29,12 +29,8 @@ describe('pipe', () => {
     class WrappingPipe implements PipeTransform {
       transform(value: any) { return new WrappedValue('Bar'); }
 
-      static ngPipeDef = ɵɵdefinePipe({
-        name: 'wrappingPipe',
-        type: WrappingPipe,
-        factory: function WrappingPipe_Factory() { return new WrappingPipe(); },
-        pure: false
-      });
+      static ngPipeDef = ɵɵdefinePipe({name: 'wrappingPipe', type: WrappingPipe, pure: false});
+      static ngFactoryFn = function WrappingPipe_Factory() { return new WrappingPipe(); };
     }
 
     function createTemplate() {

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -29,7 +29,7 @@ describe('pipe', () => {
     class WrappingPipe implements PipeTransform {
       transform(value: any) { return new WrappedValue('Bar'); }
 
-      static ngFactoryFn = function WrappingPipe_Factory() { return new WrappingPipe(); };
+      static ngFactoryDef = function WrappingPipe_Factory() { return new WrappingPipe(); };
       static ngPipeDef = ɵɵdefinePipe({name: 'wrappingPipe', type: WrappingPipe, pure: false});
     }
 

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -866,7 +866,7 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
-        static ngFactoryFn =
+        static ngFactoryDef =
             () => { return new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)); }
 
         static ngComponentDef = ɵɵdefineComponent({
@@ -900,7 +900,7 @@ describe('providers', () => {
             [{provide: String, useValue: 'foo'}, {provide: Number, useValue: 2, multi: true}],
       })
       class ComponentWithProviders {
-        static ngFactoryFn = () => new ComponentWithProviders();
+        static ngFactoryDef = () => new ComponentWithProviders();
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -953,35 +953,32 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
-        static ngFactoryFn = () =>
-            new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number))
+        static ngFactoryDef =
+            () => { return new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)); }
 
-                static ngComponentDef = ɵɵdefineComponent({
-                  type: Repeated,
-                  selectors: [['repeated']],
-                  consts: 2,
-                  vars: 2,
-                  template: function(fs: RenderFlags, ctx: Repeated) {
-                    if (fs & RenderFlags.Create) {
-                      ɵɵtext(0);
-                      ɵɵtext(1);
-                    }
-                    if (fs & RenderFlags.Update) {
-                      ɵɵselect(0);
-                      ɵɵtextBinding(ctx.s);
-                      ɵɵselect(1);
-                      ɵɵtextBinding(ctx.n);
-                    }
-                  },
-                  features: [
-                    ɵɵProvidersFeature(
-                        [{provide: Number, useValue: 1, multi: true}],
-                        [
-                          {provide: String, useValue: 'bar'},
-                          {provide: Number, useValue: 2, multi: true}
-                        ]),
-                  ],
-                });
+        static ngComponentDef = ɵɵdefineComponent({
+          type: Repeated,
+          selectors: [['repeated']],
+          consts: 2,
+          vars: 2,
+          template: function(fs: RenderFlags, ctx: Repeated) {
+            if (fs & RenderFlags.Create) {
+              ɵɵtext(0);
+              ɵɵtext(1);
+            }
+            if (fs & RenderFlags.Update) {
+              ɵɵselect(0);
+              ɵɵtextBinding(ctx.s);
+              ɵɵselect(1);
+              ɵɵtextBinding(ctx.n);
+            }
+          },
+          features: [
+            ɵɵProvidersFeature(
+                [{provide: Number, useValue: 1, multi: true}],
+                [{provide: String, useValue: 'bar'}, {provide: Number, useValue: 2, multi: true}]),
+          ],
+        });
       }
 
       @Component({
@@ -993,7 +990,7 @@ describe('providers', () => {
         viewProviders: [{provide: toString, useValue: 'foo'}],
       })
       class ComponentWithProviders {
-        static ngFactoryFn = () => new ComponentWithProviders();
+        static ngFactoryDef = () => new ComponentWithProviders();
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -1042,7 +1039,7 @@ describe('providers', () => {
     class EmbeddedComponent {
       constructor(private s: String) {}
 
-      static ngFactoryFn = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
+      static ngFactoryDef = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
       static ngComponentDef = ɵɵdefineComponent({
         type: EmbeddedComponent,
         selectors: [['embedded-cmp']],
@@ -1064,7 +1061,7 @@ describe('providers', () => {
     class HostComponent {
       constructor(public vcref: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-      static ngFactoryFn = () => hostComponent = new HostComponent(
+      static ngFactoryDef = () => hostComponent = new HostComponent(
           ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
           static ngComponentDef = ɵɵdefineComponent({
@@ -1090,7 +1087,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
-      static ngFactoryFn = () => new AppComponent();
+      static ngFactoryDef = () => new AppComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1252,7 +1249,7 @@ describe('providers', () => {
     class MyComponent {
       constructor() {}
 
-      static ngFactoryFn = () => new MyComponent();
+      static ngFactoryDef = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-cmp']],
@@ -1279,7 +1276,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
-      static ngFactoryFn = () => new AppComponent();
+      static ngFactoryDef = () => new AppComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1342,7 +1339,9 @@ describe('providers', () => {
       class MyComponent {
         constructor(foo: InjectableWithLifeCycleHooks) {}
 
-        static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks));
+        static ngFactoryDef =
+            () => { return new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks)); }
+
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComponent,
           selectors: [['my-comp']],
@@ -1369,7 +1368,7 @@ describe('providers', () => {
       class App {
         public condition = true;
 
-        static ngFactoryFn = () => new App();
+        static ngFactoryDef = () => new App();
         static ngComponentDef = ɵɵdefineComponent({
           type: App,
           selectors: [['app-cmp']],
@@ -1444,7 +1443,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildComponent {
-    static ngFactoryFn = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
+    static ngFactoryDef = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
     static ngComponentDef = ɵɵdefineComponent({
       type: ViewChildComponent,
       selectors: [['view-child']],
@@ -1461,7 +1460,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildDirective {
-    static ngFactoryFn = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
+    static ngFactoryDef = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ViewChildDirective,
       selectors: [['view-child']],
@@ -1470,40 +1469,40 @@ function expectProvidersScenario(defs: {
   }
 
   class ContentChildComponent {
-    static ngFactoryFn = () =>
-        testComponentInjection(defs.contentChild, new ContentChildComponent())
+    static ngFactoryDef =
+        () => { return testComponentInjection(defs.contentChild, new ContentChildComponent()); }
 
-            static ngComponentDef = ɵɵdefineComponent({
-              type: ContentChildComponent,
-              selectors: [['content-child']],
-              consts: 1,
-              vars: 0,
-              template: function(fs: RenderFlags, ctx: ParentComponent) {
-                if (fs & RenderFlags.Create) {
-                  ɵɵtext(0, 'content-child');
-                }
-              },
-              features: defs.contentChild &&
-                  [ɵɵProvidersFeature(
-                      defs.contentChild.providers || [], defs.contentChild.viewProviders || [])],
-            });
+    static ngComponentDef = ɵɵdefineComponent({
+      type: ContentChildComponent,
+      selectors: [['content-child']],
+      consts: 1,
+      vars: 0,
+      template: function(fs: RenderFlags, ctx: ParentComponent) {
+        if (fs & RenderFlags.Create) {
+          ɵɵtext(0, 'content-child');
+        }
+      },
+      features: defs.contentChild &&
+          [ɵɵProvidersFeature(
+              defs.contentChild.providers || [], defs.contentChild.viewProviders || [])],
+    });
   }
 
   class ContentChildDirective {
-    static ngFactoryFn = () =>
-        testDirectiveInjection(defs.contentChild, new ContentChildDirective())
+    static ngFactoryDef =
+        () => { return testDirectiveInjection(defs.contentChild, new ContentChildDirective()); }
 
-            static ngDirectiveDef = ɵɵdefineDirective({
-              type: ContentChildDirective,
-              selectors: [['content-child']],
-              features: defs.contentChild &&
-                  [ɵɵProvidersFeature(defs.contentChild.directiveProviders || [])],
-            });
+    static ngDirectiveDef = ɵɵdefineDirective({
+      type: ContentChildDirective,
+      selectors: [['content-child']],
+      features:
+          defs.contentChild && [ɵɵProvidersFeature(defs.contentChild.directiveProviders || [])],
+    });
   }
 
 
   class ParentComponent {
-    static ngFactoryFn = () => testComponentInjection(defs.parent, new ParentComponent());
+    static ngFactoryDef = () => testComponentInjection(defs.parent, new ParentComponent());
     static ngComponentDef = ɵɵdefineComponent({
       type: ParentComponent,
       selectors: [['parent']],
@@ -1521,7 +1520,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective {
-    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective());
+    static ngFactoryDef = () => testDirectiveInjection(defs.parent, new ParentDirective());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective,
       selectors: [['parent']],
@@ -1530,7 +1529,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective2 {
-    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective2());
+    static ngFactoryDef = () => testDirectiveInjection(defs.parent, new ParentDirective2());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective2,
       selectors: [['parent']],
@@ -1540,7 +1539,7 @@ function expectProvidersScenario(defs: {
 
 
   class App {
-    static ngFactoryFn = () => testComponentInjection(defs.app, new App());
+    static ngFactoryDef = () => testComponentInjection(defs.app, new App());
     static ngComponentDef = ɵɵdefineComponent({
       type: App,
       selectors: [['app']],

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -866,6 +866,9 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
+        static ngFactoryFn =
+            () => { return new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)); }
+
         static ngComponentDef = ɵɵdefineComponent({
           type: Repeated,
           selectors: [['repeated']],
@@ -884,8 +887,6 @@ describe('providers', () => {
             }
           }
         });
-        static ngFactoryFn = () =>
-            new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number))
       }
 
       @Component({
@@ -899,6 +900,7 @@ describe('providers', () => {
             [{provide: String, useValue: 'foo'}, {provide: Number, useValue: 2, multi: true}],
       })
       class ComponentWithProviders {
+        static ngFactoryFn = () => new ComponentWithProviders();
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -933,7 +935,6 @@ describe('providers', () => {
           ],
           directives: [Repeated]
         });
-        static ngFactoryFn = () => new ComponentWithProviders();
       }
 
       const fixture = new ComponentFixture(ComponentWithProviders);
@@ -952,31 +953,35 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
-        static ngComponentDef = ɵɵdefineComponent({
-          type: Repeated,
-          selectors: [['repeated']],
-          consts: 2,
-          vars: 2,
-          template: function(fs: RenderFlags, ctx: Repeated) {
-            if (fs & RenderFlags.Create) {
-              ɵɵtext(0);
-              ɵɵtext(1);
-            }
-            if (fs & RenderFlags.Update) {
-              ɵɵselect(0);
-              ɵɵtextBinding(ctx.s);
-              ɵɵselect(1);
-              ɵɵtextBinding(ctx.n);
-            }
-          },
-          features: [
-            ɵɵProvidersFeature(
-                [{provide: Number, useValue: 1, multi: true}],
-                [{provide: String, useValue: 'bar'}, {provide: Number, useValue: 2, multi: true}]),
-          ],
-        });
         static ngFactoryFn = () =>
             new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number))
+
+                static ngComponentDef = ɵɵdefineComponent({
+                  type: Repeated,
+                  selectors: [['repeated']],
+                  consts: 2,
+                  vars: 2,
+                  template: function(fs: RenderFlags, ctx: Repeated) {
+                    if (fs & RenderFlags.Create) {
+                      ɵɵtext(0);
+                      ɵɵtext(1);
+                    }
+                    if (fs & RenderFlags.Update) {
+                      ɵɵselect(0);
+                      ɵɵtextBinding(ctx.s);
+                      ɵɵselect(1);
+                      ɵɵtextBinding(ctx.n);
+                    }
+                  },
+                  features: [
+                    ɵɵProvidersFeature(
+                        [{provide: Number, useValue: 1, multi: true}],
+                        [
+                          {provide: String, useValue: 'bar'},
+                          {provide: Number, useValue: 2, multi: true}
+                        ]),
+                  ],
+                });
       }
 
       @Component({
@@ -988,6 +993,7 @@ describe('providers', () => {
         viewProviders: [{provide: toString, useValue: 'foo'}],
       })
       class ComponentWithProviders {
+        static ngFactoryFn = () => new ComponentWithProviders();
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -1018,7 +1024,6 @@ describe('providers', () => {
           features: [ɵɵProvidersFeature([], [{provide: String, useValue: 'foo'}])],
           directives: [Repeated]
         });
-        static ngFactoryFn = () => new ComponentWithProviders();
       }
 
       const fixture = new ComponentFixture(ComponentWithProviders);
@@ -1037,6 +1042,7 @@ describe('providers', () => {
     class EmbeddedComponent {
       constructor(private s: String) {}
 
+      static ngFactoryFn = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
       static ngComponentDef = ɵɵdefineComponent({
         type: EmbeddedComponent,
         selectors: [['embedded-cmp']],
@@ -1052,29 +1058,29 @@ describe('providers', () => {
           }
         }
       });
-      static ngFactoryFn = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
     }
 
     @Component({template: `foo`, providers: [{provide: String, useValue: 'From host component'}]})
     class HostComponent {
       constructor(public vcref: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-      static ngComponentDef = ɵɵdefineComponent({
-        type: HostComponent,
-        selectors: [['host-cmp']],
-        consts: 1,
-        vars: 0,
-        template: (rf: RenderFlags, cmp: HostComponent) => {
-          if (rf & RenderFlags.Create) {
-            ɵɵtext(0, 'foo');
-          }
-        },
-        features: [
-          ɵɵProvidersFeature([{provide: String, useValue: 'From host component'}]),
-        ],
-      });
       static ngFactoryFn = () => hostComponent = new HostComponent(
           ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
+
+          static ngComponentDef = ɵɵdefineComponent({
+            type: HostComponent,
+            selectors: [['host-cmp']],
+            consts: 1,
+            vars: 0,
+            template: (rf: RenderFlags, cmp: HostComponent) => {
+              if (rf & RenderFlags.Create) {
+                ɵɵtext(0, 'foo');
+              }
+            },
+            features: [
+              ɵɵProvidersFeature([{provide: String, useValue: 'From host component'}]),
+            ],
+          });
     }
 
     @Component({
@@ -1084,6 +1090,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
+      static ngFactoryFn = () => new AppComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1099,7 +1106,6 @@ describe('providers', () => {
         ],
         directives: [HostComponent]
       });
-      static ngFactoryFn = () => new AppComponent();
     }
 
     it('should not cross the root view boundary, and use the root view injector', () => {
@@ -1246,6 +1252,7 @@ describe('providers', () => {
     class MyComponent {
       constructor() {}
 
+      static ngFactoryFn = () => new MyComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-cmp']],
@@ -1262,7 +1269,6 @@ describe('providers', () => {
               [{provide: Number, useValue: 123}]),
         ],
       });
-      static ngFactoryFn = () => new MyComponent();
     }
 
     @Component({
@@ -1273,6 +1279,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
+      static ngFactoryFn = () => new AppComponent();
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1290,7 +1297,6 @@ describe('providers', () => {
         ],
         directives: [MyComponent]
       });
-      static ngFactoryFn = () => new AppComponent();
     }
 
     it('should work from within the template', () => {
@@ -1336,6 +1342,7 @@ describe('providers', () => {
       class MyComponent {
         constructor(foo: InjectableWithLifeCycleHooks) {}
 
+        static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks));
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComponent,
           selectors: [['my-comp']],
@@ -1348,7 +1355,6 @@ describe('providers', () => {
           },
           features: [ɵɵProvidersFeature([InjectableWithLifeCycleHooks])]
         });
-        static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks));
       }
 
       @Component({
@@ -1363,6 +1369,7 @@ describe('providers', () => {
       class App {
         public condition = true;
 
+        static ngFactoryFn = () => new App();
         static ngComponentDef = ɵɵdefineComponent({
           type: App,
           selectors: [['app-cmp']],
@@ -1392,7 +1399,6 @@ describe('providers', () => {
           },
           directives: [MyComponent]
         });
-        static ngFactoryFn = () => new App();
       }
 
       const fixture = new ComponentFixture(App);
@@ -1438,6 +1444,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildComponent {
+    static ngFactoryFn = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
     static ngComponentDef = ɵɵdefineComponent({
       type: ViewChildComponent,
       selectors: [['view-child']],
@@ -1451,50 +1458,52 @@ function expectProvidersScenario(defs: {
       features: defs.viewChild &&
           [ɵɵProvidersFeature(defs.viewChild.providers || [], defs.viewChild.viewProviders || [])]
     });
-    static ngFactoryFn = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
   }
 
   class ViewChildDirective {
+    static ngFactoryFn = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ViewChildDirective,
       selectors: [['view-child']],
       features: defs.viewChild && [ɵɵProvidersFeature(defs.viewChild.directiveProviders || [])],
     });
-    static ngFactoryFn = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
   }
 
   class ContentChildComponent {
-    static ngComponentDef = ɵɵdefineComponent({
-      type: ContentChildComponent,
-      selectors: [['content-child']],
-      consts: 1,
-      vars: 0,
-      template: function(fs: RenderFlags, ctx: ParentComponent) {
-        if (fs & RenderFlags.Create) {
-          ɵɵtext(0, 'content-child');
-        }
-      },
-      features: defs.contentChild &&
-          [ɵɵProvidersFeature(
-              defs.contentChild.providers || [], defs.contentChild.viewProviders || [])],
-    });
     static ngFactoryFn = () =>
         testComponentInjection(defs.contentChild, new ContentChildComponent())
+
+            static ngComponentDef = ɵɵdefineComponent({
+              type: ContentChildComponent,
+              selectors: [['content-child']],
+              consts: 1,
+              vars: 0,
+              template: function(fs: RenderFlags, ctx: ParentComponent) {
+                if (fs & RenderFlags.Create) {
+                  ɵɵtext(0, 'content-child');
+                }
+              },
+              features: defs.contentChild &&
+                  [ɵɵProvidersFeature(
+                      defs.contentChild.providers || [], defs.contentChild.viewProviders || [])],
+            });
   }
 
   class ContentChildDirective {
-    static ngDirectiveDef = ɵɵdefineDirective({
-      type: ContentChildDirective,
-      selectors: [['content-child']],
-      features:
-          defs.contentChild && [ɵɵProvidersFeature(defs.contentChild.directiveProviders || [])],
-    });
     static ngFactoryFn = () =>
         testDirectiveInjection(defs.contentChild, new ContentChildDirective())
+
+            static ngDirectiveDef = ɵɵdefineDirective({
+              type: ContentChildDirective,
+              selectors: [['content-child']],
+              features: defs.contentChild &&
+                  [ɵɵProvidersFeature(defs.contentChild.directiveProviders || [])],
+            });
   }
 
 
   class ParentComponent {
+    static ngFactoryFn = () => testComponentInjection(defs.parent, new ParentComponent());
     static ngComponentDef = ɵɵdefineComponent({
       type: ParentComponent,
       selectors: [['parent']],
@@ -1509,29 +1518,29 @@ function expectProvidersScenario(defs: {
           [ɵɵProvidersFeature(defs.parent.providers || [], defs.parent.viewProviders || [])],
       directives: [ViewChildComponent, ViewChildDirective]
     });
-    static ngFactoryFn = () => testComponentInjection(defs.parent, new ParentComponent());
   }
 
   class ParentDirective {
+    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective,
       selectors: [['parent']],
       features: defs.parent && [ɵɵProvidersFeature(defs.parent.directiveProviders || [])],
     });
-    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective());
   }
 
   class ParentDirective2 {
+    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective2());
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective2,
       selectors: [['parent']],
       features: defs.parent && [ɵɵProvidersFeature(defs.parent.directive2Providers || [])],
     });
-    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective2());
   }
 
 
   class App {
+    static ngFactoryFn = () => testComponentInjection(defs.app, new App());
     static ngComponentDef = ɵɵdefineComponent({
       type: App,
       selectors: [['app']],
@@ -1551,7 +1560,6 @@ function expectProvidersScenario(defs: {
         ContentChildDirective
       ]
     });
-    static ngFactoryFn = () => testComponentInjection(defs.app, new App());
   }
 
 

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -869,7 +869,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: Repeated,
           selectors: [['repeated']],
-          factory: () => new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)),
           consts: 2,
           vars: 2,
           template: function(fs: RenderFlags, ctx: Repeated) {
@@ -885,6 +884,8 @@ describe('providers', () => {
             }
           }
         });
+        static ngFactoryFn = () =>
+            new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number))
       }
 
       @Component({
@@ -901,7 +902,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
-          factory: () => new ComponentWithProviders(),
           consts: 2,
           vars: 0,
           template: function(fs: RenderFlags, ctx: ComponentWithProviders) {
@@ -933,6 +933,7 @@ describe('providers', () => {
           ],
           directives: [Repeated]
         });
+        static ngFactoryFn = () => new ComponentWithProviders();
       }
 
       const fixture = new ComponentFixture(ComponentWithProviders);
@@ -954,7 +955,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: Repeated,
           selectors: [['repeated']],
-          factory: () => new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)),
           consts: 2,
           vars: 2,
           template: function(fs: RenderFlags, ctx: Repeated) {
@@ -975,6 +975,8 @@ describe('providers', () => {
                 [{provide: String, useValue: 'bar'}, {provide: Number, useValue: 2, multi: true}]),
           ],
         });
+        static ngFactoryFn = () =>
+            new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number))
       }
 
       @Component({
@@ -989,7 +991,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
-          factory: () => new ComponentWithProviders(),
           consts: 2,
           vars: 0,
           template: function(fs: RenderFlags, ctx: ComponentWithProviders) {
@@ -1017,6 +1018,7 @@ describe('providers', () => {
           features: [ɵɵProvidersFeature([], [{provide: String, useValue: 'foo'}])],
           directives: [Repeated]
         });
+        static ngFactoryFn = () => new ComponentWithProviders();
       }
 
       const fixture = new ComponentFixture(ComponentWithProviders);
@@ -1038,7 +1040,6 @@ describe('providers', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: EmbeddedComponent,
         selectors: [['embedded-cmp']],
-        factory: () => new EmbeddedComponent(ɵɵdirectiveInject(String)),
         consts: 1,
         vars: 1,
         template: (rf: RenderFlags, cmp: EmbeddedComponent) => {
@@ -1051,6 +1052,7 @@ describe('providers', () => {
           }
         }
       });
+      static ngFactoryFn = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
     }
 
     @Component({template: `foo`, providers: [{provide: String, useValue: 'From host component'}]})
@@ -1060,8 +1062,6 @@ describe('providers', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: HostComponent,
         selectors: [['host-cmp']],
-        factory: () => hostComponent = new HostComponent(
-                     ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver()),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, cmp: HostComponent) => {
@@ -1073,6 +1073,8 @@ describe('providers', () => {
           ɵɵProvidersFeature([{provide: String, useValue: 'From host component'}]),
         ],
       });
+      static ngFactoryFn = () => hostComponent = new HostComponent(
+          ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
     }
 
     @Component({
@@ -1085,7 +1087,6 @@ describe('providers', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
-        factory: () => new AppComponent(),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, cmp: AppComponent) => {
@@ -1098,6 +1099,7 @@ describe('providers', () => {
         ],
         directives: [HostComponent]
       });
+      static ngFactoryFn = () => new AppComponent();
     }
 
     it('should not cross the root view boundary, and use the root view injector', () => {
@@ -1247,7 +1249,6 @@ describe('providers', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-cmp']],
-        factory: () => new MyComponent(),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, cmp: MyComponent) => {
@@ -1261,6 +1262,7 @@ describe('providers', () => {
               [{provide: Number, useValue: 123}]),
         ],
       });
+      static ngFactoryFn = () => new MyComponent();
     }
 
     @Component({
@@ -1274,7 +1276,6 @@ describe('providers', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
-        factory: () => new AppComponent(),
         consts: 1,
         vars: 0,
         template: (rf: RenderFlags, cmp: AppComponent) => {
@@ -1289,6 +1290,7 @@ describe('providers', () => {
         ],
         directives: [MyComponent]
       });
+      static ngFactoryFn = () => new AppComponent();
     }
 
     it('should work from within the template', () => {
@@ -1337,7 +1339,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: MyComponent,
           selectors: [['my-comp']],
-          factory: () => new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks)),
           consts: 1,
           vars: 0,
           template: (rf: RenderFlags, ctx: MyComponent) => {
@@ -1347,6 +1348,7 @@ describe('providers', () => {
           },
           features: [ɵɵProvidersFeature([InjectableWithLifeCycleHooks])]
         });
+        static ngFactoryFn = () => new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks));
       }
 
       @Component({
@@ -1364,7 +1366,6 @@ describe('providers', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: App,
           selectors: [['app-cmp']],
-          factory: () => new App(),
           consts: 2,
           vars: 0,
           template: (rf: RenderFlags, ctx: App) => {
@@ -1391,6 +1392,7 @@ describe('providers', () => {
           },
           directives: [MyComponent]
         });
+        static ngFactoryFn = () => new App();
       }
 
       const fixture = new ComponentFixture(App);
@@ -1441,26 +1443,24 @@ function expectProvidersScenario(defs: {
       selectors: [['view-child']],
       consts: 1,
       vars: 0,
-      factory: () => testComponentInjection(defs.viewChild, new ViewChildComponent()),
       template: function(fs: RenderFlags, ctx: ViewChildComponent) {
         if (fs & RenderFlags.Create) {
           ɵɵtext(0, 'view-child');
         }
       },
       features: defs.viewChild &&
-          [
-            ɵɵProvidersFeature(defs.viewChild.providers || [], defs.viewChild.viewProviders || []),
-          ],
+          [ɵɵProvidersFeature(defs.viewChild.providers || [], defs.viewChild.viewProviders || [])]
     });
+    static ngFactoryFn = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
   }
 
   class ViewChildDirective {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ViewChildDirective,
       selectors: [['view-child']],
-      factory: () => testDirectiveInjection(defs.viewChild, new ViewChildDirective()),
       features: defs.viewChild && [ɵɵProvidersFeature(defs.viewChild.directiveProviders || [])],
     });
+    static ngFactoryFn = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
   }
 
   class ContentChildComponent {
@@ -1469,7 +1469,6 @@ function expectProvidersScenario(defs: {
       selectors: [['content-child']],
       consts: 1,
       vars: 0,
-      factory: () => testComponentInjection(defs.contentChild, new ContentChildComponent()),
       template: function(fs: RenderFlags, ctx: ParentComponent) {
         if (fs & RenderFlags.Create) {
           ɵɵtext(0, 'content-child');
@@ -1479,16 +1478,19 @@ function expectProvidersScenario(defs: {
           [ɵɵProvidersFeature(
               defs.contentChild.providers || [], defs.contentChild.viewProviders || [])],
     });
+    static ngFactoryFn = () =>
+        testComponentInjection(defs.contentChild, new ContentChildComponent())
   }
 
   class ContentChildDirective {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ContentChildDirective,
       selectors: [['content-child']],
-      factory: () => testDirectiveInjection(defs.contentChild, new ContentChildDirective()),
       features:
           defs.contentChild && [ɵɵProvidersFeature(defs.contentChild.directiveProviders || [])],
     });
+    static ngFactoryFn = () =>
+        testDirectiveInjection(defs.contentChild, new ContentChildDirective())
   }
 
 
@@ -1498,7 +1500,6 @@ function expectProvidersScenario(defs: {
       selectors: [['parent']],
       consts: 1,
       vars: 0,
-      factory: () => testComponentInjection(defs.parent, new ParentComponent()),
       template: function(fs: RenderFlags, ctx: ParentComponent) {
         if (fs & RenderFlags.Create) {
           ɵɵelement(0, 'view-child');
@@ -1508,24 +1509,25 @@ function expectProvidersScenario(defs: {
           [ɵɵProvidersFeature(defs.parent.providers || [], defs.parent.viewProviders || [])],
       directives: [ViewChildComponent, ViewChildDirective]
     });
+    static ngFactoryFn = () => testComponentInjection(defs.parent, new ParentComponent());
   }
 
   class ParentDirective {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective,
       selectors: [['parent']],
-      factory: () => testDirectiveInjection(defs.parent, new ParentDirective()),
       features: defs.parent && [ɵɵProvidersFeature(defs.parent.directiveProviders || [])],
     });
+    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective());
   }
 
   class ParentDirective2 {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: ParentDirective2,
       selectors: [['parent']],
-      factory: () => testDirectiveInjection(defs.parent, new ParentDirective2()),
       features: defs.parent && [ɵɵProvidersFeature(defs.parent.directive2Providers || [])],
     });
+    static ngFactoryFn = () => testDirectiveInjection(defs.parent, new ParentDirective2());
   }
 
 
@@ -1535,7 +1537,6 @@ function expectProvidersScenario(defs: {
       selectors: [['app']],
       consts: 2,
       vars: 0,
-      factory: () => testComponentInjection(defs.app, new App()),
       template: function(fs: RenderFlags, ctx: App) {
         if (fs & RenderFlags.Create) {
           ɵɵelementStart(0, 'parent');
@@ -1550,6 +1551,7 @@ function expectProvidersScenario(defs: {
         ContentChildDirective
       ]
     });
+    static ngFactoryFn = () => testComponentInjection(defs.app, new App());
   }
 
 

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -19,6 +19,7 @@ describe('object literals', () => {
     // TODO(issue/24571): remove '!'.
     config !: {[key: string]: any};
 
+    static ngFactoryFn = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
     static ngComponentDef = ɵɵdefineComponent({
       type: ObjectComp,
       selectors: [['object-comp']],
@@ -27,7 +28,6 @@ describe('object literals', () => {
       template: function ObjectComp_Template() {},
       inputs: {config: 'config'}
     });
-    static ngFactoryFn = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
   }
 
   const defs = [ObjectComp];

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -22,12 +22,12 @@ describe('object literals', () => {
     static ngComponentDef = ɵɵdefineComponent({
       type: ObjectComp,
       selectors: [['object-comp']],
-      factory: function ObjectComp_Factory() { return objectComp = new ObjectComp(); },
       consts: 0,
       vars: 1,
       template: function ObjectComp_Template() {},
       inputs: {config: 'config'}
     });
+    static ngFactoryFn = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
   }
 
   const defs = [ObjectComp];

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -19,7 +19,7 @@ describe('object literals', () => {
     // TODO(issue/24571): remove '!'.
     config !: {[key: string]: any};
 
-    static ngFactoryFn = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
+    static ngFactoryDef = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
     static ngComponentDef = ɵɵdefineComponent({
       type: ObjectComp,
       selectors: [['object-comp']],

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -217,7 +217,7 @@ describe('query', () => {
       class MyDirective {
         constructor(public service: Service) {}
 
-        static ngFactoryFn = function MyDirective_Factory() {
+        static ngFactoryDef = function MyDirective_Factory() {
           return directive = new MyDirective(ɵɵdirectiveInject(Service));
         };
         static ngDirectiveDef = ɵɵdefineDirective({
@@ -245,7 +245,7 @@ describe('query', () => {
           service?: Service;
           alias?: Alias;
 
-          static ngFactoryFn = function App_Factory() { return new App(); };
+          static ngFactoryDef = function App_Factory() { return new App(); };
           static ngComponentDef = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -290,7 +290,7 @@ describe('query', () => {
         class App {
           service?: Service;
 
-          static ngFactoryFn = function App_Factory() { return new App(); };
+          static ngFactoryDef = function App_Factory() { return new App(); };
           static ngComponentDef = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -833,7 +833,7 @@ describe('query', () => {
         let childInstance: Child;
 
         class Child {
-          static ngFactoryFn = () => childInstance = new Child();
+          static ngFactoryDef = () => childInstance = new Child();
           static ngComponentDef = ɵɵdefineComponent({
             type: Child,
             selectors: [['child']],
@@ -1406,7 +1406,7 @@ describe('query', () => {
         this.vcr.createEmbeddedView(this.temp);
       }
 
-      static ngFactoryFn = () => new SomeDir(
+      static ngFactoryDef = () => new SomeDir(
           ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
 
           static ngDirectiveDef = ɵɵdefineDirective({
@@ -1467,7 +1467,7 @@ describe('query', () => {
         this.contentCheckedQuerySnapshot = this.foos ? this.foos.length : 0;
       }
 
-      static ngFactoryFn = () => withContentInstance = new WithContentDirective();
+      static ngFactoryDef = () => withContentInstance = new WithContentDirective();
       static ngDirectiveDef = ɵɵdefineDirective({
         type: WithContentDirective,
         selectors: [['', 'with-content', '']],
@@ -1655,7 +1655,7 @@ describe('query', () => {
     it('should report results to appropriate queries where deep content queries are nested', () => {
       class QueryDirective {
         fooBars: any;
-        static ngFactoryFn = () => new QueryDirective();
+        static ngFactoryDef = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1720,7 +1720,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
-        static ngFactoryFn = () => new QueryDirective();
+        static ngFactoryDef = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1777,7 +1777,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
-        static ngFactoryFn = () => new QueryDirective();
+        static ngFactoryDef = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1838,7 +1838,7 @@ describe('query', () => {
        () => {
          class ShallowQueryDirective {
            foos: any;
-           static ngFactoryFn = () => new ShallowQueryDirective();
+           static ngFactoryDef = () => new ShallowQueryDirective();
            static ngDirectiveDef = ɵɵdefineDirective({
              type: ShallowQueryDirective,
              selectors: [['', 'shallow-query', '']],
@@ -1859,7 +1859,7 @@ describe('query', () => {
 
          class DeepQueryDirective {
            foos: any;
-           static ngFactoryFn = () => new DeepQueryDirective();
+           static ngFactoryDef = () => new DeepQueryDirective();
            static ngDirectiveDef = ɵɵdefineDirective({
              type: DeepQueryDirective,
              selectors: [['', 'deep-query', '']],
@@ -1922,7 +1922,7 @@ describe('query', () => {
     class TextDirective {
       value !: string;
 
-      static ngFactoryFn = () => new TextDirective();
+      static ngFactoryDef = () => new TextDirective();
       static ngDirectiveDef = ɵɵdefineDirective(
           {type: TextDirective, selectors: [['', 'text', '']], inputs: {value: 'text'}});
     }
@@ -1934,7 +1934,7 @@ describe('query', () => {
         // @ContentChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
-        static ngFactoryFn = () => contentQueryDirective = new ContentQueryDirective();
+        static ngFactoryDef = () => contentQueryDirective = new ContentQueryDirective();
         static ngComponentDef = ɵɵdefineDirective({
           type: ContentQueryDirective,
           selectors: [['', 'content-query', '']],
@@ -2002,7 +2002,7 @@ describe('query', () => {
         // @ViewChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
-        static ngFactoryFn = () => new ViewQueryComponent();
+        static ngFactoryDef = () => new ViewQueryComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: ViewQueryComponent,
           selectors: [['view-query']],

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -220,11 +220,11 @@ describe('query', () => {
         static ngDirectiveDef = ɵɵdefineDirective({
           type: MyDirective,
           selectors: [['', 'myDir', '']],
-          factory: function MyDirective_Factory() {
-            return directive = new MyDirective(ɵɵdirectiveInject(Service));
-          },
           features: [ɵɵProvidersFeature([Service, {provide: Alias, useExisting: Service}])],
         });
+        static ngFactoryFn = function MyDirective_Factory() {
+          return directive = new MyDirective(ɵɵdirectiveInject(Service));
+        };
       }
 
       beforeEach(() => directive = null);
@@ -250,7 +250,6 @@ describe('query', () => {
             selectors: [['app']],
             consts: 1,
             vars: 0,
-            factory: function App_Factory() { return new App(); },
             template: function App_Template(rf: RenderFlags, ctx: App) {
               if (rf & RenderFlags.Create) {
                 ɵɵelement(0, 'div', ['myDir']);
@@ -271,6 +270,7 @@ describe('query', () => {
             },
             directives: [MyDirective]
           });
+          static ngFactoryFn = function App_Factory() { return new App(); };
         }
 
         const componentFixture = new ComponentFixture(App);
@@ -295,7 +295,6 @@ describe('query', () => {
             selectors: [['app']],
             consts: 1,
             vars: 0,
-            factory: function App_Factory() { return new App(); },
             template: function App_Template(rf: RenderFlags, ctx: App) {
               if (rf & RenderFlags.Create) {
                 ɵɵelement(0, 'div', ['myDir']);
@@ -312,6 +311,7 @@ describe('query', () => {
             },
             directives: [MyDirective]
           });
+          static ngFactoryFn = function App_Factory() { return new App(); };
         }
 
         const componentFixture = new ComponentFixture(App);
@@ -836,12 +836,12 @@ describe('query', () => {
           static ngComponentDef = ɵɵdefineComponent({
             type: Child,
             selectors: [['child']],
-            factory: () => childInstance = new Child(),
             consts: 0,
             vars: 0,
             template: (rf: RenderFlags, ctx: Child) => {},
             exportAs: ['child']
           });
+          static ngFactoryFn = () => childInstance = new Child();
         }
 
         /**
@@ -1409,10 +1409,9 @@ describe('query', () => {
       static ngDirectiveDef = ɵɵdefineDirective({
         type: SomeDir,
         selectors: [['', 'someDir', '']],
-        factory:
-            () => new SomeDir(
-                ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
       });
+      static ngFactoryFn = () => new SomeDir(
+          ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
     }
 
     function AppComponent_Template_1(rf: RenderFlags, ctx: any) {
@@ -1470,7 +1469,6 @@ describe('query', () => {
       static ngDirectiveDef = ɵɵdefineDirective({
         type: WithContentDirective,
         selectors: [['', 'with-content', '']],
-        factory: () => withContentInstance = new WithContentDirective(),
         contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
           if (rf & RenderFlags.Create) {
             ɵɵcontentQuery(dirIndex, ['foo'], true);
@@ -1481,6 +1479,7 @@ describe('query', () => {
           }
         }
       });
+      static ngFactoryFn = () => withContentInstance = new WithContentDirective();
     }
 
     it('should support content queries for directives', () => {
@@ -1659,7 +1658,6 @@ describe('query', () => {
           type: QueryDirective,
           selectors: [['', 'query', '']],
           exportAs: ['query'],
-          factory: () => new QueryDirective(),
           contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
             // @ContentChildren('foo, bar, baz', {descendants: true})
             // fooBars: QueryList<ElementRef>;
@@ -1672,6 +1670,7 @@ describe('query', () => {
             }
           }
         });
+        static ngFactoryFn = () => new QueryDirective();
       }
 
       let outInstance: QueryDirective;
@@ -1724,7 +1723,6 @@ describe('query', () => {
           type: QueryDirective,
           selectors: [['', 'query', '']],
           exportAs: ['query'],
-          factory: () => new QueryDirective(),
           contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
             // @ContentChildren('foo', {descendants: true})
             // fooBars: QueryList<ElementRef>;
@@ -1737,6 +1735,7 @@ describe('query', () => {
             }
           }
         });
+        static ngFactoryFn = () => new QueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -1781,7 +1780,6 @@ describe('query', () => {
           type: QueryDirective,
           selectors: [['', 'query', '']],
           exportAs: ['query'],
-          factory: () => new QueryDirective(),
           contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
             // @ContentChildren('foo', {descendants: true})
             // fooBars: QueryList<ElementRef>;
@@ -1794,6 +1792,7 @@ describe('query', () => {
             }
           }
         });
+        static ngFactoryFn = () => new QueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -1842,7 +1841,6 @@ describe('query', () => {
              type: ShallowQueryDirective,
              selectors: [['', 'shallow-query', '']],
              exportAs: ['shallow-query'],
-             factory: () => new ShallowQueryDirective(),
              contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
                // @ContentChildren('foo', {descendants: false})
                // foos: QueryList<ElementRef>;
@@ -1855,6 +1853,7 @@ describe('query', () => {
                }
              }
            });
+           static ngFactoryFn = () => new ShallowQueryDirective();
          }
 
          class DeepQueryDirective {
@@ -1863,7 +1862,6 @@ describe('query', () => {
              type: DeepQueryDirective,
              selectors: [['', 'deep-query', '']],
              exportAs: ['deep-query'],
-             factory: () => new DeepQueryDirective(),
              contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
                // @ContentChildren('foo', {descendants: true})
                // foos: QueryList<ElementRef>;
@@ -1876,6 +1874,7 @@ describe('query', () => {
                }
              }
            });
+           static ngFactoryFn = () => new DeepQueryDirective();
          }
 
          let shallowInstance: ShallowQueryDirective;
@@ -1922,12 +1921,9 @@ describe('query', () => {
     class TextDirective {
       value !: string;
 
-      static ngDirectiveDef = ɵɵdefineDirective({
-        type: TextDirective,
-        selectors: [['', 'text', '']],
-        factory: () => new TextDirective(),
-        inputs: {value: 'text'}
-      });
+      static ngDirectiveDef = ɵɵdefineDirective(
+          {type: TextDirective, selectors: [['', 'text', '']], inputs: {value: 'text'}});
+      static ngFactoryFn = () => new TextDirective();
     }
 
     it('should register content matches from top to bottom', () => {
@@ -1940,7 +1936,6 @@ describe('query', () => {
         static ngComponentDef = ɵɵdefineDirective({
           type: ContentQueryDirective,
           selectors: [['', 'content-query', '']],
-          factory: () => contentQueryDirective = new ContentQueryDirective(),
           contentQueries: (rf: RenderFlags, ctx: any, dirIndex: number) => {
             // @ContentChildren(TextDirective, {descendants: true})
             // texts: QueryList<TextDirective>;
@@ -1953,6 +1948,7 @@ describe('query', () => {
             }
           }
         });
+        static ngFactoryFn = () => contentQueryDirective = new ContentQueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -2008,7 +2004,6 @@ describe('query', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: ViewQueryComponent,
           selectors: [['view-query']],
-          factory: () => new ViewQueryComponent(),
           template: function(rf: RenderFlags, ctx: ViewQueryComponent) {
             if (rf & RenderFlags.Create) {
               ɵɵelement(0, 'span', ['text', 'A']);
@@ -2034,6 +2029,7 @@ describe('query', () => {
           },
           directives: [TextDirective]
         });
+        static ngFactoryFn = () => new ViewQueryComponent();
       }
 
       const fixture = new ComponentFixture(ViewQueryComponent);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -217,14 +217,14 @@ describe('query', () => {
       class MyDirective {
         constructor(public service: Service) {}
 
+        static ngFactoryFn = function MyDirective_Factory() {
+          return directive = new MyDirective(ɵɵdirectiveInject(Service));
+        };
         static ngDirectiveDef = ɵɵdefineDirective({
           type: MyDirective,
           selectors: [['', 'myDir', '']],
           features: [ɵɵProvidersFeature([Service, {provide: Alias, useExisting: Service}])],
         });
-        static ngFactoryFn = function MyDirective_Factory() {
-          return directive = new MyDirective(ɵɵdirectiveInject(Service));
-        };
       }
 
       beforeEach(() => directive = null);
@@ -245,6 +245,7 @@ describe('query', () => {
           service?: Service;
           alias?: Alias;
 
+          static ngFactoryFn = function App_Factory() { return new App(); };
           static ngComponentDef = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -270,7 +271,6 @@ describe('query', () => {
             },
             directives: [MyDirective]
           });
-          static ngFactoryFn = function App_Factory() { return new App(); };
         }
 
         const componentFixture = new ComponentFixture(App);
@@ -290,6 +290,7 @@ describe('query', () => {
         class App {
           service?: Service;
 
+          static ngFactoryFn = function App_Factory() { return new App(); };
           static ngComponentDef = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -311,7 +312,6 @@ describe('query', () => {
             },
             directives: [MyDirective]
           });
-          static ngFactoryFn = function App_Factory() { return new App(); };
         }
 
         const componentFixture = new ComponentFixture(App);
@@ -833,6 +833,7 @@ describe('query', () => {
         let childInstance: Child;
 
         class Child {
+          static ngFactoryFn = () => childInstance = new Child();
           static ngComponentDef = ɵɵdefineComponent({
             type: Child,
             selectors: [['child']],
@@ -841,7 +842,6 @@ describe('query', () => {
             template: (rf: RenderFlags, ctx: Child) => {},
             exportAs: ['child']
           });
-          static ngFactoryFn = () => childInstance = new Child();
         }
 
         /**
@@ -1406,12 +1406,13 @@ describe('query', () => {
         this.vcr.createEmbeddedView(this.temp);
       }
 
-      static ngDirectiveDef = ɵɵdefineDirective({
-        type: SomeDir,
-        selectors: [['', 'someDir', '']],
-      });
       static ngFactoryFn = () => new SomeDir(
           ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
+
+          static ngDirectiveDef = ɵɵdefineDirective({
+            type: SomeDir,
+            selectors: [['', 'someDir', '']],
+          });
     }
 
     function AppComponent_Template_1(rf: RenderFlags, ctx: any) {
@@ -1466,6 +1467,7 @@ describe('query', () => {
         this.contentCheckedQuerySnapshot = this.foos ? this.foos.length : 0;
       }
 
+      static ngFactoryFn = () => withContentInstance = new WithContentDirective();
       static ngDirectiveDef = ɵɵdefineDirective({
         type: WithContentDirective,
         selectors: [['', 'with-content', '']],
@@ -1479,7 +1481,6 @@ describe('query', () => {
           }
         }
       });
-      static ngFactoryFn = () => withContentInstance = new WithContentDirective();
     }
 
     it('should support content queries for directives', () => {
@@ -1654,6 +1655,7 @@ describe('query', () => {
     it('should report results to appropriate queries where deep content queries are nested', () => {
       class QueryDirective {
         fooBars: any;
+        static ngFactoryFn = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1670,7 +1672,6 @@ describe('query', () => {
             }
           }
         });
-        static ngFactoryFn = () => new QueryDirective();
       }
 
       let outInstance: QueryDirective;
@@ -1719,6 +1720,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
+        static ngFactoryFn = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1735,7 +1737,6 @@ describe('query', () => {
             }
           }
         });
-        static ngFactoryFn = () => new QueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -1776,6 +1777,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
+        static ngFactoryFn = () => new QueryDirective();
         static ngDirectiveDef = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1792,7 +1794,6 @@ describe('query', () => {
             }
           }
         });
-        static ngFactoryFn = () => new QueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -1837,6 +1838,7 @@ describe('query', () => {
        () => {
          class ShallowQueryDirective {
            foos: any;
+           static ngFactoryFn = () => new ShallowQueryDirective();
            static ngDirectiveDef = ɵɵdefineDirective({
              type: ShallowQueryDirective,
              selectors: [['', 'shallow-query', '']],
@@ -1853,11 +1855,11 @@ describe('query', () => {
                }
              }
            });
-           static ngFactoryFn = () => new ShallowQueryDirective();
          }
 
          class DeepQueryDirective {
            foos: any;
+           static ngFactoryFn = () => new DeepQueryDirective();
            static ngDirectiveDef = ɵɵdefineDirective({
              type: DeepQueryDirective,
              selectors: [['', 'deep-query', '']],
@@ -1874,7 +1876,6 @@ describe('query', () => {
                }
              }
            });
-           static ngFactoryFn = () => new DeepQueryDirective();
          }
 
          let shallowInstance: ShallowQueryDirective;
@@ -1921,9 +1922,9 @@ describe('query', () => {
     class TextDirective {
       value !: string;
 
+      static ngFactoryFn = () => new TextDirective();
       static ngDirectiveDef = ɵɵdefineDirective(
           {type: TextDirective, selectors: [['', 'text', '']], inputs: {value: 'text'}});
-      static ngFactoryFn = () => new TextDirective();
     }
 
     it('should register content matches from top to bottom', () => {
@@ -1933,6 +1934,7 @@ describe('query', () => {
         // @ContentChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
+        static ngFactoryFn = () => contentQueryDirective = new ContentQueryDirective();
         static ngComponentDef = ɵɵdefineDirective({
           type: ContentQueryDirective,
           selectors: [['', 'content-query', '']],
@@ -1948,7 +1950,6 @@ describe('query', () => {
             }
           }
         });
-        static ngFactoryFn = () => contentQueryDirective = new ContentQueryDirective();
       }
 
       const AppComponent = createComponent(
@@ -2001,6 +2002,7 @@ describe('query', () => {
         // @ViewChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
+        static ngFactoryFn = () => new ViewQueryComponent();
         static ngComponentDef = ɵɵdefineComponent({
           type: ViewQueryComponent,
           selectors: [['view-query']],
@@ -2029,7 +2031,6 @@ describe('query', () => {
           },
           directives: [TextDirective]
         });
-        static ngFactoryFn = () => new ViewQueryComponent();
       }
 
       const fixture = new ComponentFixture(ViewQueryComponent);

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -368,7 +368,7 @@ export function createComponent(
     viewProviders: Provider[] = [], hostBindings?: HostBindingsFunction<any>): ComponentType<any> {
   return class Component {
     value: any;
-    static ngFactoryFn = () => new Component;
+    static ngFactoryDef = () => new Component;
     static ngComponentDef = ɵɵdefineComponent({
       type: Component,
       selectors: [[name]],
@@ -387,7 +387,7 @@ export function createComponent(
 export function createDirective(
     name: string, {exportAs}: {exportAs?: string[]} = {}): DirectiveType<any> {
   return class Directive {
-    static ngFactoryFn = () => new Directive();
+    static ngFactoryDef = () => new Directive();
     static ngDirectiveDef = ɵɵdefineDirective({
       type: Directive,
       selectors: [['', name, '']],

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -368,6 +368,7 @@ export function createComponent(
     viewProviders: Provider[] = [], hostBindings?: HostBindingsFunction<any>): ComponentType<any> {
   return class Component {
     value: any;
+    static ngFactoryFn = () => new Component;
     static ngComponentDef = ɵɵdefineComponent({
       type: Component,
       selectors: [[name]],
@@ -380,19 +381,18 @@ export function createComponent(
       features: (providers.length > 0 || viewProviders.length > 0)?
       [ɵɵProvidersFeature(providers || [], viewProviders || [])]: []
     });
-    static ngFactoryFn = () => new Component;
   };
 }
 
 export function createDirective(
     name: string, {exportAs}: {exportAs?: string[]} = {}): DirectiveType<any> {
   return class Directive {
+    static ngFactoryFn = () => new Directive();
     static ngDirectiveDef = ɵɵdefineDirective({
       type: Directive,
       selectors: [['', name, '']],
       exportAs: exportAs,
     });
-    static ngFactoryFn = () => new Directive();
   };
 }
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -260,7 +260,6 @@ export function renderTemplate<T>(
     selectView(hostLView, null);  // SUSPECT! why do we need to enter the View?
 
     const def: ComponentDef<any> = ɵɵdefineComponent({
-      factory: () => null,
       selectors: [],
       type: Object,
       template: templateFn,
@@ -374,7 +373,6 @@ export function createComponent(
       selectors: [[name]],
       consts: consts,
       vars: vars,
-      factory: () => new Component,
       template: template,
       viewQuery: viewQuery,
       directives: directives, hostBindings,
@@ -382,6 +380,7 @@ export function createComponent(
       features: (providers.length > 0 || viewProviders.length > 0)?
       [ɵɵProvidersFeature(providers || [], viewProviders || [])]: []
     });
+    static ngFactoryFn = () => new Component;
   };
 }
 
@@ -391,9 +390,9 @@ export function createDirective(
     static ngDirectiveDef = ɵɵdefineDirective({
       type: Directive,
       selectors: [['', name, '']],
-      factory: () => new Directive(),
       exportAs: exportAs,
     });
+    static ngFactoryFn = () => new Directive();
   };
 }
 

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -26,7 +26,7 @@ describe('renderer factory lifecycle', () => {
   rendererFactory.end = () => logs.push('end');
 
   class SomeComponent {
-    static ngFactoryFn = () => new SomeComponent;
+    static ngFactoryDef = () => new SomeComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: SomeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -46,7 +46,7 @@ describe('renderer factory lifecycle', () => {
   }
 
   class SomeComponentWhichThrows {
-    static ngFactoryFn = () => new SomeComponentWhichThrows;
+    static ngFactoryDef = () => new SomeComponentWhichThrows;
     static ngComponentDef = ɵɵdefineComponent({
       type: SomeComponentWhichThrows,
       encapsulation: ViewEncapsulation.None,
@@ -150,7 +150,7 @@ describe('Renderer2 destruction hooks', () => {
 
   it('should call renderer.destroy for each component destroyed', () => {
     class SimpleComponent {
-      static ngFactoryFn = () => new SimpleComponent;
+      static ngFactoryDef = () => new SimpleComponent;
       static ngComponentDef = ɵɵdefineComponent({
         type: SimpleComponent,
         encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -40,9 +40,9 @@ describe('renderer factory lifecycle', () => {
         if (rf & RenderFlags.Update) {
           logs.push('component update');
         }
-      },
-      factory: () => new SomeComponent
+      }
     });
+    static ngFactoryFn = () => new SomeComponent;
   }
 
   class SomeComponentWhichThrows {
@@ -54,9 +54,9 @@ describe('renderer factory lifecycle', () => {
       vars: 0,
       template: function(rf: RenderFlags, ctx: SomeComponentWhichThrows) {
         throw(new Error('SomeComponentWhichThrows threw'));
-      },
-      factory: () => new SomeComponentWhichThrows
+      }
     });
+    static ngFactoryFn = () => new SomeComponentWhichThrows;
   }
 
   function Template(rf: RenderFlags, ctx: any) {
@@ -161,8 +161,8 @@ describe('Renderer2 destruction hooks', () => {
             ɵɵelement(0, 'span');
           }
         },
-        factory: () => new SimpleComponent,
       });
+      static ngFactoryFn = () => new SimpleComponent;
     }
 
     let condition = true;

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -26,6 +26,7 @@ describe('renderer factory lifecycle', () => {
   rendererFactory.end = () => logs.push('end');
 
   class SomeComponent {
+    static ngFactoryFn = () => new SomeComponent;
     static ngComponentDef = ɵɵdefineComponent({
       type: SomeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -42,10 +43,10 @@ describe('renderer factory lifecycle', () => {
         }
       }
     });
-    static ngFactoryFn = () => new SomeComponent;
   }
 
   class SomeComponentWhichThrows {
+    static ngFactoryFn = () => new SomeComponentWhichThrows;
     static ngComponentDef = ɵɵdefineComponent({
       type: SomeComponentWhichThrows,
       encapsulation: ViewEncapsulation.None,
@@ -56,7 +57,6 @@ describe('renderer factory lifecycle', () => {
         throw(new Error('SomeComponentWhichThrows threw'));
       }
     });
-    static ngFactoryFn = () => new SomeComponentWhichThrows;
   }
 
   function Template(rf: RenderFlags, ctx: any) {
@@ -150,6 +150,7 @@ describe('Renderer2 destruction hooks', () => {
 
   it('should call renderer.destroy for each component destroyed', () => {
     class SimpleComponent {
+      static ngFactoryFn = () => new SimpleComponent;
       static ngComponentDef = ɵɵdefineComponent({
         type: SimpleComponent,
         encapsulation: ViewEncapsulation.None,
@@ -162,7 +163,6 @@ describe('Renderer2 destruction hooks', () => {
           }
         },
       });
-      static ngFactoryFn = () => new SimpleComponent;
     }
 
     let condition = true;

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -32,11 +32,10 @@ describe('ViewContainerRef', () => {
     static ngDirectiveDef = ɵɵdefineDirective({
       type: DirectiveWithVCRef,
       selectors: [['', 'vcref', '']],
-      factory: () => directiveInstance = new DirectiveWithVCRef(
-
-                   ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver()),
       inputs: {tplRef: 'tplRef', name: 'name'}
     });
+    static ngFactoryFn = () => directiveInstance = new DirectiveWithVCRef(
+        ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
     // TODO(issue/24571): remove '!'.
     tplRef !: TemplateRef<{}>;
@@ -60,16 +59,17 @@ describe('ViewContainerRef', () => {
              static ngDirectiveDef = ɵɵdefineDirective({
                type: TestDirective,
                selectors: [['', 'testdir', '']],
-               factory: () => {
-                 const instance = new TestDirective(
-                     ɵɵdirectiveInject(ViewContainerRef as any),
-                     ɵɵdirectiveInject(TemplateRef as any));
-
-                 directiveInstances.push(instance);
-
-                 return instance;
-               }
              });
+             static ngFactoryFn =
+                 () => {
+                   const instance = new TestDirective(
+                       ɵɵdirectiveInject(ViewContainerRef as any),
+                       ɵɵdirectiveInject(TemplateRef as any));
+
+                   directiveInstances.push(instance);
+
+                   return instance;
+                 }
 
              constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<{}>) {}
 
@@ -103,7 +103,6 @@ describe('ViewContainerRef', () => {
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
                selectors: [['test-cmp']],
-               factory: () => new TestComponent(),
                consts: 4,
                vars: 0,
                template: (rf: RenderFlags, cmp: TestComponent) => {
@@ -116,6 +115,7 @@ describe('ViewContainerRef', () => {
                },
                directives: [TestDirective]
              });
+             static ngFactoryFn = () => new TestComponent();
            }
 
            const fixture = new ComponentFixture(TestComponent);
@@ -134,13 +134,10 @@ describe('ViewContainerRef', () => {
            let directiveInstance: TestDirective;
 
            class TestDirective {
-             static ngDirectiveDef = ɵɵdefineDirective({
-               type: TestDirective,
-               selectors: [['', 'testdir', '']],
-               factory: () => directiveInstance = new TestDirective(
-                            ɵɵdirectiveInject(ViewContainerRef as any),
-                            ɵɵdirectiveInject(TemplateRef as any))
-             });
+             static ngDirectiveDef =
+                 ɵɵdefineDirective({type: TestDirective, selectors: [['', 'testdir', '']]});
+             static ngFactoryFn = () => directiveInstance = new TestDirective(
+                 ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
 
              constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<{}>) {}
 
@@ -178,7 +175,6 @@ describe('ViewContainerRef', () => {
                selectors: [['test-cmp']],
                consts: 4,
                vars: 0,
-               factory: () => new TestComponent(),
                template: (rf: RenderFlags, cmp: TestComponent) => {
                  if (rf & RenderFlags.Create) {
                    ɵɵtext(0, 'before|');
@@ -204,6 +200,7 @@ describe('ViewContainerRef', () => {
                },
                directives: [TestDirective]
              });
+             static ngFactoryFn = () => new TestComponent();
            }
 
            const fixture = new ComponentFixture(TestComponent);
@@ -242,13 +239,12 @@ describe('ViewContainerRef', () => {
           static ngComponentDef = ɵɵdefineComponent({
             type: AppComp,
             selectors: [['app-comp']],
-            factory:
-                () => new AppComp(
-                    ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver()),
             consts: 0,
             vars: 0,
             template: (rf: RenderFlags, cmp: AppComp) => {}
           });
+          static ngFactoryFn = () => new AppComp(
+              ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
         }
 
         class DynamicComp {
@@ -259,11 +255,11 @@ describe('ViewContainerRef', () => {
           static ngComponentDef = ɵɵdefineComponent({
             type: DynamicComp,
             selectors: [['dynamic-comp']],
-            factory: () => dynamicComp = new DynamicComp(),
             consts: 0,
             vars: 0,
             template: (rf: RenderFlags, cmp: DynamicComp) => {}
           });
+          static ngFactoryFn = () => dynamicComp = new DynamicComp();
         }
 
         it('should return ComponentRef with ChangeDetectorRef attached to root view', () => {
@@ -358,12 +354,12 @@ describe('ViewContainerRef', () => {
       static ngComponentDef = ɵɵdefineComponent({
         type: AppCmpt,
         selectors: [['app']],
-        factory: () => new AppCmpt(
-                     ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver()),
         consts: 0,
         vars: 0,
         template: (rf: RenderFlags, cmp: AppCmpt) => {}
       });
+      static ngFactoryFn = () =>
+          new AppCmpt(ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
       constructor(private _vcRef: ViewContainerRef, private _cfResolver: ComponentFactoryResolver) {
       }
@@ -427,7 +423,6 @@ describe('ViewContainerRef', () => {
         static ngComponentDef = ɵɵdefineComponent({
           type: DynamicCompWithViewQueries,
           selectors: [['dynamic-cmpt-with-view-queries']],
-          factory: () => dynamicComp = new DynamicCompWithViewQueries(),
           consts: 2,
           vars: 0,
           template: (rf: RenderFlags, ctx: DynamicCompWithViewQueries) => {
@@ -448,6 +443,7 @@ describe('ViewContainerRef', () => {
             }
           }
         });
+        static ngFactoryFn = () => dynamicComp = new DynamicCompWithViewQueries();
       }
 
       const fixture = new ComponentFixture(AppCmpt);
@@ -484,11 +480,11 @@ describe('ViewContainerRef', () => {
             ɵɵelementEnd();
           }
         },
-        // We want the ViewRef, so we rely on the knowledge that `ViewRef` is actually given
-        // when injecting `ChangeDetectorRef`.
-        factory: () => new CompWithListenerThatDestroysItself(
-                     ɵɵdirectiveInject(ChangeDetectorRef as any)),
       });
+      // We want the ViewRef, so we rely on the knowledge that `ViewRef` is actually given
+      // when injecting `ChangeDetectorRef`.
+      static ngFactoryFn = () =>
+          new CompWithListenerThatDestroysItself(ɵɵdirectiveInject(ChangeDetectorRef as any))
     }
 
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -29,13 +29,14 @@ describe('ViewContainerRef', () => {
   beforeEach(() => directiveInstance = null);
 
   class DirectiveWithVCRef {
-    static ngDirectiveDef = ɵɵdefineDirective({
-      type: DirectiveWithVCRef,
-      selectors: [['', 'vcref', '']],
-      inputs: {tplRef: 'tplRef', name: 'name'}
-    });
     static ngFactoryFn = () => directiveInstance = new DirectiveWithVCRef(
         ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
+
+        static ngDirectiveDef = ɵɵdefineDirective({
+          type: DirectiveWithVCRef,
+          selectors: [['', 'vcref', '']],
+          inputs: {tplRef: 'tplRef', name: 'name'}
+        });
 
     // TODO(issue/24571): remove '!'.
     tplRef !: TemplateRef<{}>;
@@ -56,10 +57,6 @@ describe('ViewContainerRef', () => {
            let directiveInstances: TestDirective[] = [];
 
            class TestDirective {
-             static ngDirectiveDef = ɵɵdefineDirective({
-               type: TestDirective,
-               selectors: [['', 'testdir', '']],
-             });
              static ngFactoryFn =
                  () => {
                    const instance = new TestDirective(
@@ -70,6 +67,11 @@ describe('ViewContainerRef', () => {
 
                    return instance;
                  }
+
+             static ngDirectiveDef = ɵɵdefineDirective({
+               type: TestDirective,
+               selectors: [['', 'testdir', '']],
+             });
 
              constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<{}>) {}
 
@@ -99,6 +101,7 @@ describe('ViewContainerRef', () => {
            class TestComponent {
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
+             static ngFactoryFn = () => new TestComponent();
              static ngComponentDef = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -115,7 +118,6 @@ describe('ViewContainerRef', () => {
                },
                directives: [TestDirective]
              });
-             static ngFactoryFn = () => new TestComponent();
            }
 
            const fixture = new ComponentFixture(TestComponent);
@@ -134,10 +136,11 @@ describe('ViewContainerRef', () => {
            let directiveInstance: TestDirective;
 
            class TestDirective {
-             static ngDirectiveDef =
-                 ɵɵdefineDirective({type: TestDirective, selectors: [['', 'testdir', '']]});
              static ngFactoryFn = () => directiveInstance = new TestDirective(
                  ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
+
+                 static ngDirectiveDef =
+                     ɵɵdefineDirective({type: TestDirective, selectors: [['', 'testdir', '']]});
 
              constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<{}>) {}
 
@@ -169,6 +172,7 @@ describe('ViewContainerRef', () => {
              condition = false;
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
+             static ngFactoryFn = () => new TestComponent();
              static ngComponentDef = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -200,7 +204,6 @@ describe('ViewContainerRef', () => {
                },
                directives: [TestDirective]
              });
-             static ngFactoryFn = () => new TestComponent();
            }
 
            const fixture = new ComponentFixture(TestComponent);
@@ -236,21 +239,24 @@ describe('ViewContainerRef', () => {
         class AppComp {
           constructor(public vcr: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-          static ngComponentDef = ɵɵdefineComponent({
-            type: AppComp,
-            selectors: [['app-comp']],
-            consts: 0,
-            vars: 0,
-            template: (rf: RenderFlags, cmp: AppComp) => {}
-          });
           static ngFactoryFn = () => new AppComp(
               ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
+
+              static ngComponentDef = ɵɵdefineComponent({
+                type: AppComp,
+                selectors: [['app-comp']],
+                consts: 0,
+                vars: 0,
+                template: (rf: RenderFlags, cmp: AppComp) => {}
+              });
         }
 
         class DynamicComp {
           doCheckCount = 0;
 
           ngDoCheck() { this.doCheckCount++; }
+
+          static ngFactoryFn = () => dynamicComp = new DynamicComp();
 
           static ngComponentDef = ɵɵdefineComponent({
             type: DynamicComp,
@@ -259,7 +265,6 @@ describe('ViewContainerRef', () => {
             vars: 0,
             template: (rf: RenderFlags, cmp: DynamicComp) => {}
           });
-          static ngFactoryFn = () => dynamicComp = new DynamicComp();
         }
 
         it('should return ComponentRef with ChangeDetectorRef attached to root view', () => {
@@ -351,15 +356,16 @@ describe('ViewContainerRef', () => {
 
     @Component({selector: 'app', template: ''})
     class AppCmpt {
-      static ngComponentDef = ɵɵdefineComponent({
-        type: AppCmpt,
-        selectors: [['app']],
-        consts: 0,
-        vars: 0,
-        template: (rf: RenderFlags, cmp: AppCmpt) => {}
-      });
       static ngFactoryFn = () =>
           new AppCmpt(ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
+
+              static ngComponentDef = ɵɵdefineComponent({
+                type: AppCmpt,
+                selectors: [['app']],
+                consts: 0,
+                vars: 0,
+                template: (rf: RenderFlags, cmp: AppCmpt) => {}
+              });
 
       constructor(private _vcRef: ViewContainerRef, private _cfResolver: ComponentFactoryResolver) {
       }
@@ -420,6 +426,7 @@ describe('ViewContainerRef', () => {
         // @ViewChildren('foo')
         foo !: QueryList<any>;
 
+        static ngFactoryFn = () => dynamicComp = new DynamicCompWithViewQueries();
         static ngComponentDef = ɵɵdefineComponent({
           type: DynamicCompWithViewQueries,
           selectors: [['dynamic-cmpt-with-view-queries']],
@@ -443,7 +450,6 @@ describe('ViewContainerRef', () => {
             }
           }
         });
-        static ngFactoryFn = () => dynamicComp = new DynamicCompWithViewQueries();
       }
 
       const fixture = new ComponentFixture(AppCmpt);
@@ -464,27 +470,28 @@ describe('ViewContainerRef', () => {
 
       ngOnDestroy() { this.viewRef.destroy(); }
 
-      static ngComponentDef = ɵɵdefineComponent({
-        type: CompWithListenerThatDestroysItself,
-        selectors: [['comp-with-listener-and-on-destroy']],
-        consts: 2,
-        vars: 0,
-        /** <button (click)="onClick()"> Click me </button> */
-        template: function CompTemplate(rf: RenderFlags, ctx: any) {
-          if (rf & RenderFlags.Create) {
-            ɵɵelementStart(0, 'button');
-            {
-              ɵɵlistener('click', function() { return ctx.onClick(); });
-              ɵɵtext(1, 'Click me');
-            }
-            ɵɵelementEnd();
-          }
-        },
-      });
       // We want the ViewRef, so we rely on the knowledge that `ViewRef` is actually given
       // when injecting `ChangeDetectorRef`.
       static ngFactoryFn = () =>
           new CompWithListenerThatDestroysItself(ɵɵdirectiveInject(ChangeDetectorRef as any))
+
+              static ngComponentDef = ɵɵdefineComponent({
+                type: CompWithListenerThatDestroysItself,
+                selectors: [['comp-with-listener-and-on-destroy']],
+                consts: 2,
+                vars: 0,
+                /** <button (click)="onClick()"> Click me </button> */
+                template: function CompTemplate(rf: RenderFlags, ctx: any) {
+                  if (rf & RenderFlags.Create) {
+                    ɵɵelementStart(0, 'button');
+                    {
+                      ɵɵlistener('click', function() { return ctx.onClick(); });
+                      ɵɵtext(1, 'Click me');
+                    }
+                    ɵɵelementEnd();
+                  }
+                },
+              });
     }
 
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -29,7 +29,7 @@ describe('ViewContainerRef', () => {
   beforeEach(() => directiveInstance = null);
 
   class DirectiveWithVCRef {
-    static ngFactoryFn = () => directiveInstance = new DirectiveWithVCRef(
+    static ngFactoryDef = () => directiveInstance = new DirectiveWithVCRef(
         ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
         static ngDirectiveDef = ɵɵdefineDirective({
@@ -57,7 +57,7 @@ describe('ViewContainerRef', () => {
            let directiveInstances: TestDirective[] = [];
 
            class TestDirective {
-             static ngFactoryFn =
+             static ngFactoryDef =
                  () => {
                    const instance = new TestDirective(
                        ɵɵdirectiveInject(ViewContainerRef as any),
@@ -101,7 +101,7 @@ describe('ViewContainerRef', () => {
            class TestComponent {
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
-             static ngFactoryFn = () => new TestComponent();
+             static ngFactoryDef = () => new TestComponent();
              static ngComponentDef = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -136,7 +136,7 @@ describe('ViewContainerRef', () => {
            let directiveInstance: TestDirective;
 
            class TestDirective {
-             static ngFactoryFn = () => directiveInstance = new TestDirective(
+             static ngFactoryDef = () => directiveInstance = new TestDirective(
                  ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
 
                  static ngDirectiveDef =
@@ -172,7 +172,7 @@ describe('ViewContainerRef', () => {
              condition = false;
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
-             static ngFactoryFn = () => new TestComponent();
+             static ngFactoryDef = () => new TestComponent();
              static ngComponentDef = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -239,16 +239,19 @@ describe('ViewContainerRef', () => {
         class AppComp {
           constructor(public vcr: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-          static ngFactoryFn = () => new AppComp(
-              ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
+          static ngFactoryDef =
+              () => {
+                return new AppComp(
+                    ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver());
+              }
 
-              static ngComponentDef = ɵɵdefineComponent({
-                type: AppComp,
-                selectors: [['app-comp']],
-                consts: 0,
-                vars: 0,
-                template: (rf: RenderFlags, cmp: AppComp) => {}
-              });
+          static ngComponentDef = ɵɵdefineComponent({
+            type: AppComp,
+            selectors: [['app-comp']],
+            consts: 0,
+            vars: 0,
+            template: (rf: RenderFlags, cmp: AppComp) => {}
+          });
         }
 
         class DynamicComp {
@@ -256,7 +259,7 @@ describe('ViewContainerRef', () => {
 
           ngDoCheck() { this.doCheckCount++; }
 
-          static ngFactoryFn = () => dynamicComp = new DynamicComp();
+          static ngFactoryDef = () => dynamicComp = new DynamicComp();
 
           static ngComponentDef = ɵɵdefineComponent({
             type: DynamicComp,
@@ -356,7 +359,7 @@ describe('ViewContainerRef', () => {
 
     @Component({selector: 'app', template: ''})
     class AppCmpt {
-      static ngFactoryFn = () =>
+      static ngFactoryDef = () =>
           new AppCmpt(ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
               static ngComponentDef = ɵɵdefineComponent({
@@ -426,7 +429,7 @@ describe('ViewContainerRef', () => {
         // @ViewChildren('foo')
         foo !: QueryList<any>;
 
-        static ngFactoryFn = () => dynamicComp = new DynamicCompWithViewQueries();
+        static ngFactoryDef = () => dynamicComp = new DynamicCompWithViewQueries();
         static ngComponentDef = ɵɵdefineComponent({
           type: DynamicCompWithViewQueries,
           selectors: [['dynamic-cmpt-with-view-queries']],
@@ -472,7 +475,7 @@ describe('ViewContainerRef', () => {
 
       // We want the ViewRef, so we rely on the knowledge that `ViewRef` is actually given
       // when injecting `ChangeDetectorRef`.
-      static ngFactoryFn = () =>
+      static ngFactoryDef = () =>
           new CompWithListenerThatDestroysItself(ɵɵdirectiveInject(ChangeDetectorRef as any))
 
               static ngComponentDef = ɵɵdefineComponent({

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -503,6 +503,7 @@ describe('TestBed', () => {
          */
         const getAOTCompiledComponent = () => {
           class ComponentClass {
+            static ngFactoryFn = () => new ComponentClass();
             static ngComponentDef = defineComponent({
               type: ComponentClass,
               selectors: [['comp']],
@@ -515,8 +516,6 @@ describe('TestBed', () => {
               },
               styles: ['body { margin: 0; }']
             });
-
-            static ngFactoryFn = () => new ComponentClass();
           }
           setClassMetadata(
               ComponentClass, [{

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -506,7 +506,6 @@ describe('TestBed', () => {
             static ngComponentDef = defineComponent({
               type: ComponentClass,
               selectors: [['comp']],
-              factory: () => new ComponentClass(),
               consts: 1,
               vars: 0,
               template: (rf: any, ctx: any) => {
@@ -516,6 +515,8 @@ describe('TestBed', () => {
               },
               styles: ['body { margin: 0; }']
             });
+
+            static ngFactoryFn = () => new ComponentClass();
           }
           setClassMetadata(
               ComponentClass, [{

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -503,7 +503,7 @@ describe('TestBed', () => {
          */
         const getAOTCompiledComponent = () => {
           class ComponentClass {
-            static ngFactoryFn = () => new ComponentClass();
+            static ngFactoryDef = () => new ComponentClass();
             static ngComponentDef = defineComponent({
               type: ComponentClass,
               selectors: [['comp']],

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -225,6 +225,7 @@ export declare class NgClassBase {
         [key: string]: any;
     } | null;
     static ngDirectiveDef: any;
+    static ngFactoryFn: any;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -309,6 +310,7 @@ export declare class NgStyleBase {
         [key: string]: any;
     } | null;
     static ngDirectiveDef: any;
+    static ngFactoryFn: any;
 }
 
 export declare class NgSwitch {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -225,7 +225,7 @@ export declare class NgClassBase {
         [key: string]: any;
     } | null;
     static ngDirectiveDef: any;
-    static ngFactoryFn: any;
+    static ngFactoryDef: any;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -310,7 +310,7 @@ export declare class NgStyleBase {
         [key: string]: any;
     } | null;
     static ngDirectiveDef: any;
-    static ngFactoryFn: any;
+    static ngFactory: any;
 }
 
 export declare class NgSwitch {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -868,7 +868,7 @@ export declare function ɵɵembeddedViewStart(viewBlockId: number, consts: numbe
 
 export declare function ɵɵenableBindings(): void;
 
-export declare type ɵɵFactoryFn<T> = () => T;
+export declare type ɵɵFactoryDef<T> = () => T;
 
 export declare function ɵɵgetCurrentView(): OpaqueViewState;
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -868,6 +868,8 @@ export declare function ɵɵembeddedViewStart(viewBlockId: number, consts: numbe
 
 export declare function ɵɵenableBindings(): void;
 
+export declare type ɵɵFactoryFn<T> = () => T;
+
 export declare function ɵɵgetCurrentView(): OpaqueViewState;
 
 export declare function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T> | null;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -771,7 +771,6 @@ export declare function ɵɵdefineBase<T>(baseDefinition: {
 export declare function ɵɵdefineComponent<T>(componentDefinition: {
     type: Type<T>;
     selectors: CssSelectorList;
-    factory: FactoryFn<T>;
     consts: number;
     vars: number;
     inputs?: {
@@ -801,7 +800,6 @@ export declare function ɵɵdefineComponent<T>(componentDefinition: {
 export declare const ɵɵdefineDirective: <T>(directiveDefinition: {
     type: Type<T>;
     selectors: (string | SelectorFlags)[][];
-    factory: FactoryFn<T>;
     inputs?: { [P in keyof T]?: string | [string, string] | undefined; } | undefined;
     outputs?: { [P in keyof T]?: string | undefined; } | undefined;
     features?: DirectiveDefFeature[] | undefined;
@@ -836,7 +834,6 @@ export declare function ɵɵdefineNgModule<T>(def: {
 export declare function ɵɵdefinePipe<T>(pipeDef: {
     name: string;
     type: Type<T>;
-    factory: FactoryFn<T>;
     pure?: boolean;
 }): never;
 


### PR DESCRIPTION
Reworks the compiler to output the factories for directives, components and pipes under a new static field called `ngFactoryFn`, instead of the usual `factory` property in their respective defs. This should eventually allow us to inject any kind of decorated class (e.g. a pipe).

**Note:** these changes are the first part of the refactor and they don't include injectables. I decided to leave injectables for a follow-up PR, because there's some more cases we need to handle when it comes to their factories. Furthermore, directives, components and pipes make up most of the compiler output tests that need to be refactored and it'll make follow-up PRs easier to review if the tests are cleaned up now.

This is part of the larger refactor for FW-1468.
