### PR TITLE
fix(platform-browser): loosen KeyEventsPlugin.addEventListener element type

### DIFF
--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -94,13 +94,13 @@ export class KeyEventsPlugin extends EventManagerPlugin {
 
   /**
    * Registers a handler for a specific element and key event.
-   * @param element The HTML element to receive event notifications.
+   * @param element The element to receive event notifications.
    * @param eventName The name of the key event to listen for.
    * @param handler A function to call when the notification occurs. Receives the
    * event object as an argument.
    * @returns The key event that was registered.
    */
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
+  addEventListener(element: Node, eventName: string, handler: Function): Function {
     const parsedEvent = KeyEventsPlugin.parseEventName(eventName)!;
 
     const outsideHandler =


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`keyEventsPlugin.addEventListener` does not accept document as first parameter according to the type. This despite the fact that the function receives [`HTMLDocument`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument) in case of `(document:keydown.escape)="..."`

## What is the new behavior?
Loosened the type of the parameter to accept [`Node`](https://developer.mozilla.org/en-US/docs/Web/API/Node), a type both [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) and [`HTMLDocument`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument) have in common. 

Alternatively, we could go with `element: HTMLElement | HTMLDocument`.

The new type `Node` is based on the most specific type I could find traversing the function, `BrowserDomAdapter.onAndCancel()`.

https://github.com/angular/angular/blob/f8096d499324cf0961f092944bbaedd05364eea1/packages/platform-browser/src/browser/browser_adapter.ts#L124

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No