### PR TITLE
feat(core): Introduce TestBed.inject to replace TestBed.get

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -677,7 +677,7 @@ describe('AppComponent', () => {
       });
 
       it('should not be loaded/registered until necessary', () => {
-        const loader: TestElementsLoader = fixture.debugElement.injector.get(ElementsLoader);
+        const loader = fixture.debugElement.injector.get(ElementsLoader) as unknown as TestElementsLoader;
         expect(loader.loadCustomElement).not.toHaveBeenCalled();
 
         setHasFloatingToc(true);

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -601,7 +601,8 @@ export class ApplicationRef {
     this.componentTypes.push(componentFactory.componentType);
 
     // Create a factory associated with the current module if it's not bound to some other
-    const ngModule = isBoundToModule(componentFactory) ? null : this._injector.get(NgModuleRef);
+    const ngModule =
+        isBoundToModule(componentFactory) ? undefined : this._injector.get(NgModuleRef);
     const selectorOrNode = rootSelectorOrNode || componentFactory.selector;
     const compRef = componentFactory.create(Injector.NULL, [], selectorOrNode, ngModule);
 

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {stringify} from '../util/stringify';
 
 import {resolveForwardRef} from './forward_ref';
@@ -55,7 +55,8 @@ export abstract class Injector {
    * @returns The instance from the injector if defined, otherwise the `notFoundValue`.
    * @throws When the `notFoundValue` is `undefined` or `Injector.THROW_IF_NOT_FOUND`.
    */
-  abstract get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  abstract get<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
   /**
    * @deprecated from v4.0.0 use Type<T> or InjectionToken<T>
    * @suppress {duplicate}

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -295,7 +295,7 @@ describe('ViewContainerRef', () => {
              const changeDetector = ref.injector.get(ChangeDetectorRef);
              changeDetector.detectChanges();
              expect(dynamicComp.doCheckCount).toEqual(1);
-             expect(changeDetector.context).toEqual(dynamicComp);
+             expect((changeDetector as any).context).toEqual(dynamicComp);
            });
 
         it('should not throw when destroying a reattached component', () => {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
+import {AbstractType, ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify, ɵɵInjectableDef} from '@angular/core';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {ComponentFixture} from './component_fixture';
@@ -56,16 +56,15 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
 
-  // TODO: switch back to official deprecation marker once TSLint issue is resolved
-  // https://github.com/palantir/tslint/issues/4522
-  /**
-   * deprecated from v8.0.0 use Type<T> or InjectionToken<T>
-   * This does not use the deprecated jsdoc tag on purpose
-   * because it renders all overloads as deprecated in TSLint
-   * due to https://github.com/palantir/tslint/issues/4522.
-   */
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
 
   execute(tokens: any[], fn: Function, context?: any): any;
@@ -104,7 +103,7 @@ export interface TestBed {
  * Note: Use `TestBed` in tests. It will be set to either `TestBedViewEngine` or `TestBedRender3`
  * according to the compiler used.
  */
-export class TestBedViewEngine implements Injector, TestBed {
+export class TestBedViewEngine implements TestBed {
   /**
    * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
    * angular module. These are common to every test in the suite.
@@ -216,16 +215,29 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine as any as TestBedStatic;
   }
 
+  static inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  static inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  static inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T|null,
+      flags?: InjectFlags): T|null {
+    return _getTestBedViewEngine().inject(token, notFoundValue, flags);
+  }
+
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
   static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
   /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject
    * @suppress {duplicate}
    */
   static get(token: any, notFoundValue?: any): any;
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
-    return _getTestBedViewEngine().get(token, notFoundValue, flags);
+    return _getTestBedViewEngine().inject(token, notFoundValue, flags);
   }
 
   static createComponent<T>(component: Type<T>): ComponentFixture<T> {
@@ -431,8 +443,7 @@ export class TestBedViewEngine implements Injector, TestBed {
     class DynamicTestModule {
     }
 
-    const compilerFactory: TestingCompilerFactory =
-        this.platform.injector.get(TestingCompilerFactory);
+    const compilerFactory = this.platform.injector.get(TestingCompilerFactory);
     this._compiler = compilerFactory.createTestingCompiler(this._compilerOptions);
     for (const summary of [this._testEnvAotSummaries, ...this._aotSummaries]) {
       this._compiler.loadAotSummaries(summary);
@@ -454,16 +465,17 @@ export class TestBedViewEngine implements Injector, TestBed {
     }
   }
 
-  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /**
-   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
-   */
-  get(token: any, notFoundValue?: any): any;
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
-      flags: InjectFlags = InjectFlags.Default): any {
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T|null,
+      flags?: InjectFlags): T|null {
     this._initIfNeeded();
-    if (token === TestBed) {
-      return this;
+    if (token as unknown === TestBed) {
+      return this as any;
     }
     // Tests can inject things from the ng module and from the compiler,
     // but the ng module can't inject things from the compiler and vice versa.
@@ -471,9 +483,19 @@ export class TestBedViewEngine implements Injector, TestBed {
     return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue, flags) : result;
   }
 
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  get(token: any, notFoundValue?: any): any;
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
+      flags: InjectFlags = InjectFlags.Default): any {
+    return this.inject(token, notFoundValue, flags);
+  }
+
   execute(tokens: any[], fn: Function, context?: any): any {
     this._initIfNeeded();
-    const params = tokens.map(t => this.get(t));
+    const params = tokens.map(t => this.inject(t));
     return fn.apply(context, params);
   }
 
@@ -575,12 +597,13 @@ export class TestBedViewEngine implements Injector, TestBed {
           `Cannot create the component ${stringify(component)} as it was not imported into the testing module!`);
     }
 
-    // TODO: Don't cast as `any`, proper type is boolean[]
-    const noNgZone = this.get(ComponentFixtureNoNgZone as any, false);
-    // TODO: Don't cast as `any`, proper type is boolean[]
-    const autoDetect: boolean = this.get(ComponentFixtureAutoDetect as any, false);
-    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone as Type<NgZone|null>, null);
-    const testComponentRenderer: TestComponentRenderer = this.get(TestComponentRenderer);
+    // TODO: Don't cast as `InjectionToken<boolean>`, declared type is boolean[]
+    const noNgZone = this.inject(ComponentFixtureNoNgZone as InjectionToken<boolean>, false);
+    // TODO: Don't cast as `InjectionToken<boolean>`, declared type is boolean[]
+    const autoDetect: boolean =
+        this.inject(ComponentFixtureAutoDetect as InjectionToken<boolean>, false);
+    const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
+    const testComponentRenderer: TestComponentRenderer = this.inject(TestComponentRenderer);
     const rootElId = `root${_nextRootElementId++}`;
     testComponentRenderer.insertRootElement(rootElId);
 
@@ -658,7 +681,7 @@ export function inject(tokens: any[], fn: Function): () => any {
       // Return an async test method that returns a Promise if AsyncTestCompleter is one of
       // the injected tokens.
       return testBed.compileComponents().then(() => {
-        const completer: AsyncTestCompleter = testBed.get(AsyncTestCompleter);
+        const completer = testBed.inject(AsyncTestCompleter);
         testBed.execute(tokens, fn, this);
         return completer.promise;
       });

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
+import {AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -114,15 +114,15 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+  inject<T>(
+      token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
+      |null;
+
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  // TODO: switch back to official deprecation marker once TSLint issue is resolved
-  // https://github.com/palantir/tslint/issues/4522
-  /**
-   * deprecated from v8.0.0 use Type<T> or InjectionToken<T>
-   * This does not use the deprecated jsdoc tag on purpose
-   * because it renders all overloads as deprecated in TSLint
-   * due to https://github.com/palantir/tslint/issues/4522.
-   */
+  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -776,7 +776,7 @@ class HiddenModule {
              const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
              const http = ref.injector.get(HttpClient);
              ref.injector.get<NgZone>(NgZone).run(() => {
-               http.get('http://localhost/testing').subscribe((body: string) => {
+               http.get<string>('http://localhost/testing').subscribe((body: string) => {
                  NgZone.assertInAngularZone();
                  expect(body).toEqual('success!');
                });
@@ -791,8 +791,8 @@ class HiddenModule {
            platform.bootstrapModule(HttpClientExampleModule).then(ref => {
              const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
              const http = ref.injector.get(HttpClient);
-             ref.injector.get<NgZone>(NgZone).run(() => {
-               http.get('http://localhost/testing').subscribe((body: string) => {
+             ref.injector.get(NgZone).run(() => {
+               http.get<string>('http://localhost/testing').subscribe((body: string) => {
                  expect(body).toEqual('success!');
                });
                expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
@@ -808,8 +808,8 @@ class HiddenModule {
         platform.bootstrapModule(HttpInterceptorExampleModule).then(ref => {
           const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
           const http = ref.injector.get(HttpClient);
-          ref.injector.get<NgZone>(NgZone).run(() => {
-            http.get('http://localhost/testing').subscribe((body: string) => {
+          ref.injector.get(NgZone).run(() => {
+            http.get<string>('http://localhost/testing').subscribe((body: string) => {
               NgZone.assertInAngularZone();
               expect(body).toEqual('success!');
             });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -456,7 +456,7 @@ export declare class InjectionToken<T> {
 }
 
 export declare abstract class Injector {
-    abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: Object;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -58,9 +58,11 @@ export interface TestBed {
     configureTestingModule(moduleDef: TestModuleMetadata): void;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
+    inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
@@ -93,17 +95,15 @@ export interface TestBedStatic {
     }): TestBedStatic;
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
+    inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+    inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): TestBedStatic;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): TestBedStatic;
-    overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
-    }): TestBedStatic;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): TestBedStatic;
@@ -111,6 +111,10 @@ export interface TestBedStatic {
         useFactory?: Function;
         useValue?: any;
         deps?: any[];
+    }): TestBedStatic;
+    overrideProvider(token: any, provider: {
+        useFactory: Function;
+        deps: any[];
     }): TestBedStatic;
     overrideTemplate(component: Type<any>, template: string): TestBedStatic;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBedStatic;


### PR DESCRIPTION
TestBed.get is not type safe, fixing it would be a massive breaking
change. The Angular team has proposed replacing it with TestBed.inject
and deprecate TestBed.get.

Fixes #26491
Fixes #29905

BREAKING CHANGE: Injector.get now accepts abstract classes to return
type-safe values. Previous implementation returned `any` through the
deprecated implementation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```ts
TestBed.get(ChangeDetectorRef) // returns any
```

Issue Number: #26491, #29905


## What is the new behavior?
```ts
// Now deprecated
TestBed.get(ChangeDetectorRef) // returns any

TestBed.inject(ChangeDetectorRef) // returns ChangeDetectorRef
```


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The breaking change affects a feature that has been deprecated since Angular 4.x
`Injector#get()` has 2 signatures:
- Typed signature, accept an `InjectionToken<T>` and a class (`Type<T>`)
- Anything else is also accepted but typed as `any`

The updated Typed signature now also accepts abstract classes (`AbstractType<T>`) which may cause compilation issues to the deprecated use of `any` as it would need to be manually downcasted to the concrete type if needed.


## Other information

Internal doc - [go/testbed.inject](http://go/testbed.inject)

**Note:** I did not update _all_ uses of `TestBed.get` in the Angular codebase to keep this diff small.
I will follow with another CL migrating all `TestBed.get` to `TestBed.inject` if this PR goes through.