### PR TITLE
fix(ivy): CUSTOM_ELEMENTS_SCHEMA error not thrown for unknown elements

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -950,7 +950,7 @@ function validateAgainstUnknownProperties(
   }
 }
 
-function matchingSchemas(hostView: LView, tagName: string | null): boolean {
+export function matchingSchemas(hostView: LView, tagName: string | null): boolean {
   const schemas = hostView[TVIEW].schemas;
 
   if (schemas !== null) {

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, NO_ERRORS_SCHEMA, NgModule} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, Component, NO_ERRORS_SCHEMA, NgModule} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('NgModule', () => {
@@ -132,6 +132,68 @@ describe('NgModule', () => {
         fixture.detectChanges();
       }).not.toThrow();
     });
-  });
 
+    it('should not throw unknown element error with CUSTOM_ELEMENTS_SCHEMA', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `<custom-el></custom-el>`,
+      })
+      class MyComp {
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        declarations: [MyComp],
+      })
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({
+        imports: [MyModule],
+      });
+
+      expect(() => {
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should throw unknown element error without CUSTOM_ELEMENTS_SCHEMA', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `<custom-el></custom-el>`,
+      })
+      class MyComp {
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [MyComp],
+      });
+
+      expect(() => {
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
+      }).toThrow();
+    });
+
+    it('should throw unknown element error over unknown property without CUSTOM_ELEMENTS_SCHEMA',
+       () => {
+         @Component({
+           selector: 'my-comp',
+           template: `<custom-el [unknown-prop]="true"></custom-el>`,
+         })
+         class MyComp {
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [MyComp],
+         });
+
+         expect(() => {
+           const fixture = TestBed.createComponent(MyComp);
+           fixture.detectChanges();
+         }).toThrowError(/CUSTOM_ELEMENTS_SCHEMA/);
+       });
+  });
 });


### PR DESCRIPTION
VE warns the user that an element is unknown and asks to verify that
the component is part of the module or to add CUSTOM_ELEMENTS_SCHEMA or
NO_ERRORS_SCHEMA. This fix ensures the error appears in Ivy as well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
VE throws error while Ivy does not when there is an unknown element

Issue Number: N/A


## What is the new behavior?
Both VE and Ivy throw the same error when there is an unknown element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
