### PR TITLE
fix(core): correct DebugElement.query typing

### DIFF
--- a/aio/content/examples/setup/src/app/app.component.spec.ts
+++ b/aio/content/examples/setup/src/app/app.component.spec.ts
@@ -16,7 +16,7 @@ describe('AppComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AppComponent);
     comp = fixture.componentInstance;
-    de = fixture.debugElement.query(By.css('h1'));
+    de = fixture.debugElement.query(By.css('h1'))!;
   });
 
   it('should create component', () => expect(comp).toBeDefined());

--- a/aio/content/examples/testing/src/app/banner/banner-initial.component.spec.ts
+++ b/aio/content/examples/testing/src/app/banner/banner-initial.component.spec.ts
@@ -2,14 +2,14 @@
 // #docregion import-by
 // #enddocregion import-by
 // #docregion import-debug-element
-import { DebugElement } from '@angular/core';
+import {DebugElement} from '@angular/core';
 // #enddocregion import-debug-element
 // #docregion v1
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 
 // #enddocregion v1
-import { BannerComponent } from './banner-initial.component';
+import {BannerComponent} from './banner-initial.component';
 
 /*
 // #docregion v1
@@ -104,7 +104,7 @@ describe('BannerComponent (with beforeEach)', () => {
   // #docregion v4-test-5
   it('should find the <p> with fixture.debugElement.query(By.css)', () => {
     const bannerDe: DebugElement = fixture.debugElement;
-    const paragraphDe = bannerDe.query(By.css('p'));
+    const paragraphDe = bannerDe.query(By.css('p'))!;
     const p: HTMLElement = paragraphDe.nativeElement;
     expect(p.textContent).toEqual('banner works!');
   });

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -1,13 +1,13 @@
 
 // #docplaster
-import { DebugElement } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import {DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 
-import { addMatchers, click } from '../../testing';
-import { Hero } from '../model/hero';
+import {addMatchers, click} from '../../testing';
+import {Hero} from '../model/hero';
 
-import { DashboardHeroComponent } from './dashboard-hero.component';
+import {DashboardHeroComponent} from './dashboard-hero.component';
 
 beforeEach(addMatchers);
 
@@ -45,7 +45,7 @@ describe('DashboardHeroComponent when tested directly', () => {
     comp = fixture.componentInstance;
 
     // find the hero's DebugElement and element
-    heroDe = fixture.debugElement.query(By.css('.hero'));
+    heroDe = fixture.debugElement.query(By.css('.hero'))!;
     heroEl = heroDe.nativeElement;
 
     // mock the hero supplied by the parent component
@@ -141,7 +141,7 @@ describe('DashboardHeroComponent when inside a test host', () => {
 });
 
 ////// Test Host Component //////
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 // #docregion test-host
 @Component({

--- a/aio/content/examples/testing/src/app/dashboard/dashboard.component.spec.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard.component.spec.ts
@@ -50,7 +50,7 @@ describe('DashboardComponent (shallow)', () => {
 
   function clickForShallow() {
     // get first <dashboard-hero> DebugElement
-    const heroDe = fixture.debugElement.query(By.css('dashboard-hero'));
+    const heroDe = fixture.debugElement.query(By.css('dashboard-hero'))!;
     heroDe.triggerEventHandler('selected', comp.heroes[0]);
   }
 });

--- a/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
@@ -211,7 +211,7 @@ describe('demo (with TestBed):', () => {
       click(heroes[0]);
       fixture.detectChanges();
 
-      const selected = fixture.debugElement.query(By.css('p'));
+      const selected = fixture.debugElement.query(By.css('p'))!;
       expect(selected).toHaveText(hero.name);
     });
 
@@ -221,7 +221,7 @@ describe('demo (with TestBed):', () => {
       const heroName = comp.heroes[0].name; // first hero's name
 
       fixture.detectChanges();
-      const ngForRow = fixture.debugElement.query(By.directive(IoComponent)); // first hero ngForRow
+      const ngForRow = fixture.debugElement.query(By.directive(IoComponent))!; // first hero ngForRow
 
       const hero = ngForRow.context.hero; // the hero object passed into the row
       expect(hero.name).toBe(heroName, 'ngRow.context.hero');
@@ -237,7 +237,7 @@ describe('demo (with TestBed):', () => {
     it('should support clicking a button', () => {
       const fixture = TestBed.createComponent(LightswitchComponent);
       const btn = fixture.debugElement.query(By.css('button'));
-      const span = fixture.debugElement.query(By.css('span')).nativeElement;
+      const span = fixture.debugElement.query(By.css('span'))!.nativeElement;
 
       fixture.detectChanges();
       expect(span.textContent).toMatch(/is off/i, 'before click');
@@ -257,7 +257,7 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
 
       const comp = fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
 
       expect(comp.name).toBe(expectedOrigName,
         `At start name should be ${expectedOrigName} `);
@@ -297,7 +297,7 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
 
       const comp =  fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
 
       expect(comp.name).toBe(expectedOrigName,
         `At start name should be ${expectedOrigName} `);
@@ -333,8 +333,8 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
 
       const comp = fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
-      const span = fixture.debugElement.query(By.css('span')).nativeElement as HTMLElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
+      const span = fixture.debugElement.query(By.css('span'))!.nativeElement as HTMLElement;
 
       // simulate user entering new name in input
       input.value = inputText;
@@ -357,7 +357,7 @@ describe('demo (with TestBed):', () => {
       const fixture = TestBed.createComponent(InputComponent);
       fixture.detectChanges();
 
-      const inputEl = fixture.debugElement.query(By.css('input'));
+      const inputEl = fixture.debugElement.query(By.css('input'))!;
 
       expect(inputEl.providerTokens).toContain(NgModel, 'NgModel directive');
 
@@ -647,7 +647,7 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
       getChild();
 
-      const btn = fixture.debugElement.query(By.css('button'));
+      const btn = fixture.debugElement.query(By.css('button'))!;
       click(btn);
 
       fixture.detectChanges();

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
@@ -138,7 +138,7 @@ class Page {
     this.heroRows = Array.from(heroRowNodes);
 
     // Find the first element with an attached HighlightDirective
-    this.highlightDe = fixture.debugElement.query(By.directive(HighlightDirective));
+    this.highlightDe = fixture.debugElement.query(By.directive(HighlightDirective))!;
 
     // Get the component's injected router navigation spy
     const routerSpy = fixture.debugElement.injector.get(Router);

--- a/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
+++ b/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
@@ -34,7 +34,7 @@ describe('HighlightDirective', () => {
     des = fixture.debugElement.queryAll(By.directive(HighlightDirective));
 
     // the h2 without the HighlightDirective
-    bareH2 = fixture.debugElement.query(By.css('h2:not([highlight])'));
+    bareH2 = fixture.debugElement.query(By.css('h2:not([highlight])'))!;
   });
 
   // color tests

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -59,14 +59,14 @@ describe('AppComponent', () => {
     component.onResize(showTopMenuWidth + 1); // wide by default
 
     const de = fixture.debugElement;
-    const docViewerDe = de.query(By.css('aio-doc-viewer'));
+    const docViewerDe = de.query(By.css('aio-doc-viewer'))!;
 
     documentService = de.injector.get<DocumentService>(DocumentService);
     docViewer = docViewerDe.nativeElement;
     docViewerComponent = docViewerDe.componentInstance;
-    hamburger = de.query(By.css('.hamburger')).nativeElement;
+    hamburger = de.query(By.css('.hamburger'))!.nativeElement;
     locationService = de.injector.get<any>(LocationService);
-    sidenav = de.query(By.directive(MatSidenav)).componentInstance;
+    sidenav = de.query(By.directive(MatSidenav))!.componentInstance;
     tocService = de.injector.get<TocService>(TocService);
 
     return waitForDoc && awaitDocRendered();
@@ -270,7 +270,7 @@ describe('AppComponent', () => {
           });
 
           it('should close when clicking in gray content area overlay', () => {
-            const sidenavBackdrop = fixture.debugElement.query(By.css('.mat-drawer-backdrop')).nativeElement;
+            const sidenavBackdrop = fixture.debugElement.query(By.css('.mat-drawer-backdrop'))!.nativeElement;
             sidenavBackdrop.click();
             fixture.detectChanges();
             expect(sidenav.opened).toBe(false);
@@ -385,7 +385,7 @@ describe('AppComponent', () => {
         createTestingModule('a/b', mode);
         await initializeTest();
         component.onResize(dockSideNavWidth + 1); // wide view
-        selectElement = fixture.debugElement.query(By.directive(SelectComponent));
+        selectElement = fixture.debugElement.query(By.directive(SelectComponent))!;
         selectComponent = selectElement.componentInstance;
       }
 
@@ -704,7 +704,7 @@ describe('AppComponent', () => {
 
     describe('footer', () => {
       it('should have version number', () => {
-        const versionEl: HTMLElement = fixture.debugElement.query(By.css('aio-footer')).nativeElement;
+        const versionEl: HTMLElement = fixture.debugElement.query(By.css('aio-footer'))!.nativeElement;
         expect(versionEl.textContent).toContain(TestHttpClient.versionInfo.full);
       });
     });
@@ -713,14 +713,14 @@ describe('AppComponent', () => {
       it('should show a message if the deployment mode is "archive"', async () => {
         createTestingModule('a/b', 'archive');
         await initializeTest();
-        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner')).nativeElement;
+        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner'))!.nativeElement;
         expect(banner.textContent).toContain('archived documentation for Angular v4');
       });
 
       it('should show no message if the deployment mode is not "archive"', async () => {
         createTestingModule('a/b', 'stable');
         await initializeTest();
-        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner')).nativeElement;
+        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner'))!.nativeElement;
         expect(banner.textContent!.trim()).toEqual('');
       });
     });
@@ -754,7 +754,7 @@ describe('AppComponent', () => {
           component.showSearchResults = true;
           fixture.detectChanges();
 
-          const searchResults = fixture.debugElement.query(By.directive(SearchResultsComponent));
+          const searchResults = fixture.debugElement.query(By.directive(SearchResultsComponent))!;
           searchResults.nativeElement.click();
           fixture.detectChanges();
 
@@ -765,7 +765,7 @@ describe('AppComponent', () => {
           component.showSearchResults = true;
           fixture.detectChanges();
 
-          const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
+          const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent))!;
           searchBox.nativeElement.click();
           fixture.detectChanges();
 
@@ -780,7 +780,7 @@ describe('AppComponent', () => {
 
       describe('keyup handling', () => {
         it('should grab focus when the / key is pressed', () => {
-          const searchBox: SearchBoxComponent = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
+          const searchBox: SearchBoxComponent = fixture.debugElement.query(By.directive(SearchBoxComponent))!.componentInstance;
           spyOn(searchBox, 'focus');
           window.document.dispatchEvent(new KeyboardEvent('keyup', { key: '/' }));
           fixture.detectChanges();
@@ -788,7 +788,7 @@ describe('AppComponent', () => {
         });
 
         it('should set focus back to the search box when the search results are displayed and the escape key is pressed', () => {
-          const searchBox: SearchBoxComponent = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
+          const searchBox: SearchBoxComponent = fixture.debugElement.query(By.directive(SearchBoxComponent))!.componentInstance;
           spyOn(searchBox, 'focus');
           component.showSearchResults = true;
           window.document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
@@ -816,7 +816,7 @@ describe('AppComponent', () => {
           component.showSearchResults = true;
           fixture.detectChanges();
 
-          const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent));
+          const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent))!;
           searchResultsComponent.triggerEventHandler('resultSelected', {});
           fixture.detectChanges();
           expect(component.showSearchResults).toBe(false);
@@ -824,7 +824,7 @@ describe('AppComponent', () => {
 
         it('should re-run the search when the search box regains focus', () => {
           const doSearchSpy = spyOn(component, 'doSearch');
-          const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
+          const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent))!;
           searchBox.triggerEventHandler('onFocus', 'some query');
           expect(doSearchSpy).toHaveBeenCalledWith('some query');
         });
@@ -875,7 +875,7 @@ describe('AppComponent', () => {
   });
 
   describe('with mocked DocViewer', () => {
-    const getDocViewer = () => fixture.debugElement.query(By.css('aio-doc-viewer'));
+    const getDocViewer = () => fixture.debugElement.query(By.css('aio-doc-viewer'))!;
     const triggerDocViewerEvent =
         (evt: 'docReady' | 'docRemoved' | 'docInserted' | 'docRendered') =>
           getDocViewer().triggerEventHandler(evt, undefined);
@@ -916,7 +916,7 @@ describe('AppComponent', () => {
       it('should initially add the starting class until a document is rendered', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
-        const sidenavContainer = fixture.debugElement.query(By.css('mat-sidenav-container')).nativeElement;
+        const sidenavContainer = fixture.debugElement.query(By.css('mat-sidenav-container'))!.nativeElement;
 
         expect(component.isStarting).toBe(true);
         expect(hamburger.classList.contains('starting')).toBe(true);
@@ -965,7 +965,7 @@ describe('AppComponent', () => {
       it('should set the transitioning class on `.app-toolbar` while a document is being rendered', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
-        const toolbar = fixture.debugElement.query(By.css('.app-toolbar'));
+        const toolbar = fixture.debugElement.query(By.css('.app-toolbar'))!;
 
         // Initially, `isTransitoning` is true.
         expect(component.isTransitioning).toBe(true);
@@ -1028,7 +1028,7 @@ describe('AppComponent', () => {
 
       it('should set the id of the doc viewer container based on the current doc', () => {
         initializeTest(false);
-        const container = fixture.debugElement.query(By.css('main.sidenav-content'));
+        const container = fixture.debugElement.query(By.css('main.sidenav-content'))!;
 
         navigateTo('guide/pipes');
         expect(component.pageId).toEqual('guide-pipes');
@@ -1045,7 +1045,7 @@ describe('AppComponent', () => {
 
       it('should not be affected by changes to the query', () => {
         initializeTest(false);
-        const container = fixture.debugElement.query(By.css('main.sidenav-content'));
+        const container = fixture.debugElement.query(By.css('main.sidenav-content'))!;
 
         navigateTo('guide/pipes');
         navigateTo('guide/other?search=http');
@@ -1136,7 +1136,7 @@ describe('AppComponent', () => {
     describe('progress bar', () => {
       const SHOW_DELAY = 200;
       const HIDE_DELAY = 500;
-      const getProgressBar = () => fixture.debugElement.query(By.directive(MatProgressBar));
+      const getProgressBar = () => fixture.debugElement.query(By.directive(MatProgressBar))!;
       const initializeAndCompleteNavigation = () => {
         initializeTest(false);
         triggerDocViewerEvent('docReady');

--- a/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
+++ b/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
@@ -215,7 +215,7 @@ describe('LiveExampleComponent', () => {
       testPath = '/tutorial/toh-pt1';
       setHostTemplate('<live-example embedded></live-example>');
       testComponent(() => {
-        expect(getDownloadAnchor().href).toContain('/toh-pt1/toh-pt1.zip');
+        expect(getDownloadAnchor()!.href).toContain('/toh-pt1/toh-pt1.zip');
       });
     });
 

--- a/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
@@ -36,7 +36,7 @@ describe('FileNotFoundSearchComponent', () => {
   });
 
   it('should pass through any results to the `aio-search-results` component', () => {
-    const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent)).componentInstance;
+    const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent))!.componentInstance;
     expect(searchResultsComponent.searchResults).toBe(null);
 
     const results = { query: 'base initial url', results: []};

--- a/aio/src/app/custom-elements/toc/toc.component.spec.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.spec.ts
@@ -23,10 +23,10 @@ describe('TocComponent', () => {
   function setPage(): typeof page {
     return {
       listItems: tocComponentDe.queryAll(By.css('ul.toc-list>li')),
-      tocHeading: tocComponentDe.query(By.css('.toc-heading')),
-      tocHeadingButtonEmbedded: tocComponentDe.query(By.css('button.toc-heading.embedded')),
-      tocH1Heading: tocComponentDe.query(By.css('.h1')),
-      tocMoreButton: tocComponentDe.query(By.css('button.toc-more-items')),
+      tocHeading: tocComponentDe.query(By.css('.toc-heading'))!,
+      tocHeadingButtonEmbedded: tocComponentDe.query(By.css('button.toc-heading.embedded'))!,
+      tocH1Heading: tocComponentDe.query(By.css('.h1'))!,
+      tocMoreButton: tocComponentDe.query(By.css('button.toc-more-items'))!,
     };
   }
 

--- a/aio/src/app/layout/notification/notification.component.spec.ts
+++ b/aio/src/app/layout/notification/notification.component.spec.ts
@@ -24,7 +24,7 @@ describe('NotificationComponent', () => {
 
   function createComponent() {
     fixture = TestBed.createComponent(TestComponent);
-    const debugElement = fixture.debugElement.query(By.directive(NotificationComponent));
+    const debugElement = fixture.debugElement.query(By.directive(NotificationComponent))!;
     component = debugElement.componentInstance;
     component.ngOnInit();
     fixture.detectChanges();
@@ -40,7 +40,7 @@ describe('NotificationComponent', () => {
     it('should render HTML elements', () => {
       configTestingModule();
       createComponent();
-      const button = fixture.debugElement.query(By.css('.action-button'));
+      const button = fixture.debugElement.query(By.css('.action-button'))!;
       expect(button.nativeElement.textContent).toEqual('Learn More');
     });
 
@@ -57,7 +57,7 @@ describe('NotificationComponent', () => {
     createComponent();
     spyOn(component, 'dismiss');
     component.dismissOnContentClick = true;
-    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder')).nativeElement;
+    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder'))!.nativeElement;
     message.click();
     expect(component.dismiss).toHaveBeenCalled();
   });
@@ -67,7 +67,7 @@ describe('NotificationComponent', () => {
     createComponent();
     spyOn(component, 'dismiss');
     component.dismissOnContentClick = false;
-    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder')).nativeElement;
+    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder'))!.nativeElement;
     message.click();
     expect(component.dismiss).not.toHaveBeenCalled();
   });
@@ -76,7 +76,7 @@ describe('NotificationComponent', () => {
     configTestingModule();
     createComponent();
     spyOn(component, 'dismiss');
-    fixture.debugElement.query(By.css('button')).triggerEventHandler('click', null);
+    fixture.debugElement.query(By.css('button'))!.triggerEventHandler('click', null);
     fixture.detectChanges();
     expect(component.dismiss).toHaveBeenCalled();
   });

--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -30,7 +30,7 @@ describe('SearchBoxComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostComponent);
     host = fixture.componentInstance;
-    component = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
+    component = fixture.debugElement.query(By.directive(SearchBoxComponent))!.componentInstance;
     fixture.detectChanges();
   });
 
@@ -65,7 +65,7 @@ describe('SearchBoxComponent', () => {
     }));
 
     it('should pass through the value of the input box', fakeAsync(() => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       input.nativeElement.value = 'some query (input)';
       component.doSearch();
       tick(300);
@@ -73,7 +73,7 @@ describe('SearchBoxComponent', () => {
     }));
 
     it('should only send events if the search value has changed', fakeAsync(() => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
 
       input.nativeElement.value = 'some query';
       component.doSearch();
@@ -93,7 +93,7 @@ describe('SearchBoxComponent', () => {
 
   describe('on input', () => {
     it('should trigger a search', () => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       spyOn(component, 'doSearch');
       input.triggerEventHandler('input', { });
       expect(component.doSearch).toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe('SearchBoxComponent', () => {
 
   describe('on keyup', () => {
     it('should trigger a search', () => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       spyOn(component, 'doSearch');
       input.triggerEventHandler('keyup', { });
       expect(component.doSearch).toHaveBeenCalled();
@@ -111,7 +111,7 @@ describe('SearchBoxComponent', () => {
 
   describe('on focus', () => {
     it('should trigger the onFocus event', () => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       input.nativeElement.value = 'some query (focus)';
       input.triggerEventHandler('focus', { });
       expect(host.focusHandler).toHaveBeenCalledWith('some query (focus)');
@@ -120,7 +120,7 @@ describe('SearchBoxComponent', () => {
 
   describe('on click', () => {
     it('should trigger a search', () => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       spyOn(component, 'doSearch');
       input.triggerEventHandler('click', { });
       expect(component.doSearch).toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe('SearchBoxComponent', () => {
 
   describe('focus', () => {
     it('should set the focus to the input box', () => {
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       component.focus();
       expect(document.activeElement).toBe(input.nativeElement);
     });

--- a/aio/src/app/shared/search-results/search-results.component.spec.ts
+++ b/aio/src/app/shared/search-results/search-results.component.spec.ts
@@ -189,7 +189,7 @@ describe('SearchResultsComponent', () => {
       setSearchResults('something', [searchResult]);
 
       fixture.detectChanges();
-      anchor = fixture.debugElement.query(By.css('a'));
+      anchor = fixture.debugElement.query(By.css('a'))!;
 
       expect(selected).toBeNull();
     });

--- a/aio/src/app/shared/select/select.component.spec.ts
+++ b/aio/src/app/shared/select/select.component.spec.ts
@@ -23,7 +23,7 @@ describe('SelectComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostComponent);
     host = fixture.componentInstance;
-    element = fixture.debugElement.query(By.directive(SelectComponent));
+    element = fixture.debugElement.query(By.directive(SelectComponent))!;
   });
 
   describe('(initially)', () => {
@@ -172,7 +172,7 @@ class HostComponent {
 }
 
 function getButton(): HTMLButtonElement {
-  return element.query(By.css('button')).nativeElement;
+  return element.query(By.css('button'))!.nativeElement;
 }
 
 function getButtonSymbol(): HTMLElement | null {

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -205,7 +205,7 @@ export declare interface DebugElement extends DebugNode {
     readonly styles: {
         [key: string]: string | null;
     };
-    query(predicate: Predicate<DebugElement>): DebugElement;
+    query(predicate: Predicate<DebugElement>): DebugElement | null;
     queryAll(predicate: Predicate<DebugElement>): DebugElement[];
     queryAllNodes(predicate: Predicate<DebugNode>): DebugNode[];
     triggerEventHandler(eventName: string, eventObj: any): void;

--- a/integration/bazel/src/hello-world/hello-world.component.spec.ts
+++ b/integration/bazel/src/hello-world/hello-world.component.spec.ts
@@ -29,7 +29,7 @@ describe('BannerComponent (inline template)', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HelloWorldComponent);
     comp = fixture.componentInstance;
-    el = fixture.debugElement.query(By.css('div')).nativeElement;
+    el = fixture.debugElement.query(By.css('div'))!.nativeElement;
   });
 
   it('should display original title', () => {

--- a/packages/compiler-cli/integrationtest/test/projection_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/projection_spec.ts
@@ -16,7 +16,7 @@ describe('content projection', () => {
     const mainCompFixture = createComponent(ProjectingComp);
 
     const debugElement = mainCompFixture.debugElement;
-    const compWithProjection = debugElement.query(By.directive(CompWithNgContent));
+    const compWithProjection = debugElement.query(By.directive(CompWithNgContent))!;
     expect(compWithProjection.children.length).toBe(1);
     expect(compWithProjection.children[0].attributes['greeting']).toEqual('Hello world!');
   });

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -59,35 +59,35 @@ export function validateHtml(
 
   cmp.count = 0;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('zero');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('zero');
   cmp.count = 1;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('un');
   cmp.count = 2;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('deux');
   cmp.count = 3;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('beaucoup');
 
   cmp.sex = 'male';
   cmp.sexB = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('homme');
-  expect(el.query(By.css('#i18n-8b')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('homme');
+  expect(el.query(By.css('#i18n-8b'))!.nativeElement).toHaveText('femme');
   cmp.sex = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('femme');
   cmp.sex = '0';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('autre');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('autre');
 
   cmp.count = 123;
   tb.detectChanges();
@@ -116,7 +116,7 @@ export function validateHtml(
 }
 
 function expectHtml(el: DebugElement, cssSelector: string): any {
-  return expect(stringifyElement(el.query(By.css(cssSelector)).nativeElement));
+  return expect(stringifyElement(el.query(By.css(cssSelector))!.nativeElement));
 }
 
 export const HTML = `

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -34,7 +34,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            const template = `<div [dot.name]="'foo'"></div>`;
            fixture = createTestComponent(template);
            fixture.detectChanges();
-           const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+           const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
            expect(myDir.value).toEqual('foo');
          }));
     });

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -88,7 +88,7 @@ export interface DebugElement extends DebugNode {
   readonly nativeElement: any;
   readonly children: DebugElement[];
 
-  query(predicate: Predicate<DebugElement>): DebugElement;
+  query(predicate: Predicate<DebugElement>): DebugElement|null;
   queryAll(predicate: Predicate<DebugElement>): DebugElement[];
   queryAllNodes(predicate: Predicate<DebugNode>): DebugNode[];
   triggerEventHandler(eventName: string, eventObj: any): void;
@@ -148,7 +148,7 @@ export class DebugElement__PRE_R3__ extends DebugNode__PRE_R3__ implements Debug
     }
   }
 
-  query(predicate: Predicate<DebugElement>): DebugElement {
+  query(predicate: Predicate<DebugElement>): DebugElement|null {
     const results = this.queryAll(predicate);
     return results[0] || null;
   }
@@ -404,7 +404,7 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     return children;
   }
 
-  query(predicate: Predicate<DebugElement>): DebugElement {
+  query(predicate: Predicate<DebugElement>): DebugElement|null {
     const results = this.queryAll(predicate);
     return results[0] || null;
   }

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -21,7 +21,7 @@ describe('attribute creation', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    const div = fixture.debugElement.query(By.css('div')).nativeElement;
+    const div = fixture.debugElement.query(By.css('div'))!.nativeElement;
     expect(div.id).toEqual('test');
     expect(div.title).toEqual('Hello');
   });
@@ -38,7 +38,7 @@ describe('attribute creation', () => {
     fixture.detectChanges();
 
 
-    const div = fixture.debugElement.query(By.css('div')).nativeElement;
+    const div = fixture.debugElement.query(By.css('div'))!.nativeElement;
     const attrs = div.attributes;
 
     expect(attrs['id'].name).toEqual('id');
@@ -68,7 +68,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.href).toEqual('https://angular.io/robots.txt');
   });
@@ -86,7 +86,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
     expect(a.getAttribute('id')).toBe('my-link');
@@ -106,7 +106,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
     expect(a.id).toBe('my-link');
@@ -130,7 +130,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
     expect(button.getAttribute('id')).toBe('my-custom-button');
     expect(button.getAttribute('tabindex')).toBe('11');
@@ -159,8 +159,8 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
-    const span = fixture.debugElement.query(By.css('span')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
+    const span = fixture.debugElement.query(By.css('span'))!.nativeElement;
 
     expect(button.getAttribute('id')).toBe('my-custom-button');
     expect(button.getAttribute('tabindex')).toBe('11');
@@ -183,7 +183,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.href.indexOf('unsafe:')).toBe(0);
 

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -248,7 +248,7 @@ describe('projection', () => {
     TestBed.configureTestingModule({declarations: [Parent, Child], imports: [CommonModule]});
 
     const fixture = TestBed.createComponent(Parent);
-    const childDebugEl = fixture.debugElement.query(By.directive(Child));
+    const childDebugEl = fixture.debugElement.query(By.directive(Child))!;
     const childInstance = childDebugEl.injector.get(Child);
     const childElement = childDebugEl.nativeElement as HTMLElement;
 
@@ -297,7 +297,7 @@ describe('projection', () => {
     TestBed.configureTestingModule({declarations: [Parent, Child], imports: [CommonModule]});
 
     const fixture = TestBed.createComponent(Parent);
-    const childDebugEl = fixture.debugElement.query(By.directive(Child));
+    const childDebugEl = fixture.debugElement.query(By.directive(Child))!;
     const childInstance = childDebugEl.injector.get(Child);
 
     childInstance.showing = true;
@@ -349,7 +349,7 @@ describe('projection', () => {
        TestBed.configureTestingModule({declarations: [Parent, Trigger, Comp]});
 
        const fixture = TestBed.createComponent(Parent);
-       const trigger = fixture.debugElement.query(By.directive(Trigger)).injector.get(Trigger);
+       const trigger = fixture.debugElement.query(By.directive(Trigger))!.injector.get(Trigger);
        fixture.detectChanges();
 
        expect(getElementHtml(fixture.nativeElement)).toBe(`<button></button><comp></comp>`);
@@ -1095,7 +1095,7 @@ describe('projection', () => {
     const fixture = TestBed.createComponent(Root);
     fixture.detectChanges();
 
-    const projectedElement = fixture.debugElement.query(By.css('div'));
+    const projectedElement = fixture.debugElement.query(By.css('div'))!;
     const {ngProjectAs, title} = projectedElement.attributes;
     expect(ngProjectAs).toBe('projectMe');
     expect(title).toBe('some title');

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -749,7 +749,7 @@ describe('di', () => {
             fixture.detectChanges();
 
             const childComponent =
-                fixture.debugElement.query(By.directive(ChildComponent)).componentInstance;
+                fixture.debugElement.query(By.directive(ChildComponent))!.componentInstance;
             expect(childComponent.injector.get('token')).toBe('CHILD');
             expect(childComponent.parentInjector.get('token')).toBe('PARENT');
           });

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -48,7 +48,7 @@ describe('directives', () => {
       TestBed.overrideTemplate(TestComponent, `<span class="fade" [test]="false"></span>`);
 
       const fixture = TestBed.createComponent(TestComponent);
-      const testDir = fixture.debugElement.query(By.directive(TestDir)).injector.get(TestDir);
+      const testDir = fixture.debugElement.query(By.directive(TestDir))!.injector.get(TestDir);
       const spanEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -85,7 +85,7 @@ describe('directives', () => {
              `<span class="fade" [prop1]="true" [test]="false" [prop2]="true"></span>`);
 
          const fixture = TestBed.createComponent(TestComponent);
-         const testDir = fixture.debugElement.query(By.directive(TestDir)).injector.get(TestDir);
+         const testDir = fixture.debugElement.query(By.directive(TestDir))!.injector.get(TestDir);
          const spanEl = fixture.nativeElement.children[0];
          fixture.detectChanges();
 
@@ -141,7 +141,7 @@ describe('directives', () => {
           {declarations: [MyComponent, DirectiveA], imports: [CommonModule]});
       const fixture = TestBed.createComponent(MyComponent);
       fixture.detectChanges();
-      const directiveA = fixture.debugElement.query(By.css('span')).injector.get(DirectiveA);
+      const directiveA = fixture.debugElement.query(By.css('span'))!.injector.get(DirectiveA);
 
       expect(directiveA.viewContainerRef).toBeTruthy();
     });
@@ -547,7 +547,7 @@ describe('directives', () => {
 
       TestBed.configureTestingModule({declarations: [TestComp, TestDir]});
       const fixture = TestBed.createComponent(TestComp);
-      const testDir = fixture.debugElement.query(By.css('span')).injector.get(TestDir);
+      const testDir = fixture.debugElement.query(By.css('span'))!.injector.get(TestDir);
 
       expect(fixture.componentInstance.value).toBe(false);
 
@@ -581,7 +581,7 @@ describe('directives', () => {
       fixture.detectChanges();
 
       const dirWithTitle =
-          fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+          fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
       const div = fixture.nativeElement.querySelector('div');
       expect(dirWithTitle.title).toBe('a');
       expect(div.getAttribute('title')).toBe('a');
@@ -601,7 +601,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          // We are checking the property here, not the attribute, because in the case of
          // [key]="value" we are always setting the property of the instance, and actually setting
@@ -624,7 +624,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('attr.title')).toBe('test');
@@ -646,7 +646,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -668,7 +668,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -688,7 +688,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('attr.title')).toBe('test');
@@ -711,7 +711,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -733,7 +733,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -753,7 +753,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.title).toBe('');
@@ -773,7 +773,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('');
          expect(div.getAttribute('title')).toBe('a');
@@ -793,7 +793,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('');
          expect(div.getAttribute('title')).toBe('a');

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -203,7 +203,7 @@ describe('host bindings', () => {
       });
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
-      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
       expect(queryResult.nativeElement.style.color).toBe('red');
     });
 
@@ -242,7 +242,7 @@ describe('host bindings', () => {
          });
          const fixture = TestBed.createComponent(App);
          fixture.detectChanges();
-         const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+         const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
          expect(queryResult.nativeElement.style.color).toBe('green');
        });
 
@@ -291,7 +291,7 @@ describe('host bindings', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const queryResult = fixture.debugElement.query(By.directive(Comp));
+      const queryResult = fixture.debugElement.query(By.directive(Comp))!;
       expect(queryResult.nativeElement.style.color).toBe('red');
     });
 
@@ -359,7 +359,7 @@ describe('host bindings', () => {
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
       await fixture.whenStable();  // wait for animations to complete
-      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
       expect(queryResult.nativeElement.style.color).toBe('yellow');
       expect(events).toEqual(['@myAnimation.start', '@myAnimation.done']);
     });
@@ -436,7 +436,7 @@ describe('host bindings', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       await fixture.whenStable();  // wait for animations to complete
-      const queryResult = fixture.debugElement.query(By.directive(Comp));
+      const queryResult = fixture.debugElement.query(By.directive(Comp))!;
       expect(queryResult.nativeElement.style.color).toBe('yellow');
       expect(events).toEqual(['@myAnimation.start', '@myAnimation.done']);
     });

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -526,7 +526,7 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       const fixture = TestBed.createComponent(Cmp);
       fixture.detectChanges();
 
-      const a = fixture.debugElement.query(By.css('a'));
+      const a = fixture.debugElement.query(By.css('a'))!;
       const dir = a.injector.get(Dir);
       expect(dir.condition).toEqual(true);
     });

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -704,7 +704,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -786,7 +786,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -825,7 +825,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -1265,7 +1265,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -1353,7 +1353,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -1395,7 +1395,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -1840,7 +1840,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -1942,7 +1942,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -1994,7 +1994,7 @@ describe('inheritance', () => {
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
         const p: HTMLParagraphElement =
-            fixture.debugElement.query(By.directive(SubDirective)).nativeElement;
+            fixture.debugElement.query(By.directive(SubDirective))!.nativeElement;
 
         expect(p.title).toBe('test1!!!');
         expect(p.accessKey).toBe('test2???');
@@ -2442,7 +2442,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -2526,7 +2526,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -2566,7 +2566,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -3003,7 +3003,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -3093,7 +3093,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -3136,7 +3136,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -3625,7 +3625,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -3719,7 +3719,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -3771,7 +3771,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test1!!!');
         expect(queryResult.nativeElement.accessKey).toBe('test2???');
@@ -4270,7 +4270,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -4364,7 +4364,7 @@ describe('inheritance', () => {
             });
             const fixture = TestBed.createComponent(App);
             fixture.detectChanges();
-            const queryResult = fixture.debugElement.query(By.css('my-comp'));
+            const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
             expect(queryResult.nativeElement.style.color).toBe('red');
           });
@@ -4413,7 +4413,7 @@ describe('inheritance', () => {
             });
             const fixture = TestBed.createComponent(App);
             fixture.detectChanges();
-            const queryResult = fixture.debugElement.query(By.css('my-comp'));
+            const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
             expect(queryResult.nativeElement.style.color).toBe('blue');
             expect(queryResult.nativeElement.style.opacity).toBe('0.5');
@@ -4455,7 +4455,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -4499,7 +4499,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -4664,7 +4664,7 @@ describe('inheritance', () => {
       fixture.detectChanges();
 
       components.forEach(component => {
-        fixture.debugElement.query(By.directive(component)).nativeElement.click();
+        fixture.debugElement.query(By.directive(component))!.nativeElement.click();
       });
       expect(events).toEqual(
           ['BaseComponent.clicked', 'ChildComponent.clicked', 'GrandChildComponent.clicked']);
@@ -5072,7 +5072,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const myComp: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(myComp.foo).toEqual('a');
         expect(myComp.bar).toEqual('b');
@@ -5199,7 +5199,7 @@ describe('inheritance', () => {
             });
             const fixture = TestBed.createComponent(App);
             fixture.detectChanges();
-            const queryResult = fixture.debugElement.query(By.css('my-comp'));
+            const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
             expect(queryResult.nativeElement.style.color).toBe('blue');
             expect(queryResult.nativeElement.style.opacity).toBe('0.5');
@@ -5242,7 +5242,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -5295,7 +5295,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.title).toBe('test1!!!');

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -1559,7 +1559,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSuperClass, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass));
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!;
     fixture.detectChanges();
 
     button.nativeElement.click();
@@ -1588,7 +1588,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, SuperComp, SubComp, SomeDir]});
     const fixture = TestBed.createComponent(MyApp);
-    const subInstance = fixture.debugElement.query(By.directive(SubComp)).componentInstance;
+    const subInstance = fixture.debugElement.query(By.directive(SubComp))!.componentInstance;
     fixture.detectChanges();
 
     expect(subInstance.dirs.length).toBe(1);
@@ -1666,7 +1666,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass)).componentInstance;
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!.componentInstance;
     fixture.detectChanges();
 
     expect(button.isDisabled).toBe(false);
@@ -1700,7 +1700,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass)).componentInstance;
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!.componentInstance;
 
     button.emitClick();
     fixture.detectChanges();
@@ -1723,7 +1723,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton));
+    const button = fixture.debugElement.query(By.directive(SubButton))!;
     fixture.detectChanges();
 
     expect(button.nativeElement.getAttribute('tabindex')).toBe('-1');
@@ -1751,7 +1751,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton));
+    const button = fixture.debugElement.query(By.directive(SubButton))!;
     fixture.detectChanges();
 
     expect(button.nativeElement.getAttribute('tabindex')).toBe('-1');
@@ -1782,7 +1782,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1811,7 +1811,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1844,7 +1844,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, SuperBaseButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1882,7 +1882,7 @@ describe('acceptance integration tests', () => {
     TestBed.configureTestingModule(
         {declarations: [SubButton, SuperBaseButton, SuperSuperBaseButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -1587,7 +1587,7 @@ describe('onInit', () => {
     fixture.componentInstance.createDynamicView();
     fixture.detectChanges();
 
-    const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+    const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
     expect(myComp.onInitCalled).toBe(true);
   });
 

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -124,7 +124,7 @@ describe('event listeners', () => {
           const noOfEventListenersRegisteredSoFar = getNoOfNativeListeners();
           const fixture = TestBed.createComponent(TestCmpt);
           fixture.detectChanges();
-          const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+          const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
 
           // We want to assert that only one native event handler was registered but still all
           // directives are notified when an event fires. This assertion can only be verified in
@@ -165,7 +165,7 @@ describe('event listeners', () => {
       });
       const fixture = TestBed.createComponent(TestCmpt);
       fixture.detectChanges();
-      const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+      const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
 
       expect(buttonDebugEl.injector.get(LikesClicks).counter).toBe(0);
 
@@ -188,7 +188,7 @@ describe('event listeners', () => {
       const fixture = TestBed.createComponent(TestCmpt);
       fixture.detectChanges();
 
-      const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+      const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
       const likesClicksDir = buttonDebugEl.injector.get(LikesClicks);
       const returnsFalseDir = buttonDebugEl.injector.get(ReturnsFalse);
       expect(likesClicksDir.counter).toBe(0);

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -41,7 +41,7 @@ describe('property bindings', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    let a = fixture.debugElement.query(By.css('a')).nativeElement;
+    let a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(a.title).toBe('Hello');
 
     fixture.componentInstance.title = 'World';
@@ -60,7 +60,7 @@ describe('property bindings', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    let a = fixture.debugElement.query(By.css('a')).nativeElement;
+    let a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(a.title).toBe('Hello');
 
     fixture.detectChanges();
@@ -75,7 +75,7 @@ describe('property bindings', () => {
 
     TestBed.configureTestingModule({declarations: [MyComp]});
     const fixture = TestBed.createComponent(MyComp);
-    const labelNode = fixture.debugElement.query(By.css('label'));
+    const labelNode = fixture.debugElement.query(By.css('label'))!;
 
     fixture.componentInstance.forValue = 'some-input';
     fixture.detectChanges();
@@ -103,7 +103,7 @@ describe('property bindings', () => {
 
        TestBed.configureTestingModule({declarations: [App, MyComp]});
        const fixture = TestBed.createComponent(App);
-       const myCompNode = fixture.debugElement.query(By.directive(MyComp));
+       const myCompNode = fixture.debugElement.query(By.directive(MyComp))!;
        fixture.componentInstance.forValue = 'hello';
        fixture.detectChanges();
        expect(myCompNode.nativeElement.getAttribute('for')).toBeFalsy();
@@ -152,7 +152,7 @@ describe('property bindings', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.query(By.css('input')).nativeElement.required).toBe(false);
+    expect(fixture.debugElement.query(By.css('input'))!.nativeElement.required).toBe(false);
   });
 
   it('should support interpolation for properties', () => {
@@ -215,8 +215,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton, OtherDir]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -248,7 +248,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -281,7 +281,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, Comp]});
       const fixture = TestBed.createComponent(App);
-      const compDebugEl = fixture.debugElement.query(By.directive(Comp));
+      const compDebugEl = fixture.debugElement.query(By.directive(Comp))!;
       fixture.detectChanges();
 
       expect(compDebugEl.nativeElement.hasAttribute('id')).toBe(false);
@@ -303,9 +303,9 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton, OtherDisabledDir]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
-      const otherDisabledDir =
-          fixture.debugElement.query(By.directive(OtherDisabledDir)).injector.get(OtherDisabledDir);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
+      const otherDisabledDir = fixture.debugElement.query(By.directive(
+          OtherDisabledDir))!.injector.get(OtherDisabledDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -333,7 +333,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, OtherDir]});
       const fixture = TestBed.createComponent(App);
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -368,7 +368,7 @@ describe('property bindings', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       let buttonElements = fixture.nativeElement.querySelectorAll('button');
-      const idDir = fixture.debugElement.query(By.directive(IdDir)).injector.get(IdDir);
+      const idDir = fixture.debugElement.query(By.directive(IdDir))!.injector.get(IdDir);
 
       expect(buttonElements.length).toBe(2);
       expect(buttonElements[0].hasAttribute('id')).toBe(false);
@@ -380,7 +380,7 @@ describe('property bindings', () => {
       fixture.componentInstance.id1 = 'four';
       fixture.detectChanges();
 
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       buttonElements = fixture.nativeElement.querySelectorAll('button');
       expect(buttonElements.length).toBe(2);
       expect(buttonElements[0].hasAttribute('id')).toBe(false);
@@ -411,7 +411,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -428,7 +428,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -447,8 +447,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -466,7 +466,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -485,7 +485,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -508,8 +508,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       const [buttonEl, listboxEl] = fixture.nativeElement.children;
       fixture.detectChanges();
 
@@ -537,8 +537,8 @@ describe('property bindings', () => {
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB], imports: [CommonModule]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       let divElements = fixture.nativeElement.querySelectorAll('div');
 
       expect(divElements.length).toBe(2);

--- a/packages/core/test/acceptance/property_interpolation_spec.ts
+++ b/packages/core/test/acceptance/property_interpolation_spec.ts
@@ -160,7 +160,7 @@ describe('property interpolation', () => {
     TestBed.configureTestingModule({declarations: [AppComp]});
     const fixture = TestBed.createComponent(AppComp);
     fixture.detectChanges();
-    const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+    const anchor = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(anchor.getAttribute('href'))
         .toEqual(
             `http://g.com/?one=1&two=2&three=3&four=4&five=5&six=6&seven=7&eight=8&nine=9&ten=10`);

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -47,7 +47,7 @@ describe('providers', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
-      const otherDir = fixture.debugElement.query(By.css('div')).injector.get(OtherDirective);
+      const otherDir = fixture.debugElement.query(By.css('div'))!.injector.get(OtherDirective);
       expect(otherDir.dirs.length).toEqual(1);
       expect(otherDir.dirs[0] instanceof SubDirective).toBe(true);
     });
@@ -577,7 +577,7 @@ describe('providers', () => {
       });
 
       const fixture = TestBed.createComponent(TestComp);
-      const myCompInstance = fixture.debugElement.query(By.css('my-comp')).injector.get(MyComp);
+      const myCompInstance = fixture.debugElement.query(By.css('my-comp'))!.injector.get(MyComp);
       expect(myCompInstance.svc.value).toEqual('some value');
     });
 
@@ -593,7 +593,7 @@ describe('providers', () => {
       });
 
       const fixture = TestBed.createComponent(TestComp);
-      const myCompInstance = fixture.debugElement.query(By.css('div')).injector.get(MyDir);
+      const myCompInstance = fixture.debugElement.query(By.css('div'))!.injector.get(MyDir);
       expect(myCompInstance.svc.value).toEqual('some value');
     });
 

--- a/packages/core/test/acceptance/pure_function_spec.ts
+++ b/packages/core/test/acceptance/pure_function_spec.ts
@@ -38,7 +38,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
 
       const firstArray = myComp.names;
       expect(firstArray).toEqual(['Nancy', 'Carson', 'Bess']);
@@ -80,7 +80,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
       expect(myComp.names).toEqual(['Nancy', 'Carson', 'Bess']);
     });
 
@@ -112,7 +112,8 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const manyPropComp = fixture.debugElement.query(By.directive(ManyPropComp)).componentInstance;
+      const manyPropComp =
+          fixture.debugElement.query(By.directive(ManyPropComp))!.componentInstance;
 
       expect(manyPropComp!.names1).toEqual(['Nancy', 'Carson']);
       expect(manyPropComp!.names2).toEqual(['George']);
@@ -191,7 +192,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
 
       const firstArray = myComp.names;
       expect(firstArray).toEqual(['Nancy', 'Carson', 'Bess', 'Hannah']);
@@ -313,7 +314,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
       const app = fixture.componentInstance;
 
       expect(myComp.names).toEqual([
@@ -359,7 +360,7 @@ describe('components using pure function instructions internally', () => {
 
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const objectComp = fixture.debugElement.query(By.directive(ObjectComp)).componentInstance;
+      const objectComp = fixture.debugElement.query(By.directive(ObjectComp))!.componentInstance;
 
       const firstObj = objectComp.config;
       expect(objectComp.config).toEqual({duration: 500, animation: 'slide'});
@@ -396,7 +397,7 @@ describe('components using pure function instructions internally', () => {
 
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const objectComp = fixture.debugElement.query(By.directive(ObjectComp)).componentInstance;
+      const objectComp = fixture.debugElement.query(By.directive(ObjectComp))!.componentInstance;
 
       expect(objectComp.config).toEqual({
         animation: 'slide',

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -389,7 +389,7 @@ describe('query logic', () => {
     it('should support selecting InjectionToken', () => {
       const fixture = TestBed.createComponent(TestInjectionTokenContentQueries);
       const instance =
-          fixture.debugElement.query(By.directive(TestInjectionTokenQueries)).componentInstance;
+          fixture.debugElement.query(By.directive(TestInjectionTokenQueries))!.componentInstance;
       fixture.detectChanges();
       expect(instance.contentFirstOption).toBeDefined();
       expect(instance.contentFirstOption instanceof TestComponentWithToken).toBe(true);
@@ -746,7 +746,7 @@ describe('query logic', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      const shallowComp = fixture.debugElement.query(By.directive(ShallowComp)).componentInstance;
+      const shallowComp = fixture.debugElement.query(By.directive(ShallowComp))!.componentInstance;
       const queryList = shallowComp!.foos;
       expect(queryList.length).toBe(0);
 
@@ -1295,10 +1295,10 @@ describe('query logic', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const lotsOfContentEl = fixture.debugElement.query(By.directive(QueryForLotsOfContent));
+        const lotsOfContentEl = fixture.debugElement.query(By.directive(QueryForLotsOfContent))!;
         const lotsOfContentInstance = lotsOfContentEl.injector.get(QueryForLotsOfContent);
 
-        const contentEl = fixture.debugElement.query(By.directive(QueryForContent));
+        const contentEl = fixture.debugElement.query(By.directive(QueryForContent))!;
         const contentInstance = contentEl.injector.get(QueryForContent);
 
         expect(lotsOfContentInstance.foos1.length).toBe(2);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1375,7 +1375,7 @@ describe('styling', () => {
       fixture.componentInstance.showing = true;
       fixture.detectChanges();
 
-      const childDir = fixture.debugElement.query(By.directive(ChildDir)).injector.get(ChildDir);
+      const childDir = fixture.debugElement.query(By.directive(ChildDir))!.injector.get(ChildDir);
       expect(childDir.parent).toBeAnInstanceOf(TestDir);
       expect(testDirDiv.classList).not.toContain('with-button');
       expect(fixture.debugElement.nativeElement.textContent).toContain('Hello');

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -637,7 +637,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [EmbeddedViewInsertionComp, VCRefDirective]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(vcRefDir.vcref.length).toEqual(0);
@@ -666,7 +666,7 @@ describe('ViewContainerRef', () => {
     it('should retrieve a ViewRef from its index, and vice versa', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -687,7 +687,7 @@ describe('ViewContainerRef', () => {
     it('should handle out of bounds cases', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -725,7 +725,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [EmbeddedViewInsertionComp, VCRefDirective]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -798,7 +798,7 @@ describe('ViewContainerRef', () => {
     it('should detach the right embedded view when an index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -828,7 +828,7 @@ describe('ViewContainerRef', () => {
     it('should detach the last embedded view when no index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -868,7 +868,7 @@ describe('ViewContainerRef', () => {
     it('should remove the right embedded view when an index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -898,7 +898,7 @@ describe('ViewContainerRef', () => {
     it('should remove the last embedded view when no index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -919,7 +919,7 @@ describe('ViewContainerRef', () => {
     it('should throw when trying to insert a removed or destroyed view', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -1008,7 +1008,7 @@ describe('ViewContainerRef', () => {
 
       const fixture = TestBed.createComponent(TestComponent);
       const vcRef =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement))
@@ -1054,7 +1054,7 @@ describe('ViewContainerRef', () => {
           {declarations: [TestComponent, HeaderComponent, VCRefDirective]});
       const fixture = TestBed.createComponent(TestComponent);
       const vcRef =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement))
@@ -1173,7 +1173,7 @@ describe('ViewContainerRef', () => {
           {declarations: [Child, StarPipe, SomeComponent, VCRefDirective]});
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.vcref.createEmbeddedView(vcRefDir.tplRef!);
@@ -1213,7 +1213,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1291,7 +1291,7 @@ describe('ViewContainerRef', () => {
 
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1324,7 +1324,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1369,7 +1369,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1396,7 +1396,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1531,7 +1531,7 @@ describe('ViewContainerRef', () => {
 
       TestBed.configureTestingModule({declarations: [Child, Parent, InsertionDir]});
       const fixture = TestBed.createComponent(Parent);
-      const child = fixture.debugElement.query(By.directive(Child)).componentInstance;
+      const child = fixture.debugElement.query(By.directive(Child))!.componentInstance;
       fixture.detectChanges();
 
       // Context should be inherited from the declaration point, not the
@@ -1844,7 +1844,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(log).toEqual([
@@ -1925,7 +1925,7 @@ describe('ViewContainerRef', () => {
           {declarations: [SomeComponent, VCRefDirective], imports: [ComponentWithHooksModule]});
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(log).toEqual([
@@ -2059,7 +2059,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [Child, Parent, VCRefDirective]});
       const fixture = TestBed.createComponent(Parent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement))
@@ -2100,7 +2100,7 @@ describe('ViewContainerRef', () => {
       const fixture = TestBed.createComponent(Parent);
       fixture.detectChanges();
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       expect(getElementHtml(fixture.nativeElement))
           .toEqual(
@@ -2171,8 +2171,8 @@ describe('ViewContainerRef', () => {
            TestBed.configureTestingModule(
                {declarations: [Parent, ChildWithSelector, VCRefDirective]});
            const fixture = TestBed.createComponent(Parent);
-           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))
-                                .injector.get(VCRefDirective);
+           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(
+               VCRefDirective);
            fixture.detectChanges();
 
            expect(getElementHtml(fixture.nativeElement))
@@ -2241,8 +2241,8 @@ describe('ViewContainerRef', () => {
            TestBed.configureTestingModule(
                {declarations: [Parent, ChildWithSelector, VCRefDirective]});
            const fixture = TestBed.createComponent(Parent);
-           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))
-                                .injector.get(VCRefDirective);
+           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(
+               VCRefDirective);
            fixture.detectChanges();
 
            expect(getElementHtml(fixture.nativeElement))

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -174,7 +174,7 @@ describe('view insertion', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const comp = fixture.debugElement.query(By.directive(Comp)).injector.get(Comp);
+      const comp = fixture.debugElement.query(By.directive(Comp))!.injector.get(Comp);
 
       expect(comp.container.indexOf(comp.view0)).toBe(0);
       expect(comp.container.indexOf(comp.view1)).toBe(1);

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -658,7 +658,7 @@ class TestCmptWithPropInterpolation {
       });
 
       it('can use a dynamic element as root for another query', () => {
-        const inner = fixture.debugElement.query(By.css('.inner'));
+        const inner = fixture.debugElement.query(By.css('.inner'))!;
         expect(inner).toBeTruthy();
         expect(inner.query(By.css('.myclass'))).toBeTruthy();
       });
@@ -730,7 +730,7 @@ class TestCmptWithPropInterpolation {
 
       onlyInIvy('VE does not match elements created outside Angular context')
           .it('when using the out-of-context element as the DebugElement query root', () => {
-            const debugElOutsideAngularContext = el.query(By.css('ul'));
+            const debugElOutsideAngularContext = el.query(By.css('ul'))!;
             expect(debugElOutsideAngularContext.queryAll(By.css('li')).length).toBe(1);
             expect(debugElOutsideAngularContext.query(By.css('li'))).toBeDefined();
           });
@@ -766,6 +766,24 @@ class TestCmptWithPropInterpolation {
 
          expect(results.map(r => r.nativeElement.nodeName.toLowerCase())).toEqual(['div', 'span']);
        });
+
+    it('DebugElement.query should return null when the child is not found', () => {
+      @Component({
+        selector: 'app-test',
+        template: '<div></div>',
+      })
+      class MyComponent {
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComponent]});
+      const fixture = TestBed.createComponent(MyComponent);
+      fixture.detectChanges();
+
+      const result = fixture.debugElement.query(By.css('not-existing'));
+
+      expect(result).toBe(null);
+    });
+
 
     it('should list providerTokens', () => {
       fixture = TestBed.createComponent(ParentComp);
@@ -836,7 +854,7 @@ class TestCmptWithPropInterpolation {
         const fixture = TestBed.createComponent(TestCmptWithPropBindings);
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(button.properties.disabled).toEqual(true);
         expect(button.properties.tabIndex).toEqual(1337);
         expect(button.properties.title).toEqual('hello');
@@ -868,7 +886,7 @@ class TestCmptWithPropInterpolation {
         const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(button.properties.title).not.toEqual('goes to input');
       });
 
@@ -876,7 +894,7 @@ class TestCmptWithPropInterpolation {
         TestBed.overrideTemplate(TestCmptWithRenderer, `<button></button>`);
         const fixture = TestBed.createComponent(TestCmptWithRenderer);
         fixture.detectChanges();
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         fixture.componentInstance.renderer.setProperty(button.nativeElement, 'title', 'myTitle');
         expect(button.properties.title).toBe('myTitle');
       });
@@ -888,7 +906,7 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
 
         const host = fixture.debugElement;
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(Object.keys(host.properties).filter(key => key.startsWith('__'))).toEqual([]);
         expect(Object.keys(host.properties).filter(key => key.startsWith('on'))).toEqual([]);
         expect(Object.keys(button.properties).filter(key => key.startsWith('__'))).toEqual([]);
@@ -903,7 +921,7 @@ class TestCmptWithPropInterpolation {
             fixture.detectChanges();
 
             const host = fixture.debugElement;
-            const button = fixture.debugElement.query(By.css('button'));
+            const button = fixture.debugElement.query(By.css('button'))!;
 
             expect(button.properties.title).toEqual('myTitle');
           });
@@ -962,7 +980,7 @@ class TestCmptWithPropInterpolation {
 
       TestBed.configureTestingModule({declarations: [TestComponent]});
       const fixture = TestBed.createComponent(TestComponent);
-      const button = fixture.debugElement.query(By.css('button'));
+      const button = fixture.debugElement.query(By.css('button'))!;
 
       expect(() => {
         button.triggerEventHandler('click', null);
@@ -987,7 +1005,7 @@ class TestCmptWithPropInterpolation {
                TestCmpt, `<parent-comp><child-comp></child-comp></parent-comp>`);
            fixture = TestBed.createComponent(TestCmpt);
 
-           const debugEl = fixture.debugElement.query(By.directive(ChildComp));
+           const debugEl = fixture.debugElement.query(By.directive(ChildComp))!;
            expect(debugEl.componentInstance).toBeAnInstanceOf(ChildComp);
          });
 
@@ -1011,7 +1029,7 @@ class TestCmptWithPropInterpolation {
            fixture = TestBed.createComponent(TestCmpt);
            fixture.detectChanges();
 
-           const debugEl = fixture.debugElement.query(By.directive(MyDir));
+           const debugEl = fixture.debugElement.query(By.directive(MyDir))!;
            expect(debugEl.componentInstance).toBeAnInstanceOf(TestCmpt);
          });
 
@@ -1040,7 +1058,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(ExampleComponent));
+           const debugNode = fixture.debugElement.query(By.directive(ExampleComponent))!;
 
            expect(debugNode.context instanceof ExampleComponent).toBe(true);
          });
@@ -1052,7 +1070,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.css('span'));
+           const debugNode = fixture.debugElement.query(By.css('span'))!;
 
            expect(debugNode.context instanceof NgIfContext).toBe(true);
          });
@@ -1064,7 +1082,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(MyDir));
+           const debugNode = fixture.debugElement.query(By.directive(MyDir))!;
 
            expect(debugNode.context instanceof TestApp).toBe(true);
          });
@@ -1097,10 +1115,10 @@ class TestCmptWithPropInterpolation {
       TestBed.overrideTemplate(TestCmpt, `<span><div id="a"><div id="b"></div></div></span>`);
       fixture = TestBed.createComponent(TestCmpt);
 
-      const divA = fixture.debugElement.query(By.css('div'));
+      const divA = fixture.debugElement.query(By.css('div'))!;
       expect(divA.nativeElement.getAttribute('id')).toBe('a');
 
-      const divB = divA.query(By.css('div'));
+      const divB = divA.query(By.css('div'))!;
       expect(divB.nativeElement.getAttribute('id')).toBe('b');
     });
 
@@ -1154,7 +1172,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(MyComp);
       fixture.detectChanges();
 
-      const firstDiv = fixture.debugElement.query(By.css('div'));
+      const firstDiv = fixture.debugElement.query(By.css('div'))!;
       const firstDivChildren = firstDiv.queryAll(By.css('span'));
 
       expect(firstDivChildren.map(child => child.nativeNode.textContent.trim())).toEqual([
@@ -1195,7 +1213,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('div')).attributes['xlink:href']).toBe('foo');
+      expect(fixture.debugElement.query(By.css('div'))!.attributes['xlink:href']).toBe('foo');
     });
 
     it('should include attributes added via Renderer2 in DebugNode.attributes', () => {
@@ -1208,7 +1226,7 @@ class TestCmptWithPropInterpolation {
 
       TestBed.configureTestingModule({declarations: [Comp]});
       const fixture = TestBed.createComponent(Comp);
-      const div = fixture.debugElement.query(By.css('div'));
+      const div = fixture.debugElement.query(By.css('div'))!;
 
       fixture.componentInstance.renderer.setAttribute(div.nativeElement, 'foo', 'bar');
 
@@ -1239,7 +1257,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
-      const button = fixture.debugElement.query(By.directive(CancelButton));
+      const button = fixture.debugElement.query(By.directive(CancelButton))!;
       button.triggerEventHandler('cancel', {});
 
       expect(calls).toBe(1, 'Expected calls to be 1 after one event.');

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -1445,8 +1445,8 @@ describe(`ChangeDetection`, () => {
                       {declarations: [MainComp, OuterComp, InnerComp, DummyDirective]})
                   .createComponent(MainComp);
         mainComp = ctx.componentInstance;
-        outerComp = ctx.debugElement.query(By.directive(OuterComp)).injector.get(OuterComp);
-        innerComp = ctx.debugElement.query(By.directive(InnerComp)).injector.get(InnerComp);
+        outerComp = ctx.debugElement.query(By.directive(OuterComp))!.injector.get(OuterComp);
+        innerComp = ctx.debugElement.query(By.directive(InnerComp))!.injector.get(InnerComp);
       });
 
       it('should dirty check projected views in regular order', () => {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -475,14 +475,14 @@ describe('projection', () => {
 
     expect(main.nativeElement).toHaveText('TREE(0:)');
 
-    const tree = main.debugElement.query(By.directive(Tree));
+    const tree = main.debugElement.query(By.directive(Tree))!;
     let manualDirective: ManualViewportDirective = tree.queryAllNodes(By.directive(
         ManualViewportDirective))[0].injector.get(ManualViewportDirective);
     manualDirective.show();
     main.detectChanges();
     expect(main.nativeElement).toHaveText('TREE(0:TREE2(1:))');
 
-    const tree2 = main.debugElement.query(By.directive(Tree2));
+    const tree2 = main.debugElement.query(By.directive(Tree2))!;
     manualDirective = tree2.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
         ManualViewportDirective);
     manualDirective.show();
@@ -688,7 +688,7 @@ describe('projection', () => {
     });
     const main = TestBed.createComponent(MainComp);
 
-    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent))!;
 
     const viewViewportDir =
         conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -111,7 +111,8 @@ function declareTests(config?: {useJit: boolean}) {
 
            TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
            const fixture = TestBed.createComponent(MyComp);
-           const dir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir) as MyDir;
+           const dir =
+               fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir) as MyDir;
 
            fixture.detectChanges();
            expect(dir.setterCalls).toEqual({'a': null, 'b': 2});
@@ -294,7 +295,7 @@ function declareTests(config?: {useJit: boolean}) {
 
       const ctx =
           TestBed.configureTestingModule({declarations: [MyComp, MyDir]}).createComponent(MyComp);
-      const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
 
       expect(dir.template).toBeUndefined();
 

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -144,7 +144,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'))!;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
     expect(greetingByCss.componentInstance).toBeAnInstanceOf(GreetingCmp);
   });
@@ -153,7 +153,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
 
     hello.detectChanges();
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'))!;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
 
     greetingByCss.componentInstance.name = 'TestBed!';
@@ -165,7 +165,7 @@ describe('TestBed', () => {
     const fixture = TestBed.createComponent(ComponentWithPropBindings);
     fixture.detectChanges();
 
-    const divElement = fixture.debugElement.query(By.css('div'));
+    const divElement = fixture.debugElement.query(By.css('div'))!;
     expect(divElement.properties.id).toEqual('one');
     expect(divElement.properties.title).toEqual('some title');
   });
@@ -174,7 +174,7 @@ describe('TestBed', () => {
     const fixture = TestBed.createComponent(ComponentWithPropBindings);
     fixture.detectChanges();
 
-    const paragraphEl = fixture.debugElement.query(By.css('p'));
+    const paragraphEl = fixture.debugElement.query(By.css('p'))!;
     expect(paragraphEl.properties.title).toEqual('( some label - some title )');
     expect(paragraphEl.properties.id).toEqual('[ some label ] [ some title ]');
   });
@@ -182,7 +182,7 @@ describe('TestBed', () => {
   it('should give access to the node injector', () => {
     const fixture = TestBed.createComponent(HelloWorld);
     fixture.detectChanges();
-    const injector = fixture.debugElement.query(By.css('greeting-cmp')).injector;
+    const injector = fixture.debugElement.query(By.css('greeting-cmp'))!.injector;
 
     // from the node injector
     const greetingCmp = injector.get(GreetingCmp);
@@ -212,7 +212,7 @@ describe('TestBed', () => {
 
   it('should give access to local refs on a node', () => {
     const withRefsCmp = TestBed.createComponent(WithRefsCmp);
-    const firstDivDebugEl = withRefsCmp.debugElement.query(By.css('div'));
+    const firstDivDebugEl = withRefsCmp.debugElement.query(By.css('div'))!;
     // assert that a native element is referenced by a local ref
     expect(firstDivDebugEl.references.firstDiv.tagName.toLowerCase()).toBe('div');
   });
@@ -221,7 +221,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp));
+    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp))!;
     expect(greetingByDirective.componentInstance).toBeAnInstanceOf(GreetingCmp);
   });
 
@@ -1151,7 +1151,7 @@ describe('TestBed', () => {
              let fixture = TestBed.createComponent(RootCmp);
              fixture.detectChanges();
 
-             let childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+             let childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
              expect(childCmpInstance.componentInstance).toBeAnInstanceOf(ChildCmp);
              expect(fixture.nativeElement.textContent).toBe('Child comp');
 
@@ -1163,7 +1163,7 @@ describe('TestBed', () => {
              fixture = TestBed.createComponent(RootCmp);
              fixture.detectChanges();
 
-             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
              expect(childCmpInstance).toBeNull();
              expect(fixture.nativeElement.textContent).toBe('');
 
@@ -1178,7 +1178,7 @@ describe('TestBed', () => {
              fixture = TestBed.createComponent(RootCmp);
              fixture.detectChanges();
 
-             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
              expect(childCmpInstance).toBeNull();
              expect(fixture.nativeElement.textContent).toBe('');
            });

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -39,7 +39,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('old value');
 
         input.nativeElement.value = 'updated value';
@@ -54,7 +54,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('loginValue');
       });
 
@@ -63,7 +63,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form'))!;
         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
       });
 
@@ -73,7 +73,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = 'updatedValue';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -90,7 +90,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -103,7 +103,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = 'Nancy';
         dispatchEvent(input.nativeElement, 'input');
         fixture.detectChanges();
@@ -196,7 +196,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         form.addControl('email', new FormControl('email'));
         fixture.detectChanges();
 
-        let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+        let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'))!;
         expect(emailInput.nativeElement.value).toEqual('email');
 
         const newForm = new FormGroup({
@@ -205,7 +205,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'))!;
         expect(emailInput as any).toBe(null);  // TODO: Review use of `any` here (#19904)
       });
 
@@ -246,7 +246,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           form.addControl('login', new FormControl('newValue'));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('newValue');
 
           input.nativeElement.value = 'user input';
@@ -304,7 +304,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           form.addControl('cities', new FormArray([new FormControl('LA')]));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('LA');
 
           input.nativeElement.value = 'MTV';
@@ -350,7 +350,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input'))!.nativeElement;
           firstInput.value = 'last one';
           dispatchEvent(firstInput, 'input');
           fixture.detectChanges();
@@ -360,7 +360,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.get([0])!.setValue('set value');
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(firstInput.value).toEqual('set value');
         });
 
@@ -382,7 +382,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          const formEl = fixture.debugElement.query(By.css('form'));
+          const formEl = fixture.debugElement.query(By.css('form'))!;
           expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
         });
 
@@ -503,7 +503,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         login.setValue('newValue');
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -515,7 +515,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
              fixture.componentInstance.control = control;
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -530,7 +530,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.disabled).toBe(true);
 
           control.enable();
@@ -548,7 +548,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
              control.disable();
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -584,7 +584,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           control.disable();
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('my-input'));
+          const input = fixture.debugElement.query(By.css('my-input'))!;
           expect(input.nativeElement.getAttribute('disabled')).toBe(null);
         });
       });
@@ -598,7 +598,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input'));
+        const loginEl = fixture.debugElement.query(By.css('input'))!;
         expect(login.touched).toBe(false);
 
         dispatchEvent(loginEl.nativeElement, 'blur');
@@ -614,7 +614,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.event = null!;
         fixture.detectChanges();
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -629,7 +629,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
         expect(formGroupDir.submitted).toBe(false);
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -643,7 +643,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset({'login': 'reset value'});
@@ -657,7 +657,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset();
@@ -676,7 +676,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(login.dirty).toBe(true);
         });
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         loginEl.value = 'newValue';
 
         dispatchEvent(loginEl, 'input');
@@ -690,7 +690,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.componentInstance.form = form;
            fixture.detectChanges();
 
-           const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
            loginEl.value = 'newValue';
            dispatchEvent(loginEl, 'input');
 
@@ -711,7 +711,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -732,7 +732,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -754,7 +754,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -786,7 +786,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -807,8 +807,8 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
 
         expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
@@ -833,7 +833,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -856,7 +856,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -882,7 +882,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           control.setValue('Nancy');
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected value to propagate to view immediately.');
           expect(control.value).toEqual('Nancy', 'Expected model value to update immediately.');
           expect(control.valid).toBe(true, 'Expected validation to run immediately.');
@@ -896,7 +896,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(control.dirty).toBe(false, 'Expected control to start out pristine.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -917,7 +917,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(control.touched).toBe(false, 'Expected control to start out untouched.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -932,7 +932,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -958,7 +958,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -979,7 +979,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
           expect(input.value).toEqual('Nancy', 'Expected value to be set in the view.');
           expect(control.value).toEqual('Nancy', 'Expected initial model value to be set.');
@@ -992,7 +992,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1021,7 +1021,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1047,7 +1047,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
           expect(values).toEqual(
@@ -1092,7 +1092,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1116,7 +1116,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1141,7 +1141,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1204,7 +1204,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected initial value to propagate to view.');
           expect(form.value).toEqual({login: 'Nancy'}, 'Expected initial value to be set.');
           expect(form.valid).toBe(true, 'Expected form to run validation on initial value.');
@@ -1217,7 +1217,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1233,7 +1233,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               .toEqual({login: ''}, 'Expected form value to remain unchanged on blur.');
           expect(formGroup.valid).toBe(false, 'Expected form validation not to run on blur.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1249,12 +1249,12 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1285,7 +1285,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           formGroup.setValue({login: 'Nancy'});
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected view value to update immediately.');
           expect(formGroup.value)
               .toEqual({login: 'Nancy'}, 'Expected form value to update immediately.');
@@ -1298,7 +1298,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
@@ -1309,7 +1309,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(formGroup.dirty).toBe(false, 'Expected dirty not to change on blur.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1322,13 +1322,13 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
           expect(formGroup.touched).toBe(false, 'Expected touched not to change until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1342,7 +1342,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1358,7 +1358,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(formGroup.dirty).toBe(false, 'Expected dirty to stay false on reset.');
           expect(formGroup.touched).toBe(false, 'Expected touched to stay false on reset.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1382,7 +1382,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1394,7 +1394,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(values).toEqual([], 'Expected no valueChanges or statusChanges on blur');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1419,13 +1419,13 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
           expect(values).toEqual(
               [], 'Expected no valueChanges or statusChanges if value unchanged.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1479,7 +1479,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           formGroup.get('signin.login')!.setValidators(validatorSpy);
           formGroup.get('signin')!.setValidators(groupValidatorSpy);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1493,7 +1493,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -1502,7 +1502,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(formGroup.touched).toBe(false, 'Expected group to become untouched.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1516,7 +1516,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1530,7 +1530,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(control.value).toEqual('', 'Expected value to remain unchanged until submit.');
           expect(control.valid).toBe(false, 'Expected no validation to occur until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1547,7 +1547,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1556,7 +1556,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(control.valid).toBe(false, 'Expected no validation to occur until submit.');
 
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1592,7 +1592,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(passwordControl.valid)
               .toBe(false, 'Expected no validation to occur until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1696,7 +1696,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -1714,7 +1714,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -1732,7 +1732,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'aa';
            input.setSelectionRange(1, 2);
            dispatchEvent(input, 'input');
@@ -1753,7 +1753,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'Nancy';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
@@ -1762,7 +1762,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            expect(fixture.componentInstance.login)
                .toEqual('initial', 'Expected ngModel value to remain unchanged on input.');
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
            dispatchEvent(form, 'submit');
            fixture.detectChanges();
            tick();
@@ -1779,7 +1779,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const checkbox = fixture.debugElement.query(By.css('input'));
+        const checkbox = fixture.debugElement.query(By.css('input'))!;
         expect(checkbox.nativeElement.checked).toBe(false);
         expect(control.hasError('required')).toEqual(true);
 
@@ -1819,10 +1819,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[required]'));
-        const minLength = fixture.debugElement.query(By.css('[minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[pattern]'));
+        const required = fixture.debugElement.query(By.css('[required]'))!!!;
+        const minLength = fixture.debugElement.query(By.css('[minlength]'))!!!;
+        const maxLength = fixture.debugElement.query(By.css('[maxlength]'))!!!;
+        const pattern = fixture.debugElement.query(By.css('[pattern]'))!!!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -1868,10 +1868,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.pattern = '.{3,}';
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]'))!!;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!!;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!!;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -1912,10 +1912,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]'))!;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -2025,7 +2025,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
            tick(100);
@@ -2040,7 +2040,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.detectChanges();
         expect(form.valid).toEqual(true);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -2058,7 +2058,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(form.hasError('required', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'wrong value';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2084,7 +2084,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(control.hasError('required')).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2115,7 +2115,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            // Setting a value in the form control that will trigger the registered asynchronous
            // validation
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'angul';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2173,7 +2173,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(resultArr.length).toEqual(1, `Expected source observable to emit once on init.`);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'a';
            dispatchEvent(input.nativeElement, 'input');
            fixture.detectChanges();
@@ -2396,7 +2396,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -2427,7 +2427,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -2455,7 +2455,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -33,7 +33,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            // model -> view
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -71,7 +71,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         const fixture = TestBed.createComponent(AppComponent);
         // We need the Await as `ngModel` writes data asynchronously into the DOM
         await fixture.detectChanges();
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.properties.checked).toBe(true);
         expect(input.nativeElement.checked).toBe(true);
       });
@@ -83,7 +83,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
          }));
 
@@ -93,7 +93,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
          }));
 
@@ -175,7 +175,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -195,7 +195,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -217,9 +217,9 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.componentInstance.first = '';
            fixture.detectChanges();
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
+           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]'))!.nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
            // ngModelGroup creates its control asynchronously
            fixture.whenStable().then(() => {
@@ -256,7 +256,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should not add novalidate when ngNoForm is used', () => {
         const fixture = initTest(NgNoFormComp);
         fixture.detectChanges();
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form'))!;
         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
       });
     });
@@ -337,7 +337,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value).toEqual('Nancy Drew', 'Expected initial view value to be set.');
              expect(form.value)
@@ -356,7 +356,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .toEqual('Carson', 'Expected view value to update on programmatic change.');
@@ -374,7 +374,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -400,7 +400,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -433,7 +433,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -455,7 +455,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -483,7 +483,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub =
                  merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -511,7 +511,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(fixture.componentInstance.events)
                  .toEqual([], 'Expected ngModelChanges not to fire.');
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              dispatchEvent(input, 'blur');
              fixture.detectChanges();
 
@@ -580,7 +580,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value).toEqual('Nancy Drew', 'Expected initial view value to be set.');
              expect(form.value)
@@ -599,7 +599,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .toEqual('Carson', 'Expected view value to update on programmatic change.');
@@ -618,7 +618,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -637,7 +637,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .toEqual('Carson', 'Expected value not to update on blur.');
              expect(form.valid).toBe(false, 'Expected validation not to run on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -653,13 +653,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
              tick();
@@ -696,7 +696,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              form.control.get('name')!.setValidators(groupValidatorSpy);
              form.control.get('name.last')!.setValidators(validatorSpy);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -711,7 +711,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -726,7 +726,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
              expect(form.dirty).toBe(false, 'Expected dirtiness not to update on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -740,7 +740,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -753,7 +753,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(form.touched).toBe(false, 'Expected touched not to update on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -767,7 +767,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -787,7 +787,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(form.dirty).toBe(false, 'Expected dirty to stay false on reset.');
              expect(form.touched).toBe(false, 'Expected touched to stay false on reset.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -812,7 +812,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub =
                  merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -826,7 +826,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
              expect(values).toEqual([], 'Expected no valueChanges or statusChanges on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -844,14 +844,14 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
              expect(fixture.componentInstance.events)
                  .toEqual([], 'Expected ngModelChanges not to fire if value unchanged.');
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Carson';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -920,7 +920,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1015,7 +1015,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const fixture = initTest(NgModelForm);
            fixture.componentInstance.event = null!;
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            dispatchEvent(form.nativeElement, 'submit');
            tick();
 
@@ -1029,7 +1029,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.submitted).toBe(false);
 
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
            dispatchEvent(formEl, 'submit');
            tick();
 
@@ -1043,8 +1043,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
-           const input = fixture.debugElement.query(By.css('input'));
+           const formEl = fixture.debugElement.query(By.css('form'))!;
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            expect(input.nativeElement.value).toBe('should be cleared');       // view value
            expect(fixture.componentInstance.name).toBe('should be cleared');  // ngModel value
@@ -1062,7 +1062,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
+           const formEl = fixture.debugElement.query(By.css('form'))!;
 
            dispatchEvent(formEl.nativeElement, 'submit');
            fixture.detectChanges();
@@ -1109,7 +1109,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(form.get('name')!.dirty).toBe(true);
            });
 
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
            inputEl.value = 'newValue';
 
            dispatchEvent(inputEl, 'input');
@@ -1122,8 +1122,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm).form;
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
            inputEl.value = 'newValue';
            dispatchEvent(inputEl, 'input');
@@ -1175,7 +1175,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css(`[name="first"]`));
+           const input = fixture.debugElement.query(By.css(`[name="first"]`))!;
            expect(input.nativeElement.disabled).toBe(true);
          }));
 
@@ -1190,7 +1190,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                const form = fixture.debugElement.children[0].injector.get(NgForm);
                expect(form.control.get('name')!.disabled).toBe(true);
 
-               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+               const customInput = fixture.debugElement.query(By.css('[name="custom"]'))!;
                expect(customInput.nativeElement.disabled).toEqual(true);
              });
            });
@@ -1212,7 +1212,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.control.get('name')!.disabled).toBe(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(input.nativeElement.disabled).toEqual(true);
 
            form.control.enable();
@@ -1231,7 +1231,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox')!;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(input.nativeElement.checked).toBe(false);
            expect(control.hasError('required')).toBe(false);
 
@@ -1267,7 +1267,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('email')!;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(control.hasError('email')).toBe(false);
 
            fixture.componentInstance.validatorEnabled = true;
@@ -1310,10 +1310,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]'))!;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1353,7 +1353,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1375,7 +1375,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1397,7 +1397,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1417,10 +1417,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]'))!;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1484,7 +1484,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
       it('should update control status', fakeAsync(() => {
            const fixture = initTest(NgModelChangeState);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            const onNgModelChange = jasmine.createSpy('onNgModelChange');
            fixture.componentInstance.onNgModelChange = onNgModelChange;
@@ -1516,7 +1516,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
     describe('IME events', () => {
       it('should determine IME event handling depending on platform by default', fakeAsync(() => {
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1551,7 +1551,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                StandaloneNgModel,
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1583,7 +1583,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
            const fixture = initTest(StandaloneNgModel);
 
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1609,7 +1609,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'aa';
            input.selectionStart = 1;
            dispatchEvent(input, 'input');

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -29,7 +29,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -46,7 +46,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -62,7 +62,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.componentInstance.form = form;
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       form.valueChanges.subscribe({
         next: (value) => {
           throw 'Should not happen';
@@ -82,7 +82,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const textarea = fixture.debugElement.query(By.css('textarea'));
+      const textarea = fixture.debugElement.query(By.css('textarea'))!;
       expect(textarea.nativeElement.value).toEqual('old');
 
       textarea.nativeElement.value = 'new';
@@ -101,7 +101,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.checked).toBe(true);
 
       input.nativeElement.checked = false;
@@ -119,7 +119,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('10');
 
         input.nativeElement.value = '20';
@@ -135,7 +135,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -160,7 +160,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
             throw 'Input[number] should not react to change event';
           }
         });
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
 
         input.nativeElement.value = '5';
         dispatchEvent(input.nativeElement, 'change');
@@ -174,7 +174,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
         control.setValue(null);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('');
       });
     });
@@ -187,8 +187,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('SF');
           expect(sfOption.nativeElement.selected).toBe(true);
 
@@ -207,8 +207,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -225,8 +225,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectWithCompareFn);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -238,7 +238,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
           // will select the second option (NY).
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select'))!;
           select.nativeElement.value = '1: Object';
           dispatchEvent(select.nativeElement, 'change');
           fixture.detectChanges();
@@ -268,7 +268,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
 
              // model -> view
@@ -298,7 +298,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(buffalo.nativeElement.selected).toBe(true);
@@ -312,7 +312,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              expect(select.nativeElement.value).toEqual('1: Object');
 
              comp.cities.pop();
@@ -334,7 +334,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(secondNYC.nativeElement.selected).toBe(true);
@@ -347,7 +347,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              comp.selectedCity = null;
              fixture.detectChanges();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
 
              select.nativeElement.value = '2: Object';
              dispatchEvent(select.nativeElement, 'change');
@@ -379,8 +379,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select'))!;
+             const sfOption = fixture.debugElement.query(By.css('option'))!;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -395,7 +395,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
              // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
              // will select the second option (NY).
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              select.nativeElement.value = '1: Object';
              dispatchEvent(select.nativeElement, 'change');
              fixture.detectChanges();
@@ -425,8 +425,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultiple);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual(`0: 'SF'`);
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -436,8 +436,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultipleNgValue);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -455,8 +455,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select'))!;
+             const sfOption = fixture.debugElement.query(By.css('option'))!;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -483,7 +483,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         };
 
         const selectOptionViaUI = (valueString: string): void => {
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select'))!;
           select.nativeElement.value = valueString;
           dispatchEvent(select.nativeElement, 'change');
           detectChangesAndTick();
@@ -557,8 +557,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
            fixture.detectChanges();
            tick();
 
-           const select = fixture.debugElement.query(By.css('select'));
-           const sfOption = fixture.debugElement.query(By.css('option'));
+           const select = fixture.debugElement.query(By.css('select'))!;
+           const sfOption = fixture.debugElement.query(By.css('option'))!;
            expect(select.nativeElement.value).toEqual('0: Object');
            expect(sfOption.nativeElement.selected).toBe(true);
          }));
@@ -685,7 +685,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           });
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('[value="no"]'));
+          const input = fixture.debugElement.query(By.css('[value="no"]'))!;
           dispatchEvent(input.nativeElement, 'change');
 
           fixture.detectChanges();
@@ -862,7 +862,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const form = fixture.debugElement.query(By.css('form'));
+             const form = fixture.debugElement.query(By.css('form'))!;
              dispatchEvent(form.nativeElement, 'reset');
              fixture.detectChanges();
              tick();
@@ -941,7 +941,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('10');
 
           input.nativeElement.value = '20';
@@ -957,7 +957,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           input.nativeElement.value = '';
           dispatchEvent(input.nativeElement, 'input');
 
@@ -979,7 +979,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           control.setValue(null);
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('');
         });
       });
@@ -991,7 +991,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.val = 4;
              fixture.detectChanges();
              tick();
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.value).toBe('4');
              fixture.detectChanges();
              tick();
@@ -1014,7 +1014,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('!aa!');
 
           input.nativeElement.value = '!bb!';
@@ -1035,7 +1035,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('my-input'));
+             const input = fixture.debugElement.query(By.css('my-input'))!;
              expect(input.componentInstance.value).toEqual('!aa!');
 
              input.componentInstance.value = '!bb!';
@@ -1086,7 +1086,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
                fixture.detectChanges();
                fixture.whenStable().then(() => {
                  // model -> view
-                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'))!;
                  expect(customInput.nativeElement.value).toEqual('Nancy');
 
                  customInput.nativeElement.value = 'Carson';

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -102,7 +102,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
          () => {
            const fixture = TestBed.createComponent(SomeApp);
-           const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+           const cmp = fixture.debugElement.query(By.css('cmp-shadow'))!.nativeElement;
            const shadow = cmp.shadowRoot.querySelector('.shadow');
 
            expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -281,7 +281,7 @@ _global.beforeEach(function() {
             };
           }
 
-          const found = !!actualFixture.debugElement.query(By.directive(expectedComponentType));
+          const found = !!actualFixture.debugElement.query(By.directive(expectedComponentType))!;
           return found ?
               {pass: true} :
               {pass: false, message: msgFn(`Expected ${expectedComponentType.name} to show`)};

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2017,7 +2017,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/0'];
          advance(fixture);
-         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         const anchor = fixture.debugElement.query(By.css('a'))!.nativeElement;
          anchor.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
@@ -2025,7 +2025,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/1'];
          advance(fixture);
-         const button = fixture.debugElement.query(By.css('button')).nativeElement;
+         const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
          button.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
@@ -4660,8 +4660,8 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/lazy/parent/child');
              expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
+             const pInj = fixture.debugElement.query(By.directive(Parent))!.injector!;
+             const cInj = fixture.debugElement.query(By.directive(Child))!.injector!;
 
              expect(pInj.get('moduleName')).toEqual('parent');
              expect(pInj.get('fromParent')).toEqual('from parent');
@@ -4776,7 +4776,7 @@ describe('Integration', () => {
 
              expect(fixture.nativeElement).toHaveText('lazy');
              const lzc =
-                 fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+                 fixture.debugElement.query(By.directive(LazyLoadedComponent))!.componentInstance;
              expect(lzc.injectedService).toBe(lzc.resolvedService);
            })));
 

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -46,8 +46,8 @@ describe('Integration', () => {
 
          const router: Router = TestBed.inject(Router);
          const fixture = createRoot(router, LinkComponent);
-         const firstLink = fixture.debugElement.query(p => p.nativeElement.id === 'first-link');
-         const secondLink = fixture.debugElement.query(p => p.nativeElement.id === 'second-link');
+         const firstLink = fixture.debugElement.query(p => p.nativeElement.id === 'first-link')!;
+         const secondLink = fixture.debugElement.query(p => p.nativeElement.id === 'second-link')!;
          router.navigateByUrl('/link-a');
          advance(fixture);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/22449

Currently `DebugElement.query` 's return type is only `DebugElement` but actually it returns `DebugElement | null`.

## What is the new behavior?

Add `| null` typing

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
