### PR TITLE
refactor(language-service): Remove redudant 'TemplateInfo' type

### DIFF
--- a/packages/language-service/src/common.ts
+++ b/packages/language-service/src/common.ts
@@ -11,26 +11,14 @@ import {CompileDirectiveMetadata, CompileDirectiveSummary, CompilePipeSummary, C
 import {Diagnostic, TemplateSource} from './types';
 
 export interface AstResult {
-  htmlAst?: HtmlAst[];
-  templateAst?: TemplateAst[];
-  directive?: CompileDirectiveMetadata;
-  directives?: CompileDirectiveSummary[];
-  pipes?: CompilePipeSummary[];
-  parseErrors?: ParseError[];
-  expressionParser?: Parser;
-  errors?: Diagnostic[];
-}
-
-export interface TemplateInfo {
-  position?: number;
-  fileName?: string;
-  template: TemplateSource;
   htmlAst: HtmlAst[];
+  templateAst: TemplateAst[];
   directive: CompileDirectiveMetadata;
   directives: CompileDirectiveSummary[];
   pipes: CompilePipeSummary[];
-  templateAst: TemplateAst[];
+  parseErrors?: ParseError[];
   expressionParser: Parser;
+  template: TemplateSource;
 }
 
 export interface AttrInfo {
@@ -45,3 +33,7 @@ export type SelectorInfo = {
   selectors: CssSelector[],
   map: Map<CssSelector, CompileDirectiveSummary>
 };
+
+export function isAstResult(result: AstResult | Diagnostic): result is AstResult {
+  return result.hasOwnProperty('templateAst');
+}

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ts from 'typescript'; // used as value and is provided at runtime
-import {TemplateInfo} from './common';
+import {AstResult} from './common';
 import {locateSymbol} from './locate_symbol';
 import {Span} from './types';
 
@@ -23,9 +23,15 @@ function ngSpanToTsTextSpan(span: Span): ts.TextSpan {
   };
 }
 
-export function getDefinitionAndBoundSpan(info: TemplateInfo): ts.DefinitionInfoAndBoundSpan|
-    undefined {
-  const symbolInfo = locateSymbol(info);
+/**
+ * Traverse the template AST and look for the symbol located at `position`, then
+ * return its definition and span of bound text.
+ * @param info
+ * @param position
+ */
+export function getDefinitionAndBoundSpan(
+    info: AstResult, position: number): ts.DefinitionInfoAndBoundSpan|undefined {
+  const symbolInfo = locateSymbol(info, position);
   if (!symbolInfo) {
     return;
   }

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -16,41 +16,28 @@ import {offsetSpan, spanOf} from './utils';
 
 /**
  * Return diagnostic information for the parsed AST of the template.
- * @param template source of the template and class information
  * @param ast contains HTML and template AST
  */
-export function getTemplateDiagnostics(
-    template: ng.TemplateSource, ast: AstResult): ng.Diagnostic[] {
+export function getTemplateDiagnostics(ast: AstResult): ng.Diagnostic[] {
   const results: ng.Diagnostic[] = [];
-
-  if (ast.parseErrors && ast.parseErrors.length) {
-    results.push(...ast.parseErrors.map(e => {
+  const {parseErrors, templateAst, htmlAst, template} = ast;
+  if (parseErrors) {
+    results.push(...parseErrors.map(e => {
       return {
         kind: ng.DiagnosticKind.Error,
         span: offsetSpan(spanOf(e.span), template.span.start),
         message: e.msg,
       };
     }));
-  } else if (ast.templateAst && ast.htmlAst) {
-    const expressionDiagnostics = getTemplateExpressionDiagnostics({
-      templateAst: ast.templateAst,
-      htmlAst: ast.htmlAst,
-      offset: template.span.start,
-      query: template.query,
-      members: template.members,
-    });
-    results.push(...expressionDiagnostics);
   }
-  if (ast.errors) {
-    results.push(...ast.errors.map(e => {
-      return {
-        kind: e.kind,
-        span: e.span || template.span,
-        message: e.message,
-      };
-    }));
-  }
-
+  const expressionDiagnostics = getTemplateExpressionDiagnostics({
+    templateAst: templateAst,
+    htmlAst: htmlAst,
+    offset: template.span.start,
+    query: template.query,
+    members: template.members,
+  });
+  results.push(...expressionDiagnostics);
   return results;
 }
 

--- a/packages/language-service/src/hover.ts
+++ b/packages/language-service/src/hover.ts
@@ -7,15 +7,21 @@
  */
 
 import * as ts from 'typescript';
-import {TemplateInfo} from './common';
+import {AstResult} from './common';
 import {locateSymbol} from './locate_symbol';
 
 // Reverse mappings of enum would generate strings
 const SYMBOL_SPACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.space];
 const SYMBOL_PUNC = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.punctuation];
 
-export function getHover(info: TemplateInfo): ts.QuickInfo|undefined {
-  const symbolInfo = locateSymbol(info);
+/**
+ * Traverse the template AST and look for the symbol located at `position`, then
+ * return the corresponding quick info.
+ * @param info template AST
+ * @param position location of the symbol
+ */
+export function getHover(info: AstResult, position: number): ts.QuickInfo|undefined {
+  const symbolInfo = locateSymbol(info, position);
   if (!symbolInfo) {
     return;
   }

--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -8,6 +8,8 @@
 
 import {getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli';
 import * as ts from 'typescript';
+
+import {isAstResult} from './common';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
 
@@ -67,7 +69,8 @@ abstract class BaseTemplate implements ng.TemplateSource {
         // TODO: There is circular dependency here between TemplateSource and
         // TypeScriptHost. Consider refactoring the code to break this cycle.
         const ast = this.host.getTemplateAst(this);
-        return getPipesTable(sourceFile, program, typeChecker, ast.pipes || []);
+        const pipes = isAstResult(ast) ? ast.pipes : [];
+        return getPipesTable(sourceFile, program, typeChecker, pipes);
       });
     }
     return this.queryCache;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -9,7 +9,7 @@
 import {CompileDirectiveMetadata, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli/src/language_services';
 
-import {AstResult, TemplateInfo} from './common';
+import {AstResult} from './common';
 
 export {
   BuiltinType,
@@ -192,12 +192,12 @@ export interface LanguageServiceHost {
   /**
    * Return the AST for both HTML and template for the contextFile.
    */
-  getTemplateAst(template: TemplateSource): AstResult;
+  getTemplateAst(template: TemplateSource): AstResult|Diagnostic;
 
   /**
    * Return the template AST for the node that corresponds to the position.
    */
-  getTemplateAstAtPosition(fileName: string, position: number): TemplateInfo|undefined;
+  getTemplateAstAtPosition(fileName: string, position: number): AstResult|undefined;
 }
 
 /**

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -10,7 +10,7 @@ import {AstPath, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, Dire
 import {DiagnosticTemplateInfo} from '@angular/compiler-cli/src/language_services';
 import * as ts from 'typescript';
 
-import {SelectorInfo, TemplateInfo} from './common';
+import {AstResult, SelectorInfo} from './common';
 import {Span} from './types';
 
 export interface SpanHolder {
@@ -67,7 +67,7 @@ export function hasTemplateReference(type: CompileTypeMetadata): boolean {
   return false;
 }
 
-export function getSelectors(info: TemplateInfo): SelectorInfo {
+export function getSelectors(info: AstResult): SelectorInfo {
   const map = new Map<CssSelector, CompileDirectiveSummary>();
   const selectors: CssSelector[] = flatten(info.directives.map(directive => {
     const selectors: CssSelector[] = CssSelector.parse(directive.selector !);
@@ -113,9 +113,9 @@ export function isTypescriptVersion(low: string, high?: string) {
   return true;
 }
 
-export function diagnosticInfoFromTemplateInfo(info: TemplateInfo): DiagnosticTemplateInfo {
+export function diagnosticInfoFromTemplateInfo(info: AstResult): DiagnosticTemplateInfo {
   return {
-    fileName: info.fileName,
+    fileName: info.template.fileName,
     offset: info.template.span.start,
     query: info.template.query,
     members: info.template.members,


### PR DESCRIPTION
The TemplateInfo type is an extension of AstResult, but it is not
necessary at all. Instead, improve the current interface for AstResult
by removing all optional fileds and include the TemplateSource in
AstResult instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
