### PR TITLE
docs: Fix table in markdown to be HTML per Angular doc style

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -59,19 +59,63 @@ The locale identifiers used by CLDR and Angular are based on [BCP47](http://www.
 These specifications change over time; the following table maps previous identifiers to current ones at
 time of writing:
 
-| Locale name                   | Old locale id     | New locale id |
-|-------------------------------|-------------------|---------------|
-| Indonesian                    | in                | id            |
-| Hebrew                        | iw                | he            |
-| Romanian Moldova              | mo                | ro-MD         |
-| Norwegian Bokmål              | no, no-NO         | nb            |
-| Serbian Latin                 | sh                | sr-Latn       |
-| Filipino                      | tl                | fil           |
-| Portuguese Brazil             | pt-BR             | pt            |
-| Chinese Simplified            | zh-cn, zh-Hans-CN | zh-Hans       |
-| Chinese Traditional           | zh-tw, zh-Hant-TW | zh-Hant       |
-| Chinese Traditional Hong Kong | zh-hk             | zh-Hant-HK    |
-
+<table>
+  <tr>
+    <th>Locale name</th>
+    <th>Old locale id</th>
+    <th>New locale id</th>
+  </tr>
+  <tr>
+    <td>Indonesian</td>
+    <td>in</td>
+    <td>id</td>
+  </tr>
+  <tr>
+    <td>Hebrew</td>
+    <td>iw</td>
+    <td>he</td>
+  </tr>
+  <tr>
+    <td>Romanian Moldova</td>
+    <td>mo</td>
+    <td>ro-MD</td>
+  </tr>
+  <tr>
+    <td>Norwegian Bokmål</td>
+    <td>no, no-NO</td>
+    <td>nb</td>
+  </tr>
+  <tr>
+    <td>Serbian Latin</td>
+    <td>sh</td>
+    <td>sr-Latn</td>
+  </tr>
+  <tr>
+    <td>Filipino</td>
+    <td>tl</td>
+    <td>fil</td>
+  </tr>
+  <tr>
+    <td>Portuguese Brazil</td>
+    <td>pt-BR</td>
+    <td>pt</td>
+  </tr>
+  <tr>
+    <td>Chinese Simplified</td>
+    <td>zh-cn, zh-Hans-CN</td>
+    <td>zh-Hans</td>
+  </tr>
+  <tr>
+    <td>Chinese Traditional</td>
+    <td>zh-tw, zh-Hant-TW</td>
+    <td>zh-Hant</td>
+  </tr>
+  <tr>
+    <td>Chinese Traditional Hong Kong</td>
+    <td>zh-hk</td>
+    <td>zh-Hant-HK</td>
+  </tr>  
+</table>
 
 ## i18n pipes
 


### PR DESCRIPTION
docs: Converted table from markdown to HTML, following issue #23978

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Tables are in markdown format
Issue Number:23978


## What is the new behavior?
Per Angular docs style, tables should be marked up in HTML

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

## Other information
