### PR TITLE
refactor(language-service): rename `host` to `tsLsHost`

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -86,7 +86,7 @@ class LanguageServiceImpl implements LanguageService {
     if (fileName.endsWith('.ts')) {
       const sf = this.host.getSourceFile(fileName);
       if (sf) {
-        return getTsDefinitionAndBoundSpan(sf, position, this.host.host);
+        return getTsDefinitionAndBoundSpan(sf, position, this.host.tsLsHost);
       }
     }
   }

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -72,7 +72,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     ngModules: [],
   };
 
-  constructor(readonly host: ts.LanguageServiceHost, private readonly tsLS: ts.LanguageService) {
+  constructor(
+      readonly tsLsHost: ts.LanguageServiceHost, private readonly tsLS: ts.LanguageService) {
     this.summaryResolver = new AotSummaryResolver(
         {
           loadSummary(filePath: string) { return null; },
@@ -81,7 +82,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
           fromSummaryFileName(filePath: string): string{return filePath;},
         },
         this.staticSymbolCache);
-    this.reflectorHost = new ReflectorHost(() => this.program, host);
+    this.reflectorHost = new ReflectorHost(() => this.program, tsLsHost);
     this.staticSymbolResolver = new StaticSymbolResolver(
         this.reflectorHost, this.staticSymbolCache, this.summaryResolver,
         (e, filePath) => this.collectError(e, filePath));
@@ -277,7 +278,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     for (const sourceFile of program.getSourceFiles()) {
       const fileName = sourceFile.fileName;
       seen.add(fileName);
-      const version = this.host.getScriptVersion(fileName);
+      const version = this.tsLsHost.getScriptVersion(fileName);
       const lastVersion = this.fileVersions.get(fileName);
       if (version !== lastVersion) {
         this.fileVersions.set(fileName, version);
@@ -333,7 +334,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
    */
   private getExternalTemplate(fileName: string): TemplateSource|undefined {
     // First get the text for the template
-    const snapshot = this.host.getScriptSnapshot(fileName);
+    const snapshot = this.tsLsHost.getScriptSnapshot(fileName);
     if (!snapshot) {
       return;
     }


### PR DESCRIPTION
Disambiguate the name of the Language Service Host used in constructing
a TypeScript Language Service Host by renaming the `host` property to
`tsLsHost`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
