### PR TITLE
build: use bazel workers for ngc and tsc in local development

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -146,6 +146,11 @@ build --incompatible_list_based_execution_strategy_selection=false
 test --incompatible_list_based_execution_strategy_selection=false
 run --incompatible_list_based_execution_strategy_selection=false
 
+# Use workers for tsc and ngc when building locally.
+# This config is overwritten on CI to as the worker strategy causes flakes on CI.
+build --strategy=AngularTemplateCompile=worker
+build --strategy=TypeScriptCompile=worker
+
 ####################################################
 # User bazel configuration
 # NOTE: This needs to be the *last* entry in the config.


### PR DESCRIPTION
Uses the worker strategy for ngc and tsc in local development.  Quick analysis of time savings

Build command executed:
`yarn bazel build //packages/core/test/acceptance:acceptance --define=compile=aot`

### Clean Build - 33.1% faster
Before:
```
real    1m39.631s
user    0m0.285s
sys     0m0.088s
```
After:
```
real    1m6.712s
user    0m0.283s
sys     0m0.106s
```

### Rebuild - 47% faster
_Rebuilds were done with a trivial comment added to `packages/core/test/acceptance/attributes_spec.ts`_

Before:
```
real    0m10.089s
user    0m0.271s
sys     0m0.119s
```
After:
```
real    0m5.265s
user    0m0.276s
sys     0m0.116s
```

