### PR TITLE
ci: exclude the upstream g3 branch from building on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,7 +770,10 @@ workflows:
   version: 2
   default_workflow:
     jobs:
-      - setup
+      - setup:
+        filters:
+          branches:
+            ignore: g3
       - lint:
           requires:
             - setup
@@ -900,9 +903,3 @@ workflows:
             branches:
               only:
                 - master
-
-# TODO:
-# - don't build the g3 branch
-# - verify that we are bootstrapping with the right yarn version coming from the docker image
-# - check local chrome version pulled from docker image
-# - remove /tools/ngcontainer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -771,9 +771,9 @@ workflows:
   default_workflow:
     jobs:
       - setup:
-        filters:
-          branches:
-            ignore: g3
+          filters:
+            branches:
+              ignore: g3
       - lint:
           requires:
             - setup


### PR DESCRIPTION
We don't need to build this branch as it's informative for the purposes of figuring out
the diff between the master and what's synced into google3.