### PR TITLE
feat(ngcc): support ignoring all entry-points within a package

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -18,6 +18,9 @@ export interface NgccProjectConfig { packages: {[packagePath: string]: NgccPacka
  * The format of a package level configuration file.
  */
 export interface NgccPackageConfig {
+  /** Do not process any of the entry-points within this package, if true. */
+  ignore?: boolean;
+
   /**
    * The entry-points to configure for this package.
    *

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -75,7 +75,12 @@ export function getEntryPointInfo(
     fs: FileSystem, config: NgccConfiguration, logger: Logger, packagePath: AbsoluteFsPath,
     entryPointPath: AbsoluteFsPath): EntryPoint|null {
   const packageJsonPath = resolve(entryPointPath, 'package.json');
-  const entryPointConfig = config.getConfig(packagePath).entryPoints[entryPointPath];
+  const packageConfig = config.getConfig(packagePath);
+  if (packageConfig.ignore === true) {
+    return null;
+  }
+
+  const entryPointConfig = packageConfig.entryPoints[entryPointPath];
   if (entryPointConfig === undefined && !fs.exists(packageJsonPath)) {
     return null;
   }

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -53,6 +53,26 @@ runInEachFileSystem(() => {
          });
        });
 
+    it('should return null if configured to ignore the package', () => {
+      loadTestFiles([
+        {
+          name: _('/project/node_modules/some_package/valid_entry_point/package.json'),
+          contents: createPackageJson('valid_entry_point'),
+        },
+        {
+          name: _(
+              '/project/node_modules/some_package/valid_entry_point/valid_entry_point.metadata.json'),
+          contents: 'some meta data',
+        },
+      ]);
+      const config = new NgccConfiguration(fs, _('/project'));
+      spyOn(config, 'getConfig').and.returnValue({ignore: true, entryPoints: {}});
+      const entryPoint = getEntryPointInfo(
+          fs, config, new MockLogger(), SOME_PACKAGE,
+          _('/project/node_modules/some_package/valid_entry_point'));
+      expect(entryPoint).toBe(null);
+    });
+
     it('should return null if configured to ignore the specified entry-point', () => {
       loadTestFiles([
         {


### PR DESCRIPTION
Ngcc can be configured to ignore certain entry-points of a package to
exclude it from processing. This is useful for entry-points that are not
Angular packages, which may be bundled in a way that is not supported by
ngcc. The ability to ignore specific entry-points allows for simply
skipping the entry-points entirely, to avoid errors in ngcc.

Prior to this commit, only specific entry-points within a package could
be ignored, not a package in its entirety. This is cumbersome for
packages like `date-fns` with over 100 entry-points, bundled in a way
that results in an error when processed by ngcc. This commit adds an
option to the configuration file to allow a package to be ignored in its
entirety, to avoid having to list over 100 entry-points explicitly in
the case of `date-fns`.

Example `ngcc.config.js` file:

```javascript
module.exports = {
  packages: {
    'date-fns': {
      ignore: true,
    },
  },
};
```
