### PR TITLE
Two ngcc fixes

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 
 import {ReferencesRegistry} from '../../../src/ngtsc/annotations';
 import {Reference} from '../../../src/ngtsc/imports';
-import {ClassDeclaration, Declaration} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ConcreteDeclaration} from '../../../src/ngtsc/reflection';
 import {ModuleWithProvidersFunction, NgccReflectionHost} from '../host/ngcc_host';
 import {hasNameIdentifier, isDefined} from '../utils';
 
@@ -23,7 +23,7 @@ export interface ModuleWithProvidersInfo {
   /**
    * The NgModule class declaration (in the .d.ts file) to add as a type parameter.
    */
-  ngModule: Declaration<ClassDeclaration>;
+  ngModule: ConcreteDeclaration<ClassDeclaration>;
 }
 
 export type ModuleWithProvidersAnalyses = Map<ts.SourceFile, ModuleWithProvidersInfo[]>;

--- a/packages/compiler-cli/ngcc/src/analysis/ngcc_references_registry.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/ngcc_references_registry.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 import {ReferencesRegistry} from '../../../src/ngtsc/annotations';
 import {Reference} from '../../../src/ngtsc/imports';
-import {Declaration, ReflectionHost} from '../../../src/ngtsc/reflection';
+import {ConcreteDeclaration, ReflectionHost} from '../../../src/ngtsc/reflection';
 import {hasNameIdentifier} from '../utils';
 
 /**
@@ -20,7 +20,7 @@ import {hasNameIdentifier} from '../utils';
  * from libraries that are compiled by ngcc.
  */
 export class NgccReferencesRegistry implements ReferencesRegistry {
-  private map = new Map<ts.Identifier, Declaration>();
+  private map = new Map<ts.Identifier, ConcreteDeclaration>();
 
   constructor(private host: ReflectionHost) {}
 
@@ -34,7 +34,7 @@ export class NgccReferencesRegistry implements ReferencesRegistry {
       // Only store relative references. We are not interested in literals.
       if (ref.bestGuessOwningModule === null && hasNameIdentifier(ref.node)) {
         const declaration = this.host.getDeclarationOfIdentifier(ref.node.name);
-        if (declaration && hasNameIdentifier(declaration.node)) {
+        if (declaration && declaration.node !== null && hasNameIdentifier(declaration.node)) {
           this.map.set(declaration.node.name, declaration);
         }
       }
@@ -45,5 +45,5 @@ export class NgccReferencesRegistry implements ReferencesRegistry {
    * Create and return a mapping for the registered resolved references.
    * @returns A map of reference identifiers to reference declarations.
    */
-  getDeclarationMap(): Map<ts.Identifier, Declaration> { return this.map; }
+  getDeclarationMap(): Map<ts.Identifier, ConcreteDeclaration> { return this.map; }
 }

--- a/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
@@ -8,7 +8,7 @@
 import * as ts from 'typescript';
 
 import {AbsoluteFsPath, absoluteFromSourceFile} from '../../../src/ngtsc/file_system';
-import {Declaration} from '../../../src/ngtsc/reflection';
+import {ConcreteDeclaration} from '../../../src/ngtsc/reflection';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {hasNameIdentifier, isDefined} from '../utils';
 import {NgccReferencesRegistry} from './ngcc_references_registry';
@@ -40,15 +40,15 @@ export class PrivateDeclarationsAnalyzer {
 
   private getPrivateDeclarations(
       rootFiles: ts.SourceFile[],
-      declarations: Map<ts.Identifier, Declaration>): PrivateDeclarationsAnalyses {
-    const privateDeclarations: Map<ts.Identifier, Declaration> = new Map(declarations);
+      declarations: Map<ts.Identifier, ConcreteDeclaration>): PrivateDeclarationsAnalyses {
+    const privateDeclarations: Map<ts.Identifier, ConcreteDeclaration> = new Map(declarations);
     const exportAliasDeclarations: Map<ts.Identifier, string> = new Map();
 
     rootFiles.forEach(f => {
       const exports = this.host.getExportsOfModule(f);
       if (exports) {
         exports.forEach((declaration, exportedName) => {
-          if (hasNameIdentifier(declaration.node)) {
+          if (declaration.node !== null && hasNameIdentifier(declaration.node)) {
             if (privateDeclarations.has(declaration.node.name)) {
               const privateDeclaration = privateDeclarations.get(declaration.node.name) !;
               if (privateDeclaration.node !== declaration.node) {

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
-import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, CtorParameter, Declaration, Decorator, TypeScriptReflectionHost, isDecoratorIdentifier, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, ClassSymbol, ConcreteDeclaration, CtorParameter, Declaration, Decorator, TypeScriptReflectionHost, isDecoratorIdentifier, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined, stripDollarSuffix} from '../utils';
@@ -243,7 +243,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
     // The identifier may have been of an additional class assignment such as `MyClass_1` that was
     // present as alias for `MyClass`. If so, resolve such aliases to their original declaration.
-    if (superDeclaration !== null) {
+    if (superDeclaration !== null && superDeclaration.node !== null) {
       const aliasedIdentifier = this.resolveAliasedClassIdentifier(superDeclaration.node);
       if (aliasedIdentifier !== null) {
         return this.getDeclarationOfIdentifier(aliasedIdentifier);
@@ -409,6 +409,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     if (!exports) return [];
     const infos: ModuleWithProvidersFunction[] = [];
     exports.forEach((declaration, name) => {
+      if (declaration.node === null) {
+        return;
+      }
       if (this.isClass(declaration.node)) {
         this.getMembersOfClass(declaration.node).forEach(member => {
           if (member.isStatic) {
@@ -497,7 +500,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     const aliasedIdentifier = initializer.left;
 
     const aliasedDeclaration = this.getDeclarationOfIdentifier(aliasedIdentifier);
-    if (aliasedDeclaration === null) {
+    if (aliasedDeclaration === null || aliasedDeclaration.node === null) {
       throw new Error(
           `Unable to locate declaration of ${aliasedIdentifier.text} in "${statement.getText()}"`);
     }
@@ -1407,7 +1410,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     }
 
     const ngModuleDeclaration = this.getDeclarationOfExpression(ngModuleValue);
-    if (!ngModuleDeclaration) {
+    if (!ngModuleDeclaration || ngModuleDeclaration.node === null) {
       throw new Error(
           `Cannot find a declaration for NgModule ${ngModuleValue.getText()} referenced in "${declaration!.getText()}"`);
     }
@@ -1416,7 +1419,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     }
     return {
       name,
-      ngModule: ngModuleDeclaration as Declaration<ClassDeclaration>, declaration, container
+      ngModule: ngModuleDeclaration as ConcreteDeclaration<ClassDeclaration>, declaration, container
     };
   }
 
@@ -1430,7 +1433,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     }
 
     const namespaceDecl = this.getDeclarationOfIdentifier(expression.expression);
-    if (!namespaceDecl || !ts.isSourceFile(namespaceDecl.node)) {
+    if (!namespaceDecl || namespaceDecl.node === null || !ts.isSourceFile(namespaceDecl.node)) {
       return null;
     }
 

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -140,7 +140,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
     const outerClassNode = getClassDeclarationFromInnerFunctionDeclaration(id.parent);
     const declaration = super.getDeclarationOfIdentifier(outerClassNode ? outerClassNode.name : id);
 
-    if (!declaration || !ts.isVariableDeclaration(declaration.node) ||
+    if (!declaration || declaration.node === null || !ts.isVariableDeclaration(declaration.node) ||
         declaration.node.initializer !== undefined ||
         // VariableDeclaration => VariableDeclarationList => VariableStatement => IIFE Block
         !ts.isBlock(declaration.node.parent.parent.parent)) {

--- a/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {ClassDeclaration, ClassSymbol, Declaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
+
+import {ClassDeclaration, ClassSymbol, ConcreteDeclaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
 
 export const PRE_R3_MARKER = '__PRE_R3__';
 export const POST_R3_MARKER = '__POST_R3__';
@@ -39,7 +40,7 @@ export interface ModuleWithProvidersFunction {
    * The declaration of the class that the `ngModule` property on the `ModuleWithProviders` object
    * refers to.
    */
-  ngModule: Declaration<ClassDeclaration>;
+  ngModule: ConcreteDeclaration<ClassDeclaration>;
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
@@ -72,7 +72,7 @@ export class UndecoratedParentMigration implements Migration {
     }
 
     const baseClazz = host.reflectionHost.getDeclarationOfIdentifier(baseClassExpr) !.node;
-    if (!isClassDeclaration(baseClazz)) {
+    if (baseClazz === null || !isClassDeclaration(baseClazz)) {
       return null;
     }
 

--- a/packages/compiler-cli/ngcc/src/packages/bundle_program.ts
+++ b/packages/compiler-cli/ngcc/src/packages/bundle_program.ts
@@ -23,6 +23,7 @@ export interface BundleProgram {
   host: ts.CompilerHost;
   path: AbsoluteFsPath;
   file: ts.SourceFile;
+  package: AbsoluteFsPath;
   r3SymbolsPath: AbsoluteFsPath|null;
   r3SymbolsFile: ts.SourceFile|null;
 }
@@ -31,7 +32,7 @@ export interface BundleProgram {
  * Create a bundle program.
  */
 export function makeBundleProgram(
-    fs: FileSystem, isCore: boolean, path: AbsoluteFsPath, r3FileName: string,
+    fs: FileSystem, isCore: boolean, pkg: AbsoluteFsPath, path: AbsoluteFsPath, r3FileName: string,
     options: ts.CompilerOptions, host: ts.CompilerHost,
     additionalFiles: AbsoluteFsPath[] = []): BundleProgram {
   const r3SymbolsPath = isCore ? findR3SymbolsPath(fs, dirname(path), r3FileName) : null;
@@ -48,7 +49,7 @@ export function makeBundleProgram(
   const file = program.getSourceFile(path) !;
   const r3SymbolsFile = r3SymbolsPath && program.getSourceFile(r3SymbolsPath) || null;
 
-  return {program, options, host, path, file, r3SymbolsPath, r3SymbolsFile};
+  return {program, options, host, package: pkg, path, file, r3SymbolsPath, r3SymbolsFile};
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -57,14 +57,15 @@ export function makeEntryPointBundle(
   // Create the bundle programs, as necessary.
   const absFormatPath = fs.resolve(entryPoint.path, formatPath);
   const typingsPath = fs.resolve(entryPoint.path, entryPoint.typings);
-  const src = makeBundleProgram(fs, isCore, absFormatPath, 'r3_symbols.js', options, srcHost);
+  const src = makeBundleProgram(
+      fs, isCore, entryPoint.package, absFormatPath, 'r3_symbols.js', options, srcHost);
   const additionalDtsFiles = transformDts && mirrorDtsFromSrc ?
       computePotentialDtsFilesFromJsFiles(fs, src.program, absFormatPath, typingsPath) :
       [];
-  const dts = transformDts ?
-      makeBundleProgram(
-          fs, isCore, typingsPath, 'r3_symbols.d.ts', options, dtsHost, additionalDtsFiles) :
-      null;
+  const dts = transformDts ? makeBundleProgram(
+                                 fs, isCore, entryPoint.package, typingsPath, 'r3_symbols.d.ts',
+                                 options, dtsHost, additionalDtsFiles) :
+                             null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
 
   return {entryPoint, format, rootDirs, isCore, isFlatCore, src, dts};

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -36,28 +36,31 @@ export function makeTestEntryPointBundle(
     dtsRootNames?: AbsoluteFsPath[]): EntryPointBundle {
   const entryPoint = makeTestEntryPoint(packageName);
   const src = makeTestBundleProgram(srcRootNames[0], isCore);
-  const dts = dtsRootNames ? makeTestDtsBundleProgram(dtsRootNames[0], isCore) : null;
+  const dts =
+      dtsRootNames ? makeTestDtsBundleProgram(dtsRootNames[0], entryPoint.package, isCore) : null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
   return {entryPoint, format, rootDirs: [absoluteFrom('/')], src, dts, isCore, isFlatCore};
 }
 
 export function makeTestBundleProgram(
-    path: AbsoluteFsPath, isCore: boolean = false): BundleProgram {
+    path: AbsoluteFsPath, isCore: boolean = false,
+    additionalFiles?: AbsoluteFsPath[]): BundleProgram {
   const fs = getFileSystem();
   const entryPointPath = fs.dirname(path);
   const rootDir = fs.dirname(entryPointPath);
   const options: ts.CompilerOptions =
       {allowJs: true, maxNodeModuleJsDepth: Infinity, checkJs: false, rootDir, rootDirs: [rootDir]};
   const host = new NgccSourcesCompilerHost(fs, options, entryPointPath);
-  return makeBundleProgram(fs, isCore, path, 'r3_symbols.js', options, host);
+  return makeBundleProgram(
+      fs, isCore, rootDir, path, 'r3_symbols.js', options, host, additionalFiles);
 }
 
 export function makeTestDtsBundleProgram(
-    path: AbsoluteFsPath, isCore: boolean = false): BundleProgram {
+    path: AbsoluteFsPath, packagePath: AbsoluteFsPath, isCore: boolean = false): BundleProgram {
   const fs = getFileSystem();
   const options = {};
   const host = new NgtscCompilerHost(fs, options);
-  return makeBundleProgram(fs, isCore, path, 'r3_symbols.d.ts', options, host);
+  return makeBundleProgram(fs, isCore, packagePath, path, 'r3_symbols.d.ts', options, host);
 }
 
 export function convertToDirectTsLibImport(filesystem: TestFile[]) {

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, Import, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, CtorParameter, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
@@ -31,6 +31,7 @@ runInEachFileSystem(() => {
     let SIMPLE_ES2015_CLASS_FILE: TestFile;
     let SIMPLE_CLASS_FILE: TestFile;
     let FOO_FUNCTION_FILE: TestFile;
+    let INLINE_EXPORT_FILE: TestFile;
     let INVALID_DECORATORS_FILE: TestFile;
     let INVALID_DECORATOR_ARGS_FILE: TestFile;
     let INVALID_PROP_DECORATORS_FILE: TestFile;
@@ -161,6 +162,18 @@ foo.decorators = [
   { type: core.Directive, args: [{ selector: '[ignored]' },] }
 ];
 exports.foo = foo;
+`,
+      };
+
+      INLINE_EXPORT_FILE = {
+        name: _('/inline_export.js'),
+        contents: `
+var core = require('@angular/core');
+function foo() {}
+foo.decorators = [
+  { type: core.Directive, args: [{ selector: '[ignored]' },] }
+];
+exports.directives = [foo];
 `,
       };
 
@@ -1629,7 +1642,7 @@ exports.ExternalModule = ExternalModule;
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())
-                     .map(entry => [entry[0], entry[1].node.getText(), entry[1].viaModule]))
+                     .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
               .toEqual([
                 ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
                 ['a', `a = 'a'`, './a_module'],
@@ -1655,7 +1668,7 @@ exports.ExternalModule = ExternalModule;
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())
-                     .map(entry => [entry[0], entry[1].node.getText(), entry[1].viaModule]))
+                     .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
               .toEqual([
                 ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
                 ['a', `a = 'a'`, _('/b_module')],
@@ -1672,6 +1685,19 @@ exports.ExternalModule = ExternalModule;
                 ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
                 ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
               ]);
+        });
+
+        it('should handle inline exports', () => {
+          loadTestFiles([INLINE_EXPORT_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(_('/inline_export.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const file = getSourceFileOrError(program, _('/inline_export.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBeNull();
+          const decl = exportDeclarations !.get('directives') as InlineDeclaration;
+          expect(decl).not.toBeUndefined();
+          expect(decl.node).toBeNull();
+          expect(decl.expression).toBeDefined();
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1992,7 +1992,7 @@ exports.ExternalModule = ExternalModule;
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
              const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const class1 =
                  getDeclaration(program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
              const host =
@@ -2006,7 +2006,7 @@ exports.ExternalModule = ExternalModule;
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const mooFn =
               getDeclaration(program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
           const host =
@@ -2019,7 +2019,7 @@ exports.ExternalModule = ExternalModule;
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const missingClass = getDeclaration(
               program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
           const host =
@@ -2032,7 +2032,7 @@ exports.ExternalModule = ExternalModule;
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const missingClass = getDeclaration(
               program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
           const host =
@@ -2046,7 +2046,7 @@ exports.ExternalModule = ExternalModule;
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
              const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const class1 = getDeclaration(
                  program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
              const host =
@@ -2060,7 +2060,7 @@ exports.ExternalModule = ExternalModule;
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+          const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const class3 =
               getDeclaration(program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
           const host =
@@ -2075,7 +2075,7 @@ exports.ExternalModule = ExternalModule;
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
              const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const internalClass = getDeclaration(
                  program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
              const host =
@@ -2090,7 +2090,7 @@ exports.ExternalModule = ExternalModule;
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
              const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'));
+             const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const class2 =
                  getDeclaration(program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
              const internalClass2 =

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -1538,8 +1538,9 @@ runInEachFileSystem(() => {
           'SomeClass',
         ]);
 
-        const values = Array.from(exportDeclarations !.values())
-                           .map(declaration => [declaration.node.getText(), declaration.viaModule]);
+        const values =
+            Array.from(exportDeclarations !.values())
+                .map(declaration => [declaration.node !.getText(), declaration.viaModule]);
         expect(values).toEqual([
           [`Directive: FnWithArg<(clazz: any) => any>`, null],
           [`a = 'a'`, null],

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -399,7 +399,7 @@ export { SomeDirective };
 
             const declaration = host.getDeclarationOfIdentifier(ngModuleRef !);
             expect(declaration).not.toBe(null);
-            expect(declaration !.node.getText()).toContain('function HttpClientXsrfModule()');
+            expect(declaration !.node !.getText()).toContain('function HttpClientXsrfModule()');
           });
         });
         describe('getVariableValue', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1842,8 +1842,9 @@ runInEachFileSystem(() => {
           'SomeClass',
         ]);
 
-        const values = Array.from(exportDeclarations !.values())
-                           .map(declaration => [declaration.node.getText(), declaration.viaModule]);
+        const values =
+            Array.from(exportDeclarations !.values())
+                .map(declaration => [declaration.node !.getText(), declaration.viaModule]);
         expect(values).toEqual([
           [`Directive: FnWithArg<(clazz: any) => any>`, null],
           [`a = 'a'`, null],

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1741,7 +1741,7 @@ runInEachFileSystem(() => {
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())
-                     .map(entry => [entry[0], entry[1].node.getText(), entry[1].viaModule]))
+                     .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
               .toEqual([
                 ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
                 ['a', `a = 'a'`, '/a_module'],

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -176,7 +176,13 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
       return null;
     }
     const exportMap = new Map<ts.Declaration, string>();
-    exports.forEach((declaration, name) => { exportMap.set(declaration.node, name); });
+    exports.forEach((declaration, name) => {
+      // It's okay to skip inline declarations, since by definition they're not target-able with a
+      // ts.Declaration anyway.
+      if (declaration.node !== null) {
+        exportMap.set(declaration.node, name);
+      }
+    });
     return exportMap;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -342,28 +342,65 @@ export interface Import {
 }
 
 /**
- * The declaration of a symbol, along with information about how it was imported into the
- * application.
+ * Base type for all `Declaration`s.
  */
-export interface Declaration<T extends ts.Declaration = ts.Declaration> {
-  /**
-   * TypeScript reference to the declaration itself.
-   */
-  node: T;
-
+export interface BaseDeclaration<T extends ts.Declaration = ts.Declaration> {
   /**
    * The absolute module path from which the symbol was imported into the application, if the symbol
    * was imported via an absolute module (even through a chain of re-exports). If the symbol is part
    * of the application and was not imported from an absolute path, this will be `null`.
    */
   viaModule: string|null;
+
+  /**
+   * TypeScript reference to the declaration itself, if one exists.
+   */
+  node: T|null;
 }
+
+/**
+ * A declaration that has an associated TypeScript `ts.Declaration`.
+ *
+ * The alternative is an `InlineDeclaration`.
+ */
+export interface ConcreteDeclaration<T extends ts.Declaration = ts.Declaration> extends
+    BaseDeclaration<T> {
+  node: T;
+}
+
+/**
+ * A declaration that does not have an associated TypeScript `ts.Declaration`, only a
+ * `ts.Expression`.
+ *
+ * This can occur in some downlevelings when an `export const VAR = ...;` (a `ts.Declaration`) is
+ * transpiled to an assignment statement (e.g. `exports.VAR = ...;`). There is no `ts.Declaration`
+ * associated with `VAR` in that case, only an expression.
+ */
+export interface InlineDeclaration extends BaseDeclaration {
+  node: null;
+
+  /**
+   * The `ts.Expression` which constitutes the value of the declaration.
+   */
+  expression: ts.Expression;
+}
+
+/**
+ * The declaration of a symbol, along with information about how it was imported into the
+ * application.
+ *
+ * This can either be a `ConcreteDeclaration` if the underlying TypeScript node for the symbol is an
+ * actual `ts.Declaration`, or an `InlineDeclaration` if the declaration was transpiled in certain
+ * downlevelings to a `ts.Expression` instead.
+ */
+export type Declaration<T extends ts.Declaration = ts.Declaration> =
+    ConcreteDeclaration<T>| InlineDeclaration;
 
 /**
  * Abstracts reflection operations on a TypeScript AST.
  *
- * Depending on the format of the code being interpreted, different concepts are represented with
- * different syntactical structures. The `ReflectionHost` abstracts over those differences and
+ * Depending on the format of the code being interpreted, different concepts are represented
+ * with different syntactical structures. The `ReflectionHost` abstracts over those differences and
  * presents a single API by which the compiler can query specific information about the AST.
  *
  * All operations on the `ReflectionHost` require the use of TypeScript `ts.Node`s with binding

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -307,8 +307,9 @@ runInEachFileSystem(() => {
         } else if (directTargetDecl === null) {
           return fail('No declaration found for DirectTarget');
         }
-        expect(targetDecl.node.getSourceFile().fileName).toBe(_('/node_modules/absolute/index.ts'));
-        expect(ts.isClassDeclaration(targetDecl.node)).toBe(true);
+        expect(targetDecl.node !.getSourceFile().fileName)
+            .toBe(_('/node_modules/absolute/index.ts'));
+        expect(ts.isClassDeclaration(targetDecl.node !)).toBe(true);
         expect(directTargetDecl.viaModule).toBe('absolute');
         expect(directTargetDecl.node).toBe(targetDecl.node);
       });


### PR DESCRIPTION
This PR fixes two ngcc bugs:

* Some downlevelings of `export const DIRECTIVES = [...]` eliminate the `ts.Declaration`, causing ngcc to not enumerate them when listing the exports of a module.
* `.d.ts` files outside of the currently compiling package were indexed and used to match classes in the package. If such a `.d.ts` file shadowed the name of a class within the compilation, it could erroneously be targeted for editing.

With these changes, ngcc can compile `nativescript-angular`!