### PR TITLE
docs(platform-browser): remove redundant JSDoc tag from `BROWSER_SANITIZATION_PROVIDERS__POST_R3__`

### DIFF
--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -34,9 +34,6 @@ const BROWSER_SANITIZATION_PROVIDERS__PRE_R3__: StaticProvider[] = [
   {provide: DomSanitizer, useClass: DomSanitizerImpl, deps: [DOCUMENT]},
 ];
 
-/**
- * @codeGenApi
- */
 export const BROWSER_SANITIZATION_PROVIDERS__POST_R3__ = [];
 
 /**


### PR DESCRIPTION
The JSDoc tag was introduced in #31934 and was not intentional according to [this discussion on Slack][1].

[1]: https://angular-team.slack.com/archives/CHB51S90D/p1566322373094100?thread_ts=1566292123.093500&cid=CHB51S90D
