### PR TITLE
refactor(core): undecorated-classes-with-di migration should never use ngtsc

### DIFF
--- a/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
@@ -12,12 +12,14 @@ import * as ts from 'typescript';
 
 /** Creates an NGC program that can be used to read and parse metadata for files. */
 export function createNgcProgram(
-    createHost: (options: ts.CompilerOptions) => ts.CompilerHost, tsconfigPath: string | null,
-    parseConfig: () => {
-      rootNames: readonly string[],
-      options: ts.CompilerOptions
-    } = () => readConfiguration(tsconfigPath !)) {
-  const {rootNames, options} = parseConfig();
+    createHost: (options: ts.CompilerOptions) => ts.CompilerHost, tsconfigPath: string) {
+  const {rootNames, options} = readConfiguration(tsconfigPath);
+
+  // https://github.com/angular/angular/commit/ec4381dd401f03bded652665b047b6b90f2b425f made Ivy
+  // the default. This breaks the assumption that "createProgram" from compiler-cli returns the
+  // NGC program. In order to ensure that the migration runs properly, we set "enableIvy" to false.
+  options.enableIvy = false;
+
   const host = createHost(options);
   const ngcProgram = createProgram({rootNames, options, host});
   const program = ngcProgram.getTsProgram();

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -25,7 +25,7 @@ ts_library(
 )
 
 jasmine_node_test(
-    name = "google3",
+    name = "test",
     deps = [
         ":test_lib",
         "@npm//shelljs",

--- a/packages/core/schematics/test/google3/BUILD.bazel
+++ b/packages/core/schematics/test/google3/BUILD.bazel
@@ -12,7 +12,7 @@ ts_library(
 )
 
 jasmine_node_test(
-    name = "test",
+    name = "google3",
     deps = [
         ":test_lib",
         "@npm//shelljs",

--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -32,7 +32,6 @@ describe('Undecorated classes with DI migration', () => {
       compilerOptions: {
         lib: ['es2015'],
       },
-      angularCompilerOptions: {enableIvy: false}
     }));
     writeFile('/angular.json', JSON.stringify({
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}


### PR DESCRIPTION
ec4381d enabled Ivy by default. This is problematic as migrations like
`undecorated-classes-with-di` depend on the `AngularCompilerProgram`
(NGC) in order to perform the migration from version 8 to version 9. In
order to ensure that the migration always runs with NGC (and doesn't get
the `NgtscProgram`), we need to explicitly disable ivy when creating the
`@angular/compiler-cli` program for the migration.