### PR TITLE
docs: remove universalProject option from app shell docs

### DIFF
--- a/aio/content/guide/app-shell.md
+++ b/aio/content/guide/app-shell.md
@@ -21,11 +21,10 @@ For an existing application, you have to manually add the `RouterModule` and def
 Use the CLI to automatically create the app shell.
 
 <code-example language="bash">
-ng generate app-shell --client-project my-app --universal-project server-app
+ng generate app-shell --client-project my-app
 </code-example>
 
-* `my-app` takes the name of your client application.
-* `server-app` takes the name of the Universal (or server) application.
+* `client-project` takes the name of your client application.
 
 After running this command you will notice that the `angular.json` configuration file has been updated to add two new targets, with a few other changes.
 


### PR DESCRIPTION
This option has been deprecated in verson 9 as it has no effect
https://github.com/angular/angular-cli/pull/15394

