### PR TITLE
build: ensure schematics are built with typescript strict flag

### DIFF
--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
@@ -166,16 +166,18 @@ function filterQueryClassMemberNodes(
   //  (1) queries used in the "ngOnInit" lifecycle hook are static.
   //  (2) inputs with setters can access queries statically.
   return classDecl.members
-      .filter(m => {
-        if (ts.isMethodDeclaration(m) && m.body && hasPropertyNameText(m.name) &&
-            STATIC_QUERY_LIFECYCLE_HOOKS[query.type].indexOf(m.name.text) !== -1) {
-          return true;
-        } else if (
-            knownInputNames && ts.isSetAccessor(m) && m.body && hasPropertyNameText(m.name) &&
-            knownInputNames.indexOf(m.name.text) !== -1) {
-          return true;
-        }
-        return false;
-      })
-      .map((member: ts.SetAccessorDeclaration | ts.MethodDeclaration) => member.body !);
+      .filter(
+          (m):
+              m is(ts.SetAccessorDeclaration | ts.MethodDeclaration) => {
+                if (ts.isMethodDeclaration(m) && m.body && hasPropertyNameText(m.name) &&
+                    STATIC_QUERY_LIFECYCLE_HOOKS[query.type].indexOf(m.name.text) !== -1) {
+                  return true;
+                } else if (
+                    knownInputNames && ts.isSetAccessor(m) && m.body &&
+                    hasPropertyNameText(m.name) && knownInputNames.indexOf(m.name.text) !== -1) {
+                  return true;
+                }
+                return false;
+              })
+      .map(member => member.body !);
 }

--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     "noImplicitReturns": true,
-    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
+    "strict": true,
     "lib": ["es2015"],
     "types": [],
     "baseUrl": ".",


### PR DESCRIPTION
Follow-up to #30993 where we build all Angular packages with
the TypeScript `--strict` flag. The flag improves overall code
health and also helps us catch issues easier.
