### PR TITLE
fix(bazel): pin `@microsoft/api-extractor`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@bazel/karma": "0.34.0",
     "@bazel/protractor": "0.34.0",
     "@bazel/typescript": "0.34.0",
-    "@microsoft/api-extractor": "^7.0.21",
+    "@microsoft/api-extractor": "7.0.21",
     "@schematics/angular": "^8.0.0-beta.15",
     "@types/angular": "^1.6.47",
     "@types/base64-js": "1.2.5",

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -29,7 +29,7 @@
     "@angular-devkit/architect": "^0.800.0-beta.15",
     "@angular-devkit/core": "^8.0.0-beta.15",
     "@angular-devkit/schematics": "^8.0.0-beta.15",
-    "@microsoft/api-extractor": "^7.0.21",
+    "@microsoft/api-extractor": "7.0.21",
     "@schematics/angular": "^8.0.0-beta.15",
     "@types/node": "6.0.84",
     "semver": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,7 +301,7 @@
     through2 "^2.0.0"
     xdg-basedir "^3.0.0"
 
-"@microsoft/api-extractor@^7.0.21":
+"@microsoft/api-extractor@7.0.21":
   version "7.0.21"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.0.21.tgz#d5ff9bba4ff7283503aac83ad489b16cad293fc7"
   integrity sha512-7lFcHNykVz0tvgOz9juXqP+a1j0EmnJ9J080CBE/171IxL4fBrpslPhqN86dNuavuPragRpBLc8Okv/bV7FJPQ==


### PR DESCRIPTION
The API of `@microsoft/api-extractor` changed in a minor version which is causes an error when using dts flattening downstream.

API wil be updated on master https://github.com/angular/angular/pull/32185
