### PR TITLE
fix(ngcc): handle compilation diagnostics

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -130,7 +130,13 @@ export class DecorationAnalyzer {
 
   protected analyzeClass(symbol: ClassSymbol): AnalyzedClass|null {
     const decorators = this.reflectionHost.getDecoratorsOfSymbol(symbol);
-    return analyzeDecorators(symbol, decorators, this.handlers);
+    const analyzedClass = analyzeDecorators(symbol, decorators, this.handlers);
+    if (analyzedClass !== null && analyzedClass.diagnostics !== undefined) {
+      for (const diagnostic of analyzedClass.diagnostics) {
+        this.diagnosticHandler(diagnostic);
+      }
+    }
+    return analyzedClass;
   }
 
   protected migrateFile(migrationHost: MigrationHost, analyzedFile: AnalyzedFile): void {

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {FileSystem} from '../../../src/ngtsc/file_system';
 import {DecorationAnalyzer} from '../analysis/decoration_analyzer';
 import {ModuleWithProvidersAnalyses, ModuleWithProvidersAnalyzer} from '../analysis/module_with_providers_analyzer';
@@ -27,7 +28,16 @@ import {Renderer} from '../rendering/renderer';
 import {RenderingFormatter} from '../rendering/rendering_formatter';
 import {UmdRenderingFormatter} from '../rendering/umd_rendering_formatter';
 import {FileToWrite} from '../rendering/utils';
+
 import {EntryPointBundle} from './entry_point_bundle';
+
+export type TransformResult = {
+  success: true; diagnostics: ts.Diagnostic[]; transformedFiles: FileToWrite[];
+} |
+{
+  success: false;
+  diagnostics: ts.Diagnostic[];
+};
 
 /**
  * A Package is stored in a directory on disk and that directory can contain one or more package
@@ -58,12 +68,17 @@ export class Transformer {
    * @param bundle the bundle to transform.
    * @returns information about the files that were transformed.
    */
-  transform(bundle: EntryPointBundle): FileToWrite[] {
+  transform(bundle: EntryPointBundle): TransformResult {
     const reflectionHost = this.getHost(bundle);
 
     // Parse and analyze the files.
     const {decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses,
-           moduleWithProvidersAnalyses} = this.analyzeProgram(reflectionHost, bundle);
+           moduleWithProvidersAnalyses, diagnostics} = this.analyzeProgram(reflectionHost, bundle);
+
+    // Bail if the analysis produced any errors.
+    if (hasErrors(diagnostics)) {
+      return {success: false, diagnostics};
+    }
 
     // Transform the source files and source maps.
     const srcFormatter = this.getRenderingFormatter(reflectionHost, bundle);
@@ -81,7 +96,7 @@ export class Transformer {
       renderedFiles = renderedFiles.concat(renderedDtsFiles);
     }
 
-    return renderedFiles;
+    return {success: true, diagnostics, transformedFiles: renderedFiles};
   }
 
   getHost(bundle: EntryPointBundle): NgccReflectionHost {
@@ -127,8 +142,10 @@ export class Transformer {
         new SwitchMarkerAnalyzer(reflectionHost, bundle.entryPoint.package);
     const switchMarkerAnalyses = switchMarkerAnalyzer.analyzeProgram(bundle.src.program);
 
-    const decorationAnalyzer =
-        new DecorationAnalyzer(this.fs, bundle, reflectionHost, referencesRegistry);
+    const diagnostics: ts.Diagnostic[] = [];
+    const decorationAnalyzer = new DecorationAnalyzer(
+        this.fs, bundle, reflectionHost, referencesRegistry,
+        diagnostic => diagnostics.push(diagnostic));
     const decorationAnalyses = decorationAnalyzer.analyzeProgram();
 
     const moduleWithProvidersAnalyzer =
@@ -142,14 +159,18 @@ export class Transformer {
         privateDeclarationsAnalyzer.analyzeProgram(bundle.src.program);
 
     return {decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses,
-            moduleWithProvidersAnalyses};
+            moduleWithProvidersAnalyses, diagnostics};
   }
 }
 
+export function hasErrors(diagnostics: ts.Diagnostic[]) {
+  return diagnostics.some(d => d.category === ts.DiagnosticCategory.Error);
+}
 
 interface ProgramAnalyses {
   decorationAnalyses: Map<ts.SourceFile, CompiledFile>;
   switchMarkerAnalyses: SwitchMarkerAnalyses;
   privateDeclarationsAnalyses: ExportInfo[];
   moduleWithProvidersAnalyses: ModuleWithProvidersAnalyses|null;
+  diagnostics: ts.Diagnostic[];
 }

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -406,6 +406,41 @@ runInEachFileSystem(() => {
       });
     });
 
+    describe('diagnostics', () => {
+      it('should fail with formatted diagnostics when an error diagnostic is produced', () => {
+        loadTestFiles([
+          {
+            name: _('/node_modules/fatal-error/package.json'),
+            contents: '{"name": "fatal-error", "es2015": "./index.js", "typings": "./index.d.ts"}',
+          },
+          {name: _('/node_modules/fatal-error/index.metadata.json'), contents: 'DUMMY DATA'},
+          {
+            name: _('/node_modules/fatal-error/index.js'),
+            contents: `
+              import {Component} from '@angular/core';
+              export class FatalError {}
+              FatalError.decorators = [
+                {type: Component, args: [{selector: 'fatal-error'}]}
+              ];
+            `,
+          },
+          {
+            name: _('/node_modules/fatal-error/index.d.ts'),
+            contents: `
+              export declare class FatalError {}
+            `,
+          },
+        ]);
+        expect(() => mainNgcc({
+                 basePath: '/node_modules',
+                 targetEntryPointPath: 'fatal-error',
+                 propertiesToConsider: ['es2015']
+               }))
+            .toThrowError(
+                /^Failed to compile entry-point fatal-error due to compilation errors:\nnode_modules\/fatal-error\/index\.js\(5,17\): error TS-992001: component is missing a template\r?\n$/);
+      });
+    });
+
     describe('logger', () => {
       it('should log info message to the console by default', () => {
         const consoleInfoSpy = spyOn(console, 'info');

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_native.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_native.ts
@@ -5,10 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+/// <reference types="node" />
+import * as os from 'os';
 import {NodeJSFileSystem} from '../../src/node_js_file_system';
 import {AbsoluteFsPath, PathSegment, PathString} from '../../src/types';
 
 import {MockFileSystem} from './mock_file_system';
+
+const isWindows = os.platform() === 'win32';
 
 export class MockFileSystemNative extends MockFileSystem {
   constructor(cwd: AbsoluteFsPath = '/' as AbsoluteFsPath) { super(undefined, cwd); }
@@ -41,6 +45,15 @@ export class MockFileSystemNative extends MockFileSystem {
   }
 
   normalize<T extends PathString>(path: T): T {
+    // When running in Windows, absolute paths are normalized to always include a drive letter. This
+    // ensures that rooted posix paths used in tests will be normalized to real Windows paths, i.e.
+    // including a drive letter. Note that the same normalization is done in emulated Windows mode
+    // (see `MockFileSystemWindows`) so that the behavior is identical between native Windows and
+    // emulated Windows mode.
+    if (isWindows) {
+      path = path.replace(/^[\/\\]/i, 'C:/') as T;
+    }
+
     return NodeJSFileSystem.prototype.normalize.call(this, path) as T;
   }
 


### PR DESCRIPTION
Previously, any diagnostics reported during the compilation of an
entry-point would not be shown to the user, but either be ignored or
cause a hard crash in case of a `FatalDiagnosticError`. This is
unfortunate, as such error instances contain information on which code
was responsible for producing the error, whereas only its error message
would not. Therefore, it was quite hard to determine where the error
originates from.

This commit introduces behavior to deal with error diagnostics in a more
graceful way. Such diagnostics will still cause the compilation to fail,
however the error message now contains formatted diagnostics.

Closes #31977
Resolves FW-1374