### PR TITLE
refactor(ivy): change types for common package defs

### DIFF
--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -65,8 +65,8 @@ export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
  * @publicApi
  */
 export class NgClassBase {
-  static ngDirectiveDef: any = ngClassDirectiveDef;
-  static ngFactoryDef: any = ngClassFactoryDef;
+  static ngDirectiveDef: never = ngClassDirectiveDef as never;
+  static ngFactoryDef: never = ngClassFactoryDef as never;
 
   constructor(protected _delegate: NgClassImpl) {}
 

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -64,8 +64,8 @@ export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
  * @publicApi
  */
 export class NgStyleBase {
-  static ngDirectiveDef: any = ngStyleDirectiveDef;
-  static ngFactory: any = ngStyleFactoryDef;
+  static ngDirectiveDef: never = ngStyleDirectiveDef as never;
+  static ngFactory: never = ngStyleFactoryDef as never;
 
   constructor(protected _delegate: NgStyleImpl) {}
 

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -224,8 +224,8 @@ export declare class NgClassBase {
     getValue(): {
         [key: string]: any;
     } | null;
-    static ngDirectiveDef: any;
-    static ngFactoryDef: any;
+    static ngDirectiveDef: never;
+    static ngFactoryDef: never;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -309,8 +309,8 @@ export declare class NgStyleBase {
     getValue(): {
         [key: string]: any;
     } | null;
-    static ngDirectiveDef: any;
-    static ngFactory: any;
+    static ngDirectiveDef: never;
+    static ngFactory: never;
 }
 
 export declare class NgSwitch {


### PR DESCRIPTION
Changes the type of the `ngDirectiveDef` and `ngFactoryDef` of the directives in `@angular/common` to `never`.
