### PR TITLE
refactor(upgrade): avoid using static inherited method

### DIFF
--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -199,7 +199,7 @@ export function downgradeComponent(info: {
         // NOTE:
         // Not using `ParentInjectorPromise.all()` (which is inherited from `SyncPromise`), because
         // Closure Compiler (or some related tool) complains:
-        // `TypeError: ...$packages$upgrade$src$common$src$downgrade_component_ParentInjectorPromise.all is not a function`
+        // `TypeError: ...$src$downgrade_component_ParentInjectorPromise.all is not a function`
         SyncPromise.all([finalParentInjector, finalModuleInjector])
             .then(([pInjector, mInjector]) => downgradeFn(pInjector, mInjector));
 

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -196,7 +196,11 @@ export function downgradeComponent(info: {
               wrapCallback(() => doDowngrade(pInjector, mInjector))();
             };
 
-        ParentInjectorPromise.all([finalParentInjector, finalModuleInjector])
+        // NOTE:
+        // Not using `ParentInjectorPromise.all()` (which is inherited from `SyncPromise`), because
+        // Closure Compiler (or some related tool) complains:
+        // `TypeError: ...$packages$upgrade$src$common$src$downgrade_component_ParentInjectorPromise.all is not a function`
+        SyncPromise.all([finalParentInjector, finalModuleInjector])
             .then(([pInjector, mInjector]) => downgradeFn(pInjector, mInjector));
 
         ranAsync = true;


### PR DESCRIPTION
Using `ParentInjectorPromise.all()` (which is a static method inherited from `SyncPromise`) causes Closure Compiler (or some related tool) to complain:

```
TypeError: ...$packages$upgrade$src$common$src$downgrade_component_ParentInjectorPromise.all is not a function
```

Switching to `SyncPromise.all()` (the static method on the parent class) to avoid this error.
