### PR TITLE
docs: add information about running clang-format with Vim

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -107,6 +107,17 @@ It will automatically pick up the settings from Angular's [settings.json](../.vs
 1. Add `<PATH_TO_YOUR_WORKSPACE>/angular/node_modules/clang-format/bin/<OS>/`
   where the OS options are: `darwin_x64`, `linux_x64`, and `win32`.
 
+### Vim
+1. Install [Vim Clang-Format](https://github.com/rhysd/vim-clang-format).
+2. Create a [project-specific `.vimrc`](https://andrew.stwrt.ca/posts/project-specific-vimrc/) in
+   your Angular directory containing
+
+```vim
+let g:clang_format#command = '$ANGULAR_PATH/node_modules/.bin/clang-format'
+```
+
+where `$ANGULAR_PATH` is an environment variable of the absolute path of your Angular directory.
+
 ## Linting/verifying your source code
 
 You can check that your code is properly formatted and adheres to coding style by running:


### PR DESCRIPTION
A clang-format plugin for Vim must point to the npm-installed
clang-format command. Add docs for this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
