### PR TITLE
refactor(language-service): Differentiate Inline and External template

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -36,7 +36,7 @@ class LanguageServiceImpl implements LanguageService {
     const results: Diagnostic[] = [];
     const templates = this.host.getTemplates(fileName);
     for (const template of templates) {
-      const ast = this.host.getTemplateAst(template, fileName);
+      const ast = this.host.getTemplateAst(template);
       results.push(...getTemplateDiagnostics(template, ast));
     }
     const declarations = this.host.getDeclarations(fileName);

--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli';
+import * as ts from 'typescript';
+import * as ng from './types';
+import {TypeScriptServiceHost} from './typescript_host';
+
+/**
+ * A base class to represent a template and which component class it is
+ * associated with. A template source could answer basic questions about
+ * top-level declarations of its class through the members() and query()
+ * methods.
+ */
+abstract class BaseTemplate implements ng.TemplateSource {
+  private readonly program: ts.Program;
+  private membersTable: ng.SymbolTable|undefined;
+  private queryCache: ng.SymbolQuery|undefined;
+
+  constructor(
+      private readonly host: TypeScriptServiceHost,
+      private readonly classDeclNode: ts.ClassDeclaration,
+      private readonly classSymbol: ng.StaticSymbol) {
+    this.program = host.program;
+  }
+
+  abstract get span(): ng.Span;
+  abstract get fileName(): string;
+  abstract get source(): string;
+
+  /**
+   * Return the Angular StaticSymbol for the class that contains this template.
+   */
+  get type() { return this.classSymbol; }
+
+  /**
+   * Return a Map-like data structure that allows users to retrieve some or all
+   * top-level declarations in the associated component class.
+   */
+  get members() {
+    if (!this.membersTable) {
+      const typeChecker = this.program.getTypeChecker();
+      const sourceFile = this.classDeclNode.getSourceFile();
+      this.membersTable =
+          getClassMembersFromDeclaration(this.program, typeChecker, sourceFile, this.classDeclNode);
+    }
+    return this.membersTable;
+  }
+
+  /**
+   * Return an engine that provides more information about symbols in the
+   * template.
+   */
+  get query() {
+    if (!this.queryCache) {
+      const program = this.program;
+      const typeChecker = program.getTypeChecker();
+      const sourceFile = this.classDeclNode.getSourceFile();
+      this.queryCache = getSymbolQuery(program, typeChecker, sourceFile, () => {
+        // Computing the ast is relatively expensive. Do it only when absolutely
+        // necessary.
+        // TODO: There is circular dependency here between TemplateSource and
+        // TypeScriptHost. Consider refactoring the code to break this cycle.
+        const ast = this.host.getTemplateAst(this);
+        return getPipesTable(sourceFile, program, typeChecker, ast.pipes || []);
+      });
+    }
+    return this.queryCache;
+  }
+}
+
+/**
+ * An InlineTemplate represents template defined in a TS file through the
+ * `template` attribute in the decorator.
+ */
+export class InlineTemplate extends BaseTemplate {
+  public readonly fileName: string;
+  public readonly source: string;
+  public readonly span: ng.Span;
+
+  constructor(
+      templateNode: ts.StringLiteralLike, classDeclNode: ts.ClassDeclaration,
+      classSymbol: ng.StaticSymbol, host: TypeScriptServiceHost) {
+    super(host, classDeclNode, classSymbol);
+    const sourceFile = templateNode.getSourceFile();
+    if (sourceFile !== classDeclNode.getSourceFile()) {
+      throw new Error(`Inline template and component class should belong to the same source file`);
+    }
+    this.fileName = sourceFile.fileName;
+    this.source = templateNode.text;
+    this.span = {
+      // TS string literal includes surrounding quotes in the start/end offsets.
+      start: templateNode.getStart() + 1,
+      end: templateNode.getEnd() - 1,
+    };
+  }
+}
+
+/**
+ * An ExternalTemplate represents template defined in an external (most likely
+ * HTML, but not necessarily) file through the `templateUrl` attribute in the
+ * decorator.
+ * Note that there is no ts.Node associated with the template because it's not
+ * a TS file.
+ */
+export class ExternalTemplate extends BaseTemplate {
+  public readonly span: ng.Span;
+
+  constructor(
+      public readonly source: string, public readonly fileName: string,
+      classDeclNode: ts.ClassDeclaration, classSymbol: ng.StaticSymbol,
+      host: TypeScriptServiceHost) {
+    super(host, classDeclNode, classSymbol);
+    this.span = {
+      start: 0,
+      end: source.length,
+    };
+  }
+}
+
+/**
+ * Given a template node, return the ClassDeclaration node that corresponds to
+ * the component class for the template.
+ *
+ * For example,
+ *
+ * @Component({
+ *   template: '<div></div>' <-- template node
+ * })
+ * class AppComponent {}
+ *           ^---- class declaration node
+ *
+ * @param node template node
+ */
+export function getClassDeclFromTemplateNode(node: ts.Node): ts.ClassDeclaration|undefined {
+  if (!ts.isStringLiteralLike(node)) {
+    return;
+  }
+  if (!node.parent || !ts.isPropertyAssignment(node.parent)) {
+    return;
+  }
+  const propAsgnNode = node.parent;
+  if (propAsgnNode.name.getText() !== 'template') {
+    return;
+  }
+  if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
+    return;
+  }
+  const objLitExprNode = propAsgnNode.parent;
+  if (!objLitExprNode.parent || !ts.isCallExpression(objLitExprNode.parent)) {
+    return;
+  }
+  const callExprNode = objLitExprNode.parent;
+  if (!callExprNode.parent || !ts.isDecorator(callExprNode.parent)) {
+    return;
+  }
+  const decorator = callExprNode.parent;
+  if (!decorator.parent || !ts.isClassDeclaration(decorator.parent)) {
+    return;
+  }
+  const classDeclNode = decorator.parent;
+  return classDeclNode;
+}

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileDirectiveMetadata, CompileMetadataResolver, CompilePipeSummary, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
+import {CompileDirectiveMetadata, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli/src/language_services';
-import * as tss from 'typescript/lib/tsserverlibrary';
 
 import {AstResult, TemplateInfo} from './common';
 
@@ -20,6 +19,7 @@ export {
   Pipes,
   Signature,
   Span,
+  StaticSymbol,
   Symbol,
   SymbolDeclaration,
   SymbolQuery,
@@ -41,16 +41,6 @@ export interface TemplateSource {
   readonly source: string;
 
   /**
-   * The version of the source. As files are modified the version should change. That is, if the
-   * `LanguageService` requesting template information for a source file and that file has changed
-   * since the last time the host was asked for the file then this version string should be
-   * different. No assumptions are made about the format of this string.
-   *
-   * The version can change more often than the source but should not change less often.
-   */
-  readonly version: string;
-
-  /**
    * The span of the template within the source file.
    */
   readonly span: Span;
@@ -69,6 +59,11 @@ export interface TemplateSource {
    * A `SymbolQuery` for the context of the template.
    */
   readonly query: SymbolQuery;
+
+  /**
+   * Name of the file that contains the template. Could be `.html` or `.ts`.
+   */
+  readonly fileName: string;
 }
 
 /**
@@ -79,7 +74,6 @@ export interface TemplateSource {
  * @publicApi
  */
 export type TemplateSources = TemplateSource[] | undefined;
-
 
 /**
  * Error information found getting declaration information
@@ -175,13 +169,6 @@ export type Declarations = Declaration[];
  */
 export interface LanguageServiceHost {
   /**
-   * Returns the template information for templates in `fileName` at the given location. If
-   * `fileName` refers to a template file then the `position` should be ignored. If the `position`
-   * is not in a template literal string then this method should return `undefined`.
-   */
-  getTemplateAt(fileName: string, position: number): TemplateSource|undefined;
-
-  /**
    * Return the template source information for all templates in `fileName` or for `fileName` if
    * it is a template file.
    */
@@ -205,7 +192,7 @@ export interface LanguageServiceHost {
   /**
    * Return the AST for both HTML and template for the contextFile.
    */
-  getTemplateAst(template: TemplateSource, contextFile: string): AstResult;
+  getTemplateAst(template: TemplateSource): AstResult;
 
   /**
    * Return the template AST for the node that corresponds to the position.
@@ -381,20 +368,20 @@ export interface LanguageService {
   /**
    * Returns a list of all error for all templates in the given file.
    */
-  getDiagnostics(fileName: string): tss.Diagnostic[];
+  getDiagnostics(fileName: string): ts.Diagnostic[];
 
   /**
    * Return the completions at the given position.
    */
-  getCompletionsAt(fileName: string, position: number): tss.CompletionInfo|undefined;
+  getCompletionsAt(fileName: string, position: number): ts.CompletionInfo|undefined;
 
   /**
    * Return the definition location for the symbol at position.
    */
-  getDefinitionAt(fileName: string, position: number): tss.DefinitionInfoAndBoundSpan|undefined;
+  getDefinitionAt(fileName: string, position: number): ts.DefinitionInfoAndBoundSpan|undefined;
 
   /**
    * Return the hover information for the symbol at position.
    */
-  getHoverAt(fileName: string, position: number): tss.QuickInfo|undefined;
+  getHoverAt(fileName: string, position: number): ts.QuickInfo|undefined;
 }

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -177,3 +177,14 @@ export function findTemplateAstAt(
 
   return new AstPath<TemplateAst>(path, position);
 }
+
+/**
+ * Return the node that most tightly encompass the specified `position`.
+ * @param node
+ * @param position
+ */
+export function findTighestNode(node: ts.Node, position: number): ts.Node|undefined {
+  if (node.getStart() <= position && position < node.getEnd()) {
+    return node.forEachChild(c => findTighestNode(c, position)) || node;
+  }
+}

--- a/packages/language-service/test/template_spec.ts
+++ b/packages/language-service/test/template_spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+import {getClassDeclFromTemplateNode} from '../src/template';
+import {toh} from './test_data';
+import {MockTypescriptHost} from './test_utils';
+
+describe('getClassDeclFromTemplateNode', () => {
+  it('should return class declaration', () => {
+    const host = new MockTypescriptHost(['/app/app.component.ts'], toh);
+    const tsLS = ts.createLanguageService(host);
+    const sourceFile = tsLS.getProgram() !.getSourceFile('/app/app.component.ts');
+    expect(sourceFile).toBeTruthy();
+    const classDecl = sourceFile !.forEachChild(function visit(node): ts.Node | undefined {
+      const candidate = getClassDeclFromTemplateNode(node);
+      if (candidate) {
+        return candidate;
+      }
+      return node.forEachChild(visit);
+    });
+    expect(classDecl).toBeTruthy();
+    expect(ts.isClassDeclaration(classDecl !)).toBe(true);
+    expect((classDecl as ts.ClassDeclaration).name !.text).toBe('AppComponent');
+  });
+});

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -66,4 +66,33 @@ describe('TypeScriptServiceHost', () => {
       ngLSHost.getSourceFile('/src/test.ng');
     }).toThrowError('Non-TS source file requested: /src/test.ng');
   });
+
+  it('should be able to find a single inline template', () => {
+    const tsLSHost = new MockTypescriptHost(['/app/app.component.ts'], toh);
+    const tsLS = ts.createLanguageService(tsLSHost);
+    const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+    const templates = ngLSHost.getTemplates('/app/app.component.ts');
+    expect(templates.length).toBe(1);
+    const template = templates[0];
+    expect(template.source).toContain('<h2>{{hero.name}} details!</h2>');
+  });
+
+  it('should be able to find multiple inline templates', () => {
+    const tsLSHost = new MockTypescriptHost(['/app/parsing-cases.ts'], toh);
+    const tsLS = ts.createLanguageService(tsLSHost);
+    const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+    const templates = ngLSHost.getTemplates('/app/parsing-cases.ts');
+    expect(templates.length).toBe(16);
+  });
+
+  it('should be able to find external template', () => {
+    const tsLSHost = new MockTypescriptHost(['/app/main.ts'], toh);
+    const tsLS = ts.createLanguageService(tsLSHost);
+    const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+    ngLSHost.getAnalyzedModules();
+    const templates = ngLSHost.getTemplates('/app/test.ng');
+    expect(templates.length).toBe(1);
+    const template = templates[0];
+    expect(template.source).toContain('<h2>{{hero.name}} details!</h2>');
+  });
 });


### PR DESCRIPTION
This commit creates two concrete classes Inline and External
TemplateSource to differentiate between templates in TS file and
HTML file.
Knowing the template type makes the code much more explicit which
filetype we are dealing with.

With these two classes, there is no need for `getTemplateAt()` method in
TypeScriptHost. Removing this method is safe since it is not used in the
extension. This reduces the API surface of TypescriptHost.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
