### PR TITLE
ci: add ivy commits to generated CHANGELOG

### DIFF
--- a/tools/gulp-tasks/changelog.js
+++ b/tools/gulp-tasks/changelog.js
@@ -11,7 +11,6 @@ module.exports = (gulp) => () => {
   const ignoredScopes = [
     'aio',
     'docs-infra',
-    'ivy',
     'zone.js',
   ];
 


### PR DESCRIPTION
Historically, we've cleaned Ivy commits out of the CHANGELOG because
Ivy was not available except as a preview. Given that Ivy will soon
be the default in 9.0.0, it no longer makes sense to remove the Ivy
commits from the log. This changes the gulp changelog task so that
Ivy commits are included by default.
