### PR TITLE
refactor(ivy): remove unused ɵɵtextBinding instruction

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -128,8 +128,6 @@ export class Identifiers {
 
   static text: o.ExternalReference = {name: 'ɵɵtext', moduleName: CORE};
 
-  static textBinding: o.ExternalReference = {name: 'ɵɵtextBinding', moduleName: CORE};
-
   static enableBindings: o.ExternalReference = {name: 'ɵɵenableBindings', moduleName: CORE};
 
   static disableBindings: o.ExternalReference = {name: 'ɵɵdisableBindings', moduleName: CORE};

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -968,8 +968,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           nodeIndex, text.sourceSpan, getTextInterpolationExpression(value),
           () => this.getUpdateInstructionArguments(value));
     } else {
-      this.updateInstruction(
-          nodeIndex, text.sourceSpan, R3.textBinding, () => [this.convertPropertyBinding(value)]);
+      error('Text nodes should be interpolated and never bound directly.');
     }
   }
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -148,7 +148,6 @@ export {
   ɵɵelementHostAttrs,
 
   ɵɵselect,
-  ɵɵtextBinding,
   ɵɵtemplate,
   ɵɵembeddedViewEnd,
   store as ɵstore,

--- a/packages/core/src/render3/features/providers_feature.ts
+++ b/packages/core/src/render3/features/providers_feature.ts
@@ -30,7 +30,7 @@ import {DirectiveDef} from '../interfaces/definition';
  *      }
  *      if (fs & RenderFlags.Update) {
  *        ɵɵselect(0);
- *        ɵɵtextBinding(ctx.greeter.greet());
+ *        ɵɵtextInterpolate(ctx.greeter.greet());
  *      }
  *    },
  *    features: [ProvidersFeature([GreeterDE])]

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -116,7 +116,6 @@ export {
   ɵɵtemplate,
 
   ɵɵtext,
-  ɵɵtextBinding,
   ɵɵtextInterpolate,
   ɵɵtextInterpolate1,
   ɵɵtextInterpolate2,

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -5,18 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {assertDataInRange, assertDefined, assertEqual} from '../../util/assert';
+import {assertDataInRange, assertEqual} from '../../util/assert';
 import {TNodeType} from '../interfaces/node';
-import {RText, isProceduralRenderer} from '../interfaces/renderer';
-import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
+import {BINDING_INDEX, HEADER_OFFSET, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {appendChild, createTextNode} from '../node_manipulation';
-import {getLView, getSelectedIndex, setIsNotParent} from '../state';
-import {NO_CHANGE} from '../tokens';
-import {renderStringify} from '../util/misc_utils';
-import {getNativeByIndex} from '../util/view_utils';
+import {getLView, setIsNotParent} from '../state';
 
-import {bind} from './property';
-import {getOrCreateTNode, textBindingInternal} from './shared';
+import {getOrCreateTNode} from './shared';
 
 
 
@@ -42,21 +37,4 @@ export function ɵɵtext(index: number, value?: any): void {
   // Text nodes are self closing.
   setIsNotParent();
   appendChild(textNative, tNode, lView);
-}
-
-/**
- * Create text node with binding
- * Bindings should be handled externally with the proper interpolation(1-8) method
- *
- * @param value Stringified value to write.
- *
- * @codeGenApi
- */
-export function ɵɵtextBinding<T>(value: T | NO_CHANGE): void {
-  const lView = getLView();
-  const index = getSelectedIndex();
-  const bound = bind(lView, value);
-  if (bound !== NO_CHANGE) {
-    textBindingInternal(lView, index, renderStringify(bound));
-  }
 }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -134,7 +134,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵselect': r3.ɵɵselect,
        'ɵɵtemplate': r3.ɵɵtemplate,
        'ɵɵtext': r3.ɵɵtext,
-       'ɵɵtextBinding': r3.ɵɵtextBinding,
        'ɵɵtextInterpolate': r3.ɵɵtextInterpolate,
        'ɵɵtextInterpolate1': r3.ɵɵtextInterpolate1,
        'ɵɵtextInterpolate2': r3.ɵɵtextInterpolate2,

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -11,7 +11,7 @@ import {withBody} from '@angular/private/testing';
 import {ChangeDetectionStrategy, DoCheck} from '../../src/core';
 import {whenRendered} from '../../src/render3/component';
 import {LifecycleHooksFeature, getRenderedText, ɵɵdefineComponent, ɵɵgetCurrentView, ɵɵproperty, ɵɵselect, ɵɵtextInterpolate1, ɵɵtextInterpolate2} from '../../src/render3/index';
-import {detectChanges, markDirty, tick, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵlistener, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {detectChanges, markDirty, tick, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵlistener, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
 import {FLAGS, LViewFlags} from '../../src/render3/interfaces/view';
@@ -39,7 +39,7 @@ describe('change detection', () => {
           }
           if (rf & RenderFlags.Update) {
             ɵɵselect(1);
-            ɵɵtextBinding(ctx.value);
+            ɵɵtextInterpolate(ctx.value);
           }
         }
       });
@@ -323,7 +323,7 @@ describe('change detection', () => {
           }
           if (rf & RenderFlags.Update) {
             ɵɵselect(0);
-            ɵɵtextBinding(ctx.value);
+            ɵɵtextInterpolate(ctx.value);
           }
         }
       });

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -9,7 +9,7 @@
 import {ViewEncapsulation, ɵɵdefineInjectable, ɵɵdefineInjector} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
 import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
-import {tick, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {tick, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {ComponentDef, RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgIf} from './common_with_def';
@@ -33,7 +33,7 @@ describe('component', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵselect(0);
-          ɵɵtextBinding(ctx.count);
+          ɵɵtextInterpolate(ctx.count);
         }
       },
       factory: () => new CounterComponent,
@@ -85,7 +85,7 @@ describe('component', () => {
           }
           if (fs & RenderFlags.Update) {
             ɵɵselect(0);
-            ɵɵtextBinding(ctx.myService.value);
+            ɵɵtextInterpolate(ctx.myService.value);
           }
         }
       });
@@ -129,7 +129,7 @@ describe('component', () => {
           }
           if (rf & RenderFlags.Update) {
             ɵɵselect(0);
-            ɵɵtextBinding(ctx.name);
+            ɵɵtextInterpolate(ctx.name);
           }
         },
         inputs: {name: 'name'}
@@ -235,7 +235,7 @@ describe('component with a container', () => {
             }
             if (rf0 & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(item);
+              ɵɵtextInterpolate(item);
             }
           }
           ɵɵembeddedViewEnd();
@@ -341,7 +341,7 @@ describe('recursive components', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵselect(0);
-          ɵɵtextBinding(ctx.data.value);
+          ɵɵtextInterpolate(ctx.data.value);
           ɵɵcontainerRefreshStart(1);
           {
             if (ctx.data.left != null) {
@@ -413,7 +413,7 @@ describe('recursive components', () => {
         }
         if (rf & RenderFlags.Update) {
           ɵɵselect(0);
-          ɵɵtextBinding(ctx.data.value);
+          ɵɵtextInterpolate(ctx.data.value);
           ɵɵselect(1);
           ɵɵproperty('ngIf', ctx.data.left);
           ɵɵselect(2);

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ComponentFixture, TemplateFixture, createComponent} from './render_util';
 
@@ -32,7 +32,7 @@ describe('JS control flow', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 ɵɵselect(1);
-                ɵɵtextBinding(ctx.message);
+                ɵɵtextInterpolate(ctx.message);
               }
             }
             ɵɵembeddedViewEnd();
@@ -345,7 +345,7 @@ describe('JS control flow', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 ɵɵselect(1);
-                ɵɵtextBinding(data[i]);
+                ɵɵtextInterpolate(data[i]);
               }
             }
             ɵɵembeddedViewEnd();
@@ -410,7 +410,7 @@ describe('JS control flow', () => {
                     }
                     if (rf2 & RenderFlags.Update) {
                       ɵɵselect(0);
-                      ɵɵtextBinding(data[0][i] + value);
+                      ɵɵtextInterpolate(data[0][i] + value);
                     }
                     ɵɵembeddedViewEnd();
                   });
@@ -478,7 +478,7 @@ describe('JS control flow', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 ɵɵselect(1);
-                ɵɵtextBinding(cafes[i].name);
+                ɵɵtextInterpolate(cafes[i].name);
                 ɵɵcontainerRefreshStart(2);
                 {
                   for (let j = 0; j < cafes[i].entrees.length; j++) {
@@ -488,7 +488,7 @@ describe('JS control flow', () => {
                     }
                     if (rf2 & RenderFlags.Update) {
                       ɵɵselect(0);
-                      ɵɵtextBinding(cafes[i].entrees[j]);
+                      ɵɵtextInterpolate(cafes[i].entrees[j]);
                     }
                     ɵɵembeddedViewEnd();
                   }
@@ -575,7 +575,7 @@ describe('JS control flow', () => {
               }
               if (rf1 & RenderFlags.Update) {
                 ɵɵselect(1);
-                ɵɵtextBinding(cafes[i].name);
+                ɵɵtextInterpolate(cafes[i].name);
                 ɵɵcontainerRefreshStart(2);
                 {
                   for (let j = 0; j < cafes[i].entrees.length; j++) {
@@ -589,7 +589,7 @@ describe('JS control flow', () => {
                       }
                       if (rf1 & RenderFlags.Update) {
                         ɵɵselect(1);
-                        ɵɵtextBinding(cafes[i].entrees[j].name);
+                        ɵɵtextInterpolate(cafes[i].entrees[j].name);
                         ɵɵcontainerRefreshStart(2);
                         {
                           for (let k = 0; k < cafes[i].entrees[j].foods.length; k++) {
@@ -599,7 +599,7 @@ describe('JS control flow', () => {
                             }
                             if (rf2 & RenderFlags.Update) {
                               ɵɵselect(0);
-                              ɵɵtextBinding(cafes[i].entrees[j].foods[k]);
+                              ɵɵtextInterpolate(cafes[i].entrees[j].foods[k]);
                             }
                             ɵɵembeddedViewEnd();
                           }
@@ -856,7 +856,7 @@ describe('JS for loop', () => {
             }
             if (rf2 & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(config.data1[i]);
+              ɵɵtextInterpolate(config.data1[i]);
             }
             ɵɵembeddedViewEnd();
           }
@@ -867,7 +867,7 @@ describe('JS for loop', () => {
             }
             if (rf2 & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(config.data2[j]);
+              ɵɵtextInterpolate(config.data2[j]);
             }
             ɵɵembeddedViewEnd();
           }
@@ -906,7 +906,7 @@ describe('function calls', () => {
       }
       if (rf & RenderFlags.Update) {
         ɵɵselect(1);
-        ɵɵtextBinding(message);
+        ɵɵtextInterpolate(message);
       }
     }
 

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -12,7 +12,7 @@ import {RenderFlags} from '@angular/core/src/render3/interfaces/definition';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHasToken, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding, ɵɵtextInterpolate2} from '../../src/render3/index';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextInterpolate, ɵɵtextInterpolate2} from '../../src/render3/index';
 import {TNODE} from '../../src/render3/interfaces/injector';
 import {TNodeType} from '../../src/render3/interfaces/node';
 import {isProceduralRenderer} from '../../src/render3/interfaces/renderer';
@@ -144,7 +144,7 @@ describe('di', () => {
                           if (rf2 & RenderFlags.Update) {
                             const dir = ɵɵreference(1) as DirA;
                             ɵɵselect(2);
-                            ɵɵtextBinding(dir.dirB.value);
+                            ɵɵtextInterpolate(dir.dirB.value);
                           }
                         }
                         ɵɵembeddedViewEnd();
@@ -399,7 +399,7 @@ describe('di', () => {
                     if (rf1 & RenderFlags.Update) {
                       const tmp = ɵɵreference(1) as any;
                       ɵɵselect(2);
-                      ɵɵtextBinding(tmp.value);
+                      ɵɵtextInterpolate(tmp.value);
                     }
                   }
                   ɵɵembeddedViewEnd();

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵreference, ɵɵselect, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {ComponentFixture, createComponent} from './render_util';
 
@@ -39,7 +39,7 @@ describe('exports', () => {
                 if (rf1 & RenderFlags.Update) {
                   const tmp = ɵɵreference(2) as any;
                   ɵɵselect(0);
-                  ɵɵtextBinding(tmp.value);
+                  ɵɵtextInterpolate(tmp.value);
                 }
               }
               ɵɵembeddedViewEnd();

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -9,7 +9,7 @@
 import {RendererType2} from '../../src/render/api';
 import {getLContext} from '../../src/render3/context_discovery';
 import {AttributeMarker, ɵɵattribute, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵhostProperty, ɵɵproperty} from '../../src/render3/index';
-import {ɵɵallocHostVars, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵallocHostVars, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {MONKEY_PATCH_KEY_NAME} from '../../src/render3/interfaces/context';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -70,7 +70,7 @@ describe('render3 integration test', () => {
             }
             if (rf1 & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(ctx.label);
+              ɵɵtextInterpolate(ctx.label);
             }
             ɵɵembeddedViewEnd();
           }

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -8,7 +8,7 @@
 
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 
-import {markDirty, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵreference, ɵɵresolveBody, ɵɵresolveDocument, ɵɵselect, ɵɵtextBinding} from '../../src/render3/index';
+import {markDirty, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵreference, ɵɵresolveBody, ɵɵresolveDocument, ɵɵselect, ɵɵtextInterpolate} from '../../src/render3/index';
 import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵgetCurrentView, ɵɵlistener, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {GlobalTargetResolver} from '../../src/render3/interfaces/renderer';
@@ -472,7 +472,7 @@ describe('event listeners', () => {
                 }
                 if (rf1 & RenderFlags.Update) {
                   ɵɵselect(3);
-                  ɵɵtextBinding(ctx.counters[i]);
+                  ɵɵtextInterpolate(ctx.counters[i]);
                 }
                 ɵɵembeddedViewEnd();
               }

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -10,7 +10,7 @@ import {Component as _Component, ComponentFactoryResolver, ElementRef, InjectFla
 import {forwardRef} from '../../src/di/forward_ref';
 import {createInjector} from '../../src/di/r3_injector';
 import {injectComponentFactoryResolver, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵselect, ɵɵtextInterpolate1} from '../../src/render3/index';
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵtext, ɵɵtextBinding} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {NgModuleFactory} from '../../src/render3/ng_module_ref';
 import {getInjector} from '../../src/render3/util/discovery_utils';
@@ -879,9 +879,9 @@ describe('providers', () => {
             }
             if (fs & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(ctx.s);
+              ɵɵtextInterpolate(ctx.s);
               ɵɵselect(1);
-              ɵɵtextBinding(ctx.n);
+              ɵɵtextInterpolate(ctx.n);
             }
           }
         });
@@ -964,9 +964,9 @@ describe('providers', () => {
             }
             if (fs & RenderFlags.Update) {
               ɵɵselect(0);
-              ɵɵtextBinding(ctx.s);
+              ɵɵtextInterpolate(ctx.s);
               ɵɵselect(1);
-              ɵɵtextBinding(ctx.n);
+              ɵɵtextInterpolate(ctx.n);
             }
           },
           features: [

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -1089,8 +1089,6 @@ export declare function ɵɵtemplateRefExtractor(tNode: TNode, currentView: LVie
 
 export declare function ɵɵtext(index: number, value?: any): void;
 
-export declare function ɵɵtextBinding<T>(value: T | NO_CHANGE): void;
-
 export declare function ɵɵtextInterpolate(v0: any): TsickleIssue1009;
 
 export declare function ɵɵtextInterpolate1(prefix: string, v0: any, suffix: string): TsickleIssue1009;


### PR DESCRIPTION
We used to generate `ɵɵtextBinding` instruction (when interpolations were separate instructions) but since then it was replaced by `ɵɵtextInterpolate` so dropping unused code.