### PR TITLE
View processing create update split

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -705,7 +705,7 @@ function createDynamicNodeAtIndex(
 
   // We are creating a dynamic node, the previous tNode might not be pointing at this node.
   // We will link ourselves into the tree later with `appendI18nNode`.
-  if (previousOrParentTNode.next === tNode) {
+  if (previousOrParentTNode && previousOrParentTNode.next === tNode) {
     previousOrParentTNode.next = null;
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -26,7 +26,7 @@ import {RComment, RElement, RText, Renderer3, RendererFactory3, isProceduralRend
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponent, isComponentDef, isContentQueryHost, isLContainer, isRootView} from '../interfaces/type_checks';
 import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from '../interfaces/view';
-import {assertNodeOfPossibleTypes, assertNodeType} from '../node_assert';
+import {assertNodeOfPossibleTypes} from '../node_assert';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
 import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, leaveView, namespaceHTMLInternal, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setPreviousOrParentTNode, setSelectedIndex} from '../state';
 import {renderStylingMap} from '../styling_next/bindings';
@@ -51,69 +51,6 @@ export const enum BindingDirection {
   Input,
   Output,
 }
-
-/**
- * Refreshes the view, executing the following steps in that order:
- * triggers init hooks, refreshes dynamic embedded views, triggers content hooks, sets host
- * bindings, refreshes child components.
- * Note: view hooks are triggered later when leaving the view.
- */
-export function refreshDescendantViews(lView: LView) {
-  const tView = lView[TVIEW];
-  const creationMode = isCreationMode(lView);
-
-  if (!creationMode) {
-    // Resetting the bindingIndex of the current LView as the next steps may trigger change
-    // detection.
-    lView[BINDING_INDEX] = tView.bindingStartIndex;
-
-    const checkNoChangesMode = getCheckNoChangesMode();
-
-    executePreOrderHooks(lView, tView, checkNoChangesMode, undefined);
-
-    refreshDynamicEmbeddedViews(lView);
-
-    // Content query results must be refreshed before content hooks are called.
-    if (tView.contentQueries !== null) {
-      refreshContentQueries(tView, lView);
-    }
-
-    resetPreOrderHookFlags(lView);
-    executeHooks(
-        lView, tView.contentHooks, tView.contentCheckHooks, checkNoChangesMode,
-        InitPhaseState.AfterContentInitHooksToBeRun, undefined);
-
-    setHostBindings(tView, lView);
-  } else {
-    // This needs to be set before children are processed to support recursive components.
-    // This must be set to false immediately after the first creation run because in an
-    // ngFor loop, all the views will be created together before update mode runs and turns
-    // off firstTemplatePass. If we don't set it here, instances will perform directive
-    // matching, etc again and again.
-    tView.firstTemplatePass = false;
-
-    // We resolve content queries specifically marked as `static` in creation mode. Dynamic
-    // content queries are resolved during change detection (i.e. update mode), after embedded
-    // views are refreshed (see block above).
-    if (tView.staticContentQueries) {
-      refreshContentQueries(tView, lView);
-    }
-  }
-
-
-  // We must materialize query results before child components are processed
-  // in case a child component has projected a container. The LContainer needs
-  // to exist so the embedded views are properly attached by the container.
-  if (!creationMode || tView.staticViewQueries) {
-    executeViewQueryFn(RenderFlags.Update, tView, lView[CONTEXT]);
-  }
-
-  const components = tView.components;
-  if (components !== null) {
-    refreshChildComponents(lView, components);
-  }
-}
-
 
 /** Sets the host bindings for the current view. */
 export function setHostBindings(tView: TView, viewData: LView): void {
@@ -186,13 +123,19 @@ function refreshContentQueries(tView: TView, lView: LView): void {
   }
 }
 
-/** Refreshes child components in the current view. */
+/** Refreshes child components in the current view (update mode). */
 function refreshChildComponents(hostLView: LView, components: number[]): void {
   for (let i = 0; i < components.length; i++) {
-    componentRefresh(hostLView, components[i]);
+    refreshComponent(hostLView, components[i]);
   }
 }
 
+/** Renders child components in the current view (creation mode). */
+function renderChildComponents(hostLView: LView, components: number[]): void {
+  for (let i = 0; i < components.length; i++) {
+    renderComponent(hostLView, components[i]);
+  }
+}
 
 /**
  * Creates a native element from a tag name, using a renderer.
@@ -380,70 +323,143 @@ export function createEmbeddedViewAndNode<T>(
 }
 
 /**
- * Used for rendering views in a LContainer (embedded views or root component views for dynamically
- * created components).
- *
- * Dynamically created views must store/retrieve their TViews differently from component views
- * because their template functions are nested in the template functions of their hosts, creating
- * closures. If their host template happens to be an embedded template in a loop (e.g. ngFor
- * inside
- * an ngFor), the nesting would mean we'd have multiple instances of the template function, so we
- * can't store TViews in the template function itself (as we do for comps). Instead, we store the
- * TView for dynamically created views on their host TNode, which only has one instance.
+ * Processes a view in the creation mode. This includes a number of steps in a specific order:
+ * - creating view query functions (if any);
+ * - executing a template function in the creation mode;
+ * - updating static queries (if any);
+ * - creating child components defined in a given view.
  */
-export function renderEmbeddedTemplate<T>(viewToRender: LView, tView: TView, context: T) {
-  const _isParent = getIsParent();
-  const _previousOrParentTNode = getPreviousOrParentTNode();
-  let oldView: LView;
-  // Will become true if the `try` block executes with no errors.
-  let safeToRunHooks = false;
+export function renderView<T>(lView: LView, tView: TView, context: T): void {
+  ngDevMode && assertEqual(isCreationMode(lView), true, 'Should be run in creation mode');
+  const oldView = enterView(lView, lView[T_HOST]);
   try {
-    oldView = enterView(viewToRender, viewToRender[T_HOST]);
-    resetPreOrderHookFlags(viewToRender);
+    if (tView.viewQuery !== null) {
+      executeViewQueryFn(RenderFlags.Create, tView, context);
+    }
+
+    // Execute a template associated with this view, if it exists. A template function might not be
+    // defined for the root component views.
     const templateFn = tView.template;
     if (templateFn !== null) {
-      executeTemplate(viewToRender, templateFn, getRenderFlags(viewToRender), context);
+      executeTemplate(lView, templateFn, RenderFlags.Create, context);
     }
-    refreshDescendantViews(viewToRender);
-    safeToRunHooks = true;
+
+    // This needs to be set before children are processed to support recursive components.
+    // This must be set to false immediately after the first creation run because in an
+    // ngFor loop, all the views will be created together before update mode runs and turns
+    // off firstTemplatePass. If we don't set it here, instances will perform directive
+    // matching, etc again and again.
+    if (tView.firstTemplatePass) {
+      tView.firstTemplatePass = false;
+    }
+
+    // We resolve content queries specifically marked as `static` in creation mode. Dynamic
+    // content queries are resolved during change detection (i.e. update mode), after embedded
+    // views are refreshed (see block above).
+    if (tView.staticContentQueries) {
+      refreshContentQueries(tView, lView);
+    }
+
+    // We must materialize query results before child components are processed
+    // in case a child component has projected a container. The LContainer needs
+    // to exist so the embedded views are properly attached by the container.
+    if (tView.staticViewQueries) {
+      executeViewQueryFn(RenderFlags.Update, tView, context);
+    }
+
+    // Render child component views.
+    const components = tView.components;
+    if (components !== null) {
+      renderChildComponents(lView, components);
+    }
+
   } finally {
-    leaveView(oldView !, safeToRunHooks);
-    setPreviousOrParentTNode(_previousOrParentTNode, _isParent);
+    lView[FLAGS] &= ~LViewFlags.CreationMode;
+    leaveView(oldView);
+  }
+}
+
+/**
+ * Processes a view in the update mode. This includes a number of steps in a specific order:
+ * - executing a template function in the update mode;
+ * - executing hooks;
+ * - refreshing queries;
+ * - setting host bindings;
+ * - refreshing child (embedded and component) views.
+ */
+export function refreshView<T>(
+    lView: LView, tView: TView, templateFn: ComponentTemplate<{}>| null, context: T) {
+  ngDevMode && assertEqual(isCreationMode(lView), false, 'Should be run in update mode');
+  let oldView = enterView(lView, lView[T_HOST]);
+  try {
+    resetPreOrderHookFlags(lView);
+
+    if (templateFn !== null) {
+      executeTemplate(lView, templateFn, RenderFlags.Update, context);
+    }
+
+    // Resetting the bindingIndex of the current LView as the next steps may trigger change
+    // detection.
+    lView[BINDING_INDEX] = tView.bindingStartIndex;
+
+    const checkNoChangesMode = getCheckNoChangesMode();
+
+    executePreOrderHooks(lView, tView, checkNoChangesMode, undefined);
+
+    refreshDynamicEmbeddedViews(lView);
+
+    // Content query results must be refreshed before content hooks are called.
+    if (tView.contentQueries !== null) {
+      refreshContentQueries(tView, lView);
+    }
+
+    resetPreOrderHookFlags(lView);
+    executeHooks(
+        lView, tView.contentHooks, tView.contentCheckHooks, checkNoChangesMode,
+        InitPhaseState.AfterContentInitHooksToBeRun, undefined);
+
+    setHostBindings(tView, lView);
+
+    if (tView.viewQuery !== null) {
+      executeViewQueryFn(RenderFlags.Update, tView, context);
+    }
+
+    // Refresh child component views.
+    const components = tView.components;
+    if (components !== null) {
+      refreshChildComponents(lView, components);
+    }
+
+    resetPreOrderHookFlags(lView);
+    executeHooks(
+        lView, tView.viewHooks, tView.viewCheckHooks, checkNoChangesMode,
+        InitPhaseState.AfterViewInitHooksToBeRun, undefined);
+
+  } finally {
+    lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
+    lView[BINDING_INDEX] = tView.bindingStartIndex;
+    leaveView(oldView);
   }
 }
 
 export function renderComponentOrTemplate<T>(
-    hostView: LView, context: T, templateFn?: ComponentTemplate<T>) {
+    hostView: LView, templateFn: ComponentTemplate<{}>| null, context: T) {
   const rendererFactory = hostView[RENDERER_FACTORY];
-  const oldView = enterView(hostView, hostView[T_HOST]);
   const normalExecutionPath = !getCheckNoChangesMode();
   const creationModeIsActive = isCreationMode(hostView);
-
-  // Will become true if the `try` block executes with no errors.
-  let safeToRunHooks = false;
   try {
     if (normalExecutionPath && !creationModeIsActive && rendererFactory.begin) {
       rendererFactory.begin();
     }
-
+    const tView = hostView[TVIEW];
     if (creationModeIsActive) {
-      // creation mode pass
-      templateFn && executeTemplate(hostView, templateFn, RenderFlags.Create, context);
-
-      refreshDescendantViews(hostView);
-      hostView[FLAGS] &= ~LViewFlags.CreationMode;
+      renderView(hostView, tView, context);
     }
-
-    // update mode pass
-    resetPreOrderHookFlags(hostView);
-    templateFn && executeTemplate(hostView, templateFn, RenderFlags.Update, context);
-    refreshDescendantViews(hostView);
-    safeToRunHooks = true;
+    refreshView(hostView, tView, templateFn, context);
   } finally {
     if (normalExecutionPath && !creationModeIsActive && rendererFactory.end) {
       rendererFactory.end();
     }
-    leaveView(oldView, safeToRunHooks);
   }
 }
 
@@ -462,15 +478,6 @@ function executeTemplate<T>(
   } finally {
     setSelectedIndex(prevSelectedIndex);
   }
-}
-
-/**
- * This function returns the default configuration of rendering flags depending on when the
- * template is in creation mode or update mode. Update block and create block are
- * always run separately.
- */
-function getRenderFlags(view: LView): RenderFlags {
-  return isCreationMode(view) ? RenderFlags.Create : RenderFlags.Update;
 }
 
 //////////////////////////
@@ -1482,8 +1489,9 @@ function refreshDynamicEmbeddedViews(lView: LView) {
         const embeddedLView = viewOrContainer[i];
         // The directives and pipes are not needed here as an existing view is only being
         // refreshed.
-        ngDevMode && assertDefined(embeddedLView[TVIEW], 'TView must be allocated');
-        renderEmbeddedTemplate(embeddedLView, embeddedLView[TVIEW], embeddedLView[CONTEXT] !);
+        const embeddedTView = embeddedLView[TVIEW];
+        ngDevMode && assertDefined(embeddedTView, 'TView must be allocated');
+        refreshView(embeddedLView, embeddedTView, embeddedTView.template, embeddedLView[CONTEXT] !);
       }
     }
     viewOrContainer = viewOrContainer[NEXT];
@@ -1497,21 +1505,24 @@ function refreshDynamicEmbeddedViews(lView: LView) {
 /**
  * Refreshes components by entering the component view and processing its bindings, queries, etc.
  *
- * @param adjustedElementIndex  Element index in LView[] (adjusted for HEADER_OFFSET)
+ * @param componentHostIdx  Element index in LView[] (adjusted for HEADER_OFFSET)
  */
-export function componentRefresh(hostLView: LView, adjustedElementIndex: number): void {
-  ngDevMode && assertDataInRange(hostLView, adjustedElementIndex);
-  const componentView = getComponentViewByIndex(adjustedElementIndex, hostLView);
-  ngDevMode &&
-      assertNodeType(hostLView[TVIEW].data[adjustedElementIndex] as TNode, TNodeType.Element);
-
-  // Only components in creation mode, attached CheckAlways
-  // components or attached, dirty OnPush components should be checked
-  if ((viewAttachedToChangeDetector(componentView) || isCreationMode(hostLView)) &&
+function refreshComponent(hostLView: LView, componentHostIdx: number): void {
+  ngDevMode && assertEqual(isCreationMode(hostLView), false, 'Should be run in update mode');
+  const componentView = getComponentViewByIndex(componentHostIdx, hostLView);
+  // Only attached components that are CheckAlways or OnPush and dirty should be refreshed
+  if (viewAttachedToChangeDetector(componentView) &&
       componentView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
-    syncViewWithBlueprint(componentView);
-    checkView(componentView, componentView[CONTEXT]);
+    const tView = componentView[TVIEW];
+    refreshView(componentView, tView, tView.template, componentView[CONTEXT]);
   }
+}
+
+function renderComponent(hostLView: LView, componentHostIdx: number) {
+  ngDevMode && assertEqual(isCreationMode(hostLView), true, 'Should be run in creation mode');
+  const componentView = getComponentViewByIndex(componentHostIdx, hostLView);
+  syncViewWithBlueprint(componentView);
+  renderView(componentView, componentView[TVIEW], componentView[CONTEXT]);
 }
 
 /**
@@ -1647,7 +1658,9 @@ export function scheduleTick(rootContext: RootContext, flags: RootContextFlags) 
 export function tickRootContext(rootContext: RootContext) {
   for (let i = 0; i < rootContext.components.length; i++) {
     const rootComponent = rootContext.components[i];
-    renderComponentOrTemplate(readPatchedLView(rootComponent) !, rootComponent);
+    const lView = readPatchedLView(rootComponent) !;
+    const tView = lView[TVIEW];
+    renderComponentOrTemplate(lView, tView.template, rootComponent);
   }
 }
 
@@ -1655,12 +1668,9 @@ export function detectChangesInternal<T>(view: LView, context: T) {
   const rendererFactory = view[RENDERER_FACTORY];
 
   if (rendererFactory.begin) rendererFactory.begin();
-
   try {
-    if (isCreationMode(view)) {
-      checkView(view, context);  // creation mode pass
-    }
-    checkView(view, context);  // update mode pass
+    const tView = view[TVIEW];
+    refreshView(view, tView, tView.template, context);
   } catch (error) {
     handleError(view, error);
     throw error;
@@ -1714,27 +1724,6 @@ export function checkNoChangesInRootView(lView: LView): void {
     detectChangesInRootView(lView);
   } finally {
     setCheckNoChangesMode(false);
-  }
-}
-
-/** Checks the view of the component provided. Does not gate on dirty checks or execute doCheck.
- */
-export function checkView<T>(hostView: LView, component: T) {
-  const hostTView = hostView[TVIEW];
-  const oldView = enterView(hostView, hostView[T_HOST]);
-  const templateFn = hostTView.template !;
-  const creationMode = isCreationMode(hostView);
-
-  // Will become true if the `try` block executes with no errors.
-  let safeToRunHooks = false;
-  try {
-    resetPreOrderHookFlags(hostView);
-    creationMode && executeViewQueryFn(RenderFlags.Create, hostTView, component);
-    executeTemplate(hostView, templateFn, getRenderFlags(hostView), component);
-    refreshDescendantViews(hostView);
-    safeToRunHooks = true;
-  } finally {
-    leaveView(oldView, safeToRunHooks);
   }
 }
 

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -10,13 +10,10 @@ import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 import {assertDefined} from '../util/assert';
 
 import {assertLViewOrUndefined} from './assert';
-import {executeHooks} from './hooks';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {TElementNode, TNode, TViewNode} from './interfaces/node';
-import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, TVIEW} from './interfaces/view';
+import {CONTEXT, DECLARATION_VIEW, LView, OpaqueViewState, TVIEW} from './interfaces/view';
 import {resetAllStylingState, resetStylingState} from './styling_next/state';
-import {isCreationMode, resetPreOrderHookFlags} from './util/view_utils';
-
 
 
 /**
@@ -461,27 +458,9 @@ export function resetComponentState() {
  * Used in lieu of enterView to make it clear when we are exiting a child view. This makes
  * the direction of traversal (up or down the view tree) a bit clearer.
  *
- * @param newView New state to become active
- * @param safeToRunHooks Whether the runtime is in a state where running lifecycle hooks is valid.
- * This is not always the case (for example, the application may have crashed and `leaveView` is
- * being executed while unwinding the call stack).
+ * @param newView New LView to become active
  */
-export function leaveView(newView: LView, safeToRunHooks: boolean): void {
-  const tView = lView[TVIEW];
-  if (isCreationMode(lView)) {
-    lView[FLAGS] &= ~LViewFlags.CreationMode;
-  } else {
-    try {
-      resetPreOrderHookFlags(lView);
-      safeToRunHooks && executeHooks(
-                            lView, tView.viewHooks, tView.viewCheckHooks, checkNoChangesMode,
-                            InitPhaseState.AfterViewInitHooksToBeRun, undefined);
-    } finally {
-      // Views are clean and in update mode after being checked, so these bits are cleared
-      lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
-      lView[BINDING_INDEX] = tView.bindingStartIndex;
-    }
-  }
+export function leaveView(newView: LView): void {
   enterView(newView, null);
 }
 

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -135,6 +135,7 @@ export function load<T>(view: LView | TData, index: number): T {
 
 export function getComponentViewByIndex(nodeIndex: number, hostView: LView): LView {
   // Could be an LView or an LContainer. If LContainer, unwrap to find LView.
+  ngDevMode && assertDataInRange(hostView, nodeIndex);
   const slotValue = hostView[nodeIndex];
   const lView = isLView(slotValue) ? slotValue : slotValue[HOST];
   return lView;

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -19,7 +19,7 @@ import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertGreaterThan, assertLessThan} from '../util/assert';
 import {assertLContainer} from './assert';
 import {NodeInjector, getParentInjectorLocation} from './di';
-import {addToViewTree, createEmbeddedViewAndNode, createLContainer, renderEmbeddedTemplate} from './instructions/shared';
+import {addToViewTree, createEmbeddedViewAndNode, createLContainer, renderView} from './instructions/shared';
 import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer, VIEW_REFS} from './interfaces/container';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RComment, RElement, isProceduralRenderer} from './interfaces/renderer';
@@ -121,7 +121,8 @@ export function createTemplateRef<T>(
           lView[QUERIES] = declarationViewLQueries.createEmbeddedView(embeddedTView);
         }
 
-        renderEmbeddedTemplate(lView, embeddedTView, context);
+        renderView(lView, embeddedTView, context);
+
         const viewRef = new ViewRef(lView, context, -1);
         viewRef._tViewNode = lView[T_HOST] as TViewNode;
         return viewRef;

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -61,6 +61,22 @@ describe('ViewContainerRef', () => {
          expect(fixture.componentInstance.foo).toBeAnInstanceOf(TemplateRef);
        });
 
+    it('should construct proper TNode / DOM tree when embedded views are created in a directive constructor',
+       () => {
+         @Component({
+           selector: 'view-insertion-test-cmpt',
+           template:
+               `<div>before<ng-template constructorDir><span>|middle|</span></ng-template>after</div>`
+         })
+         class ViewInsertionTestCmpt {
+         }
+
+         TestBed.configureTestingModule({declarations: [ViewInsertionTestCmpt, ConstructorDir]});
+
+         const fixture = TestBed.createComponent(ViewInsertionTestCmpt);
+         expect(fixture.nativeElement).toHaveText('before|middle|after');
+       });
+
     it('should use comment node of host ng-container as insertion marker', () => {
       @Component({template: 'hello'})
       class HelloComp {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -204,12 +204,6 @@
     "name": "checkNoChangesMode"
   },
   {
-    "name": "checkView"
-  },
-  {
-    "name": "componentRefresh"
-  },
-  {
     "name": "concatString"
   },
   {
@@ -399,9 +393,6 @@
     "name": "getPreviousOrParentTNode"
   },
   {
-    "name": "getRenderFlags"
-  },
-  {
     "name": "getRenderParent"
   },
   {
@@ -463,9 +454,6 @@
   },
   {
     "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCreationMode"
   },
   {
     "name": "isCssClassMatching"
@@ -546,13 +534,16 @@
     "name": "refreshChildComponents"
   },
   {
+    "name": "refreshComponent"
+  },
+  {
     "name": "refreshContentQueries"
   },
   {
-    "name": "refreshDescendantViews"
+    "name": "refreshDynamicEmbeddedViews"
   },
   {
-    "name": "refreshDynamicEmbeddedViews"
+    "name": "refreshView"
   },
   {
     "name": "registerInitialStylingOnTNode"
@@ -564,10 +555,13 @@
     "name": "registerPreOrderHooks"
   },
   {
+    "name": "renderChildComponents"
+  },
+  {
     "name": "renderComponent"
   },
   {
-    "name": "renderEmbeddedTemplate"
+    "name": "renderComponent"
   },
   {
     "name": "renderInitialStyling"
@@ -577,6 +571,9 @@
   },
   {
     "name": "renderStylingMap"
+  },
+  {
+    "name": "renderView"
   },
   {
     "name": "resetAllStylingState"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -174,12 +174,6 @@
     "name": "checkNoChangesMode"
   },
   {
-    "name": "checkView"
-  },
-  {
-    "name": "componentRefresh"
-  },
-  {
     "name": "createLView"
   },
   {
@@ -321,9 +315,6 @@
     "name": "getPreviousOrParentTNode"
   },
   {
-    "name": "getRenderFlags"
-  },
-  {
     "name": "getRenderParent"
   },
   {
@@ -355,9 +346,6 @@
   },
   {
     "name": "isComponentDef"
-  },
-  {
-    "name": "isCreationMode"
   },
   {
     "name": "isFactory"
@@ -411,22 +399,31 @@
     "name": "refreshChildComponents"
   },
   {
-    "name": "refreshContentQueries"
+    "name": "refreshComponent"
   },
   {
-    "name": "refreshDescendantViews"
+    "name": "refreshContentQueries"
   },
   {
     "name": "refreshDynamicEmbeddedViews"
   },
   {
+    "name": "refreshView"
+  },
+  {
+    "name": "renderChildComponents"
+  },
+  {
     "name": "renderComponent"
   },
   {
-    "name": "renderEmbeddedTemplate"
+    "name": "renderComponent"
   },
   {
     "name": "renderStringify"
+  },
+  {
+    "name": "renderView"
   },
   {
     "name": "resetAllStylingState"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -510,16 +510,10 @@
     "name": "checkNoChangesMode"
   },
   {
-    "name": "checkView"
-  },
-  {
     "name": "cleanUpView"
   },
   {
     "name": "collectNativeNodes"
-  },
-  {
-    "name": "componentRefresh"
   },
   {
     "name": "concatString"
@@ -891,9 +885,6 @@
     "name": "getPropValuesStartPosition"
   },
   {
-    "name": "getRenderFlags"
-  },
-  {
     "name": "getRenderParent"
   },
   {
@@ -1185,13 +1176,16 @@
     "name": "refreshChildComponents"
   },
   {
+    "name": "refreshComponent"
+  },
+  {
     "name": "refreshContentQueries"
   },
   {
-    "name": "refreshDescendantViews"
+    "name": "refreshDynamicEmbeddedViews"
   },
   {
-    "name": "refreshDynamicEmbeddedViews"
+    "name": "refreshView"
   },
   {
     "name": "registerBinding"
@@ -1215,6 +1209,12 @@
     "name": "removeView"
   },
   {
+    "name": "renderChildComponents"
+  },
+  {
+    "name": "renderComponent"
+  },
+  {
     "name": "renderComponent"
   },
   {
@@ -1224,9 +1224,6 @@
     "name": "renderDetachView"
   },
   {
-    "name": "renderEmbeddedTemplate"
-  },
-  {
     "name": "renderInitialStyling"
   },
   {
@@ -1234,6 +1231,9 @@
   },
   {
     "name": "renderStylingMap"
+  },
+  {
+    "name": "renderView"
   },
   {
     "name": "resetAllStylingState"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -607,7 +607,6 @@ describe('di', () => {
           null, createTView(-1, null, 1, 0, null, null, null, null), null, LViewFlags.CheckAlways,
           null, null, {} as any, {} as any);
       const oldView = enterView(contentView, null);
-      let safeToRunHooks = false;
       try {
         const parentTNode =
             getOrCreateTNode(contentView[TVIEW], null, 0, TNodeType.Element, null, null);
@@ -618,9 +617,8 @@ describe('di', () => {
 
         const injector = getOrCreateNodeInjectorForNode(parentTNode, contentView);
         expect(injector).not.toEqual(-1);
-        safeToRunHooks = true;
       } finally {
-        leaveView(oldView, safeToRunHooks);
+        leaveView(oldView);
       }
     });
   });

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -277,7 +277,7 @@ export function renderTemplate<T>(
         hostLView, componentTView, context, LViewFlags.CheckAlways, hostNode, hostTNode,
         providedRendererFactory, renderer, sanitizer);
   }
-  renderComponentOrTemplate(componentView, context, templateFn);
+  renderComponentOrTemplate(componentView, templateFn, context);
   return componentView;
 }
 


### PR DESCRIPTION
This PR splits view processing into a set of 2 dedicated functions: 
* `renderView` (to process a view in the creation mode)
* `refreshView` (to process a view in the update mode) 

Such split allows us to greatly reduce a number of checks (memory access and computation) for both create and update mode.

This PR has all the commits as they were written to ease review. The essential part (new  `renderView` and `refreshView` functions) is in the first commit of this PR, the follow up commits are mostly refactors and cleanups (turns out that we can express _lots_ of the existing logic in terms of `renderView` and `refreshView` functions).

With all the changes in this PR we get _massive_ perf improvement (~2s -> ~1s in a dedicated benchmark) for view traversal _and_ great reduction in number of concepts / code duplication.