### PR TITLE
feat(language-service): add definitions for templateUrl

### DIFF
--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as path from 'path';
 import * as ts from 'typescript'; // used as value and is provided at runtime
 import {TemplateInfo} from './common';
 import {locateSymbol} from './locate_symbol';
-import {Span} from './types';
+import {Span, TemplateSource} from './types';
+import {findTightestNode} from './utils';
 
 /**
  * Convert Angular Span to TypeScript TextSpan. Angular Span has 'start' and
@@ -52,4 +54,61 @@ export function getDefinitionAndBoundSpan(info: TemplateInfo): ts.DefinitionInfo
   return {
       definitions, textSpan,
   };
+}
+
+/**
+ * Gets an Angular-specific definition in a TypeScript source file.
+ */
+export function getTsDefinitionAndBoundSpan(
+    sf: ts.SourceFile, position: number,
+    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+  const node = findTightestNode(sf, position);
+  if (!node) return;
+  switch (node.kind) {
+    case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+      // Attempt to extract definition of a URL in a property assignment.
+      return getUrlFromProperty(node as ts.StringLiteralLike, readTemplate);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Attempts to get the definition of a file whose URL is specified in a property assignment.
+ * Currently applies to `templateUrl` properties.
+ */
+function getUrlFromProperty(
+    urlNode: ts.StringLiteralLike,
+    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+  const sf = urlNode.getSourceFile();
+  const parent = urlNode.parent;
+  if (!ts.isPropertyAssignment(parent)) return;
+
+  switch (parent.name.getText()) {
+    case 'templateUrl':
+      // Extract definition of the template file specified by this `templateUrl` property.
+      const url = path.join(path.dirname(sf.fileName), urlNode.text);
+      const templates = readTemplate(url);
+      const templateDefinitions = templates.map(tmpl => {
+        return {
+          kind: ts.ScriptElementKind.externalModuleName,
+          name: url,
+          containerKind: ts.ScriptElementKind.unknown,
+          containerName: '',
+          textSpan: ngSpanToTsTextSpan(tmpl.span),
+          fileName: url,
+        };
+      });
+
+      return {
+        definitions: templateDefinitions,
+        textSpan: {
+          start: urlNode.getStart(),
+          length: urlNode.getWidth(),
+        },
+      };
+    default:
+      return undefined;
+  }
 }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -8,7 +8,7 @@
 
 import * as tss from 'typescript/lib/tsserverlibrary';
 import {getTemplateCompletions, ngCompletionToTsCompletionEntry} from './completions';
-import {getDefinitionAndBoundSpan} from './definitions';
+import {getDefinitionAndBoundSpan, getTsDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic, uniqueBySpan} from './diagnostics';
 import {getHover} from './hover';
 import {Diagnostic, LanguageService} from './types';
@@ -73,6 +73,16 @@ class LanguageServiceImpl implements LanguageService {
     const templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
     if (templateInfo) {
       return getDefinitionAndBoundSpan(templateInfo);
+    }
+
+    // Attempt to get Angular-specific definitions in a TypeScript file, like templates defined
+    // in a `templateUrl` property.
+    if (fileName.endsWith('.ts')) {
+      const sf = this.host.getSourceFile(fileName);
+      if (sf) {
+        const readTemplate = this.host.getTemplates.bind(this.host);
+        return getTsDefinitionAndBoundSpan(sf, position, readTemplate);
+      }
     }
   }
 

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -254,6 +254,26 @@ describe('definitions', () => {
     }
   });
 
+  it('should be able to find a template from a url', () => {
+    const fileName = addCode(`
+      @Component({
+        templateUrl: './«test».ng',
+      })
+      export class MyComponent {}`);
+
+    const marker = getReferenceMarkerFor(fileName, 'test');
+    const result = ngService.getDefinitionAt(fileName, marker.start);
+
+    expect(result).toBeDefined();
+    const {textSpan, definitions} = result !;
+
+    expect(definitions).toBeDefined();
+    expect(definitions !.length).toBe(1);
+    const [def] = definitions !;
+    expect(def.fileName).toBe('/app/test.ng');
+    expect(def.textSpan).toEqual({start: 0, length: 172});
+  });
+
   /**
    * Append a snippet of code to `app.component.ts` and return the file name.
    * There must not be any name collision with existing code.


### PR DESCRIPTION
Adds support for `getDefinitionAt` when called on a templateUrl
property assignment.

The currrent architecture for getting definitions is designed to be
called on templates, so we have to introduce a new
`getTsDefinitionAndBoundSpan` method to get Angular-specific definitions
in TypeScript files and pass a `readTemplate` closure that will read the
contents of a template using `TypeScriptServiceHost#getTemplates`. We
can probably go in and make this nicer in a future PR, though I'm not
sure what the best architecture should be yet.

Part of angular/vscode-ng-language-service#111

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: angular/vscode-ng-language-service#111


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information