### PR TITLE
refactor(language-service): Return ts.CompletionInfo for getCompletionsAt()

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -498,3 +498,12 @@ function expandedAttr(attr: AttrInfo): AttrInfo[] {
 function lowerName(name: string): string {
   return name && (name[0].toLowerCase() + name.substr(1));
 }
+
+export function ngCompletionToTsCompletionEntry(completion: Completion): ts.CompletionEntry {
+  return {
+    name: completion.name,
+    kind: completion.kind as ts.ScriptElementKind,
+    kindModifiers: '',
+    sortText: completion.sort,
+  };
+}

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -130,3 +130,21 @@ export function ngDiagnosticToTsDiagnostic(
     source: 'ng',
   };
 }
+
+export function uniqueBySpan<T extends{span: Span}>(elements: T[]): T[] {
+  const result: T[] = [];
+  const map = new Map<number, Set<number>>();
+  for (const element of elements) {
+    const {span} = element;
+    let set = map.get(span.start);
+    if (!set) {
+      set = new Set();
+      map.set(span.start, set);
+    }
+    if (!set.has(span.end)) {
+      set.add(span.end);
+      result.push(element);
+    }
+  }
+  return result;
+}

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -6,16 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompilePipeSummary} from '@angular/compiler';
 import * as tss from 'typescript/lib/tsserverlibrary';
-
-import {getTemplateCompletions} from './completions';
+import {getTemplateCompletions, ngCompletionToTsCompletionEntry} from './completions';
 import {getDefinitionAndBoundSpan} from './definitions';
-import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic} from './diagnostics';
+import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic, uniqueBySpan} from './diagnostics';
 import {getHover} from './hover';
-import {Completion, Diagnostic, LanguageService, Span} from './types';
+import {Diagnostic, LanguageService} from './types';
 import {TypeScriptServiceHost} from './typescript_host';
-
 
 /**
  * Create an instance of an Angular `LanguageService`.
@@ -53,21 +50,22 @@ class LanguageServiceImpl implements LanguageService {
     return uniqueBySpan(results).map(d => ngDiagnosticToTsDiagnostic(d, sourceFile));
   }
 
-  getPipesAt(fileName: string, position: number): CompilePipeSummary[] {
+  getCompletionsAt(fileName: string, position: number): tss.CompletionInfo|undefined {
     this.host.getAnalyzedModules();  // same role as 'synchronizeHostData'
     const templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
-    if (templateInfo) {
-      return templateInfo.pipes;
+    if (!templateInfo) {
+      return;
     }
-    return [];
-  }
-
-  getCompletionsAt(fileName: string, position: number): Completion[]|undefined {
-    this.host.getAnalyzedModules();  // same role as 'synchronizeHostData'
-    const templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
-    if (templateInfo) {
-      return getTemplateCompletions(templateInfo);
+    const results = getTemplateCompletions(templateInfo);
+    if (!results || !results.length) {
+      return;
     }
+    return {
+      isGlobalCompletion: false,
+      isMemberCompletion: false,
+      isNewIdentifierLocation: false,
+      entries: results.map(ngCompletionToTsCompletionEntry),
+    };
   }
 
   getDefinitionAt(fileName: string, position: number): tss.DefinitionInfoAndBoundSpan|undefined {
@@ -85,22 +83,4 @@ class LanguageServiceImpl implements LanguageService {
       return getHover(templateInfo);
     }
   }
-}
-
-function uniqueBySpan<T extends{span: Span}>(elements: T[]): T[] {
-  const result: T[] = [];
-  const map = new Map<number, Set<number>>();
-  for (const element of elements) {
-    const {span} = element;
-    let set = map.get(span.start);
-    if (!set) {
-      set = new Set();
-      map.set(span.start, set);
-    }
-    if (!set.has(span.end)) {
-      set.add(span.end);
-      result.push(element);
-    }
-  }
-  return result;
 }

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript'; // used as value, passed in by tsserver at runtime
 import * as tss from 'typescript/lib/tsserverlibrary'; // used as type only
 
 import {createLanguageService} from './language_service';
-import {Completion} from './types';
 import {TypeScriptServiceHost} from './typescript_host';
 
 const projectHostMap = new WeakMap<tss.server.Project, TypeScriptServiceHost>();
@@ -22,16 +20,6 @@ export function getExternalFiles(project: tss.server.Project): string[]|undefine
     const externalFiles = host.getTemplateReferences();
     return externalFiles;
   }
-}
-
-function completionToEntry(c: Completion): tss.CompletionEntry {
-  return {
-    // TODO: remove any and fix type error.
-    kind: c.kind as any,
-    name: c.name,
-    sortText: c.sort,
-    kindModifiers: ''
-  };
 }
 
 export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
@@ -60,16 +48,7 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
         return results;
       }
     }
-    const results = ngLS.getCompletionsAt(fileName, position);
-    if (!results || !results.length) {
-      return;
-    }
-    return {
-      isGlobalCompletion: false,
-      isMemberCompletion: false,
-      isNewIdentifierLocation: false,
-      entries: results.map(completionToEntry),
-    };
+    return ngLS.getCompletionsAt(fileName, position);
   }
 
   function getQuickInfoAtPosition(fileName: string, position: number): tss.QuickInfo|undefined {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -376,7 +376,7 @@ export interface LanguageService {
   /**
    * Returns a list of all the external templates referenced by the project.
    */
-  getTemplateReferences(): string[]|undefined;
+  getTemplateReferences(): string[];
 
   /**
    * Returns a list of all error for all templates in the given file.
@@ -386,7 +386,7 @@ export interface LanguageService {
   /**
    * Return the completions at the given position.
    */
-  getCompletionsAt(fileName: string, position: number): Completion[]|undefined;
+  getCompletionsAt(fileName: string, position: number): tss.CompletionInfo|undefined;
 
   /**
    * Return the definition location for the symbol at position.
@@ -397,9 +397,4 @@ export interface LanguageService {
    * Return the hover information for the symbol at position.
    */
   getHoverAt(fileName: string, position: number): tss.QuickInfo|undefined;
-
-  /**
-   * Return the pipes that are available at the given position.
-   */
-  getPipesAt(fileName: string, position: number): CompilePipeSummary[];
 }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -229,24 +229,23 @@ export class MyComponent {
 
 
 function expectEntries(
-    locationMarker: string, completions: Completion[] | undefined, ...names: string[]) {
+    locationMarker: string, completion: ts.CompletionInfo | undefined, ...names: string[]) {
   let entries: {[name: string]: boolean} = {};
-  if (!completions) {
+  if (!completion) {
     throw new Error(
         `Expected result from ${locationMarker} to include ${names.join(', ')} but no result provided`);
   }
-  if (!completions.length) {
+  if (!completion.entries.length) {
     throw new Error(
         `Expected result from ${locationMarker} to include ${names.join(', ')} an empty result provided`);
-  } else {
-    for (let entry of completions) {
-      entries[entry.name] = true;
-    }
-    let missing = names.filter(name => !entries[name]);
-    if (missing.length) {
-      throw new Error(
-          `Expected result from ${locationMarker} to include at least one of the following, ${missing.join(', ')}, in the list of entries ${completions.map(entry => entry.name).join(', ')}`);
-    }
+  }
+  for (const entry of completion.entries) {
+    entries[entry.name] = true;
+  }
+  let missing = names.filter(name => !entries[name]);
+  if (missing.length) {
+    throw new Error(
+        `Expected result from ${locationMarker} to include at least one of the following, ${missing.join(', ')}, in the list of entries ${completion.entries.map(entry => entry.name).join(', ')}`);
   }
 }
 


### PR DESCRIPTION
Part 3/3 of language-service refactoring:
Change all language service APIs to return TS value since Angular LS
will be a proper tsserver plugin. This reduces the need to transform
results among Angular <--> TS <--> LSP.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
