### PR TITLE
ci: copy bazelrc files to home RC locations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,12 @@ var_8: &yarn_install
 var_9: &setup_circleci_bazel_config
   run:
     name: Setting up CircleCI bazel configuration
-    command: sudo cp .circleci/bazel.linux.rc /etc/bazel.bazelrc
+    command: sudo cp .circleci/bazel.linux.rc $HOME/.bazelrc
 
 var_9_win: &setup_circleci_bazel_config_win
   run:
     name: Setting up CircleCI bazel configuration
-    command: copy .circleci\bazel.windows.rc $env:ProgramData\bazel.bazelrc
+    command: copy .circleci\bazel.windows.rc $env:USERPROFILE\.bazelrc
 
 var_10: &restore_cache
   restore_cache:


### PR DESCRIPTION
Copy CircleCI `.bazelrc` files as home RC file rather than system RC file (as outlined [here](https://docs.bazel.build/versions/master/guide.html#bazelrc)).

This results in our CircleCI bazelrc config being loaded later than our `.bazelrc` next to the `WORKSPACE` file, so its rules are interpretted later and therefore are used when in conflict with the `.bazelrc` file next to `WORKSPACE`