### PR TITLE
perf(ivy): properly initialise global state in the element_text_create benchmark

### DIFF
--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -10,6 +10,7 @@ import {createTNode, createTView} from '../../../../src/render3/instructions/sha
 import {ɵɵtext} from '../../../../src/render3/instructions/text';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
+import {resetComponentState} from '../../../../src/render3/state';
 import {createAndRenderLView} from '../setup';
 
 `<div>
@@ -64,6 +65,9 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
 const embeddedTView = createTView(-1, testTemplate, 21, 0, null, null, null, null);
+
+// initialize global state
+resetComponentState();
 
 // create view once so we don't profile first template pass
 createAndRenderLView(null, embeddedTView, viewTNode);


### PR DESCRIPTION
Without the `resetComponentState()` the `elementDepthCount` global state was `undefined` so trying to increment / decrement it was causing type coercion which was showing up under a profiler