### PR TITLE
Hooks refactor

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 13164,
+        "main": 13411,
         "polyfills": 45340
       }
     }

--- a/packages/core/src/render3/instructions/select.ts
+++ b/packages/core/src/render3/instructions/select.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {assertGreaterThan, assertLessThan} from '../../util/assert';
+import {assertDataInRange, assertGreaterThan} from '../../util/assert';
 import {executePreOrderHooks} from '../hooks';
 import {HEADER_OFFSET, LView, TVIEW} from '../interfaces/view';
 import {getCheckNoChangesMode, getLView, setSelectedIndex} from '../state';
@@ -33,18 +33,15 @@ import {getCheckNoChangesMode, getLView, setSelectedIndex} from '../state';
  * @codeGenApi
  */
 export function ɵɵselect(index: number): void {
-  ngDevMode && assertGreaterThan(index, -1, 'Invalid index');
-  ngDevMode &&
-      assertLessThan(
-          index, getLView().length - HEADER_OFFSET, 'Should be within range for the view data');
-  const lView = getLView();
-  selectInternal(lView, index);
+  selectInternal(getLView(), index, getCheckNoChangesMode());
 }
 
+export function selectInternal(lView: LView, index: number, checkNoChangesMode: boolean) {
+  ngDevMode && assertGreaterThan(index, -1, 'Invalid index');
+  ngDevMode && assertDataInRange(lView, index + HEADER_OFFSET);
 
-export function selectInternal(lView: LView, index: number) {
   // Flush the initial hooks for elements in the view that have been added up to this point.
-  executePreOrderHooks(lView, lView[TVIEW], getCheckNoChangesMode(), index);
+  executePreOrderHooks(lView, lView[TVIEW], checkNoChangesMode, index);
 
   // We must set the selected index *after* running the hooks, because hooks may have side-effects
   // that cause other template functions to run, thus updating the selected index, which is global

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -452,10 +452,10 @@ function executeTemplate<T>(
   const prevSelectedIndex = getSelectedIndex();
   try {
     setActiveHostElement(null);
-    if (rf & RenderFlags.Update) {
+    if (rf & RenderFlags.Update && lView.length > HEADER_OFFSET) {
       // When we're updating, have an inherent ɵɵselect(0) so we don't have to generate that
       // instruction for most update blocks
-      selectInternal(lView, 0);
+      selectInternal(lView, 0, getCheckNoChangesMode());
     }
     templateFn(rf, context);
   } finally {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -252,13 +252,13 @@
     "name": "enterView"
   },
   {
+    "name": "executeCheckHooks"
+  },
+  {
     "name": "executeContentQueries"
   },
   {
-    "name": "executeHooks"
-  },
-  {
-    "name": "executePreOrderHooks"
+    "name": "executeInitAndCheckHooks"
   },
   {
     "name": "executeTemplate"
@@ -415,6 +415,9 @@
   },
   {
     "name": "incrementActiveDirectiveId"
+  },
+  {
+    "name": "incrementInitPhaseFlags"
   },
   {
     "name": "initNodeFlags"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -210,10 +210,10 @@
     "name": "enterView"
   },
   {
-    "name": "executeHooks"
+    "name": "executeCheckHooks"
   },
   {
-    "name": "executePreOrderHooks"
+    "name": "executeInitAndCheckHooks"
   },
   {
     "name": "executeTemplate"
@@ -322,6 +322,9 @@
   },
   {
     "name": "incrementActiveDirectiveId"
+  },
+  {
+    "name": "incrementInitPhaseFlags"
   },
   {
     "name": "initNodeFlags"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -633,19 +633,19 @@
     "name": "enterView"
   },
   {
+    "name": "executeCheckHooks"
+  },
+  {
     "name": "executeContentQueries"
   },
   {
-    "name": "executeHooks"
+    "name": "executeInitAndCheckHooks"
   },
   {
     "name": "executeListenerWithErrorHandling"
   },
   {
     "name": "executeOnDestroys"
-  },
-  {
-    "name": "executePreOrderHooks"
   },
   {
     "name": "executeTemplate"
@@ -937,6 +937,9 @@
   },
   {
     "name": "incrementActiveDirectiveId"
+  },
+  {
+    "name": "incrementInitPhaseFlags"
   },
   {
     "name": "initNodeFlags"


### PR DESCRIPTION
This PR splits hooks processing functions into:
- init-specific (slower but less common);
- check-specific (faster and more common).

On a local machine this change speeds up the `noop_change_detection` micro-benchmark from ~1.7s down to ~0.8s (x2 improvement).

Check individual commit messages for more details.