### PR TITLE
build: remove the deprecated `aio` commit message scope

### DIFF
--- a/tools/validate-commit-message/commit-message.json
+++ b/tools/validate-commit-message/commit-message.json
@@ -13,7 +13,6 @@
     "test"
   ],
   "scopes": [
-    "aio",
     "animations",
     "bazel",
     "benchpress",


### PR DESCRIPTION
The `aio` commit message scope was renamed to `docs-infra` (which is more descriptive) in #24295. Although it has been removed from the documentation, the legacy `aio` scope was kept in the [list of valid scopes][1] to cater for in-flight PRs that already used it. As a result, it still shows up as a recommended, valid scope in the error message shown when commit message validation fails during `git commit`. This is misleading, especially for new contributors.

Since we have been "manually" discouraging people from using `aio`, there should be no open PRs by now (and if there are, they should be changed to `docs-infra`), so it is safe to remove it from the list of allowed scopes.

Related discussion: https://github.com/angular/angular/pull/32273#pullrequestreview-279767931

[1]: https://github.com/angular/angular/blob/3df54be9e4580986cf4714b22f6b2800ee593939/tools/validate-commit-message/commit-message.json#L16
