### PR TITLE
refactor(core): undecorated-classes-with-decorated-fields migration commits empty updates

### DIFF
--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
@@ -65,8 +65,13 @@ function runUndecoratedClassesMigration(tree: Tree, tsconfigPath: string, basePa
       file => !file.isDeclarationFile && !program.isSourceFileFromExternalLibrary(file));
 
   sourceFiles.forEach(sourceFile => {
-    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
     const classes = getUndecoratedClassesWithDecoratedFields(sourceFile, typeChecker);
+
+    if (classes.length === 0) {
+      return;
+    }
+
+    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
 
     classes.forEach((current, index) => {
       // If it's the first class that we're processing in this file, add `Directive` to the imports.


### PR DESCRIPTION
Commit 904a2018e0d3394ad91ffb6472f8271af7845295 introduced a new migration for undecorated classes with
decorated Angular class members. Currently the migration always calls
`tree.beginUpdate` and `tree.commitUpdate` (even if there are no changes).

This causes unnecessary updates to be reported to developers running `ng update`.
Once an update is committed, the CLI will report the update regardless of whether any
changes were made or not.

This behavior can be observed in the `ng_update_migrations` integration test. See:
https://circleci.com/gh/angular/angular/438470#tests/containers/3. Notice how all
source files are denoted as `UPDATED`.