### PR TITLE
refactor(language-service): Omit typechecking for finding directives

### DIFF
--- a/packages/language-service/test/template_spec.ts
+++ b/packages/language-service/test/template_spec.ts
@@ -12,7 +12,26 @@ import {toh} from './test_data';
 import {MockTypescriptHost} from './test_utils';
 
 describe('getClassDeclFromTemplateNode', () => {
-  it('should return class declaration', () => {
+
+  it('should find class declaration in syntax-only mode', () => {
+    const sourceFile = ts.createSourceFile(
+        'foo.ts', `
+        @Component({
+          template: '<div></div>'
+        })
+        class MyComponent {}`,
+        ts.ScriptTarget.ES2015, true /* setParentNodes */);
+    function visit(node: ts.Node): ts.ClassDeclaration|undefined {
+      return getClassDeclFromTemplateNode(node) || node.forEachChild(visit);
+    }
+    const classDecl = sourceFile.forEachChild(visit);
+    expect(classDecl).toBeTruthy();
+    expect(classDecl !.kind).toBe(ts.SyntaxKind.ClassDeclaration);
+    expect((classDecl as ts.ClassDeclaration).name !.text).toBe('MyComponent');
+  });
+
+
+  it('should return class declaration for AppComponent', () => {
     const host = new MockTypescriptHost(['/app/app.component.ts'], toh);
     const tsLS = ts.createLanguageService(host);
     const sourceFile = tsLS.getProgram() !.getSourceFile('/app/app.component.ts');

--- a/packages/language-service/test/utils_spec.ts
+++ b/packages/language-service/test/utils_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+import {getDirectiveClassLike} from '../src/utils';
+
+describe('getDirectiveClassLike()', () => {
+  it('should return a directive class', () => {
+    const sourceFile = ts.createSourceFile(
+        'foo.ts', `
+      @NgModule({
+        declarations: [],
+      })
+      class AppModule {}
+    `,
+        ts.ScriptTarget.ES2015);
+    const result = sourceFile.forEachChild(c => {
+      const directive = getDirectiveClassLike(c);
+      if (directive) {
+        return directive;
+      }
+    });
+    expect(result).toBeTruthy();
+    const {decoratorId, classDecl} = result !;
+    expect(decoratorId.kind).toBe(ts.SyntaxKind.Identifier);
+    expect((decoratorId as ts.Identifier).text).toBe('NgModule');
+    expect(classDecl.name !.text).toBe('AppModule');
+  });
+});


### PR DESCRIPTION
Remove unnecessary private method `getDeclarationFromNode` and moved
some logic to utils instead so that it can be tested in isolation of the
Language Service infrastructure.
The use of typechecker to check the directive is also not necessary,
since `resolver.getNonNormalizedDirectiveMetadata()` will check if the
directive is actually an Angular entity.

Misc:
- Fixed typo for `getTightestNode()`
- Added extra test for `getClassDeclFromTemplateNode()`


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
