### PR TITLE
ci: temporarily disable chrome mobile tests on android

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -29,8 +29,11 @@ var CIconfiguration = {
   'Edge': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Android4.4': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Android5': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
-  'Android6': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'Android7': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  // TODO: Re-enable Android6 and Android7 as these are just temporarily disabled because
+  // the browsers don't capture. This seems to be because the browsers are not able to
+  // establish a connection to the karma server through the tunnel.
+  'Android6': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Android7': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Safari7': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari8': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari9': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},


### PR DESCRIPTION
Temporarily disables saucelabs tests for Chrome Mobile on
android devices. This is because the browsers constantly do not
capture in Karma due to some connectivity issue where the
browsers are not able to load the karma page.