### PR TITLE
perf(ivy): don't read global state when interpolated values don't change

### DIFF
--- a/packages/core/src/render3/instructions/attribute_interpolation.ts
+++ b/packages/core/src/render3/instructions/attribute_interpolation.ts
@@ -41,11 +41,11 @@ import {TsickleIssue1009, elementAttributeInternal} from './shared';
 export function ɵɵattributeInterpolate1(
     attrName: string, prefix: string, v0: any, suffix: string, sanitizer?: SanitizerFn,
     namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate1;
 }
@@ -79,11 +79,11 @@ export function ɵɵattributeInterpolate1(
 export function ɵɵattributeInterpolate2(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, suffix: string,
     sanitizer?: SanitizerFn, namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate2;
 }
@@ -120,11 +120,11 @@ export function ɵɵattributeInterpolate2(
 export function ɵɵattributeInterpolate3(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string, sanitizer?: SanitizerFn, namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate3;
 }
@@ -163,11 +163,11 @@ export function ɵɵattributeInterpolate3(
 export function ɵɵattributeInterpolate4(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string, sanitizer?: SanitizerFn, namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate4;
 }
@@ -209,12 +209,12 @@ export function ɵɵattributeInterpolate5(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string, sanitizer?: SanitizerFn,
     namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue =
       interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate5;
 }
@@ -258,12 +258,12 @@ export function ɵɵattributeInterpolate6(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string, sanitizer?: SanitizerFn,
     namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue =
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate6;
 }
@@ -362,12 +362,12 @@ export function ɵɵattributeInterpolate8(
     attrName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string, sanitizer?: SanitizerFn, namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolatedValue = interpolation8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolatedValue, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolatedValue, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolate8;
 }
@@ -401,11 +401,11 @@ export function ɵɵattributeInterpolate8(
 export function ɵɵattributeInterpolateV(
     attrName: string, values: any[], sanitizer?: SanitizerFn,
     namespace?: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
-    elementAttributeInternal(index, attrName, interpolated, lView, sanitizer, namespace);
+    elementAttributeInternal(
+        getSelectedIndex(), attrName, interpolated, lView, sanitizer, namespace);
   }
   return ɵɵattributeInterpolateV;
 }

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -81,10 +81,9 @@ export function ɵɵpropertyInterpolate(
 export function ɵɵpropertyInterpolate1(
     propName: string, prefix: string, v0: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation1(getLView(), prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate1;
 }
@@ -122,10 +121,9 @@ export function ɵɵpropertyInterpolate1(
 export function ɵɵpropertyInterpolate2(
     propName: string, prefix: string, v0: any, i0: string, v1: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation2(getLView(), prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate2;
 }
@@ -166,10 +164,9 @@ export function ɵɵpropertyInterpolate2(
 export function ɵɵpropertyInterpolate3(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation3(getLView(), prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate3;
 }
@@ -212,10 +209,9 @@ export function ɵɵpropertyInterpolate3(
 export function ɵɵpropertyInterpolate4(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation4(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate4;
 }
@@ -260,11 +256,10 @@ export function ɵɵpropertyInterpolate4(
 export function ɵɵpropertyInterpolate5(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue =
       interpolation5(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate5;
 }
@@ -312,11 +307,10 @@ export function ɵɵpropertyInterpolate6(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue =
       interpolation6(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate6;
 }
@@ -366,11 +360,10 @@ export function ɵɵpropertyInterpolate7(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation7(
       getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate7;
 }
@@ -422,11 +415,10 @@ export function ɵɵpropertyInterpolate8(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const interpolatedValue = interpolation8(
       getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolate8;
 }
@@ -463,11 +455,9 @@ export function ɵɵpropertyInterpolate8(
  */
 export function ɵɵpropertyInterpolateV(
     propName: string, values: any[], sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const index = getSelectedIndex();
-
   const interpolatedValue = interpolationV(getLView(), values);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(index, propName, interpolatedValue, sanitizer);
+    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
   }
   return ɵɵpropertyInterpolateV;
 }

--- a/packages/core/src/render3/instructions/text_interpolation.ts
+++ b/packages/core/src/render3/instructions/text_interpolation.ts
@@ -58,11 +58,10 @@ export function ɵɵtextInterpolate(v0: any): TsickleIssue1009 {
  * @codeGenApi
  */
 export function ɵɵtextInterpolate1(prefix: string, v0: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation1(lView, prefix, v0, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate1;
 }
@@ -88,11 +87,10 @@ export function ɵɵtextInterpolate1(prefix: string, v0: any, suffix: string): T
  */
 export function ɵɵtextInterpolate2(
     prefix: string, v0: any, i0: string, v1: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate2;
 }
@@ -120,11 +118,10 @@ export function ɵɵtextInterpolate2(
 export function ɵɵtextInterpolate3(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate3;
 }
@@ -152,11 +149,10 @@ export function ɵɵtextInterpolate3(
 export function ɵɵtextInterpolate4(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate4;
 }
@@ -184,11 +180,10 @@ export function ɵɵtextInterpolate4(
 export function ɵɵtextInterpolate5(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate5;
 }
@@ -218,12 +213,11 @@ export function ɵɵtextInterpolate5(
 export function ɵɵtextInterpolate6(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated =
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate6;
 }
@@ -252,12 +246,11 @@ export function ɵɵtextInterpolate7(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, i5: string, v6: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated =
       interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate7;
 }
@@ -286,12 +279,11 @@ export function ɵɵtextInterpolate8(
     prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string, v3: any,
     i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolation8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolate8;
 }
@@ -321,11 +313,10 @@ export function ɵɵtextInterpolate8(
  * @codeGenApi
  */
 export function ɵɵtextInterpolateV(values: any[]): TsickleIssue1009 {
-  const index = getSelectedIndex();
   const lView = getLView();
   const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, index, interpolated as string);
+    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolateV;
 }


### PR DESCRIPTION
This PR refactors code so the global state (`getSelectedIndex()`) is not accessed until it is needed (interpolated value actually changed). Most of the CD loops will see most of the interpolations unchanged so it is important to guard global state access. 