### PR TITLE
build(docs-infra): add empty `codeGenApi` JSDoc tag definition

### DIFF
--- a/aio/tools/transforms/angular-api-package/tag-defs/codeGenApi.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/codeGenApi.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {name: 'codeGenApi'};
+};


### PR DESCRIPTION
This avoids warning such as the following ([example][1]):

```
warn: Invalid tags found -
  doc "platform-browser/ÉµBROWSER_SANITIZATION_PROVIDERS__POST_R3__" (const)
  from file "platform-browser/src/browser.ts"
```

[1]: https://circleci.com/gh/angular/angular/427064
