### PR TITLE
feat(common): serialize to JSON if explicitly set in Content-Type and…

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -241,7 +241,8 @@ export class HttpRequest<T> {
     // it has been detected as a content type before, just return the stringified
     // result, if it has not already been stringified.
     if (this.headers.get('Content-Type') === 'application/json') {
-      if (typeof this.body === 'string' && /(^(\[|\{|\"|\d))|(true|false|null)/.test(this.body)) {
+      if (typeof this.body === 'string' &&
+          /(^(\[|\{|\"|\d))|(true|false|null)/.test(this.body.trim())) {
         // body has already been serialized to JSON
         return this.body;
       } else {

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -237,6 +237,18 @@ export class HttpRequest<T> {
    * transmission to the server.
    */
   serializeBody(): ArrayBuffer|Blob|FormData|string|null {
+    // If Content-Type header was explicitly set to 'application/json' or
+    // it has been detected as a content type before, just return the stringified
+    // result, if it has not already been stringified.
+    if (this.headers.get('Content-Type') === 'application/json') {
+      if (typeof this.body === 'string' && /(^(\[|\{|\"|\d))|(true|false|null)/.test(this.body)) {
+        // body has already been serialized to JSON
+        return this.body;
+      } else {
+        return JSON.stringify(this.body);
+      }
+    }
+
     // If no body is present, no need to serialize it.
     if (this.body === null) {
       return null;

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -110,8 +110,16 @@ const TEST_STRING = `I'm a body!`;
         const req = baseReq.clone({body: {data: 'test data'}});
         expect(req.detectContentTypeHeader()).toBe('application/json');
       });
+      it('handles boolean value true as json', () => {
+        const req = baseReq.clone({body: {data: true}});
+        expect(req.detectContentTypeHeader()).toBe('application/json');
+      });
+      it('handles boolean value false as json', () => {
+        const req = baseReq.clone({body: {data: false}});
+        expect(req.detectContentTypeHeader()).toBe('application/json');
+      });
     });
-    describe('body serialization', () => {
+    describe('default body serialization', () => {
       const baseReq = new HttpRequest('POST', '/test', null);
       it('handles a null body', () => { expect(baseReq.serializeBody()).toBeNull(); });
       it('passes ArrayBuffers through', () => {
@@ -137,6 +145,35 @@ const TEST_STRING = `I'm a body!`;
         expect(withParams.serializeBody()).toEqual('first=value&second=other');
         expect(withParams.detectContentTypeHeader())
             .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
+      });
+    });
+    describe('body serialization with Content-Type explicitly set to "application/json"', () => {
+      const headers = new HttpHeaders({'Content-Type': 'application/json'});
+      const baseReq = new HttpRequest('POST', '/test', null, {headers});
+      it('handles a JSON null body', () => { expect(baseReq.serializeBody()).toBe('null'); });
+      it('serializes pure JSON strings', () => {
+        const body = 'purestring';
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+      });
+      it('serializes pure JSON boolean true', () => {
+        const body = true;
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+      });
+      it('serializes pure JSON boolean false', () => {
+        const body = false;
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+      });
+      it('serializes objects to JSON strings', () => {
+        const body = {'somekey': 123, 'someotherkey': 'val'};
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+      });
+      it('serializes arrays to JSON strings', () => {
+        const body = [123, 'someval'];
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+      });
+      it('serializes numbers to JSON strings', () => {
+        const body = 123;
+        expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
       });
     });
     describe('parameter handling', () => {

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -152,28 +152,49 @@ const TEST_STRING = `I'm a body!`;
       const baseReq = new HttpRequest('POST', '/test', null, {headers});
       it('handles a JSON null body', () => { expect(baseReq.serializeBody()).toBe('null'); });
       it('serializes pure JSON strings', () => {
-        const body = 'purestring';
+        let body = 'purestring';
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
+        // skip also if provided with serialized string and beginning whitespaces
+        body = '  \"purestring\"';
+        expect(baseReq.clone({body}).serializeBody()).toBe(body);
       });
       it('serializes pure JSON boolean true', () => {
         const body = true;
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
       });
       it('serializes pure JSON boolean false', () => {
         const body = false;
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
       });
       it('serializes objects to JSON strings', () => {
         const body = {'somekey': 123, 'someotherkey': 'val'};
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
       });
       it('serializes arrays to JSON strings', () => {
         const body = [123, 'someval'];
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
       });
       it('serializes numbers to JSON strings', () => {
         const body = 123;
         expect(baseReq.clone({body}).serializeBody()).toBe(JSON.stringify(body));
+        // skip if already provided serialized
+        expect(baseReq.clone({body: JSON.stringify(body)}).serializeBody())
+            .toBe(JSON.stringify(body));
       });
     });
     describe('parameter handling', () => {


### PR DESCRIPTION
… not already serialized

RFC 8259 and ECMA-404 define a simple string, boolean and null as valid JSON.
If Content-Type has been explicitly set to 'application/json' the HttpClient should
determine if the body has already been serialized and if not, serialize it.

Not breaking.
Relates to #31973, #31974

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently you are able to e.g. provide a string, that is not a serialized JSON and want to send it to a Server that expects 'application/json' Content-Type. The HttpClient would not serialize that string and thus send an invalid JSON string and parsing will fail on the server side.
Even though HttpClient knows it needs to send JSON, it doesn't make sure that the data already has been serialized. It just assumes that this is the case for a string.

Relating Issue Number: #31973


## What is the new behavior?
If Content-Type is explicitly set to 'application/json', the HttpClient will check the body, if it is a string, if it is already parsed JSON and otherwise parse it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No, because if people have already provided parsed JSON, then it won't get parsed again.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other Notes
We already tried to solve this issue in #31974, but the discussions lead to a non-breaking solution being a better choice here, which was the motivation for this PR.