### PR TITLE
refactor(ivy): remove load instruction

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -202,8 +202,6 @@ export class Identifiers {
   static i18nPostprocess: o.ExternalReference = {name: 'ɵɵi18nPostprocess', moduleName: CORE};
   static i18nLocalize: o.ExternalReference = {name: 'ɵɵi18nLocalize', moduleName: CORE};
 
-  static load: o.ExternalReference = {name: 'ɵɵload', moduleName: CORE};
-
   static pipe: o.ExternalReference = {name: 'ɵɵpipe', moduleName: CORE};
 
   static projection: o.ExternalReference = {name: 'ɵɵprojection', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -152,7 +152,6 @@ export {
   ɵɵtemplate,
   ɵɵembeddedViewEnd,
   store as ɵstore,
-  ɵɵload,
   ɵɵpipe,
   ɵɵBaseDef,
   ComponentDef as ɵComponentDef,

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -14,7 +14,7 @@ import {_sanitizeUrl, sanitizeSrcset} from '../sanitization/url_sanitizer';
 import {addAllToArray} from '../util/array_utils';
 import {assertDataInRange, assertDefined, assertEqual, assertGreaterThan} from '../util/assert';
 import {attachPatchData} from './context_discovery';
-import {bind, setDelayProjection, ɵɵload} from './instructions/all';
+import {bind, setDelayProjection} from './instructions/all';
 import {attachI18nOpCodesDebug} from './instructions/lview_debug';
 import {TsickleIssue1009, allocExpando, elementAttributeInternal, elementPropertyInternal, getOrCreateTNode, setInputsForProperty, textBindingInternal} from './instructions/shared';
 import {LContainer, NATIVE} from './interfaces/container';
@@ -29,7 +29,7 @@ import {getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPrev
 import {NO_CHANGE} from './tokens';
 import {renderStringify} from './util/misc_utils';
 import {findComponentView} from './util/view_traversal_utils';
-import {getNativeByIndex, getNativeByTNode, getTNode} from './util/view_utils';
+import {getNativeByIndex, getNativeByTNode, getTNode, load} from './util/view_utils';
 
 
 const MARKER = `�`;
@@ -912,7 +912,7 @@ function removeNode(index: number, viewData: LView) {
     nativeRemoveNode(viewData[RENDERER], removedPhRNode);
   }
 
-  const slotValue = ɵɵload(index) as RElement | RComment | LContainer;
+  const slotValue = load(viewData, index) as RElement | RComment | LContainer;
   if (isLContainer(slotValue)) {
     const lContainer = slotValue as LContainer;
     if (removedPhTNode.type !== TNodeType.Container) {

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -72,7 +72,6 @@ export {
   ɵɵinjectAttribute,
 
   ɵɵlistener,
-  ɵɵload,
 
   ɵɵnamespaceHTML,
   ɵɵnamespaceMathML,

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -16,7 +16,7 @@ import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, T_HOST} from '../i
 import {assertNodeType} from '../node_assert';
 import {appendChild, removeView} from '../node_manipulation';
 import {getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
-import {getNativeByTNode, loadInternal} from '../util/view_utils';
+import {getNativeByTNode, load} from '../util/view_utils';
 
 import {addToViewTree, createDirectivesAndLocals, createLContainer, createTView, getOrCreateTNode, resolveDirectives} from './shared';
 
@@ -100,7 +100,7 @@ export function ɵɵtemplate(
 export function ɵɵcontainerRefreshStart(index: number): void {
   const lView = getLView();
   const tView = lView[TVIEW];
-  let previousOrParentTNode = loadInternal(tView.data, index) as TNode;
+  let previousOrParentTNode = load(tView.data, index) as TNode;
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Container);
   setPreviousOrParentTNode(previousOrParentTNode, true);
 

--- a/packages/core/src/render3/instructions/storage.ts
+++ b/packages/core/src/render3/instructions/storage.ts
@@ -7,7 +7,7 @@
  */
 import {HEADER_OFFSET, TVIEW} from '../interfaces/view';
 import {getContextLView, getLView} from '../state';
-import {loadInternal} from '../util/view_utils';
+import {load} from '../util/view_utils';
 
 /** Store a value in the `data` at a given `index`. */
 export function store<T>(index: number, value: T): void {
@@ -35,14 +35,5 @@ export function store<T>(index: number, value: T): void {
  */
 export function ɵɵreference<T>(index: number) {
   const contextLView = getContextLView();
-  return loadInternal<T>(contextLView, index);
-}
-
-/**
- * Retrieves a value from current `viewData`.
- *
- * @codeGenApi
- */
-export function ɵɵload<T>(index: number): T {
-  return loadInternal<T>(getLView(), index);
+  return load<T>(contextLView, index);
 }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -76,7 +76,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵgetCurrentView': r3.ɵɵgetCurrentView,
        'ɵɵrestoreView': r3.ɵɵrestoreView,
        'ɵɵlistener': r3.ɵɵlistener,
-       'ɵɵload': r3.ɵɵload,
        'ɵɵprojection': r3.ɵɵprojection,
        'ɵɵupdateSyntheticHostBinding': r3.ɵɵupdateSyntheticHostBinding,
        'ɵɵcomponentHostSyntheticListener': r3.ɵɵcomponentHostSyntheticListener,

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -9,12 +9,13 @@
 import {WrappedValue} from '../change_detection/change_detection_util';
 import {PipeTransform} from '../change_detection/pipe_transform';
 
-import {store, ɵɵload} from './instructions/all';
+import {store} from './instructions/all';
 import {PipeDef, PipeDefList} from './interfaces/definition';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
 import {ɵɵpureFunction1, ɵɵpureFunction2, ɵɵpureFunction3, ɵɵpureFunction4, ɵɵpureFunctionV} from './pure_function';
 import {getLView} from './state';
 import {NO_CHANGE} from './tokens';
+import {load} from './util/view_utils';
 
 
 
@@ -82,7 +83,7 @@ function getPipeDef(name: string, registry: PipeDefList | null): PipeDef<any> {
  * @codeGenApi
  */
 export function ɵɵpipeBind1(index: number, slotOffset: number, v1: any): any {
-  const pipeInstance = ɵɵload<PipeTransform>(index);
+  const pipeInstance = load<PipeTransform>(getLView(), index);
   return unwrapValue(
       isPure(index) ? ɵɵpureFunction1(slotOffset, pipeInstance.transform, v1, pipeInstance) :
                       pipeInstance.transform(v1));
@@ -102,7 +103,7 @@ export function ɵɵpipeBind1(index: number, slotOffset: number, v1: any): any {
  * @codeGenApi
  */
 export function ɵɵpipeBind2(index: number, slotOffset: number, v1: any, v2: any): any {
-  const pipeInstance = ɵɵload<PipeTransform>(index);
+  const pipeInstance = load<PipeTransform>(getLView(), index);
   return unwrapValue(
       isPure(index) ? ɵɵpureFunction2(slotOffset, pipeInstance.transform, v1, v2, pipeInstance) :
                       pipeInstance.transform(v1, v2));
@@ -123,7 +124,7 @@ export function ɵɵpipeBind2(index: number, slotOffset: number, v1: any, v2: an
  * @codeGenApi
  */
 export function ɵɵpipeBind3(index: number, slotOffset: number, v1: any, v2: any, v3: any): any {
-  const pipeInstance = ɵɵload<PipeTransform>(index);
+  const pipeInstance = load<PipeTransform>(getLView(), index);
   return unwrapValue(
       isPure(index) ?
           ɵɵpureFunction3(slotOffset, pipeInstance.transform, v1, v2, v3, pipeInstance) :
@@ -147,7 +148,7 @@ export function ɵɵpipeBind3(index: number, slotOffset: number, v1: any, v2: an
  */
 export function ɵɵpipeBind4(
     index: number, slotOffset: number, v1: any, v2: any, v3: any, v4: any): any {
-  const pipeInstance = ɵɵload<PipeTransform>(index);
+  const pipeInstance = load<PipeTransform>(getLView(), index);
   return unwrapValue(
       isPure(index) ?
           ɵɵpureFunction4(slotOffset, pipeInstance.transform, v1, v2, v3, v4, pipeInstance) :
@@ -167,7 +168,7 @@ export function ɵɵpipeBind4(
  * @codeGenApi
  */
 export function ɵɵpipeBindV(index: number, slotOffset: number, values: [any, ...any[]]): any {
-  const pipeInstance = ɵɵload<PipeTransform>(index);
+  const pipeInstance = load<PipeTransform>(getLView(), index);
   return unwrapValue(
       isPure(index) ? ɵɵpureFunctionV(slotOffset, pipeInstance.transform, values, pipeInstance) :
                       pipeInstance.transform.apply(pipeInstance, values));

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -128,7 +128,7 @@ export function getTNode(index: number, view: LView): TNode {
 }
 
 /** Retrieves a value from any `LView` or `TData`. */
-export function loadInternal<T>(view: LView | TData, index: number): T {
+export function load<T>(view: LView | TData, index: number): T {
   ngDevMode && assertDataInRange(view, index + HEADER_OFFSET);
   return view[index + HEADER_OFFSET];
 }

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1089,7 +1089,7 @@
     "name": "listenerInternal"
   },
   {
-    "name": "loadInternal"
+    "name": "load"
   },
   {
     "name": "locateDirectiveOrProvider"

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -9,12 +9,12 @@
 import {ElementRef, QueryList, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {EventEmitter} from '../..';
-import {AttributeMarker, detectChanges, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵload, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdirectiveInject, ɵɵelement, ɵɵelementContainerEnd, ɵɵelementContainerStart, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ɵɵcontentQuery, ɵɵloadQuery, ɵɵqueryRefresh, ɵɵviewQuery} from '../../src/render3/query';
 import {getLView} from '../../src/render3/state';
-import {getNativeByIndex} from '../../src/render3/util/view_utils';
+import {getNativeByIndex, load} from '../../src/render3/util/view_utils';
 import {ɵɵtemplateRefExtractor} from '../../src/render3/view_engine_compatibility_prebound';
 
 import {ComponentFixture, TemplateFixture, createComponent, createDirective, getDirectiveOnNode, renderComponent} from './render_util';
@@ -1701,8 +1701,9 @@ describe('query', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              outInstance = ɵɵload<QueryDirective>(1);
-              inInstance = ɵɵload<QueryDirective>(5);
+              const lView = getLView();
+              outInstance = load<QueryDirective>(lView, 1);
+              inInstance = load<QueryDirective>(lView, 5);
             }
           },
           10, 0, [QueryDirective]);
@@ -1758,8 +1759,9 @@ describe('query', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              outInstance = ɵɵload<QueryDirective>(1);
-              inInstance = ɵɵload<QueryDirective>(3);
+              const lView = getLView();
+              outInstance = load<QueryDirective>(lView, 1);
+              inInstance = load<QueryDirective>(lView, 3);
             }
           },
           7, 0, [QueryDirective]);
@@ -1814,8 +1816,9 @@ describe('query', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              outInstance = ɵɵload<QueryDirective>(1);
-              inInstance = ɵɵload<QueryDirective>(3);
+              const lView = getLView();
+              outInstance = load<QueryDirective>(lView, 1);
+              inInstance = load<QueryDirective>(lView, 3);
             }
           },
           7, 0, [QueryDirective]);
@@ -1902,8 +1905,9 @@ describe('query', () => {
                  ɵɵelementEnd();
                }
                if (rf & RenderFlags.Update) {
-                 shallowInstance = ɵɵload<ShallowQueryDirective>(1);
-                 deepInstance = ɵɵload<DeepQueryDirective>(2);
+                 const lView = getLView();
+                 shallowInstance = load<ShallowQueryDirective>(lView, 1);
+                 deepInstance = load<DeepQueryDirective>(lView, 2);
                }
              },
              8, 0, [ShallowQueryDirective, DeepQueryDirective]);

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -924,8 +924,6 @@ export declare function ɵɵinjectPipeChangeDetectorRef(flags?: InjectFlags): Ch
 
 export declare function ɵɵlistener(eventName: string, listenerFn: (e?: any) => any, useCapture?: boolean, eventTargetResolver?: GlobalTargetResolver): void;
 
-export declare function ɵɵload<T>(index: number): T;
-
 export declare function ɵɵloadQuery<T>(): QueryList<T>;
 
 export declare function ɵɵnamespaceHTML(): void;


### PR DESCRIPTION
These changes remove the `ɵɵload` instruction which isn't being generated anymore.