### PR TITLE
perf(ngcc): add support for parallel execution of tasks

### DIFF
--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -82,6 +82,10 @@ grep "FocusMonitor.decorators =" node_modules/@angular/cdk/bundles/cdk-a11y.umd.
 ivy-ngcc -l debug | grep 'Skipping'
 if [[ $? != 0 ]]; then exit 1; fi
 
+# Does it process the tasks in parallel?
+ivy-ngcc -l debug | grep 'Running ngcc on ClusterExecutor'
+if [[ $? != 0 ]]; then exit 1; fi
+
 # Check that running it with logging level error outputs nothing
 ivy-ngcc -l error | grep '.' && exit 1
 

--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -1,102 +1,150 @@
 #!/bin/bash
 
-set -e -x
+# Do not immediately exit on error to allow the `assertSucceeded` function to handle the error.
+#
+# NOTE:
+# Each statement should be followed by an `assertSucceeded`/`assertFailed` or `exit 1` statement.
+set +e -x
 
 PATH=$PATH:$(npm bin)
 
+function assertFailed {
+  if [[ $? -eq 0 ]]; then
+    echo "FAIL: $1";
+    exit 1;
+  fi
+}
+
+function assertSucceeded {
+  if [[ $? -ne 0 ]]; then
+    echo "FAIL: $1";
+    exit 1;
+  fi
+}
+
+
 ivy-ngcc --help
+assertSucceeded "Expected 'ivy-ngcc --help' to succeed."
 
 # node --inspect-brk $(npm bin)/ivy-ngcc -f esm2015
 # Run ngcc and check it logged compilation output as expected
 ivy-ngcc | grep 'Compiling'
-if [[ $? != 0 ]]; then exit 1; fi
+assertSucceeded "Expected 'ivy-ngcc' to log 'Compiling'."
+
 
 # Did it add the appropriate build markers?
 
   # - esm2015
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm2015": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'esm2015' in '@angular/common'."
 
   # - fesm2015
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm2015": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'fesm2015' in '@angular/common'."
+
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"es2015": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'es2015' in '@angular/common'."
 
   # - esm5
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm5": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'esm5' in '@angular/common'."
 
   # - fesm5
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"module": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'module' in '@angular/common'."
+
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm5": "'
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'fesm5' in '@angular/common'."
+
 
 # Did it replace the PRE_R3 markers correctly?
   grep "= SWITCH_COMPILE_COMPONENT__POST_R3__" node_modules/@angular/core/fesm2015/core.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm2015)."
+
   grep "= SWITCH_COMPILE_COMPONENT__POST_R3__" node_modules/@angular/core/fesm5/core.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm5)."
+
 
 # Did it compile @angular/core/ApplicationModule correctly?
   grep "ApplicationModule.ngModuleDef = ɵɵdefineNgModule" node_modules/@angular/core/fesm2015/core.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm2015)."
+
   grep "ApplicationModule.ngModuleDef = ɵɵdefineNgModule" node_modules/@angular/core/fesm5/core.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm5)."
+
   grep "ApplicationModule.ngModuleDef = ɵngcc0.ɵɵdefineNgModule" node_modules/@angular/core/esm2015/src/application_module.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm2015)."
+
   grep "ApplicationModule.ngModuleDef = ɵngcc0.ɵɵdefineNgModule" node_modules/@angular/core/esm5/src/application_module.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm5)."
+
 
 # Did it transform @angular/core typing files correctly?
   grep "import [*] as ɵngcc0 from './src/r3_symbols';" node_modules/@angular/core/core.d.ts
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add an import for 'src/r3_symbols' in '@angular/core' typings."
+
   grep "static ngInjectorDef: ɵngcc0.ɵɵInjectorDef<ApplicationModule>;" node_modules/@angular/core/core.d.ts
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to add a definition for 'ApplicationModule.ngInjectorDef' in '@angular/core' typings."
+
 
 # Did it generate a base factory call for synthesized constructors correctly?
   grep "const ɵMatTable_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(MatTable);" node_modules/@angular/material/esm2015/table.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm2015)."
+
   grep "const ɵMatTable_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(MatTable);" node_modules/@angular/material/esm5/table.es5.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected 'ivy-ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm5)."
+
 
 # Did it generate a base definition for undecorated classes with inputs and view queries?
-grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm2015/menu.js
-if [[ $? != 0 ]]; then exit 1; fi
-grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm5/menu.es5.js
-if [[ $? != 0 ]]; then exit 1; fi
+  grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm2015/menu.js
+  assertSucceeded "Expected 'ivy-ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm2015)."
+
+  grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm5/menu.es5.js
+  assertSucceeded "Expected 'ivy-ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm5)."
+
 
 # Did it handle namespace imported decorators in UMD using `__decorate` syntax?
-grep "type: i0.Injectable" node_modules/@angular/common/bundles/common.umd.js
-# (and ensure the @angular/common package is indeed using `__decorate` syntax)
-grep "JsonPipe = __decorate(" node_modules/@angular/common/bundles/common.umd.js.__ivy_ngcc_bak
+  grep "type: i0.Injectable" node_modules/@angular/common/bundles/common.umd.js
+  assertSucceeded "Expected 'ivy-ngcc' to correctly handle '__decorate' syntax in '@angular/common' (umd)."
+
+  # (and ensure the @angular/common package is indeed using `__decorate` syntax)
+  grep "JsonPipe = __decorate(" node_modules/@angular/common/bundles/common.umd.js.__ivy_ngcc_bak
+  assertSucceeded "Expected '@angular/common' (umd) to actually use '__decorate' syntax."
+
 
 # Did it handle namespace imported decorators in UMD using static properties?
-grep "type: core.Injectable," node_modules/@angular/cdk/bundles/cdk-a11y.umd.js
-# (and ensure the @angular/cdk/a11y package is indeed using static properties)
-grep "FocusMonitor.decorators =" node_modules/@angular/cdk/bundles/cdk-a11y.umd.js.__ivy_ngcc_bak
+  grep "type: core.Injectable," node_modules/@angular/cdk/bundles/cdk-a11y.umd.js
+  assertSucceeded "Expected 'ivy-ngcc' to correctly handle decorators via static properties in '@angular/cdk/a11y' (umd)."
+
+  # (and ensure the @angular/cdk/a11y package is indeed using static properties)
+  grep "FocusMonitor.decorators =" node_modules/@angular/cdk/bundles/cdk-a11y.umd.js.__ivy_ngcc_bak
+  assertSucceeded "Expected '@angular/cdk/a11y' (umd) to actually have decorators via static properties."
+
 
 # Can it be safely run again (as a noop)?
 # And check that it logged skipping compilation as expected
 ivy-ngcc -l debug | grep 'Skipping'
-if [[ $? != 0 ]]; then exit 1; fi
+assertSucceeded "Expected 'ivy-ngcc -l debug' to successfully rerun (as a noop) and log 'Skipping'."
 
 # Does it process the tasks in parallel?
 ivy-ngcc -l debug | grep 'Running ngcc on ClusterExecutor'
-if [[ $? != 0 ]]; then exit 1; fi
+assertSucceeded "Expected 'ivy-ngcc -l debug' to run in parallel mode (using 'ClusterExecutor')."
 
 # Check that running it with logging level error outputs nothing
-ivy-ngcc -l error | grep '.' && exit 1
+ivy-ngcc -l error | grep '.'
+assertFailed "Expected 'ivy-ngcc -l error' to not output anything."
 
 # Does running it with --formats fail?
-ivy-ngcc --formats fesm2015 && exit 1
+ivy-ngcc --formats fesm2015
+assertFailed "Expected 'ivy-ngcc --formats fesm2015' to fail (since '--formats' is deprecated)."
 
 # Now try compiling the app using the ngcc compiled libraries
 ngc -p tsconfig-app.json
+assertSucceeded "Expected the app to successfully compile with the ngcc-processed libraries."
 
 # Did it compile the main.ts correctly (including the ngIf and MatButton directives)?
   grep "directives: \[.*\.NgIf.*\]" dist/src/main.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected the compiled app's 'main.ts' to list 'NgIf' in 'directives'."
+
   grep "directives: \[.*\.MatButton.*\]" dist/src/main.js
-  if [[ $? != 0 ]]; then exit 1; fi
+  assertSucceeded "Expected the compiled app's 'main.ts' to list 'MatButton' in 'directives'."

--- a/packages/compiler-cli/ngcc/index.ts
+++ b/packages/compiler-cli/ngcc/index.ts
@@ -7,14 +7,16 @@
  */
 import {CachedFileSystem, NodeJSFileSystem, setFileSystem} from '../src/ngtsc/file_system';
 
-import {mainNgcc} from './src/main';
+import {AsyncNgccOptions, NgccOptions, SyncNgccOptions, mainNgcc} from './src/main';
 export {ConsoleLogger, LogLevel} from './src/logging/console_logger';
 export {Logger} from './src/logging/logger';
-export {NgccOptions} from './src/main';
+export {AsyncNgccOptions, NgccOptions, SyncNgccOptions} from './src/main';
 export {PathMappings} from './src/utils';
 
-export function process(...args: Parameters<typeof mainNgcc>) {
+export function process(options: AsyncNgccOptions): Promise<void>;
+export function process(options: SyncNgccOptions): void;
+export function process(options: NgccOptions): void|Promise<void> {
   // Recreate the file system on each call to reset the cache
   setFileSystem(new CachedFileSystem(new NodeJSFileSystem()));
-  return mainNgcc(...args);
+  return mainNgcc(options);
 }

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -14,6 +14,8 @@ import {ConsoleLogger, LogLevel} from './src/logging/console_logger';
 
 // CLI entry point
 if (require.main === module) {
+  const startTime = Date.now();
+
   const args = process.argv.slice(2);
   const options =
       yargs
@@ -67,14 +69,22 @@ if (require.main === module) {
 
   (async() => {
     try {
+      const logger = logLevel && new ConsoleLogger(LogLevel[logLevel]);
+
       await mainNgcc({
         basePath: baseSourcePath,
         propertiesToConsider,
         targetEntryPointPath,
         compileAllFormats,
-        logger: logLevel && new ConsoleLogger(LogLevel[logLevel]),
+        logger,
         async: true,
       });
+
+      if (logger) {
+        const duration = Math.round((Date.now() - startTime) / 1000);
+        logger.debug(`Run ngcc in ${duration}s.`);
+      }
+
       process.exitCode = 0;
     } catch (e) {
       console.error(e.stack || e.message);

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -64,17 +64,21 @@ if (require.main === module) {
   const targetEntryPointPath = options['t'] ? options['t'] : undefined;
   const compileAllFormats = !options['first-only'];
   const logLevel = options['l'] as keyof typeof LogLevel | undefined;
-  try {
-    mainNgcc({
-      basePath: baseSourcePath,
-      propertiesToConsider,
-      targetEntryPointPath,
-      compileAllFormats,
-      logger: logLevel && new ConsoleLogger(LogLevel[logLevel]),
-    });
-    process.exitCode = 0;
-  } catch (e) {
-    console.error(e.stack || e.message);
-    process.exitCode = 1;
-  }
+
+  (async() => {
+    try {
+      await mainNgcc({
+        basePath: baseSourcePath,
+        propertiesToConsider,
+        targetEntryPointPath,
+        compileAllFormats,
+        logger: logLevel && new ConsoleLogger(LogLevel[logLevel]),
+        async: true,
+      });
+      process.exitCode = 0;
+    } catch (e) {
+      console.error(e.stack || e.message);
+      process.exitCode = 1;
+    }
+  })();
 }

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -63,16 +63,17 @@ export interface DependencyDiagnostics {
 export type PartiallyOrderedEntryPoints = PartiallyOrderedList<EntryPoint>;
 
 /**
- * A list of entry-points, sorted by their dependencies.
+ * A list of entry-points, sorted by their dependencies, and the dependency graph.
  *
  * The `entryPoints` array will be ordered so that no entry point depends upon an entry point that
  * appears later in the array.
  *
- * Some entry points or their dependencies may be have been ignored. These are captured for
+ * Some entry points or their dependencies may have been ignored. These are captured for
  * diagnostic purposes in `invalidEntryPoints` and `ignoredDependencies` respectively.
  */
 export interface SortedEntryPointsInfo extends DependencyDiagnostics {
   entryPoints: PartiallyOrderedEntryPoints;
+  graph: DepGraph<EntryPoint>;
 }
 
 /**
@@ -109,6 +110,7 @@ export class DependencyResolver {
     return {
       entryPoints: (sortedEntryPointNodes as PartiallyOrderedList<string>)
                        .map(path => graph.getNodeData(path)),
+      graph,
       invalidEntryPoints,
       ignoredDependencies,
     };

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -9,7 +9,8 @@
 import {DepGraph} from 'dependency-graph';
 import {AbsoluteFsPath, FileSystem, resolve} from '../../../src/ngtsc/file_system';
 import {Logger} from '../logging/logger';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from '../packages/entry_point';
+import {EntryPoint, EntryPointFormat, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from '../packages/entry_point';
+import {PartiallyOrderedList} from '../utils';
 import {DependencyHost, DependencyInfo} from './dependency_host';
 
 const builtinNodeJsModules = new Set<string>(require('module').builtinModules);
@@ -52,6 +53,16 @@ export interface DependencyDiagnostics {
 }
 
 /**
+ * Represents a partially ordered list of entry-points.
+ *
+ * The entry-points' order/precedence is such that dependent entry-points always come later than
+ * their dependencies in the list.
+ *
+ * See `DependencyResolver#sortEntryPointsByDependency()`.
+ */
+export type PartiallyOrderedEntryPoints = PartiallyOrderedList<EntryPoint>;
+
+/**
  * A list of entry-points, sorted by their dependencies.
  *
  * The `entryPoints` array will be ordered so that no entry point depends upon an entry point that
@@ -60,7 +71,9 @@ export interface DependencyDiagnostics {
  * Some entry points or their dependencies may be have been ignored. These are captured for
  * diagnostic purposes in `invalidEntryPoints` and `ignoredDependencies` respectively.
  */
-export interface SortedEntryPointsInfo extends DependencyDiagnostics { entryPoints: EntryPoint[]; }
+export interface SortedEntryPointsInfo extends DependencyDiagnostics {
+  entryPoints: PartiallyOrderedEntryPoints;
+}
 
 /**
  * A class that resolves dependencies between entry-points.
@@ -94,7 +107,8 @@ export class DependencyResolver {
     }
 
     return {
-      entryPoints: sortedEntryPointNodes.map(path => graph.getNodeData(path)),
+      entryPoints: (sortedEntryPointNodes as PartiallyOrderedList<string>)
+                       .map(path => graph.getNodeData(path)),
       invalidEntryPoints,
       ignoredDependencies,
     };

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -7,6 +7,7 @@
  */
 
 import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
+import {PartiallyOrderedList} from '../utils';
 
 
 /**
@@ -31,6 +32,21 @@ export interface Executor {
   execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn):
       void|Promise<void>;
 }
+
+/**
+ * Represents a partially ordered list of tasks.
+ *
+ * The ordering/precedence of tasks is determined by the inter-dependencies between their associated
+ * entry-points. Specifically, the tasks' order/precedence is such that tasks associated to
+ * dependent entry-points always come after tasks associated with their dependencies.
+ *
+ * As result of this ordering, it is guaranteed that - by processing tasks in the order in which
+ * they appear in the list - a task's dependencies will always have been processed before processing
+ * the task itself.
+ *
+ * See `DependencyResolver#sortEntryPointsByDependency()`.
+ */
+export type PartiallyOrderedTasks = PartiallyOrderedList<Task>;
 
 /** Represents a unit of work: processing a specific format property of an entry-point. */
 export interface Task {

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -24,7 +24,8 @@ export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => Compil
  * The type of the function that orchestrates and executes the required work (i.e. analyzes the
  * entry-points, processes the resulting tasks, does book-keeping and validates the final outcome).
  */
-export type ExecuteFn = (analyzeFn: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => void;
+export type ExecuteFn =
+    (analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => void;
 
 /** Represents metadata related to the processing of an entry-point. */
 export interface EntryPointProcessingMetadata {

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -33,7 +33,7 @@ export interface ExecutionOptions {
 export interface Executor {
   execute(
       analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn,
-      options: ExecutionOptions): void;
+      options: ExecutionOptions): void|Promise<void>;
 }
 
 /** Represents metadata related to the processing of an entry-point. */

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -20,12 +20,21 @@ export type CompileFn = (task: Task) => void;
 /** The type of the function that creates the `CompileFn` function used to process tasks. */
 export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => CompileFn;
 
+/** Options related to the orchestration/execution of tasks. */
+export interface ExecutionOptions {
+  compileAllFormats: boolean;
+  propertiesToConsider: string[];
+}
+
 /**
- * The type of the function that orchestrates and executes the required work (i.e. analyzes the
- * entry-points, processes the resulting tasks, does book-keeping and validates the final outcome).
+ * A class that orchestrates and executes the required work (i.e. analyzes the entry-points,
+ * processes the resulting tasks, does book-keeping and validates the final outcome).
  */
-export type ExecuteFn =
-    (analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => void;
+export interface Executor {
+  execute(
+      analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn,
+      options: ExecutionOptions): void;
+}
 
 /** Represents metadata related to the processing of an entry-point. */
 export interface EntryPointProcessingMetadata {

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -8,11 +8,14 @@
 
 import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 
-/** The type of the function that analyzes entry-points and creates the list of tasks. */
-export type AnalyzeEntryPointsFn = () => {
-  processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>;
-  tasks: Task[];
-};
+
+/**
+ * The type of the function that analyzes entry-points and creates the list of tasks.
+ *
+ * @return A list of tasks that need to be executed in order to process the necessary format
+ *         properties for all entry-points.
+ */
+export type AnalyzeEntryPointsFn = () => Task[];
 
 /** The type of the function that can process/compile a task. */
 export type CompileFn = (task: Task) => void;
@@ -27,15 +30,6 @@ export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => Compil
 export interface Executor {
   execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn):
       void|Promise<void>;
-}
-
-/** Represents metadata related to the processing of an entry-point. */
-export interface EntryPointProcessingMetadata {
-  /**
-   * Whether the typings for the entry-point have been successfully processed (or were already
-   * processed).
-   */
-  hasProcessedTypings: boolean;
 }
 
 /** Represents a unit of work: processing a specific format property of an entry-point. */

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -20,20 +20,13 @@ export type CompileFn = (task: Task) => void;
 /** The type of the function that creates the `CompileFn` function used to process tasks. */
 export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => CompileFn;
 
-/** Options related to the orchestration/execution of tasks. */
-export interface ExecutionOptions {
-  compileAllFormats: boolean;
-  propertiesToConsider: string[];
-}
-
 /**
  * A class that orchestrates and executes the required work (i.e. analyzes the entry-points,
  * processes the resulting tasks, does book-keeping and validates the final outcome).
  */
 export interface Executor {
-  execute(
-      analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn,
-      options: ExecutionOptions): void|Promise<void>;
+  execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn):
+      void|Promise<void>;
 }
 
 /** Represents metadata related to the processing of an entry-point. */
@@ -43,12 +36,6 @@ export interface EntryPointProcessingMetadata {
    * processed).
    */
   hasProcessedTypings: boolean;
-
-  /**
-   * Whether at least one format has been successfully processed (or was already processed) for the
-   * entry-point.
-   */
-  hasAnyProcessedFormat: boolean;
 }
 
 /** Represents a unit of work: processing a specific format property of an entry-point. */

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -15,7 +15,7 @@ import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
  * @return A list of tasks that need to be executed in order to process the necessary format
  *         properties for all entry-points.
  */
-export type AnalyzeEntryPointsFn = () => Task[];
+export type AnalyzeEntryPointsFn = () => TaskQueue;
 
 /** The type of the function that can process/compile a task. */
 export type CompileFn = (task: Task) => void;
@@ -64,4 +64,44 @@ export const enum TaskProcessingOutcome {
 
   /** Successfully processed the target format property. */
   Processed,
+}
+
+/**
+ * A wrapper around a list of tasks and providing utility methods for getting the next task of
+ * interest and determining when all tasks have been completed.
+ *
+ * (This allows different implementations to impose different constraints on when a task's
+ * processing can start.)
+ */
+export interface TaskQueue {
+  /** Whether all tasks have been completed. */
+  allTasksCompleted: boolean;
+
+  /**
+   * Get the next task whose processing can start (if any).
+   *
+   * This implicitly marks the task as in-progress.
+   * (This information is used to determine whether all tasks have been completed.)
+   *
+   * @return The next task available for processing or `null`, if no task can be processed at the
+   *         moment (including if there are no more unprocessed tasks).
+   */
+  getNextTask(): Task|null;
+
+  /**
+   * Mark a task as completed.
+   *
+   * This removes the task from the internal list of in-progress tasks.
+   * (This information is used to determine whether all tasks have been completed.)
+   *
+   * @param task The task to mark as completed.
+   */
+  markTaskCompleted(task: Task): void;
+
+  /**
+   * Return a string representation of the task queue (for debugging purposes).
+   *
+   * @return A string representation of the task queue.
+   */
+  toString(): string;
 }

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -9,23 +9,22 @@
 import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 
 /** The type of the function that analyzes entry-points and creates the list of tasks. */
-export type AnalyzeFn = () => {
+export type AnalyzeEntryPointsFn = () => {
   processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>;
   tasks: Task[];
 };
 
-/**
- * The type of the function that creates the `compile()` function, which in turn can be used to
- * process tasks.
- */
-export type CreateCompileFn =
-    (onTaskCompleted: (task: Task, outcome: TaskProcessingOutcome) => void) => (task: Task) => void;
+/** The type of the function that can process/compile a task. */
+export type CompileFn = (task: Task) => void;
+
+/** The type of the function that creates the `CompileFn` function used to process tasks. */
+export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => CompileFn;
 
 /**
  * The type of the function that orchestrates and executes the required work (i.e. analyzes the
  * entry-points, processes the resulting tasks, does book-keeping and validates the final outcome).
  */
-export type ExecuteFn = (analyzeFn: AnalyzeFn, createCompileFn: CreateCompileFn) => void;
+export type ExecuteFn = (analyzeFn: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => void;
 
 /** Represents metadata related to the processing of an entry-point. */
 export interface EntryPointProcessingMetadata {
@@ -63,6 +62,9 @@ export interface Task {
   /** Whether to also process typings for this entry-point as part of the task. */
   processDts: boolean;
 }
+
+/** A function to be called once a task has been processed. */
+export type TaskCompletedCallback = (task: Task, outcome: TaskProcessingOutcome) => void;
 
 /** Represents the outcome of processing a `Task`. */
 export const enum TaskProcessingOutcome {

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty, JsonObject} from '../packages/entry_point';
 import {PartiallyOrderedList} from '../utils';
 
 
@@ -49,7 +49,7 @@ export interface Executor {
 export type PartiallyOrderedTasks = PartiallyOrderedList<Task>;
 
 /** Represents a unit of work: processing a specific format property of an entry-point. */
-export interface Task {
+export interface Task extends JsonObject {
   /** The `EntryPoint` which needs to be processed as part of the task. */
   entryPoint: EntryPoint;
 

--- a/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
+import {JsonObject} from '../../packages/entry_point';
+import {PackageJsonChange} from '../../writing/package_json_updater';
+import {Task, TaskProcessingOutcome} from '../api';
+
+
+/** A message reporting that an unrecoverable error occurred. */
+export interface ErrorMessage extends JsonObject {
+  type: 'error';
+  error: string;
+}
+
+/** A message requesting the processing of a task. */
+export interface ProcessTaskMessage extends JsonObject {
+  type: 'process-task';
+  task: Task;
+}
+
+/**
+ * A message reporting the result of processing the currently assigned task.
+ *
+ * NOTE: To avoid the communication overhead, the task is not included in the message. Instead, the
+ *       master is responsible for keeping a mapping of workers to their currently assigned tasks.
+ */
+export interface TaskCompletedMessage extends JsonObject {
+  type: 'task-completed';
+  outcome: TaskProcessingOutcome;
+}
+
+/** A message requesting the update of a `package.json` file. */
+export interface UpdatePackageJsonMessage extends JsonObject {
+  type: 'update-package-json';
+  packageJsonPath: AbsoluteFsPath;
+  changes: PackageJsonChange[];
+}
+
+/** The type of messages sent from the cluster master to cluster workers. */
+export type MessageFromMaster = ProcessTaskMessage;
+
+/** The type of messages sent from cluster workers to the cluster master. */
+export type MessageFromWorker = ErrorMessage | TaskCompletedMessage | UpdatePackageJsonMessage;

--- a/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
@@ -42,8 +42,8 @@ export interface UpdatePackageJsonMessage extends JsonObject {
   changes: PackageJsonChange[];
 }
 
-/** The type of messages sent from the cluster master to cluster workers. */
-export type MessageFromMaster = ProcessTaskMessage;
-
 /** The type of messages sent from cluster workers to the cluster master. */
 export type MessageFromWorker = ErrorMessage | TaskCompletedMessage | UpdatePackageJsonMessage;
+
+/** The type of messages sent from the cluster master to cluster workers. */
+export type MessageToWorker = ProcessTaskMessage;

--- a/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {Logger} from '../../logging/logger';
+import {PackageJsonUpdater} from '../../writing/package_json_updater';
+import {AnalyzeEntryPointsFn, CreateCompileFn, Executor} from '../api';
+
+import {ClusterMaster} from './master';
+import {ClusterWorker} from './worker';
+
+
+/**
+ * An `Executor` that processes tasks in parallel (on multiple processes) and completes
+ * asynchronously.
+ */
+export class ClusterExecutor implements Executor {
+  constructor(
+      private workerCount: number, private logger: Logger,
+      private pkgJsonUpdater: PackageJsonUpdater) {}
+
+  async execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn):
+      Promise<void> {
+    if (cluster.isMaster) {
+      this.logger.debug(
+          `Running ngcc on ${this.constructor.name} (using ${this.workerCount} worker processes).`);
+
+      // This process is the cluster master.
+      const master =
+          new ClusterMaster(this.workerCount, this.logger, this.pkgJsonUpdater, analyzeEntryPoints);
+      return master.run();
+    } else {
+      // This process is a cluster worker.
+      const worker = new ClusterWorker(createCompileFn);
+      return worker.run();
+    }
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {resolve} from '../../../../src/ngtsc/file_system';
+import {Logger} from '../../logging/logger';
+import {PackageJsonUpdater} from '../../writing/package_json_updater';
+import {AnalyzeEntryPointsFn, Task, TaskQueue} from '../api';
+import {onTaskCompleted, stringifyTask} from '../utils';
+
+import {MessageFromWorker, TaskCompletedMessage, UpdatePackageJsonMessage} from './api';
+import {Deferred, sendMessageToWorker} from './utils';
+
+
+/**
+ * The cluster master is responsible for analyzing all entry-points, planning the work that needs to
+ * be done, distributing it to worker-processes and collecting/post-processing the results.
+ */
+export class ClusterMaster {
+  private finishedDeferred = new Deferred<void>();
+  private taskAssignments = new Map<number, Task|null>();
+  private taskQueue: TaskQueue;
+
+  constructor(
+      private workerCount: number, private logger: Logger,
+      private pkgJsonUpdater: PackageJsonUpdater, analyzeEntryPoints: AnalyzeEntryPointsFn) {
+    if (!cluster.isMaster) {
+      throw new Error('Tried to instantiate `ClusterMaster` on a worker process.');
+    }
+
+    this.taskQueue = analyzeEntryPoints();
+  }
+
+  run(): Promise<void> {
+    // Set up listeners for worker events (emitted on `cluster`).
+    cluster.on('online', this.wrapEventHandler(worker => this.onWorkerOnline(worker.id)));
+
+    cluster.on(
+        'message', this.wrapEventHandler((worker, msg) => this.onWorkerMessage(worker.id, msg)));
+
+    cluster.on(
+        'exit',
+        this.wrapEventHandler((worker, code, signal) => this.onWorkerExit(worker, code, signal)));
+
+    // Start the workers.
+    for (let i = 0; i < this.workerCount; i++) {
+      cluster.fork();
+    }
+
+    return this.finishedDeferred.promise.then(() => this.stopWorkers(), err => {
+      this.stopWorkers();
+      return Promise.reject(err);
+    });
+  }
+
+  /** Try to find available (idle) workers and assign them available (non-blocked) tasks. */
+  private maybeDistributeWork(): void {
+    let isWorkerAvailable = false;
+    let isWorkAvailable = false;
+
+    // First, check whether all tasks have been completed.
+    if (this.taskQueue.allTasksCompleted) {
+      return this.finishedDeferred.resolve();
+    }
+
+    // Look for available workers and available tasks to assign to them.
+    for (const [workerId, assignedTask] of Array.from(this.taskAssignments)) {
+      if (assignedTask !== null) {
+        // This worker already has a job; check other workers.
+        continue;
+      } else {
+        // This worker is available.
+        isWorkerAvailable = true;
+      }
+
+      // This worker needs a job. See if any are available.
+      const task = this.taskQueue.getNextTask();
+      if (task === null) {
+        // No suitable work available right now.
+        break;
+      } else {
+        // There is work available.
+        isWorkAvailable = true;
+      }
+
+      // Process the next task on the worker.
+      this.taskAssignments.set(workerId, task);
+      sendMessageToWorker(workerId, {type: 'process-task', task});
+
+      isWorkerAvailable = false;
+      isWorkAvailable = false;
+    }
+
+    // If there are no available workers or no available tasks, log (for debugging purposes).
+    if (!isWorkerAvailable) {
+      this.logger.debug(
+          `All ${this.taskAssignments.size} workers are currently busy and cannot take on more ` +
+          'work.');
+    } else if (!isWorkAvailable) {
+      const busyWorkers = Array.from(this.taskAssignments)
+                              .filter(([_workerId, task]) => task !== null)
+                              .map(([workerId]) => workerId);
+      const totalWorkerCount = this.taskAssignments.size;
+      const idleWorkerCount = totalWorkerCount - busyWorkers.length;
+
+      this.logger.debug(
+          `No assignments for ${idleWorkerCount} idle (out of ${totalWorkerCount} total) ` +
+          `workers. Busy workers: ${busyWorkers.join(', ')}`);
+
+      if (busyWorkers.length === 0) {
+        // This is a bug:
+        // All workers are idle (meaning no tasks are in progress) and `taskQueue.allTasksCompleted`
+        // is `false`, but there is still no assignable work.
+        throw new Error(
+            'There are still unprocessed tasks in the queue and no tasks are currently in ' +
+            `progress, yet the queue did not return any available tasks: ${this.taskQueue}`);
+      }
+    }
+  }
+
+  /** Handle a worker's exiting. (Might be intentional or not.) */
+  private onWorkerExit(worker: cluster.Worker, code: number|null, signal: string|null): void {
+    // If the worker's exiting was intentional, nothing to do.
+    if (worker.exitedAfterDisconnect) return;
+
+    // The worker exited unexpectedly: Determine it's status and take an appropriate action.
+    const currentTask = this.taskAssignments.get(worker.id);
+
+    this.logger.warn(
+        `Worker #${worker.id} exited unexpectedly (code: ${code} | signal: ${signal}).\n` +
+        `  Current assignment: ${(currentTask == null) ? '-' : stringifyTask(currentTask)}`);
+
+    if (currentTask == null) {
+      // The crashed worker process was not in the middle of a task:
+      // Just spawn another process.
+      this.logger.debug(`Spawning another worker process to replace #${worker.id}...`);
+      this.taskAssignments.delete(worker.id);
+      cluster.fork();
+    } else {
+      // The crashed worker process was in the middle of a task:
+      // Impossible to know whether we can recover (without ending up with a corrupted entry-point).
+      throw new Error(
+          'Process unexpectedly crashed, while processing format property ' +
+          `${currentTask.formatProperty} for entry-point '${currentTask.entryPoint.path}'.`);
+    }
+  }
+
+  /** Handle a message from a worker. */
+  private onWorkerMessage(workerId: number, msg: MessageFromWorker): void {
+    if (!this.taskAssignments.has(workerId)) {
+      const knownWorkers = Array.from(this.taskAssignments.keys());
+      throw new Error(
+          `Received message from unknown worker #${workerId} (known workers: ` +
+          `${knownWorkers.join(', ')}): ${JSON.stringify(msg)}`);
+    }
+
+    switch (msg.type) {
+      case 'error':
+        throw new Error(`Error on worker #${workerId}: ${msg.error}`);
+      case 'task-completed':
+        return this.onWorkerTaskCompleted(workerId, msg);
+      case 'update-package-json':
+        return this.onWorkerUpdatePackageJson(workerId, msg);
+      default:
+        throw new Error(
+            `Invalid message received from worker #${workerId}: ${JSON.stringify(msg)}`);
+    }
+  }
+
+  /** Handle a worker's coming online. */
+  private onWorkerOnline(workerId: number): void {
+    if (this.taskAssignments.has(workerId)) {
+      throw new Error(`Invariant violated: Worker #${workerId} came online more than once.`);
+    }
+
+    this.taskAssignments.set(workerId, null);
+    this.maybeDistributeWork();
+  }
+
+  /** Handle a worker's having completed their assigned task. */
+  private onWorkerTaskCompleted(workerId: number, msg: TaskCompletedMessage): void {
+    const task = this.taskAssignments.get(workerId) || null;
+
+    if (task === null) {
+      throw new Error(
+          `Expected worker #${workerId} to have a task assigned, while handling message: ` +
+          JSON.stringify(msg));
+    }
+
+    onTaskCompleted(this.pkgJsonUpdater, task, msg.outcome);
+
+    this.taskQueue.markTaskCompleted(task);
+    this.taskAssignments.set(workerId, null);
+    this.maybeDistributeWork();
+  }
+
+  /** Handle a worker's request to update a `package.json` file. */
+  private onWorkerUpdatePackageJson(workerId: number, msg: UpdatePackageJsonMessage): void {
+    const task = this.taskAssignments.get(workerId) || null;
+
+    if (task === null) {
+      throw new Error(
+          `Expected worker #${workerId} to have a task assigned, while handling message: ` +
+          JSON.stringify(msg));
+    }
+
+    const expectedPackageJsonPath = resolve(task.entryPoint.path, 'package.json');
+    const parsedPackageJson = task.entryPoint.packageJson;
+
+    if (expectedPackageJsonPath !== msg.packageJsonPath) {
+      throw new Error(
+          `Received '${msg.type}' message from worker #${workerId} for '${msg.packageJsonPath}', ` +
+          `but was expecting '${expectedPackageJsonPath}' (based on task assignment).`);
+    }
+
+    // NOTE: Although the change in the parsed `package.json` will be reflected in tasks objects
+    //       locally and thus also in future `process-task` messages sent to worker processes, any
+    //       processes already running and processing a task for the same entry-point will not get
+    //       the change.
+    //       Do not rely on having an up-to-date `package.json` representation in worker processes.
+    //       In other words, task processing should only rely on the info that was there when the
+    //       file was initially parsed (during entry-point analysis) and not on the info that might
+    //       be added later (during task processing).
+    this.pkgJsonUpdater.writeChanges(msg.changes, msg.packageJsonPath, parsedPackageJson);
+  }
+
+  /** Stop all workers and stop listening on cluster events. */
+  private stopWorkers(): void {
+    const workers = Object.values(cluster.workers) as cluster.Worker[];
+    this.logger.debug(`Stopping ${workers.length} workers...`);
+
+    cluster.removeAllListeners();
+    workers.forEach(worker => worker.kill());
+  }
+
+  /**
+   * Wrap an event handler to ensure that `finishedDeferred` will be rejected on error (regardless
+   * if the handler completes synchronously or asynchronously).
+   */
+  private wrapEventHandler<Args extends unknown[]>(fn: (...args: Args) => void|Promise<void>):
+      (...args: Args) => Promise<void> {
+    return async(...args: Args) => {
+      try {
+        await fn(...args);
+      } catch (err) {
+        this.finishedDeferred.reject(err);
+      }
+    };
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -64,7 +64,6 @@ export class ClusterMaster {
   /** Try to find available (idle) workers and assign them available (non-blocked) tasks. */
   private maybeDistributeWork(): void {
     let isWorkerAvailable = false;
-    let isWorkAvailable = false;
 
     // First, check whether all tasks have been completed.
     if (this.taskQueue.allTasksCompleted) {
@@ -86,9 +85,6 @@ export class ClusterMaster {
       if (task === null) {
         // No suitable work available right now.
         break;
-      } else {
-        // There is work available.
-        isWorkAvailable = true;
       }
 
       // Process the next task on the worker.
@@ -96,7 +92,6 @@ export class ClusterMaster {
       sendMessageToWorker(workerId, {type: 'process-task', task});
 
       isWorkerAvailable = false;
-      isWorkAvailable = false;
     }
 
     // If there are no available workers or no available tasks, log (for debugging purposes).
@@ -104,7 +99,7 @@ export class ClusterMaster {
       this.logger.debug(
           `All ${this.taskAssignments.size} workers are currently busy and cannot take on more ` +
           'work.');
-    } else if (!isWorkAvailable) {
+    } else {
       const busyWorkers = Array.from(this.taskAssignments)
                               .filter(([_workerId, task]) => task !== null)
                               .map(([workerId]) => workerId);

--- a/packages/compiler-cli/ngcc/src/execution/cluster/package_json_updater.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/package_json_updater.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
+import {JsonObject} from '../../packages/entry_point';
+import {PackageJsonChange, PackageJsonUpdate, PackageJsonUpdater, applyChange} from '../../writing/package_json_updater';
+
+import {sendMessageToMaster} from './utils';
+
+
+/**
+ * A `PackageJsonUpdater` that can safely handle update operations on multiple processes.
+ */
+export class ClusterPackageJsonUpdater implements PackageJsonUpdater {
+  constructor(private delegate: PackageJsonUpdater) {}
+
+  createUpdate(): PackageJsonUpdate {
+    return new PackageJsonUpdate((...args) => this.writeChanges(...args));
+  }
+
+  writeChanges(
+      changes: PackageJsonChange[], packageJsonPath: AbsoluteFsPath,
+      preExistingParsedJson?: JsonObject): void {
+    if (cluster.isMaster) {
+      // This is the master process:
+      // Actually apply the changes to the file on disk.
+      return this.delegate.writeChanges(changes, packageJsonPath, preExistingParsedJson);
+    }
+
+    // This is a worker process:
+    // Apply the changes in-memory (if necessary) and send a message to the master process.
+    if (preExistingParsedJson) {
+      for (const [propPath, value] of changes) {
+        if (propPath.length === 0) {
+          throw new Error(`Missing property path for writing value to '${packageJsonPath}'.`);
+        }
+
+        applyChange(preExistingParsedJson, propPath, value);
+      }
+    }
+
+    sendMessageToMaster({
+      type: 'update-package-json',
+      packageJsonPath,
+      changes,
+    });
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+import {MessageFromMaster, MessageFromWorker} from './api';
+
+
+/** Expose a `Promise` instance as well as APIs for resolving/rejecting it. */
+export class Deferred<T> {
+  /**
+   * Resolve the associated promise with the specified value.
+   * If the value is a rejection (constructed with `Promise.reject()`), the promise will be rejected
+   * instead.
+   *
+   * @param value The value to resolve the promise with.
+   */
+  resolve !: (value: T) => void;
+
+  /**
+   * Rejects the associated promise with the specified reason.
+   *
+   * @param reason The rejection reason.
+   */
+  reject !: (reason: any) => void;
+
+  /** The `Promise` instance associated with this deferred. */
+  promise = new Promise<T>((resolve, reject) => {
+    this.resolve = resolve;
+    this.reject = reject;
+  });
+}
+
+/**
+ * Send a message to the cluster master.
+ * (This function should be invoked from cluster workers only.)
+ *
+ * @param msg The message to send to the cluster master.
+ */
+export const sendMessageToMaster = (msg: MessageFromWorker): void => {
+  if (cluster.isMaster) {
+    throw new Error('Unable to send message to the master process: Already on the master process.');
+  }
+
+  if (process.send === undefined) {
+    // Theoretically, this should never happen on a worker process.
+    throw new Error('Unable to send message to the master process: Missing `process.send()`.');
+  }
+
+  process.send(msg);
+};
+
+/**
+ * Send a message to a cluster worker.
+ * (This function should be invoked from the cluster master only.)
+ *
+ * @param workerId The ID of the recipient worker.
+ * @param msg The message to send to the worker.
+ */
+export const sendMessageToWorker = (workerId: number, msg: MessageFromMaster): void => {
+  if (!cluster.isMaster) {
+    throw new Error('Unable to send message to worker process: Sender is not the master process.');
+  }
+
+  const worker = cluster.workers[workerId];
+
+  if ((worker === undefined) || worker.isDead() || !worker.isConnected()) {
+    throw new Error(
+        'Unable to send message to worker process: Recipient does not exist or has disconnected.');
+  }
+
+  worker.send(msg);
+};

--- a/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
@@ -9,7 +9,9 @@
 /// <reference types="node" />
 
 import * as cluster from 'cluster';
-import {MessageFromMaster, MessageFromWorker} from './api';
+
+import {MessageFromWorker, MessageToWorker} from './api';
+
 
 
 /** Expose a `Promise` instance as well as APIs for resolving/rejecting it. */
@@ -63,7 +65,7 @@ export const sendMessageToMaster = (msg: MessageFromWorker): void => {
  * @param workerId The ID of the recipient worker.
  * @param msg The message to send to the worker.
  */
-export const sendMessageToWorker = (workerId: number, msg: MessageFromMaster): void => {
+export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): void => {
   if (!cluster.isMaster) {
     throw new Error('Unable to send message to worker process: Sender is not the master process.');
   }

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {CompileFn, CreateCompileFn} from '../api';
+
+import {MessageFromMaster} from './api';
+import {sendMessageToMaster} from './utils';
+
+
+/**
+ * A cluster worker is responsible for processing one task (i.e. one format property for a specific
+ * entry-point) at a time and reporting results back to the cluster master.
+ */
+export class ClusterWorker {
+  private compile: CompileFn;
+
+  constructor(createCompileFn: CreateCompileFn) {
+    if (cluster.isMaster) {
+      throw new Error('Tried to instantiate `ClusterWorker` on the master process.');
+    }
+
+    this.compile =
+        createCompileFn((_task, outcome) => sendMessageToMaster({type: 'task-completed', outcome}));
+  }
+
+  run(): Promise<void> {
+    // Listen for `ProcessTaskMessage`s and process tasks.
+    cluster.worker.on('message', (msg: MessageFromMaster) => {
+      try {
+        switch (msg.type) {
+          case 'process-task':
+            return this.compile(msg.task);
+          default:
+            throw new Error(
+                `Invalid message received on worker #${cluster.worker.id}: ${JSON.stringify(msg)}`);
+        }
+      } catch (err) {
+        sendMessageToMaster({
+          type: 'error',
+          error: (err instanceof Error) ? (err.stack || err.message) : err,
+        });
+      }
+    });
+
+    // Return a promise that is never resolved.
+    return new Promise(() => undefined);
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -12,7 +12,7 @@ import * as cluster from 'cluster';
 
 import {CompileFn, CreateCompileFn} from '../api';
 
-import {MessageFromMaster} from './api';
+import {MessageToWorker} from './api';
 import {sendMessageToMaster} from './utils';
 
 
@@ -34,7 +34,7 @@ export class ClusterWorker {
 
   run(): Promise<void> {
     // Listen for `ProcessTaskMessage`s and process tasks.
-    cluster.worker.on('message', (msg: MessageFromMaster) => {
+    cluster.worker.on('message', (msg: MessageToWorker) => {
       try {
         switch (msg.type) {
           case 'process-task':

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -27,11 +27,17 @@ export class SingleProcessExecutor implements Executor {
         createCompileFn((task, outcome) => onTaskCompleted(this.pkgJsonUpdater, task, outcome));
 
     // Process all tasks.
+    this.logger.debug('Processing tasks...');
+    const startTime = Date.now();
+
     while (!taskQueue.allTasksCompleted) {
       const task = taskQueue.getNextTask() !;
       compile(task);
       taskQueue.markTaskCompleted(task);
     }
+
+    const duration = Math.round((Date.now() - startTime) / 1000);
+    this.logger.debug(`Processed tasks in ${duration}s.`);
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -22,13 +22,15 @@ export class SingleProcessExecutor implements Executor {
   execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn): void {
     this.logger.debug(`Running ngcc on ${this.constructor.name}.`);
 
-    const tasks = analyzeEntryPoints();
+    const taskQueue = analyzeEntryPoints();
     const compile =
         createCompileFn((task, outcome) => onTaskCompleted(this.pkgJsonUpdater, task, outcome));
 
     // Process all tasks.
-    for (const task of tasks) {
+    while (!taskQueue.allTasksCompleted) {
+      const task = taskQueue.getNextTask() !;
       compile(task);
+      taskQueue.markTaskCompleted(task);
     }
   }
 }

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -44,3 +44,12 @@ export class SingleProcessExecutor implements Executor {
     checkForUnprocessedEntryPoints(processingMetadataPerEntryPoint, options.propertiesToConsider);
   }
 }
+
+/**
+ * An `Executor` that processes all tasks serially, but still completes asynchronously.
+ */
+export class AsyncSingleProcessExecutor extends SingleProcessExecutor {
+  async execute(...args: Parameters<Executor['execute']>): Promise<void> {
+    return super.execute(...args);
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -9,8 +9,8 @@
 import {Logger} from '../logging/logger';
 import {PackageJsonUpdater} from '../writing/package_json_updater';
 
-import {AnalyzeEntryPointsFn, CreateCompileFn, ExecutionOptions, Executor} from './api';
-import {checkForUnprocessedEntryPoints, onTaskCompleted} from './utils';
+import {AnalyzeEntryPointsFn, CreateCompileFn, Executor} from './api';
+import {onTaskCompleted} from './utils';
 
 
 /**
@@ -19,9 +19,7 @@ import {checkForUnprocessedEntryPoints, onTaskCompleted} from './utils';
 export class SingleProcessExecutor implements Executor {
   constructor(private logger: Logger, private pkgJsonUpdater: PackageJsonUpdater) {}
 
-  execute(
-      analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn,
-      options: ExecutionOptions): void {
+  execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn): void {
     this.logger.debug(`Running ngcc on ${this.constructor.name}.`);
 
     const {processingMetadataPerEntryPoint, tasks} = analyzeEntryPoints();
@@ -31,17 +29,8 @@ export class SingleProcessExecutor implements Executor {
 
     // Process all tasks.
     for (const task of tasks) {
-      const processingMeta = processingMetadataPerEntryPoint.get(task.entryPoint.path) !;
-
-      // If we only need one format processed and we already have one for the corresponding
-      // entry-point, skip the task.
-      if (!options.compileAllFormats && processingMeta.hasAnyProcessedFormat) continue;
-
       compile(task);
     }
-
-    // Check for entry-points for which we could not process any format at all.
-    checkForUnprocessedEntryPoints(processingMetadataPerEntryPoint, options.propertiesToConsider);
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -22,10 +22,9 @@ export class SingleProcessExecutor implements Executor {
   execute(analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn): void {
     this.logger.debug(`Running ngcc on ${this.constructor.name}.`);
 
-    const {processingMetadataPerEntryPoint, tasks} = analyzeEntryPoints();
-    const compile = createCompileFn(
-        (task, outcome) =>
-            onTaskCompleted(this.pkgJsonUpdater, processingMetadataPerEntryPoint, task, outcome));
+    const tasks = analyzeEntryPoints();
+    const compile =
+        createCompileFn((task, outcome) => onTaskCompleted(this.pkgJsonUpdater, task, outcome));
 
     // Process all tasks.
     for (const task of tasks) {

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Logger} from '../logging/logger';
+import {PackageJsonUpdater} from '../writing/package_json_updater';
+
+import {AnalyzeEntryPointsFn, CreateCompileFn, ExecutionOptions, Executor} from './api';
+import {checkForUnprocessedEntryPoints, onTaskCompleted} from './utils';
+
+
+/**
+ * An `Executor` that processes all tasks serially and completes synchronously.
+ */
+export class SingleProcessExecutor implements Executor {
+  constructor(private logger: Logger, private pkgJsonUpdater: PackageJsonUpdater) {}
+
+  execute(
+      analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn,
+      options: ExecutionOptions): void {
+    this.logger.debug(`Running ngcc on ${this.constructor.name}.`);
+
+    const {processingMetadataPerEntryPoint, tasks} = analyzeEntryPoints();
+    const compile = createCompileFn(
+        (task, outcome) =>
+            onTaskCompleted(this.pkgJsonUpdater, processingMetadataPerEntryPoint, task, outcome));
+
+    // Process all tasks.
+    for (const task of tasks) {
+      const processingMeta = processingMetadataPerEntryPoint.get(task.entryPoint.path) !;
+
+      // If we only need one format processed and we already have one for the corresponding
+      // entry-point, skip the task.
+      if (!options.compileAllFormats && processingMeta.hasAnyProcessedFormat) continue;
+
+      compile(task);
+    }
+
+    // Check for entry-points for which we could not process any format at all.
+    checkForUnprocessedEntryPoints(processingMetadataPerEntryPoint, options.propertiesToConsider);
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/task_selection/base_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/task_selection/base_task_queue.ts
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Task, TaskQueue} from '../api';
+import {PartiallyOrderedTasks, Task, TaskQueue} from '../api';
 import {stringifyTask} from '../utils';
 
 
 /**
  * A base `TaskQueue` implementation to be used as base for concrete implementations.
- *
- * NOTE: It is assumed that `tasks` are sorted in such a way that tasks associated to dependent
- *       entry-points always come after tasks associated with their dependencies.
- *       See `DependencyResolver#sortEntryPointsByDependency()`.
  */
 export abstract class BaseTaskQueue implements TaskQueue {
   get allTasksCompleted(): boolean {
@@ -23,7 +19,7 @@ export abstract class BaseTaskQueue implements TaskQueue {
   }
   protected inProgressTasks = new Set<Task>();
 
-  constructor(protected tasks: Task[]) {}
+  constructor(protected tasks: PartiallyOrderedTasks) {}
 
   abstract getNextTask(): Task|null;
 

--- a/packages/compiler-cli/ngcc/src/execution/task_selection/base_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/task_selection/base_task_queue.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Task, TaskQueue} from '../api';
+import {stringifyTask} from '../utils';
+
+
+/**
+ * A base `TaskQueue` implementation to be used as base for concrete implementations.
+ *
+ * NOTE: It is assumed that `tasks` are sorted in such a way that tasks associated to dependent
+ *       entry-points always come after tasks associated with their dependencies.
+ *       See `DependencyResolver#sortEntryPointsByDependency()`.
+ */
+export abstract class BaseTaskQueue implements TaskQueue {
+  get allTasksCompleted(): boolean {
+    return (this.tasks.length === 0) && (this.inProgressTasks.size === 0);
+  }
+  protected inProgressTasks = new Set<Task>();
+
+  constructor(protected tasks: Task[]) {}
+
+  abstract getNextTask(): Task|null;
+
+  markTaskCompleted(task: Task): void {
+    if (!this.inProgressTasks.has(task)) {
+      throw new Error(
+          `Trying to mark task that was not in progress as completed: ${stringifyTask(task)}`);
+    }
+
+    this.inProgressTasks.delete(task);
+  }
+
+  toString(): string {
+    const inProgTasks = Array.from(this.inProgressTasks);
+
+    return `${this.constructor.name}\n` +
+        `  All tasks completed: ${this.allTasksCompleted}\n` +
+        `  Unprocessed tasks (${this.tasks.length}): ${this.stringifyTasks(this.tasks, '    ')}\n` +
+        `  In-progress tasks (${inProgTasks.length}): ${this.stringifyTasks(inProgTasks, '    ')}`;
+  }
+
+  protected stringifyTasks(tasks: Task[], indentation: string): string {
+    return tasks.map(task => `\n${indentation}- ${stringifyTask(task)}`).join('');
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/task_selection/parallel_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/task_selection/parallel_task_queue.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DepGraph} from 'dependency-graph';
+
+import {EntryPoint} from '../../packages/entry_point';
+import {PartiallyOrderedTasks, Task} from '../api';
+import {stringifyTask} from '../utils';
+
+import {BaseTaskQueue} from './base_task_queue';
+
+
+/**
+ * A `TaskQueue` implementation that assumes tasks are processed in parallel, thus has to ensure a
+ * task's dependencies have been processed before processing the task.
+ */
+export class ParallelTaskQueue extends BaseTaskQueue {
+  /**
+   * A mapping from each task to the list of tasks that are blocking it (if any).
+   *
+   * A task can block another task, if the latter's entry-point depends on the former's entry-point
+   * _and_ the former is also generating typings (i.e. has `processDts: true`).
+   *
+   * NOTE: If a task is not generating typings, then it cannot affect anything which depends on its
+   *       entry-point, regardless of the dependency graph. To put this another way, only the task
+   *       which produces the typings for a dependency needs to have been completed.
+   */
+  private blockedTasks: Map<Task, Set<Task>>;
+
+  constructor(tasks: PartiallyOrderedTasks, graph: DepGraph<EntryPoint>) {
+    const blockedTasks = computeBlockedTasks(tasks, graph);
+    const sortedTasks = sortTasksByPriority(tasks, blockedTasks);
+
+    super(sortedTasks);
+    this.blockedTasks = blockedTasks;
+  }
+
+  getNextTask(): Task|null {
+    // Look for the first available (i.e. not blocked) task.
+    // (NOTE: Since tasks are sorted by priority, the first available one is the best choice.)
+    const nextTaskIdx = this.tasks.findIndex(task => !this.blockedTasks.has(task));
+    if (nextTaskIdx === -1) return null;
+
+    // Remove the task from the list of available tasks and add it to the list of in-progress tasks.
+    const nextTask = this.tasks[nextTaskIdx];
+    this.tasks.splice(nextTaskIdx, 1);
+    this.inProgressTasks.add(nextTask);
+
+    return nextTask;
+  }
+
+  markTaskCompleted(task: Task): void {
+    super.markTaskCompleted(task);
+
+    const unblockedTasks: Task[] = [];
+
+    // Remove the completed task from the lists of tasks blocking other tasks.
+    for (const [otherTask, blockingTasks] of Array.from(this.blockedTasks)) {
+      if (blockingTasks.has(task)) {
+        blockingTasks.delete(task);
+
+        // If the other task is not blocked any more, mark it for unblocking.
+        if (blockingTasks.size === 0) {
+          unblockedTasks.push(otherTask);
+        }
+      }
+    }
+
+    // Unblock tasks that are no longer blocked.
+    unblockedTasks.forEach(task => this.blockedTasks.delete(task));
+  }
+
+  toString(): string {
+    return `${super.toString()}\n` +
+        `  Blocked tasks (${this.blockedTasks.size}): ${this.stringifyBlockedTasks('    ')}`;
+  }
+
+  private stringifyBlockedTasks(indentation: string): string {
+    return Array.from(this.blockedTasks)
+        .map(
+            ([task, blockingTasks]) =>
+                `\n${indentation}- ${stringifyTask(task)} (${blockingTasks.size}): ` +
+                this.stringifyTasks(Array.from(blockingTasks), `${indentation}    `))
+        .join('');
+  }
+}
+
+// Helpers
+
+/**
+ * Compute a mapping of blocked tasks to the tasks that are blocking them.
+ *
+ * As a performance optimization, we take into account the fact that `tasks` are sorted in such a
+ * way that a task can only be blocked by earlier tasks (i.e. dependencies always come before
+ * dependants in the list of tasks).
+ *
+ * @param tasks A (partially ordered) list of tasks.
+ * @param graph The dependency graph between entry-points.
+ * @return The map of blocked tasks to the tasks that are blocking them.
+ */
+function computeBlockedTasks(
+    tasks: PartiallyOrderedTasks, graph: DepGraph<EntryPoint>): Map<Task, Set<Task>> {
+  const blockedTasksMap = new Map<Task, Set<Task>>();
+  const candidateBlockers = new Map<string, Task>();
+
+  tasks.forEach(task => {
+    // Find the earlier tasks (`candidateBlockers`) that are blocking this task.
+    const deps = graph.dependenciesOf(task.entryPoint.path);
+    const blockingTasks =
+        deps.filter(dep => candidateBlockers.has(dep)).map(dep => candidateBlockers.get(dep) !);
+
+    // If this task is blocked, add it to the map of blocked tasks.
+    if (blockingTasks.length > 0) {
+      blockedTasksMap.set(task, new Set(blockingTasks));
+    }
+
+    // If this task can be potentially blocking (i.e. it generates typings), add it to the list
+    // of candidate blockers for subsequent tasks.
+    if (task.processDts) {
+      const entryPointPath = task.entryPoint.path;
+
+      // There should only be one task per entry-point that generates typings (and thus can block
+      // other tasks), so the following should theoretically never happen, but check just in case.
+      if (candidateBlockers.has(entryPointPath)) {
+        const otherTask = candidateBlockers.get(entryPointPath) !;
+
+        throw new Error(
+            'Invariant violated: Multiple tasks are assigned generating typings for ' +
+            `'${entryPointPath}':\n  - ${stringifyTask(otherTask)}\n  - ${stringifyTask(task)}`);
+      }
+
+      candidateBlockers.set(entryPointPath, task);
+    }
+  });
+
+  return blockedTasksMap;
+}
+
+/**
+ * Sort a list of tasks by priority.
+ *
+ * Priority is determined by the number of other tasks that a task is (transitively) blocking:
+ * The more tasks a task is blocking the higher its priority is, because processing it will
+ * potentially unblock more tasks.
+ *
+ * To keep the behavior predictable, if two tasks block the same number of other tasks, their
+ * relative order in the original `tasks` lists is preserved.
+ *
+ * @param tasks A (partially ordered) list of tasks.
+ * @param blockedTasks A mapping from a task to the list of tasks that are blocking it (if any).
+ * @return The list of tasks sorted by priority.
+ */
+function sortTasksByPriority(
+    tasks: PartiallyOrderedTasks, blockedTasks: Map<Task, Set<Task>>): PartiallyOrderedTasks {
+  const priorityPerTask = new Map<Task, [number, number]>();
+  const allBlockingTaskSets = Array.from(blockedTasks.values());
+  const computePriority = (task: Task, idx: number): [number, number] =>
+      [allBlockingTaskSets.reduce(
+           (count, blockingTasks) => count + (blockingTasks.has(task) ? 1 : 0), 0),
+       idx,
+  ];
+
+  tasks.forEach((task, i) => priorityPerTask.set(task, computePriority(task, i)));
+
+  return tasks.slice().sort((task1, task2) => {
+    const [p1, idx1] = priorityPerTask.get(task1) !;
+    const [p2, idx2] = priorityPerTask.get(task2) !;
+
+    return (p2 - p1) || (idx1 - idx2);
+  });
+}

--- a/packages/compiler-cli/ngcc/src/execution/task_selection/serial_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/task_selection/serial_task_queue.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Task} from '../api';
+import {stringifyTask} from '../utils';
+
+import {BaseTaskQueue} from './base_task_queue';
+
+
+/**
+ * A `TaskQueue` implementation that assumes tasks are processed serially and each one is completed
+ * before requesting the next one.
+ */
+export class SerialTaskQueue extends BaseTaskQueue {
+  getNextTask(): Task|null {
+    const nextTask = this.tasks.shift() || null;
+
+    if (nextTask) {
+      if (this.inProgressTasks.size > 0) {
+        // `SerialTaskQueue` can have max one in-progress task.
+        const inProgressTask = this.inProgressTasks.values().next().value;
+        throw new Error(
+            'Trying to get next task, while there is already a task in progress: ' +
+            stringifyTask(inProgressTask));
+      }
+
+      this.inProgressTasks.add(nextTask);
+    }
+
+    return nextTask;
+  }
+}

--- a/packages/compiler-cli/ngcc/src/execution/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/utils.ts
@@ -11,14 +11,12 @@ import {markAsProcessed} from '../packages/build_marker';
 import {PackageJsonFormatProperties} from '../packages/entry_point';
 import {PackageJsonUpdater} from '../writing/package_json_updater';
 
-import {EntryPointProcessingMetadata, Task, TaskProcessingOutcome} from './api';
+import {Task, TaskProcessingOutcome} from './api';
 
 
 /** A helper function for handling a task's being completed. */
 export const onTaskCompleted =
-    (pkgJsonUpdater: PackageJsonUpdater,
-     processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>, task: Task,
-     outcome: TaskProcessingOutcome, ): void => {
+    (pkgJsonUpdater: PackageJsonUpdater, task: Task, outcome: TaskProcessingOutcome): void => {
       const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
 
       if (outcome === TaskProcessingOutcome.Processed) {
@@ -27,8 +25,6 @@ export const onTaskCompleted =
             [...formatPropertiesToMarkAsProcessed];
 
         if (processDts) {
-          const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
-          processingMeta.hasProcessedTypings = true;
           propsToMarkAsProcessed.push('typings');
         }
 

--- a/packages/compiler-cli/ngcc/src/execution/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/utils.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {resolve} from '../../../src/ngtsc/file_system';
+import {markAsProcessed} from '../packages/build_marker';
+import {PackageJsonFormatProperties} from '../packages/entry_point';
+import {PackageJsonUpdater} from '../writing/package_json_updater';
+
+import {EntryPointProcessingMetadata, Task, TaskProcessingOutcome} from './api';
+
+
+/**
+ * A helper function for checking for unprocessed entry-points (i.e. entry-points for which we could
+ * not process any format at all).
+ */
+export const checkForUnprocessedEntryPoints =
+    (processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>,
+     propertiesToConsider: string[]): void => {
+      const unprocessedEntryPointPaths =
+          Array.from(processingMetadataPerEntryPoint.entries())
+              .filter(([, processingMeta]) => !processingMeta.hasAnyProcessedFormat)
+              .map(([entryPointPath]) => `\n  - ${entryPointPath}`)
+              .join('');
+
+      if (unprocessedEntryPointPaths) {
+        throw new Error(
+            'Failed to compile any formats for the following entry-points (tried ' +
+            `${propertiesToConsider.join(', ')}): ${unprocessedEntryPointPaths}`);
+      }
+    };
+
+/** A helper function for handling a task's being completed. */
+export const onTaskCompleted =
+    (pkgJsonUpdater: PackageJsonUpdater,
+     processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>, task: Task,
+     outcome: TaskProcessingOutcome, ): void => {
+      const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
+      const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
+      processingMeta.hasAnyProcessedFormat = true;
+
+      if (outcome === TaskProcessingOutcome.Processed) {
+        const packageJsonPath = resolve(entryPoint.path, 'package.json');
+        const propsToMarkAsProcessed: PackageJsonFormatProperties[] =
+            [...formatPropertiesToMarkAsProcessed];
+
+        if (processDts) {
+          processingMeta.hasProcessedTypings = true;
+          propsToMarkAsProcessed.push('typings');
+        }
+
+        markAsProcessed(
+            pkgJsonUpdater, entryPoint.packageJson, packageJsonPath, propsToMarkAsProcessed);
+      }
+    };

--- a/packages/compiler-cli/ngcc/src/execution/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/utils.ts
@@ -14,34 +14,12 @@ import {PackageJsonUpdater} from '../writing/package_json_updater';
 import {EntryPointProcessingMetadata, Task, TaskProcessingOutcome} from './api';
 
 
-/**
- * A helper function for checking for unprocessed entry-points (i.e. entry-points for which we could
- * not process any format at all).
- */
-export const checkForUnprocessedEntryPoints =
-    (processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>,
-     propertiesToConsider: string[]): void => {
-      const unprocessedEntryPointPaths =
-          Array.from(processingMetadataPerEntryPoint.entries())
-              .filter(([, processingMeta]) => !processingMeta.hasAnyProcessedFormat)
-              .map(([entryPointPath]) => `\n  - ${entryPointPath}`)
-              .join('');
-
-      if (unprocessedEntryPointPaths) {
-        throw new Error(
-            'Failed to compile any formats for the following entry-points (tried ' +
-            `${propertiesToConsider.join(', ')}): ${unprocessedEntryPointPaths}`);
-      }
-    };
-
 /** A helper function for handling a task's being completed. */
 export const onTaskCompleted =
     (pkgJsonUpdater: PackageJsonUpdater,
      processingMetadataPerEntryPoint: Map<string, EntryPointProcessingMetadata>, task: Task,
      outcome: TaskProcessingOutcome, ): void => {
       const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
-      const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
-      processingMeta.hasAnyProcessedFormat = true;
 
       if (outcome === TaskProcessingOutcome.Processed) {
         const packageJsonPath = resolve(entryPoint.path, 'package.json');
@@ -49,6 +27,7 @@ export const onTaskCompleted =
             [...formatPropertiesToMarkAsProcessed];
 
         if (processDts) {
+          const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
           processingMeta.hasProcessedTypings = true;
           propsToMarkAsProcessed.push('typings');
         }

--- a/packages/compiler-cli/ngcc/src/execution/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/utils.ts
@@ -32,3 +32,7 @@ export const onTaskCompleted =
             pkgJsonUpdater, entryPoint.packageJson, packageJsonPath, propsToMarkAsProcessed);
       }
     };
+
+/** Stringify a task for debugging purposes. */
+export const stringifyTask = (task: Task): string =>
+    `{entryPoint: ${task.entryPoint.name}, formatProperty: ${task.formatProperty}, processDts: ${task.processDts}}`;

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -87,7 +87,7 @@ export function mainNgcc(
   const fileSystem = getFileSystem();
 
   // The function for performing the analysis.
-  const analyzeFn: AnalyzeEntryPointsFn = () => {
+  const analyzeEntryPoints: AnalyzeEntryPointsFn = () => {
     const supportedPropertiesToConsider = ensureSupportedProperties(propertiesToConsider);
 
     const moduleResolver = new ModuleResolver(fileSystem, pathMappings);
@@ -188,9 +188,9 @@ export function mainNgcc(
   };
 
   // The function for actually planning and getting the work done.
-  const executeFn: ExecuteFn =
-      (analyzeFn: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => {
-        const {processingMetadataPerEntryPoint, tasks} = analyzeFn();
+  const execute: ExecuteFn =
+      (analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => {
+        const {processingMetadataPerEntryPoint, tasks} = analyzeEntryPoints();
         const compile = createCompileFn((task, outcome) => {
           const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
           const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
@@ -236,7 +236,7 @@ export function mainNgcc(
         }
       };
 
-  return executeFn(analyzeFn, createCompileFn);
+  return execute(analyzeEntryPoints, createCompileFn);
 }
 
 function ensureSupportedProperties(properties: string[]): EntryPointJsonProperty[] {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -141,6 +141,9 @@ export function mainNgcc(
 
   // The function for performing the analysis.
   const analyzeEntryPoints: AnalyzeEntryPointsFn = () => {
+    logger.debug('Analyzing entry-points...');
+    const startTime = Date.now();
+
     const supportedPropertiesToConsider = ensureSupportedProperties(propertiesToConsider);
 
     const moduleResolver = new ModuleResolver(fileSystem, pathMappings);
@@ -196,6 +199,11 @@ export function mainNgcc(
           `${propertiesToConsider.join(', ')}): ` +
           unprocessableEntryPointPaths.map(path => `\n  - ${path}`).join(''));
     }
+
+    const duration = Math.round((Date.now() - startTime) / 1000);
+    logger.debug(
+        `Analyzed ${entryPoints.length} entry-points in ${duration}s. ` +
+        `(Total tasks: ${tasks.length})`);
 
     return getTaskQueue(inParallel, tasks, graph);
   };

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -16,7 +16,7 @@ import {ModuleResolver} from './dependencies/module_resolver';
 import {UmdDependencyHost} from './dependencies/umd_dependency_host';
 import {DirectoryWalkerEntryPointFinder} from './entry_point_finder/directory_walker_entry_point_finder';
 import {TargetedEntryPointFinder} from './entry_point_finder/targeted_entry_point_finder';
-import {AnalyzeEntryPointsFn, CreateCompileFn, EntryPointProcessingMetadata, Executor, Task, TaskProcessingOutcome} from './execution/api';
+import {AnalyzeEntryPointsFn, CreateCompileFn, Executor, Task, TaskProcessingOutcome} from './execution/api';
 import {AsyncSingleProcessExecutor, SingleProcessExecutor} from './execution/single_process_executor';
 import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
@@ -138,7 +138,6 @@ export function mainNgcc(
         fileSystem, pkgJsonUpdater, logger, dependencyResolver, config, absBasePath,
         targetEntryPointPath, pathMappings, supportedPropertiesToConsider, compileAllFormats);
 
-    const processingMetadataPerEntryPoint = new Map<string, EntryPointProcessingMetadata>();
     const unprocessableEntryPointPaths: string[] = [];
     const tasks: Task[] = [];
 
@@ -165,8 +164,6 @@ export function mainNgcc(
         // Only process typings for the first property (if not already processed).
         processDts = false;
       }
-
-      processingMetadataPerEntryPoint.set(entryPoint.path, {hasProcessedTypings});
     }
 
     // Check for entry-points for which we could not process any format at all.
@@ -177,7 +174,7 @@ export function mainNgcc(
           unprocessableEntryPointPaths.map(path => `\n  - ${path}`).join(''));
     }
 
-    return {processingMetadataPerEntryPoint, tasks};
+    return tasks;
   };
 
   // The function for creating the `compile()` function.

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -16,8 +16,9 @@ import {ModuleResolver} from './dependencies/module_resolver';
 import {UmdDependencyHost} from './dependencies/umd_dependency_host';
 import {DirectoryWalkerEntryPointFinder} from './entry_point_finder/directory_walker_entry_point_finder';
 import {TargetedEntryPointFinder} from './entry_point_finder/targeted_entry_point_finder';
-import {AnalyzeEntryPointsFn, CreateCompileFn, Executor, Task, TaskProcessingOutcome} from './execution/api';
+import {AnalyzeEntryPointsFn, CreateCompileFn, Executor, Task, TaskProcessingOutcome, TaskQueue} from './execution/api';
 import {AsyncSingleProcessExecutor, SingleProcessExecutor} from './execution/single_process_executor';
+import {SerialTaskQueue} from './execution/task_selection/serial_task_queue';
 import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
 import {hasBeenProcessed, markAsProcessed} from './packages/build_marker';
@@ -174,7 +175,7 @@ export function mainNgcc(
           unprocessableEntryPointPaths.map(path => `\n  - ${path}`).join(''));
     }
 
-    return tasks;
+    return new SerialTaskQueue(tasks);
   };
 
   // The function for creating the `compile()` function.

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -17,7 +17,7 @@ import {UmdDependencyHost} from './dependencies/umd_dependency_host';
 import {DirectoryWalkerEntryPointFinder} from './entry_point_finder/directory_walker_entry_point_finder';
 import {TargetedEntryPointFinder} from './entry_point_finder/targeted_entry_point_finder';
 import {AnalyzeEntryPointsFn, CreateCompileFn, EntryPointProcessingMetadata, Executor, Task, TaskProcessingOutcome} from './execution/api';
-import {SingleProcessExecutor} from './execution/single_process_executor';
+import {AsyncSingleProcessExecutor, SingleProcessExecutor} from './execution/single_process_executor';
 import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
 import {hasBeenProcessed, markAsProcessed} from './packages/build_marker';
@@ -32,11 +32,12 @@ import {NewEntryPointFileWriter} from './writing/new_entry_point_file_writer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from './writing/package_json_updater';
 
 /**
- * The options to configure the ngcc compiler.
+ * The options to configure the ngcc compiler for synchronous execution.
  */
-export interface NgccOptions {
+export interface SyncNgccOptions {
   /** The absolute path to the `node_modules` folder that contains the packages to process. */
   basePath: string;
+
   /**
    * The path to the primary package to be processed. If not absolute then it must be relative to
    * `basePath`.
@@ -44,35 +45,59 @@ export interface NgccOptions {
    * All its dependencies will need to be processed too.
    */
   targetEntryPointPath?: string;
+
   /**
    * Which entry-point properties in the package.json to consider when processing an entry-point.
    * Each property should hold a path to the particular bundle format for the entry-point.
    * Defaults to all the properties in the package.json.
    */
   propertiesToConsider?: string[];
+
   /**
    * Whether to process all formats specified by (`propertiesToConsider`)  or to stop processing
    * this entry-point at the first matching format. Defaults to `true`.
    */
   compileAllFormats?: boolean;
+
   /**
    * Whether to create new entry-points bundles rather than overwriting the original files.
    */
   createNewEntryPointFormats?: boolean;
+
   /**
    * Provide a logger that will be called with log messages.
    */
   logger?: Logger;
+
   /**
    * Paths mapping configuration (`paths` and `baseUrl`), as found in `ts.CompilerOptions`.
    * These are used to resolve paths to locally built Angular libraries.
    */
   pathMappings?: PathMappings;
+
   /**
    * Provide a file-system service that will be used by ngcc for all file interactions.
    */
   fileSystem?: FileSystem;
+
+  /**
+   * Whether the compilation should run and return asynchronously. Allowing asynchronous execution
+   * may speed up the compilation by utilizing multiple CPU cores (if available).
+   *
+   * Default: `false` (i.e. run synchronously)
+   */
+  async?: false;
 }
+
+/**
+ * The options to configure the ngcc compiler for asynchronous execution.
+ */
+export type AsyncNgccOptions = Omit<SyncNgccOptions, 'async'>& {async: true};
+
+/**
+ * The options to configure the ngcc compiler.
+ */
+export type NgccOptions = AsyncNgccOptions | SyncNgccOptions;
 
 /**
  * This is the main entry-point into ngcc (aNGular Compatibility Compiler).
@@ -82,10 +107,13 @@ export interface NgccOptions {
  *
  * @param options The options telling ngcc what to compile and how.
  */
+export function mainNgcc(options: AsyncNgccOptions): Promise<void>;
+export function mainNgcc(options: SyncNgccOptions): void;
 export function mainNgcc(
     {basePath, targetEntryPointPath, propertiesToConsider = SUPPORTED_FORMAT_PROPERTIES,
      compileAllFormats = true, createNewEntryPointFormats = false,
-     logger = new ConsoleLogger(LogLevel.info), pathMappings}: NgccOptions): void {
+     logger = new ConsoleLogger(LogLevel.info), pathMappings, async = false}: NgccOptions): void|
+    Promise<void> {
   const fileSystem = getFileSystem();
   const pkgJsonUpdater = new DirectPackageJsonUpdater(fileSystem);
 
@@ -191,7 +219,7 @@ export function mainNgcc(
   };
 
   // The executor for actually planning and getting the work done.
-  const executor = getExecutor(logger, pkgJsonUpdater);
+  const executor = getExecutor(async, logger, pkgJsonUpdater);
   const execOpts = {compileAllFormats, propertiesToConsider};
 
   return executor.execute(analyzeEntryPoints, createCompileFn, execOpts);
@@ -226,8 +254,12 @@ function getFileWriter(
                                       new InPlaceFileWriter(fs);
 }
 
-function getExecutor(logger: Logger, pkgJsonUpdater: PackageJsonUpdater): Executor {
-  return new SingleProcessExecutor(logger, pkgJsonUpdater);
+function getExecutor(async: boolean, logger: Logger, pkgJsonUpdater: PackageJsonUpdater): Executor {
+  if (async) {
+    return new AsyncSingleProcessExecutor(logger, pkgJsonUpdater);
+  } else {
+    return new SingleProcessExecutor(logger, pkgJsonUpdater);
+  }
 }
 
 function getEntryPoints(

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -10,20 +10,20 @@ import * as ts from 'typescript';
 import {AbsoluteFsPath, FileSystem, absoluteFrom, dirname, getFileSystem, resolve} from '../../src/ngtsc/file_system';
 
 import {CommonJsDependencyHost} from './dependencies/commonjs_dependency_host';
-import {DependencyResolver, InvalidEntryPoint, SortedEntryPointsInfo} from './dependencies/dependency_resolver';
+import {DependencyResolver, InvalidEntryPoint, PartiallyOrderedEntryPoints, SortedEntryPointsInfo} from './dependencies/dependency_resolver';
 import {EsmDependencyHost} from './dependencies/esm_dependency_host';
 import {ModuleResolver} from './dependencies/module_resolver';
 import {UmdDependencyHost} from './dependencies/umd_dependency_host';
 import {DirectoryWalkerEntryPointFinder} from './entry_point_finder/directory_walker_entry_point_finder';
 import {TargetedEntryPointFinder} from './entry_point_finder/targeted_entry_point_finder';
-import {AnalyzeEntryPointsFn, CreateCompileFn, Executor, Task, TaskProcessingOutcome, TaskQueue} from './execution/api';
+import {AnalyzeEntryPointsFn, CreateCompileFn, Executor, PartiallyOrderedTasks, Task, TaskProcessingOutcome} from './execution/api';
 import {AsyncSingleProcessExecutor, SingleProcessExecutor} from './execution/single_process_executor';
 import {SerialTaskQueue} from './execution/task_selection/serial_task_queue';
 import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
 import {hasBeenProcessed, markAsProcessed} from './packages/build_marker';
 import {NgccConfiguration} from './packages/configuration';
-import {EntryPoint, EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
+import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
 import {makeEntryPointBundle} from './packages/entry_point_bundle';
 import {Transformer} from './packages/transformer';
 import {PathMappings} from './utils';
@@ -140,7 +140,8 @@ export function mainNgcc(
         targetEntryPointPath, pathMappings, supportedPropertiesToConsider, compileAllFormats);
 
     const unprocessableEntryPointPaths: string[] = [];
-    const tasks: Task[] = [];
+    // The tasks are partially ordered by virtue of the entry-points being partially ordered too.
+    const tasks: PartiallyOrderedTasks = [] as any;
 
     for (const entryPoint of entryPoints) {
       const packageJson = entryPoint.packageJson;
@@ -278,7 +279,7 @@ function getEntryPoints(
     fs: FileSystem, pkgJsonUpdater: PackageJsonUpdater, logger: Logger,
     resolver: DependencyResolver, config: NgccConfiguration, basePath: AbsoluteFsPath,
     targetEntryPointPath: string | undefined, pathMappings: PathMappings | undefined,
-    propertiesToConsider: string[], compileAllFormats: boolean): EntryPoint[] {
+    propertiesToConsider: string[], compileAllFormats: boolean): PartiallyOrderedEntryPoints {
   const {entryPoints, invalidEntryPoints} = (targetEntryPointPath !== undefined) ?
       getTargetedEntryPoints(
           fs, pkgJsonUpdater, logger, resolver, config, basePath, targetEntryPointPath,
@@ -297,7 +298,11 @@ function getTargetedEntryPoints(
   if (hasProcessedTargetEntryPoint(
           fs, absoluteTargetEntryPointPath, propertiesToConsider, compileAllFormats)) {
     logger.debug('The target entry-point has already been processed');
-    return {entryPoints: [], invalidEntryPoints: [], ignoredDependencies: []};
+    return {
+      entryPoints: [] as unknown as PartiallyOrderedEntryPoints,
+      invalidEntryPoints: [],
+      ignoredDependencies: [],
+    };
   }
   const finder = new TargetedEntryPointFinder(
       fs, config, logger, resolver, basePath, absoluteTargetEntryPointPath, pathMappings);

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -16,12 +16,13 @@ import {ModuleResolver} from './dependencies/module_resolver';
 import {UmdDependencyHost} from './dependencies/umd_dependency_host';
 import {DirectoryWalkerEntryPointFinder} from './entry_point_finder/directory_walker_entry_point_finder';
 import {TargetedEntryPointFinder} from './entry_point_finder/targeted_entry_point_finder';
-import {AnalyzeEntryPointsFn, CreateCompileFn, EntryPointProcessingMetadata, ExecuteFn, Task, TaskProcessingOutcome} from './execution/api';
+import {AnalyzeEntryPointsFn, CreateCompileFn, EntryPointProcessingMetadata, Executor, Task, TaskProcessingOutcome} from './execution/api';
+import {SingleProcessExecutor} from './execution/single_process_executor';
 import {ConsoleLogger, LogLevel} from './logging/console_logger';
 import {Logger} from './logging/logger';
 import {hasBeenProcessed, markAsProcessed} from './packages/build_marker';
 import {NgccConfiguration} from './packages/configuration';
-import {EntryPoint, EntryPointJsonProperty, EntryPointPackageJson, PackageJsonFormatProperties, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
 import {makeEntryPointBundle} from './packages/entry_point_bundle';
 import {Transformer} from './packages/transformer';
 import {PathMappings} from './utils';
@@ -189,56 +190,11 @@ export function mainNgcc(
     };
   };
 
-  // The function for actually planning and getting the work done.
-  const execute: ExecuteFn =
-      (analyzeEntryPoints: AnalyzeEntryPointsFn, createCompileFn: CreateCompileFn) => {
-        const {processingMetadataPerEntryPoint, tasks} = analyzeEntryPoints();
-        const compile = createCompileFn((task, outcome) => {
-          const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
-          const processingMeta = processingMetadataPerEntryPoint.get(entryPoint.path) !;
-          processingMeta.hasAnyProcessedFormat = true;
+  // The executor for actually planning and getting the work done.
+  const executor = getExecutor(logger, pkgJsonUpdater);
+  const execOpts = {compileAllFormats, propertiesToConsider};
 
-          if (outcome === TaskProcessingOutcome.Processed) {
-            const packageJsonPath = fileSystem.resolve(entryPoint.path, 'package.json');
-            const propsToMarkAsProcessed: PackageJsonFormatProperties[] =
-                [...formatPropertiesToMarkAsProcessed];
-
-            if (processDts) {
-              processingMeta.hasProcessedTypings = true;
-              propsToMarkAsProcessed.push('typings');
-            }
-
-            markAsProcessed(
-                pkgJsonUpdater, entryPoint.packageJson, packageJsonPath, propsToMarkAsProcessed);
-          }
-        });
-
-        // Process all tasks.
-        for (const task of tasks) {
-          const processingMeta = processingMetadataPerEntryPoint.get(task.entryPoint.path) !;
-
-          // If we only need one format processed and we already have one for the corresponding
-          // entry-point, skip the task.
-          if (!compileAllFormats && processingMeta.hasAnyProcessedFormat) continue;
-
-          compile(task);
-        }
-
-        // Check for entry-points for which we could not process any format at all.
-        const unprocessedEntryPointPaths =
-            Array.from(processingMetadataPerEntryPoint.entries())
-                .filter(([, processingMeta]) => !processingMeta.hasAnyProcessedFormat)
-                .map(([entryPointPath]) => `\n  - ${entryPointPath}`)
-                .join('');
-
-        if (unprocessedEntryPointPaths) {
-          throw new Error(
-              'Failed to compile any formats for the following entry-points (tried ' +
-              `${propertiesToConsider.join(', ')}): ${unprocessedEntryPointPaths}`);
-        }
-      };
-
-  return execute(analyzeEntryPoints, createCompileFn);
+  return executor.execute(analyzeEntryPoints, createCompileFn, execOpts);
 }
 
 function ensureSupportedProperties(properties: string[]): EntryPointJsonProperty[] {
@@ -268,6 +224,10 @@ function getFileWriter(
     createNewEntryPointFormats: boolean): FileWriter {
   return createNewEntryPointFormats ? new NewEntryPointFileWriter(fs, pkgJsonUpdater) :
                                       new InPlaceFileWriter(fs);
+}
+
+function getExecutor(logger: Logger, pkgJsonUpdater: PackageJsonUpdater): Executor {
+  return new SingleProcessExecutor(logger, pkgJsonUpdater);
 }
 
 function getEntryPoints(

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -139,14 +139,24 @@ export function mainNgcc(
         targetEntryPointPath, pathMappings, supportedPropertiesToConsider, compileAllFormats);
 
     const processingMetadataPerEntryPoint = new Map<string, EntryPointProcessingMetadata>();
+    const unprocessableEntryPointPaths: string[] = [];
     const tasks: Task[] = [];
 
     for (const entryPoint of entryPoints) {
       const packageJson = entryPoint.packageJson;
       const hasProcessedTypings = hasBeenProcessed(packageJson, 'typings', entryPoint.path);
       const {propertiesToProcess, equivalentPropertiesMap} =
-          getPropertiesToProcess(packageJson, supportedPropertiesToConsider);
+          getPropertiesToProcess(packageJson, supportedPropertiesToConsider, compileAllFormats);
       let processDts = !hasProcessedTypings;
+
+      if (propertiesToProcess.length === 0) {
+        // This entry-point is unprocessable (i.e. there is no format property that is of interest
+        // and can be processed). This will result in an error, but continue looping over
+        // entry-points in order to collect all unprocessable ones and display a more informative
+        // error.
+        unprocessableEntryPointPaths.push(entryPoint.path);
+        continue;
+      }
 
       for (const formatProperty of propertiesToProcess) {
         const formatPropertiesToMarkAsProcessed = equivalentPropertiesMap.get(formatProperty) !;
@@ -156,10 +166,15 @@ export function mainNgcc(
         processDts = false;
       }
 
-      processingMetadataPerEntryPoint.set(entryPoint.path, {
-        hasProcessedTypings,
-        hasAnyProcessedFormat: false,
-      });
+      processingMetadataPerEntryPoint.set(entryPoint.path, {hasProcessedTypings});
+    }
+
+    // Check for entry-points for which we could not process any format at all.
+    if (unprocessableEntryPointPaths.length > 0) {
+      throw new Error(
+          'Unable to process any formats for the following entry-points (tried ' +
+          `${propertiesToConsider.join(', ')}): ` +
+          unprocessableEntryPointPaths.map(path => `\n  - ${path}`).join(''));
     }
 
     return {processingMetadataPerEntryPoint, tasks};
@@ -220,9 +235,8 @@ export function mainNgcc(
 
   // The executor for actually planning and getting the work done.
   const executor = getExecutor(async, logger, pkgJsonUpdater);
-  const execOpts = {compileAllFormats, propertiesToConsider};
 
-  return executor.execute(analyzeEntryPoints, createCompileFn, execOpts);
+  return executor.execute(analyzeEntryPoints, createCompileFn);
 }
 
 function ensureSupportedProperties(properties: string[]): EntryPointJsonProperty[] {
@@ -376,7 +390,8 @@ function logInvalidEntryPoints(logger: Logger, invalidEntryPoints: InvalidEntryP
  *   former has been processed.
  */
 function getPropertiesToProcess(
-    packageJson: EntryPointPackageJson, propertiesToConsider: EntryPointJsonProperty[]): {
+    packageJson: EntryPointPackageJson, propertiesToConsider: EntryPointJsonProperty[],
+    compileAllFormats: boolean): {
   propertiesToProcess: EntryPointJsonProperty[];
   equivalentPropertiesMap: Map<EntryPointJsonProperty, EntryPointJsonProperty[]>;
 } {
@@ -395,6 +410,9 @@ function getPropertiesToProcess(
     // Process this property, because it is the first one to map to this format-path.
     formatPathsToConsider.add(formatPath);
     propertiesToProcess.push(prop);
+
+    // If we only need one format processed, there is no need to process any more properties.
+    if (!compileAllFormats) break;
   }
 
   const formatPathToProperties: {[formatPath: string]: EntryPointJsonProperty[]} = {};

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath, FileSystem, dirname} from '../../../src/ngtsc/file_system';
-import {EntryPointJsonProperty, EntryPointPackageJson} from './entry_point';
+import {EntryPointPackageJson, PackageJsonFormatProperties} from './entry_point';
 
 export const NGCC_VERSION = '0.0.0-PLACEHOLDER';
 
@@ -23,7 +23,7 @@ export const NGCC_VERSION = '0.0.0-PLACEHOLDER';
  * @throws Error if the entry-point has already been processed with a different ngcc version.
  */
 export function hasBeenProcessed(
-    packageJson: EntryPointPackageJson, format: EntryPointJsonProperty | 'typings',
+    packageJson: EntryPointPackageJson, format: PackageJsonFormatProperties,
     entryPointPath: AbsoluteFsPath): boolean {
   if (!packageJson.__processed_by_ivy_ngcc__) {
     return false;
@@ -50,7 +50,7 @@ export function hasBeenProcessed(
  */
 export function markAsProcessed(
     fs: FileSystem, packageJson: EntryPointPackageJson, packageJsonPath: AbsoluteFsPath,
-    properties: (EntryPointJsonProperty | 'typings')[]) {
+    properties: PackageJsonFormatProperties[]) {
   const processed =
       packageJson.__processed_by_ivy_ngcc__ || (packageJson.__processed_by_ivy_ngcc__ = {});
 

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -59,15 +59,19 @@ export function markAsProcessed(
   }
 
   const scripts = packageJson.scripts || (packageJson.scripts = {});
-  scripts.prepublishOnly__ivy_ngcc_bak =
-      scripts.prepublishOnly__ivy_ngcc_bak || scripts.prepublishOnly;
-
-  scripts.prepublishOnly = 'node --eval \"console.error(\'' +
+  const oldPrepublishOnly = scripts.prepublishOnly;
+  const newPrepublishOnly = 'node --eval \"console.error(\'' +
       'ERROR: Trying to publish a package that has been compiled by NGCC. This is not allowed.\\n' +
       'Please delete and rebuild the package, without compiling with NGCC, before attempting to publish.\\n' +
       'Note that NGCC may have been run by importing this package into another project that is being built with Ivy enabled.\\n' +
       '\')\" ' +
       '&& exit 1';
+
+  if (oldPrepublishOnly && (oldPrepublishOnly !== newPrepublishOnly)) {
+    scripts.prepublishOnly__ivy_ngcc_bak = oldPrepublishOnly;
+  }
+
+  scripts.prepublishOnly = newPrepublishOnly;
 
   // Just in case this package.json was synthesized due to a custom configuration
   // we will ensure that the path to the containing folder exists before we write the file.

--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath, FileSystem, dirname} from '../../../src/ngtsc/file_system';
+import {PackageJsonUpdater} from '../writing/package_json_updater';
 import {EntryPointPackageJson, PackageJsonFormatProperties} from './entry_point';
 
 export const NGCC_VERSION = '0.0.0-PLACEHOLDER';
@@ -42,24 +43,25 @@ export function hasBeenProcessed(
  * Write a build marker for the given entry-point and format properties, to indicate that they have
  * been compiled by this version of ngcc.
  *
- * @param fs The current file-system being used.
+ * @param pkgJsonUpdater The writer to use for updating `package.json`.
  * @param packageJson The parsed contents of the `package.json` file for the entry-point.
  * @param packageJsonPath The absolute path to the `package.json` file.
  * @param properties The properties in the `package.json` of the formats for which we are writing
  *                   the marker.
  */
 export function markAsProcessed(
-    fs: FileSystem, packageJson: EntryPointPackageJson, packageJsonPath: AbsoluteFsPath,
-    properties: PackageJsonFormatProperties[]) {
-  const processed =
-      packageJson.__processed_by_ivy_ngcc__ || (packageJson.__processed_by_ivy_ngcc__ = {});
+    pkgJsonUpdater: PackageJsonUpdater, packageJson: EntryPointPackageJson,
+    packageJsonPath: AbsoluteFsPath, formatProperties: PackageJsonFormatProperties[]): void {
+  const update = pkgJsonUpdater.createUpdate();
 
-  for (const prop of properties) {
-    processed[prop] = NGCC_VERSION;
+  // Update the format properties to mark them as processed.
+  for (const prop of formatProperties) {
+    update.addChange(['__processed_by_ivy_ngcc__', prop], NGCC_VERSION);
   }
 
-  const scripts = packageJson.scripts || (packageJson.scripts = {});
-  const oldPrepublishOnly = scripts.prepublishOnly;
+  // Update the `prepublishOnly` script (keeping a backup, if necessary) to prevent `ngcc`'d
+  // packages from getting accidentally published.
+  const oldPrepublishOnly = packageJson.scripts && packageJson.scripts.prepublishOnly;
   const newPrepublishOnly = 'node --eval \"console.error(\'' +
       'ERROR: Trying to publish a package that has been compiled by NGCC. This is not allowed.\\n' +
       'Please delete and rebuild the package, without compiling with NGCC, before attempting to publish.\\n' +
@@ -68,13 +70,10 @@ export function markAsProcessed(
       '&& exit 1';
 
   if (oldPrepublishOnly && (oldPrepublishOnly !== newPrepublishOnly)) {
-    scripts.prepublishOnly__ivy_ngcc_bak = oldPrepublishOnly;
+    update.addChange(['scripts', 'prepublishOnly__ivy_ngcc_bak'], oldPrepublishOnly);
   }
 
-  scripts.prepublishOnly = newPrepublishOnly;
+  update.addChange(['scripts', 'prepublishOnly'], newPrepublishOnly);
 
-  // Just in case this package.json was synthesized due to a custom configuration
-  // we will ensure that the path to the containing folder exists before we write the file.
-  fs.ensureDir(dirname(packageJsonPath));
-  fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  update.writeChanges(packageJsonPath, packageJson);
 }

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -7,7 +7,7 @@
  */
 import * as vm from 'vm';
 import {AbsoluteFsPath, FileSystem, dirname, join, resolve} from '../../../src/ngtsc/file_system';
-import {PackageJsonFormatProperties} from './entry_point';
+import {PackageJsonFormatPropertiesMap} from './entry_point';
 
 /**
  * The format of a project level configuration file.
@@ -41,7 +41,7 @@ export interface NgccEntryPointConfig {
    * This property, if provided, holds values that will override equivalent properties in an
    * entry-point's package.json file.
    */
-  override?: PackageJsonFormatProperties;
+  override?: PackageJsonFormatPropertiesMap;
 }
 
 const NGCC_CONFIG_FILENAME = 'ngcc.config.js';

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -38,6 +38,11 @@ export interface EntryPoint {
   compiledByAngular: boolean;
 }
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonArray | JsonObject | undefined;
+export interface JsonArray extends Array<JsonValue> {}
+export interface JsonObject { [key: string]: JsonValue; }
+
 export interface PackageJsonFormatPropertiesMap {
   fesm2015?: string;
   fesm5?: string;
@@ -55,7 +60,7 @@ export type PackageJsonFormatProperties = keyof PackageJsonFormatPropertiesMap;
 /**
  * The properties that may be loaded from the `package.json` file.
  */
-export interface EntryPointPackageJson extends PackageJsonFormatPropertiesMap {
+export interface EntryPointPackageJson extends JsonObject, PackageJsonFormatPropertiesMap {
   name: string;
   scripts?: Record<string, string>;
   __processed_by_ivy_ngcc__?: Record<string, string>;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -23,7 +23,7 @@ export type EntryPointFormat = 'esm5' | 'esm2015' | 'umd' | 'commonjs';
  * An object containing information about an entry-point, including paths
  * to each of the possible entry-point formats.
  */
-export interface EntryPoint {
+export interface EntryPoint extends JsonObject {
   /** The name of the package (e.g. `@angular/core`). */
   name: string;
   /** The parsed package.json file for this entry-point. */

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -38,7 +38,7 @@ export interface EntryPoint {
   compiledByAngular: boolean;
 }
 
-export interface PackageJsonFormatProperties {
+export interface PackageJsonFormatPropertiesMap {
   fesm2015?: string;
   fesm5?: string;
   es2015?: string;  // if exists then it is actually FESM2015
@@ -50,16 +50,18 @@ export interface PackageJsonFormatProperties {
   typings?: string;  // TypeScript .d.ts files
 }
 
+export type PackageJsonFormatProperties = keyof PackageJsonFormatPropertiesMap;
+
 /**
  * The properties that may be loaded from the `package.json` file.
  */
-export interface EntryPointPackageJson extends PackageJsonFormatProperties {
+export interface EntryPointPackageJson extends PackageJsonFormatPropertiesMap {
   name: string;
   scripts?: Record<string, string>;
   __processed_by_ivy_ngcc__?: Record<string, string>;
 }
 
-export type EntryPointJsonProperty = Exclude<keyof PackageJsonFormatProperties, 'types'|'typings'>;
+export type EntryPointJsonProperty = Exclude<PackageJsonFormatProperties, 'types'|'typings'>;
 // We need to keep the elements of this const and the `EntryPointJsonProperty` type in sync.
 export const SUPPORTED_FORMAT_PROPERTIES: EntryPointJsonProperty[] =
     ['fesm2015', 'fesm5', 'es2015', 'esm2015', 'esm5', 'main', 'module'];

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {AbsoluteFsPath, FileSystem, absoluteFrom} from '../../../src/ngtsc/file_system';
-import {NgtscCompilerHost} from '../../../src/ngtsc/file_system/src/compiler_host';
+import {AbsoluteFsPath, FileSystem, NgtscCompilerHost, absoluteFrom} from '../../../src/ngtsc/file_system';
 import {PathMappings} from '../utils';
 import {BundleProgram, makeBundleProgram} from './bundle_program';
 import {EntryPoint, EntryPointFormat} from './entry_point';

--- a/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
+++ b/packages/compiler-cli/ngcc/src/packages/ngcc_compiler_host.ts
@@ -7,8 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {FileSystem} from '../../../src/ngtsc/file_system';
-import {NgtscCompilerHost} from '../../../src/ngtsc/file_system/src/compiler_host';
+import {FileSystem, NgtscCompilerHost} from '../../../src/ngtsc/file_system';
 import {isRelativePath} from '../utils';
 
 /**

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -8,6 +8,28 @@
 import * as ts from 'typescript';
 import {AbsoluteFsPath, FileSystem, absoluteFrom} from '../../src/ngtsc/file_system';
 
+/**
+ * A list (`Array`) of partially ordered `T` items.
+ *
+ * The items in the list are partially ordered in the sense that any element has either the same or
+ * higher precedence than any element which appears later in the list. What "higher precedence"
+ * means and how it is determined is implementation-dependent.
+ *
+ * See [PartiallyOrderedSet](https://en.wikipedia.org/wiki/Partially_ordered_set) for more details.
+ * (Refraining from using the term "set" here, to avoid confusion with JavaScript's
+ * [Set](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set).)
+ *
+ * NOTE: A plain `Array<T>` is not assignable to a `PartiallyOrderedList<T>`, but a
+ *       `PartiallyOrderedList<T>` is assignable to an `Array<T>`.
+ */
+export interface PartiallyOrderedList<T> extends Array<T> {
+  _partiallyOrdered: true;
+
+  map<U>(callbackfn: (value: T, index: number, array: PartiallyOrderedList<T>) => U, thisArg?: any):
+      PartiallyOrderedList<U>;
+  slice(...args: Parameters<Array<T>['slice']>): PartiallyOrderedList<T>;
+}
+
 export function getOriginalSymbol(checker: ts.TypeChecker): (symbol: ts.Symbol) => ts.Symbol {
   return function(symbol: ts.Symbol) {
     return ts.SymbolFlags.Alias & symbol.flags ? checker.getAliasedSymbol(symbol) : symbol;

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -14,7 +14,7 @@ import {FileWriter} from './file_writer';
 
 /**
  * This FileWriter overwrites the transformed file, in-place, while creating
- * a back-up of the original file with an extra `.bak` extension.
+ * a back-up of the original file with an extra `.__ivy_ngcc_bak` extension.
  */
 export class InPlaceFileWriter implements FileWriter {
   constructor(protected fs: FileSystem) {}

--- a/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
+++ b/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AbsoluteFsPath, FileSystem, dirname} from '../../../src/ngtsc/file_system';
+import {JsonObject, JsonValue} from '../packages/entry_point';
+
+
+export type PackageJsonChange = [string[], JsonValue];
+export type WritePackageJsonChangesFn =
+    (changes: PackageJsonChange[], packageJsonPath: AbsoluteFsPath, parsedJson?: JsonObject) =>
+        void;
+
+/**
+ * A utility object that can be used to safely update values in a `package.json` file.
+ *
+ * Example usage:
+ * ```ts
+ * const updatePackageJson = packageJsonUpdater
+ *     .createUpdate()
+ *     .addChange(['name'], 'package-foo')
+ *     .addChange(['scripts', 'foo'], 'echo FOOOO...')
+ *     .addChange(['dependencies', 'bar'], '1.0.0')
+ *     .writeChanges('/foo/package.json');
+ *     // or
+ *     // .writeChanges('/foo/package.json', inMemoryParsedJson);
+ * ```
+ */
+export interface PackageJsonUpdater {
+  /**
+   * Create a `PackageJsonUpdate` object, which provides a fluent API for batching updates to a
+   * `package.json` file. (Batching the updates is useful, because it avoid unnecessary I/O
+   * operations.)
+   */
+  createUpdate(): PackageJsonUpdate;
+
+  /**
+   * Write a set of changes to the specified `package.json` file and (and optionally a pre-existing,
+   * in-memory representation of it).
+   *
+   * @param changes The set of changes to apply.
+   * @param packageJsonPath The path to the `package.json` file that needs to be updated.
+   * @param parsedJson A pre-existing, in-memory representation of the `package.json` file that
+   *                   needs to be updated as well.
+   */
+  writeChanges(
+      changes: PackageJsonChange[], packageJsonPath: AbsoluteFsPath, parsedJson?: JsonObject): void;
+}
+
+/**
+ * A utility class providing a fluent API for recording multiple changes to a `package.json` file
+ * (and optionally its in-memory parsed representation).
+ *
+ * NOTE: This class should generally not be instantiated directly; instances are implicitly created
+ *       via `PackageJsonUpdater#createUpdate()`.
+ */
+export class PackageJsonUpdate {
+  private changes: PackageJsonChange[] = [];
+  private applied = false;
+
+  constructor(private writeChangesImpl: WritePackageJsonChangesFn) {}
+
+  /**
+   * Record a change to a `package.json` property. If the ancestor objects do not yet exist in the
+   * `package.json` file, they will be created.
+   *
+   * @param propertyPath The path of a (possibly nested) property to update.
+   * @param value The new value to set the property to.
+   */
+  addChange(propertyPath: string[], value: JsonValue): this {
+    this.ensureNotApplied();
+    this.changes.push([propertyPath, value]);
+    return this;
+  }
+
+  /**
+   * Write the recorded changes to the associated `package.json` file (and optionally a
+   * pre-existing, in-memory representation of it).
+   *
+   * @param packageJsonPath The path to the `package.json` file that needs to be updated.
+   * @param parsedJson A pre-existing, in-memory representation of the `package.json` file that
+   *                   needs to be updated as well.
+   */
+  writeChanges(packageJsonPath: AbsoluteFsPath, parsedJson?: JsonObject): void {
+    this.ensureNotApplied();
+    this.writeChangesImpl(this.changes, packageJsonPath, parsedJson);
+    this.applied = true;
+  }
+
+  private ensureNotApplied() {
+    if (this.applied) {
+      throw new Error('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+    }
+  }
+}
+
+/** A `PackageJsonUpdater` that writes directly to the file-system. */
+export class DirectPackageJsonUpdater implements PackageJsonUpdater {
+  constructor(private fs: FileSystem) {}
+
+  createUpdate(): PackageJsonUpdate {
+    return new PackageJsonUpdate((...args) => this.writeChanges(...args));
+  }
+
+  writeChanges(
+      changes: PackageJsonChange[], packageJsonPath: AbsoluteFsPath,
+      preExistingParsedJson?: JsonObject): void {
+    if (changes.length === 0) {
+      throw new Error(`No changes to write to '${packageJsonPath}'.`);
+    }
+
+    // Read and parse the `package.json` content.
+    // NOTE: We are not using `preExistingParsedJson` (even if specified) to avoid corrupting the
+    //       content on disk in case `preExistingParsedJson` is outdated.
+    const parsedJson =
+        this.fs.exists(packageJsonPath) ? JSON.parse(this.fs.readFile(packageJsonPath)) : {};
+
+    // Apply all changes to both the canonical representation (read from disk) and any pre-existing,
+    // in-memory representation.
+    for (const [propPath, value] of changes) {
+      if (propPath.length === 0) {
+        throw new Error(`Missing property path for writing value to '${packageJsonPath}'.`);
+      }
+
+      applyChange(parsedJson, propPath, value);
+
+      if (preExistingParsedJson) {
+        applyChange(preExistingParsedJson, propPath, value);
+      }
+    }
+
+    // Ensure the containing directory exists (in case this is a synthesized `package.json` due to a
+    // custom configuration) and write the updated content to disk.
+    this.fs.ensureDir(dirname(packageJsonPath));
+    this.fs.writeFile(packageJsonPath, `${JSON.stringify(parsedJson, null, 2)}\n`);
+  }
+}
+
+// Helpers
+export function applyChange(ctx: JsonObject, propPath: string[], value: JsonValue): void {
+  const lastPropIdx = propPath.length - 1;
+  const lastProp = propPath[lastPropIdx];
+
+  for (let i = 0; i < lastPropIdx; i++) {
+    const key = propPath[i];
+    const newCtx = ctx.hasOwnProperty(key) ? ctx[key] : (ctx[key] = {});
+
+    if ((typeof newCtx !== 'object') || (newCtx === null) || Array.isArray(newCtx)) {
+      throw new Error(`Property path '${propPath.join('.')}' does not point to an object.`);
+    }
+
+    ctx = newCtx;
+  }
+
+  ctx[lastProp] = value;
+}

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -24,6 +24,7 @@ ts_library(
         "//packages/compiler-cli/test/helpers",
         "@npm//@types/convert-source-map",
         "@npm//convert-source-map",
+        "@npm//dependency-graph",
         "@npm//magic-string",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {ClusterExecutor} from '../../../src/execution/cluster/executor';
+import {ClusterMaster} from '../../../src/execution/cluster/master';
+import {ClusterWorker} from '../../../src/execution/cluster/worker';
+import {PackageJsonUpdater} from '../../../src/writing/package_json_updater';
+import {MockLogger} from '../../helpers/mock_logger';
+import {mockProperty} from '../../helpers/spy_utils';
+
+
+describe('ClusterExecutor', () => {
+  const setMockClusterIsMasterValue = mockProperty(cluster, 'isMaster');
+  let masterRunSpy: jasmine.Spy;
+  let workerRunSpy: jasmine.Spy;
+  let mockLogger: MockLogger;
+  let executor: ClusterExecutor;
+
+  beforeEach(() => {
+    masterRunSpy = spyOn(ClusterMaster.prototype, 'run');
+    workerRunSpy = spyOn(ClusterWorker.prototype, 'run');
+
+    mockLogger = new MockLogger();
+    executor = new ClusterExecutor(42, mockLogger, null as unknown as PackageJsonUpdater);
+  });
+
+  describe('execute()', () => {
+    describe('(on cluster master)', () => {
+      beforeEach(() => setMockClusterIsMasterValue(true));
+
+      it('should log debug info about the executor', () => {
+        const anyFn: () => any = () => undefined;
+        executor.execute(anyFn, anyFn);
+
+        expect(mockLogger.logs.debug).toEqual([
+          ['Running ngcc on ClusterExecutor (using 42 worker processes).'],
+        ]);
+      });
+
+      it('should delegate to `ClusterMaster#run()`', async() => {
+        masterRunSpy.and.returnValue('CusterMaster#run()');
+        const analyzeEntryPointsSpy = jasmine.createSpy('analyzeEntryPoints');
+        const createCompilerFnSpy = jasmine.createSpy('createCompilerFn');
+
+        expect(await executor.execute(analyzeEntryPointsSpy, createCompilerFnSpy))
+            .toBe('CusterMaster#run()' as any);
+
+        expect(masterRunSpy).toHaveBeenCalledWith();
+        expect(workerRunSpy).not.toHaveBeenCalled();
+
+        expect(analyzeEntryPointsSpy).toHaveBeenCalledWith();
+        expect(createCompilerFnSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('(on cluster worker)', () => {
+      beforeEach(() => setMockClusterIsMasterValue(false));
+
+      it('should not log debug info about the executor', () => {
+        const anyFn: () => any = () => undefined;
+        executor.execute(anyFn, anyFn);
+
+        expect(mockLogger.logs.debug).toEqual([]);
+      });
+
+      it('should delegate to `ClusterWorker#run()`', async() => {
+        workerRunSpy.and.returnValue('CusterWorker#run()');
+        const analyzeEntryPointsSpy = jasmine.createSpy('analyzeEntryPoints');
+        const createCompilerFnSpy = jasmine.createSpy('createCompilerFn');
+
+        expect(await executor.execute(analyzeEntryPointsSpy, createCompilerFnSpy))
+            .toBe('CusterWorker#run()' as any);
+
+        expect(masterRunSpy).not.toHaveBeenCalledWith();
+        expect(workerRunSpy).toHaveBeenCalled();
+
+        expect(analyzeEntryPointsSpy).not.toHaveBeenCalled();
+        expect(createCompilerFnSpy).toHaveBeenCalledWith(jasmine.any(Function));
+      });
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
@@ -19,7 +19,7 @@ import {mockProperty} from '../../helpers/spy_utils';
 
 
 describe('ClusterExecutor', () => {
-  const setMockClusterIsMasterValue = mockProperty(cluster, 'isMaster');
+  const runAsClusterMaster = mockProperty(cluster, 'isMaster');
   let masterRunSpy: jasmine.Spy;
   let workerRunSpy: jasmine.Spy;
   let mockLogger: MockLogger;
@@ -35,7 +35,7 @@ describe('ClusterExecutor', () => {
 
   describe('execute()', () => {
     describe('(on cluster master)', () => {
-      beforeEach(() => setMockClusterIsMasterValue(true));
+      beforeEach(() => runAsClusterMaster(true));
 
       it('should log debug info about the executor', () => {
         const anyFn: () => any = () => undefined;
@@ -63,7 +63,7 @@ describe('ClusterExecutor', () => {
     });
 
     describe('(on cluster worker)', () => {
-      beforeEach(() => setMockClusterIsMasterValue(false));
+      beforeEach(() => runAsClusterMaster(false));
 
       it('should not log debug info about the executor', () => {
         const anyFn: () => any = () => undefined;

--- a/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+
+import {absoluteFrom as _} from '../../../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../../../src/ngtsc/file_system/testing';
+import {ClusterPackageJsonUpdater} from '../../../src/execution/cluster/package_json_updater';
+import {JsonObject} from '../../../src/packages/entry_point';
+import {PackageJsonUpdate, PackageJsonUpdater} from '../../../src/writing/package_json_updater';
+import {mockProperty} from '../../helpers/spy_utils';
+
+
+runInEachFileSystem(() => {
+  describe('ClusterPackageJsonUpdater', () => {
+    const setMockClusterIsMasterValue = mockProperty(cluster, 'isMaster');
+    const setMockProcessSendValue = mockProperty(process, 'send');
+    let processSendSpy: jasmine.Spy;
+    let delegate: PackageJsonUpdater;
+    let updater: ClusterPackageJsonUpdater;
+
+    beforeEach(() => {
+      processSendSpy = jasmine.createSpy('process.send');
+      setMockProcessSendValue(processSendSpy);
+
+      delegate = new MockPackageJsonUpdater();
+      updater = new ClusterPackageJsonUpdater(delegate);
+    });
+
+    describe('createUpdate()', () => {
+      [true, false].forEach(
+          isMaster => describe(`(on cluster ${isMaster ? 'master' : 'worker'})`, () => {
+            beforeEach(() => setMockClusterIsMasterValue(isMaster));
+
+            it('should return a `PackageJsonUpdate` instance',
+               () => { expect(updater.createUpdate()).toEqual(jasmine.any(PackageJsonUpdate)); });
+
+            it('should wire up the `PackageJsonUpdate` with its `writeChanges()` method', () => {
+              const writeChangesSpy = spyOn(updater, 'writeChanges');
+              const jsonPath = _('/foo/package.json');
+              const update = updater.createUpdate();
+
+              update.addChange(['foo'], 'updated');
+              update.writeChanges(jsonPath);
+
+              expect(writeChangesSpy)
+                  .toHaveBeenCalledWith([[['foo'], 'updated']], jsonPath, undefined);
+            });
+          }));
+    });
+
+    describe('writeChanges()', () => {
+      describe('(on cluster master)', () => {
+        beforeEach(() => setMockClusterIsMasterValue(true));
+        afterEach(() => expect(processSendSpy).not.toHaveBeenCalled());
+
+        it('should forward the call to the delegate `PackageJsonUpdater`', () => {
+          const jsonPath = _('/foo/package.json');
+          const parsedJson = {foo: 'bar'};
+
+          updater.createUpdate().addChange(['foo'], 'updated').writeChanges(jsonPath, parsedJson);
+
+          expect(delegate.writeChanges)
+              .toHaveBeenCalledWith([[['foo'], 'updated']], jsonPath, parsedJson);
+        });
+
+        it('should throw, if trying to re-apply an already applied update', () => {
+          const update = updater.createUpdate().addChange(['foo'], 'updated');
+
+          expect(() => update.writeChanges(_('/foo/package.json'))).not.toThrow();
+          expect(() => update.writeChanges(_('/foo/package.json')))
+              .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+          expect(() => update.writeChanges(_('/bar/package.json')))
+              .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+        });
+      });
+
+      describe('(on cluster worker)', () => {
+        beforeEach(() => setMockClusterIsMasterValue(false));
+
+        it('should send an `update-package-json` message to the master process', () => {
+          const jsonPath = _('/foo/package.json');
+
+          const writeToProp = (propPath: string[], parsed?: JsonObject) =>
+              updater.createUpdate().addChange(propPath, 'updated').writeChanges(jsonPath, parsed);
+
+          writeToProp(['foo']);
+          expect(processSendSpy).toHaveBeenCalledWith({
+            type: 'update-package-json',
+            packageJsonPath: jsonPath,
+            changes: [[['foo'], 'updated']],
+          });
+
+          writeToProp(['bar', 'baz', 'qux'], {});
+          expect(processSendSpy).toHaveBeenCalledWith({
+            type: 'update-package-json',
+            packageJsonPath: jsonPath,
+            changes: [[['bar', 'baz', 'qux'], 'updated']],
+          });
+        });
+
+        it('should update an in-memory representation (if provided)', () => {
+          const jsonPath = _('/foo/package.json');
+          const parsedJson: JsonObject = {
+            foo: true,
+            bar: {baz: 'OK'},
+          };
+
+          const update =
+              updater.createUpdate().addChange(['foo'], false).addChange(['bar', 'baz'], 42);
+
+          // Not updated yet.
+          expect(parsedJson).toEqual({
+            foo: true,
+            bar: {baz: 'OK'},
+          });
+
+          update.writeChanges(jsonPath, parsedJson);
+
+          // Updated now.
+          expect(parsedJson).toEqual({
+            foo: false,
+            bar: {baz: 42},
+          });
+        });
+
+        it('should create any missing ancestor objects', () => {
+          const jsonPath = _('/foo/package.json');
+          const parsedJson: JsonObject = {foo: {}};
+
+          updater.createUpdate()
+              .addChange(['foo', 'bar', 'baz', 'qux'], 'updated')
+              .writeChanges(jsonPath, parsedJson);
+
+          expect(parsedJson).toEqual({
+            foo: {
+              bar: {
+                baz: {
+                  qux: 'updated',
+                },
+              },
+            },
+          });
+        });
+
+        it('should throw, if a property-path is empty', () => {
+          const jsonPath = _('/foo/package.json');
+
+          expect(() => updater.createUpdate().addChange([], 'missing').writeChanges(jsonPath, {}))
+              .toThrowError(`Missing property path for writing value to '${jsonPath}'.`);
+        });
+
+        it('should throw, if a property-path points to a non-object intermediate value', () => {
+          const jsonPath = _('/foo/package.json');
+          const parsedJson = {foo: null, bar: 42, baz: {qux: []}};
+
+          const writeToProp = (propPath: string[], parsed?: JsonObject) =>
+              updater.createUpdate().addChange(propPath, 'updated').writeChanges(jsonPath, parsed);
+
+          expect(() => writeToProp(['foo', 'child'], parsedJson))
+              .toThrowError('Property path \'foo.child\' does not point to an object.');
+          expect(() => writeToProp(['bar', 'child'], parsedJson))
+              .toThrowError('Property path \'bar.child\' does not point to an object.');
+          expect(() => writeToProp(['baz', 'qux', 'child'], parsedJson))
+              .toThrowError('Property path \'baz.qux.child\' does not point to an object.');
+
+          // It should not throw, if no parsed representation is provided.
+          // (The error will still be thrown on the master process, but that is out of scope for
+          // this test.)
+          expect(() => writeToProp(['foo', 'child'])).not.toThrow();
+        });
+
+        it('should throw, if trying to re-apply an already applied update', () => {
+          const update = updater.createUpdate().addChange(['foo'], 'updated');
+
+          expect(() => update.writeChanges(_('/foo/package.json'))).not.toThrow();
+          expect(() => update.writeChanges(_('/foo/package.json')))
+              .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+          expect(() => update.writeChanges(_('/bar/package.json')))
+              .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+        });
+      });
+    });
+
+    // Helpers
+    class MockPackageJsonUpdater implements PackageJsonUpdater {
+      createUpdate = jasmine.createSpy('MockPackageJsonUpdater#createUpdate');
+      writeChanges = jasmine.createSpy('MockPackageJsonUpdater#writeChanges');
+    }
+  });
+});

--- a/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/// <reference types="node" />
+
+import * as cluster from 'cluster';
+import {EventEmitter} from 'events';
+
+import {Task, TaskCompletedCallback, TaskProcessingOutcome} from '../../../src/execution/api';
+import {ClusterWorker} from '../../../src/execution/cluster/worker';
+import {mockProperty} from '../../helpers/spy_utils';
+
+
+describe('ClusterWorker', () => {
+  const setMockClusterIsMasterValue = mockProperty(cluster, 'isMaster');
+  const setMockProcessSendValue = mockProperty(process, 'send');
+  let processSendSpy: jasmine.Spy;
+  let compileFnSpy: jasmine.Spy;
+  let createCompileFnSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    compileFnSpy = jasmine.createSpy('compileFn');
+    createCompileFnSpy = jasmine.createSpy('createCompileFn').and.returnValue(compileFnSpy);
+
+    processSendSpy = jasmine.createSpy('process.send');
+    setMockProcessSendValue(processSendSpy);
+  });
+
+  describe('constructor()', () => {
+    describe('(on cluster master)', () => {
+      beforeEach(() => setMockClusterIsMasterValue(true));
+
+      it('should throw an error', () => {
+        expect(() => new ClusterWorker(createCompileFnSpy))
+            .toThrowError('Tried to instantiate `ClusterWorker` on the master process.');
+        expect(createCompileFnSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('(on cluster worker)', () => {
+      beforeEach(() => setMockClusterIsMasterValue(false));
+
+      it('should create the `compileFn()`', () => {
+        new ClusterWorker(createCompileFnSpy);
+        expect(createCompileFnSpy).toHaveBeenCalledWith(jasmine.any(Function));
+      });
+
+      it('should set up `compileFn()` to send a `task-completed` message to master', () => {
+        new ClusterWorker(createCompileFnSpy);
+        const onTaskCompleted: TaskCompletedCallback = createCompileFnSpy.calls.argsFor(0)[0];
+
+        onTaskCompleted(null as any, TaskProcessingOutcome.AlreadyProcessed);
+        expect(processSendSpy).toHaveBeenCalledTimes(1);
+        expect(processSendSpy).toHaveBeenCalledWith({
+          type: 'task-completed',
+          outcome: TaskProcessingOutcome.AlreadyProcessed,
+        });
+
+        onTaskCompleted(null as any, TaskProcessingOutcome.Processed);
+        expect(processSendSpy).toHaveBeenCalledTimes(2);
+        expect(processSendSpy).toHaveBeenCalledWith({
+          type: 'task-completed',
+          outcome: TaskProcessingOutcome.Processed,
+        });
+      });
+    });
+  });
+
+  describe('run()', () => {
+    describe(
+        '(on cluster master)',
+        () => {/* No tests needed, becasue the constructor would have thrown. */});
+
+    describe('(on cluster worker)', () => {
+      // The `cluster.worker` property is normally `undefined` on the master process and set to the
+      // current `cluster.Worker` on worker processes.
+      const setMockClusterWorkerValue = mockProperty(cluster, 'worker');
+      let worker: ClusterWorker;
+
+      beforeEach(() => {
+        setMockClusterIsMasterValue(false);
+        setMockClusterWorkerValue(Object.assign(new EventEmitter(), {id: 42}) as cluster.Worker);
+
+        worker = new ClusterWorker(createCompileFnSpy);
+      });
+
+      it('should return a promise (that is never resolved)', done => {
+        const promise = worker.run();
+
+        expect(promise).toEqual(jasmine.any(Promise));
+
+        promise.then(
+            () => done.fail('Expected promise not to resolve'),
+            () => done.fail('Expected promise not to reject'));
+
+        // We can't wait forever to verify that the promise is not resolved, but at least verify
+        // that it is not resolved immediately.
+        setTimeout(done, 100);
+      });
+
+      it('should handle `process-task` messages', () => {
+        const mockTask = { foo: 'bar' } as unknown as Task;
+
+        worker.run();
+        cluster.worker.emit('message', {type: 'process-task', task: mockTask});
+
+        expect(compileFnSpy).toHaveBeenCalledWith(mockTask);
+        expect(processSendSpy).not.toHaveBeenCalled();
+      });
+
+      it('should send errors during task processing back to the master process', () => {
+        let err: string|Error;
+        compileFnSpy.and.callFake(() => { throw err; });
+
+        worker.run();
+
+        err = 'Error string.';
+        cluster.worker.emit('message', {type: 'process-task', task: {} as Task});
+        expect(processSendSpy).toHaveBeenCalledWith({type: 'error', error: err});
+
+        err = new Error('Error object.');
+        cluster.worker.emit('message', {type: 'process-task', task: {} as Task});
+        expect(processSendSpy).toHaveBeenCalledWith({type: 'error', error: err.stack});
+      });
+
+      it('should throw, when an unknown message type is received', () => {
+        worker.run();
+        cluster.worker.emit('message', {type: 'unknown', foo: 'bar'});
+
+        expect(compileFnSpy).not.toHaveBeenCalled();
+        expect(processSendSpy).toHaveBeenCalledWith({
+          type: 'error',
+          error: jasmine.stringMatching(
+              'Error: Invalid message received on worker #42: {"type":"unknown","foo":"bar"}'),
+        });
+      });
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
@@ -17,8 +17,8 @@ import {mockProperty} from '../../helpers/spy_utils';
 
 
 describe('ClusterWorker', () => {
-  const setMockClusterIsMasterValue = mockProperty(cluster, 'isMaster');
-  const setMockProcessSendValue = mockProperty(process, 'send');
+  const runAsClusterMaster = mockProperty(cluster, 'isMaster');
+  const mockProcessSend = mockProperty(process, 'send');
   let processSendSpy: jasmine.Spy;
   let compileFnSpy: jasmine.Spy;
   let createCompileFnSpy: jasmine.Spy;
@@ -28,12 +28,12 @@ describe('ClusterWorker', () => {
     createCompileFnSpy = jasmine.createSpy('createCompileFn').and.returnValue(compileFnSpy);
 
     processSendSpy = jasmine.createSpy('process.send');
-    setMockProcessSendValue(processSendSpy);
+    mockProcessSend(processSendSpy);
   });
 
   describe('constructor()', () => {
     describe('(on cluster master)', () => {
-      beforeEach(() => setMockClusterIsMasterValue(true));
+      beforeEach(() => runAsClusterMaster(true));
 
       it('should throw an error', () => {
         expect(() => new ClusterWorker(createCompileFnSpy))
@@ -43,7 +43,7 @@ describe('ClusterWorker', () => {
     });
 
     describe('(on cluster worker)', () => {
-      beforeEach(() => setMockClusterIsMasterValue(false));
+      beforeEach(() => runAsClusterMaster(false));
 
       it('should create the `compileFn()`', () => {
         new ClusterWorker(createCompileFnSpy);
@@ -79,12 +79,12 @@ describe('ClusterWorker', () => {
     describe('(on cluster worker)', () => {
       // The `cluster.worker` property is normally `undefined` on the master process and set to the
       // current `cluster.Worker` on worker processes.
-      const setMockClusterWorkerValue = mockProperty(cluster, 'worker');
+      const mockClusterWorker = mockProperty(cluster, 'worker');
       let worker: ClusterWorker;
 
       beforeEach(() => {
-        setMockClusterIsMasterValue(false);
-        setMockClusterWorkerValue(Object.assign(new EventEmitter(), {id: 42}) as cluster.Worker);
+        runAsClusterMaster(false);
+        mockClusterWorker(Object.assign(new EventEmitter(), {id: 42}) as cluster.Worker);
 
         worker = new ClusterWorker(createCompileFnSpy);
       });

--- a/packages/compiler-cli/ngcc/test/execution/task_selection/parallel_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/task_selection/parallel_task_queue_spec.ts
@@ -1,0 +1,556 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DepGraph} from 'dependency-graph';
+
+import {PartiallyOrderedTasks, Task, TaskQueue} from '../../../src/execution/api';
+import {ParallelTaskQueue} from '../../../src/execution/task_selection/parallel_task_queue';
+import {EntryPoint} from '../../../src/packages/entry_point';
+
+
+describe('ParallelTaskQueue', () => {
+  // Helpers
+  /**
+   * Create a `TaskQueue` by generating mock tasks (optionally with interdependencies).
+   *
+   * NOTE 1: The first task for each entry-point generates typings (which is similar to what happens
+   *         in the actual code).
+   * NOTE 2: The `ParallelTaskQueue` implementation relies on the fact that tasks are sorted in such
+   *         a way that a task can only be blocked by earlier tasks (i.e. dependencies always come
+   *         before dependants in the list of tasks).
+   *         To preserve this attribute, you need to ensure that entry-points will only depend on
+   *         entry-points with a lower index. Take this into account when defining `entryPointDeps`.
+   *         (Failing to do so, will result in an error.)
+   *
+   * @param entryPointCount The number of different entry-points to mock.
+   * @param tasksPerEntryPointCount The number of tasks to generate per entry-point (i.e. simulating
+   *                                processing multiple format properties).
+   * @param entryPointDeps An object mapping an entry-point to its dependencies. Keys are
+   *                       entry-point indices and values are arrays of entry-point indices that the
+   *                       entry-point corresponding to the key depends on.
+   *                       For example, if entry-point #2 depends on entry-points #0 and #1,
+   *                       `entryPointDeps` would be `{2: [0, 1]}`.
+   * @return An object with the following properties:
+   *         - `graph`: The dependency graph for the generated mock entry-point.
+   *         - `tasks`: The (partially ordered) list of generated mock tasks.
+   *         - `queue`: The created `TaskQueue`.
+   */
+  const createQueue = (entryPointCount: number, tasksPerEntryPointCount = 1, entryPointDeps: {
+    [entryPointIndex: string]: number[]
+  } = {}): {tasks: PartiallyOrderedTasks, graph: DepGraph<EntryPoint>, queue: TaskQueue} => {
+    const entryPoints: EntryPoint[] = [];
+    const tasks: PartiallyOrderedTasks = [] as any;
+    const graph = new DepGraph<EntryPoint>();
+
+    // Create the entry-points and the associated tasks.
+    for (let epIdx = 0; epIdx < entryPointCount; epIdx++) {
+      const entryPoint = {
+        name: `entry-point-${epIdx}`,
+        path: `/path/to/entry/point/${epIdx}`,
+      } as EntryPoint;
+
+      entryPoints.push(entryPoint);
+      graph.addNode(entryPoint.path);
+
+      for (let tIdx = 0; tIdx < tasksPerEntryPointCount; tIdx++) {
+        tasks.push({ entryPoint, formatProperty: `prop-${tIdx}`, processDts: tIdx === 0, } as Task);
+      }
+    }
+
+    // Define entry-point interdependencies.
+    for (const epIdx of Object.keys(entryPointDeps).map(strIdx => +strIdx)) {
+      const fromPath = entryPoints[epIdx].path;
+      for (const depIdx of entryPointDeps[epIdx]) {
+        // Ensure that each entry-point only depends on entry-points at a lower index.
+        if (depIdx >= epIdx) {
+          throw Error(
+              'Invalid `entryPointDeps`: Entry-points can only depend on entry-points at a lower ' +
+              `index, but entry-point #${epIdx} depends on #${depIdx} in: ` +
+              JSON.stringify(entryPointDeps, null, 2));
+        }
+
+        const toPath = entryPoints[depIdx].path;
+        graph.addDependency(fromPath, toPath);
+      }
+    }
+
+    return {tasks, graph, queue: new ParallelTaskQueue(tasks.slice(), graph)};
+  };
+
+  /**
+   * Simulate processing the next task:
+   * - Request the next task from the specified queue.
+   * - If a task was returned, mark it as completed.
+   * - Return the task (this allows making assertions against the picked tasks in tests).
+   *
+   * @param queue The `TaskQueue` to get the next task from.
+   * @return The "processed" task (if any).
+   */
+  const processNextTask = (queue: TaskQueue): ReturnType<TaskQueue['getNextTask']> => {
+    const task = queue.getNextTask();
+    if (task !== null) queue.markTaskCompleted(task);
+    return task;
+  };
+
+  describe('allTaskCompleted', () => {
+    it('should be `false`, when there are unprocessed tasks', () => {
+      const {queue} = createQueue(2);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(false);
+    });
+
+    it('should be `false`, when there are tasks in progress', () => {
+      const {queue} = createQueue(2);
+
+      queue.getNextTask();
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(false);  // The first task is still in progress.
+    });
+
+    it('should be `true`, when there are no unprocess or in-progress tasks', () => {
+      const {queue} = createQueue(3);
+
+      const task1 = queue.getNextTask() !;
+      const task2 = queue.getNextTask() !;
+      const task3 = queue.getNextTask() !;
+      expect(queue.allTasksCompleted).toBe(false);
+
+      queue.markTaskCompleted(task1);
+      queue.markTaskCompleted(task3);
+      expect(queue.allTasksCompleted).toBe(false);  // The second task is still in progress.
+
+      queue.markTaskCompleted(task2);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should be `true`, if the queue was empty from the beginning', () => {
+      const {queue} = createQueue(0);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should remain `true` once the queue has been emptied', () => {
+      const {queue} = createQueue(1);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(true);
+
+      queue.getNextTask();
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+  });
+
+  describe('constructor()', () => {
+    it('should throw, if there are multiple tasks that generate typings for a single entry-point',
+       () => {
+         const {tasks, graph} = createQueue(2, 2, {
+           0: [],   // Entry-point #0 does not depend on anything.
+           1: [0],  // Entry-point #1 depends on #0.
+         });
+         tasks[1].processDts = true;  // Tweak task #1 to also generate typings.
+
+         expect(() => new ParallelTaskQueue(tasks, graph))
+             .toThrowError(
+                 'Invariant violated: Multiple tasks are assigned generating typings for ' +
+                 '\'/path/to/entry/point/0\':\n' +
+                 '  - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+                 '  - {entryPoint: entry-point-0, formatProperty: prop-1, processDts: true}');
+       });
+  });
+
+  describe('getNextTask()', () => {
+    it('should return the tasks in order (when they are not blocked by other tasks)', () => {
+      const {tasks, queue} = createQueue(3, 2, {});  // 2 tasks per entry-point; no dependencies.
+
+      expect(queue.getNextTask()).toBe(tasks[0]);
+      expect(queue.getNextTask()).toBe(tasks[1]);
+      expect(queue.getNextTask()).toBe(tasks[2]);
+      expect(queue.getNextTask()).toBe(tasks[3]);
+      expect(queue.getNextTask()).toBe(tasks[4]);
+      expect(queue.getNextTask()).toBe(tasks[5]);
+    });
+
+    it('should return `null`, when there are no more tasks', () => {
+      const {tasks, queue} = createQueue(3);
+      tasks.forEach(() => expect(queue.getNextTask()).not.toBe(null));
+
+      expect(queue.getNextTask()).toBe(null);
+      expect(queue.getNextTask()).toBe(null);
+
+      const {tasks: tasks2, queue: queue2} = createQueue(0);
+
+      expect(tasks2).toEqual([]);
+      expect(queue.getNextTask()).toBe(null);
+      expect(queue.getNextTask()).toBe(null);
+    });
+
+    it('should return `null`, if all unprocessed tasks are blocked', () => {
+      const {tasks, queue} = createQueue(2, 2, {
+        0: [],   // Entry-point #0 does not depend on anything.
+        1: [0],  // Entry-point #1 depends on #0.
+      });
+
+      // Verify that the first two tasks are for the first entry-point.
+      expect(tasks[0].entryPoint.name).toBe('entry-point-0');
+      expect(tasks[1].entryPoint.name).toBe('entry-point-0');
+
+      // Verify that the last two tasks are for the second entry-point.
+      expect(tasks[2].entryPoint.name).toBe('entry-point-1');
+      expect(tasks[3].entryPoint.name).toBe('entry-point-1');
+
+      // Return the first two tasks first, since they are not blocked.
+      expect(queue.getNextTask()).toBe(tasks[0]);
+      expect(queue.getNextTask()).toBe(tasks[1]);
+
+      // No task available, until task #0 (which geenrates typings for entry-point #0) is completed.
+      expect(tasks[0].processDts).toBe(true);
+      expect(tasks[1].processDts).toBe(false);
+
+      queue.markTaskCompleted(tasks[1]);
+      expect(queue.getNextTask()).toBe(null);
+
+      // Finally, unblock tasks for entry-point #1, once task #0 is completed.
+      queue.markTaskCompleted(tasks[0]);
+      expect(queue.getNextTask()).toBe(tasks[2]);
+      expect(queue.getNextTask()).toBe(tasks[3]);
+    });
+
+    it('should prefer tasks that are blocking many tasks', () => {
+      // Tasks by priority: #1, #0, #2, #3
+      // - Entry-point #0 transitively blocks 1 entry-point(s): 2
+      // - Entry-point #1 transitively blocks 2 entry-point(s): 2, 3
+      // - Entry-point #2 transitively blocks 0 entry-point(s): -
+      // - Entry-point #3 transitively blocks 0 entry-point(s): -
+      const {tasks, queue} = createQueue(5, 1, {
+        0: [],
+        1: [],
+        2: [0, 1],
+        3: [1],
+      });
+
+      // First return task #1, since it blocks the most other tasks.
+      expect(processNextTask(queue)).toBe(tasks[1]);
+
+      // Then return task #0, since it blocks the most other tasks after #1.
+      expect(processNextTask(queue)).toBe(tasks[0]);
+
+      // Then return task #2, since it comes before #3.
+      expect(processNextTask(queue)).toBe(tasks[2]);
+
+      // Finally return task #3.
+      expect(processNextTask(queue)).toBe(tasks[3]);
+    });
+
+    it('should return a lower priority task, if higher priority tasks are blocked', () => {
+      // Tasks by priority: #0, #1, #3, #2, #4
+      // - Entry-point #0 transitively blocks 3 entry-point(s): 1, 2, 4
+      // - Entry-point #1 transitively blocks 2 entry-point(s): 2, 4
+      // - Entry-point #2 transitively blocks 0 entry-point(s): -
+      // - Entry-point #3 transitively blocks 1 entry-point(s): 4
+      // - Entry-point #4 transitively blocks 0 entry-point(s): -
+      const deps = {
+        0: [],
+        1: [0],
+        2: [0, 1],
+        3: [],
+        4: [0, 1, 3],
+      };
+
+      const {tasks, queue} = createQueue(5, 1, deps);
+
+      // First return task #0, since that blocks the most other tasks.
+      expect(queue.getNextTask()).toBe(tasks[0]);
+
+      // While task #0 is still in progress, return task #3.
+      // Despite task #3's having a lower priority than #1 (blocking 1 vs 2 other tasks), task #1 is
+      // currently blocked on #0 (while #3 is not blocked by anything).
+      expect(queue.getNextTask()).toBe(tasks[3]);
+
+      // Use the same dependencies as above, but complete task #0 before asking for another task to
+      // verify that task #1 would be returned in this case.
+      const {tasks: tasks2, queue: queue2} = createQueue(5, 1, deps);
+
+      expect(processNextTask(queue2)).toBe(tasks2[0]);
+      expect(processNextTask(queue2)).toBe(tasks2[1]);
+    });
+
+    it('should keep they initial relative order of tasks for tasks with the same priority', () => {
+      // Tasks by priority: #1, #3, #0, #2, #4
+      // - Entry-point #0 transitively blocks 0 entry-point(s): -
+      // - Entry-point #1 transitively blocks 1 entry-point(s): 2
+      // - Entry-point #2 transitively blocks 0 entry-point(s): -
+      // - Entry-point #3 transitively blocks 1 entry-point(s): 4
+      // - Entry-point #4 transitively blocks 0 entry-point(s): -
+      const {tasks, queue} = createQueue(5, 1, {
+        0: [],
+        1: [],
+        2: [1],
+        3: [],
+        4: [3],
+      });
+
+      // First return task #1 (even if it has the same priority as #3), because it comes before #3
+      // in the initial task list.
+      // Note that task #0 is not returned (even if it comes first in the initial task list),
+      // because it has a lower priority (i.e. blocks fewer other tasks).
+      expect(processNextTask(queue)).toBe(tasks[1]);
+
+      // Then return task #3 (skipping over both #0 and #2), becasue it blocks the most other tasks.
+      expect(processNextTask(queue)).toBe(tasks[3]);
+
+      // The rest of the tasks (#0, #2, #4) block no tasks, so their initial relative order is
+      // preserved.
+      expect(queue.getNextTask()).toBe(tasks[0]);
+      expect(queue.getNextTask()).toBe(tasks[2]);
+      expect(queue.getNextTask()).toBe(tasks[4]);
+    });
+  });
+
+  describe('markTaskCompleted()', () => {
+    it('should mark a task as completed', () => {
+      const {queue} = createQueue(2);
+
+      const task1 = queue.getNextTask() !;
+      const task2 = queue.getNextTask() !;
+      expect(queue.allTasksCompleted).toBe(false);
+
+      queue.markTaskCompleted(task1);
+      queue.markTaskCompleted(task2);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should throw, if the specified task is not in progress', () => {
+      const {tasks, queue} = createQueue(3);
+      queue.getNextTask();
+
+      expect(() => queue.markTaskCompleted(tasks[2]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as completed: ` +
+              `{entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}`);
+    });
+
+    it('should remove the completed task from the lists of blocking tasks (so other tasks can be unblocked)',
+       () => {
+         const {tasks, queue} = createQueue(3, 1, {
+           0: [],      // Entry-point #0 does not depend on anything.
+           1: [0],     // Entry-point #1 depends on #0.
+           2: [0, 1],  // Entry-point #2 depends on #0 and #1.
+         });
+
+         // Pick task #0 first, since it is the only one that is not blocked by other tasks.
+         expect(queue.getNextTask()).toBe(tasks[0]);
+
+         // No task available, until task #0 is completed.
+         expect(queue.getNextTask()).toBe(null);
+
+         // Once task #0 is completed, task #1 is unblocked.
+         queue.markTaskCompleted(tasks[0]);
+         expect(queue.getNextTask()).toBe(tasks[1]);
+
+         // Task #2 is still blocked on #1.
+         expect(queue.getNextTask()).toBe(null);
+
+         // Once task #1 is completed, task #2 is unblocked.
+         queue.markTaskCompleted(tasks[1]);
+         expect(queue.getNextTask()).toBe(tasks[2]);
+       });
+  });
+
+  describe('toString()', () => {
+    it('should include the `TaskQueue` constructor\'s name', () => {
+      const {queue} = createQueue(0);
+      expect(queue.toString()).toMatch(/^ParallelTaskQueue\n/);
+    });
+
+    it('should include the value of `allTasksCompleted`', () => {
+      const {queue: queue1} = createQueue(0);
+      expect(queue1.toString()).toContain('  All tasks completed: true\n');
+
+      const {queue: queue2} = createQueue(3);
+      expect(queue2.toString()).toContain('  All tasks completed: false\n');
+
+      processNextTask(queue2);
+      processNextTask(queue2);
+      const task = queue2.getNextTask() !;
+
+      expect(queue2.toString()).toContain('  All tasks completed: false\n');
+
+      queue2.markTaskCompleted(task);
+      expect(queue2.toString()).toContain('  All tasks completed: true\n');
+    });
+
+    it('should include the unprocessed tasks', () => {
+      const {queue} = createQueue(3);
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (3): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n');
+
+      const task1 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (2): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n');
+
+      queue.markTaskCompleted(task1);
+      const task2 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n');
+
+      queue.markTaskCompleted(task2);
+      processNextTask(queue);
+      expect(queue.toString()).toContain('  Unprocessed tasks (0): \n');
+    });
+
+    it('should include the in-progress tasks', () => {
+      const {queue} = createQueue(3);
+      expect(queue.toString()).toContain('  In-progress tasks (0): \n');
+
+      const task1 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  In-progress tasks (1): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n');
+
+      queue.markTaskCompleted(task1);
+      const task2 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  In-progress tasks (1): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n');
+
+      queue.markTaskCompleted(task2);
+      processNextTask(queue);
+      expect(queue.toString()).toContain('  In-progress tasks (0): \n');
+    });
+
+    it('should include the blocked/blocking tasks', () => {
+      // Entry-point #0 transitively blocks 2 entry-point(s): 1, 3
+      // Entry-point #1 transitively blocks 1 entry-point(s): 3
+      // Entry-point #2 transitively blocks 1 entry-point(s): 3
+      // Entry-point #3 transitively blocks 0 entry-point(s): -
+      const {tasks, queue} = createQueue(4, 2, {
+        1: [0],
+        3: [1, 2],
+      });
+
+      // Since there 4 entry-points and two tasks per entry-point (8 tasks in total), in comments
+      // below, tasks are denoted as `#X.Y` (where `X` is the entry-point index and Y is the task
+      // index).
+      // For example, the second task for the third entry-point would be `#2.1`.
+
+      expect(queue.toString())
+          .toContain(
+              '  Blocked tasks (4): \n' +
+              // Tasks #1.0 and #1.1 are blocked by #0.0.
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true} (1): \n' +
+              '        - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false} (1): \n' +
+              '        - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              // Tasks #3.0 and #3.1 are blocked by #0.0 (transitively), #1.0 and #2.0.
+              '    - {entryPoint: entry-point-3, formatProperty: prop-0, processDts: true} (3): \n' +
+              '        - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '        - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '        - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-3, formatProperty: prop-1, processDts: false} (3): \n' +
+              '        - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '        - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '        - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}');
+
+      expect(processNextTask(queue)).toBe(tasks[0]);  // Process #0.0.
+      expect(processNextTask(queue)).toBe(tasks[2]);  // Process #1.0.
+      expect(queue.toString())
+          .toContain(
+              '  Blocked tasks (2): \n' +
+              // Tasks #3.0 and #3.1 are blocked by #2.0.
+              '    - {entryPoint: entry-point-3, formatProperty: prop-0, processDts: true} (1): \n' +
+              '        - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-3, formatProperty: prop-1, processDts: false} (1): \n' +
+              '        - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}');
+
+      expect(processNextTask(queue)).toBe(tasks[4]);  // Process #2.0.
+      expect(queue.toString()).toContain('  Blocked tasks (0): ');
+    });
+
+    it('should display all info together', () => {
+      // An initially empty queue.
+      const {queue: queue1} = createQueue(0);
+      expect(queue1.toString())
+          .toBe(
+              'ParallelTaskQueue\n' +
+              '  All tasks completed: true\n' +
+              '  Unprocessed tasks (0): \n' +
+              '  In-progress tasks (0): \n' +
+              '  Blocked tasks (0): ');
+
+      // A queue with three tasks (and one interdependency).
+      const {tasks: tasks2, queue: queue2} = createQueue(3, 1, {2: [1]});
+      expect(queue2.toString())
+          .toBe(
+              'ParallelTaskQueue\n' +
+              '  All tasks completed: false\n' +
+              '  Unprocessed tasks (3): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n' +
+              '  In-progress tasks (0): \n' +
+              '  Blocked tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true} (1): \n' +
+              '        - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}');
+
+      // Start processing tasks #1 and #0 (#2 is still blocked on #1).
+      expect(queue2.getNextTask()).toBe(tasks2[1]);
+      expect(queue2.getNextTask()).toBe(tasks2[0]);
+      expect(queue2.toString())
+          .toBe(
+              'ParallelTaskQueue\n' +
+              '  All tasks completed: false\n' +
+              '  Unprocessed tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n' +
+              '  In-progress tasks (2): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '  Blocked tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true} (1): \n' +
+              '        - {entryPoint: entry-point-1, formatProperty: prop-0, processDts: true}');
+
+      // Complete task #1 nd start processing #2 (which is not unblocked).
+      queue2.markTaskCompleted(tasks2[1]);
+      expect(queue2.getNextTask()).toBe(tasks2[2]);
+      expect(queue2.toString())
+          .toBe(
+              'ParallelTaskQueue\n' +
+              '  All tasks completed: false\n' +
+              '  Unprocessed tasks (0): \n' +
+              '  In-progress tasks (2): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}\n' +
+              '  Blocked tasks (0): ');
+
+      // Complete tasks #2 and #0. All tasks are now completed.
+      queue2.markTaskCompleted(tasks2[2]);
+      queue2.markTaskCompleted(tasks2[0]);
+      expect(queue2.toString())
+          .toBe(
+              'ParallelTaskQueue\n' +
+              '  All tasks completed: true\n' +
+              '  Unprocessed tasks (0): \n' +
+              '  In-progress tasks (0): \n' +
+              '  Blocked tasks (0): ');
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/execution/task_selection/serial_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/task_selection/serial_task_queue_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Task, TaskQueue} from '../../../src/execution/api';
+import {PartiallyOrderedTasks, Task, TaskQueue} from '../../../src/execution/api';
 import {SerialTaskQueue} from '../../../src/execution/task_selection/serial_task_queue';
 
 
@@ -15,15 +15,15 @@ describe('SerialTaskQueue', () => {
   /**
    * Create a `TaskQueue` by generating mock tasks.
    *
-   * NOTE: Tasks as even indices generate typings.
+   * NOTE: Tasks at even indices generate typings.
    *
    * @param taskCount The number of tasks to generate.
    * @return An object with the following properties:
-   *         - `tasks`: The list of generated mock tasks.
+   *         - `tasks`: The (partially ordered) list of generated mock tasks.
    *         - `queue`: The created `TaskQueue`.
    */
-  const createQueue = (taskCount: number): {tasks: Task[], queue: TaskQueue} => {
-    const tasks: Task[] = [];
+  const createQueue = (taskCount: number): {tasks: PartiallyOrderedTasks, queue: TaskQueue} => {
+    const tasks: PartiallyOrderedTasks = [] as any;
     for (let i = 0; i < taskCount; i++) {
       tasks.push({
         entryPoint: {name: `entry-point-${i}`}, formatProperty: `prop-${i}`,
@@ -48,7 +48,7 @@ describe('SerialTaskQueue', () => {
     return task;
   };
 
-  describe('allTaskCompleted', () => {
+  describe('allTasksCompleted', () => {
     it('should be `false`, when there are unprocessed tasks', () => {
       const {queue} = createQueue(2);
       expect(queue.allTasksCompleted).toBe(false);
@@ -64,7 +64,7 @@ describe('SerialTaskQueue', () => {
       expect(queue.allTasksCompleted).toBe(false);
     });
 
-    it('should be `true`, when there are no unprocess or in-progress tasks', () => {
+    it('should be `true`, when there are no unprocessed or in-progress tasks', () => {
       const {queue} = createQueue(3);
 
       processNextTask(queue);

--- a/packages/compiler-cli/ngcc/test/execution/task_selection/serial_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/task_selection/serial_task_queue_spec.ts
@@ -1,0 +1,267 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Task, TaskQueue} from '../../../src/execution/api';
+import {SerialTaskQueue} from '../../../src/execution/task_selection/serial_task_queue';
+
+
+describe('SerialTaskQueue', () => {
+  // Helpers
+  /**
+   * Create a `TaskQueue` by generating mock tasks.
+   *
+   * NOTE: Tasks as even indices generate typings.
+   *
+   * @param taskCount The number of tasks to generate.
+   * @return An object with the following properties:
+   *         - `tasks`: The list of generated mock tasks.
+   *         - `queue`: The created `TaskQueue`.
+   */
+  const createQueue = (taskCount: number): {tasks: Task[], queue: TaskQueue} => {
+    const tasks: Task[] = [];
+    for (let i = 0; i < taskCount; i++) {
+      tasks.push({
+        entryPoint: {name: `entry-point-${i}`}, formatProperty: `prop-${i}`,
+            processDts: i % 2 === 0,
+      } as Task);
+    }
+    return {tasks, queue: new SerialTaskQueue(tasks.slice())};
+  };
+
+  /**
+   * Simulate processing the next task:
+   * - Request the next task from the specified queue.
+   * - If a task was returned, mark it as completed.
+   * - Return the task (this allows making assertions against the picked tasks in tests).
+   *
+   * @param queue The `TaskQueue` to get the next task from.
+   * @return The "processed" task (if any).
+   */
+  const processNextTask = (queue: TaskQueue): ReturnType<TaskQueue['getNextTask']> => {
+    const task = queue.getNextTask();
+    if (task !== null) queue.markTaskCompleted(task);
+    return task;
+  };
+
+  describe('allTaskCompleted', () => {
+    it('should be `false`, when there are unprocessed tasks', () => {
+      const {queue} = createQueue(2);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(false);
+    });
+
+    it('should be `false`, when there are tasks in progress', () => {
+      const {queue} = createQueue(1);
+      queue.getNextTask();
+
+      expect(queue.allTasksCompleted).toBe(false);
+    });
+
+    it('should be `true`, when there are no unprocess or in-progress tasks', () => {
+      const {queue} = createQueue(3);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should be `true`, if the queue was empty from the beginning', () => {
+      const {queue} = createQueue(0);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should remain `true` once the queue has been emptied', () => {
+      const {queue} = createQueue(1);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(true);
+
+      processNextTask(queue);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+  });
+
+  describe('getNextTask()', () => {
+    it('should return the tasks in order', () => {
+      const {tasks, queue} = createQueue(3);
+
+      expect(processNextTask(queue)).toBe(tasks[0]);
+      expect(processNextTask(queue)).toBe(tasks[1]);
+      expect(processNextTask(queue)).toBe(tasks[2]);
+    });
+
+    it('should return `null`, when there are no more tasks', () => {
+      const {tasks, queue} = createQueue(3);
+      tasks.forEach(() => expect(processNextTask(queue)).not.toBe(null));
+
+      expect(processNextTask(queue)).toBe(null);
+      expect(processNextTask(queue)).toBe(null);
+
+      const {tasks: tasks2, queue: queue2} = createQueue(0);
+
+      expect(tasks2).toEqual([]);
+      expect(processNextTask(queue2)).toBe(null);
+      expect(processNextTask(queue2)).toBe(null);
+    });
+
+    it('should throw, if a task is already in progress', () => {
+      const {queue} = createQueue(3);
+      queue.getNextTask();
+
+      expect(() => queue.getNextTask())
+          .toThrowError(
+              `Trying to get next task, while there is already a task in progress: ` +
+              `{entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}`);
+    });
+  });
+
+  describe('markTaskCompleted()', () => {
+    it('should mark a task as completed, so that the next task can be picked', () => {
+      const {queue} = createQueue(3);
+      const task = queue.getNextTask() !;
+
+      expect(() => queue.getNextTask()).toThrow();
+
+      queue.markTaskCompleted(task);
+      expect(() => queue.getNextTask()).not.toThrow();
+    });
+
+    it('should throw, if the specified task is not in progress', () => {
+      const {tasks, queue} = createQueue(3);
+      queue.getNextTask();
+
+      expect(() => queue.markTaskCompleted(tasks[2]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as completed: ` +
+              `{entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}`);
+    });
+  });
+
+  describe('toString()', () => {
+    it('should include the `TaskQueue` constructor\'s name', () => {
+      const {queue} = createQueue(0);
+      expect(queue.toString()).toMatch(/^SerialTaskQueue\n/);
+    });
+
+    it('should include the value of `allTasksCompleted`', () => {
+      const {queue: queue1} = createQueue(0);
+      expect(queue1.toString()).toContain('  All tasks completed: true\n');
+
+      const {queue: queue2} = createQueue(3);
+      expect(queue2.toString()).toContain('  All tasks completed: false\n');
+
+      processNextTask(queue2);
+      processNextTask(queue2);
+      const task = queue2.getNextTask() !;
+
+      expect(queue2.toString()).toContain('  All tasks completed: false\n');
+
+      queue2.markTaskCompleted(task);
+      expect(queue2.toString()).toContain('  All tasks completed: true\n');
+    });
+
+    it('should include the unprocessed tasks', () => {
+      const {queue} = createQueue(3);
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (3): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n');
+
+      const task1 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (2): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n');
+
+      queue.markTaskCompleted(task1);
+      const task2 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  Unprocessed tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n');
+
+      queue.markTaskCompleted(task2);
+      processNextTask(queue);
+      expect(queue.toString()).toContain('  Unprocessed tasks (0): \n');
+    });
+
+    it('should include the in-progress tasks', () => {
+      const {queue} = createQueue(3);
+      expect(queue.toString()).toContain('  In-progress tasks (0): ');
+
+      const task1 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  In-progress tasks (1): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}');
+
+      queue.markTaskCompleted(task1);
+      const task2 = queue.getNextTask() !;
+      expect(queue.toString())
+          .toContain(
+              '  In-progress tasks (1): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}');
+
+      queue.markTaskCompleted(task2);
+      processNextTask(queue);
+      expect(queue.toString()).toContain('  In-progress tasks (0): ');
+    });
+
+    it('should display all info together', () => {
+      const {queue: queue1} = createQueue(0);
+      expect(queue1.toString())
+          .toBe(
+              'SerialTaskQueue\n' +
+              '  All tasks completed: true\n' +
+              '  Unprocessed tasks (0): \n' +
+              '  In-progress tasks (0): ');
+
+      const {queue: queue2} = createQueue(3);
+      expect(queue2.toString())
+          .toBe(
+              'SerialTaskQueue\n' +
+              '  All tasks completed: false\n' +
+              '  Unprocessed tasks (3): \n' +
+              '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}\n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n' +
+              '  In-progress tasks (0): ');
+
+      processNextTask(queue2);
+      const task = queue2.getNextTask() !;
+      expect(queue2.toString())
+          .toBe(
+              'SerialTaskQueue\n' +
+              '  All tasks completed: false\n' +
+              '  Unprocessed tasks (1): \n' +
+              '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n' +
+              '  In-progress tasks (1): \n' +
+              '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}');
+
+      queue2.markTaskCompleted(task);
+      processNextTask(queue2);
+      expect(queue2.toString())
+          .toBe(
+              'SerialTaskQueue\n' +
+              '  All tasks completed: true\n' +
+              '  Unprocessed tasks (0): \n' +
+              '  In-progress tasks (0): ');
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/helpers/spy_utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/spy_utils.ts
@@ -6,15 +6,63 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** An object with helpers for mocking/spying on an object's property. */
 export interface IPropertySpyHelpers<T, P extends keyof T> {
+  /**
+   * A `jasmine.Spy` for `get` operations on the property (i.e. reading the current property value).
+   * (This is useful in case one needs to make assertions against property reads.)
+   */
   getSpy: jasmine.Spy;
+
+  /**
+   * A `jasmine.Spy` for `set` operations on the property (i.e. setting a new property value).
+   * (This is useful in case one needs to make assertions against property writes.)
+   */
   setSpy: jasmine.Spy;
 
+  /** Install the getter/setter spies for the property. */
   installSpies(): void;
+
+  /**
+   * Uninstall the property spies and restore the original value (from before installing the
+   * spies), including the property descriptor.
+   */
   uninstallSpies(): void;
+
+  /** Update the current value of the mocked property. */
   setMockValue(value: T[P]): void;
 }
 
+/**
+ * Set up mocking an object's property (using spies) and return a function for updating the mocked
+ * property's value during tests.
+ *
+ * This is, essentially, a wrapper around `spyProperty()` which additionally takes care of
+ * installing the spies before each test (via `beforeEach()`) and uninstalling them after each test
+ * (via `afterEach()`).
+ *
+ * Example usage:
+ *
+ * ```ts
+ * describe('something', () => {
+ *   // Assuming `window.foo` is an object...
+ *   const mockWindowFooBar = mockProperty(window.foo, 'bar');
+ *
+ *   it('should do this', () => {
+ *     mockWindowFooBar('baz');
+ *     expect(window.foo.bar).toBe('baz');
+ *
+ *     mockWindowFooBar('qux');
+ *     expect(window.foo.bar).toBe('qux');
+ *   });
+ * });
+ * ```
+ *
+ * @param ctx The object whose property needs to be spied on.
+ * @param prop The name of the property to spy on.
+ *
+ * @return A function for updating the current value of the mocked property.
+ */
 export const mockProperty =
     <T, P extends keyof T>(ctx: T, prop: P): IPropertySpyHelpers<T, P>['setMockValue'] => {
       const {setMockValue, installSpies, uninstallSpies} = spyProperty(ctx, prop);
@@ -25,6 +73,21 @@ export const mockProperty =
       return setMockValue;
     };
 
+/**
+ * Return utility functions to help mock and spy on an object's property.
+ *
+ * It supports spying on properties that are either defined on the object instance itself or on its
+ * prototype. It also supports spying on non-writable properties (as long as they are configurable).
+ *
+ * NOTE: Unlike `jasmine`'s spying utilities, spies are not automatically installed/uninstalled, so
+ *       the caller is responsible for manually taking care of that (by calling
+ *       `installSpies()`/`uninstallSpies()` as necessary).
+ *
+ * @param ctx The object whose property needs to be spied on.
+ * @param prop The name of the property to spy on.
+ *
+ * @return An object with helpers for mocking/spying on an object's property.
+ */
 export const spyProperty = <T, P extends keyof T>(ctx: T, prop: P): IPropertySpyHelpers<T, P> => {
   const originalDescriptor = Object.getOwnPropertyDescriptor(ctx, prop);
 

--- a/packages/compiler-cli/ngcc/test/helpers/spy_utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/spy_utils.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface IPropertySpyHelpers<T, P extends keyof T> {
+  getSpy: jasmine.Spy;
+  setSpy: jasmine.Spy;
+
+  installSpies(): void;
+  uninstallSpies(): void;
+  setMockValue(value: T[P]): void;
+}
+
+export const mockProperty =
+    <T, P extends keyof T>(ctx: T, prop: P): IPropertySpyHelpers<T, P>['setMockValue'] => {
+      const {setMockValue, installSpies, uninstallSpies} = spyProperty(ctx, prop);
+
+      beforeEach(installSpies);
+      afterEach(uninstallSpies);
+
+      return setMockValue;
+    };
+
+export const spyProperty = <T, P extends keyof T>(ctx: T, prop: P): IPropertySpyHelpers<T, P> => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(ctx, prop);
+
+  let value = ctx[prop];
+  const setMockValue = (mockValue: typeof value) => value = mockValue;
+  const setSpy = jasmine.createSpy(`set ${prop}`).and.callFake(setMockValue);
+  const getSpy = jasmine.createSpy(`get ${prop}`).and.callFake(() => value);
+
+  const installSpies = () => {
+    value = ctx[prop];
+    Object.defineProperty(ctx, prop, {
+      configurable: true,
+      enumerable: originalDescriptor ? originalDescriptor.enumerable : true,
+      get: getSpy,
+      set: setSpy,
+    });
+  };
+  const uninstallSpies = () =>
+      originalDescriptor ? Object.defineProperty(ctx, prop, originalDescriptor) : delete ctx[prop];
+
+  return {installSpies, uninstallSpies, setMockValue, getSpy, setSpy};
+};

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -11,6 +11,7 @@ import {loadStandardTestFiles, loadTestFiles} from '../../../test/helpers';
 import {mainNgcc} from '../../src/main';
 import {markAsProcessed} from '../../src/packages/build_marker';
 import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES} from '../../src/packages/entry_point';
+import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
 import {MockLogger} from '../helpers/mock_logger';
 
 const testFiles = loadStandardTestFiles({fakeCore: false, rxjs: true});
@@ -19,10 +20,12 @@ runInEachFileSystem(() => {
   describe('ngcc main()', () => {
     let _: typeof absoluteFrom;
     let fs: FileSystem;
+    let pkgJsonUpdater: PackageJsonUpdater;
 
     beforeEach(() => {
       _ = absoluteFrom;
       fs = getFileSystem();
+      pkgJsonUpdater = new DirectPackageJsonUpdater(fs);
       initMockFileSystem(fs, testFiles);
     });
 
@@ -195,7 +198,8 @@ runInEachFileSystem(() => {
       const basePath = _('/node_modules');
       const targetPackageJsonPath = join(basePath, packagePath, 'package.json');
       const targetPackage = loadPackage(packagePath);
-      markAsProcessed(fs, targetPackage, targetPackageJsonPath, ['typings', ...properties]);
+      markAsProcessed(
+          pkgJsonUpdater, targetPackage, targetPackageJsonPath, ['typings', ...properties]);
     }
 
 

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -5,6 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+/// <reference types="node" />
+
+import * as os from 'os';
+
 import {AbsoluteFsPath, FileSystem, absoluteFrom, getFileSystem, join} from '../../../src/ngtsc/file_system';
 import {Folder, MockFileSystem, TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles, loadTestFiles} from '../../../test/helpers';
@@ -14,6 +19,7 @@ import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTI
 import {Transformer} from '../../src/packages/transformer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
 import {MockLogger} from '../helpers/mock_logger';
+
 
 const testFiles = loadStandardTestFiles({fakeCore: false, rxjs: true});
 
@@ -28,6 +34,9 @@ runInEachFileSystem(() => {
       fs = getFileSystem();
       pkgJsonUpdater = new DirectPackageJsonUpdater(fs);
       initMockFileSystem(fs, testFiles);
+
+      // Force single-process execution in unit tests by mocking available CPUs to 1.
+      spyOn(os, 'cpus').and.returnValue([{model: 'Mock CPU'}]);
     });
 
     it('should run ngcc without errors for esm2015', () => {
@@ -402,7 +411,6 @@ runInEachFileSystem(() => {
           propertiesToConsider: ['module', 'fesm5', 'esm5'],
           compileAllFormats: false,
           logger: new MockLogger(),
-
         });
         // * In the Angular packages fesm5 and module have the same underlying format,
         //   so both are marked as compiled.

--- a/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
@@ -147,6 +147,26 @@ runInEachFileSystem(() => {
         expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');
         expect(pkg.scripts.prepublishOnly__ivy_ngcc_bak).toBe(prepublishOnly);
       });
+
+      it(`should not keep backup of overwritten 'prepublishOnly' script`, () => {
+        const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
+        const fs = getFileSystem();
+        let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
+
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
+
+        pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
+        expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');
+        expect(pkg.scripts.prepublishOnly__ivy_ngcc_bak).toBeUndefined();
+
+        // Running again, now that there is `prepublishOnly` script (created by `ngcc`), it should
+        // still not back it up as `prepublishOnly__ivy_ngcc_bak`.
+        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
+
+        pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
+        expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');
+        expect(pkg.scripts.prepublishOnly__ivy_ngcc_bak).toBeUndefined();
+      });
     });
 
     describe('hasBeenProcessed', () => {

--- a/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
@@ -9,6 +9,7 @@ import {AbsoluteFsPath, absoluteFrom, getFileSystem} from '../../../src/ngtsc/fi
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {hasBeenProcessed, markAsProcessed} from '../../src/packages/build_marker';
+import {DirectPackageJsonUpdater} from '../../src/writing/package_json_updater';
 
 runInEachFileSystem(() => {
   describe('Marker files', () => {
@@ -82,11 +83,12 @@ runInEachFileSystem(() => {
       it('should write properties in the package.json containing the version placeholder', () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
+        const pkgUpdater = new DirectPackageJsonUpdater(fs);
         let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__).toBeUndefined();
         expect(pkg.scripts).toBeUndefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
@@ -94,7 +96,7 @@ runInEachFileSystem(() => {
         expect(pkg.__processed_by_ivy_ngcc__.esm5).toBeUndefined();
         expect(pkg.scripts.prepublishOnly).toBeDefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
@@ -106,18 +108,19 @@ runInEachFileSystem(() => {
       it('should update the packageJson object in-place', () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
+        const pkgUpdater = new DirectPackageJsonUpdater(fs);
         const pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.__processed_by_ivy_ngcc__).toBeUndefined();
         expect(pkg.scripts).toBeUndefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5']);
         expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBeUndefined();
         expect(pkg.__processed_by_ivy_ngcc__.esm5).toBeUndefined();
         expect(pkg.scripts.prepublishOnly).toBeDefined();
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['esm2015', 'esm5']);
         expect(pkg.__processed_by_ivy_ngcc__.fesm2015).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.fesm5).toBe('0.0.0-PLACEHOLDER');
         expect(pkg.__processed_by_ivy_ngcc__.esm2015).toBe('0.0.0-PLACEHOLDER');
@@ -128,21 +131,24 @@ runInEachFileSystem(() => {
       it('should one perform one write operation for all updated properties', () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
+        const pkgUpdater = new DirectPackageJsonUpdater(fs);
         const writeFileSpy = spyOn(fs, 'writeFile');
         let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5', 'esm2015', 'esm5']);
+        markAsProcessed(
+            pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015', 'fesm5', 'esm2015', 'esm5']);
         expect(writeFileSpy).toHaveBeenCalledTimes(1);
       });
 
       it(`should keep backup of existing 'prepublishOnly' script`, () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
+        const pkgUpdater = new DirectPackageJsonUpdater(fs);
         const prepublishOnly = 'existing script';
         let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         pkg.scripts = {prepublishOnly};
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');
         expect(pkg.scripts.prepublishOnly__ivy_ngcc_bak).toBe(prepublishOnly);
@@ -151,9 +157,10 @@ runInEachFileSystem(() => {
       it(`should not keep backup of overwritten 'prepublishOnly' script`, () => {
         const COMMON_PACKAGE_PATH = _('/node_modules/@angular/common/package.json');
         const fs = getFileSystem();
+        const pkgUpdater = new DirectPackageJsonUpdater(fs);
         let pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
 
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
 
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');
@@ -161,7 +168,7 @@ runInEachFileSystem(() => {
 
         // Running again, now that there is `prepublishOnly` script (created by `ngcc`), it should
         // still not back it up as `prepublishOnly__ivy_ngcc_bak`.
-        markAsProcessed(fs, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
+        markAsProcessed(pkgUpdater, pkg, COMMON_PACKAGE_PATH, ['fesm2015']);
 
         pkg = JSON.parse(fs.readFile(COMMON_PACKAGE_PATH));
         expect(pkg.scripts.prepublishOnly).toContain('This is not allowed');

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -13,6 +13,7 @@ import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, getEntryPointInfo}
 import {EntryPointBundle, makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {FileWriter} from '../../src/writing/file_writer';
 import {NewEntryPointFileWriter} from '../../src/writing/new_entry_point_file_writer';
+import {DirectPackageJsonUpdater} from '../../src/writing/package_json_updater';
 import {MockLogger} from '../helpers/mock_logger';
 import {loadPackageJson} from '../packages/entry_point_spec';
 
@@ -100,7 +101,7 @@ runInEachFileSystem(() => {
     describe('writeBundle() [primary entry-point]', () => {
       beforeEach(() => {
         fs = getFileSystem();
-        fileWriter = new NewEntryPointFileWriter(fs);
+        fileWriter = new NewEntryPointFileWriter(fs, new DirectPackageJsonUpdater(fs));
         const config = new NgccConfiguration(fs, _('/'));
         entryPoint = getEntryPointInfo(
             fs, config, new MockLogger(), _('/node_modules/test'), _('/node_modules/test')) !;
@@ -236,7 +237,7 @@ runInEachFileSystem(() => {
     describe('writeBundle() [secondary entry-point]', () => {
       beforeEach(() => {
         fs = getFileSystem();
-        fileWriter = new NewEntryPointFileWriter(fs);
+        fileWriter = new NewEntryPointFileWriter(fs, new DirectPackageJsonUpdater(fs));
         const config = new NgccConfiguration(fs, _('/'));
         entryPoint = getEntryPointInfo(
             fs, config, new MockLogger(), _('/node_modules/test'), _('/node_modules/test/a')) !;
@@ -361,7 +362,7 @@ runInEachFileSystem(() => {
     describe('writeBundle() [entry-point (with files placed outside entry-point folder)]', () => {
       beforeEach(() => {
         fs = getFileSystem();
-        fileWriter = new NewEntryPointFileWriter(fs);
+        fileWriter = new NewEntryPointFileWriter(fs, new DirectPackageJsonUpdater(fs));
         const config = new NgccConfiguration(fs, _('/'));
         entryPoint = getEntryPointInfo(
             fs, config, new MockLogger(), _('/node_modules/test'), _('/node_modules/test/b')) !;

--- a/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteFsPath, FileSystem, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadTestFiles} from '../../../test/helpers';
+import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
+
+runInEachFileSystem(() => {
+  describe('DirectPackageJsonUpdater', () => {
+    let _: typeof absoluteFrom;
+    let fs: FileSystem;
+    let updater: PackageJsonUpdater;
+
+    // Helpers
+    const readJson = (path: AbsoluteFsPath) => JSON.parse(fs.readFile(path));
+
+    beforeEach(() => {
+      _ = absoluteFrom;
+      fs = getFileSystem();
+      updater = new DirectPackageJsonUpdater(fs);
+    });
+
+    it('should update a `package.json` file on disk', () => {
+      const jsonPath = _('/foo/package.json');
+      loadTestFiles([
+        {name: jsonPath, contents: '{"foo": true, "bar": {"baz": "OK"}}'},
+      ]);
+
+      const update = updater.createUpdate().addChange(['foo'], false).addChange(['bar', 'baz'], 42);
+
+      // Not updated yet.
+      expect(readJson(jsonPath)).toEqual({
+        foo: true,
+        bar: {baz: 'OK'},
+      });
+
+      update.writeChanges(jsonPath);
+
+      // Updated now.
+      expect(readJson(jsonPath)).toEqual({
+        foo: false,
+        bar: {baz: 42},
+      });
+    });
+
+    it('should update an in-memory representation (if provided)', () => {
+      const jsonPath = _('/foo/package.json');
+      loadTestFiles([
+        {name: jsonPath, contents: '{"foo": true, "bar": {"baz": "OK"}}'},
+      ]);
+
+      const pkg = readJson(jsonPath);
+      const update = updater.createUpdate().addChange(['foo'], false).addChange(['bar', 'baz'], 42);
+
+      // Not updated yet.
+      expect(pkg).toEqual({
+        foo: true,
+        bar: {baz: 'OK'},
+      });
+
+      update.writeChanges(jsonPath, pkg);
+
+      // Updated now.
+      expect(pkg).toEqual({
+        foo: false,
+        bar: {baz: 42},
+      });
+    });
+
+    it('should create the `package.json` file, if it does not exist', () => {
+      const jsonPath = _('/foo/package.json');
+      expect(fs.exists(jsonPath)).toBe(false);
+
+      updater.createUpdate()
+          .addChange(['foo'], false)
+          .addChange(['bar', 'baz'], 42)
+          .writeChanges(jsonPath);
+
+      expect(fs.exists(jsonPath)).toBe(true);
+      expect(readJson(jsonPath)).toEqual({
+        foo: false,
+        bar: {baz: 42},
+      });
+    });
+
+    it('should create any missing ancestor objects', () => {
+      const jsonPath = _('/foo/package.json');
+      loadTestFiles([
+        {name: jsonPath, contents: '{"foo": {}}'},
+      ]);
+
+      const pkg = readJson(jsonPath);
+      updater.createUpdate()
+          .addChange(['foo', 'bar', 'baz', 'qux'], 'updated')
+          .writeChanges(jsonPath, pkg);
+
+      expect(readJson(jsonPath)).toEqual(pkg);
+      expect(pkg).toEqual({
+        foo: {
+          bar: {
+            baz: {
+              qux: 'updated',
+            },
+          },
+        },
+      });
+    });
+
+    it('should throw, if no changes have been recorded', () => {
+      const jsonPath = _('/foo/package.json');
+
+      expect(() => updater.createUpdate().writeChanges(jsonPath))
+          .toThrowError(`No changes to write to '${jsonPath}'.`);
+    });
+
+    it('should throw, if a property-path is empty', () => {
+      const jsonPath = _('/foo/package.json');
+
+      expect(() => updater.createUpdate().addChange([], 'missing').writeChanges(jsonPath))
+          .toThrowError(`Missing property path for writing value to '${jsonPath}'.`);
+    });
+
+    it('should throw, if a property-path points to a non-object intermediate value', () => {
+      const jsonPath = _('/foo/package.json');
+      loadTestFiles([
+        {name: jsonPath, contents: '{"foo": null, "bar": 42, "baz": {"qux": []}}'},
+      ]);
+
+      const writeToProp = (propPath: string[]) =>
+          updater.createUpdate().addChange(propPath, 'updated').writeChanges(jsonPath);
+
+      expect(() => writeToProp(['foo', 'child']))
+          .toThrowError('Property path \'foo.child\' does not point to an object.');
+      expect(() => writeToProp(['bar', 'child']))
+          .toThrowError('Property path \'bar.child\' does not point to an object.');
+      expect(() => writeToProp(['baz', 'qux', 'child']))
+          .toThrowError('Property path \'baz.qux.child\' does not point to an object.');
+    });
+
+    it('should throw, if trying to re-apply an already applied update', () => {
+      const update = updater.createUpdate().addChange(['foo'], 'updated');
+
+      expect(() => update.writeChanges(_('/foo/package.json'))).not.toThrow();
+      expect(() => update.writeChanges(_('/foo/package.json')))
+          .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+      expect(() => update.writeChanges(_('/bar/package.json')))
+          .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+    });
+  });
+});


### PR DESCRIPTION
This is a continuation of the work started in #32052 to speed up `ngcc` by adding support for executing tasks in parallel (when async execution is acceptable).

##
This PR includes numerous refactorings to clean up/simplify the code and prepare the introduction of  parallel task execution. It also includes a tiny fix: ``only back up the original `prepublishOnly` script and not the overwritten one``

See the individual commit messages for more details.

---

**Notes on testing**

I have added unit tests for all added/modified code except for the `ClusterMaster` class, because:
- It mostly orchestrates other parts (that are independently tested).
- The most important parts of its functionality are covered by integration tests.
- I didn't want to spend too much time on testing it before a first review (in case the implementation changed drastically).

The integration tests at [ngcc/test/integration/ngcc_spec.ts](https://github.com/angular/angular/blob/f5bec3ff5/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts), which are run under bazel, don't play well with spawning multiple processes, so they are only run on one process (which means they don't exercise the `ClusterExecutor`).

The integration tests at [integration/ngcc/test.sh](https://github.com/angular/angular/blob/f5bec3ff5/integration/ngcc/test.sh) do run in parallel mode (and only in that mode, since that is the only option with `ivy-ngcc`).

Other than that, I have manually verified that `ngcc` can successfully build angular.io in parallel mode (with various command-line argument combinations) and that the resulting `node_modules/`are identical to those produced in sync mode with the following exceptions:
- `package.json > __processed_by_ivy_ngcc__` might have properties in different order.
    _This is expected, since now the order is which tests are run/completed is different and non-deterministic._
- Some generated variable names can be different (mostly(/only?) noticed in UMD bundles). E.g. `data_r50` vs `data_r450`.
    _Not sure why that is and whether it is problematic._

##
**Notes on performance**

For processing angular.io, I have observed speed improvement between 1.8x (on my Windows laptop - 7 workers) to 2.6x (on Linux CI - 8 workers). This was a little surprizing, since task processing (which runs on multiple processes) takes up 80%-90% and all workers are busy most of the time (i.e. there are rarely idle workers).

More investigation is needed to better understand/improve those numbers, but this can happen after the PR lands.

Fun fact:
There doesn't seem to be much improvement above 4 workers. Even with up to 20 workers on CI, the duration was the same (if not worse: 29s vs 23s).

---

**TODO**

- [x] Get the PR reviewed.
- [x] Determine whether the differences in variable names (in UMD bundles?) are an issue.<sup>1</sup>
- [x] ~~Determine whether we need unit tests for `ClusterMaster`.~~

<sup>1</sup>: The differences are in "shared context vars" generated via [BindingScope#generateSharedContextVar()][1] by the [TemplateDefinitionBuilder][2] instantiated in [compileComponentFromMetadata()][3]. Since these are local to the template, we don't mind having duplicate names in different entry-points or formats.

[1]: https://github.com/angular/angular/blob/4c3674f66/packages/compiler/src/render3/view/template.ts#L1651-L1652
[2]: https://github.com/angular/angular/blob/4c3674f66/packages/compiler/src/render3/view/compiler.ts#L229-L232
[3]: https://github.com/angular/angular/blob/4c3674f66/packages/compiler/src/render3/view/compiler.ts#L187