### PR TITLE
fix(common): serialize string to JSON if explicitly set in Content-Type

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -241,6 +241,11 @@ export class HttpRequest<T> {
     if (this.body === null) {
       return null;
     }
+    // If Content-Type was explicitly set to JSON, also stringify a simple string.
+    // A simple string value is also valid JSON according to RFC 8259 and ECMA-404.
+    if (typeof this.body === 'string' && this.headers.get('Content-Type') === 'application/json') {
+      return JSON.stringify(this.body);
+    }
     // Check whether the body is already in a serialized form. If so,
     // it can just be returned directly.
     if (isArrayBuffer(this.body) || isBlob(this.body) || isFormData(this.body) ||

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -118,9 +118,14 @@ const TEST_STRING = `I'm a body!`;
         const body = new ArrayBuffer(4);
         expect(baseReq.clone({body}).serializeBody()).toBe(body);
       });
-      it('passes strings through', () => {
+      it('passes strings through, if Content-Type not explicitly set', () => {
         const body = 'hello world';
         expect(baseReq.clone({body}).serializeBody()).toBe(body);
+      });
+      it('serializes strings as json, if Content-Type is explicitly set', () => {
+        const body = 'hello world';
+        const headers = new HttpHeaders({'Content-Type': 'application/json'});
+        expect(baseReq.clone({body, headers}).serializeBody()).toBe(JSON.stringify(body));
       });
       it('serializes arrays as json', () => {
         expect(baseReq.clone({body: ['a', 'b']}).serializeBody()).toBe('["a","b"]');


### PR DESCRIPTION
RFC 8259 and ECMA-404 define that a simple string is valid JSON.
If Content-Type has been explicitly set to 'application/json' the HttpClient should
assume that it needs to be serialized.

Closes  #31973

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x  ] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31973


## What is the new behavior?
If Content-Type is set to 'application/json' the body will also be serialized, if it is typeof string already.

## Does this PR introduce a breaking change?

- [ x ] Yes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Existing POST requests, that have a pure string payload, are serializing the body before calling http.post at the moment. This change would cause them to be serialized a second time, which would break the consistency of their POST-request.
