### PR TITLE
refactor/fix(ivy): ngcc - a few refactorings and a fix

### DIFF
--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
+
+/** The type of the function that analyzes entry-points and creates the list of tasks. */
+export type AnalyzeFn = () => {
+  processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>;
+  tasks: Task[];
+};
+
+/**
+ * The type of the function that creates the `compile()` function, which in turn can be used to
+ * process tasks.
+ */
+export type CreateCompileFn =
+    (onTaskCompleted: (task: Task, outcome: TaskProcessingOutcome) => void) => (task: Task) => void;
+
+/**
+ * The type of the function that orchestrates and executes the required work (i.e. analyzes the
+ * entry-points, processes the resulting tasks, does book-keeping and validates the final outcome).
+ */
+export type ExecuteFn = (analyzeFn: AnalyzeFn, createCompileFn: CreateCompileFn) => void;
+
+/** Represents metadata related to the processing of an entry-point. */
+export interface EntryPointProcessingMetadata {
+  /**
+   * A mapping from a format property (i.e. an `EntryPointJsonProperty`) to the list of format
+   * properties that point to the same format-path and as a result need to be marked as processed,
+   * once the former is processed.
+   */
+  propertyToPropertiesToMarkAsProcessed: Map<EntryPointJsonProperty, EntryPointJsonProperty[]>;
+
+  /**
+   * Whether the typings for the entry-point have been successfully processed (or were already
+   * processed).
+   */
+  hasProcessedTypings: boolean;
+
+  /**
+   * Whether at least one format has been successfully processed (or was already processed) for the
+   * entry-point.
+   */
+  hasAnyProcessedFormat: boolean;
+}
+
+/** Represents a unit of work: processing a specific format property of an entry-point. */
+export interface Task {
+  /** The `EntryPoint` which needs to be processed as part of the task. */
+  entryPoint: EntryPoint;
+
+  /**
+   * The `package.json` format property to process (i.e. the property which points to the file that
+   * is the program entry-point).
+   */
+  formatProperty: EntryPointJsonProperty;
+
+  /** Whether to also process typings for this entry-point as part of the task. */
+  processDts: boolean;
+}
+
+/** Represents the outcome of processing a `Task`. */
+export const enum TaskProcessingOutcome {
+  /** The target format property was already processed - didn't have to do anything. */
+  AlreadyProcessed,
+
+  /** Successfully processed the target format property. */
+  Processed,
+}

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -30,13 +30,6 @@ export type ExecuteFn = (analyzeFn: AnalyzeFn, createCompileFn: CreateCompileFn)
 /** Represents metadata related to the processing of an entry-point. */
 export interface EntryPointProcessingMetadata {
   /**
-   * A mapping from a format property (i.e. an `EntryPointJsonProperty`) to the list of format
-   * properties that point to the same format-path and as a result need to be marked as processed,
-   * once the former is processed.
-   */
-  propertyToPropertiesToMarkAsProcessed: Map<EntryPointJsonProperty, EntryPointJsonProperty[]>;
-
-  /**
    * Whether the typings for the entry-point have been successfully processed (or were already
    * processed).
    */
@@ -59,6 +52,13 @@ export interface Task {
    * is the program entry-point).
    */
   formatProperty: EntryPointJsonProperty;
+
+  /**
+   * The list of all format properties (including `task.formatProperty`) that should be marked as
+   * processed once the taksk has been completed, because they point to the format-path that will be
+   * processed as part of the task.
+   */
+  formatPropertiesToMarkAsProcessed: EntryPointJsonProperty[];
 
   /** Whether to also process typings for this entry-point as part of the task. */
   processDts: boolean;

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -166,13 +166,12 @@ export function mainNgcc(
       }
 
       const bundle = makeEntryPointBundle(
-          fileSystem, entryPoint, formatPath, isCore, formatProperty, format, processDts,
-          pathMappings, true);
+          fileSystem, entryPoint, formatPath, isCore, format, processDts, pathMappings, true);
 
       logger.info(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
 
       const transformedFiles = transformer.transform(bundle);
-      fileWriter.writeBundle(entryPoint, bundle, transformedFiles);
+      fileWriter.writeBundle(entryPoint, bundle, transformedFiles, formatProperty);
 
       onTaskCompleted(task, TaskProcessingOutcome.Processed);
     };

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -134,24 +134,19 @@ export function mainNgcc(
             fileSystem, entryPoint, formatPath, isCore, property, format, processDts, pathMappings,
             true);
 
-        if (bundle) {
-          logger.info(`Compiling ${entryPoint.name} : ${property} as ${format}`);
-          const transformedFiles = transformer.transform(bundle);
-          fileWriter.writeBundle(entryPoint, bundle, transformedFiles);
-          compiledFormats.add(formatPath);
+        logger.info(`Compiling ${entryPoint.name} : ${property} as ${format}`);
+        const transformedFiles = transformer.transform(bundle);
+        fileWriter.writeBundle(entryPoint, bundle, transformedFiles);
+        compiledFormats.add(formatPath);
 
-          const propsToMarkAsProcessed = pathToPropsMap.get(formatPath) !;
-          if (processDts) {
-            propsToMarkAsProcessed.push('typings');
-            processDts = false;
-          }
-
-          markAsProcessed(
-              fileSystem, entryPointPackageJson, entryPointPackageJsonPath, propsToMarkAsProcessed);
-        } else {
-          logger.warn(
-              `Skipping ${entryPoint.name} : ${format} (no valid entry point file for this format).`);
+        const propsToMarkAsProcessed = pathToPropsMap.get(formatPath) !;
+        if (processDts) {
+          propsToMarkAsProcessed.push('typings');
+          processDts = false;
         }
+
+        markAsProcessed(
+            fileSystem, entryPointPackageJson, entryPointPackageJsonPath, propsToMarkAsProcessed);
       }
     }
 

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -171,7 +171,7 @@ export function mainNgcc(
       logger.info(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
 
       const transformedFiles = transformer.transform(bundle);
-      fileWriter.writeBundle(entryPoint, bundle, transformedFiles, formatProperty);
+      fileWriter.writeBundle(bundle, transformedFiles, formatProperty);
 
       onTaskCompleted(task, TaskProcessingOutcome.Processed);
     };

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -23,7 +23,7 @@ export const NGCC_VERSION = '0.0.0-PLACEHOLDER';
  * @throws Error if the entry-point has already been processed with a different ngcc version.
  */
 export function hasBeenProcessed(
-    packageJson: EntryPointPackageJson, format: EntryPointJsonProperty): boolean {
+    packageJson: EntryPointPackageJson, format: EntryPointJsonProperty | 'typings'): boolean {
   if (!packageJson.__processed_by_ivy_ngcc__) {
     return false;
   }
@@ -49,7 +49,7 @@ export function hasBeenProcessed(
  */
 export function markAsProcessed(
     fs: FileSystem, packageJson: EntryPointPackageJson, packageJsonPath: AbsoluteFsPath,
-    properties: EntryPointJsonProperty[]) {
+    properties: (EntryPointJsonProperty | 'typings')[]) {
   const processed =
       packageJson.__processed_by_ivy_ngcc__ || (packageJson.__processed_by_ivy_ngcc__ = {});
 

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -58,7 +58,7 @@ export interface EntryPointPackageJson extends PackageJsonFormatProperties {
   __processed_by_ivy_ngcc__?: {[key: string]: string};
 }
 
-export type EntryPointJsonProperty = keyof(PackageJsonFormatProperties);
+export type EntryPointJsonProperty = Exclude<keyof PackageJsonFormatProperties, 'types'|'typings'>;
 // We need to keep the elements of this const and the `EntryPointJsonProperty` type in sync.
 export const SUPPORTED_FORMAT_PROPERTIES: EntryPointJsonProperty[] =
     ['fesm2015', 'fesm5', 'es2015', 'esm2015', 'esm5', 'main', 'module'];
@@ -122,7 +122,8 @@ export function getEntryPointInfo(
  * @returns An entry-point format or `undefined` if none match the given property.
  */
 export function getEntryPointFormat(
-    fs: FileSystem, entryPoint: EntryPoint, property: string): EntryPointFormat|undefined {
+    fs: FileSystem, entryPoint: EntryPoint, property: EntryPointJsonProperty): EntryPointFormat|
+    undefined {
   switch (property) {
     case 'fesm2015':
       return 'esm2015';

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -44,7 +44,7 @@ export interface EntryPointBundle {
 export function makeEntryPointBundle(
     fs: FileSystem, entryPoint: EntryPoint, formatPath: string, isCore: boolean,
     formatProperty: EntryPointJsonProperty, format: EntryPointFormat, transformDts: boolean,
-    pathMappings?: PathMappings, mirrorDtsFromSrc: boolean = false): EntryPointBundle|null {
+    pathMappings?: PathMappings, mirrorDtsFromSrc: boolean = false): EntryPointBundle {
   // Create the TS program and necessary helpers.
   const options: ts.CompilerOptions = {
     allowJs: true,

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -10,7 +10,7 @@ import {AbsoluteFsPath, FileSystem, absoluteFrom} from '../../../src/ngtsc/file_
 import {NgtscCompilerHost} from '../../../src/ngtsc/file_system/src/compiler_host';
 import {PathMappings} from '../utils';
 import {BundleProgram, makeBundleProgram} from './bundle_program';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty} from './entry_point';
+import {EntryPoint, EntryPointFormat} from './entry_point';
 import {NgccSourcesCompilerHost} from './ngcc_compiler_host';
 
 /**
@@ -19,7 +19,6 @@ import {NgccSourcesCompilerHost} from './ngcc_compiler_host';
  */
 export interface EntryPointBundle {
   entryPoint: EntryPoint;
-  formatProperty: EntryPointJsonProperty;
   format: EntryPointFormat;
   isCore: boolean;
   isFlatCore: boolean;
@@ -34,7 +33,6 @@ export interface EntryPointBundle {
  * @param entryPoint The entry-point that contains the bundle.
  * @param formatPath The path to the source files for this bundle.
  * @param isCore This entry point is the Angular core package.
- * @param formatProperty The property in the package.json that holds the formatPath.
  * @param format The underlying format of the bundle.
  * @param transformDts Whether to transform the typings along with this bundle.
  * @param pathMappings An optional set of mappings to use when compiling files.
@@ -43,8 +41,8 @@ export interface EntryPointBundle {
  */
 export function makeEntryPointBundle(
     fs: FileSystem, entryPoint: EntryPoint, formatPath: string, isCore: boolean,
-    formatProperty: EntryPointJsonProperty, format: EntryPointFormat, transformDts: boolean,
-    pathMappings?: PathMappings, mirrorDtsFromSrc: boolean = false): EntryPointBundle {
+    format: EntryPointFormat, transformDts: boolean, pathMappings?: PathMappings,
+    mirrorDtsFromSrc: boolean = false): EntryPointBundle {
   // Create the TS program and necessary helpers.
   const options: ts.CompilerOptions = {
     allowJs: true,
@@ -69,7 +67,7 @@ export function makeEntryPointBundle(
       null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
 
-  return {entryPoint, format, formatProperty, rootDirs, isCore, isFlatCore, src, dts};
+  return {entryPoint, format, rootDirs, isCore, isFlatCore, src, dts};
 }
 
 function computePotentialDtsFilesFromJsFiles(

--- a/packages/compiler-cli/ngcc/src/writing/file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/file_writer.ts
@@ -16,5 +16,5 @@ import {FileToWrite} from '../rendering/utils';
 export interface FileWriter {
   writeBundle(
       bundle: EntryPointBundle, transformedFiles: FileToWrite[],
-      formatProperty: EntryPointJsonProperty): void;
+      formatProperties: EntryPointJsonProperty[]): void;
 }

--- a/packages/compiler-cli/ngcc/src/writing/file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/file_writer.ts
@@ -6,7 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {EntryPoint} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 
@@ -14,6 +14,7 @@ import {FileToWrite} from '../rendering/utils';
  * Responsible for writing out the transformed files to disk.
  */
 export interface FileWriter {
-  writeBundle(entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[]):
-      void;
+  writeBundle(
+      entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      formatProperty: EntryPointJsonProperty): void;
 }

--- a/packages/compiler-cli/ngcc/src/writing/file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/file_writer.ts
@@ -6,7 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
+import {EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 
@@ -15,6 +15,6 @@ import {FileToWrite} from '../rendering/utils';
  */
 export interface FileWriter {
   writeBundle(
-      entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      bundle: EntryPointBundle, transformedFiles: FileToWrite[],
       formatProperty: EntryPointJsonProperty): void;
 }

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -21,7 +21,7 @@ export class InPlaceFileWriter implements FileWriter {
 
   writeBundle(
       _bundle: EntryPointBundle, transformedFiles: FileToWrite[],
-      _formatProperty?: EntryPointJsonProperty) {
+      _formatProperties?: EntryPointJsonProperty[]) {
     transformedFiles.forEach(file => this.writeFileAndBackup(file));
   }
 

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {FileSystem, absoluteFrom, dirname} from '../../../src/ngtsc/file_system';
-import {EntryPoint} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 import {FileWriter} from './file_writer';
@@ -19,7 +19,9 @@ import {FileWriter} from './file_writer';
 export class InPlaceFileWriter implements FileWriter {
   constructor(protected fs: FileSystem) {}
 
-  writeBundle(_entryPoint: EntryPoint, _bundle: EntryPointBundle, transformedFiles: FileToWrite[]) {
+  writeBundle(
+      _entryPoint: EntryPoint, _bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      _formatProperty?: EntryPointJsonProperty) {
     transformedFiles.forEach(file => this.writeFileAndBackup(file));
   }
 

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {FileSystem, absoluteFrom, dirname} from '../../../src/ngtsc/file_system';
-import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
+import {EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 import {FileWriter} from './file_writer';
@@ -20,7 +20,7 @@ export class InPlaceFileWriter implements FileWriter {
   constructor(protected fs: FileSystem) {}
 
   writeBundle(
-      _entryPoint: EntryPoint, _bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      _bundle: EntryPointBundle, transformedFiles: FileToWrite[],
       _formatProperty?: EntryPointJsonProperty) {
     transformedFiles.forEach(file => this.writeFileAndBackup(file));
   }

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -25,12 +25,14 @@ const NGCC_DIRECTORY = '__ivy_ngcc__';
  * `InPlaceFileWriter`).
  */
 export class NewEntryPointFileWriter extends InPlaceFileWriter {
-  writeBundle(entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[]) {
+  writeBundle(
+      entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      formatProperty: EntryPointJsonProperty) {
     // The new folder is at the root of the overall package
     const ngccFolder = join(entryPoint.package, NGCC_DIRECTORY);
     this.copyBundle(bundle, entryPoint.package, ngccFolder);
     transformedFiles.forEach(file => this.writeFile(file, entryPoint.package, ngccFolder));
-    this.updatePackageJson(entryPoint, bundle.formatProperty, ngccFolder);
+    this.updatePackageJson(entryPoint, formatProperty, ngccFolder);
   }
 
   protected copyBundle(

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -27,13 +27,13 @@ const NGCC_DIRECTORY = '__ivy_ngcc__';
 export class NewEntryPointFileWriter extends InPlaceFileWriter {
   writeBundle(
       bundle: EntryPointBundle, transformedFiles: FileToWrite[],
-      formatProperty: EntryPointJsonProperty) {
+      formatProperties: EntryPointJsonProperty[]) {
     // The new folder is at the root of the overall package
     const entryPoint = bundle.entryPoint;
     const ngccFolder = join(entryPoint.package, NGCC_DIRECTORY);
     this.copyBundle(bundle, entryPoint.package, ngccFolder);
     transformedFiles.forEach(file => this.writeFile(file, entryPoint.package, ngccFolder));
-    this.updatePackageJson(entryPoint, formatProperty, ngccFolder);
+    this.updatePackageJson(entryPoint, formatProperties, ngccFolder);
   }
 
   protected copyBundle(
@@ -63,12 +63,18 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
   }
 
   protected updatePackageJson(
-      entryPoint: EntryPoint, formatProperty: EntryPointJsonProperty, ngccFolder: AbsoluteFsPath) {
-    const formatPath = join(entryPoint.path, entryPoint.packageJson[formatProperty] !);
-    const newFormatPath = join(ngccFolder, relative(entryPoint.package, formatPath));
-    const newFormatProperty = formatProperty + '_ivy_ngcc';
-    (entryPoint.packageJson as any)[newFormatProperty] = relative(entryPoint.path, newFormatPath);
+      entryPoint: EntryPoint, formatProperties: EntryPointJsonProperty[],
+      ngccFolder: AbsoluteFsPath) {
+    const packageJson = entryPoint.packageJson;
+
+    for (const formatProperty of formatProperties) {
+      const formatPath = join(entryPoint.path, packageJson[formatProperty] !);
+      const newFormatPath = join(ngccFolder, relative(entryPoint.package, formatPath));
+      const newFormatProperty = formatProperty + '_ivy_ngcc';
+      (packageJson as any)[newFormatProperty] = relative(entryPoint.path, newFormatPath);
+    }
+
     this.fs.writeFile(
-        join(entryPoint.path, 'package.json'), JSON.stringify(entryPoint.packageJson));
+        join(entryPoint.path, 'package.json'), `${JSON.stringify(packageJson, null, 2)}\n`);
   }
 }

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -26,9 +26,10 @@ const NGCC_DIRECTORY = '__ivy_ngcc__';
  */
 export class NewEntryPointFileWriter extends InPlaceFileWriter {
   writeBundle(
-      entryPoint: EntryPoint, bundle: EntryPointBundle, transformedFiles: FileToWrite[],
+      bundle: EntryPointBundle, transformedFiles: FileToWrite[],
       formatProperty: EntryPointJsonProperty) {
     // The new folder is at the root of the overall package
+    const entryPoint = bundle.entryPoint;
     const ngccFolder = join(entryPoint.package, NGCC_DIRECTORY);
     this.copyBundle(bundle, entryPoint.package, ngccFolder);
     transformedFiles.forEach(file => this.writeFile(file, entryPoint.package, ngccFolder));

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -96,8 +96,7 @@ runInEachFileSystem(() => {
         loadTestFiles(testFiles);
         loadFakeCore(getFileSystem());
         const rootFiles = getRootFiles(testFiles);
-        const bundle =
-            makeTestEntryPointBundle('test-package', 'es2015', 'esm2015', false, rootFiles);
+        const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
         program = bundle.src.program;
 
         const reflectionHost =

--- a/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
@@ -330,7 +330,7 @@ runInEachFileSystem(() => {
         loadTestFiles(TEST_PROGRAM);
         loadTestFiles(TEST_DTS_PROGRAM);
         const bundle = makeTestEntryPointBundle(
-            'test-package', 'esm2015', 'esm2015', false, getRootFiles(TEST_PROGRAM),
+            'test-package', 'esm2015', false, getRootFiles(TEST_PROGRAM),
             getRootFiles(TEST_DTS_PROGRAM));
         program = bundle.src.program;
         dtsProgram = bundle.dts;

--- a/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
@@ -236,8 +236,7 @@ runInEachFileSystem(() => {
     loadTestFiles(jsProgram);
     loadTestFiles(dtsProgram);
     const {src: {program}, dts} = makeTestEntryPointBundle(
-        'test-package', 'esm2015', 'esm2015', false, getRootFiles(jsProgram),
-        getRootFiles(dtsProgram));
+        'test-package', 'esm2015', false, getRootFiles(jsProgram), getRootFiles(dtsProgram));
     const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
     const referencesRegistry = new NgccReferencesRegistry(host);
     const analyzer = new PrivateDeclarationsAnalyzer(host, referencesRegistry);

--- a/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
@@ -72,7 +72,7 @@ runInEachFileSystem(() => {
       it('should check for switchable markers in all the files of the program', () => {
         loadTestFiles(TEST_PROGRAM);
         const bundle = makeTestEntryPointBundle(
-            'test', 'esm2015', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
+            'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
         const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
         const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
@@ -103,7 +103,7 @@ runInEachFileSystem(() => {
       it('should ignore files that are outside the package', () => {
         loadTestFiles(TEST_PROGRAM);
         const bundle = makeTestEntryPointBundle(
-            'test', 'esm2015', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
+            'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
         const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
         const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 import {AbsoluteFsPath, NgtscCompilerHost, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {TestFile} from '../../../src/ngtsc/file_system/testing';
 import {BundleProgram, makeBundleProgram} from '../../src/packages/bundle_program';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty} from '../../src/packages/entry_point';
+import {EntryPoint, EntryPointFormat} from '../../src/packages/entry_point';
 import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {NgccSourcesCompilerHost} from '../../src/packages/ngcc_compiler_host';
 
@@ -32,19 +32,13 @@ export function makeTestEntryPoint(
  * @param dtsFiles The typings files to include the bundle.
  */
 export function makeTestEntryPointBundle(
-    packageName: string, formatProperty: EntryPointJsonProperty, format: EntryPointFormat,
-    isCore: boolean, srcRootNames: AbsoluteFsPath[],
+    packageName: string, format: EntryPointFormat, isCore: boolean, srcRootNames: AbsoluteFsPath[],
     dtsRootNames?: AbsoluteFsPath[]): EntryPointBundle {
   const entryPoint = makeTestEntryPoint(packageName);
   const src = makeTestBundleProgram(srcRootNames[0], isCore);
   const dts = dtsRootNames ? makeTestDtsBundleProgram(dtsRootNames[0], isCore) : null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
-  return {
-    entryPoint,
-    formatProperty,
-    format,
-    rootDirs: [absoluteFrom('/')], src, dts, isCore, isFlatCore
-  };
+  return {entryPoint, format, rootDirs: [absoluteFrom('/')], src, dts, isCore, isFlatCore};
 }
 
 export function makeTestBundleProgram(

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -382,6 +382,28 @@ runInEachFileSystem(() => {
             .toMatch(ANGULAR_CORE_IMPORT_REGEX);
         expect(fs.exists(_(`/node_modules/@angular/common/common.d.ts.__ivy_ngcc_bak`))).toBe(true);
       });
+
+      it('should update `package.json` for all matching format properties', () => {
+        mainNgcc({
+          basePath: '/node_modules/@angular/core',
+          createNewEntryPointFormats: true,
+          propertiesToConsider: ['fesm2015', 'fesm5'],
+        });
+
+        const pkg: any = loadPackage('@angular/core');
+
+        // `es2015` is an alias of `fesm2015`.
+        expect(pkg.fesm2015).toEqual('./fesm2015/core.js');
+        expect(pkg.es2015).toEqual('./fesm2015/core.js');
+        expect(pkg.fesm2015_ivy_ngcc).toEqual('__ivy_ngcc__/fesm2015/core.js');
+        expect(pkg.es2015_ivy_ngcc).toEqual('__ivy_ngcc__/fesm2015/core.js');
+
+        // `module` is an alias of `fesm5`.
+        expect(pkg.fesm5).toEqual('./fesm5/core.js');
+        expect(pkg.module).toEqual('./fesm5/core.js');
+        expect(pkg.fesm5_ivy_ngcc).toEqual('__ivy_ngcc__/fesm5/core.js');
+        expect(pkg.module_ivy_ngcc).toEqual('__ivy_ngcc__/fesm5/core.js');
+      });
     });
 
     describe('logger', () => {

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -200,6 +200,17 @@ runInEachFileSystem(() => {
 
 
     describe('with propertiesToConsider', () => {
+      it('should complain if none of the properties in the `propertiesToConsider` list is supported',
+         () => {
+           const propertiesToConsider = ['es1337', 'fesm42'];
+           const errorMessage =
+               'No supported format property to consider among [es1337, fesm42]. Supported ' +
+               'properties: fesm2015, fesm5, es2015, esm2015, esm5, main, module';
+
+           expect(() => mainNgcc({basePath: '/node_modules', propertiesToConsider}))
+               .toThrowError(errorMessage);
+         });
+
       it('should only compile the entry-point formats given in the `propertiesToConsider` list',
          () => {
            mainNgcc({

--- a/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
@@ -161,7 +161,7 @@ runInEachFileSystem(() => {
     loadFakeCore(getFileSystem());
     const errors: ts.Diagnostic[] = [];
     const rootFiles = getRootFiles(testFiles);
-    const bundle = makeTestEntryPointBundle('test-package', 'es2015', 'esm2015', false, rootFiles);
+    const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
     const program = bundle.src.program;
 
     const reflectionHost =

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -145,7 +145,7 @@ runInEachFileSystem(() => {
            compiledByAngular: true,
          };
          const esm5bundle =
-             makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', 'esm5', true) !;
+             makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', 'esm5', true);
 
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toEqual(jasmine.arrayWithExactContents([
@@ -193,7 +193,7 @@ runInEachFileSystem(() => {
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', 'esm5', /* transformDts */ true,
-             /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true) !;
+             /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toContain(absoluteFrom('/node_modules/test/internal.js'));
          expect(esm5bundle.dts !.program.getSourceFiles().map(sf => sf.fileName))
@@ -214,7 +214,7 @@ runInEachFileSystem(() => {
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', 'esm5', /* transformDts */ true,
-             /* pathMappings */ undefined, /* mirrorDtsFromSrc */ false) !;
+             /* pathMappings */ undefined, /* mirrorDtsFromSrc */ false);
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toContain(absoluteFrom('/node_modules/test/internal.js'));
          expect(esm5bundle.dts !.program.getSourceFiles().map(sf => sf.fileName))

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -144,8 +144,7 @@ runInEachFileSystem(() => {
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
          };
-         const esm5bundle =
-             makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', 'esm5', true);
+         const esm5bundle = makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', true);
 
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toEqual(jasmine.arrayWithExactContents([
@@ -192,7 +191,7 @@ runInEachFileSystem(() => {
            compiledByAngular: true,
          };
          const esm5bundle = makeEntryPointBundle(
-             fs, entryPoint, './index.js', false, 'esm5', 'esm5', /* transformDts */ true,
+             fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,
              /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toContain(absoluteFrom('/node_modules/test/internal.js'));
@@ -213,7 +212,7 @@ runInEachFileSystem(() => {
            compiledByAngular: true,
          };
          const esm5bundle = makeEntryPointBundle(
-             fs, entryPoint, './index.js', false, 'esm5', 'esm5', /* transformDts */ true,
+             fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,
              /* pathMappings */ undefined, /* mirrorDtsFromSrc */ false);
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toContain(absoluteFrom('/node_modules/test/internal.js'));

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -149,8 +149,7 @@ exports.D = D;
       loadTestFiles([file]);
       const fs = getFileSystem();
       const logger = new MockLogger();
-      const bundle =
-          makeTestEntryPointBundle('test-package', 'module', 'commonjs', false, [file.name]);
+      const bundle = makeTestEntryPointBundle('test-package', 'commonjs', false, [file.name]);
       const typeChecker = bundle.src.program.getTypeChecker();
       const host = new CommonJsReflectionHost(logger, false, bundle.src.program, bundle.src.host);
       const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -61,8 +61,7 @@ function createTestRenderer(
   const fs = getFileSystem();
   const isCore = packageName === '@angular/core';
   const bundle = makeTestEntryPointBundle(
-      'test-package', 'es2015', 'esm2015', isCore, getRootFiles(files),
-      dtsFiles && getRootFiles(dtsFiles));
+      'test-package', 'esm2015', isCore, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles));
   const typeChecker = bundle.src.program.getTypeChecker();
   const host = new Esm2015ReflectionHost(logger, isCore, typeChecker, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -26,7 +26,7 @@ function setup(file: {name: AbsoluteFsPath, contents: string}) {
   loadTestFiles([file]);
   const fs = getFileSystem();
   const logger = new MockLogger();
-  const bundle = makeTestEntryPointBundle('test-package', 'module', 'esm5', false, [file.name]);
+  const bundle = makeTestEntryPointBundle('test-package', 'esm5', false, [file.name]);
   const typeChecker = bundle.src.program.getTypeChecker();
   const host = new Esm5ReflectionHost(logger, false, typeChecker);
   const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -31,8 +31,7 @@ function setup(files: TestFile[], dtsFiles?: TestFile[]) {
   }
   const logger = new MockLogger();
   const bundle = makeTestEntryPointBundle(
-      'test-package', 'es2015', 'esm2015', false, getRootFiles(files),
-      dtsFiles && getRootFiles(dtsFiles)) !;
+      'test-package', 'esm2015', false, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles)) !;
   const typeChecker = bundle.src.program.getTypeChecker();
   const host = new Esm2015ReflectionHost(logger, false, typeChecker, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -63,8 +63,7 @@ function createTestRenderer(
   const fs = getFileSystem();
   const isCore = packageName === '@angular/core';
   const bundle = makeTestEntryPointBundle(
-      'test-package', 'es2015', 'esm2015', isCore, getRootFiles(files),
-      dtsFiles && getRootFiles(dtsFiles));
+      'test-package', 'esm2015', isCore, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles));
   const typeChecker = bundle.src.program.getTypeChecker();
   const host = new Esm2015ReflectionHost(logger, isCore, typeChecker, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -25,7 +25,7 @@ function setup(file: TestFile) {
   loadTestFiles([file]);
   const fs = getFileSystem();
   const logger = new MockLogger();
-  const bundle = makeTestEntryPointBundle('test-package', 'esm5', 'esm5', false, [file.name]);
+  const bundle = makeTestEntryPointBundle('test-package', 'esm5', false, [file.name]);
   const src = bundle.src;
   const host = new UmdReflectionHost(logger, false, src.program, src.host);
   const referencesRegistry = new NgccReferencesRegistry(host);

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -8,7 +8,6 @@
 import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
-import {EntryPoint} from '../../src/packages/entry_point';
 import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {InPlaceFileWriter} from '../../src/writing/in_place_file_writer';
 
@@ -32,7 +31,7 @@ runInEachFileSystem(() => {
     it('should write all the FileInfo to the disk', () => {
       const fs = getFileSystem();
       const fileWriter = new InPlaceFileWriter(fs);
-      fileWriter.writeBundle({} as EntryPoint, {} as EntryPointBundle, [
+      fileWriter.writeBundle({} as EntryPointBundle, [
         {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
         {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
         {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
@@ -49,7 +48,7 @@ runInEachFileSystem(() => {
     it('should create backups of all files that previously existed', () => {
       const fs = getFileSystem();
       const fileWriter = new InPlaceFileWriter(fs);
-      fileWriter.writeBundle({} as EntryPoint, {} as EntryPointBundle, [
+      fileWriter.writeBundle({} as EntryPointBundle, [
         {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
         {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
         {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
@@ -72,10 +71,7 @@ runInEachFileSystem(() => {
       const absoluteBackupPath = _('/package/path/already-backed-up.js');
       expect(
           () => fileWriter.writeBundle(
-              {} as EntryPoint, {} as EntryPointBundle,
-              [
-                {path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'},
-              ]))
+              {} as EntryPointBundle, [{path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'}]))
           .toThrowError(
               `Tried to overwrite ${absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.`);
     });

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -95,13 +95,16 @@ runInEachFileSystem(() => {
       });
 
       it('should write the modified files to a new folder', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/esm5.js'),
-            contents: 'export function FooTop() {} // MODIFIED'
-          },
-          {path: _('/node_modules/test/esm5.js.map'), contents: 'MODIFIED MAPPING DATA'},
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/esm5.js'),
+                contents: 'export function FooTop() {} // MODIFIED'
+              },
+              {path: _('/node_modules/test/esm5.js.map'), contents: 'MODIFIED MAPPING DATA'},
+            ],
+            'module');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/esm5.js')))
             .toEqual('export function FooTop() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/esm5.js'))).toEqual('export function FooTop() {}');
@@ -111,12 +114,15 @@ runInEachFileSystem(() => {
       });
 
       it('should also copy unmodified files in the program', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/es2015/foo.js'),
-            contents: 'export class FooTop {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/es2015/foo.js'),
+                contents: 'export class FooTop {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/es2015/foo.js')))
             .toEqual('export class FooTop {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/es2015/foo.js')))
@@ -128,22 +134,28 @@ runInEachFileSystem(() => {
       });
 
       it('should update the package.json properties', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/esm5.js'),
-            contents: 'export function FooTop() {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/esm5.js'),
+                contents: 'export function FooTop() {} // MODIFIED'
+              },
+            ],
+            'module');
         expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
         }));
 
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/es2015/foo.js'),
-            contents: 'export class FooTop {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/es2015/foo.js'),
+                contents: 'export class FooTop {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
           es2015_ivy_ngcc: '__ivy_ngcc__/es2015/index.js',
@@ -151,13 +163,16 @@ runInEachFileSystem(() => {
       });
 
       it('should overwrite and backup typings files', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/index.d.ts'),
-            contents: 'export declare class FooTop {} // MODIFIED'
-          },
-          {path: _('/node_modules/test/index.d.ts.map'), contents: 'MODIFIED MAPPING DATA'},
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/index.d.ts'),
+                contents: 'export declare class FooTop {} // MODIFIED'
+              },
+              {path: _('/node_modules/test/index.d.ts.map'), contents: 'MODIFIED MAPPING DATA'},
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/index.d.ts')))
             .toEqual('export declare class FooTop {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/index.d.ts.__ivy_ngcc_bak')))
@@ -184,24 +199,30 @@ runInEachFileSystem(() => {
       });
 
       it('should write the modified file to a new folder', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/a/esm5.js'),
-            contents: 'export function FooA() {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/a/esm5.js'),
+                contents: 'export function FooA() {} // MODIFIED'
+              },
+            ],
+            'module');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/a/esm5.js')))
             .toEqual('export function FooA() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/esm5.js'))).toEqual('export function FooA() {}');
       });
 
       it('should also copy unmodified files in the program', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/a/es2015/foo.js'),
-            contents: 'export class FooA {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/a/es2015/foo.js'),
+                contents: 'export class FooA {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/a/es2015/foo.js')))
             .toEqual('export class FooA {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/es2015/foo.js')))
@@ -213,22 +234,28 @@ runInEachFileSystem(() => {
       });
 
       it('should update the package.json properties', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/a/esm5.js'),
-            contents: 'export function FooA() {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/a/esm5.js'),
+                contents: 'export function FooA() {} // MODIFIED'
+              },
+            ],
+            'module');
         expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
         }));
 
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/a/es2015/foo.js'),
-            contents: 'export class FooA {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/a/es2015/foo.js'),
+                contents: 'export class FooA {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
           es2015_ivy_ngcc: '../__ivy_ngcc__/a/es2015/index.js',
@@ -236,12 +263,15 @@ runInEachFileSystem(() => {
       });
 
       it('should overwrite and backup typings files', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/a/index.d.ts'),
-            contents: 'export declare class FooA {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/a/index.d.ts'),
+                contents: 'export declare class FooA {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/a/index.d.ts')))
             .toEqual('export declare class FooA {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/index.d.ts.__ivy_ngcc_bak')))
@@ -262,12 +292,15 @@ runInEachFileSystem(() => {
       });
 
       it('should write the modified file to a new folder', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/lib/esm5.js'),
-            contents: 'export function FooB() {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/lib/esm5.js'),
+                contents: 'export function FooB() {} // MODIFIED'
+              },
+            ],
+            'module');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/lib/esm5.js')))
             .toEqual('export function FooB() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/lib/esm5.js')))
@@ -275,12 +308,15 @@ runInEachFileSystem(() => {
       });
 
       it('should also copy unmodified files in the program', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/lib/es2015/foo.js'),
-            contents: 'export class FooB {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/lib/es2015/foo.js'),
+                contents: 'export class FooB {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/lib/es2015/foo.js')))
             .toEqual('export class FooB {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/lib/es2015/foo.js')))
@@ -293,43 +329,55 @@ runInEachFileSystem(() => {
 
       it('should not copy typings files within the package (i.e. from a different entry-point)',
          () => {
-           fileWriter.writeBundle(entryPoint, esm2015bundle, [
-             {
-               path: _('/node_modules/test/lib/es2015/foo.js'),
-               contents: 'export class FooB {} // MODIFIED'
-             },
-           ]);
+           fileWriter.writeBundle(
+               entryPoint, esm2015bundle,
+               [
+                 {
+                   path: _('/node_modules/test/lib/es2015/foo.js'),
+                   contents: 'export class FooB {} // MODIFIED'
+                 },
+               ],
+               'es2015');
            expect(fs.exists(_('/node_modules/test/__ivy_ngcc__/a/index.d.ts'))).toEqual(false);
          });
 
       it('should not copy files outside of the package', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/lib/es2015/foo.js'),
-            contents: 'export class FooB {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/lib/es2015/foo.js'),
+                contents: 'export class FooB {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.exists(_('/node_modules/test/other/index.d.ts'))).toEqual(false);
         expect(fs.exists(_('/node_modules/test/events/events.js'))).toEqual(false);
       });
 
       it('should update the package.json properties', () => {
-        fileWriter.writeBundle(entryPoint, esm5bundle, [
-          {
-            path: _('/node_modules/test/lib/esm5.js'),
-            contents: 'export function FooB() {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/lib/esm5.js'),
+                contents: 'export function FooB() {} // MODIFIED'
+              },
+            ],
+            'module');
         expect(loadPackageJson(fs, '/node_modules/test/b')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/lib/esm5.js',
         }));
 
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/lib/es2015/foo.js'),
-            contents: 'export class FooB {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/lib/es2015/foo.js'),
+                contents: 'export class FooB {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(loadPackageJson(fs, '/node_modules/test/b')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/lib/esm5.js',
           es2015_ivy_ngcc: '../__ivy_ngcc__/lib/es2015/index.js',
@@ -337,12 +385,15 @@ runInEachFileSystem(() => {
       });
 
       it('should overwrite and backup typings files', () => {
-        fileWriter.writeBundle(entryPoint, esm2015bundle, [
-          {
-            path: _('/node_modules/test/typings/index.d.ts'),
-            contents: 'export declare class FooB {} // MODIFIED'
-          },
-        ]);
+        fileWriter.writeBundle(
+            entryPoint, esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/typings/index.d.ts'),
+                contents: 'export declare class FooB {} // MODIFIED'
+              },
+            ],
+            'es2015');
         expect(fs.readFile(_('/node_modules/test/typings/index.d.ts')))
             .toEqual('export declare class FooB {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/typings/index.d.ts.__ivy_ngcc_bak')))
@@ -356,7 +407,6 @@ runInEachFileSystem(() => {
       fs: FileSystem, entryPoint: EntryPoint, formatProperty: EntryPointJsonProperty,
       format: EntryPointFormat): EntryPointBundle {
     return makeEntryPointBundle(
-        fs, entryPoint, entryPoint.packageJson[formatProperty] !, false, formatProperty, format,
-        true);
+        fs, entryPoint, entryPoint.packageJson[formatProperty] !, false, format, true);
   }
 });

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -357,6 +357,6 @@ runInEachFileSystem(() => {
       format: EntryPointFormat): EntryPointBundle {
     return makeEntryPointBundle(
         fs, entryPoint, entryPoint.packageJson[formatProperty] !, false, formatProperty, format,
-        true) !;
+        true);
   }
 });

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -32,8 +32,15 @@ runInEachFileSystem(() => {
 
         {
           name: _('/node_modules/test/package.json'),
-          contents:
-              '{"module": "./esm5.js", "es2015": "./es2015/index.js", "typings": "./index.d.ts"}'
+          contents: `
+            {
+              "module": "./esm5.js",
+              "fesm2015": "./es2015/index.js",
+              "fesm5": "./esm5.js",
+              "es2015": "./es2015/index.js",
+              "typings": "./index.d.ts"
+            }
+          `,
         },
         {name: _('/node_modules/test/index.d.ts'), contents: 'export declare class FooTop {}'},
         {name: _('/node_modules/test/index.d.ts.map'), contents: 'ORIGINAL MAPPING DATA'},
@@ -44,8 +51,15 @@ runInEachFileSystem(() => {
         {name: _('/node_modules/test/es2015/foo.js'), contents: 'export class FooTop {}'},
         {
           name: _('/node_modules/test/a/package.json'),
-          contents:
-              `{"module": "./esm5.js", "es2015": "./es2015/index.js", "typings": "./index.d.ts"}`
+          contents: `
+            {
+              "module": "./esm5.js",
+              "fesm2015": "./es2015/index.js",
+              "fesm5": "./esm5.js",
+              "es2015": "./es2015/index.js",
+              "typings": "./index.d.ts"
+            }
+          `,
         },
         {name: _('/node_modules/test/a/index.d.ts'), contents: 'export declare class FooA {}'},
         {name: _('/node_modules/test/a/index.metadata.json'), contents: '...'},
@@ -104,7 +118,7 @@ runInEachFileSystem(() => {
               },
               {path: _('/node_modules/test/esm5.js.map'), contents: 'MODIFIED MAPPING DATA'},
             ],
-            'module');
+            ['module']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/esm5.js')))
             .toEqual('export function FooTop() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/esm5.js'))).toEqual('export function FooTop() {}');
@@ -122,7 +136,7 @@ runInEachFileSystem(() => {
                 contents: 'export class FooTop {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/es2015/foo.js')))
             .toEqual('export class FooTop {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/es2015/foo.js')))
@@ -142,7 +156,7 @@ runInEachFileSystem(() => {
                 contents: 'export function FooTop() {} // MODIFIED'
               },
             ],
-            'module');
+            ['module']);
         expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
         }));
@@ -155,10 +169,42 @@ runInEachFileSystem(() => {
                 contents: 'export class FooTop {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
           es2015_ivy_ngcc: '__ivy_ngcc__/es2015/index.js',
+        }));
+      });
+
+      it('should be able to update multiple package.json properties at once', () => {
+        fileWriter.writeBundle(
+            esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/esm5.js'),
+                contents: 'export function FooTop() {} // MODIFIED'
+              },
+            ],
+            ['module', 'fesm5']);
+        expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
+          module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
+          fesm5_ivy_ngcc: '__ivy_ngcc__/esm5.js',
+        }));
+
+        fileWriter.writeBundle(
+            esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/es2015/foo.js'),
+                contents: 'export class FooTop {} // MODIFIED'
+              },
+            ],
+            ['es2015', 'fesm2015']);
+        expect(loadPackageJson(fs, '/node_modules/test')).toEqual(jasmine.objectContaining({
+          module_ivy_ngcc: '__ivy_ngcc__/esm5.js',
+          fesm5_ivy_ngcc: '__ivy_ngcc__/esm5.js',
+          es2015_ivy_ngcc: '__ivy_ngcc__/es2015/index.js',
+          fesm2015_ivy_ngcc: '__ivy_ngcc__/es2015/index.js',
         }));
       });
 
@@ -172,7 +218,7 @@ runInEachFileSystem(() => {
               },
               {path: _('/node_modules/test/index.d.ts.map'), contents: 'MODIFIED MAPPING DATA'},
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/index.d.ts')))
             .toEqual('export declare class FooTop {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/index.d.ts.__ivy_ngcc_bak')))
@@ -207,7 +253,7 @@ runInEachFileSystem(() => {
                 contents: 'export function FooA() {} // MODIFIED'
               },
             ],
-            'module');
+            ['module']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/a/esm5.js')))
             .toEqual('export function FooA() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/esm5.js'))).toEqual('export function FooA() {}');
@@ -222,7 +268,7 @@ runInEachFileSystem(() => {
                 contents: 'export class FooA {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/a/es2015/foo.js')))
             .toEqual('export class FooA {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/es2015/foo.js')))
@@ -242,7 +288,7 @@ runInEachFileSystem(() => {
                 contents: 'export function FooA() {} // MODIFIED'
               },
             ],
-            'module');
+            ['module']);
         expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
         }));
@@ -255,10 +301,42 @@ runInEachFileSystem(() => {
                 contents: 'export class FooA {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
           es2015_ivy_ngcc: '../__ivy_ngcc__/a/es2015/index.js',
+        }));
+      });
+
+      it('should be able to update multiple package.json properties at once', () => {
+        fileWriter.writeBundle(
+            esm5bundle,
+            [
+              {
+                path: _('/node_modules/test/a/esm5.js'),
+                contents: 'export function FooA() {} // MODIFIED'
+              },
+            ],
+            ['module', 'fesm5']);
+        expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
+          module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
+          fesm5_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
+        }));
+
+        fileWriter.writeBundle(
+            esm2015bundle,
+            [
+              {
+                path: _('/node_modules/test/a/es2015/foo.js'),
+                contents: 'export class FooA {} // MODIFIED'
+              },
+            ],
+            ['es2015', 'fesm2015']);
+        expect(loadPackageJson(fs, '/node_modules/test/a')).toEqual(jasmine.objectContaining({
+          module_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
+          fesm5_ivy_ngcc: '../__ivy_ngcc__/a/esm5.js',
+          es2015_ivy_ngcc: '../__ivy_ngcc__/a/es2015/index.js',
+          fesm2015_ivy_ngcc: '../__ivy_ngcc__/a/es2015/index.js',
         }));
       });
 
@@ -271,7 +349,7 @@ runInEachFileSystem(() => {
                 contents: 'export declare class FooA {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/a/index.d.ts')))
             .toEqual('export declare class FooA {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/a/index.d.ts.__ivy_ngcc_bak')))
@@ -300,7 +378,7 @@ runInEachFileSystem(() => {
                 contents: 'export function FooB() {} // MODIFIED'
               },
             ],
-            'module');
+            ['module']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/lib/esm5.js')))
             .toEqual('export function FooB() {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/lib/esm5.js')))
@@ -316,7 +394,7 @@ runInEachFileSystem(() => {
                 contents: 'export class FooB {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/__ivy_ngcc__/lib/es2015/foo.js')))
             .toEqual('export class FooB {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/lib/es2015/foo.js')))
@@ -337,7 +415,7 @@ runInEachFileSystem(() => {
                    contents: 'export class FooB {} // MODIFIED'
                  },
                ],
-               'es2015');
+               ['es2015']);
            expect(fs.exists(_('/node_modules/test/__ivy_ngcc__/a/index.d.ts'))).toEqual(false);
          });
 
@@ -350,7 +428,7 @@ runInEachFileSystem(() => {
                 contents: 'export class FooB {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.exists(_('/node_modules/test/other/index.d.ts'))).toEqual(false);
         expect(fs.exists(_('/node_modules/test/events/events.js'))).toEqual(false);
       });
@@ -364,7 +442,7 @@ runInEachFileSystem(() => {
                 contents: 'export function FooB() {} // MODIFIED'
               },
             ],
-            'module');
+            ['module']);
         expect(loadPackageJson(fs, '/node_modules/test/b')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/lib/esm5.js',
         }));
@@ -377,7 +455,7 @@ runInEachFileSystem(() => {
                 contents: 'export class FooB {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(loadPackageJson(fs, '/node_modules/test/b')).toEqual(jasmine.objectContaining({
           module_ivy_ngcc: '../__ivy_ngcc__/lib/esm5.js',
           es2015_ivy_ngcc: '../__ivy_ngcc__/lib/es2015/index.js',
@@ -393,7 +471,7 @@ runInEachFileSystem(() => {
                 contents: 'export declare class FooB {} // MODIFIED'
               },
             ],
-            'es2015');
+            ['es2015']);
         expect(fs.readFile(_('/node_modules/test/typings/index.d.ts')))
             .toEqual('export declare class FooB {} // MODIFIED');
         expect(fs.readFile(_('/node_modules/test/typings/index.d.ts.__ivy_ngcc_bak')))

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -96,7 +96,7 @@ runInEachFileSystem(() => {
 
       it('should write the modified files to a new folder', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/esm5.js'),
@@ -115,7 +115,7 @@ runInEachFileSystem(() => {
 
       it('should also copy unmodified files in the program', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/es2015/foo.js'),
@@ -135,7 +135,7 @@ runInEachFileSystem(() => {
 
       it('should update the package.json properties', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/esm5.js'),
@@ -148,7 +148,7 @@ runInEachFileSystem(() => {
         }));
 
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/es2015/foo.js'),
@@ -164,7 +164,7 @@ runInEachFileSystem(() => {
 
       it('should overwrite and backup typings files', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/index.d.ts'),
@@ -200,7 +200,7 @@ runInEachFileSystem(() => {
 
       it('should write the modified file to a new folder', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/a/esm5.js'),
@@ -215,7 +215,7 @@ runInEachFileSystem(() => {
 
       it('should also copy unmodified files in the program', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/a/es2015/foo.js'),
@@ -235,7 +235,7 @@ runInEachFileSystem(() => {
 
       it('should update the package.json properties', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/a/esm5.js'),
@@ -248,7 +248,7 @@ runInEachFileSystem(() => {
         }));
 
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/a/es2015/foo.js'),
@@ -264,7 +264,7 @@ runInEachFileSystem(() => {
 
       it('should overwrite and backup typings files', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/a/index.d.ts'),
@@ -293,7 +293,7 @@ runInEachFileSystem(() => {
 
       it('should write the modified file to a new folder', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/lib/esm5.js'),
@@ -309,7 +309,7 @@ runInEachFileSystem(() => {
 
       it('should also copy unmodified files in the program', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/lib/es2015/foo.js'),
@@ -330,7 +330,7 @@ runInEachFileSystem(() => {
       it('should not copy typings files within the package (i.e. from a different entry-point)',
          () => {
            fileWriter.writeBundle(
-               entryPoint, esm2015bundle,
+               esm2015bundle,
                [
                  {
                    path: _('/node_modules/test/lib/es2015/foo.js'),
@@ -343,7 +343,7 @@ runInEachFileSystem(() => {
 
       it('should not copy files outside of the package', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/lib/es2015/foo.js'),
@@ -357,7 +357,7 @@ runInEachFileSystem(() => {
 
       it('should update the package.json properties', () => {
         fileWriter.writeBundle(
-            entryPoint, esm5bundle,
+            esm5bundle,
             [
               {
                 path: _('/node_modules/test/lib/esm5.js'),
@@ -370,7 +370,7 @@ runInEachFileSystem(() => {
         }));
 
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/lib/es2015/foo.js'),
@@ -386,7 +386,7 @@ runInEachFileSystem(() => {
 
       it('should overwrite and backup typings files', () => {
         fileWriter.writeBundle(
-            entryPoint, esm2015bundle,
+            esm2015bundle,
             [
               {
                 path: _('/node_modules/test/typings/index.d.ts'),


### PR DESCRIPTION
This PR mostly contains refactorings I did to get the code in a state that it is more easily parallelizable. Since these refactorings are good on their own (independently of parallelization), I thought it would be a good idea to split them out into a separate PR. 

There is also a minor fix for correctly recording all new entry-points in `package.json` when `createNewEntryPointFormats` is true.

(See individual commit messages for details.)