### PR TITLE
fix(language-service): Create DirectiveKind enum

### DIFF
--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -11,7 +11,7 @@ import {getExpressionScope} from '@angular/compiler-cli/src/language_services';
 
 import {AstResult} from './common';
 import {getExpressionSymbol} from './expressions';
-import {Definition, Span, Symbol} from './types';
+import {Definition, DirectiveKind, Span, Symbol} from './types';
 import {diagnosticInfoFromTemplateInfo, findTemplateAstAt, inSpan, offsetSpan, spanOf} from './utils';
 
 export interface SymbolInfo {
@@ -58,7 +58,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
             const component = ast.directives.find(d => d.directive.isComponent);
             if (component) {
               symbol = info.template.query.getTypeSymbol(component.directive.type.reference);
-              symbol = symbol && new OverrideKindSymbol(symbol, 'component');
+              symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.COMPONENT);
               span = spanOf(ast);
             } else {
               // Find a directive that matches the element name
@@ -66,7 +66,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
                   d => d.directive.selector != null && d.directive.selector.indexOf(ast.name) >= 0);
               if (directive) {
                 symbol = info.template.query.getTypeSymbol(directive.directive.type.reference);
-                symbol = symbol && new OverrideKindSymbol(symbol, 'directive');
+                symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.DIRECTIVE);
                 span = spanOf(ast);
               }
             }
@@ -79,7 +79,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
           visitEvent(ast) {
             if (!attributeValueSymbol(ast.handler, /* inEvent */ true)) {
               symbol = findOutputBinding(info, path, ast);
-              symbol = symbol && new OverrideKindSymbol(symbol, 'event');
+              symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
               span = spanOf(ast);
             }
           },
@@ -170,8 +170,8 @@ function invertMap(obj: {[name: string]: string}): {[name: string]: string} {
  * Wrap a symbol and change its kind to component.
  */
 class OverrideKindSymbol implements Symbol {
-  public readonly kind: string;
-  constructor(private sym: Symbol, kindOverride: string) { this.kind = kindOverride; }
+  public readonly kind: DirectiveKind;
+  constructor(private sym: Symbol, kindOverride: DirectiveKind) { this.kind = kindOverride; }
 
   get name(): string { return this.sym.name; }
 

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -250,6 +250,15 @@ export enum DiagnosticKind {
 }
 
 /**
+ * The type of Angular directive. Used for QuickInfo in template.
+ */
+export enum DirectiveKind {
+  COMPONENT = 'component',
+  DIRECTIVE = 'directive',
+  EVENT = 'event',
+}
+
+/**
  * A template diagnostics message chain. This is similar to the TypeScript
  * DiagnosticMessageChain. The messages are intended to be formatted as separate
  * sentence fragments and indented.


### PR DESCRIPTION
Hovering over a selector, the QuickInfo display string is something
like:
```
(component) AppComponent
```
where `component` is the symbol kind.
Prior to this, there was no types to indicate the possible values of a
symbol. This PR creates an enum to represent that.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
