### PR TITLE
fix(compiler): Support for combining host-context and host selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -304,7 +304,8 @@ export class ShadowCss {
     if (part.indexOf(_polyfillHost) > -1) {
       return this._colonHostPartReplacer(host, part, suffix);
     } else {
-      return host + part + suffix + ', ' + part + ' ' + host + suffix;
+      const updatedSuffix = suffix.indexOf(host) === 0 ? suffix : host + suffix;
+      return (part + updatedSuffix + ', ' + part + ' ' + updatedSuffix);
     }
   }
 

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -197,6 +197,29 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       });
     });
 
+    describe((':host-context and :host combination selector'), () => {
+      it('should handle tag selector', () => {
+        expect(s(':host-context(div):host(.x) {}', 'contenta', 'a-host'))
+            .toEqual('div.x[a-host], div .x[a-host] {}');
+        expect(s(':host-context(ul):host(.x) > .y {}', 'contenta', 'a-host'))
+            .toEqual('ul.x[a-host] > .y[contenta], ul .x[a-host] > .y[contenta] {}');
+      });
+
+      it('should handle class selector', () => {
+        expect(s(':host-context(.x):host(.y) {}', 'contenta', 'a-host'))
+            .toEqual('.x.y[a-host], .x .y[a-host] {}');
+        expect(s(':host-context(.x):host(.y) > .z {}', 'contenta', 'a-host'))
+            .toEqual('.x.y[a-host] > .z[contenta], .x .y[a-host] > .z[contenta] {}');
+      });
+
+      it('should handle attribute selector', () => {
+        expect(s(':host-context([a="b"]):host(.y) {}', 'contenta', 'a-host'))
+            .toEqual('[a="b"].y[a-host], [a="b"] .y[a-host] {}');
+        expect(s(':host-context([a=b]):host(.y) {}', 'contenta', 'a-host'))
+            .toEqual('[a=b].y[a-host], [a="b"] .y[a-host] {}');
+      });
+    });
+
     it('should support polyfill-next-selector', () => {
       let css = s('polyfill-next-selector {content: \'x > y\'} z {}', 'contenta');
       expect(css).toEqual('x[contenta] > y[contenta]{}');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14349
```
:host-context(.a):host(.b) => .a[host].b[host], .a [host] -no-combinator.b[host]
```

## What is the new behavior?

```
:host-context(.a):host(.b) => .a.b[host], .a .b[host]
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
