### PR TITLE
fix(ngcc): handle deep imports that already have an extension

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath, FileSystem, PathSegment} from '../../../src/ngtsc/file_system';
+import {resolveFileWithPostfixes} from '../utils';
+
 import {ModuleResolver} from './module_resolver';
 
 export interface DependencyHost {
@@ -32,10 +34,15 @@ export abstract class DependencyHostBase implements DependencyHost {
     const dependencies = new Set<AbsoluteFsPath>();
     const missing = new Set<AbsoluteFsPath|PathSegment>();
     const deepImports = new Set<AbsoluteFsPath>();
-    const alreadySeen = new Set<AbsoluteFsPath>();
 
-    this.recursivelyFindDependencies(
-        entryPointPath, dependencies, missing, deepImports, alreadySeen);
+    const resolvedFile =
+        resolveFileWithPostfixes(this.fs, entryPointPath, ['', '.js', '/index.js']);
+    if (resolvedFile !== null) {
+      const alreadySeen = new Set<AbsoluteFsPath>();
+      this.recursivelyFindDependencies(
+          resolvedFile, dependencies, missing, deepImports, alreadySeen);
+    }
+
     return {dependencies, missing, deepImports};
   }
 

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -25,7 +25,7 @@ export class ModuleResolver {
   private pathMappings: ProcessedPathMapping[];
 
   constructor(private fs: FileSystem, pathMappings?: PathMappings, private relativeExtensions = [
-    '.js', '/index.js'
+    '', '.js', '/index.js'
   ]) {
     this.pathMappings = pathMappings ? this.processPathMappings(pathMappings) : [];
   }

--- a/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
@@ -83,6 +83,12 @@ runInEachFileSystem(() => {
           const resolver = new ModuleResolver(getFileSystem());
           expect(resolver.resolveModuleImport('./y', _('/libs/local-package/index.js'))).toBe(null);
         });
+
+        it('should resolve modules that already include an extension', () => {
+          const resolver = new ModuleResolver(getFileSystem());
+          expect(resolver.resolveModuleImport('./x.js', _('/libs/local-package/index.js')))
+              .toEqual(new ResolvedRelativeModule(_('/libs/local-package/x.js')));
+        });
       });
 
       describe('with non-mapped external paths', () => {


### PR DESCRIPTION
**refactor(ngcc): avoid repeated file resolution during dependency scan**

During the recursive processing of dependencies, ngcc resolves the
requested file to an actual location on disk, by testing various
extensions. For recursive calls however, the path is known to have been
resolved in the module resolver. Therefore, it is safe to move the path
resolution to the initial caller into the recursive process.

Note that this is not expected to improve the performance of ngcc, as
the call to `resolveFileWithPostfixes` is known to succeed immediately,
as the provided path is known to exist without needing to add any
postfixes. Furthermore, the FileSystem caches whether files exist, so
the additional check that we used to do was cheap.

---

**fix(ngcc): handle deep imports that already have an extension**

During the dependency analysis phase of ngcc, imports are resolved to
files on disk according to certain module resolution rules. Since module
specifiers are typically missing extensions, or can refer to index.js
barrel files within a directory, the module resolver attempts several
postfixes when searching for a module import on disk. Module  specifiers
that already include an extension, however, would fail to be resolved as
ngcc's module resolver failed to check the location on disk without
adding any postfixes.

Closes #32097