### PR TITLE
docs(core): Mark TestBed.get as deprecated

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -162,11 +162,11 @@ export class TestBedRender3 implements TestBed {
     return _getTestBedRender3().inject(token, notFoundValue, flags);
   }
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   static get(token: any, notFoundValue?: any): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
@@ -271,11 +271,11 @@ export class TestBedRender3 implements TestBed {
     return result === UNDEFINED ? this.compiler.injector.get(token, notFoundValue, flags) : result;
   }
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     return this.inject(token, notFoundValue, flags);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -62,9 +62,9 @@ export interface TestBed {
       token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
       |null;
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
 
   execute(tokens: any[], fn: Function, context?: any): any;
@@ -226,14 +226,14 @@ export class TestBedViewEngine implements TestBed {
     return _getTestBedViewEngine().inject(token, notFoundValue, flags);
   }
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
   /**
-   * TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject
+   * @deprecated from v9.0.0 use TestBed.inject
    * @suppress {duplicate}
    */
   static get(token: any, notFoundValue?: any): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   static get(
       token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
@@ -483,11 +483,11 @@ export class TestBedViewEngine implements TestBed {
     return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue, flags) : result;
   }
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     return this.inject(token, notFoundValue, flags);

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -120,9 +120,9 @@ export interface TestBedStatic {
       token: Type<T>|InjectionToken<T>|AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T
       |null;
 
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
-  /** TODO(goodwine): Mark as deprecated from v9.0.0 use TestBed.inject */
+  /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -58,8 +58,8 @@ export interface TestBed {
     configureTestingModule(moduleDef: TestModuleMetadata): void;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get(token: any, notFoundValue?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    /** @deprecated */ get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
@@ -95,8 +95,8 @@ export interface TestBedStatic {
     }): TestBedStatic;
     configureTestingModule(moduleDef: TestModuleMetadata): TestBedStatic;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
-    get(token: any, notFoundValue?: any): any;
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    /** @deprecated */ get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue: null, flags?: InjectFlags): T | null;
     inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;


### PR DESCRIPTION
We should now use TestBed.inject
See #32200

Fixes #26491

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Marked `TestBed.get` as `@deprecated`


## What is the current behavior?
`TestBed.get` is usable

Issue Number: #26491 


## What is the new behavior?
`TestBed.get` is usable BUT deprecated.
We should now use `TestBed.inject` from Angular 9.0.0+

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Not a breaking change but it will affect linters until users migrate, it should be a warning, not a failure.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
