### PR TITLE
fix(zone.js): fix browser legacy package should not reference Zone directly

### DIFF
--- a/packages/zone.js/DEVELOPER.md
+++ b/packages/zone.js/DEVELOPER.md
@@ -85,7 +85,7 @@ For example, the current version is `0.9.1`, and we want to release a new versio
 - create a new tag in `angular` repo. The `tag` must be `zone.js-<version>`, so in this example we need to create the tag `zone.js-0.10.0`.
 
 ```
-$ TAG=zone.js-0.10.0
+$ export TAG=zone.js-0.10.0
 $ git tag $TAG
 ```
 

--- a/packages/zone.js/lib/browser/api-util.ts
+++ b/packages/zone.js/lib/browser/api-util.ts
@@ -10,7 +10,6 @@ import {globalSources, patchEventPrototype, patchEventTarget, zoneSymbolEventNam
 import {ADD_EVENT_LISTENER_STR, ArraySlice, FALSE_STR, ObjectCreate, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, REMOVE_EVENT_LISTENER_STR, TRUE_STR, ZONE_SYMBOL_PREFIX, attachOriginToPatched, bindArguments, isBrowser, isIEOrEdge, isMix, isNode, patchClass, patchMacroTask, patchMethod, patchOnProperties, wrapWithCurrentZone} from '../common/utils';
 
 import {patchCallbacks} from './browser-util';
-import {_redefineProperty} from './define-property';
 import {eventNames, filterProperties} from './property-descriptor';
 
 Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
@@ -44,7 +43,7 @@ Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   api.wrapWithCurrentZone = wrapWithCurrentZone;
   api.filterProperties = filterProperties;
   api.attachOriginToPatched = attachOriginToPatched;
-  api._redefineProperty = _redefineProperty;
+  api._redefineProperty = Object.defineProperty;
   api.patchCallbacks = patchCallbacks;
   api.getGlobalObjects = () =>
       ({globalSources, zoneSymbolEventNames, eventNames, isBrowser, isMix, isNode, TRUE_STR,

--- a/packages/zone.js/lib/browser/browser-legacy.ts
+++ b/packages/zone.js/lib/browser/browser-legacy.ts
@@ -10,15 +10,20 @@
  * @suppress {missingRequire}
  */
 
-import {propertyPatch} from './define-property';
+import {_redefineProperty, propertyPatch} from './define-property';
 import {eventTargetLegacyPatch} from './event-target-legacy';
 import {propertyDescriptorLegacyPatch} from './property-descriptor-legacy';
 import {registerElementPatch} from './register-element';
 
 (function(_global: any) {
-  _global[Zone.__symbol__('legacyPatch')] = function() {
+  const symbolPrefix = _global['__Zone_symbol_prefix'] || '__zone_symbol__';
+  function __symbol__(name: string) { return symbolPrefix + name; }
+  _global[__symbol__('legacyPatch')] = function() {
     const Zone = _global['Zone'];
-    Zone.__load_patch('defineProperty', () => { propertyPatch(); });
+    Zone.__load_patch('defineProperty', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+      api._redefineProperty = _redefineProperty;
+      propertyPatch();
+    });
     Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       registerElementPatch(global, api);
     });

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -11,14 +11,19 @@
  * things like redefining `createdCallback` on an element.
  */
 
-const zoneSymbol = Zone.__symbol__;
-const _defineProperty = (Object as any)[zoneSymbol('defineProperty')] = Object.defineProperty;
-const _getOwnPropertyDescriptor = (Object as any)[zoneSymbol('getOwnPropertyDescriptor')] =
-    Object.getOwnPropertyDescriptor;
-const _create = Object.create;
-const unconfigurablesKey = zoneSymbol('unconfigurables');
+let zoneSymbol: any;
+let _defineProperty: any;
+let _getOwnPropertyDescriptor: any;
+let _create: any;
+let unconfigurablesKey: any;
 
 export function propertyPatch() {
+  zoneSymbol = Zone.__symbol__;
+  _defineProperty = (Object as any)[zoneSymbol('defineProperty')] = Object.defineProperty;
+  _getOwnPropertyDescriptor = (Object as any)[zoneSymbol('getOwnPropertyDescriptor')] =
+      Object.getOwnPropertyDescriptor;
+  _create = Object.create;
+  unconfigurablesKey = zoneSymbol('unconfigurables');
   Object.defineProperty = function(obj: any, prop: string, desc: any) {
     if (isUnconfigurable(obj, prop)) {
       throw new TypeError('Cannot assign to read only property \'' + prop + '\' of ' + obj);

--- a/packages/zone.js/test/BUILD.bazel
+++ b/packages/zone.js/test/BUILD.bazel
@@ -235,6 +235,11 @@ karma_tests = {
         "//packages/zone.js/dist:zone-evergreen-dist-dev-test",
         "//packages/zone.js/dist:zone-testing-dist-dev-test",
     ],
+    "browser_legacy_test": [
+        "//packages/zone.js/dist:zone-legacy-dist-dev-test",
+        "//packages/zone.js/dist:zone-evergreen-dist-dev-test",
+        "//packages/zone.js/dist:zone-testing-dist-dev-test",
+    ],
 }
 
 karma_test(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/pull/31975

in legacy browser, the browser will
1. load `zone-legacy.js` to init some `factory methods` to patch some old APIs, those patch 
will not be called immediately, `zone-legacy.js` will register those factory methods to `global['__zone_symbol__('legacyPatch')']`, `zone-evergreen.js` will call those old APIs later.
2. load `zone-evergreen.js` and call global['__zone_symbol__('legacyPatch')'] to patch `legacy apis`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
