### PR TITLE
feat(language-service): add definitions for templateUrl

### DIFF
--- a/integration/language_service_plugin/goldens/templateUrlDefinition.json
+++ b/integration/language_service_plugin/goldens/templateUrlDefinition.json
@@ -1,0 +1,32 @@
+{
+  "seq": 0,
+  "type": "response",
+  "command": "definitionAndBoundSpan",
+  "request_seq": 2,
+  "success": true,
+  "body": {
+    "definitions": [
+      {
+        "file": "${PWD}/project/app/widget.component.html",
+        "start": {
+          "line": 1,
+          "offset": 1
+        },
+        "end": {
+          "line": 2,
+          "offset": 1
+        }
+      }
+    ],
+    "textSpan": {
+      "start": {
+        "line": 5,
+        "offset": 16
+      },
+      "end": {
+        "line": 5,
+        "offset": 41
+      }
+    }
+  }
+}

--- a/integration/language_service_plugin/goldens/templateUrlDefinition.json
+++ b/integration/language_service_plugin/goldens/templateUrlDefinition.json
@@ -13,7 +13,7 @@
           "offset": 1
         },
         "end": {
-          "line": 2,
+          "line": 1,
           "offset": 1
         }
       }
@@ -21,11 +21,11 @@
     "textSpan": {
       "start": {
         "line": 5,
-        "offset": 16
+        "offset": 17
       },
       "end": {
         "line": 5,
-        "offset": 41
+        "offset": 40
       }
     }
   }

--- a/integration/language_service_plugin/test.ts
+++ b/integration/language_service_plugin/test.ts
@@ -1,23 +1,29 @@
-import { fork, ChildProcess } from 'child_process';
-import { join } from 'path';
-import { Client } from './tsclient';
-import { goldenMatcher } from './matcher';
+import {ChildProcess, fork} from 'child_process';
+import {join} from 'path';
+
+import {goldenMatcher} from './matcher';
+import {Client} from './tsclient';
 
 describe('Angular Language Service', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */
   const PWD = process.env.PWD!;
-  const SERVER_PATH = "./node_modules/typescript/lib/tsserver.js";
+  const SERVER_PATH = './node_modules/typescript/lib/tsserver.js';
   let server: ChildProcess;
   let client: Client;
 
   beforeEach(() => {
     jasmine.addMatchers(goldenMatcher);
-    server = fork(SERVER_PATH, [
-      '--logVerbosity', 'verbose',
-      '--logFile', join(PWD, 'tsserver.log'),
-    ], {
-        stdio: ['pipe', 'pipe', 'inherit', 'ipc'],
-      });
+    server = fork(
+        SERVER_PATH,
+        [
+          '--logVerbosity',
+          'verbose',
+          '--logFile',
+          join(PWD, 'tsserver.log'),
+        ],
+        {
+          stdio: ['pipe', 'pipe', 'inherit', 'ipc'],
+        });
     client = new Client(server);
     client.listen();
   });
@@ -35,13 +41,13 @@ describe('Angular Language Service', () => {
     });
     expect(response).toMatchGolden('configure.json');
     response = await client.sendRequest('compilerOptionsForInferredProjects', {
-      "options": {
-        module: "CommonJS",
-        target: "ES6",
+      'options': {
+        module: 'CommonJS',
+        target: 'ES6',
         allowSyntheticDefaultImports: true,
         allowNonTsExtensions: true,
         allowJs: true,
-        jsx: "Preserve"
+        jsx: 'Preserve'
       }
     });
     expect(response).toMatchGolden('compilerOptionsForInferredProjects.json');
@@ -52,10 +58,7 @@ describe('Angular Language Service', () => {
     });
     // Server does not send response to geterr request
     // https://github.com/Microsoft/TypeScript/blob/master/lib/protocol.d.ts#L1770
-    client.sendRequest('geterr', {
-      delay: 0,
-      files: [`${PWD}/project/app/app.module.ts`]
-    });
+    client.sendRequest('geterr', {delay: 0, files: [`${PWD}/project/app/app.module.ts`]});
   });
 
   it('should perform completions', async () => {
@@ -63,13 +66,13 @@ describe('Angular Language Service', () => {
       hostInfo: 'vscode',
     });
     await client.sendRequest('compilerOptionsForInferredProjects', {
-      "options": {
-        module: "CommonJS",
-        target: "ES6",
+      'options': {
+        module: 'CommonJS',
+        target: 'ES6',
         allowSyntheticDefaultImports: true,
         allowNonTsExtensions: true,
         allowJs: true,
-        jsx: "Preserve"
+        jsx: 'Preserve'
       }
     });
 
@@ -77,10 +80,7 @@ describe('Angular Language Service', () => {
       file: `${PWD}/project/app/app.component.ts`,
     });
 
-    client.sendRequest('geterr', {
-      delay: 0,
-      files: [`${PWD}/project/app/app.component.ts`]
-    });
+    client.sendRequest('geterr', {delay: 0, files: [`${PWD}/project/app/app.component.ts`]});
 
     client.sendRequest('change', {
       file: `${PWD}/project/app/app.component.ts`,
@@ -144,14 +144,14 @@ describe('Angular Language Service', () => {
       file: `${PWD}/project/app/app.component.ts`,
     });
 
-     const resp1 = await client.sendRequest('reload', {
+    const resp1 = await client.sendRequest('reload', {
       file: `${PWD}/project/app/app.component.ts`,
       tmpFile: `${PWD}/project/app/app.component.ts`,
     }) as any;
     expect(resp1.command).toBe('reload');
     expect(resp1.success).toBe(true);
 
-     const resp2 = await client.sendRequest('definitionAndBoundSpan', {
+    const resp2 = await client.sendRequest('definitionAndBoundSpan', {
       file: `${PWD}/project/app/app.component.ts`,
       line: 5,
       offset: 28,
@@ -159,4 +159,23 @@ describe('Angular Language Service', () => {
     expect(resp2).toMatchGolden('definitionAndBoundSpan.json');
   });
 
+  it('should perform definitionAndBoundSpan for template URLs', async () => {
+    client.sendRequest('open', {
+      file: `${PWD}/project/app/widget.component.ts`,
+    });
+
+    const resp1 = await client.sendRequest('reload', {
+      file: `${PWD}/project/app/widget.component.ts`,
+      tmpFile: `${PWD}/project/app/widget.component.ts`,
+    }) as any;
+    expect(resp1.command).toBe('reload');
+    expect(resp1.success).toBe(true);
+
+    const resp2 = await client.sendRequest('definitionAndBoundSpan', {
+      file: `${PWD}/project/app/widget.component.ts`,
+      line: 5,
+      offset: 19,
+    });
+    expect(resp2).toMatchGolden('templateUrlDefinition.json');
+  });
 });

--- a/integration/language_service_plugin/test.ts
+++ b/integration/language_service_plugin/test.ts
@@ -1,12 +1,11 @@
 import {ChildProcess, fork} from 'child_process';
 import {join} from 'path';
-
 import {goldenMatcher} from './matcher';
 import {Client} from './tsclient';
 
 describe('Angular Language Service', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */
-  const PWD = process.env.PWD!;
+  const PWD = process.env.PWD !;
   const SERVER_PATH = './node_modules/typescript/lib/tsserver.js';
   let server: ChildProcess;
   let client: Client;
@@ -28,14 +27,14 @@ describe('Angular Language Service', () => {
     client.listen();
   });
 
-  afterEach(async () => {
+  afterEach(async() => {
     client.sendRequest('exit', {});
 
     // Give server process some time to flush all messages
     await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
-  it('should be launched as tsserver plugin', async () => {
+  it('should be launched as tsserver plugin', async() => {
     let response = await client.sendRequest('configure', {
       hostInfo: 'vscode',
     });
@@ -61,7 +60,7 @@ describe('Angular Language Service', () => {
     client.sendRequest('geterr', {delay: 0, files: [`${PWD}/project/app/app.module.ts`]});
   });
 
-  it('should perform completions', async () => {
+  it('should perform completions', async() => {
     await client.sendRequest('configure', {
       hostInfo: 'vscode',
     });
@@ -99,7 +98,7 @@ describe('Angular Language Service', () => {
     expect(response).toMatchGolden('completionInfo.json');
   });
 
-  it('should perform quickinfo', async () => {
+  it('should perform quickinfo', async() => {
     client.sendRequest('open', {
       file: `${PWD}/project/app/app.component.ts`,
     });
@@ -119,7 +118,7 @@ describe('Angular Language Service', () => {
     expect(resp2).toMatchGolden('quickinfo.json');
   });
 
-  it('should perform definition', async () => {
+  it('should perform definition', async() => {
     client.sendRequest('open', {
       file: `${PWD}/project/app/app.component.ts`,
     });
@@ -139,7 +138,7 @@ describe('Angular Language Service', () => {
     expect(resp2).toMatchGolden('definition.json');
   });
 
-  it('should perform definitionAndBoundSpan', async () => {
+  it('should perform definitionAndBoundSpan', async() => {
     client.sendRequest('open', {
       file: `${PWD}/project/app/app.component.ts`,
     });
@@ -159,7 +158,7 @@ describe('Angular Language Service', () => {
     expect(resp2).toMatchGolden('definitionAndBoundSpan.json');
   });
 
-  it('should perform definitionAndBoundSpan for template URLs', async () => {
+  it('should perform definitionAndBoundSpan for template URLs', async() => {
     client.sendRequest('open', {
       file: `${PWD}/project/app/widget.component.ts`,
     });

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -68,14 +68,14 @@ export function getDefinitionAndBoundSpan(
  */
 export function getTsDefinitionAndBoundSpan(
     sf: ts.SourceFile, position: number,
-    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+    tsLsHost: Readonly<ts.LanguageServiceHost>): ts.DefinitionInfoAndBoundSpan|undefined {
   const node = findTightestNode(sf, position);
   if (!node) return;
   switch (node.kind) {
     case ts.SyntaxKind.StringLiteral:
     case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
       // Attempt to extract definition of a URL in a property assignment.
-      return getUrlFromProperty(node as ts.StringLiteralLike, readTemplate);
+      return getUrlFromProperty(node as ts.StringLiteralLike, tsLsHost);
     default:
       return undefined;
   }
@@ -88,7 +88,7 @@ export function getTsDefinitionAndBoundSpan(
  */
 function getUrlFromProperty(
     urlNode: ts.StringLiteralLike,
-    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+    tsLsHost: Readonly<ts.LanguageServiceHost>): ts.DefinitionInfoAndBoundSpan|undefined {
   const asgn = getPropertyAssignmentFromValue(urlNode);
   if (!asgn) return;
   // If the URL is not a property of a class decorator, don't generate definitions for it.
@@ -99,23 +99,27 @@ function getUrlFromProperty(
     case 'templateUrl':
       // Extract definition of the template file specified by this `templateUrl` property.
       const url = path.join(path.dirname(sf.fileName), urlNode.text);
-      const templates = readTemplate(url);
-      const templateDefinitions = templates.map(tmpl => {
-        return {
-          kind: ts.ScriptElementKind.externalModuleName,
-          name: url,
-          containerKind: ts.ScriptElementKind.unknown,
-          containerName: '',
-          textSpan: ngSpanToTsTextSpan(tmpl.span),
-          fileName: url,
-        };
-      });
+
+      // If the file does not exist, bail. It is possible that the TypeScript language service host
+      // does not have a `fileExists` method, in which case optimistically assume the file exists.
+      if (tsLsHost.fileExists && !tsLsHost.fileExists(url)) return;
+
+      const templateDefinitions: ts.DefinitionInfo[] = [{
+        kind: ts.ScriptElementKind.externalModuleName,
+        name: url,
+        containerKind: ts.ScriptElementKind.unknown,
+        containerName: '',
+        // Reading the template is expensive, so don't provide a preview.
+        textSpan: {start: 0, length: 0},
+        fileName: url,
+      }];
 
       return {
         definitions: templateDefinitions,
         textSpan: {
-          start: urlNode.getStart(),
-          length: urlNode.getWidth(),
+          // Exclude opening and closing quotes in the url span.
+          start: urlNode.getStart() + 1,
+          length: urlNode.getWidth() - 2,
         },
       };
     default:

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as path from 'path';
 import * as ts from 'typescript'; // used as value and is provided at runtime
 import {AstResult} from './common';
 import {locateSymbol} from './locate_symbol';
-import {Span} from './types';
+import {Span, TemplateSource} from './types';
+import {findTightestNode} from './utils';
 
 /**
  * Convert Angular Span to TypeScript TextSpan. Angular Span has 'start' and
@@ -58,4 +60,61 @@ export function getDefinitionAndBoundSpan(
   return {
       definitions, textSpan,
   };
+}
+
+/**
+ * Gets an Angular-specific definition in a TypeScript source file.
+ */
+export function getTsDefinitionAndBoundSpan(
+    sf: ts.SourceFile, position: number,
+    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+  const node = findTightestNode(sf, position);
+  if (!node) return;
+  switch (node.kind) {
+    case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+      // Attempt to extract definition of a URL in a property assignment.
+      return getUrlFromProperty(node as ts.StringLiteralLike, readTemplate);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Attempts to get the definition of a file whose URL is specified in a property assignment.
+ * Currently applies to `templateUrl` properties.
+ */
+function getUrlFromProperty(
+    urlNode: ts.StringLiteralLike,
+    readTemplate: (file: string) => TemplateSource[]): ts.DefinitionInfoAndBoundSpan|undefined {
+  const sf = urlNode.getSourceFile();
+  const parent = urlNode.parent;
+  if (!ts.isPropertyAssignment(parent)) return;
+
+  switch (parent.name.getText()) {
+    case 'templateUrl':
+      // Extract definition of the template file specified by this `templateUrl` property.
+      const url = path.join(path.dirname(sf.fileName), urlNode.text);
+      const templates = readTemplate(url);
+      const templateDefinitions = templates.map(tmpl => {
+        return {
+          kind: ts.ScriptElementKind.externalModuleName,
+          name: url,
+          containerKind: ts.ScriptElementKind.unknown,
+          containerName: '',
+          textSpan: ngSpanToTsTextSpan(tmpl.span),
+          fileName: url,
+        };
+      });
+
+      return {
+        definitions: templateDefinitions,
+        textSpan: {
+          start: urlNode.getStart(),
+          length: urlNode.getWidth(),
+        },
+      };
+    default:
+      return undefined;
+  }
 }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -86,8 +86,7 @@ class LanguageServiceImpl implements LanguageService {
     if (fileName.endsWith('.ts')) {
       const sf = this.host.getSourceFile(fileName);
       if (sf) {
-        const readTemplate = this.host.getTemplates.bind(this.host);
-        return getTsDefinitionAndBoundSpan(sf, position, readTemplate);
+        return getTsDefinitionAndBoundSpan(sf, position, this.host.host);
       }
     }
   }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -10,7 +10,7 @@ import * as tss from 'typescript/lib/tsserverlibrary';
 
 import {isAstResult} from './common';
 import {getTemplateCompletions, ngCompletionToTsCompletionEntry} from './completions';
-import {getDefinitionAndBoundSpan} from './definitions';
+import {getDefinitionAndBoundSpan, getTsDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic, uniqueBySpan} from './diagnostics';
 import {getHover} from './hover';
 import {Diagnostic, LanguageService} from './types';
@@ -79,6 +79,16 @@ class LanguageServiceImpl implements LanguageService {
     const templateInfo = this.host.getTemplateAstAtPosition(fileName, position);
     if (templateInfo) {
       return getDefinitionAndBoundSpan(templateInfo, position);
+    }
+
+    // Attempt to get Angular-specific definitions in a TypeScript file, like templates defined
+    // in a `templateUrl` property.
+    if (fileName.endsWith('.ts')) {
+      const sf = this.host.getSourceFile(fileName);
+      if (sf) {
+        const readTemplate = this.host.getTemplates.bind(this.host);
+        return getTsDefinitionAndBoundSpan(sf, position, readTemplate);
+      }
     }
   }
 

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -18,7 +18,6 @@ import {Declaration, DeclarationError, Diagnostic, DiagnosticKind, DiagnosticMes
 import {findTightestNode, getDirectiveClassLike} from './utils';
 
 
-
 /**
  * Create a `LanguageServiceHost`
  */

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -18,6 +18,7 @@ import {Declaration, DeclarationError, Diagnostic, DiagnosticKind, DiagnosticMes
 import {findTightestNode, getDirectiveClassLike} from './utils';
 
 
+
 /**
  * Create a `LanguageServiceHost`
  */
@@ -73,8 +74,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     ngModules: [],
   };
 
-  constructor(
-      private readonly host: ts.LanguageServiceHost, private readonly tsLS: ts.LanguageService) {
+  constructor(readonly host: ts.LanguageServiceHost, private readonly tsLS: ts.LanguageService) {
     this.summaryResolver = new AotSummaryResolver(
         {
           loadSummary(filePath: string) { return null; },

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -254,6 +254,26 @@ describe('definitions', () => {
     }
   });
 
+  it('should be able to find a template from a url', () => {
+    const fileName = addCode(`
+      @Component({
+        templateUrl: './«test».ng',
+      })
+      export class MyComponent {}`);
+
+    const marker = getReferenceMarkerFor(fileName, 'test');
+    const result = ngService.getDefinitionAt(fileName, marker.start);
+
+    expect(result).toBeDefined();
+    const {textSpan, definitions} = result !;
+
+    expect(definitions).toBeDefined();
+    expect(definitions !.length).toBe(1);
+    const [def] = definitions !;
+    expect(def.fileName).toBe('/app/test.ng');
+    expect(def.textSpan).toEqual({start: 0, length: 172});
+  });
+
   /**
    * Append a snippet of code to `app.component.ts` and return the file name.
    * There must not be any name collision with existing code.

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -267,11 +267,13 @@ describe('definitions', () => {
     expect(result).toBeDefined();
     const {textSpan, definitions} = result !;
 
+    expect(textSpan).toEqual({start: marker.start - 2, length: 9});
+
     expect(definitions).toBeDefined();
     expect(definitions !.length).toBe(1);
     const [def] = definitions !;
     expect(def.fileName).toBe('/app/test.ng');
-    expect(def.textSpan).toEqual({start: 0, length: 172});
+    expect(def.textSpan).toEqual({start: 0, length: 0});
   });
 
   /**


### PR DESCRIPTION
Adds support for `getDefinitionAt` when called on a templateUrl
property assignment.

The currrent architecture for getting definitions is designed to be
called on templates, so we have to introduce a new
`getTsDefinitionAndBoundSpan` method to get Angular-specific definitions
in TypeScript files and pass the TypeScript language service host to this
new method so that URLs can be verified to exist.

Closes angular/vscode-ng-language-service#111
Closes #13888
Closes #13890

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: angular/vscode-ng-language-service#111


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information