### PR TITLE
fix(zone.js): a path traversal attack in test

### DIFF
--- a/packages/zone.js/simple-server.js
+++ b/packages/zone.js/simple-server.js
@@ -13,19 +13,28 @@ let server;
 
 const localFolder = __dirname;
 
+function writeNotFound(res) {
+  res.writeHead(404, {'Content-Type': 'text/html'});
+  res.end('<h1>404, Not Found!</h1>');
+}
+
 function requestHandler(req, res) {
   if (req.url === '/close') {
     res.end('server closing');
     setTimeout(() => { process.exit(0); }, 1000);
   } else {
-    const file = localFolder + req.url;
+    const file = path.resolve(localFolder, req.url);
+    if (!file.startsWith(localFolder + '/')) {
+      writeNotFound(res);
+      return;
+    }
 
     fs.readFile(file, function(err, contents) {
       if (!err) {
         res.end(contents);
       } else {
-        res.writeHead(404, {'Content-Type': 'text/html'});
-        res.end('<h1>404, Not Found!</h1>');
+        writeNotFound(res);
+        return;
       };
     });
   };


### PR DESCRIPTION
`simple-server.js` is vulnerable to a trivial path traversal attack, i.e. an
attacker can supply a path like `../../etc/passwd` to read arbitrary files on
the server. This change fixes the issue by properly resolving the path, and then
only serving files under the current directory (as intended).

This is not really a security issue, given the code is not part of Angular, but
rather just testing infrastructure for Angular itself, and the CI servers are
not expected to contain confidential information, but still worth fixing for
code hygiene.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?

Path traversal attack issue.

## What is the new behavior?

No more path traversals!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
