### PR TITLE
fix(ivy): reset binding index before executing a template in `refreshView` call

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -377,13 +377,13 @@ export function refreshView<T>(
   try {
     resetPreOrderHookFlags(lView);
 
-    if (templateFn !== null) {
-      executeTemplate(lView, templateFn, RenderFlags.Update, context);
-    }
-
     // Resetting the bindingIndex of the current LView as the next steps may trigger change
     // detection.
     lView[BINDING_INDEX] = tView.bindingStartIndex;
+
+    if (templateFn !== null) {
+      executeTemplate(lView, templateFn, RenderFlags.Update, context);
+    }
 
     const checkNoChangesMode = getCheckNoChangesMode();
     const hooksInitPhaseCompleted =


### PR DESCRIPTION
Prior to this change, the `BINDING_INDEX` of a given lView was reset after processing a template. However change detection can be triggered as a result of View queries processing, thus leading to the subsequent `refreshView` call (and executing a template), which in turn operated with the binding index that was not reset after the previous `refreshView` call. This commit updates the logic to reset binding index before we execute template, so that we always get the right binding index.

This PR resolves FW-1516.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No