### PR TITLE
fix(language-service): Use ts.CompletionEntry for completions

### DIFF
--- a/integration/language_service_plugin/goldens/completionInfo.json
+++ b/integration/language_service_plugin/goldens/completionInfo.json
@@ -12,253 +12,211 @@
       {
         "name": "anchor",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "anchor"
       },
       {
         "name": "big",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "big"
       },
       {
         "name": "blink",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "blink"
       },
       {
         "name": "bold",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "bold"
       },
       {
         "name": "charAt",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "charAt"
       },
       {
         "name": "charCodeAt",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "charCodeAt"
       },
       {
         "name": "codePointAt",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "codePointAt"
       },
       {
         "name": "concat",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "concat"
       },
       {
         "name": "endsWith",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "endsWith"
       },
       {
         "name": "fixed",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "fixed"
       },
       {
         "name": "fontcolor",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "fontcolor"
       },
       {
         "name": "fontsize",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "fontsize"
       },
       {
         "name": "includes",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "includes"
       },
       {
         "name": "indexOf",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "indexOf"
       },
       {
         "name": "italics",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "italics"
       },
       {
         "name": "lastIndexOf",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "lastIndexOf"
       },
       {
         "name": "length",
         "kind": "property",
-        "kindModifiers": "",
         "sortText": "length"
       },
       {
         "name": "link",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "link"
       },
       {
         "name": "localeCompare",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "localeCompare"
       },
       {
         "name": "match",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "match"
       },
       {
         "name": "normalize",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "normalize"
       },
       {
         "name": "repeat",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "repeat"
       },
       {
         "name": "replace",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "replace"
       },
       {
         "name": "search",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "search"
       },
       {
         "name": "slice",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "slice"
       },
       {
         "name": "small",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "small"
       },
       {
         "name": "split",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "split"
       },
       {
         "name": "startsWith",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "startsWith"
       },
       {
         "name": "strike",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "strike"
       },
       {
         "name": "sub",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "sub"
       },
       {
         "name": "substr",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "substr"
       },
       {
         "name": "substring",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "substring"
       },
       {
         "name": "sup",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "sup"
       },
       {
         "name": "toLocaleLowerCase",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "toLocaleLowerCase"
       },
       {
         "name": "toLocaleUpperCase",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "toLocaleUpperCase"
       },
       {
         "name": "toLowerCase",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "toLowerCase"
       },
       {
         "name": "toString",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "toString"
       },
       {
         "name": "toUpperCase",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "toUpperCase"
       },
       {
         "name": "trim",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "trim"
       },
       {
         "name": "trimLeft",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "trimLeft"
       },
       {
         "name": "trimRight",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "trimRight"
       },
       {
         "name": "valueOf",
         "kind": "method",
-        "kindModifiers": "",
         "sortText": "valueOf"
       }
     ]

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -9,7 +9,7 @@
 import * as tss from 'typescript/lib/tsserverlibrary';
 
 import {isAstResult} from './common';
-import {getTemplateCompletions, ngCompletionToTsCompletionEntry} from './completions';
+import {getTemplateCompletions} from './completions';
 import {getDefinitionAndBoundSpan, getTsDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic, uniqueBySpan} from './diagnostics';
 import {getHover} from './hover';
@@ -70,7 +70,7 @@ class LanguageServiceImpl implements LanguageService {
       isGlobalCompletion: false,
       isMemberCompletion: false,
       isNewIdentifierLocation: false,
-      entries: results.map(ngCompletionToTsCompletionEntry),
+      entries: results,
     };
   }
 

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -259,6 +259,24 @@ export enum DirectiveKind {
 }
 
 /**
+ * ScriptElementKind for completion.
+ */
+export enum CompletionKind {
+  ATTRIBUTE = 'attribute',
+  COMPONENT = 'component',
+  ELEMENT = 'element',
+  ENTITY = 'entity',
+  HTML_ATTRIBUTE = 'html attribute',
+  KEY = 'key',
+  METHOD = 'method',
+  PIPE = 'pipe',
+  PROPERTY = 'property',
+  REFERENCE = 'reference',
+  TYPE = 'type',
+  VARIABLE = 'variable',
+}
+
+/**
  * A template diagnostics message chain. This is similar to the TypeScript
  * DiagnosticMessageChain. The messages are intended to be formatted as separate
  * sentence fragments and indented.

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -86,23 +86,6 @@ export function removeSuffix(value: string, suffix: string) {
   return value;
 }
 
-export function uniqueByName < T extends {
-  name: string;
-}
-> (elements: T[] | undefined): T[]|undefined {
-  if (elements) {
-    const result: T[] = [];
-    const set = new Set<string>();
-    for (const element of elements) {
-      if (!set.has(element.name)) {
-        set.add(element.name);
-        result.push(element);
-      }
-    }
-    return result;
-  }
-}
-
 export function isTypescriptVersion(low: string, high?: string) {
   const version = ts.version;
 

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -6,20 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import 'reflect-metadata';
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completion} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
 import {MockTypescriptHost} from './test_utils';
 
 describe('completions', () => {
-  let documentRegistry = ts.createDocumentRegistry();
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
-  let service = ts.createLanguageService(mockHost, documentRegistry);
+  let service = ts.createLanguageService(mockHost);
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
 


### PR DESCRIPTION
This is a prerequisite to fix a bug in template completions whereby
completion of the string `ti` for the variable `title` results in
`tititle`.

This is because the position where the completion is requested is used
to insert the completion text. This is incorrect. Instead, a
`replacementSpan` should be used to indicate the span of text that needs
to be replaced. Angular's own `Completion` interface is insufficient to
hold this information. Instead, we should just use ts.CompletionEntry.

Also added string enum for `CompletionKind`, which is similar to
ts.ScriptElementKind but contains more info about HTML entities.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
