### PR TITLE
docs: update i18n docs sample to cater for latest raw-loader version

### DIFF
--- a/aio/content/examples/i18n/doc-files/main.2.ts
+++ b/aio/content/examples/i18n/doc-files/main.2.ts
@@ -12,7 +12,7 @@ if (environment.production) {
 // use the require method provided by webpack
 declare const require;
 // we use the webpack raw-loader to return the content as a string
-const translations = require(`raw-loader!./locale/messages.fr.xlf`);
+const translations = require('raw-loader!./locale/messages.fr.xlf').default;
 
 platformBrowserDynamic().bootstrapModule(AppModule, {
   providers: [

--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -707,22 +707,24 @@ the CLI configuration file, `angular.json`.
         "i18nLocale": "fr",
         "i18nMissingTranslation": "error",
       }
-// ...
-"serve": {
-  "builder": "@angular-devkit/build-angular:dev-server",
-  "options": {
-    "browserTarget": "my-project:build"
+    }
   },
-  "configurations": {
-    "production": {
-      "browserTarget": "my-project:build:production"
+  ...
+  "serve": {
+    "builder": "@angular-devkit/build-angular:dev-server",
+    "options": {
+      "browserTarget": "my-project:build"
     },
-    "fr": {
-      "browserTarget": "my-project:build:fr"
+    "configurations": {
+      "production": {
+        "browserTarget": "my-project:build:production"
+      },
+      "fr": {
+        "browserTarget": "my-project:build:fr"
+      }
     }
   }
-},
-
+}
 ```
 
 The same configuration options can also be provided through the CLI with your existing `production` configuration.


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`raw-loader` version 2+ which is used in the CLI version 8 introduced a breaking change and now uses `export default` instead of `module.exports`.

See: https://github.com/webpack-contrib/raw-loader/blob/master/CHANGELOG.md#200-2019-03-18

Closes #32333



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
