### PR TITLE
fix(compiler): correctly parse attributes with a dot in the name

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -278,7 +278,7 @@ export class BindingParser {
     // Check for special cases (prefix style, attr, class)
     if (parts.length > 1) {
       if (parts[0] == ATTRIBUTE_PREFIX) {
-        boundPropertyName = parts[1];
+        boundPropertyName = parts.slice(1).join(PROPERTY_PARTS_SEPARATOR);
         if (!skipValidation) {
           this._validatePropertyOrAttributeName(boundPropertyName, boundProp.sourceSpan, true);
         }

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -566,6 +566,16 @@ class ArrayConsole implements Console {
           ]);
         });
 
+        it('should parse mixed case bound attributes with dot in the attribute name', () => {
+          expect(humanizeTplAst(parse('<div [attr.someAttr.someAttrSuffix]="v">', []))).toEqual([
+            [ElementAst, 'div'],
+            [
+              BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr.someAttrSuffix',
+              'v', null
+            ]
+          ]);
+        });
+
         it('should parse and dash case bound classes', () => {
           expect(humanizeTplAst(parse('<div [class.some-class]="v">', []))).toEqual([
             [ElementAst, 'div'],


### PR DESCRIPTION
Previously the compiler would ignore everything in the attribute
name after the first dot. For example
`<div [attr.someAttr.attrSuffix]="var"></div>`
is turned into `<div someAttr="varValue"></div>`.

This commit ensures that whole attribute name is captured.
Now `<div [attr.someAttr.attrSuffix]="var"></div>`
is turned into `<div someAttr.attrSuffix="varValue"></div>`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
element
```<div [attr.someProp.propSuffix]="var"></div>```
turns into 
```<div someProp="varValue"></div>```  (note the `propSuffix` is cut)


Issue Number: https://github.com/angular/angular/issues/31334


## What is the new behavior?
element 
```<div [attr.someProp.propSuffix]="var"></div>```
result this html 
```<div someProp.propSuffix="varValue"></div>``` (note the `propSuffix` now exists)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
