### PR TITLE
build: mention where to find the invalid commit message, when validation fails

### DIFF
--- a/scripts/git/commit-msg.js
+++ b/scripts/git/commit-msg.js
@@ -24,7 +24,10 @@ if (msgFile) {
     isValid = checkMsg(firstLine);
 
     if (!isValid) {
-        console.error('\nCheck CONTRIBUTING.md at the root of the repo for more information.');
+        console.error(
+            '\nCheck CONTRIBUTING.md at the root of the repo for more information.' +
+            '\n' +
+            '\n(In case you need the invalid commit message, it should be stored in \'.git/COMMIT_EDITMSG\'.)');
     }
 }
 


### PR DESCRIPTION
Whenever someone tries to commit (by running `git commit` directly or indirectly), a `commit-msg` git hook is run to validate the commit message. If the validation fails, an error message is printed and the commit is aborted.

Occasionally, people may have written a non-trivial commit message which could turn out to be invalid (due a small typo for example). In that case, it is frustrating to "lose" the whole message and have to write it all over again (from memory). This is frustrating and has happened to me enough times to finally seek a solution.

Fortunately, it turns out that git stores the last commit message in `.git/COMMIT_EDITMSG`, so it is easy to get it back (as long as you know where to look for it). This commit mentions this info in the validation error to help people that might not know about it.

(This issue is probably mostly relevant for people using git from the command-line and not through a UI, but it won't hurt in either case.)
