### PR TITLE
fix(ivy): ngtsc throws if "flatModuleOutFile" is set to null

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -116,7 +116,7 @@ export class NgtscProgram implements api.Program {
     rootFiles.push(this.typeCheckFilePath);
 
     let entryPoint: AbsoluteFsPath|null = null;
-    if (options.flatModuleOutFile !== undefined) {
+    if (options.flatModuleOutFile != null && options.flatModuleOutFile !== '') {
       entryPoint = findFlatIndexEntryPoint(normalizedRootNames);
       if (entryPoint === null) {
         // This error message talks specifically about having a single .ts file in "files". However

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -145,7 +145,8 @@ export class NgtscTestEnvironment {
     this.multiCompileHostExt.invalidate(absFilePath);
   }
 
-  tsconfig(extraOpts: {[key: string]: string | boolean} = {}, extraRootDirs?: string[]): void {
+  tsconfig(extraOpts: {[key: string]: string | boolean | null} = {}, extraRootDirs?: string[]):
+      void {
     const tsconfig: {[key: string]: any} = {
       extends: './tsconfig-base.json',
       angularCompilerOptions: {...extraOpts, enableIvy: true},

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2943,6 +2943,35 @@ runInEachFileSystem(os => {
         expect(env.getContents('./public-api/index.js')).toContain(`export * from '../test';`);
       });
 
+      it('should not throw if "flatModuleOutFile" is set to null', () => {
+        env.tsconfig({
+          'flatModuleOutFile': null,
+        });
+
+        env.write('test.ts', `export const SOME_EXPORT = 'some-export'`);
+        // The "driveMain" method automatically ensures that there is no
+        // exception and that the build succeeded.
+        env.driveMain();
+      });
+
+      it('should not throw or produce flat module index if "flatModuleOutFile" is set to ' +
+             'empty string',
+         () => {
+           env.tsconfig({
+             'flatModuleOutFile': '',
+           });
+
+           env.write('test.ts', `export const SOME_EXPORT = 'some-export'`);
+           // The "driveMain" method automatically ensures that there is no
+           // exception and that the build succeeded.
+           env.driveMain();
+           // Previously ngtsc incorrectly tried generating a flat module index
+           // file if the "flatModuleOutFile" was set to an empty string. ngtsc
+           // just wrote the bundle file with an empty filename (just extension).
+           env.assertDoesNotExist('.js');
+           env.assertDoesNotExist('.d.ts');
+         });
+
       it('should report an error when a flat module index is requested but no entrypoint can be determined',
          () => {
            env.tsconfig({'flatModuleOutFile': 'flat.js'});


### PR DESCRIPTION
In ngc is was valid to set the "flatModuleOutFile" option to "null". This is sometimes
necessary if a tsconfig extends from another one but the "fatModuleOutFile" option
needs to be unset (note that "undefined" does not exist as value in JSON)

Now if ngtsc is used to compile the project, ngtsc will fail with an error because it
tries to do string manipulation on the "flatModuleOutFile". This happens because
ngtsc only skips flat module indices if the option is set to "undefined".

Since this is not compatible with what was supported in ngc and such exceptions
should be avoided, the flat module check is now aligned with ngc.

```
TypeError: Cannot read property 'replace' of null
    at Object.normalizeSeparators (/home/circleci/project/node_modules/@angular/compiler-cli/src/ngtsc/util/src/path.js:35:21)
    at new NgtscProgram (/home/circleci/project/node_modules/@angular/compiler-cli/src/ngtsc/program.js:126:52)
```

Additionally setting the `flatModuleOutFile` option to an empty string
currently results in unexpected behavior. No errors is thrown, but the
flat module index file will be `.ts` (no file name; just extension). This is now
also fixed by treating an empty string similarly to `null` and `undefined`.