### PR TITLE
fix(forms): accept number length in length validators

### DIFF
--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -333,7 +333,7 @@ export const MIN_LENGTH_VALIDATOR: any = {
 
 /**
  * A directive that adds minimum length validation to controls marked with the
- * `minlength` attribute. The directive is provided with the `NG_VALIDATORS` mult-provider list.
+ * `minlength` attribute. The directive is provided with the `NG_VALIDATORS` multi-provider list.
  * 
  * @see [Form Validation](guide/form-validation)
  *
@@ -369,7 +369,7 @@ export class MinLengthValidator implements Validator,
    * Tracks changes to the the minimum length bound to this directive.
    */
   // TODO(issue/24571): remove '!'.
-  @Input() minlength !: string;
+  @Input() minlength !: string | number;
 
   /**
    * @description
@@ -403,7 +403,8 @@ export class MinLengthValidator implements Validator,
   registerOnValidatorChange(fn: () => void): void { this._onChange = fn; }
 
   private _createValidator(): void {
-    this._validator = Validators.minLength(parseInt(this.minlength, 10));
+    this._validator = Validators.minLength(
+        typeof this.minlength === 'number' ? this.minlength : parseInt(this.minlength, 10));
   }
 }
 
@@ -455,7 +456,7 @@ export class MaxLengthValidator implements Validator,
    * Tracks changes to the the maximum length bound to this directive.
    */
   // TODO(issue/24571): remove '!'.
-  @Input() maxlength !: string;
+  @Input() maxlength !: string | number;
 
   /**
    * @description
@@ -489,7 +490,8 @@ export class MaxLengthValidator implements Validator,
   registerOnValidatorChange(fn: () => void): void { this._onChange = fn; }
 
   private _createValidator(): void {
-    this._validator = Validators.maxLength(parseInt(this.maxlength, 10));
+    this._validator = Validators.maxLength(
+        typeof this.maxlength === 'number' ? this.maxlength : parseInt(this.maxlength, 10));
   }
 }
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -330,14 +330,14 @@ export declare class FormsModule {
 }
 
 export declare class MaxLengthValidator implements Validator, OnChanges {
-    maxlength: string;
+    maxlength: string | number;
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
 }
 
 export declare class MinLengthValidator implements Validator, OnChanges {
-    minlength: string;
+    minlength: string | number;
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Both `MinLengthValidator` and `MaxLengthValidator` accepted only string inputs for the length required, which throws with Ivy and `fullTemplateTypeCheck` enabled:

    <!-- min = 2 in the component -->
    <input [minlength]="min">
with:

    Type 'number' is not assignable to type 'string | undefined'

## What is the new behavior?


This relaxes the accepted type to `string | number` to avoid breakage when developers switch to Ivy and fTTC.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If someone extends one of these validators in their own code, then yes, they'll have to pdate the type of the `minlength`/`maxlength` field.


## Other information
