### PR TITLE
fix(language-service): Make Definition and QuickInfo compatible with TS LS

### DIFF
--- a/integration/language_service_plugin/goldens/definitionAndBoundSpan.json
+++ b/integration/language_service_plugin/goldens/definitionAndBoundSpan.json
@@ -20,12 +20,12 @@
     ],
     "textSpan": {
       "start": {
-        "line": 7,
-        "offset": 30
+        "line": 5,
+        "offset": 26
       },
       "end": {
-        "line": 7,
-        "offset": 47
+        "line": 5,
+        "offset": 30
       }
     }
   }

--- a/integration/language_service_plugin/goldens/quickinfo.json
+++ b/integration/language_service_plugin/goldens/quickinfo.json
@@ -5,7 +5,7 @@
   "request_seq": 2,
   "success": true,
   "body": {
-    "kind": "",
+    "kind": "property",
     "kindModifiers": "",
     "start": {
       "line": 5,
@@ -15,7 +15,7 @@
       "line": 5,
       "offset": 30
     },
-    "displayString": "property name of AppComponent",
+    "displayString": "(property) AppComponent.name",
     "documentation": "",
     "tags": []
   }

--- a/packages/language-service/src/hover.ts
+++ b/packages/language-service/src/hover.ts
@@ -6,23 +6,42 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as ts from 'typescript';
 import {TemplateInfo} from './common';
 import {locateSymbol} from './locate_symbol';
-import {Hover, HoverTextSection, Symbol} from './types';
 
-export function getHover(info: TemplateInfo): Hover|undefined {
-  const result = locateSymbol(info);
-  if (result) {
-    return {text: hoverTextOf(result.symbol), span: result.span};
-  }
-}
+// Reverse mappings of enum would generate strings
+const SYMBOL_SPACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.space];
+const SYMBOL_PUNC = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.punctuation];
 
-function hoverTextOf(symbol: Symbol): HoverTextSection[] {
-  const result: HoverTextSection[] =
-      [{text: symbol.kind}, {text: ' '}, {text: symbol.name, language: symbol.language}];
-  const container = symbol.container;
-  if (container) {
-    result.push({text: ' of '}, {text: container.name, language: container.language});
+export function getHover(info: TemplateInfo): ts.QuickInfo|undefined {
+  const symbolInfo = locateSymbol(info);
+  if (!symbolInfo) {
+    return;
   }
-  return result;
+  const {symbol, span} = symbolInfo;
+  const containerDisplayParts: ts.SymbolDisplayPart[] = symbol.container ?
+      [
+        {text: symbol.container.name, kind: symbol.container.kind},
+        {text: '.', kind: SYMBOL_PUNC},
+      ] :
+      [];
+  return {
+    kind: symbol.kind as ts.ScriptElementKind,
+    kindModifiers: '',  // kindModifier info not available on 'ng.Symbol'
+    textSpan: {
+      start: span.start,
+      length: span.end - span.start,
+    },
+    // this would generate a string like '(property) ClassX.propY'
+    // 'kind' in displayParts does not really matter because it's dropped when
+    // displayParts get converted to string.
+    displayParts: [
+      {text: '(', kind: SYMBOL_PUNC}, {text: symbol.kind, kind: symbol.kind},
+      {text: ')', kind: SYMBOL_PUNC}, {text: ' ', kind: SYMBOL_SPACE}, ...containerDisplayParts,
+      {text: symbol.name, kind: symbol.kind},
+      // TODO: Append type info as well, but Symbol doesn't expose that!
+      // Ideally hover text should be like '(property) ClassX.propY: string'
+    ],
+  };
 }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -8,9 +8,9 @@
 
 import {CompileMetadataResolver, CompilePipeSummary} from '@angular/compiler';
 import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli/src/language_services';
-
+import * as tss from 'typescript/lib/tsserverlibrary';
 import {getTemplateCompletions} from './completions';
-import {getDefinition} from './definitions';
+import {getDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics} from './diagnostics';
 import {getHover} from './hover';
 import {Completion, Diagnostic, DiagnosticKind, Diagnostics, Hover, LanguageService, LanguageServiceHost, Location, Span, TemplateSource} from './types';
@@ -29,8 +29,6 @@ export function createLanguageService(host: LanguageServiceHost): LanguageServic
 
 class LanguageServiceImpl implements LanguageService {
   constructor(private host: LanguageServiceHost) {}
-
-  private get metadataResolver(): CompileMetadataResolver { return this.host.resolver; }
 
   getTemplateReferences(): string[] { return this.host.getTemplateReferences(); }
 
@@ -65,14 +63,14 @@ class LanguageServiceImpl implements LanguageService {
     }
   }
 
-  getDefinitionAt(fileName: string, position: number): Location[]|undefined {
+  getDefinitionAt(fileName: string, position: number): tss.DefinitionInfoAndBoundSpan|undefined {
     let templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
     if (templateInfo) {
-      return getDefinition(templateInfo);
+      return getDefinitionAndBoundSpan(templateInfo);
     }
   }
 
-  getHoverAt(fileName: string, position: number): Hover|undefined {
+  getHoverAt(fileName: string, position: number): tss.QuickInfo|undefined {
     let templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
     if (templateInfo) {
       return getHover(templateInfo);

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -8,6 +8,8 @@
 
 import {CompileDirectiveMetadata, CompileMetadataResolver, CompilePipeSummary, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli/src/language_services';
+import * as tss from 'typescript/lib/tsserverlibrary';
+
 import {AstResult, TemplateInfo} from './common';
 
 export {
@@ -394,12 +396,12 @@ export interface LanguageService {
   /**
    * Return the definition location for the symbol at position.
    */
-  getDefinitionAt(fileName: string, position: number): Location[]|undefined;
+  getDefinitionAt(fileName: string, position: number): tss.DefinitionInfoAndBoundSpan|undefined;
 
   /**
    * Return the hover information for the symbol at position.
    */
-  getHoverAt(fileName: string, position: number): Hover|undefined;
+  getHoverAt(fileName: string, position: number): tss.QuickInfo|undefined;
 
   /**
    * Return the pipes that are available at the given position.

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -28,43 +28,43 @@ describe('hover', () => {
   it('should be able to find field in an interpolation', () => {
     hover(
         ` @Component({template: '{{«name»}}'}) export class MyComponent { name: string; }`,
-        'property name of MyComponent');
+        '(property) MyComponent.name');
   });
 
   it('should be able to find a field in a attribute reference', () => {
     hover(
         ` @Component({template: '<input [(ngModel)]="«name»">'}) export class MyComponent { name: string; }`,
-        'property name of MyComponent');
+        '(property) MyComponent.name');
   });
 
   it('should be able to find a method from a call', () => {
     hover(
         ` @Component({template: '<div (click)="«ᐱmyClickᐱ()»;"></div>'}) export class MyComponent { myClick() { }}`,
-        'method myClick of MyComponent');
+        '(method) MyComponent.myClick');
   });
 
   it('should be able to find a field reference in an *ngIf', () => {
     hover(
         ` @Component({template: '<div *ngIf="«include»"></div>'}) export class MyComponent { include = true;}`,
-        'property include of MyComponent');
+        '(property) MyComponent.include');
   });
 
   it('should be able to find a reference to a component', () => {
     hover(
         ` @Component({template: '«<ᐱtestᐱ-comp></test-comp>»'}) export class MyComponent { }`,
-        'component TestComponent');
+        '(component) TestComponent');
   });
 
   it('should be able to find an event provider', () => {
     hover(
         ` @Component({template: '<test-comp «(ᐱtestᐱ)="myHandler()"»></div>'}) export class MyComponent { myHandler() {} }`,
-        'event testEvent of TestComponent');
+        '(event) TestComponent.testEvent');
   });
 
   it('should be able to find an input provider', () => {
     hover(
         ` @Component({template: '<test-comp «[ᐱtcNameᐱ]="name"»></div>'}) export class MyComponent { name = 'my name'; }`,
-        'property name of TestComponent');
+        '(property) TestComponent.name');
   });
 
   it('should be able to ignore a reference declaration', () => {
@@ -87,10 +87,13 @@ describe('hover', () => {
                             []).concat(markers.definitions[referenceName] || []);
         for (const reference of references) {
           tests++;
-          const hover = ngService.getHoverAt(fileName, reference.start);
-          if (!hover) throw new Error(`Expected a hover at location ${reference.start}`);
-          expect(hover.span).toEqual(reference);
-          expect(toText(hover)).toEqual(hoverText);
+          const quickInfo = ngService.getHoverAt(fileName, reference.start);
+          if (!quickInfo) throw new Error(`Expected a hover at location ${reference.start}`);
+          expect(quickInfo.textSpan).toEqual({
+            start: reference.start,
+            length: reference.end - reference.start,
+          });
+          expect(toText(quickInfo)).toEqual(hoverText);
         }
       }
       expect(tests).toBeGreaterThan(0);  // If this fails the test is wrong.
@@ -109,5 +112,8 @@ describe('hover', () => {
     }
   }
 
-  function toText(hover: Hover): string { return hover.text.map(h => h.text).join(''); }
+  function toText(quickInfo: ts.QuickInfo): string {
+    const displayParts = quickInfo.displayParts || [];
+    return displayParts.map(p => p.text).join('');
+  }
 });

--- a/packages/language-service/test/test_data.ts
+++ b/packages/language-service/test/test_data.ts
@@ -139,11 +139,11 @@ export class ForUsingComponent {
 @Component({template: '<div #div> <test-comp #test1> {{~{test-comp-content}}} {{test1.~{test-comp-after-test}name}} {{div.~{test-comp-after-div}.innerText}} </test-comp> </div> <test-comp #test2></test-comp>'})
 export class References {}
 
-@Component({selector: 'test-comp', template: '<div>Testing: {{name}}</div>'})
+~{start-test-comp}@Component({selector: 'test-comp', template: '<div>Testing: {{name}}</div>'})
 export class TestComponent {
   «@Input('ᐱtcNameᐱ') name = 'test';»
   «@Output('ᐱtestᐱ') testEvent = new EventEmitter();»
-}
+}~{end-test-comp}
 
 @Component({templateUrl: 'test.ng'})
 export class TemplateReference {


### PR DESCRIPTION
Now that the Angular LS is a proper tsserver plugin, it does not make
sense for it to maintain its own language service API.

This is part one of the effort to remove our custom LanguageService
interface.
This interface is cumbersome because it forces us to do two transformations:
  ng def -> ts def -> lsp definition

The TS LS interface is more comprehensive anyway, so this allows the Angular LS
to return more information.

As part of this change, the hover text for an item is changed from
`property propY of ClassX`
to
`(property) ClassX.propY`
so that it's more consistent with tsserver result.

See screenshot below:
![hover](https://user-images.githubusercontent.com/2941178/62396980-625c1800-b529-11e9-8ece-a596af9f9b40.png)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
