### PR TITLE
perf(ivy): avoid for-of loops at runtime

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -95,7 +95,8 @@ export function ɵɵInheritDefinitionFeature(definition: DirectiveDef<any>| Comp
       // Run parent features
       const features = superDef.features;
       if (features) {
-        for (const feature of features) {
+        for (let i = 0; i < features.length; i++) {
+          const feature = features[i];
           if (feature && feature.ngInherit) {
             (feature as DirectiveDefFeature)(definition);
           }

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -91,13 +91,13 @@ class TQueries_ implements TQueries {
   elementStart(tView: TView, tNode: TNode): void {
     ngDevMode && assertFirstTemplatePass(
                      tView, 'Queries should collect results on the first template pass only');
-    for (let query of this.queries) {
-      query.elementStart(tView, tNode);
+    for (let i = 0; i < this.queries.length; i++) {
+      this.queries[i].elementStart(tView, tNode);
     }
   }
   elementEnd(tNode: TNode): void {
-    for (let query of this.queries) {
-      query.elementEnd(tNode);
+    for (let i = 0; i < this.queries.length; i++) {
+      this.queries[i].elementEnd(tNode);
     }
   }
   embeddedTView(tNode: TNode): TQueries|null {
@@ -123,8 +123,8 @@ class TQueries_ implements TQueries {
   template(tView: TView, tNode: TNode): void {
     ngDevMode && assertFirstTemplatePass(
                      tView, 'Queries should collect results on the first template pass only');
-    for (let query of this.queries) {
-      query.template(tView, tNode);
+    for (let i = 0; i < this.queries.length; i++) {
+      this.queries[i].template(tView, tNode);
     }
   }
 
@@ -367,8 +367,9 @@ function collectQueryResults<T>(lView: LView, queryIndex: number, result: T[]): 
         // collect matches for views created from this declaration container and inserted into
         // different containers
         if (declarationLContainer[MOVED_VIEWS] !== null) {
-          for (let embeddedLView of declarationLContainer[MOVED_VIEWS] !) {
-            collectQueryResults(embeddedLView, childQueryIndex, result);
+          const embeddedLViews = declarationLContainer[MOVED_VIEWS] !;
+          for (let i = 0; i < embeddedLViews.length; i++) {
+            collectQueryResults(embeddedLViews[i], childQueryIndex, result);
           }
         }
       }


### PR DESCRIPTION
TypeScript downlevels `for-of` loops for ES5 targets. As a result, generated output contains extra code, including a try-catch block, which has code size and performance implications. This is especially important for runtime code where we want to keep it as small as possible. This commit changes `for-of` loops in runtime code to regular `for` loops.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: performance improvement.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No