### PR TITLE
feat(forms): provide hooks for linking FormControl to ControlValueAccessor

### DIFF
--- a/packages/forms/src/directives/form_hooks.ts
+++ b/packages/forms/src/directives/form_hooks.ts
@@ -13,11 +13,11 @@ import {NgControl} from './ng_control';
 /**
  * @description
  * `InjectionToken` to provide to register hooks on reactive forms.
- * Provide a FormHooks instance with this token.
+ * Provide a FormsHook instance with this token.
  * @ngModule ReactiveFormsModule
  * @publicApi
  */
-export const NG_FORM_HOOKS = new InjectionToken('NgFormHooks');
+export const NG_FORMS_HOOK = new InjectionToken('NgFormsHook');
 
 /**
  * @description
@@ -31,7 +31,7 @@ export const NG_FORM_HOOKS = new InjectionToken('NgFormHooks');
  *
  * ```ts
  * @Injectable()
- * class MyFormHooks implements FormHooks {
+ * class MyFormsHook implements FormsHook {
  *   ...
  * }
  * ```
@@ -50,7 +50,7 @@ export const NG_FORM_HOOKS = new InjectionToken('NgFormHooks');
  * @ngModule ReactiveFormsModule
  * @publicApi
  */
-export interface FormHooks {
+export interface FormsHook {
   /**
    * @description
    * Hook called when connection between FormControl and NgControl is established.

--- a/packages/forms/src/directives/form_hooks.ts
+++ b/packages/forms/src/directives/form_hooks.ts
@@ -1,12 +1,20 @@
-import {InjectionToken} from "@angular/core";
-import { FormControl } from "../model";
-import { NgControl } from "./ng_control";
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+import {FormControl} from '../model';
+import {NgControl} from './ng_control';
 
 /**
- * Token to provide to use register hooks to reactive forms. provide a FormHooks instance with this token.
+ * Token to provide to use register hooks to reactive forms. provide a FormHooks instance with this
+ * token.
  */
-export const NG_FORM_HOOKS =
-  new InjectionToken('NgFormHooks');
+export const NG_FORM_HOOKS = new InjectionToken('NgFormHooks');
 
 /**
  * @description

--- a/packages/forms/src/directives/form_hooks.ts
+++ b/packages/forms/src/directives/form_hooks.ts
@@ -11,8 +11,11 @@ import {FormControl} from '../model';
 import {NgControl} from './ng_control';
 
 /**
- * Token to provide to use register hooks to reactive forms. provide a FormHooks instance with this
- * token.
+ * @description
+ * `InjectionToken` to provide to register hooks on reactive forms.
+ * Provide a FormHooks instance with this token.
+ * @ngModule ReactiveFormsModule
+ * @publicApi
  */
 export const NG_FORM_HOOKS = new InjectionToken('NgFormHooks');
 

--- a/packages/forms/src/directives/form_hooks.ts
+++ b/packages/forms/src/directives/form_hooks.ts
@@ -1,0 +1,62 @@
+import {InjectionToken} from "@angular/core";
+import { FormControl } from "../model";
+import { NgControl } from "./ng_control";
+
+/**
+ * Token to provide to use register hooks to reactive forms. provide a FormHooks instance with this token.
+ */
+export const NG_FORM_HOOKS =
+  new InjectionToken('NgFormHooks');
+
+/**
+ * @description
+ * Allows to hook into the link between FormControl and NgControl
+ *
+ * @see [Reactive Forms Guide](guide/reactive-forms)
+ *
+ * @usageNotes
+ *
+ * ### create a service implementing this interface and provide it:
+ *
+ * ```ts
+ * @Injectable()
+ * class MyFormHooks implements FormHooks {
+ *   ...
+ * }
+ * ```
+ *
+ * ```ts
+ * @NgModule({
+ *   imports: [
+ *     ReactiveFormsModule
+ *   ],
+ *   providers: [
+ *     {provide: NG_FORM_HOOKS, useClass: MyFormHooks}
+ *   ]
+ * }
+ * ```
+ *
+ * @ngModule ReactiveFormsModule
+ * @publicApi
+ */
+export interface FormHooks {
+  /**
+   * @description
+   * Hook called when connection between FormControl and NgControl is established.
+   * the targeted component's ControlValueAccessor is accessible via dir.valueAccessor.
+   *
+   * @param control the FormControl element specified via [formControl] or [formControlName]
+   * @param dir the NgControl (the formControl/formControlName directive object)
+   */
+  setUpControl?(control: FormControl, dir: NgControl): void;
+
+  /**
+   * @description
+   * Hook called when connection between FormControl and NgControl is loosened.
+   * You should clean up here if you create additional resources/links in setUpControl.
+   *
+   * @param control the FormControl element specified via [formControl] or [formControlName]
+   * @param dir the NgControl (the formControl/formControlName directive object)
+   */
+  cleanUpControl?(control: FormControl, dir: NgControl): void;
+}

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -11,11 +11,11 @@ import {Directive, EventEmitter, Inject, InjectionToken, Input, OnChanges, Optio
 import {FormControl} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
+import {FormHooks, NG_FORM_HOOKS} from '../form_hooks';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
-import {_ngModelWarning, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl, cleanUpControl} from '../shared';
+import {_ngModelWarning, cleanUpControl, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
-import {FormHooks, NG_FORM_HOOKS} from '../form_hooks';
 
 
 /**

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -11,7 +11,7 @@ import {Directive, EventEmitter, Inject, InjectionToken, Input, OnChanges, Optio
 import {FormControl} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
-import {FormHooks, NG_FORM_HOOKS} from '../form_hooks';
+import {FormsHook, NG_FORMS_HOOK} from '../form_hooks';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
 import {_ngModelWarning, cleanUpControl, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
@@ -169,7 +169,7 @@ export class FormControlDirective extends NgControl implements OnChanges {
               @Optional() @Self() @Inject(NG_VALUE_ACCESSOR)
               valueAccessors: ControlValueAccessor[],
               @Optional() @Inject(NG_MODEL_WITH_FORM_CONTROL_WARNING) private _ngModelWarningConfig: string|null,
-              @Optional() @Inject(NG_FORM_HOOKS) private formHooks?: FormHooks) {
+              @Optional() @Inject(NG_FORMS_HOOK) private formsHook?: FormsHook) {
                 super();
                 this._rawValidators = validators || [];
                 this._rawAsyncValidators = asyncValidators || [];
@@ -186,9 +186,9 @@ export class FormControlDirective extends NgControl implements OnChanges {
               ngOnChanges(changes: SimpleChanges): void {
                 if (this._isControlChanged(changes)) {
                   if (changes.form.previousValue) {
-                    cleanUpControl(changes.form.previousValue, this, this.formHooks);
+                    cleanUpControl(changes.form.previousValue, this, this.formsHook);
                   }
-                  setUpControl(this.form, this, this.formHooks);
+                  setUpControl(this.form, this, this.formsHook);
                   if (this.control.disabled && this.valueAccessor !.setDisabledState) {
                     this.valueAccessor !.setDisabledState !(true);
                   }

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -16,6 +16,7 @@ import {cleanUpControl, composeAsyncValidators, composeValidators, removeDir, se
 
 import {FormControlName} from './form_control_name';
 import {FormArrayName, FormGroupName} from './form_group_name';
+import {FormHooks, NG_FORM_HOOKS} from "../form_hooks";
 
 export const formDirectiveProvider: any = {
   provide: ControlContainer,
@@ -31,7 +32,7 @@ export const formDirectiveProvider: any = {
  * `FormGroup` instance to match any child `FormControl`, `FormGroup`,
  * and `FormArray` instances to child `FormControlName`, `FormGroupName`,
  * and `FormArrayName` directives.
- * 
+ *
  * @see [Reactive Forms Guide](guide/reactive-forms)
  * @see `AbstractControl`
  *
@@ -82,7 +83,8 @@ export class FormGroupDirective extends ControlContainer implements Form,
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: any[],
-      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators: any[]) {
+      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators: any[],
+      @Optional() @Inject(NG_FORM_HOOKS) private formHooks?: FormHooks) {
     super();
   }
 
@@ -129,7 +131,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
    */
   addControl(dir: FormControlName): FormControl {
     const ctrl: any = this.form.get(dir.path);
-    setUpControl(ctrl, dir);
+    setUpControl(ctrl, dir, this.formHooks);
     ctrl.updateValueAndValidity({emitEvent: false});
     this.directives.push(dir);
     return ctrl;
@@ -251,8 +253,8 @@ export class FormGroupDirective extends ControlContainer implements Form,
     this.directives.forEach(dir => {
       const newCtrl: any = this.form.get(dir.path);
       if (dir.control !== newCtrl) {
-        cleanUpControl(dir.control, dir);
-        if (newCtrl) setUpControl(newCtrl, dir);
+        cleanUpControl(dir.control, dir, this.formHooks);
+        if (newCtrl) setUpControl(newCtrl, dir, this.formHooks);
         (dir as{control: FormControl}).control = newCtrl;
       }
     });

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -10,7 +10,7 @@ import {Directive, EventEmitter, Inject, Input, OnChanges, Optional, Output, Sel
 import {FormArray, FormControl, FormGroup} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';
 import {ControlContainer} from '../control_container';
-import {FormHooks, NG_FORM_HOOKS} from '../form_hooks';
+import {FormsHook, NG_FORMS_HOOK} from '../form_hooks';
 import {Form} from '../form_interface';
 import {ReactiveErrors} from '../reactive_errors';
 import {cleanUpControl, composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from '../shared';
@@ -84,7 +84,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: any[],
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators: any[],
-      @Optional() @Inject(NG_FORM_HOOKS) private formHooks?: FormHooks) {
+      @Optional() @Inject(NG_FORMS_HOOK) private formsHook?: FormsHook) {
     super();
   }
 
@@ -131,7 +131,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
    */
   addControl(dir: FormControlName): FormControl {
     const ctrl: any = this.form.get(dir.path);
-    setUpControl(ctrl, dir, this.formHooks);
+    setUpControl(ctrl, dir, this.formsHook);
     ctrl.updateValueAndValidity({emitEvent: false});
     this.directives.push(dir);
     return ctrl;
@@ -253,8 +253,8 @@ export class FormGroupDirective extends ControlContainer implements Form,
     this.directives.forEach(dir => {
       const newCtrl: any = this.form.get(dir.path);
       if (dir.control !== newCtrl) {
-        cleanUpControl(dir.control, dir, this.formHooks);
-        if (newCtrl) setUpControl(newCtrl, dir, this.formHooks);
+        cleanUpControl(dir.control, dir, this.formsHook);
+        if (newCtrl) setUpControl(newCtrl, dir, this.formsHook);
         (dir as{control: FormControl}).control = newCtrl;
       }
     });

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -10,13 +10,13 @@ import {Directive, EventEmitter, Inject, Input, OnChanges, Optional, Output, Sel
 import {FormArray, FormControl, FormGroup} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';
 import {ControlContainer} from '../control_container';
+import {FormHooks, NG_FORM_HOOKS} from '../form_hooks';
 import {Form} from '../form_interface';
 import {ReactiveErrors} from '../reactive_errors';
 import {cleanUpControl, composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from '../shared';
 
 import {FormControlName} from './form_control_name';
 import {FormArrayName, FormGroupName} from './form_group_name';
-import {FormHooks, NG_FORM_HOOKS} from "../form_hooks";
 
 export const formDirectiveProvider: any = {
   provide: ControlContainer,

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -16,6 +16,7 @@ import {CheckboxControlValueAccessor} from './checkbox_value_accessor';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
 import {DefaultValueAccessor} from './default_value_accessor';
+import {FormHooks} from './form_hooks';
 import {NgControl} from './ng_control';
 import {normalizeAsyncValidator, normalizeValidator} from './normalize_validator';
 import {NumberValueAccessor} from './number_value_accessor';
@@ -26,7 +27,6 @@ import {ReactiveErrors} from './reactive_errors';
 import {SelectControlValueAccessor} from './select_control_value_accessor';
 import {SelectMultipleControlValueAccessor} from './select_multiple_control_value_accessor';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
-import {FormHooks} from './form_hooks';
 
 
 export function controlPath(name: string, parent: ControlContainer): string[] {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -16,7 +16,7 @@ import {CheckboxControlValueAccessor} from './checkbox_value_accessor';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
 import {DefaultValueAccessor} from './default_value_accessor';
-import {FormHooks} from './form_hooks';
+import {FormsHook} from './form_hooks';
 import {NgControl} from './ng_control';
 import {normalizeAsyncValidator, normalizeValidator} from './normalize_validator';
 import {NumberValueAccessor} from './number_value_accessor';
@@ -33,7 +33,7 @@ export function controlPath(name: string, parent: ControlContainer): string[] {
   return [...parent.path !, name];
 }
 
-export function setUpControl(control: FormControl, dir: NgControl, formHooks?: FormHooks): void {
+export function setUpControl(control: FormControl, dir: NgControl, formsHook?: FormsHook): void {
   if (!control) _throwError(dir, 'Cannot find control with');
   if (!dir.valueAccessor) _throwError(dir, 'No value accessor for form control with');
 
@@ -51,8 +51,8 @@ export function setUpControl(control: FormControl, dir: NgControl, formHooks?: F
         (isDisabled: boolean) => { dir.valueAccessor !.setDisabledState !(isDisabled); });
   }
 
-  if (formHooks && formHooks.setUpControl) {
-    formHooks.setUpControl(control, dir);
+  if (formsHook && formsHook.setUpControl) {
+    formsHook.setUpControl(control, dir);
   }
 
   // re-run validation when validator binding changes, e.g. minlength=3 -> minlength=4
@@ -67,7 +67,7 @@ export function setUpControl(control: FormControl, dir: NgControl, formHooks?: F
   });
 }
 
-export function cleanUpControl(control: FormControl, dir: NgControl, formHooks?: FormHooks) {
+export function cleanUpControl(control: FormControl, dir: NgControl, formsHook?: FormsHook) {
   dir.valueAccessor !.registerOnChange(() => _noControlError(dir));
   dir.valueAccessor !.registerOnTouched(() => _noControlError(dir));
 
@@ -83,8 +83,8 @@ export function cleanUpControl(control: FormControl, dir: NgControl, formHooks?:
     }
   });
 
-  if (formHooks && formHooks.cleanUpControl) {
-    formHooks.cleanUpControl(control, dir);
+  if (formsHook && formsHook.cleanUpControl) {
+    formsHook.cleanUpControl(control, dir);
   }
 
   if (control) control._clearChangeFns();

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -25,7 +25,7 @@ export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor
 export {ControlContainer} from './directives/control_container';
 export {ControlValueAccessor, NG_VALUE_ACCESSOR} from './directives/control_value_accessor';
 export {COMPOSITION_BUFFER_MODE, DefaultValueAccessor} from './directives/default_value_accessor';
-export {FormHooks, NG_FORM_HOOKS} from './directives/form_hooks';
+export {FormsHook, NG_FORMS_HOOK} from './directives/form_hooks';
 export {Form} from './directives/form_interface';
 export {NgControl} from './directives/ng_control';
 export {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_status';

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -25,6 +25,7 @@ export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor
 export {ControlContainer} from './directives/control_container';
 export {ControlValueAccessor, NG_VALUE_ACCESSOR} from './directives/control_value_accessor';
 export {COMPOSITION_BUFFER_MODE, DefaultValueAccessor} from './directives/default_value_accessor';
+export {FormHooks, NG_FORM_HOOKS} from './directives/form_hooks';
 export {Form} from './directives/form_interface';
 export {NgControl} from './directives/ng_control';
 export {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_status';
@@ -44,7 +45,6 @@ export {FormGroupName} from './directives/reactive_directives/form_group_name';
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
 export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
-export {NG_FORM_HOOKS, FormHooks} from './directives/form_hooks';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -44,6 +44,7 @@ export {FormGroupName} from './directives/reactive_directives/form_group_name';
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
 export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
+export {NG_FORM_HOOKS, FormHooks} from './directives/form_hooks';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';

--- a/packages/forms/test/reactive_form_hooks_integration_spec.ts
+++ b/packages/forms/test/reactive_form_hooks_integration_spec.ts
@@ -6,34 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Component, Input, Type } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  FormControl,
-  FormHooks,
-  FormGroup,
-  FormsModule,
-  NG_FORM_HOOKS,
-  NgControl,
-  ReactiveFormsModule,
-  NG_VALUE_ACCESSOR,
-  ControlValueAccessor,
-  ValidatorFn,
-  AbstractControlOptions,
-  AsyncValidatorFn
-} from '@angular/forms';
-import { By } from "@angular/platform-browser";
+import {Component, Input, Type} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {AbstractControlOptions, AsyncValidatorFn, ControlValueAccessor, FormControl, FormGroup, FormHooks, FormsModule, NG_FORM_HOOKS, NG_VALUE_ACCESSOR, NgControl, ReactiveFormsModule, ValidatorFn} from '@angular/forms';
+import {By} from '@angular/platform-browser';
 
 {
   describe('reactive forms FormHooks integration tests', () => {
 
-    function initTest<T>(formHooks: FormHooks, component: Type<T>,
-                         ...directives: Type<any>[]): ComponentFixture<T> {
+    function initTest<T>(
+        formHooks: FormHooks, component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
       TestBed.configureTestingModule({
-          declarations: [component, ...directives],
-          imports: [FormsModule, ReactiveFormsModule],
-          providers: [{provide: NG_FORM_HOOKS, useValue: formHooks}]
-        });
+        declarations: [component, ...directives],
+        imports: [FormsModule, ReactiveFormsModule],
+        providers: [{provide: NG_FORM_HOOKS, useValue: formHooks}]
+      });
       return TestBed.createComponent(component);
     }
 
@@ -42,14 +29,12 @@ import { By } from "@angular/platform-browser";
 
       beforeEach(() => {
         hooks = {
-          setUpControl(control: FormControl, dir: NgControl): void {
-          },
-          cleanUpControl(control: FormControl, dir: NgControl): void {
-          }
-        }
+          setUpControl(control: FormControl, dir: NgControl): void{},
+          cleanUpControl(control: FormControl, dir: NgControl): void{}
+        };
       });
 
-      it ('setUpControl should be called when control is linked via formControl', () => {
+      it('setUpControl should be called when control is linked via formControl', () => {
         spyOn(hooks, 'setUpControl');
         const fixture = initTest(hooks, FormControlComp);
         const control = new FormControl('value');
@@ -58,7 +43,7 @@ import { By } from "@angular/platform-browser";
         expect(hooks.setUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
       });
 
-      it ('cleanUpControl should be called when formControl is changed via formControl', () => {
+      it('cleanUpControl should be called when formControl is changed via formControl', () => {
         const spy = spyOn(hooks, 'cleanUpControl');
         const fixture = initTest(hooks, FormControlComp);
         const control = new FormControl('value');
@@ -70,7 +55,7 @@ import { By } from "@angular/platform-browser";
         expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
       });
 
-      it ('setUpControl should be called when formControl is changed via formControl', () => {
+      it('setUpControl should be called when formControl is changed via formControl', () => {
         const spy = spyOn(hooks, 'setUpControl');
         const fixture = initTest(hooks, FormControlComp);
         fixture.componentInstance.control = new FormControl('value');
@@ -82,80 +67,72 @@ import { By } from "@angular/platform-browser";
         expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
       });
 
-      it ('setUpControl should be called when control is linked via formGroup->formControlName', () => {
-        spyOn(hooks, 'setUpControl');
-        const fixture = initTest(hooks, FormGroupComp);
-        const control = new FormControl('value');
-        fixture.componentInstance.formGroup = new FormGroup({
-          control: control
-        });
-        fixture.detectChanges();
-        expect(hooks.setUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
-      });
+      it('setUpControl should be called when control is linked via formGroup->formControlName',
+         () => {
+           spyOn(hooks, 'setUpControl');
+           const fixture = initTest(hooks, FormGroupComp);
+           const control = new FormControl('value');
+           fixture.componentInstance.formGroup = new FormGroup({control: control});
+           fixture.detectChanges();
+           expect(hooks.setUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+         });
 
-      it ('cleanUpControl should be called when formControlName is changed via formGroup->formControlName', () => {
-        const spy = spyOn(hooks, 'cleanUpControl');
-        const fixture = initTest(hooks, FormGroupComp);
-        const control = new FormControl('value');
-        const group = new FormGroup({
-          control: control
-        });
-        fixture.componentInstance.formGroup = group;
-        fixture.detectChanges();
-        spy.calls.reset();
-        group.setControl('control', new FormControl('other value'));
-        fixture.detectChanges();
-        expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
-      });
+      it('cleanUpControl should be called when formControlName is changed via formGroup->formControlName',
+         () => {
+           const spy = spyOn(hooks, 'cleanUpControl');
+           const fixture = initTest(hooks, FormGroupComp);
+           const control = new FormControl('value');
+           const group = new FormGroup({control: control});
+           fixture.componentInstance.formGroup = group;
+           fixture.detectChanges();
+           spy.calls.reset();
+           group.setControl('control', new FormControl('other value'));
+           fixture.detectChanges();
+           expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+         });
 
-      it ('setUpControl should be called when formControlName is changed via formGroup->formControlName', () => {
-        const spy = spyOn(hooks, 'setUpControl');
-        const fixture = initTest(hooks, FormGroupComp);
-        const control = new FormControl('value');
-        const group = new FormGroup({
-          control: control
-        });
-        fixture.componentInstance.formGroup = group;
-        fixture.detectChanges();
-        spy.calls.reset();
-        const newControl = new FormControl('other value');
-        group.setControl('control', newControl);
-        fixture.detectChanges();
-        expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
-      });
+      it('setUpControl should be called when formControlName is changed via formGroup->formControlName',
+         () => {
+           const spy = spyOn(hooks, 'setUpControl');
+           const fixture = initTest(hooks, FormGroupComp);
+           const control = new FormControl('value');
+           const group = new FormGroup({control: control});
+           fixture.componentInstance.formGroup = group;
+           fixture.detectChanges();
+           spy.calls.reset();
+           const newControl = new FormControl('other value');
+           group.setControl('control', newControl);
+           fixture.detectChanges();
+           expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
+         });
 
-      it ('cleanUpControl should be called when formGroup is changed via formGroup->formControlName', () => {
-        const spy = spyOn(hooks, 'cleanUpControl');
-        const fixture = initTest(hooks, FormGroupComp);
-        const control = new FormControl('value');
-        fixture.componentInstance.formGroup = new FormGroup({
-          control: control
-        });
-        fixture.detectChanges();
-        spy.calls.reset();
-        fixture.componentInstance.formGroup = new FormGroup({
-          control: new FormControl('other value')
-        });
-        fixture.detectChanges();
-        expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
-      });
+      it('cleanUpControl should be called when formGroup is changed via formGroup->formControlName',
+         () => {
+           const spy = spyOn(hooks, 'cleanUpControl');
+           const fixture = initTest(hooks, FormGroupComp);
+           const control = new FormControl('value');
+           fixture.componentInstance.formGroup = new FormGroup({control: control});
+           fixture.detectChanges();
+           spy.calls.reset();
+           fixture.componentInstance.formGroup =
+               new FormGroup({control: new FormControl('other value')});
+           fixture.detectChanges();
+           expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+         });
 
-      it ('setUpControl should be called when formGroup is changed via formGroup->formControlName', () => {
-        const spy = spyOn(hooks, 'setUpControl');
-        const fixture = initTest(hooks, FormGroupComp);
-        const control = new FormControl('value');
-        fixture.componentInstance.formGroup = new FormGroup({
-          control: control
-        });
-        fixture.detectChanges();
-        spy.calls.reset();
-        const newControl = new FormControl('other value');
-        fixture.componentInstance.formGroup = new FormGroup({
-          control: newControl
-        });
-        fixture.detectChanges();
-        expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
-      });
+      it('setUpControl should be called when formGroup is changed via formGroup->formControlName',
+         () => {
+           const spy = spyOn(hooks, 'setUpControl');
+           const fixture = initTest(hooks, FormGroupComp);
+           const control = new FormControl('value');
+           fixture.componentInstance.formGroup = new FormGroup({control: control});
+           fixture.detectChanges();
+           spy.calls.reset();
+           const newControl = new FormControl('other value');
+           fixture.componentInstance.formGroup = new FormGroup({control: newControl});
+           fixture.detectChanges();
+           expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
+         });
     });
 
     describe('FormHooks for postfix', () => {
@@ -163,32 +140,34 @@ import { By } from "@angular/platform-browser";
 
       beforeEach(() => {
         hooks = {
-          setUpControl(control: FormControl, dir: NgControl): void {
+          setUpControl(control: FormControl, dir: NgControl) {
             const accessor = dir.valueAccessor;
-            if (accessor != null && isCustomControlValueAccessor(accessor) && isCustomFormControl(control)) {
+            if (accessor != null && isCustomControlValueAccessor(accessor) &&
+                isCustomFormControl(control)) {
               control.registerOnPostfixChange(postfix => accessor.setPostfix(postfix));
               accessor.setPostfix(control.postfix);
             }
           },
-          cleanUpControl(control: FormControl, dir: NgControl): void {
+          cleanUpControl(control: FormControl, dir: NgControl) {
             if (isCustomFormControl(control)) {
               control.clearPostfixChangeFunctions();
             }
           }
-        }
+        };
       });
 
-      it ('is set at startup', () => {
+      it('is set at startup', () => {
         const fixture = initTest(hooks, FormCustomControlComp, FormHookCustomControl);
         const control = new CustomFormControl('42');
         control.postfix = 'cm';
         fixture.componentInstance.control = control;
         fixture.detectChanges();
-        const customComponent = fixture.debugElement.query(By.css('form-custom-control')).componentInstance as FormHookCustomControl;
+        const customComponent = fixture.debugElement.query(By.css('form-custom-control'))
+                                    .componentInstance as FormHookCustomControl;
         expect(customComponent.postfix).toEqual('cm');
       });
 
-      it ('is set at change', () => {
+      it('is set at change', () => {
         const fixture = initTest(hooks, FormCustomControlComp, FormHookCustomControl);
         const control = new CustomFormControl('42');
         control.postfix = 'cm';
@@ -196,7 +175,8 @@ import { By } from "@angular/platform-browser";
         fixture.detectChanges();
         control.postfix = 'km';
         fixture.detectChanges();
-        const customComponent = fixture.debugElement.query(By.css('form-custom-control')).componentInstance as FormHookCustomControl;
+        const customComponent = fixture.debugElement.query(By.css('form-custom-control'))
+                                    .componentInstance as FormHookCustomControl;
         expect(customComponent.postfix).toEqual('km');
       });
     });
@@ -207,31 +187,42 @@ import { By } from "@angular/platform-browser";
 @Component({selector: 'form-control-comp', template: `<input type="text" [formControl]="control">`})
 class FormControlComp {
   // TODO(issue/24571): remove '!'.
-  control!: FormControl;
+  control !: FormControl;
 }
 
-@Component({selector: 'form-group-comp', template: `<form [formGroup]="formGroup"><input type="text" formControlName="control"></form>`})
+@Component({
+  selector: 'form-group-comp',
+  template: `<form [formGroup]="formGroup"><input type="text" formControlName="control"></form>`
+})
 class FormGroupComp {
   // TODO(issue/24571): remove '!'.
-  formGroup!: FormGroup;
+  formGroup !: FormGroup;
 }
 
-@Component({selector: 'form-group-name-comp', template: `<form [formGroup]="formGroup"><div formGroupName="subGroup"><input type="text" formControlName="control"></div></form>`})
+@Component({
+  selector: 'form-group-name-comp',
+  template:
+      `<form [formGroup]="formGroup"><div formGroupName="subGroup"><input type="text" formControlName="control"></div></form>`
+})
 class FormGroupNameComp {
   // TODO(issue/24571): remove '!'.
-  formGroup!: FormGroup;
+  formGroup !: FormGroup;
 }
 
-@Component({selector: 'form-custom-control-comp', template: `<form-custom-control [formControl]="control"></form-custom-control>`})
+@Component({
+  selector: 'form-custom-control-comp',
+  template: `<form-custom-control [formControl]="control"></form-custom-control>`
+})
 class FormCustomControlComp {
   // TODO(issue/24571): remove '!'.
-  control!: FormControl;
+  control !: FormControl;
 }
 
 interface CustomControlValueAccessor extends ControlValueAccessor {
   setPostfix(postfix: string): void;
 }
-function isCustomControlValueAccessor(obj: ControlValueAccessor): obj is CustomControlValueAccessor {
+function isCustomControlValueAccessor(obj: ControlValueAccessor):
+    obj is CustomControlValueAccessor {
   return (<CustomControlValueAccessor>obj).setPostfix !== undefined;
 }
 class CustomFormControl extends FormControl {
@@ -240,17 +231,17 @@ class CustomFormControl extends FormControl {
   get postfix(): string { return this._postfix; }
   set postfix(value: string) {
     this._postfix = value;
-    for (let f of this._onPostfixChange) { f(value); }
+    for (let f of this._onPostfixChange) {
+      f(value);
+    }
   }
-  constructor(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null) {
+  constructor(
+      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
     super(formState, validatorOrOpts, asyncValidator);
   }
-  registerOnPostfixChange(fn: (postfix: string) => void): void {
-    this._onPostfixChange.push(fn);
-  }
-  clearPostfixChangeFunctions(): void {
-    this._onPostfixChange = [];
-  }
+  registerOnPostfixChange(fn: (postfix: string) => void): void { this._onPostfixChange.push(fn); }
+  clearPostfixChangeFunctions(): void { this._onPostfixChange = []; }
 }
 function isCustomFormControl(obj: FormControl): obj is CustomFormControl {
   return (<CustomFormControl>obj).registerOnPostfixChange !== undefined;
@@ -258,7 +249,8 @@ function isCustomFormControl(obj: FormControl): obj is CustomFormControl {
 
 @Component({
   selector: 'form-custom-control',
-  template: `<input name="custom" [(ngModel)]="model" (ngModelChange)="changeFn($event)" [disabled]="isDisabled"><span class="postfix">{{postfix}}</span>`,
+  template:
+      `<input name="custom" [(ngModel)]="model" (ngModelChange)="changeFn($event)" [disabled]="isDisabled"><span class="postfix">{{postfix}}</span>`,
   providers: [{provide: NG_VALUE_ACCESSOR, multi: true, useExisting: FormHookCustomControl}]
 })
 class FormHookCustomControl implements CustomControlValueAccessor {
@@ -277,5 +269,5 @@ class FormHookCustomControl implements CustomControlValueAccessor {
 
   setDisabledState(isDisabled: boolean) { this.isDisabled = isDisabled; }
 
-  setPostfix(postfix: string) { this.postfix = postfix };
+  setPostfix(postfix: string) { this.postfix = postfix; }
 }

--- a/packages/forms/test/reactive_form_hooks_integration_spec.ts
+++ b/packages/forms/test/reactive_form_hooks_integration_spec.ts
@@ -8,24 +8,24 @@
 
 import {Component, Input, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {AbstractControlOptions, AsyncValidatorFn, ControlValueAccessor, FormControl, FormGroup, FormHooks, FormsModule, NG_FORM_HOOKS, NG_VALUE_ACCESSOR, NgControl, ReactiveFormsModule, ValidatorFn} from '@angular/forms';
+import {AbstractControlOptions, AsyncValidatorFn, ControlValueAccessor, FormControl, FormGroup, FormsHook, FormsModule, NG_FORMS_HOOK, NG_VALUE_ACCESSOR, NgControl, ReactiveFormsModule, ValidatorFn} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 
 {
-  describe('reactive forms FormHooks integration tests', () => {
+  describe('reactive forms FormsHook integration tests', () => {
 
     function initTest<T>(
-        formHooks: FormHooks, component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
+        formsHook: FormsHook, component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
       TestBed.configureTestingModule({
         declarations: [component, ...directives],
         imports: [FormsModule, ReactiveFormsModule],
-        providers: [{provide: NG_FORM_HOOKS, useValue: formHooks}]
+        providers: [{provide: NG_FORMS_HOOK, useValue: formsHook}]
       });
       return TestBed.createComponent(component);
     }
 
-    describe('FormHooks', () => {
-      let hooks: FormHooks;
+    describe('FormsHook', () => {
+      let hooks: FormsHook;
 
       beforeEach(() => {
         hooks = {
@@ -135,8 +135,8 @@ import {By} from '@angular/platform-browser';
          });
     });
 
-    describe('FormHooks for postfix', () => {
-      let hooks: FormHooks;
+    describe('FormsHook for postfix', () => {
+      let hooks: FormsHook;
 
       beforeEach(() => {
         hooks = {

--- a/packages/forms/test/reactive_form_hooks_integration_spec.ts
+++ b/packages/forms/test/reactive_form_hooks_integration_spec.ts
@@ -1,0 +1,281 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Component, Input, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormControl,
+  FormHooks,
+  FormGroup,
+  FormsModule,
+  NG_FORM_HOOKS,
+  NgControl,
+  ReactiveFormsModule,
+  NG_VALUE_ACCESSOR,
+  ControlValueAccessor,
+  ValidatorFn,
+  AbstractControlOptions,
+  AsyncValidatorFn
+} from '@angular/forms';
+import { By } from "@angular/platform-browser";
+
+{
+  describe('reactive forms FormHooks integration tests', () => {
+
+    function initTest<T>(formHooks: FormHooks, component: Type<T>,
+                         ...directives: Type<any>[]): ComponentFixture<T> {
+      TestBed.configureTestingModule({
+          declarations: [component, ...directives],
+          imports: [FormsModule, ReactiveFormsModule],
+          providers: [{provide: NG_FORM_HOOKS, useValue: formHooks}]
+        });
+      return TestBed.createComponent(component);
+    }
+
+    describe('FormHooks', () => {
+      let hooks: FormHooks;
+
+      beforeEach(() => {
+        hooks = {
+          setUpControl(control: FormControl, dir: NgControl): void {
+          },
+          cleanUpControl(control: FormControl, dir: NgControl): void {
+          }
+        }
+      });
+
+      it ('setUpControl should be called when control is linked via formControl', () => {
+        spyOn(hooks, 'setUpControl');
+        const fixture = initTest(hooks, FormControlComp);
+        const control = new FormControl('value');
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        expect(hooks.setUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+      });
+
+      it ('cleanUpControl should be called when formControl is changed via formControl', () => {
+        const spy = spyOn(hooks, 'cleanUpControl');
+        const fixture = initTest(hooks, FormControlComp);
+        const control = new FormControl('value');
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        spy.calls.reset();
+        fixture.componentInstance.control = new FormControl('other value');
+        fixture.detectChanges();
+        expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+      });
+
+      it ('setUpControl should be called when formControl is changed via formControl', () => {
+        const spy = spyOn(hooks, 'setUpControl');
+        const fixture = initTest(hooks, FormControlComp);
+        fixture.componentInstance.control = new FormControl('value');
+        fixture.detectChanges();
+        spy.calls.reset();
+        const newControl = new FormControl('other value');
+        fixture.componentInstance.control = newControl;
+        fixture.detectChanges();
+        expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
+      });
+
+      it ('setUpControl should be called when control is linked via formGroup->formControlName', () => {
+        spyOn(hooks, 'setUpControl');
+        const fixture = initTest(hooks, FormGroupComp);
+        const control = new FormControl('value');
+        fixture.componentInstance.formGroup = new FormGroup({
+          control: control
+        });
+        fixture.detectChanges();
+        expect(hooks.setUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+      });
+
+      it ('cleanUpControl should be called when formControlName is changed via formGroup->formControlName', () => {
+        const spy = spyOn(hooks, 'cleanUpControl');
+        const fixture = initTest(hooks, FormGroupComp);
+        const control = new FormControl('value');
+        const group = new FormGroup({
+          control: control
+        });
+        fixture.componentInstance.formGroup = group;
+        fixture.detectChanges();
+        spy.calls.reset();
+        group.setControl('control', new FormControl('other value'));
+        fixture.detectChanges();
+        expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+      });
+
+      it ('setUpControl should be called when formControlName is changed via formGroup->formControlName', () => {
+        const spy = spyOn(hooks, 'setUpControl');
+        const fixture = initTest(hooks, FormGroupComp);
+        const control = new FormControl('value');
+        const group = new FormGroup({
+          control: control
+        });
+        fixture.componentInstance.formGroup = group;
+        fixture.detectChanges();
+        spy.calls.reset();
+        const newControl = new FormControl('other value');
+        group.setControl('control', newControl);
+        fixture.detectChanges();
+        expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
+      });
+
+      it ('cleanUpControl should be called when formGroup is changed via formGroup->formControlName', () => {
+        const spy = spyOn(hooks, 'cleanUpControl');
+        const fixture = initTest(hooks, FormGroupComp);
+        const control = new FormControl('value');
+        fixture.componentInstance.formGroup = new FormGroup({
+          control: control
+        });
+        fixture.detectChanges();
+        spy.calls.reset();
+        fixture.componentInstance.formGroup = new FormGroup({
+          control: new FormControl('other value')
+        });
+        fixture.detectChanges();
+        expect(hooks.cleanUpControl).toHaveBeenCalledWith(control, jasmine.any(Object));
+      });
+
+      it ('setUpControl should be called when formGroup is changed via formGroup->formControlName', () => {
+        const spy = spyOn(hooks, 'setUpControl');
+        const fixture = initTest(hooks, FormGroupComp);
+        const control = new FormControl('value');
+        fixture.componentInstance.formGroup = new FormGroup({
+          control: control
+        });
+        fixture.detectChanges();
+        spy.calls.reset();
+        const newControl = new FormControl('other value');
+        fixture.componentInstance.formGroup = new FormGroup({
+          control: newControl
+        });
+        fixture.detectChanges();
+        expect(hooks.setUpControl).toHaveBeenCalledWith(newControl, jasmine.any(Object));
+      });
+    });
+
+    describe('FormHooks for postfix', () => {
+      let hooks: FormHooks;
+
+      beforeEach(() => {
+        hooks = {
+          setUpControl(control: FormControl, dir: NgControl): void {
+            const accessor = dir.valueAccessor;
+            if (accessor != null && isCustomControlValueAccessor(accessor) && isCustomFormControl(control)) {
+              control.registerOnPostfixChange(postfix => accessor.setPostfix(postfix));
+              accessor.setPostfix(control.postfix);
+            }
+          },
+          cleanUpControl(control: FormControl, dir: NgControl): void {
+            if (isCustomFormControl(control)) {
+              control.clearPostfixChangeFunctions();
+            }
+          }
+        }
+      });
+
+      it ('is set at startup', () => {
+        const fixture = initTest(hooks, FormCustomControlComp, FormHookCustomControl);
+        const control = new CustomFormControl('42');
+        control.postfix = 'cm';
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        const customComponent = fixture.debugElement.query(By.css('form-custom-control')).componentInstance as FormHookCustomControl;
+        expect(customComponent.postfix).toEqual('cm');
+      });
+
+      it ('is set at change', () => {
+        const fixture = initTest(hooks, FormCustomControlComp, FormHookCustomControl);
+        const control = new CustomFormControl('42');
+        control.postfix = 'cm';
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        control.postfix = 'km';
+        fixture.detectChanges();
+        const customComponent = fixture.debugElement.query(By.css('form-custom-control')).componentInstance as FormHookCustomControl;
+        expect(customComponent.postfix).toEqual('km');
+      });
+    });
+
+  });
+}
+
+@Component({selector: 'form-control-comp', template: `<input type="text" [formControl]="control">`})
+class FormControlComp {
+  // TODO(issue/24571): remove '!'.
+  control!: FormControl;
+}
+
+@Component({selector: 'form-group-comp', template: `<form [formGroup]="formGroup"><input type="text" formControlName="control"></form>`})
+class FormGroupComp {
+  // TODO(issue/24571): remove '!'.
+  formGroup!: FormGroup;
+}
+
+@Component({selector: 'form-group-name-comp', template: `<form [formGroup]="formGroup"><div formGroupName="subGroup"><input type="text" formControlName="control"></div></form>`})
+class FormGroupNameComp {
+  // TODO(issue/24571): remove '!'.
+  formGroup!: FormGroup;
+}
+
+@Component({selector: 'form-custom-control-comp', template: `<form-custom-control [formControl]="control"></form-custom-control>`})
+class FormCustomControlComp {
+  // TODO(issue/24571): remove '!'.
+  control!: FormControl;
+}
+
+interface CustomControlValueAccessor extends ControlValueAccessor {
+  setPostfix(postfix: string): void;
+}
+function isCustomControlValueAccessor(obj: ControlValueAccessor): obj is CustomControlValueAccessor {
+  return (<CustomControlValueAccessor>obj).setPostfix !== undefined;
+}
+class CustomFormControl extends FormControl {
+  private _onPostfixChange: Function[] = [];
+  private _postfix = '';
+  get postfix(): string { return this._postfix; }
+  set postfix(value: string) {
+    this._postfix = value;
+    for (let f of this._onPostfixChange) { f(value); }
+  }
+  constructor(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null) {
+    super(formState, validatorOrOpts, asyncValidator);
+  }
+  registerOnPostfixChange(fn: (postfix: string) => void): void {
+    this._onPostfixChange.push(fn);
+  }
+  clearPostfixChangeFunctions(): void {
+    this._onPostfixChange = [];
+  }
+}
+function isCustomFormControl(obj: FormControl): obj is CustomFormControl {
+  return (<CustomFormControl>obj).registerOnPostfixChange !== undefined;
+}
+
+@Component({
+  selector: 'form-custom-control',
+  template: `<input name="custom" [(ngModel)]="model" (ngModelChange)="changeFn($event)" [disabled]="isDisabled"><span class="postfix">{{postfix}}</span>`,
+  providers: [{provide: NG_VALUE_ACCESSOR, multi: true, useExisting: FormHookCustomControl}]
+})
+class FormHookCustomControl implements CustomControlValueAccessor {
+  // TODO(issue/24571): remove '!'.
+  model !: string;
+  @Input('disabled') isDisabled: boolean = false;
+  // TODO(issue/24571): remove '!'.
+  changeFn !: (value: any) => void;
+  postfix = '';
+
+  writeValue(value: any) { this.model = value; }
+
+  registerOnChange(fn: (value: any) => void) { this.changeFn = fn; }
+
+  registerOnTouched() {}
+
+  setDisabledState(isDisabled: boolean) { this.isDisabled = isDisabled; }
+
+  setPostfix(postfix: string) { this.postfix = postfix };
+}

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -244,7 +244,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     /** @deprecated */ update: EventEmitter<any>;
     readonly validator: ValidatorFn | null;
     viewModel: any;
-    constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
+    constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null, formsHook?: FormsHook | undefined);
     ngOnChanges(changes: SimpleChanges): void;
     viewToModelUpdate(newValue: any): void;
 }
@@ -304,7 +304,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     ngSubmit: EventEmitter<any>;
     readonly path: string[];
     readonly submitted: boolean;
-    constructor(_validators: any[], _asyncValidators: any[]);
+    constructor(_validators: any[], _asyncValidators: any[], formsHook?: FormsHook | undefined);
     addControl(dir: FormControlName): FormControl;
     addFormArray(dir: FormArrayName): void;
     addFormGroup(dir: FormGroupName): void;
@@ -324,6 +324,11 @@ export declare class FormGroupDirective extends ControlContainer implements Form
 export declare class FormGroupName extends AbstractFormGroupDirective implements OnInit, OnDestroy {
     name: string;
     constructor(parent: ControlContainer, validators: any[], asyncValidators: any[]);
+}
+
+export interface FormsHook {
+    cleanUpControl?(control: FormControl, dir: NgControl): void;
+    setUpControl?(control: FormControl, dir: NgControl): void;
 }
 
 export declare class FormsModule {
@@ -346,6 +351,8 @@ export declare class MinLengthValidator implements Validator, OnChanges {
 }
 
 export declare const NG_ASYNC_VALIDATORS: InjectionToken<(Function | Validator)[]>;
+
+export declare const NG_FORMS_HOOK: InjectionToken<unknown>;
 
 export declare const NG_VALIDATORS: InjectionToken<(Function | Validator)[]>;
 


### PR DESCRIPTION
Allows to hook into setup (and cleanup) of the connection made between a FormControl and a ControlValueAccessor.
With these hooks, projects can extend FormControl and use their features in custom components, e.g:
- automatic display of form errors
- display meta-data to form-control, e.g. enumeration list (for selection components), unit postfix, etc

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 32004

Reactive Forms only transport value and disabled state to ControlValueAccessor

## What is the new behavior?
By providing a FormHooks service, projects can add additional behaviour to inputs bound with reactive forms. (see issue #32004 for details)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
