### PR TITLE
ci: remove unused artifact uploads from test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,13 +247,6 @@ jobs:
       - run:
           command: yarn bazel test //... --build_tag_filters=-ivy-only --test_tag_filters=-ivy-only
           no_output_timeout: 20m
-      - run: mkdir ~/testlogs
-      - run: cp -Lr dist/testlogs/* ~/testlogs
-      - store_test_results:
-          # Bazel always writes test.xml files under this directory
-          path: ~/testlogs
-      - store_artifacts:
-          path: ~/testlogs
 
   # Temporary job to test what will happen when we flip the Ivy flag to true
   test_ivy_aot:


### PR DESCRIPTION
cc: @AndrewKushnir - I discovered we can remove the upload that was taking an unexpectedly long time