### PR TITLE
fix(ivy): debug node names should match user declaration

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -247,7 +247,17 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     return this.nativeNode.nodeType == Node.ELEMENT_NODE ? this.nativeNode as Element : null;
   }
 
-  get name(): string { return this.nativeNode.nodeName; }
+  get name(): string {
+    try {
+      const context = loadLContext(this.nativeNode) !;
+      const lView = context.lView;
+      const tData = lView[TVIEW].data;
+      const tNode = tData[context.nodeIndex] as TNode;
+      return tNode.tagName !;
+    } catch (e) {
+      return this.nativeNode.nodeName;
+    }
+  }
 
   /**
    *  Gets a map of property names to property values for an element.

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -1036,4 +1036,19 @@ class TestCmptWithPropBindings {
     }
     expect(superParentName).not.toEqual('');
   });
+
+  it('should match node name with declared casing', () => {
+    @Component({template: `<div></div><myComponent></myComponent>`})
+    class Wrapper {
+    }
+
+    @Component({selector: 'myComponent', template: ''})
+    class MyComponent {
+    }
+
+    const fixture = TestBed.configureTestingModule({declarations: [Wrapper, MyComponent]})
+                        .createComponent(Wrapper);
+    expect(fixture.debugElement.query(e => e.name === 'myComponent')).toBeTruthy();
+    expect(fixture.debugElement.query(e => e.name === 'div')).toBeTruthy();
+  });
 }


### PR DESCRIPTION
Querying for elements by name generally fails in Ivy because users most frequently search for names by lower case whereas Ivy currently returns the node names as uppercase (the test added to the spec fails both cases in Ivy but passes in VE). The current behavior of VE is to return the name as it was declared in the template. This PR matches that behavior in Ivy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently node names in Ivy return all caps from the `nativeNode.nodeName`

Issue Number: N/A


## What is the new behavior?
Debug Element node names will match the TNode tagName.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

