### PR TITLE
refactor(language-service): add generic decorator property verifications

### DIFF
--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -150,7 +150,7 @@ export function getPropertyAssignmentFromValue(value: ts.Node): ts.PropertyAssig
  *
  * @param propAsgn property assignment
  */
-export function getClassDeclFromDecoratorProperty(propAsgnNode: ts.PropertyAssignment):
+export function getClassDeclFromDecoratorProp(propAsgnNode: ts.PropertyAssignment):
     ts.ClassDeclaration|undefined {
   if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
     return;
@@ -179,5 +179,5 @@ export function getClassDeclFromDecoratorProperty(propAsgnNode: ts.PropertyAssig
  * @param prop property assignment
  */
 export function isClassDecoratorProperty(propAsgn: ts.PropertyAssignment): boolean {
-  return getClassDeclFromDecoratorProperty(propAsgn) !== undefined;
+  return !!getClassDeclFromDecoratorProp(propAsgn);
 }

--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -124,30 +124,34 @@ export class ExternalTemplate extends BaseTemplate {
 }
 
 /**
- * Given a template node, return the ClassDeclaration node that corresponds to
- * the component class for the template.
+ * Returns a property assignment from the assignment value, or `undefined` if there is no
+ * assignment.
+ */
+export function getPropertyAssignmentFromValue(value: ts.Node): ts.PropertyAssignment|undefined {
+  if (!value.parent || !ts.isPropertyAssignment(value.parent)) {
+    return;
+  }
+  return value.parent;
+}
+
+/**
+ * Given a decorator property assignment, return the ClassDeclaration node that corresponds to the
+ * directive class the property applies to.
+ * If the property assignment is not on a class decorator, no declaration is returned.
  *
  * For example,
  *
  * @Component({
- *   template: '<div></div>' <-- template node
+ *   template: '<div></div>'
+ *   ^^^^^^^^^^^^^^^^^^^^^^^---- property assignment
  * })
  * class AppComponent {}
  *           ^---- class declaration node
  *
- * @param node template node
+ * @param propAsgn property assignment
  */
-export function getClassDeclFromTemplateNode(node: ts.Node): ts.ClassDeclaration|undefined {
-  if (!ts.isStringLiteralLike(node)) {
-    return;
-  }
-  if (!node.parent || !ts.isPropertyAssignment(node.parent)) {
-    return;
-  }
-  const propAsgnNode = node.parent;
-  if (propAsgnNode.name.getText() !== 'template') {
-    return;
-  }
+export function getClassDeclFromDecoratorProperty(propAsgnNode: ts.PropertyAssignment):
+    ts.ClassDeclaration|undefined {
   if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
     return;
   }
@@ -165,4 +169,15 @@ export function getClassDeclFromTemplateNode(node: ts.Node): ts.ClassDeclaration
   }
   const classDeclNode = decorator.parent;
   return classDeclNode;
+}
+
+/**
+ * Determines if a property assignment is on a class decorator.
+ * See `getClassDeclFromDecoratorProperty`, which gets the class the decorator is applied to, for
+ * more details.
+ *
+ * @param prop property assignment
+ */
+export function isClassDecoratorProperty(propAsgn: ts.PropertyAssignment): boolean {
+  return getClassDeclFromDecoratorProperty(propAsgn) !== undefined;
 }

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -13,9 +13,10 @@ import * as ts from 'typescript';
 import {AstResult, TemplateInfo} from './common';
 import {createLanguageService} from './language_service';
 import {ReflectorHost} from './reflector_host';
-import {ExternalTemplate, getClassDeclFromDecoratorProperty, getPropertyAssignmentFromValue, InlineTemplate} from './template';
+import {ExternalTemplate, InlineTemplate, getClassDeclFromDecoratorProp, getPropertyAssignmentFromValue} from './template';
 import {Declaration, DeclarationError, Diagnostic, DiagnosticKind, DiagnosticMessageChain, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
 import {findTightestNode, getDirectiveClassLike} from './utils';
+
 
 /**
  * Create a `LanguageServiceHost`
@@ -133,18 +134,16 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
    * same role as 'synchronizeHostData' in tsserver.
    */
   getAnalyzedModules(): NgAnalyzedModules {
-    if (this.upToDate()) { return this.analyzedModules; }
+    if (this.upToDate()) {
+      return this.analyzedModules;
+    }
 
     // Invalidate caches
     this.templateReferences = [];
     this.fileToComponent.clear();
     this.collectedErrors.clear();
 
-    const analyzeHost = {
-      isSourceFile(filePath: string) {
-        return true;
-      }
-    };
+    const analyzeHost = {isSourceFile(filePath: string) { return true; }};
     const programFiles = this.program.getSourceFiles().map(sf => sf.fileName);
     this.analyzedModules =
         analyzeNgModules(programFiles, analyzeHost, this.staticSymbolResolver, this.resolver);
@@ -315,7 +314,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     if (!tmplAsgn || tmplAsgn.name.getText() !== 'template') {
       return;
     }
-    const classDecl = getClassDeclFromDecoratorProperty(tmplAsgn);
+    const classDecl = getClassDeclFromDecoratorProp(tmplAsgn);
     if (!classDecl || !classDecl.name) {  // Does not handle anonymous class
       return;
     }

--- a/packages/language-service/test/template_spec.ts
+++ b/packages/language-service/test/template_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ts from 'typescript';
-import {getClassDeclFromDecoratorProperty} from '../src/template';
+import {getClassDeclFromDecoratorProp} from '../src/template';
 import {toh} from './test_data';
 import {MockTypescriptHost} from './test_utils';
 
@@ -23,7 +23,7 @@ describe('getClassDeclFromTemplateNode', () => {
         ts.ScriptTarget.ES2015, true /* setParentNodes */);
     function visit(node: ts.Node): ts.ClassDeclaration|undefined {
       if (ts.isPropertyAssignment(node)) {
-        return getClassDeclFromDecoratorProperty(node);
+        return getClassDeclFromDecoratorProp(node);
       }
       return node.forEachChild(visit);
     }
@@ -39,9 +39,9 @@ describe('getClassDeclFromTemplateNode', () => {
     const tsLS = ts.createLanguageService(host);
     const sourceFile = tsLS.getProgram() !.getSourceFile('/app/app.component.ts');
     expect(sourceFile).toBeTruthy();
-    const classDecl = sourceFile !.forEachChild(function visit(node): ts.Node|undefined {
+    const classDecl = sourceFile !.forEachChild(function visit(node): ts.Node | undefined {
       if (ts.isPropertyAssignment(node)) {
-        return getClassDeclFromDecoratorProperty(node);
+        return getClassDeclFromDecoratorProp(node);
       }
       return node.forEachChild(visit);
     });


### PR DESCRIPTION
This PR makes finding class declarations properties in decorators are
applied to more generic to all properties that may be in a decorator,
and adds helper methods enabling getting the property assignment of a
property value and verifying that a property assignment is actually in a
decorator applied to a class.

This is done so that it will be easier to provide Angular definitions
for decorator properties moving forward. Most immediately, this will
provide decorator class verification for #32238.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
