### PR TITLE
Tslib as peerDependency

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -12,11 +12,9 @@
   "typings": "./animations.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,13 +12,11 @@
   "typings": "./common.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "locales": "locales",
   "peerDependencies": {
     "rxjs": "^6.5.3",
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -19,11 +19,11 @@
     "magic-string": "^0.25.0",
     "semver": "^6.3.0",
     "source-map": "^0.6.1",
-    "tslib": "^1.9.0",
     "yargs": "13.1.0"
   },
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0",
     "typescript": ">=3.4 <3.6"
   },
   "engines": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -12,7 +12,7 @@
   "typings": "./compiler.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "tslib": "^1.9.0"
   },
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,11 +12,9 @@
   "typings": "./core.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "rxjs": "^6.5.3",
+    "tslib": "^1.9.0",
     "zone.js": "~0.10.2"
   },
   "repository": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -12,13 +12,11 @@
   "typings": "./elements.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.5.3"
+    "rxjs": "^6.5.3",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -12,14 +12,12 @@
   "typings": "./forms.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
-    "rxjs": "^6.5.3",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "rxjs": "^6.5.3",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -12,13 +12,11 @@
   "typings": "./http.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
-    "rxjs": "^6.5.3",
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "rxjs": "^6.5.3",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -12,14 +12,12 @@
   "typings": "./platform-browser-dynamic.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -12,12 +12,10 @@
   "typings": "./platform-browser.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/common": "0.0.0-PLACEHOLDER"
+    "@angular/common": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -18,11 +18,11 @@
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "dependencies": {
     "domino": "^2.1.2",
-    "tslib": "^1.9.0",
     "xhr2": "^0.1.4"
   },
   "repository": {

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -12,15 +12,13 @@
   "typings": "./platform-webworker-dynamic.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "@angular/platform-webworker": "0.0.0-PLACEHOLDER"
+    "@angular/platform-webworker": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -12,13 +12,11 @@
   "typings": "./platform-webworker.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -25,13 +25,13 @@
   },
   "homepage": "https://github.com/angular/angular/tree/master/packages/router",
   "dependencies": {
-    "tslib": "^1.9.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "rxjs": "^6.5.3"
+    "rxjs": "^6.5.3",
+    "tslib": "^1.9.0"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -12,12 +12,10 @@
   "typings": "./service-worker.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/common": "0.0.0-PLACEHOLDER"
+    "@angular/common": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -12,14 +12,12 @@
   "typings": "./upgrade.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.9.0"
-  },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
feat: change tslib from direct dependency to peerDependency

BREAKING CHANGE: 

We no longer directly have a direct depedency on `tslib`. Instead it is now listed a `peerDependency`. 

Users not using the CLI will need to manually install `tslib` via;
```
yarn add tslib
```
or
```
npm install tslib --save
```


Reference: TOOL-836