### PR TITLE
refactor(core): fixes for undecorated-classes migration after manual testing in CLI

### DIFF
--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -1028,7 +1028,10 @@ describe('Undecorated classes with DI migration', () => {
                     provide: NG_VALIDATORS,
                     useExisting: BaseComponent,
                     multi: true
-                }]
+                }],
+            host: {
+                "[class.is-enabled]": "isEnabled === true"
+            }
         })
         export class PassThrough extends BaseComponent {}`);
       expect(tree.readContent('/index.ts')).toContain(dedent `
@@ -1041,7 +1044,10 @@ describe('Undecorated classes with DI migration', () => {
                     provide: NG_VALIDATORS,
                     useExisting: BaseComponent,
                     multi: true
-                }]
+                }],
+            host: {
+                "[class.is-enabled]": "isEnabled === true"
+            }
         })
         export class MyComp extends PassThrough {}`);
       expect(tree.readContent('/index.ts')).toContain(dedent `
@@ -1082,7 +1088,10 @@ describe('Undecorated classes with DI migration', () => {
                     provide: NG_VALIDATORS,
                     useExisting: BaseComponent,
                     multi: true
-                }]
+                }],
+            host: {
+                "[class.is-enabled]": "isEnabled === true"
+            }
         })
         export class MyComp extends BaseComponent {}`);
     });
@@ -1239,6 +1248,9 @@ describe('Undecorated classes with DI migration', () => {
                 member: 'None'
               },
               providers: [{__symbolic: 'reference', name: 'testValidators'}],
+              host: {
+                '[class.is-enabled]': 'isEnabled === true',
+              }
             }]
           }],
           members: {}

--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -210,6 +210,39 @@ describe('Undecorated classes with DI migration', () => {
       export class MyPipe extends PipeTransform {}`);
   });
 
+  it('should not decorate base class if no constructor is inherited', () => {
+    writeFile('/index.ts', dedent `
+      import {Component, NgModule, Directive} from '@angular/core';
+
+      export class BaseClassWithoutCtor {
+        someUnrelatedProp = true;
+      }
+
+      @Directive({selector: 'my-dir'})
+      export class MyDirective extends BaseClassWithoutCtor {}
+
+      @Pipe()
+      export class MyPipe extends BaseClassWithoutCtor {}
+
+      @NgModule({declarations: [MyDirective, MyPipe]})
+      export class AppModule {}
+    `);
+
+    runMigration();
+
+    expect(tree.readContent('/index.ts')).toContain(dedent `
+
+      export class BaseClassWithoutCtor {
+        someUnrelatedProp = true;
+      }
+
+      @Directive({selector: 'my-dir'})
+      export class MyDirective extends BaseClassWithoutCtor {}
+
+      @Pipe()
+      export class MyPipe extends BaseClassWithoutCtor {}`);
+  });
+
   it('should not decorate base class if directive/component/provider defines a constructor', () => {
     writeFile('/index.ts', dedent `
       import {Component, Injectable, NgModule, NgZone} from '@angular/core';


### PR DESCRIPTION
I just did some manual testing of the `undecorated-classes-with-di` migration in a few CLI projects as there are known differences between the testing and running with `ng update @angular/core`

Besides #32318 it looks like there are two cases that need to be handled better. In the first case invalid AST is constructed from NGC metadata. In the second one, base classes are incorrectly decorated if there is no explicit constructor defined at all.

Additionally the logic for handling the undecorated base class scenario of the migration has been slightly improved by avoiding duplication for handling directives and providers.

See individual commits.

**Note**: It's not obvious for me whether we should denote these things as `fix(..)` for now as we don't want to show these in the changelog yet. The migrations are not enabled/released yet.