### PR TITLE
fix(core): ngNoopZone should have the same signature with ngZone

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -325,11 +325,17 @@ export class NoopNgZone implements NgZone {
   readonly onStable: EventEmitter<any> = new EventEmitter();
   readonly onError: EventEmitter<any> = new EventEmitter();
 
-  run(fn: () => any): any { return fn(); }
+  run(fn: (...args: any[]) => any, applyThis?: any, applyArgs?: any): any {
+    return fn.apply(applyThis, applyArgs);
+  }
 
-  runGuarded(fn: () => any): any { return fn(); }
+  runGuarded(fn: (...args: any[]) => any, applyThis?: any, applyArgs?: any): any {
+    return fn.apply(applyThis, applyArgs);
+  }
 
-  runOutsideAngular(fn: () => any): any { return fn(); }
+  runOutsideAngular(fn: (...args: any[]) => any): any { return fn(); }
 
-  runTask<T>(fn: () => any): any { return fn(); }
+  runTask(fn: (...args: any[]) => any, applyThis?: any, applyArgs?: any, name?: string): any {
+    return fn.apply(applyThis, applyArgs);
+  }
 }

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -182,6 +182,36 @@ function runNgZoneNoLog(fn: () => any) {
       expect(runs).toBe(true);
     });
 
+    it('should run with this context and arguments', () => {
+      let runs = false;
+      let applyThisArray: any[] = [];
+      let applyArgsArray: any[] = [];
+      const testContext = {};
+      const testArgs = ['args'];
+      ngZone.run(function(this: any, arg: any) {
+        applyThisArray.push(this);
+        applyArgsArray.push([arg]);
+        ngZone.runGuarded(function(this: any, argGuarded: any) {
+          applyThisArray.push(this);
+          applyArgsArray.push([argGuarded]);
+          ngZone.runOutsideAngular(function(this: any, argOutsideAngular: any) {
+            applyThisArray.push(this);
+            applyArgsArray.push([argOutsideAngular]);
+            runs = true;
+          });
+        }, this, [arg]);
+      }, testContext, testArgs);
+      expect(runs).toBe(true);
+      expect(applyThisArray.length).toBe(3);
+      expect(applyArgsArray.length).toBe(3);
+      expect(applyThisArray[0]).toBe(testContext);
+      expect(applyThisArray[1]).toBe(testContext);
+      expect(applyThisArray[2]).not.toBe(testContext);
+      expect(applyArgsArray[0]).toEqual(testArgs);
+      expect(applyArgsArray[1]).toEqual(testArgs);
+      expect(applyArgsArray[2]).toEqual([undefined]);
+    });
+
     it('should have EventEmitter instances', () => {
       expect(ngZone.onError instanceof EventEmitter).toBe(true);
       expect(ngZone.onStable instanceof EventEmitter).toBe(true);


### PR DESCRIPTION
Close #32063

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32063 
if we use ngNoopZone and call `run(fn, applyThis, applyArgs)`, the `applyThis/applyArgs` will be ignored.

## What is the new behavior?
Will use `applyThis, applyArgs` correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
