### PR TITLE
fix(ivy): get name directly from nativeNode

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -247,7 +247,7 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     return this.nativeNode.nodeType == Node.ELEMENT_NODE ? this.nativeNode as Element : null;
   }
 
-  get name(): string { return this.nativeElement !.nodeName; }
+  get name(): string { return this.nativeNode.nodeName; }
 
   /**
    *  Gets a map of property names to property values for an element.

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -1018,4 +1018,22 @@ class TestCmptWithPropBindings {
     });
 
   });
+
+  it('should not error when accessing node name', () => {
+    @Component({template: ''})
+    class EmptyComponent {
+    }
+
+    const fixture = TestBed.configureTestingModule({declarations: [EmptyComponent]})
+                        .createComponent(EmptyComponent);
+    let node = fixture.debugElement;
+    let superParentName = '';
+    // Traverse upwards, all the way to #document, which is not a
+    // Node.ELEMENT_NODE
+    while (node) {
+      superParentName = node.name;
+      node = node.parent !;
+    }
+    expect(superParentName).not.toEqual('');
+  });
 }


### PR DESCRIPTION
Because the implementation of nativeElement can return null, getting the nodeName from nativeElement can result in an error. An example of when this would fail:
``` 
while(node) { 
  console.log(node.name);
  node = node.parent; 
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
debugNode.name sometimes throws an error.

Issue Number: N/A


## What is the new behavior?
debugNode.name does not throw an error when accessing nodes not of type Node.ELEMENT_NODE

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
