### PR TITLE
fix(ngcc): support static evaluation of `exports` object in CommonJS

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -33,6 +33,13 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
   }
 
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
+    // The "exports" object is available as global in CommonJS bundles, without a `ts.Declaration`
+    // nor `ts.Expression` in the source file. Since it represents the source file's exports, the
+    // source file itself can be used as declaration node.
+    if (id.text === 'exports') {
+      return {node: id.getSourceFile(), viaModule: null};
+    }
+
     return this.getCommonJsImportedDeclaration(id) || super.getDeclarationOfIdentifier(id);
   }
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -12,7 +12,7 @@ import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/test
 import {ClassMemberKind, CtorParameter, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
-import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
+import {CommonJsReflectionHost, isCommonJsExportStatement} from '../../src/host/commonjs_host';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
 import {getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
@@ -1629,6 +1629,19 @@ exports.ExternalModule = ExternalModule;
           expect(actualDeclaration).not.toBe(null);
           expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
           expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        });
+
+        it('should return a declaration for the "exports" variable', () => {
+          loadTestFiles([INLINE_EXPORT_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(INLINE_EXPORT_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const file = getSourceFileOrError(program, INLINE_EXPORT_FILE.name);
+
+          const exportsIdentifier =
+              file.statements.find(isCommonJsExportStatement) !.expression.left.expression;
+          const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+          expect(exportDeclaration).not.toBeNull();
+          expect(exportDeclaration !.node).toBe(file);
         });
       });
 


### PR DESCRIPTION
In CommonJS bundles, the `exports` object is available as global
variable, without a `ts.Declaration` nor `ts.Expression` in the source
file. During static interpretation of expressions that read from the
`exports` object, ngtsc attempts to resolve the declaration node of the
"exports" variable in order to determine the value it represents. As no
such declaration exists, the evaluation results in a dynamic value.

Since the `exports` variable represents the source file's exports, the
source file itself can be used as declaration node for any "exports"
variable in CommonJS bundles. Doing so allows ngtsc to evaluate its
value correctly, as source file declarations are interpreted as the
public exports of the source file.
