### PR TITLE
docs: Fix typo in singleton-services.md page

### DIFF
--- a/aio/content/guide/singleton-services.md
+++ b/aio/content/guide/singleton-services.md
@@ -1,6 +1,6 @@
 # Singleton services
 
-A singleton service is a service for which only once instance exists in an app.
+A singleton service is a service for which only one instance exists in an app.
 
 For a sample app using the app-wide singleton service that this page describes, see the
 <live-example name="ngmodules"></live-example> showcasing all the documented features of NgModules.


### PR DESCRIPTION
Fix typo by replacing the word "once" with "one" on the Singleton Services documentation page.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is a typo on the [Singleton Services](https://angular.io/guide/singleton-services) documentation page, on the very first line. The sentence reads "A singleton service is a service for which only once instance exists in an app", whereas it should read "A singleton service is a service for which only one instance exists in an app".

Issue Number: N/A


## What is the new behavior?
Replace first sentence with the proper word.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
