### PR TITLE
build(docs-infra): upgrade cli command docs sources to 43fc440c0

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-with-ivy": "yarn ~~build",
     "prebuild-with-ivy-ci": "yarn setup-local --no-build-packages && node scripts/switch-to-ivy",
     "build-with-ivy-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js de49294bf",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 43fc440c0",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#8.2.x](https://github.com/angular/angular/tree/8.2.x) from [cli-builds#8.2.x](https://github.com/angular/cli-builds/tree/8.2.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/de49294bf...43fc440c0):

**Modified**
- help/serve.json

##