### PR TITLE
Support type-then-feature naming convention

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -284,7 +284,7 @@ Naming conventions are hugely important to maintainability and readability. This
 
 
 
-**Do** follow a pattern that describes the symbol's feature then its type. The recommended pattern is `feature.type.ts`.
+**Do** follow a pattern that describes the symbol's feature and type. The recommended pattern is `feature.type.ts`. A supported alternate pattern is `type.feature.ts`.
 
 
 </div>
@@ -295,7 +295,7 @@ Naming conventions are hugely important to maintainability and readability. This
 
 
 
-**Why?** Naming conventions help provide a consistent way to find content at a glance. Consistency within the project is vital. Consistency with a team is important. Consistency across a company provides tremendous efficiency.
+**Why?** Naming conventions help provide a consistent way to find content at a glance. Consistency within the project is vital. Consistency with a team is important. Consistency across a company provides tremendous efficiency. For small projects with few features, it is efficient to look up component by a known feature. For large projects with many features, it may be relatively easier to narrow down the search space to components, then search through potentially unknown features for a desired component.
 
 
 </div>
@@ -317,7 +317,7 @@ Naming conventions are hugely important to maintainability and readability. This
 
 
 
-**Why?** Names of folders and files should clearly convey their intent. For example, `app/heroes/hero-list.component.ts` may contain a component that manages a list of heroes.
+**Why?** Names of folders and files should clearly convey their intent. For example, `app/heroes/hero-list.component.ts` may contain a component that manages a list of heroes. When using `--flat=false`, `app/heroes/hero-list-component/hero-list.component.ts` allows systems and humans to more efficiently group and distinguish types without needing to enter a deeper directory level.
 
 
 </div>


### PR DESCRIPTION
Related: https://github.com/angular/angular-cli/issues/15351

support type-first naming which is more intuitive and efficient for some users and systems, plus it is consistent with hungarian-like naming which is an additional type guard in situations where TS isn't typesafe.

Currently, requiring hungarian-like naming and angular naming guidelines compliance leads to some rediculous situations like:
`import { ServiceAnalyticsService } from './service-analytics/service-analytics.service.ts`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
