### PR TITLE
ci: update material commit we use to run integration tests

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -80,7 +80,7 @@ setPublicVar MATERIAL_REPO_TMP_DIR "/tmp/material2"
 setPublicVar MATERIAL_REPO_URL "https://github.com/angular/material2.git"
 setPublicVar MATERIAL_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI "config.yml".
-setPublicVar MATERIAL_REPO_COMMIT "701302dc482d7e4b77990b24e3b5ab330bbf1aa5"
+setPublicVar MATERIAL_REPO_COMMIT "eaf70ca2a0600757041633976b29ab5a95d08296"
 
 # Source `$BASH_ENV` to make the variables available immediately.
 source $BASH_ENV;


### PR DESCRIPTION
This PR just updates the Material commit we use for our Material integration tests.