### PR TITLE
build: add .vimrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pubspec.lock
 *.swo
 modules/.settings
 modules/.vscode
+.vimrc
 
 # Don't check in secret files
 *secret.js

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pubspec.lock
 modules/.settings
 modules/.vscode
 .vimrc
+.nvimrc
 
 # Don't check in secret files
 *secret.js


### PR DESCRIPTION
Vim users may need to create a custom `.vimrc` when developing on the
Angular project. The primary use case of this is setting the
clang-format executable to `node_modules/.bin/clang-format`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
