### PR TITLE
refactor(language-service): Return ts.Diagnostic[] for getDiagnostics

### DIFF
--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -7,11 +7,50 @@
  */
 
 import {NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
+import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli/src/language_services';
+import * as ts from 'typescript';
+
 import {AstResult} from './common';
 import {Declarations, Diagnostic, DiagnosticKind, DiagnosticMessageChain, Diagnostics, Span, TemplateSource} from './types';
+import {offsetSpan, spanOf} from './utils';
 
 export interface AstProvider {
   getTemplateAst(template: TemplateSource, fileName: string): AstResult;
+}
+
+export function getTemplateDiagnostics(template: TemplateSource, ast: AstResult): Diagnostics {
+  const results: Diagnostics = [];
+
+  if (ast.parseErrors && ast.parseErrors.length) {
+    results.push(...ast.parseErrors.map<Diagnostic>(e => {
+      return {
+        kind: DiagnosticKind.Error,
+        span: offsetSpan(spanOf(e.span), template.span.start),
+        message: e.msg,
+      };
+    }));
+  } else if (ast.templateAst && ast.htmlAst) {
+    const info: DiagnosticTemplateInfo = {
+      templateAst: ast.templateAst,
+      htmlAst: ast.htmlAst,
+      offset: template.span.start,
+      query: template.query,
+      members: template.members,
+    };
+    const expressionDiagnostics = getTemplateExpressionDiagnostics(info);
+    results.push(...expressionDiagnostics);
+  }
+  if (ast.errors) {
+    results.push(...ast.errors.map<Diagnostic>(e => {
+      return {
+        kind: e.kind,
+        span: e.span || template.span,
+        message: e.message,
+      };
+    }));
+  }
+
+  return results;
 }
 
 export function getDeclarationDiagnostics(
@@ -59,4 +98,35 @@ export function getDeclarationDiagnostics(
   }
 
   return results;
+}
+
+function diagnosticChainToDiagnosticChain(chain: DiagnosticMessageChain):
+    ts.DiagnosticMessageChain {
+  return {
+    messageText: chain.message,
+    category: ts.DiagnosticCategory.Error,
+    code: 0,
+    next: chain.next ? diagnosticChainToDiagnosticChain(chain.next) : undefined
+  };
+}
+
+function diagnosticMessageToDiagnosticMessageText(message: string | DiagnosticMessageChain): string|
+    ts.DiagnosticMessageChain {
+  if (typeof message === 'string') {
+    return message;
+  }
+  return diagnosticChainToDiagnosticChain(message);
+}
+
+export function ngDiagnosticToTsDiagnostic(
+    d: Diagnostic, file: ts.SourceFile | undefined): ts.Diagnostic {
+  return {
+    file,
+    start: d.span.start,
+    length: d.span.end - d.span.start,
+    messageText: diagnosticMessageToDiagnosticMessageText(d.message),
+    category: ts.DiagnosticCategory.Error,
+    code: 0,
+    source: 'ng',
+  };
 }

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -190,7 +190,7 @@ export interface LanguageServiceHost {
    * Return the template source information for all templates in `fileName` or for `fileName` if
    * it is a template file.
    */
-  getTemplates(fileName: string): TemplateSources;
+  getTemplates(fileName: string): TemplateSource[];
 
   /**
    * Returns the Angular declarations in the given file.
@@ -386,7 +386,7 @@ export interface LanguageService {
   /**
    * Returns a list of all error for all templates in the given file.
    */
-  getDiagnostics(fileName: string): Diagnostic[];
+  getDiagnostics(fileName: string): tss.Diagnostic[];
 
   /**
    * Return the completions at the given position.

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -170,16 +170,16 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     return analyzedModules;
   }
 
-  getTemplates(fileName: string): TemplateSources {
+  getTemplates(fileName: string): TemplateSource[] {
+    const results: TemplateSource[] = [];
     if (fileName.endsWith('.ts')) {
       let version = this.host.getScriptVersion(fileName);
-      let result: TemplateSource[] = [];
 
       // Find each template string in the file
       let visit = (child: ts.Node) => {
         let templateSource = this.getSourceFromNode(fileName, version, child);
         if (templateSource) {
-          result.push(templateSource);
+          results.push(templateSource);
         } else {
           ts.forEachChild(child, visit);
         }
@@ -190,17 +190,17 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
         this.context = (sourceFile as any).path || sourceFile.fileName;
         ts.forEachChild(sourceFile, visit);
       }
-      return result.length ? result : undefined;
     } else {
       this.ensureTemplateMap();
       const componentSymbol = this.fileToComponent.get(fileName);
       if (componentSymbol) {
         const templateSource = this.getTemplateAt(fileName, 0);
         if (templateSource) {
-          return [templateSource];
+          results.push(templateSource);
         }
       }
     }
+    return results;
   }
 
   getDeclarations(fileName: string): Declarations {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -34,7 +34,7 @@ describe('diagnostics', () => {
   describe('for semantic errors', () => {
     const fileName = '/app/test.ng';
 
-    function diagnostics(template: string): Diagnostics {
+    function diagnostics(template: string): ts.Diagnostic[] {
       try {
         mockHost.override(fileName, template);
         return ngService.getDiagnostics(fileName) !;
@@ -185,7 +185,7 @@ describe('diagnostics', () => {
       addCode(code, fileName => {
         const diagnostic = findDiagnostic(ngService.getDiagnostics(fileName) !, 'pipe') !;
         expect(diagnostic).not.toBeUndefined();
-        expect(diagnostic.span.end - diagnostic.span.start).toBeLessThan(11);
+        expect(diagnostic.length).toBeLessThan(11);
       });
     });
 
@@ -379,13 +379,13 @@ describe('diagnostics', () => {
       }
     }
 
-    function expectOnlyModuleDiagnostics(diagnostics: Diagnostics | undefined) {
+    function expectOnlyModuleDiagnostics(diagnostics: ts.Diagnostic[] | undefined) {
       // Expect only the 'MyComponent' diagnostic
       if (!diagnostics) throw new Error('Expecting Diagnostics');
       if (diagnostics.length > 1) {
         const unexpectedDiagnostics =
-            diagnostics.filter(diag => !diagnosticMessageContains(diag.message, 'MyComponent'))
-                .map(diag => `(${diag.span.start}:${diag.span.end}): ${diag.message}`);
+            diagnostics.filter(diag => !diagnosticMessageContains(diag.messageText, 'MyComponent'))
+                .map(diag => `(${diag.start}:${diag.start! + diag.length!}): ${diag.messageText}`);
 
         if (unexpectedDiagnostics.length) {
           fail(`Unexpected diagnostics:\n  ${unexpectedDiagnostics.join('\n  ')}`);
@@ -393,7 +393,7 @@ describe('diagnostics', () => {
         }
       }
       expect(diagnostics.length).toBe(1);
-      expect(diagnosticMessageContains(diagnostics[0].message, 'MyComponent')).toBeTruthy();
+      expect(diagnosticMessageContains(diagnostics[0].messageText, 'MyComponent')).toBeTruthy();
     }
   });
 });

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -331,18 +331,19 @@ function removeReferenceMarkers(value: string): string {
   return value.replace(referenceMarker, (match, text) => text.replace(/ᐱ/g, ''));
 }
 
-export function noDiagnostics(diagnostics: Diagnostics) {
+export function noDiagnostics(diagnostics: ts.Diagnostic[]) {
   if (diagnostics && diagnostics.length) {
-    throw new Error(`Unexpected diagnostics: \n  ${diagnostics.map(d => d.message).join('\n  ')}`);
+    throw new Error(
+        `Unexpected diagnostics: \n  ${diagnostics.map(d => d.messageText).join('\n  ')}`);
   }
 }
 
 export function diagnosticMessageContains(
-    message: string | DiagnosticMessageChain, messageFragment: string): boolean {
+    message: string | ts.DiagnosticMessageChain, messageFragment: string): boolean {
   if (typeof message == 'string') {
     return message.indexOf(messageFragment) >= 0;
   }
-  if (message.message.indexOf(messageFragment) >= 0) {
+  if (message.messageText.indexOf(messageFragment) >= 0) {
     return true;
   }
   if (message.next) {
@@ -351,16 +352,17 @@ export function diagnosticMessageContains(
   return false;
 }
 
-export function findDiagnostic(diagnostics: Diagnostic[], messageFragment: string): Diagnostic|
-    undefined {
-  return diagnostics.find(d => diagnosticMessageContains(d.message, messageFragment));
+export function findDiagnostic(
+    diagnostics: ts.Diagnostic[], messageFragment: string): ts.Diagnostic|undefined {
+  return diagnostics.find(d => diagnosticMessageContains(d.messageText, messageFragment));
 }
 
 export function includeDiagnostic(
-    diagnostics: Diagnostics, message: string, text?: string, len?: string): void;
+    diagnostics: ts.Diagnostic[], message: string, text?: string, len?: string): void;
 export function includeDiagnostic(
-    diagnostics: Diagnostics, message: string, at?: number, len?: number): void;
-export function includeDiagnostic(diagnostics: Diagnostics, message: string, p1?: any, p2?: any) {
+    diagnostics: ts.Diagnostic[], message: string, at?: number, len?: number): void;
+export function includeDiagnostic(
+    diagnostics: ts.Diagnostic[], message: string, p1?: any, p2?: any) {
   expect(diagnostics).toBeDefined();
   if (diagnostics) {
     const diagnostic = findDiagnostic(diagnostics, message);
@@ -368,13 +370,12 @@ export function includeDiagnostic(diagnostics: Diagnostics, message: string, p1?
     if (diagnostic && p1 != null) {
       const at = typeof p1 === 'number' ? p1 : p2.indexOf(p1);
       const len = typeof p2 === 'number' ? p2 : p1.length;
-      expect(diagnostic.span.start)
+      expect(diagnostic.start)
           .toEqual(
               at,
-              `expected message '${message}' was reported at ${diagnostic.span.start} but should be ${at}`);
+              `expected message '${message}' was reported at ${diagnostic.start} but should be ${at}`);
       if (len != null) {
-        expect(diagnostic.span.end - diagnostic.span.start)
-            .toEqual(len, `expected '${message}'s span length to be ${len}`);
+        expect(diagnostic.length).toEqual(len, `expected '${message}'s span length to be ${len}`);
       }
     }
   }


### PR DESCRIPTION
Part 2/3 of language service refactoring:
Now that the language service is a proper tsserver plugin, all LS
interfaces should return TS values. This PR refactors the
ng.getDiagnostics() API to return ts.Diagnostic[] instead of
ng.Diagnostic[].

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
