### PR TITLE
refactor(benchpress): remove two mutable exports from largetable/util.ts

### DIFF
--- a/modules/benchmarks/src/largetable/util.ts
+++ b/modules/benchmarks/src/largetable/util.ts
@@ -13,8 +13,8 @@ export class TableCell {
 }
 
 let tableCreateCount: number;
-export let maxRow: number;
-export let maxCol: number;
+let maxRow: number;
+let maxCol: number;
 let numberData: TableCell[][];
 let charData: TableCell[][];
 

--- a/modules/benchmarks/src/tree/ng2_static/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_static/tree.ts
@@ -9,7 +9,7 @@
 import {Component, Input, NgModule} from '@angular/core';
 import {BrowserModule, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
-import {TreeNode, emptyTree, maxDepth} from '../util';
+import {TreeNode, emptyTree, getMaxDepth} from '../util';
 
 let trustedEmptyColor: SafeStyle;
 let trustedGreyColor: SafeStyle;
@@ -40,8 +40,8 @@ export class RootTreeComponent {
 
 function createModule(): any {
   const components: any[] = [RootTreeComponent];
-  for (let i = 0; i <= maxDepth; i++) {
-    components.push(createTreeComponent(i, i === maxDepth));
+  for (let i = 0; i <= getMaxDepth(); i++) {
+    components.push(createTreeComponent(i, i === getMaxDepth()));
   }
 
   @NgModule({imports: [BrowserModule], bootstrap: [RootTreeComponent], declarations: [components]})

--- a/modules/benchmarks/src/tree/util.ts
+++ b/modules/benchmarks/src/tree/util.ts
@@ -25,9 +25,13 @@ export class TreeNode {
 }
 
 let treeCreateCount: number;
-export let maxDepth: number;
+let maxDepth: number;
 let numberData: TreeNode;
 let charData: TreeNode;
+
+export function getMaxDepth() {
+  return maxDepth;
+}
 
 init();
 


### PR DESCRIPTION
Mutable exports, i.e. using this pattern

```
export let x = 0;
export function f() {
  x += 1;
}
```

is problematic to transpile to CommonJS and Goog.module systems, we are
working on banning it google internal codebase. Luckily here it appears
the exports were never needed externally.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
