### PR TITLE
feat(language-service): Completions for custom-event bindings

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -242,9 +242,10 @@ function attributeValueCompletions(
   if (!path.tail) {
     return [];
   }
+  const includeEvents = !!path.first(BoundEventAst);
   const dinfo = diagnosticInfoFromTemplateInfo(info);
-  const visitor =
-      new ExpressionVisitor(info, position, () => getExpressionScope(dinfo, path, false), attr);
+  const visitor = new ExpressionVisitor(
+      info, position, () => getExpressionScope(dinfo, path, includeEvents), attr);
   path.tail.visit(visitor, null);
   const {results} = visitor;
   if (results.length) {

--- a/packages/language-service/src/symbols.ts
+++ b/packages/language-service/src/symbols.ts
@@ -309,6 +309,11 @@ export interface SymbolQuery {
   getElementType(type: Symbol): Symbol|undefined;
 
   /**
+   * Return type arguments of generic type.
+   */
+  getTypeArguments(type: Symbol): Symbol[];
+
+  /**
    * Return a type that is the non-nullable version of the given type. If `type` is already
    * non-nullable, return `type`.
    */

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -132,6 +132,19 @@ class TypeScriptSymbolQuery implements SymbolQuery {
     }
   }
 
+  getTypeArguments(type: Symbol): Symbol[] {
+    const result: Symbol[] = [];
+    if (type && type instanceof TypeWrapper && type.tsType.symbol) {
+      const typeArguments: ts.Type[]|undefined = (type.tsType as any).typeArguments;
+      if (typeArguments && typeArguments.length) {
+        for (const parameter of typeArguments) {
+          result.push(new TypeWrapper(parameter, type.context));
+        }
+      }
+    }
+    return result;
+  }
+
   getNonNullableType(symbol: Symbol): Symbol {
     if (symbol instanceof TypeWrapper && (typeof this.checker.getNonNullableType == 'function')) {
       const tsType = symbol.tsType;

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -421,6 +421,26 @@ describe('completions', () => {
     // });
   });
 
+  describe('custom event binding', () => {
+    it('should be able to get completions for event name', () => {
+      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'custom-event-name');
+      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      expectContain(completions, CompletionKind.ATTRIBUTE, ['(deleteRequest)']);
+    });
+
+    it('should be able to get completions for $event variable', () => {
+      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'custom-event-binding');
+      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      expectContain(completions, CompletionKind.VARIABLE, ['$event']);
+    });
+
+    it('should be able to get completions for event members', () => {
+      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'custom-event-members');
+      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['name', 'age', 'street']);
+    });
+  });
+
   describe('replacement span', () => {
     it('should not generate replacement entries for zero-length replacements', () => {
       const fileName = mockHost.addCode(`

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -50,6 +50,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.TemplateReference,
     ParsingCases.TestComponent,
     ParsingCases.TwoWayBinding,
+    ParsingCases.CustomEventComponent
   ]
 })
 export class AppModule {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -202,3 +202,17 @@ export class EmptyInterpolation {
   title = 'Some title';
   subTitle = 'Some sub title';
 }
+
+@Component({
+  selector: 'custom-event-comp',
+  template: `
+  <custom-event-comp ~{custom-event-name}></custom-event-comp>
+  <custom-event-comp 
+    (deleteRequest)="log(~{custom-event-binding}$event.~{custom-event-members}name)">
+  </custom-event-comp>
+  `
+})
+export class CustomEventComponent {
+  @Output() deleteRequest = new EventEmitter<Person>();
+  log(text: string): void {}
+}

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -94,7 +94,7 @@ describe('TypeScriptServiceHost', () => {
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
     const templates = ngLSHost.getTemplates('/app/parsing-cases.ts');
-    expect(templates.length).toBe(18);
+    expect(templates.length).toBe(19);
   });
 
   it('should be able to find external template', () => {


### PR DESCRIPTION
Resolves type of $event variable in a event binding. So language service can provide completions for $event type members.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The method getEventDeclaration() always returns "any" type for the event. So language service can't provide completions for $event variable. 

Issue Number: #25545


## What is the new behavior?
 Determine the type of the event based on the `Observable<T>` or `EventEmitter<T>` types.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
