### PR TITLE
perf(ivy): avoid first template pass checks during view creation

### DIFF
--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -11,14 +11,14 @@ import {attachPatchData} from '../context_discovery';
 import {executePreOrderHooks, registerPostOrderHooks} from '../hooks';
 import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {ComponentTemplate} from '../interfaces/definition';
-import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType} from '../interfaces/node';
+import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType, TViewNode} from '../interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild, removeView} from '../node_manipulation';
 import {getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
 import {getNativeByTNode, load} from '../util/view_utils';
 
-import {addToViewTree, createDirectivesAndLocals, createLContainer, createTView, getOrCreateTNode, resolveDirectives} from './shared';
+import {addToViewTree, createDirectivesAndLocals, createLContainer, createTNode, createTView, getOrCreateTNode, resolveDirectives} from './shared';
 
 
 
@@ -78,6 +78,10 @@ export function ɵɵtemplate(
     const embeddedTView = tContainerNode.tViews = createTView(
         -1, templateFn, consts, vars, tView.directiveRegistry, tView.pipeRegistry, null,
         tView.schemas);
+    const embeddedTViewNode = createTNode(tView, null, TNodeType.View, -1, null, null) as TViewNode;
+    embeddedTViewNode.injectorIndex = tContainerNode.injectorIndex;
+    embeddedTView.node = embeddedTViewNode;
+
     if (tView.queries !== null) {
       tView.queries.template(tView, tContainerNode);
       embeddedTView.queries = tView.queries.embeddedTView(tContainerNode);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -305,24 +305,6 @@ export function allocExpando(view: LView, numSlotsToAlloc: number) {
 //////////////////////////
 
 /**
- * Used for creating the LView of a dynamic embedded view, either through
- * ViewContainerRef.createEmbeddedView() or TemplateRef.createEmbeddedView().
- */
-export function createEmbeddedViewAndNode<T>(
-    tView: TView, context: T, declarationView: LView, injectorIndex: number): LView {
-  const lView = createLView(declarationView, tView, context, LViewFlags.CheckAlways, null, null);
-  lView[DECLARATION_VIEW] = declarationView;
-
-  assignTViewNodeToLView(tView, null, -1, lView);
-
-  if (tView.firstTemplatePass) {
-    tView.node !.injectorIndex = injectorIndex;
-  }
-
-  return lView;
-}
-
-/**
  * Processes a view in the creation mode. This includes a number of steps in a specific order:
  * - creating view query functions (if any);
  * - executing a template function in the creation mode;

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -106,11 +106,14 @@ export function getNativeByTNode(tNode: TNode, lView: LView): RNode {
  * @param lView
  */
 export function getNativeByTNodeOrNull(tNode: TNode, lView: LView): RNode|null {
-  ngDevMode && assertTNodeForLView(tNode, lView);
   const index = tNode.index;
-  const node: RNode|null = index == -1 ? null : unwrapRNode(lView[index]);
-  ngDevMode && node !== null && assertDomNode(node);
-  return node;
+  if (index !== -1) {
+    ngDevMode && assertTNodeForLView(tNode, lView);
+    const node: RNode|null = unwrapRNode(lView[index]);
+    ngDevMode && node !== null && assertDomNode(node);
+    return node;
+  }
+  return null;
 }
 
 

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -17,16 +17,15 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_Vie
 import {Renderer2} from '../render/api';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertGreaterThan, assertLessThan} from '../util/assert';
+
 import {assertLContainer} from './assert';
 import {NodeInjector, getParentInjectorLocation} from './di';
-import {addToViewTree, createEmbeddedViewAndNode, createLContainer, renderView} from './instructions/shared';
+import {addToViewTree, createLContainer, createLView, renderView} from './instructions/shared';
 import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer, VIEW_REFS} from './interfaces/container';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RComment, RElement, isProceduralRenderer} from './interfaces/renderer';
-
 import {isComponent, isLContainer, isLView, isRootView} from './interfaces/type_checks';
-import {CONTEXT, DECLARATION_LCONTAINER, LView, QUERIES, RENDERER, TView, T_HOST} from './interfaces/view';
-
+import {CONTEXT, DECLARATION_LCONTAINER, LView, LViewFlags, QUERIES, RENDERER, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode, removeView} from './node_manipulation';
 import {getParentInjectorTNode} from './node_util';
@@ -108,9 +107,9 @@ export function createTemplateRef<T>(
 
       createEmbeddedView(context: T): viewEngine_EmbeddedViewRef<T> {
         const embeddedTView = this._declarationTContainer.tViews as TView;
-        const lView = createEmbeddedViewAndNode(
-            embeddedTView, context, this._declarationView,
-            this._declarationTContainer.injectorIndex);
+        const lView = createLView(
+            this._declarationView, embeddedTView, context, LViewFlags.CheckAlways, null,
+            embeddedTView.node);
 
         const declarationLContainer = this._declarationView[this._declarationTContainer.index];
         ngDevMode && assertLContainer(declarationLContainer);

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -471,9 +471,6 @@
     "name": "assertTemplate"
   },
   {
-    "name": "assignTViewNodeToLView"
-  },
-  {
     "name": "attachPatchData"
   },
   {
@@ -535,9 +532,6 @@
   },
   {
     "name": "createElementRef"
-  },
-  {
-    "name": "createEmbeddedViewAndNode"
   },
   {
     "name": "createLContainer"


### PR DESCRIPTION
This PR removes the `firstTemplatePass` checks from the embedded view creation by observing that we can create a host `TViewNode` while creating an embedded `TView`. It also removes some code as a "side effect".

There are further optimisations (both code size and runtime perf) possible - we could delay creation of an embedded TView until  a `TemplateRef` is injected. But this move will have to wait till we get rid of JS block instructions (will be much easier to do then).