### PR TITLE
feat(ivy): use the schema registry to check DOM bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3TargetBinder, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
+import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3TargetBinder, SchemaMetadata, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {CycleAnalyzer} from '../../cycles';
@@ -396,6 +396,7 @@ export class ComponentDecoratorHandler implements
 
     const matcher = new SelectorMatcher<DirectiveMeta>();
     const pipes = new Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>();
+    let schemas: SchemaMetadata[] = [];
 
     const scope = this.scopeReader.getScopeForComponent(node);
     if (scope !== null) {
@@ -410,10 +411,12 @@ export class ComponentDecoratorHandler implements
         }
         pipes.set(name, ref as Reference<ClassDeclaration<ts.ClassDeclaration>>);
       }
+      schemas = scope.schemas;
     }
 
     const bound = new R3TargetBinder(matcher).bind({template: template.nodes});
-    ctx.addTemplate(new Reference(node), bound, pipes, meta.templateSourceMapping, template.file);
+    ctx.addTemplate(
+        new Reference(node), bound, pipes, schemas, meta.templateSourceMapping, template.file);
   }
 
   resolve(node: ClassDeclaration, analysis: ComponentHandlerData): ResolveResult {

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -73,6 +73,16 @@ export enum ErrorCode {
    * expression.
    */
   NGCC_MIGRATION_DYNAMIC_BASE_CLASS = 7003,
+
+  /**
+   * An element name failed validation against the DOM schema.
+   */
+  SCHEMA_INVALID_ELEMENT = 8001,
+
+  /**
+   * An element's attribute name failed validation against the DOM schema.
+   */
+  SCHEMA_INVALID_ATTRIBUTE = 8002,
 }
 
 export function ngErrorCode(code: ErrorCode): number {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DirectiveMeta as T2DirectiveMeta} from '@angular/compiler';
+import {DirectiveMeta as T2DirectiveMeta, SchemaMetadata} from '@angular/compiler';
 
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
@@ -19,6 +19,7 @@ export interface NgModuleMeta {
   declarations: Reference<ClassDeclaration>[];
   imports: Reference<ClassDeclaration>[];
   exports: Reference<ClassDeclaration>[];
+  schemas: SchemaMetadata[];
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -59,6 +59,7 @@ export class DtsMetadataReader implements MetadataReader {
           this.checker, exportMetadata, ref.ownedByModuleGuess, resolutionContext),
       imports: extractReferencesFromType(
           this.checker, importMetadata, ref.ownedByModuleGuess, resolutionContext),
+      schemas: [],
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -400,7 +400,9 @@ export class NgtscProgram implements api.Program {
         applyTemplateContextGuards: true,
         checkQueries: false,
         checkTemplateBodies: true,
-        checkTypeOfBindings: true,
+        checkTypeOfInputBindings: true,
+        // Even in full template type-checking mode, DOM binding checks are not quite ready yet.
+        checkTypeOfDomBindings: false,
         checkTypeOfPipes: true,
         strictSafeNavigationTypes: true,
       };
@@ -409,7 +411,8 @@ export class NgtscProgram implements api.Program {
         applyTemplateContextGuards: false,
         checkQueries: false,
         checkTemplateBodies: false,
-        checkTypeOfBindings: false,
+        checkTypeOfInputBindings: false,
+        checkTypeOfDomBindings: false,
         checkTypeOfPipes: false,
         strictSafeNavigationTypes: false,
       };

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ExternalExpr} from '@angular/compiler';
+import {ExternalExpr, SchemaMetadata} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, makeDiagnostic} from '../../diagnostics';
@@ -28,6 +28,7 @@ export interface LocalNgModuleData {
 export interface LocalModuleScope extends ExportScope {
   compilation: ScopeData;
   reexports: Reexport[]|null;
+  schemas: SchemaMetadata[];
 }
 
 /**
@@ -375,6 +376,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       },
       exported,
       reexports,
+      schemas: ngModule.schemas,
     };
     this.cache.set(ref.node, scope);
     return scope;

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -52,6 +52,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       declarations: [Dir1, Dir2, Pipe1],
       exports: [Dir1, Pipe1],
+      schemas: [],
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) !;
@@ -67,18 +68,21 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [ModuleB],
       declarations: [DirA],
       exports: [],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
       exports: [ModuleC, DirB],
       declarations: [DirB],
-      imports: []
+      imports: [],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
       declarations: [DirCI, DirCE],
       exports: [DirCE],
-      imports: []
+      imports: [],
+      schemas: [],
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -94,12 +98,14 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [ModuleB],
       imports: [],
       declarations: [],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
       declarations: [Dir],
       exports: [Dir],
       imports: [],
+      schemas: [],
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -115,18 +121,21 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [DirA, DirA],
       imports: [ModuleB, ModuleC],
       exports: [DirA, DirA, DirB, ModuleB],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
       declarations: [DirB],
       imports: [],
       exports: [DirB],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
       declarations: [],
       imports: [],
       exports: [ModuleB],
+      schemas: [],
     });
 
     const scope = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -149,6 +158,7 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [],
       imports: [],
       declarations: [DirInModule],
+      schemas: [],
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) !;
@@ -163,12 +173,14 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir],
       imports: [ModuleB],
       declarations: [],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
       declarations: [Dir],
       exports: [Dir],
       imports: [],
+      schemas: [],
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -183,12 +195,14 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir],
       imports: [],
       declarations: [],
+      schemas: [],
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
       declarations: [Dir],
       exports: [Dir],
       imports: [],
+      schemas: [],
     });
 
     expect(scopeRegistry.getScopeOfModule(ModuleA.node)).toBe(null);

--- a/packages/compiler-cli/src/ngtsc/typecheck/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/metadata",

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, DirectiveMeta} from '@angular/compiler';
+import {BoundTarget, DirectiveMeta, SchemaMetadata} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -45,6 +45,11 @@ export interface TypeCheckBlockMetadata {
    * Pipes used in the template of the component.
    */
   pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>;
+
+  /**
+   * Schemas that apply to this template.
+   */
+  schemas: SchemaMetadata[];
 }
 
 export interface TypeCtorMetadata {
@@ -72,8 +77,23 @@ export interface TypeCheckingConfig {
    * checked, but not the assignment of the resulting type to the `input` property of whichever
    * directive or component is receiving the binding. If set to `true`, both sides of the assignment
    * are checked.
+   *
+   * This flag only affects bindings to components/directives. Bindings to the DOM are checked if
+   * `checkTypeOfDomBindings` is set.
    */
-  checkTypeOfBindings: boolean;
+  checkTypeOfInputBindings: boolean;
+
+  /**
+   * Whether to check the left-hand side type of binding operations to DOM properties.
+   *
+   * As `checkTypeOfBindings`, but only applies to bindings to DOM properties.
+   *
+   * This does not affect the use of the `DomSchemaChecker` to validate the template against the DOM
+   * schema. Rather, this flag is an experimental, not yet complete feature which uses the
+   * lib.dom.d.ts DOM typings in TypeScript to validate that DOM bindings are of the correct type
+   * for assignability to the underlying DOM element properties.
+   */
+  checkTypeOfDomBindings: boolean;
 
   /**
    * Whether to include type information from pipes in the type-checking operation.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DomElementSchemaRegistry, ParseSourceSpan, SchemaMetadata, TmplAstElement} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {ErrorCode} from '../../diagnostics';
+
+import {TcbSourceResolver, makeTemplateDiagnostic} from './diagnostics';
+
+const REGISTRY = new DomElementSchemaRegistry();
+
+/**
+ * Checks every non-Angular element/property processed in a template and potentially produces
+ * `ts.Diagnostic`s related to improper usage.
+ *
+ * A `DomSchemaChecker`'s job is to check DOM nodes and their attributes written used in templates
+ * and produce `ts.Diagnostic`s if the nodes don't conform to the DOM specification. It acts as a
+ * collector for these diagnostics, and can be queried later to retrieve the list of any that have
+ * been generated.
+ */
+export interface DomSchemaChecker {
+  /**
+   * Get the `ts.Diagnostic`s that have been generated via `checkElement` and `checkProperty` calls
+   * thus far.
+   */
+  readonly diagnostics: ReadonlyArray<ts.Diagnostic>;
+
+  /**
+   * Check a non-Angular element and record any diagnostics about it.
+   *
+   * @param id the template ID, suitable for resolution with a `TcbSourceResolver`.
+   * @param element the element node in question.
+   * @param schemas any active schemas for the template, which might affect the validity of the
+   * element.
+   */
+  checkElement(id: string, element: TmplAstElement, schemas: SchemaMetadata[]): void;
+
+  /**
+   * Check a property binding on an element and record any diagnostics about it.
+   *
+   * @param id the template ID, suitable for resolution with a `TcbSourceResolver`.
+   * @param element the element node in question.
+   * @param name the name of the property being checked.
+   * @param span the source span of the binding. This is redundant with `element.attributes` but is
+   * passed separately to avoid having to look up the particular property name.
+   * @param schemas any active schemas for the template, which might affect the validity of the
+   * property.
+   */
+  checkProperty(
+      id: string, element: TmplAstElement, name: string, span: ParseSourceSpan,
+      schemas: SchemaMetadata[]): void;
+}
+
+/**
+ * Checks non-Angular elements and properties against the `DomElementSchemaRegistry`, a schema
+ * maintained by the Angular team via extraction from a browser IDL.
+ */
+export class RegistryDomSchemaChecker {
+  private _diagnostics: ts.Diagnostic[] = [];
+
+  get diagnostics(): ReadonlyArray<ts.Diagnostic> { return this._diagnostics; }
+
+  constructor(private resolver: TcbSourceResolver) {}
+
+  checkElement(id: string, element: TmplAstElement, schemas: SchemaMetadata[]): void {
+    if (!REGISTRY.hasElement(element.name, schemas)) {
+      const mapping = this.resolver.getSourceMapping(id);
+      const diag = makeTemplateDiagnostic(
+          mapping, element.sourceSpan, ts.DiagnosticCategory.Error,
+          ErrorCode.SCHEMA_INVALID_ELEMENT, `'${element.name}' is not a valid HTML element.`);
+      this._diagnostics.push(diag);
+    }
+  }
+
+  checkProperty(
+      id: string, element: TmplAstElement, name: string, span: ParseSourceSpan,
+      schemas: SchemaMetadata[]): void {
+    if (!REGISTRY.hasProperty(element.name, name, schemas)) {
+      const mapping = this.resolver.getSourceMapping(id);
+      const diag = makeTemplateDiagnostic(
+          mapping, span, ts.DiagnosticCategory.Error, ErrorCode.SCHEMA_INVALID_ATTRIBUTE,
+          `'${name}' is not a valid property of <${element.name}>.`);
+      this._diagnostics.push(diag);
+    }
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '@angular/compiler';
+
+import {TemplateSourceMapping} from './api';
+import {SourceLocation, TcbSourceResolver} from './diagnostics';
+import {computeLineStartsMap, getLineAndCharacterFromPosition} from './line_mappings';
+
+/**
+ * Represents the source of a template that was processed during type-checking. This information is
+ * used when translating parse offsets in diagnostics back to their original line/column location.
+ */
+export class TemplateSource {
+  private lineStarts: number[]|null = null;
+
+  constructor(readonly mapping: TemplateSourceMapping, private file: ParseSourceFile) {}
+
+  toParseSourceSpan(start: number, end: number): ParseSourceSpan {
+    const startLoc = this.toParseLocation(start);
+    const endLoc = this.toParseLocation(end);
+    return new ParseSourceSpan(startLoc, endLoc);
+  }
+
+  private toParseLocation(position: number) {
+    const lineStarts = this.acquireLineStarts();
+    const {line, character} = getLineAndCharacterFromPosition(lineStarts, position);
+    return new ParseLocation(this.file, position, line, character);
+  }
+
+  private acquireLineStarts(): number[] {
+    if (this.lineStarts === null) {
+      this.lineStarts = computeLineStartsMap(this.file.content);
+    }
+    return this.lineStarts;
+  }
+}
+
+/**
+ * Assigns IDs to templates and keeps track of their origins.
+ *
+ * Implements `TcbSourceResolver` to resolve the source of a template based on these IDs.
+ */
+export class TcbSourceManager implements TcbSourceResolver {
+  private nextTcbId: number = 1;
+  /**
+   * This map keeps track of all template sources that have been type-checked by the id that is
+   * attached to a TCB's function declaration as leading trivia. This enables translation of
+   * diagnostics produced for TCB code to their source location in the template.
+   */
+  private templateSources = new Map<string, TemplateSource>();
+
+  captureSource(mapping: TemplateSourceMapping, file: ParseSourceFile): string {
+    const id = `tcb${this.nextTcbId++}`;
+    this.templateSources.set(id, new TemplateSource(mapping, file));
+    return id;
+  }
+
+  getSourceMapping(id: string): TemplateSourceMapping {
+    if (!this.templateSources.has(id)) {
+      throw new Error(`Unexpected unknown TCB ID: ${id}`);
+    }
+    return this.templateSources.get(id) !.mapping;
+  }
+
+  sourceLocationToSpan(location: SourceLocation): ParseSourceSpan|null {
+    if (!this.templateSources.has(location.id)) {
+      return null;
+    }
+    const templateSource = this.templateSources.get(location.id) !;
+    return templateSource.toParseSourceSpan(location.start, location.end);
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -13,8 +13,10 @@ import {ClassDeclaration} from '../../reflection';
 import {ImportManager} from '../../translator';
 
 import {TypeCheckBlockMetadata, TypeCheckingConfig} from './api';
+import {DomSchemaChecker} from './dom';
 import {Environment} from './environment';
 import {generateTypeCheckBlock} from './type_check_block';
+
 
 /**
  * An `Environment` representing the single type-checking file into which most (if not all) Type
@@ -35,9 +37,10 @@ export class TypeCheckFile extends Environment {
   }
 
   addTypeCheckBlock(
-      ref: Reference<ClassDeclaration<ts.ClassDeclaration>>, meta: TypeCheckBlockMetadata): void {
+      ref: Reference<ClassDeclaration<ts.ClassDeclaration>>, meta: TypeCheckBlockMetadata,
+      domSchemaChecker: DomSchemaChecker): void {
     const fnId = ts.createIdentifier(`_tcb${this.nextTcbId++}`);
-    const fn = generateTypeCheckBlock(this, ref, fnId, meta);
+    const fn = generateTypeCheckBlock(this, ref, fnId, meta, domSchemaChecker);
     this.tcbStatements.push(fn);
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -133,7 +133,7 @@ runInEachFileSystem(() => {
     });
 
     it('interprets interpolation as strings', () => {
-      const messages = diagnose(`<blockquote cite="{{ person }}"></blockquote>`, `
+      const messages = diagnose(`<blockquote title="{{ person }}"></blockquote>`, `
       class TestComponent {
         person: {};
       }`);
@@ -149,8 +149,8 @@ runInEachFileSystem(() => {
       }`);
 
       expect(messages).toEqual([
-        `synthetic.html(1, 6): Property 'srcc' does not exist on type 'HTMLImageElement'. Did you mean 'src'?`,
         `synthetic.html(1, 29): Property 'heihgt' does not exist on type 'TestComponent'. Did you mean 'height'?`,
+        `synthetic.html(1, 6): 'srcc' is not a valid property of <img>.`,
       ]);
     });
 

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -77,3 +77,6 @@ export enum ChangeDetectionStrategy {
   OnPush = 0,
   Default = 1
 }
+
+export const CUSTOM_ELEMENTS_SCHEMA: any = false;
+export const NO_ERRORS_SCHEMA: any = false;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -31,6 +31,7 @@ import * as core from './core';
 import {publishFacade} from './jit_compiler_facade';
 import {global} from './util';
 
+export {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from './core';
 export {core};
 
 export * from './version';


### PR DESCRIPTION
Previously, ngtsc attempted to use the .d.ts schema for HTML elements to
check bindings to DOM properties. However, the TypeScript lib.dom.d.ts
schema does not perfectly align with the Angular DomElementSchemaRegistry,
and these inconsistencies would cause issues in apps. There is also the
concern of supporting both CUSTOM_ELEMENTS_SCHEMA and NO_ERRORS_SCHEMA which
would have been very difficult to do in the existing system.

With this commit, the DomElementSchemaRegistry is employed in ngtsc to check
bindings to the DOM. Previous work on producing template diagnostics is used
to support generation of this different kind of error with the same high
quality of error message.

---

Reviewers: only the last commit is important.