### PR TITLE
fix(ivy): DebugElement.query when there is a node outside Angular context

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -16,7 +16,7 @@ import {TStylingContext} from '../render3/styling_next/interfaces';
 import {stylingMapToStringMap} from '../render3/styling_next/map_based_bindings';
 import {NodeStylingDebug} from '../render3/styling_next/styling_debug';
 import {isStylingContext} from '../render3/styling_next/util';
-import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/util/discovery_utils';
+import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, isPropMetadataString, renderStringify} from '../render3/util/misc_utils';
 import {findComponentView} from '../render3/util/view_traversal_utils';
 import {getComponentViewByIndex, getNativeByTNodeOrNull} from '../render3/util/view_utils';
@@ -272,7 +272,11 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
    *  - attribute bindings (e.g. `[attr.role]="menu"`)
    */
   get properties(): {[key: string]: any;} {
-    const context = loadLContext(this.nativeNode) !;
+    const context = loadLContext(this.nativeNode, false);
+    if (context == null) {
+      return {};
+    }
+
     const lView = context.lView;
     const tData = lView[TVIEW].data;
     const tNode = tData[context.nodeIndex] as TNode;
@@ -297,7 +301,11 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
       return attributes;
     }
 
-    const context = loadLContext(element);
+    const context = loadLContext(element, false);
+    if (context == null) {
+      return {};
+    }
+
     const lView = context.lView;
     const tNodeAttrs = (lView[TVIEW].data[context.nodeIndex] as TNode).attrs;
     const lowercaseTNodeAttrs: string[] = [];
@@ -413,22 +421,23 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
 }
 
 function _getStylingDebugInfo(element: any, isClassBased: boolean) {
-  if (element) {
-    const context = loadLContextFromNode(element);
-    const lView = context.lView;
-    const tData = lView[TVIEW].data;
-    const tNode = tData[context.nodeIndex] as TNode;
-    if (isClassBased) {
-      return isStylingContext(tNode.classes) ?
-          new NodeStylingDebug(tNode.classes as TStylingContext, lView, true).values :
-          stylingMapToStringMap(tNode.classes);
-    } else {
-      return isStylingContext(tNode.styles) ?
-          new NodeStylingDebug(tNode.styles as TStylingContext, lView, false).values :
-          stylingMapToStringMap(tNode.styles);
-    }
+  const context = loadLContext(element, false);
+  if (!context) {
+    return {};
   }
-  return {};
+
+  const lView = context.lView;
+  const tData = lView[TVIEW].data;
+  const tNode = tData[context.nodeIndex] as TNode;
+  if (isClassBased) {
+    return isStylingContext(tNode.classes) ?
+        new NodeStylingDebug(tNode.classes as TStylingContext, lView, true).values :
+        stylingMapToStringMap(tNode.classes);
+  } else {
+    return isStylingContext(tNode.styles) ?
+        new NodeStylingDebug(tNode.styles as TStylingContext, lView, false).values :
+        stylingMapToStringMap(tNode.styles);
+  }
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Ivy throws an error when using DebugElement.query on node where a child was added with document.appendChild

Issue Number: N/A


## What is the new behavior?
No error is thrown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
