### PR TITLE
refactor(ivy): write initial style/class values by writing attributes

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -30,6 +30,7 @@ import {assertNodeOfPossibleTypes, assertNodeType} from '../node_assert';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
 import {enterView, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, getSelectedIndex, incrementActiveDirectiveId, leaveView, namespaceHTMLInternal, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setPreviousOrParentTNode, setSelectedIndex} from '../state';
 import {renderStylingMap} from '../styling_next/bindings';
+import {getInitialStylingValue} from '../styling_next/util';
 import {NO_CHANGE} from '../tokens';
 import {ANIMATION_PROP_PREFIX, isAnimationProp} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
@@ -1861,6 +1862,22 @@ export function textBindingInternal(lView: LView, index: number, value: string):
  * style and class entries to the element.
  */
 export function renderInitialStyling(renderer: Renderer3, native: RElement, tNode: TNode) {
-  renderStylingMap(renderer, native, tNode.classes, true);
-  renderStylingMap(renderer, native, tNode.styles, false);
+  const classValue = getInitialStylingValue(tNode.classes);
+  if (classValue) {
+    setStaticAttr(native, renderer, 'class', classValue);
+  }
+
+  const styleValue = getInitialStylingValue(tNode.styles);
+  if (styleValue) {
+    setStaticAttr(native, renderer, 'style', styleValue);
+  }
+}
+
+function setStaticAttr(native: RElement, renderer: Renderer3, name: string, value: string) {
+  ngDevMode && ngDevMode.rendererSetAttribute++;
+  if (isProceduralRenderer(renderer)) {
+    renderer.setAttribute(native, name, value);
+  } else {
+    native.setAttribute(name, value);
+  }
 }

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -117,9 +117,6 @@
     "name": "RENDERER_FACTORY"
   },
   {
-    "name": "RendererStyleFlags3"
-  },
-  {
     "name": "SANITIZER"
   },
   {
@@ -576,9 +573,6 @@
     "name": "renderStringify"
   },
   {
-    "name": "renderStylingMap"
-  },
-  {
     "name": "resetAllStylingState"
   },
   {
@@ -607,9 +601,6 @@
   },
   {
     "name": "setBindingRoot"
-  },
-  {
-    "name": "setClass"
   },
   {
     "name": "setCurrentDirectiveDef"
@@ -651,7 +642,7 @@
     "name": "setSelectedIndex"
   },
   {
-    "name": "setStyle"
+    "name": "setStaticAttr"
   },
   {
     "name": "setTNodeAndViewData"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1233,9 +1233,6 @@
     "name": "renderStringify"
   },
   {
-    "name": "renderStylingMap"
-  },
-  {
     "name": "resetAllStylingState"
   },
   {
@@ -1327,6 +1324,9 @@
   },
   {
     "name": "setSelectedIndex"
+  },
+  {
+    "name": "setStaticAttr"
   },
   {
     "name": "setStyle"


### PR DESCRIPTION
Prior to this patch, static classes and styles were applied using
the DOM `element.classList` and `element.style` APIs. Because Angular
controls the creation of elements, static styling values can be
applied directly using `setAttribute`. This patch refactors element
creation to do this.
