### PR TITLE
test: make largetable test work in g3

### DIFF
--- a/modules/benchmarks/src/largetable/render3/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/render3/BUILD.bazel
@@ -6,7 +6,10 @@ load("//modules/benchmarks:benchmark_test.bzl", "benchmark_test")
 
 ng_module(
     name = "largetable_lib",
-    srcs = glob(["**/*.ts"]),
+    srcs = [
+        "index_aot.ts",
+        "table.ts",
+    ],
     tags = ["ivy-only"],
     deps = [
         "//modules/benchmarks/src:util_lib",
@@ -14,13 +17,12 @@ ng_module(
         "//packages:types",
         "//packages/common",
         "//packages/core",
-        "@npm//reflect-metadata",
     ],
 )
 
 ng_rollup_bundle(
     name = "bundle",
-    entry_point = ":index.ts",
+    entry_point = ":index_aot.ts",
     tags = ["ivy-only"],
     deps = [
         ":largetable_lib",
@@ -30,12 +32,12 @@ ng_rollup_bundle(
 
 ts_devserver(
     name = "devserver",
-    static_files = [
-        ":bundle.min_debug.js",
-        ":bundle.min.js",
-        "index.html",
-    ],
+    index_html = "index.html",
+    port = 4200,
     tags = ["ivy-only"],
+    deps = [
+        ":bundle.min_debug.js",
+    ],
 )
 
 benchmark_test(

--- a/modules/benchmarks/src/largetable/render3/index.html
+++ b/modules/benchmarks/src/largetable/render3/index.html
@@ -28,12 +28,6 @@
     <largetable id="root"></largetable>
   </div>
 
-  <script>
-    // TODO(mlaval): remove once we have a proper solution
-    ngDevMode = false;
-    var bazelBundle = document.location.search.endsWith('debug') ? 'bundle.min_debug.js' : 'bundle.min.js';
-    document.write('<script src="' + bazelBundle + '">\u003c/script>');
-  </script>
 </body>
 
 </html>

--- a/modules/benchmarks/src/largetable/render3/index_aot.ts
+++ b/modules/benchmarks/src/largetable/render3/index_aot.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import 'reflect-metadata';
 import {ɵrenderComponent as renderComponent} from '@angular/core';
 
 import {bindAction, profile} from '../../util';


### PR DESCRIPTION
This PR modifies the `largetable` render3 (ivy) test so that it works in
g3.

1. `index.ts` must be named `index_aot.ts`
2. Scripts should be loaded via `ts_devserver` and not as an explicit
script tag in the HTML.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
