### PR TITLE
Fix format of callout header

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -73,8 +73,8 @@ the component **subscribes** to the method's return value.
 The subscription callback copies the data fields into the component's `config` object,
 which is data-bound in the component template for display.
 
-<div class="alert is-helpful">
-**Why write a service?**
+<div class="callout is-helpful">
+ <header>Why write a service?</header>
 
 This example is so simple that it is tempting to write the `Http.get()` inside the
 component itself and skip the service.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Callout header shows up as `**Why write a service?**`

Issue Number: N/A


## What is the new behavior?
Change from alert to callout with proper header.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No