### PR TITLE
 fix(ivy): ngcc - correctly detect formats processed in previous runs (and other minor improvements)

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath, FileSystem, absoluteFrom, dirname, getFileSystem, resolve} from '../../src/ngtsc/file_system';
+
 import {CommonJsDependencyHost} from './dependencies/commonjs_dependency_host';
 import {DependencyResolver, InvalidEntryPoint, SortedEntryPointsInfo} from './dependencies/dependency_resolver';
 import {EsmDependencyHost} from './dependencies/esm_dependency_host';
@@ -17,13 +18,14 @@ import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
 import {hasBeenProcessed, markAsProcessed} from './packages/build_marker';
 import {NgccConfiguration} from './packages/configuration';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
 import {makeEntryPointBundle} from './packages/entry_point_bundle';
 import {Transformer} from './packages/transformer';
 import {PathMappings} from './utils';
 import {FileWriter} from './writing/file_writer';
 import {InPlaceFileWriter} from './writing/in_place_file_writer';
 import {NewEntryPointFileWriter} from './writing/new_entry_point_file_writer';
+
 
 /**
  * The options to configure the ngcc compiler.
@@ -68,8 +70,6 @@ export interface NgccOptions {
   fileSystem?: FileSystem;
 }
 
-const SUPPORTED_FORMATS: EntryPointFormat[] = ['esm5', 'esm2015', 'umd', 'commonjs'];
-
 /**
  * This is the main entry-point into ngcc (aNGular Compatibility Compiler).
  *
@@ -110,14 +110,14 @@ export function mainNgcc(
 
     const hasProcessedDts = hasBeenProcessed(entryPointPackageJson, 'typings');
 
-    for (let i = 0; i < propertiesToConsider.length; i++) {
-      const property = propertiesToConsider[i] as EntryPointJsonProperty;
+    for (const property of propertiesToConsider as EntryPointJsonProperty[]) {
       const formatPath = entryPointPackageJson[property];
       const format = getEntryPointFormat(fileSystem, entryPoint, property);
 
       // No format then this property is not supposed to be compiled.
-      if (!formatPath || !format || SUPPORTED_FORMATS.indexOf(format) === -1) continue;
+      if (!formatPath || !format) continue;
 
+      // The `formatPath` which the property maps to is already processed - nothing to do.
       if (hasBeenProcessed(entryPointPackageJson, property)) {
         compiledFormats.add(formatPath);
         logger.debug(`Skipping ${entryPoint.name} : ${property} (already compiled).`);

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -38,17 +38,25 @@ export function hasBeenProcessed(
 }
 
 /**
- * Write a build marker for the given entry-point and format property, to indicate that it has
+ * Write a build marker for the given entry-point and format properties, to indicate that they have
  * been compiled by this version of ngcc.
  *
- * @param entryPoint the entry-point to write a marker.
- * @param format the property in the package.json of the format for which we are writing the marker.
+ * @param fs The current file-system being used.
+ * @param packageJson The parsed contents of the `package.json` file for the entry-point.
+ * @param packageJsonPath The absolute path to the `package.json` file.
+ * @param properties The properties in the `package.json` of the formats for which we are writing
+ *                   the marker.
  */
 export function markAsProcessed(
     fs: FileSystem, packageJson: EntryPointPackageJson, packageJsonPath: AbsoluteFsPath,
-    format: EntryPointJsonProperty) {
-  if (!packageJson.__processed_by_ivy_ngcc__) packageJson.__processed_by_ivy_ngcc__ = {};
-  packageJson.__processed_by_ivy_ngcc__[format] = NGCC_VERSION;
+    properties: EntryPointJsonProperty[]) {
+  const processed =
+      packageJson.__processed_by_ivy_ngcc__ || (packageJson.__processed_by_ivy_ngcc__ = {});
+
+  for (const prop of properties) {
+    processed[prop] = NGCC_VERSION;
+  }
+
   // Just in case this package.json was synthesized due to a custom configuration
   // we will ensure that the path to the containing folder exists before we write the file.
   fs.ensureDir(dirname(packageJsonPath));

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -86,6 +86,12 @@ runInEachFileSystem(() => {
         // `test-package` has no Angular but is marked as processed.
         expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toEqual({
           es2015: '0.0.0-PLACEHOLDER',
+          esm2015: '0.0.0-PLACEHOLDER',
+          esm5: '0.0.0-PLACEHOLDER',
+          fesm2015: '0.0.0-PLACEHOLDER',
+          fesm5: '0.0.0-PLACEHOLDER',
+          main: '0.0.0-PLACEHOLDER',
+          module: '0.0.0-PLACEHOLDER',
         });
 
         // * `core` is a dependency of `test-package`, but it is not processed, since test-package
@@ -164,9 +170,7 @@ runInEachFileSystem(() => {
       const basePath = _('/node_modules');
       const targetPackageJsonPath = join(basePath, packagePath, 'package.json');
       const targetPackage = loadPackage(packagePath);
-      markAsProcessed(fs, targetPackage, targetPackageJsonPath, 'typings');
-      properties.forEach(
-          property => markAsProcessed(fs, targetPackage, targetPackageJsonPath, property));
+      markAsProcessed(fs, targetPackage, targetPackageJsonPath, ['typings', ...properties]);
     }
 
 

--- a/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
@@ -79,31 +79,54 @@ runInEachFileSystem(() => {
     });
 
     describe('markAsProcessed', () => {
-      it('should write a property in the package.json containing the version placeholder', () => {
+      it('should write properties in the package.json containing the version placeholder', () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
         let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__).toBeUndefined();
-        expect(pkg.__processed_by_ivy_ngcc__).toBeUndefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, 'fesm2015');
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
-        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toEqual('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBeUndefined();
         expect(pkg.__processed_by_ivy_ngcc__.esm5).toBeUndefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, 'esm5');
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
-        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toEqual('0.0.0-PLACEHOLDER');
-        expect(pkg.__processed_by_ivy_ngcc__.esm5).toEqual('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm5).toBe('0.0.0-PLACEHOLDER');
       });
 
       it('should update the packageJson object in-place', () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
-        let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
+        const pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__).toBeUndefined();
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, 'fesm2015');
-        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toEqual('0.0.0-PLACEHOLDER');
+
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
+        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBeUndefined();
+        expect(pkg.__processed_by_ivy_ngcc__.esm5).toBeUndefined();
+
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
+        expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBe('0.0.0-PLACEHOLDER');
+        expect(pkg.__processed_by_ivy_ngcc__.esm5).toBe('0.0.0-PLACEHOLDER');
+      });
+
+      it('should one perform one write operation for all updated properties', () => {
+        const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
+        const fs = getFileSystem();
+        const writeFileSpy = spyOn(fs, 'writeFile');
+        let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
+
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5', 'esm2015', 'esm5']);
+        expect(writeFileSpy).toHaveBeenCalledTimes(1);
       });
     });
 


### PR DESCRIPTION
The main fix is correctly detecting formats processed in previous runs, so that `ngcc` does not process them again.

The PR also includes some other minor improvements; see individual commit messages for details.