### PR TITLE
build: patch terser to create proper source-maps [do not merge]

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,12 @@ http_archive(
     name = "build_bazel_rules_nodejs",
     patch_args = ["-p1"],
     # Patch https://github.com/bazelbuild/rules_nodejs/pull/903
-    patches = ["//tools:rollup_bundle_commonjs_ignoreGlobal.patch"],
+    # Patch "terser" used by the rollup bazel rule to create proper
+    # source-maps: https://github.com/terser-js/terser/pull/342
+    patches = [
+        "//tools:rollup_bundle_commonjs_ignoreGlobal.patch",
+        "//tools:rollup_terser_incorrect_source_maps.patch",
+    ],
     sha256 = "da217044d24abd16667324626a33581f3eaccabf80985b2688d6a08ed2f864be",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.37.1/rules_nodejs-0.37.1.tar.gz"],
 )

--- a/tools/rollup_terser_incorrect_source_maps.patch
+++ b/tools/rollup_terser_incorrect_source_maps.patch
@@ -1,0 +1,25 @@
+diff --git a/internal/rollup/postinstall-patches.js b/internal/rollup/postinstall-patches.js
+index 3e0720e..0f6f8e7 100644
+--- a/internal/rollup/postinstall-patches.js
++++ b/internal/rollup/postinstall-patches.js
+@@ -43,3 +43,20 @@ console.log(
+     '\n# patch: @buxlabs/amd-to-es6 to generate namespace imports instead of default imports');
+ sed('-i', 'ImportDefaultSpecifier', 'ImportNamespaceSpecifier',
+     'node_modules/@buxlabs/amd-to-es6/src/lib/getImportDeclaration.js');
++
++// Fix terser bug where generated code (e.g. from rollup) is incorrectly mapped to
++// source files. See: https://github.com/terser-js/terser/pull/342
++const terminateSegmentSnippet = `
++  var generatedPos = { line: gen_line + options.dest_line_diff, column: gen_col };
++  if (generatedPos.column !== 0) {
++    generator.addMapping({
++        generated: generatedPos,
++        original: null,
++        source: null,
++        name: null
++    });
++  }
++`
++sed('-i', /if \(info.source === null\) {/, `$& ${terminateSegmentSnippet}`,
++    'node_modules/terser/dist/bundle.js');
++sed('-i', 'process.env.TERSER_NO_BUNDLE', 'true', 'node_modules/terser/bin/uglifyjs');


### PR DESCRIPTION
Currently terser is in a broken state where technically unmapped
bytes in the input file are mapped back to random source files.

To clarify the term "unmapped bytes": In the input file there are bytes
which cannot be mapped back to any source file. This can happen if code
will be generated by tools automatically. e.g. TSC generating decorator helpers, or
rollup creating bundles of multiple files (there will be boilerplate to merge multiple
files into a bundle). These bytes do not originate from any source-file and therefore
are "unmapped". Read more about 1-variable length segments in the [source-map spec](https://sourcemaps.info/spec.html)

In the current state of Terser where unmapped bytes are mapped to
random source-files, size tracking tools are not able to determine
accurate payload size contribution numbers of individual source-files,
nor do the broken source-maps help with debugging Angular packages
as some bytes are incorrectly mapping to a wrong file (this is not a
big deal though as the generated code is not likely to be debugged).

For context why we try to fix the terser bug on our side now: A PR
to fix this bug on the terser side has been submitted but it had to
be reverted due to a bug in the latest `mozilla/source-map` library.
Terser reverted the fix that hit the bug in `mozilla/source-map` as
they wanted to unblock consumers that use the latest `source-map`
package. Problem is that the bug in the `source-map` package is widely
spread and there doesn't seem to be a fix for it any time soon. Meaning
that source-maps need to stay broken/incorrect as fixing them would
always cause developers to hit the `source-map` bug...

This PR should just be an example of how correct source-maps
should look like (helpful when comparing size differences)

See `source-map` bug: https://github.com/mozilla/source-map/issues/385
See Terser fix: https://github.com/terser-js/terser/pull/342.