### PR TITLE
docs(language-service): update integration test information

### DIFF
--- a/integration/language_service_plugin/README.md
+++ b/integration/language_service_plugin/README.md
@@ -1,25 +1,18 @@
 # Angular Language Service Test
 
 This directory is an integration test for `@angular/language-service` to ensure
-that various versions of the server can be loaded in the supported versions of 
+that various versions of the server can be loaded in the supported versions of
 TypeScript's language service.
 
-## New supported version of TypeScript
-
-To add a new supported version of TypeScript:
-
-1) Create directory in `typescripts` to hold the new version following the pattern
-   of the other versions.
-2) Add the directory name to the end of the `TYPESCRIPTS` variable in the 
-   `scripts/env.sh` file.
-3) Run `scripts/update_golden.sh` to generate the expected files.
-4) Verify the expected output is reasonable by comparing to a known good output
-   from a previous version.
+The tests can be run with `yarn test`. Before doing so, please install all dependencies in this
+directory and the Angular repo root directory with `yarn install`, and
+[build Angular](../../docs/DEVELOPER.md#building).
 
 ## Update golden files
 
-If the expected output needs to be updated run `scripts/update_golden.sh` to
-update the expected output of the server.
+If the expected output needs to be updated run `yarn golden my-golden.json`, replacing
+`my-golden.json` with the golden file to be updated. Do not qualify the file with a directory path.
+See [generate.ts](./generate.ts) for more information.
 
 ## Adding a new fixture
 
@@ -30,7 +23,7 @@ I also hand modified the input to remove superfluous request.
 
 Once a new fixture is created:
 
-1) Add the fixture base name (without the .json) to `FIXTURES` in 
-   `scripts/env.sh`.
-2) Run `scripts/udpate_golden.sh` to produce the expected output files.
+1) Add the fixture name to `goldens/`
+2) Run `yarn golden my-golden.json`, replacing `my-golden.json` with the new fixture name, to
+   produce the expected output files.
 3) Hand validate the expected output is reasonable.

--- a/integration/language_service_plugin/README.md
+++ b/integration/language_service_plugin/README.md
@@ -3,13 +3,21 @@
 This directory is an integration test for `@angular/language-service` to ensure
 that the language service works correctly as a `tsserver` plugin.
 
+To use the tests:
+
+- Use `yarn install` to install all dependencies in this directory and in the Angular repo root
+    directory.
+- From the Angular repo root directory, build Angular in the `dist/packages-dist` folder with
+    `./scripts/build-packages-dist.sh`.
+- In this directory, run the tests with `yarn test`.
+
 The tests can be run with `yarn test`. Before doing so, please install all dependencies in this
 directory and the Angular repo root directory with `yarn install`, and
 [build Angular](../../docs/DEVELOPER.md#building).
 
 ## Update golden files
 
-If the expected output needs to be updated run `yarn golden my-golden.json`, replacing
+If the expected output needs to be updated, run `yarn golden my-golden.json`, replacing
 `my-golden.json` with the golden file to be updated. Do not qualify the file with a directory path.
 See [generate.ts](./generate.ts) for more information.
 
@@ -25,4 +33,4 @@ Once a new fixture is created:
 1) Add the fixture name to `goldens/`
 2) Run `yarn golden my-golden.json`, replacing `my-golden.json` with the new fixture name, to
    produce the expected output files.
-3) Hand validate the expected output is reasonable.
+3) Hand validate that the expected output is reasonable.

--- a/integration/language_service_plugin/README.md
+++ b/integration/language_service_plugin/README.md
@@ -11,10 +11,6 @@ To use the tests:
     `./scripts/build-packages-dist.sh`.
 - In this directory, run the tests with `yarn test`.
 
-The tests can be run with `yarn test`. Before doing so, please install all dependencies in this
-directory and the Angular repo root directory with `yarn install`, and
-[build Angular](../../docs/DEVELOPER.md#building).
-
 ## Update golden files
 
 If the expected output needs to be updated, run `yarn golden my-golden.json`, replacing

--- a/integration/language_service_plugin/README.md
+++ b/integration/language_service_plugin/README.md
@@ -1,8 +1,7 @@
 # Angular Language Service Test
 
 This directory is an integration test for `@angular/language-service` to ensure
-that various versions of the server can be loaded in the supported versions of
-TypeScript's language service.
+that the language service works correctly as a `tsserver` plugin.
 
 The tests can be run with `yarn test`. Before doing so, please install all dependencies in this
 directory and the Angular repo root directory with `yarn install`, and


### PR DESCRIPTION
The documentation for the langauge service plugin integration test
appears to be stale. Remove section about new versions of TypeScript,
which appear not to be tested, and update the information about
generating and updating goldens to reflect the new way of doing so.
Add information about install deps in the repo root, this directory, and
building Angular before testing.

Also remove trailing whitespace on one line.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

See commit message

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
