### PR TITLE
fix(ngcc): do not analyze dependencies for non Angular entry-points

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -44,7 +44,7 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
   private processNextPath(): void {
     const path = this.unprocessedPaths.shift() !;
     const entryPoint = this.getEntryPoint(path);
-    if (entryPoint !== null) {
+    if (entryPoint !== null && entryPoint.compiledByAngular) {
       this.unsortedEntryPoints.set(entryPoint.path, entryPoint);
       const deps = this.resolver.getEntryPointDependencies(entryPoint);
       deps.dependencies.forEach(dep => {

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -121,6 +121,31 @@ runInEachFileSystem(() => {
         expect(entryPoints).toEqual([]);
       });
 
+      // https://github.com/angular/angular/issues/32302
+      it('should return an empty array if the target path is not an Angular entry-point with typings',
+         () => {
+           const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
+           loadTestFiles([
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/package.json'),
+               contents: '{"typings": "./index.d.ts"}'
+             },
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/index.d.ts'),
+               contents: 'export declare class MyClass {}'
+             },
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/index.js'),
+               contents: 'export class MyClass {}'
+             },
+           ]);
+           const finder = new TargetedEntryPointFinder(
+               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'),
+               targetPath, undefined);
+           const {entryPoints} = finder.findEntryPoints();
+           expect(entryPoints).toEqual([]);
+         });
+
       it('should handle nested node_modules folders', () => {
         const targetPath = _Abs('/nested_node_modules/node_modules/outer');
         loadTestFiles([


### PR DESCRIPTION
When ngcc is called for a specific entry-point, it has to determine
which dependencies to transitively process. To accomplish this, ngcc
traverses the full import graph of the entry-points it encounters, for
which it uses a dependency host to find all module imports. Since
imports look different in the various bundle formats ngcc supports, a
specific dependency host is used depending on the information provided
in an entry-points `package.json` file. If there's not enough
information in the `package.json` file for ngcc to be able to determine
which dependency host to use, ngcc would fail with an error.

If, however, the entry-point is not compiled by Angular, it is not
necessary to process any of its dependencies. None of them can have
been compiled by Angular so ngcc does not need to know about them.
Therefore, this commit changes the behavior to avoid recursing into
dependencies of entry-points that are not compiled by Angular.

In particular, this fixes an issue for packages that have dependencies
on the `date-fns` package. This package has various secondary
entry-points that have a `package.json` file only containing a `typings`
field, without providing additional fields for ngcc to know which
dependency host to use. By not needing a dependency host at all, the
error is avoided.

Fixes #32302
