### PR TITLE
docs: fix typo in Workspace Config guide code snippet (sourceMaps --> sourceMap)

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -348,7 +348,7 @@ For example:
 
 <code-example language="json">
 
-   "sourceMaps": { "scripts": true, "styles": false, "hidden": true, "vendor": true }
+   "sourceMap": { "scripts": true, "styles": false, "hidden": true, "vendor": true }
 
 </code-example>
 


### PR DESCRIPTION
There doesn't seem to exist `sourceMaps` (plural) property in `projects -> {project name} -> architect -> build -> configurations -> {configuration name} ->sourceMaps` as this throws:

```
Schema validation failed with the following errors:
  Data path "" should NOT have additional properties(sourceMaps).
```

Changing it to singular `sourceMap` fixed it for me. I am on CLI `v8.1.3`

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x ] Documentation content changes

## Does this PR introduce a breaking change?

- [x ] No

