### PR TITLE
ci: use local strategy for AngularTemplateCompile and TypescriptCompile on CI

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -37,5 +37,5 @@ build --verbose_failures=true
 # > Example job: https://circleci.com/gh/angular/angular/385517
 # We expect that TypeScript compilations will parallelize wider than the number of local cores anyway
 # so we should saturate remote workers with TS compilations
-build --strategy=TypeScriptCompile=standalone
-build --strategy=AngularTemplateCompile=standalone
+build --strategy=AngularTemplateCompile=local
+build --strategy=TypeScriptCompile=local


### PR DESCRIPTION
Addresses CI performance regression originally introduced in #31471

cc: @alexeagle 