### PR TITLE
refactor(ivy): generate ngFactoryDef for injectables

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise, ɵlooseIdentical} from '@angular/core';
+import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise, ɵlooseIdentical} from '@angular/core';
 import {Observable, SubscriptionLike} from 'rxjs';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -67,7 +67,6 @@ const _observableStrategy = new ObservableStrategy();
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'async', pure: false})
 export class AsyncPipe implements OnDestroy, PipeTransform {
   private _latestValue: any = null;

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -24,7 +24,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @ngModule CommonModule
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'lowercase'})
 export class LowerCasePipe implements PipeTransform {
   /**
@@ -68,7 +67,6 @@ const unicodeWordMatch =
  * @ngModule CommonModule
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'titlecase'})
 export class TitleCasePipe implements PipeTransform {
   /**
@@ -93,7 +91,6 @@ export class TitleCasePipe implements PipeTransform {
  * @ngModule CommonModule
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'uppercase'})
 export class UpperCasePipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatDate} from '../i18n/format_date';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -150,7 +150,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @publicApi
  */
 // clang-format on
-@Injectable()
 @Pipe({name: 'date', pure: true})
 export class DatePipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private locale: string) {}

--- a/packages/common/src/pipes/i18n_plural_pipe.ts
+++ b/packages/common/src/pipes/i18n_plural_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 import {NgLocalization, getPluralCategory} from '../i18n/localization';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -26,7 +26,6 @@ const _INTERPOLATION_REGEXP: RegExp = /#/g;
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'i18nPlural', pure: true})
 export class I18nPluralPipe implements PipeTransform {
   constructor(private _localization: NgLocalization) {}

--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -26,7 +26,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'i18nSelect', pure: true})
 export class I18nSelectPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/json_pipe.ts
+++ b/packages/common/src/pipes/json_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -23,7 +23,6 @@ import {Injectable, Pipe, PipeTransform} from '@angular/core';
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'json', pure: false})
 export class JsonPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform} from '@angular/core';
+import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform} from '@angular/core';
 
 function makeKeyValuePair<K, V>(key: K, value: V): KeyValue<K, V> {
   return {key: key, value: value};
@@ -43,7 +43,6 @@ export interface KeyValue<K, V> {
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'keyvalue', pure: false})
 export class KeyValuePipe implements PipeTransform {
   constructor(private readonly differs: KeyValueDiffers) {}

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatCurrency, formatNumber, formatPercent} from '../i18n/format_number';
 import {getCurrencySymbol} from '../i18n/locale_data_api';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
@@ -46,7 +46,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'number'})
 export class DecimalPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -100,7 +99,6 @@ export class DecimalPipe implements PipeTransform {
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'percent'})
 export class PercentPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -155,7 +153,6 @@ export class PercentPipe implements PipeTransform {
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'currency'})
 export class CurrencyPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}

--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -44,7 +44,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @publicApi
  */
-@Injectable()
 @Pipe({name: 'slice', pure: false})
 export class SlicePipe implements PipeTransform {
   /**

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -171,8 +171,12 @@ export class DecorationAnalyzer {
     for (const {handler, analysis} of clazz.matches) {
       const result = handler.compile(clazz.declaration, analysis, constantPool);
       if (Array.isArray(result)) {
-        compilations.push(...result);
-      } else {
+        result.forEach(current => {
+          if (!compilations.some(compilation => compilation.name === current.name)) {
+            compilations.push(current);
+          }
+        });
+      } else if (!compilations.some(compilation => compilation.name === result.name)) {
         compilations.push(result);
       }
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3TargetBinder, SchemaMetadata, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
+import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, Identifiers, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3TargetBinder, SchemaMetadata, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {CycleAnalyzer} from '../../cycles';
@@ -486,7 +486,7 @@ export class ComponentDecoratorHandler implements
       CompileResult[] {
     const meta = analysis.meta;
     const res = compileComponentFromMetadata(meta, pool, makeBindingParser());
-    const factoryRes = compileNgFactoryDefField(meta);
+    const factoryRes = compileNgFactoryDefField({...meta, injectFn: Identifiers.directiveInject});
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, EMPTY_SOURCE_SPAN, Expression, ParseError, ParsedHostBindings, R3DirectiveMetadata, R3QueryMetadata, Statement, WrappedNodeExpr, compileDirectiveFromMetadata, makeBindingParser, parseHostBindings, verifyHostBindings} from '@angular/compiler';
+import {ConstantPool, EMPTY_SOURCE_SPAN, Expression, Identifiers, ParseError, ParsedHostBindings, R3DirectiveMetadata, R3QueryMetadata, Statement, WrappedNodeExpr, compileDirectiveFromMetadata, makeBindingParser, parseHostBindings, verifyHostBindings} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -94,7 +94,7 @@ export class DirectiveDecoratorHandler implements
       CompileResult[] {
     const meta = analysis.meta;
     const res = compileDirectiveFromMetadata(meta, pool, makeBindingParser());
-    const factoryRes = compileNgFactoryDefField(meta);
+    const factoryRes = compileNgFactoryDefField({...meta, injectFn: Identifiers.directiveInject});
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -16,11 +16,13 @@ import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPr
 
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getConstructorDependencies, getValidConstructorDependencies, validateConstructorDependencies} from './util';
+import {findAngularDecorator, getConstructorDependencies, getValidConstructorDependencies, isAngularCore, unwrapForwardRef, validateConstructorDependencies} from './util';
 
 export interface InjectableHandlerData {
   meta: R3InjectableMetadata;
   metadataStmt: Statement|null;
+  ctorDeps: R3DependencyMetadata[]|'invalid'|null;
+  needsFactory: boolean;
 }
 
 /**
@@ -50,51 +52,65 @@ export class InjectableDecoratorHandler implements
   }
 
   analyze(node: ClassDeclaration, decorator: Decorator): AnalysisOutput<InjectableHandlerData> {
+    const meta = extractInjectableMetadata(node, decorator, this.reflector);
+    const decorators = this.reflector.getDecoratorsOfDeclaration(node);
+
     return {
       analysis: {
-        meta: extractInjectableMetadata(
-            node, decorator, this.reflector, this.defaultImportRecorder, this.isCore,
+        meta,
+        ctorDeps: extractInjectableCtorDeps(
+            node, meta, decorator, this.reflector, this.defaultImportRecorder, this.isCore,
             this.strictCtorDeps),
         metadataStmt: generateSetClassMetadataCall(
             node, this.reflector, this.defaultImportRecorder, this.isCore),
+        // Avoid generating multiple factories if a class has
+        // more Angular decorators, apart from Injectable.
+        needsFactory: !decorators ||
+            decorators.every(current => !isAngularCore(current) || current.name === 'Injectable')
       },
     };
   }
 
   compile(node: ClassDeclaration, analysis: InjectableHandlerData): CompileResult[] {
-    const meta = analysis.meta;
     const res = compileIvyInjectable(analysis.meta);
     const statements = res.statements;
-    const factoryRes = compileNgFactoryDefField({
-      name: meta.name,
-      type: meta.type,
-      typeArgumentCount: meta.typeArgumentCount,
-      deps: meta.ctorDeps,
-      injectFn: Identifiers.inject
-    });
-    if (analysis.metadataStmt !== null) {
-      factoryRes.statements.push(analysis.metadataStmt);
-    }
-    return [
-      factoryRes, {
-        name: 'ngInjectableDef',
-        initializer: res.expression, statements,
-        type: res.type,
+    const results: CompileResult[] = [];
+
+    if (analysis.needsFactory) {
+      const meta = analysis.meta;
+      const factoryRes = compileNgFactoryDefField({
+        name: meta.name,
+        type: meta.type,
+        typeArgumentCount: meta.typeArgumentCount,
+        deps: analysis.ctorDeps,
+        injectFn: Identifiers.inject
+      });
+      if (analysis.metadataStmt !== null) {
+        factoryRes.statements.push(analysis.metadataStmt);
       }
-    ];
+      results.push(factoryRes);
+    }
+
+    results.push({
+      name: 'ngInjectableDef',
+      initializer: res.expression, statements,
+      type: res.type,
+    });
+
+    return results;
   }
 }
 
 /**
- * Read metadata from the `@Injectable` decorator and produce the `IvyInjectableMetadata`, the input
+ * Read metadata from the `@Injectable` decorator and produce the `IvyInjectableMetadata`, the
+ * input
  * metadata needed to run `compileIvyInjectable`.
  *
  * A `null` return value indicates this is @Injectable has invalid data.
  */
 function extractInjectableMetadata(
-    clazz: ClassDeclaration, decorator: Decorator, reflector: ReflectionHost,
-    defaultImportRecorder: DefaultImportRecorder, isCore: boolean,
-    strictCtorDeps: boolean): R3InjectableMetadata {
+    clazz: ClassDeclaration, decorator: Decorator,
+    reflector: ReflectionHost): R3InjectableMetadata {
   const name = clazz.name.text;
   const type = new WrappedNodeExpr(clazz.name);
   const typeArgumentCount = reflector.getGenericArityOfClass(clazz) || 0;
@@ -103,53 +119,13 @@ function extractInjectableMetadata(
         ErrorCode.DECORATOR_NOT_CALLED, decorator.node, '@Injectable must be called');
   }
   if (decorator.args.length === 0) {
-    // Ideally, using @Injectable() would have the same effect as using @Injectable({...}), and be
-    // subject to the same validation. However, existing Angular code abuses @Injectable, applying
-    // it to things like abstract classes with constructors that were never meant for use with
-    // Angular's DI.
-    //
-    // To deal with this, @Injectable() without an argument is more lenient, and if the constructor
-    // signature does not work for DI then an ngInjectableDef that throws.
-    let ctorDeps: R3DependencyMetadata[]|'invalid'|null = null;
-    if (strictCtorDeps) {
-      ctorDeps = getValidConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
-    } else {
-      const possibleCtorDeps =
-          getConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
-      if (possibleCtorDeps !== null) {
-        if (possibleCtorDeps.deps !== null) {
-          // This use of @Injectable has valid constructor dependencies.
-          ctorDeps = possibleCtorDeps.deps;
-        } else {
-          // This use of @Injectable is technically invalid. Generate a factory function which
-          // throws
-          // an error.
-          // TODO(alxhub): log warnings for the bad use of @Injectable.
-          ctorDeps = 'invalid';
-        }
-      }
-    }
     return {
       name,
       type,
       typeArgumentCount,
-      providedIn: new LiteralExpr(null), ctorDeps,
+      providedIn: new LiteralExpr(null),
     };
   } else if (decorator.args.length === 1) {
-    const rawCtorDeps = getConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
-    let ctorDeps: R3DependencyMetadata[]|'invalid'|null = null;
-
-    // rawCtorDeps will be null if the class has no constructor.
-    if (rawCtorDeps !== null) {
-      if (rawCtorDeps.deps !== null) {
-        // A constructor existed and had valid dependencies.
-        ctorDeps = rawCtorDeps.deps;
-      } else {
-        // A constructor existed but had invalid dependencies.
-        ctorDeps = 'invalid';
-      }
-    }
-
     const metaNode = decorator.args[0];
     // Firstly make sure the decorator argument is an inline literal - if not, it's illegal to
     // transport references from one location to another. This is the problem that lowering
@@ -181,27 +157,25 @@ function extractInjectableMetadata(
         name,
         type,
         typeArgumentCount,
-        ctorDeps,
         providedIn,
-        useValue: new WrappedNodeExpr(meta.get('useValue') !),
+        useValue: new WrappedNodeExpr(unwrapForwardRef(meta.get('useValue') !, reflector)),
       };
     } else if (meta.has('useExisting')) {
       return {
         name,
         type,
         typeArgumentCount,
-        ctorDeps,
         providedIn,
-        useExisting: new WrappedNodeExpr(meta.get('useExisting') !),
+        useExisting: new WrappedNodeExpr(unwrapForwardRef(meta.get('useExisting') !, reflector)),
       };
     } else if (meta.has('useClass')) {
       return {
         name,
         type,
         typeArgumentCount,
-        ctorDeps,
         providedIn,
-        useClass: new WrappedNodeExpr(meta.get('useClass') !), userDeps,
+        useClass: new WrappedNodeExpr(unwrapForwardRef(meta.get('useClass') !, reflector)),
+        userDeps,
       };
     } else if (meta.has('useFactory')) {
       // useFactory is special - the 'deps' property must be analyzed.
@@ -211,14 +185,10 @@ function extractInjectableMetadata(
         type,
         typeArgumentCount,
         providedIn,
-        useFactory: factory, ctorDeps, userDeps,
+        useFactory: factory, userDeps,
       };
     } else {
-      if (strictCtorDeps) {
-        // Since use* was not provided, validate the deps according to strictCtorDeps.
-        validateConstructorDependencies(clazz, rawCtorDeps);
-      }
-      return {name, type, typeArgumentCount, providedIn, ctorDeps};
+      return {name, type, typeArgumentCount, providedIn};
     }
   } else {
     throw new FatalDiagnosticError(
@@ -226,7 +196,69 @@ function extractInjectableMetadata(
   }
 }
 
+function extractInjectableCtorDeps(
+    clazz: ClassDeclaration, meta: R3InjectableMetadata, decorator: Decorator,
+    reflector: ReflectionHost, defaultImportRecorder: DefaultImportRecorder, isCore: boolean,
+    strictCtorDeps: boolean) {
+  if (decorator.args === null) {
+    throw new FatalDiagnosticError(
+        ErrorCode.DECORATOR_NOT_CALLED, decorator.node, '@Injectable must be called');
+  }
 
+  let ctorDeps: R3DependencyMetadata[]|'invalid'|null = null;
+
+  if (decorator.args.length === 0) {
+    // Ideally, using @Injectable() would have the same effect as using @Injectable({...}), and be
+    // subject to the same validation. However, existing Angular code abuses @Injectable, applying
+    // it to things like abstract classes with constructors that were never meant for use with
+    // Angular's DI.
+    //
+    // To deal with this, @Injectable() without an argument is more lenient, and if the
+    // constructor
+    // signature does not work for DI then an ngInjectableDef that throws.
+    if (strictCtorDeps) {
+      ctorDeps = getValidConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
+    } else {
+      const possibleCtorDeps =
+          getConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
+      if (possibleCtorDeps !== null) {
+        if (possibleCtorDeps.deps !== null) {
+          // This use of @Injectable has valid constructor dependencies.
+          ctorDeps = possibleCtorDeps.deps;
+        } else {
+          // This use of @Injectable is technically invalid. Generate a factory function which
+          // throws
+          // an error.
+          // TODO(alxhub): log warnings for the bad use of @Injectable.
+          ctorDeps = 'invalid';
+        }
+      }
+    }
+
+    return ctorDeps;
+  } else if (decorator.args.length === 1) {
+    const rawCtorDeps = getConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
+
+    // rawCtorDeps will be null if the class has no constructor.
+    if (rawCtorDeps !== null) {
+      if (rawCtorDeps.deps !== null) {
+        // A constructor existed and had valid dependencies.
+        ctorDeps = rawCtorDeps.deps;
+      } else {
+        // A constructor existed but had invalid dependencies.
+        ctorDeps = 'invalid';
+      }
+    }
+
+    if (strictCtorDeps && !meta.useValue && !meta.useExisting && !meta.useClass &&
+        !meta.useFactory) {
+      // Since use* was not provided, validate the deps according to strictCtorDeps.
+      validateConstructorDependencies(clazz, rawCtorDeps);
+    }
+  }
+
+  return ctorDeps;
+}
 
 function getDep(dep: ts.Expression, reflector: ReflectionHost): R3DependencyMetadata {
   const meta: R3DependencyMetadata = {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3PipeMetadata, Statement, WrappedNodeExpr, compilePipeFromMetadata} from '@angular/compiler';
+import {Identifiers, R3PipeMetadata, Statement, WrappedNodeExpr, compilePipeFromMetadata} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -109,7 +109,11 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
   compile(node: ClassDeclaration, analysis: PipeHandlerData): CompileResult[] {
     const meta = analysis.meta;
     const res = compilePipeFromMetadata(meta);
-    const factoryRes = compileNgFactoryDefField({...meta, isPipe: true});
+    const factoryRes = compileNgFactoryDefField({
+      ...meta,
+      injectFn: Identifiers.directiveInject,
+      isPipe: true,
+    });
     if (analysis.metadataStmt !== null) {
       factoryRes.statements.push(analysis.metadataStmt);
     }

--- a/packages/compiler-cli/src/ngtsc/imports/src/core.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/core.ts
@@ -53,6 +53,7 @@ const CORE_SUPPORTED_SYMBOLS = new Map<string, string>([
   ['ɵɵdefineNgModule', 'ɵɵdefineNgModule'],
   ['ɵɵsetNgModuleScope', 'ɵɵsetNgModuleScope'],
   ['ɵɵinject', 'ɵɵinject'],
+  ['ɵɵFactoryDef', 'ɵɵFactoryDef'],
   ['ɵsetClassMetadata', 'setClassMetadata'],
   ['ɵɵInjectableDef', 'ɵɵInjectableDef'],
   ['ɵɵInjectorDef', 'ɵɵInjectorDef'],

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -353,10 +353,14 @@ export class IvyCompilation {
       const compileMatchRes =
           match.handler.compile(node as ClassDeclaration, match.analyzed.analysis, constantPool);
       this.perf.stop(compileSpan);
-      if (!Array.isArray(compileMatchRes)) {
+      if (Array.isArray(compileMatchRes)) {
+        compileMatchRes.forEach(result => {
+          if (!res.some(r => r.name === result.name)) {
+            res.push(result);
+          }
+        });
+      } else if (!res.some(result => result.name === compileMatchRes.name)) {
         res.push(compileMatchRes);
-      } else {
-        res.push(...compileMatchRes);
       }
     }
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -102,49 +102,6 @@ describe('compiler compliance: dependency injection', () => {
     expectEmit(result.source, def, 'Incorrect injectable definition');
   });
 
-  it('should not reference the ngFactoryDef if the injectable has an alternate factory', () => {
-    const files = {
-      app: {
-        'spec.ts': `
-          import {Injectable} from '@angular/core';
-
-          class MyAlternateService {}
-
-          @Injectable({
-            useFactory: () => new MyAlternateFactory()
-          })
-          export class MyService {
-          }
-        `
-      }
-    };
-
-    const factory = `
-      MyService.ngFactoryDef = function MyService_Factory(t) {
-        return new (t || MyService)();
-      }`;
-
-    const def = `
-      MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
-        token: MyService,
-        factory: function MyService_Factory(t) {
-          var r = null;
-          if (t) {
-            (r = new t());
-          } else {
-            (r = (() => new MyAlternateFactory())());
-          }
-          return r;
-        },
-        providedIn: null
-      });
-    `;
-
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, factory, 'Incorrect factory definition');
-    expectEmit(result.source, def, 'Incorrect injectable definition');
-  });
-
   it('should create a single ngFactoryDef if the class has more than one decorator', () => {
     const files = {
       app: {
@@ -164,5 +121,239 @@ describe('compiler compliance: dependency injection', () => {
     expect(matches ? matches.length : 0).toBe(1);
   });
 
+  it('should delegate directly to the alternate factory when setting `useClass` without `deps`',
+     () => {
+       const files = {
+         app: {
+           'spec.ts': `
+              import {Injectable} from '@angular/core';
+
+              class MyAlternateService {}
+
+              function alternateFactory() {
+                return new MyAlternateService();
+              }
+
+              @Injectable({
+                useFactory: alternateFactory
+              })
+              export class MyService {
+              }
+            `
+         }
+       };
+
+       const def = `
+          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+            token: MyService,
+            factory: function() {
+              return alternateFactory();
+            },
+            providedIn: null
+          });
+        `;
+
+       const result = compile(files, angularFiles);
+       expectEmit(result.source, def, 'Incorrect injectable definition');
+     });
+
+  it('should not delegate directly to the alternate factory when setting `useClass` with `deps`',
+     () => {
+       const files = {
+         app: {
+           'spec.ts': `
+              import {Injectable} from '@angular/core';
+
+              class SomeDep {}
+              class MyAlternateService {}
+
+              @Injectable({
+                useFactory: () => new MyAlternateFactory(),
+                deps: [SomeDep]
+              })
+              export class MyService {
+              }
+            `
+         }
+       };
+
+       const def = `
+          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+            token: MyService,
+            factory: function MyService_Factory(t) {
+              var r = null;
+              if (t) {
+                (r = new t());
+              } else {
+                (r = (() => new MyAlternateFactory())($r3$.ɵɵinject(SomeDep)));
+              }
+              return r;
+            },
+            providedIn: null
+          });
+        `;
+
+       const result = compile(files, angularFiles);
+       expectEmit(result.source, def, 'Incorrect injectable definition');
+     });
+
+  it('should delegate directly to the alternate class factory when setting `useClass` without `deps`',
+     () => {
+       const files = {
+         app: {
+           'spec.ts': `
+              import {Injectable} from '@angular/core';
+
+              @Injectable()
+              class MyAlternateService {}
+
+              @Injectable({
+                useClass: MyAlternateService
+              })
+              export class MyService {
+              }
+            `
+         }
+       };
+
+       const factory = `
+          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+            token: MyService,
+            factory: function() {
+              return MyAlternateService.ngFactoryDef();
+            },
+            providedIn: null
+          });
+        `;
+
+       const result = compile(files, angularFiles);
+       expectEmit(result.source, factory, 'Incorrect factory definition');
+     });
+
+  it('should not delegate directly to the alternate class when setting `useClass` with `deps`',
+     () => {
+       const files = {
+         app: {
+           'spec.ts': `
+            import {Injectable} from '@angular/core';
+
+            class SomeDep {}
+
+            @Injectable()
+            class MyAlternateService {}
+
+            @Injectable({
+              useClass: MyAlternateService,
+              deps: [SomeDep]
+            })
+            export class MyService {
+            }
+          `
+         }
+       };
+
+       const factory = `
+          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+            token: MyService,
+            factory: function MyService_Factory(t) {
+              var r = null;
+              if (t) {
+                (r = new t());
+              } else {
+                (r = new MyAlternateService($r3$.ɵɵinject(SomeDep)));
+              }
+              return r;
+            },
+            providedIn: null
+          });
+        `;
+
+       const result = compile(files, angularFiles);
+       expectEmit(result.source, factory, 'Incorrect factory definition');
+     });
+
+  it('should unwrap forward refs when delegating to a different factory', () => {
+    const files = {
+      app: {
+        'spec.ts': `
+            import {Injectable, forwardRef} from '@angular/core';
+
+            @Injectable({providedIn: 'root', useClass: forwardRef(() => SomeProviderImpl)})
+            abstract class SomeProvider {
+            }
+
+            @Injectable()
+            class SomeProviderImpl extends SomeProvider {
+            }
+          `
+      }
+    };
+
+    const factory = `
+      SomeProvider.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+        token: SomeProvider,
+        factory: function() {
+          return SomeProviderImpl.ngFactoryDef();
+        },
+        providedIn: 'root'
+      });
+    `;
+
+    const result = compile(files, angularFiles);
+    expectEmit(result.source, factory, 'Incorrect factory definition');
+  });
+
+  it('should have the pipe factory take precedence over the injectable factory, if a class has multiple decorators',
+     () => {
+       const files = {
+         app: {
+           'spec.ts': `
+            import {Component, NgModule, Pipe, PipeTransform, Injectable} from '@angular/core';
+
+            @Injectable()
+            class Service {}
+
+            @Injectable()
+            @Pipe({name: 'myPipe'})
+            export class MyPipe implements PipeTransform {
+              constructor(service: Service) {}
+              transform(value: any, ...args: any[]) { return value; }
+            }
+
+            @Pipe({name: 'myOtherPipe'})
+            @Injectable()
+            export class MyOtherPipe implements PipeTransform {
+              constructor(service: Service) {}
+              transform(value: any, ...args: any[]) { return value; }
+            }
+
+            @Component({
+              selector: 'my-app',
+              template: '{{0 | myPipe | myOtherPipe}}'
+            })
+            export class MyApp {}
+
+            @NgModule({declarations: [MyPipe, MyOtherPipe, MyApp], declarations: [Service]})
+            export class MyModule {}
+          `
+         }
+       };
+
+       const result = compile(files, angularFiles);
+       const source = result.source;
+
+       const MyPipeFactory = `
+        MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵdirectiveInject(Service)); };
+      `;
+
+       const MyOtherPipeFactory = `
+        MyOtherPipe.ngFactoryDef = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵdirectiveInject(Service)); };
+      `;
+
+       expectEmit(source, MyPipeFactory, 'Invalid pipe factory function');
+       expectEmit(source, MyOtherPipeFactory, 'Invalid pipe factory function');
+       expect(source.match(/MyPipe\.ngFactoryDef =/g) !.length).toBe(1);
+       expect(source.match(/MyOtherPipe\.ngFactoryDef =/g) !.length).toBe(1);
+     });
 
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -90,8 +90,8 @@ describe('compiler compliance: dependency injection', () => {
     const def = `
       MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
         token: MyService,
-        factory: function() {
-          return MyService.ngFactoryDef();
+        factory: function(t) {
+          return MyService.ngFactoryDef(t);
         },
         providedIn: null
       });
@@ -121,7 +121,7 @@ describe('compiler compliance: dependency injection', () => {
     expect(matches ? matches.length : 0).toBe(1);
   });
 
-  it('should delegate directly to the alternate factory when setting `useClass` without `deps`',
+  it('should delegate directly to the alternate factory when setting `useFactory` without `deps`',
      () => {
        const files = {
          app: {
@@ -157,7 +157,7 @@ describe('compiler compliance: dependency injection', () => {
        expectEmit(result.source, def, 'Incorrect injectable definition');
      });
 
-  it('should not delegate directly to the alternate factory when setting `useClass` with `deps`',
+  it('should not delegate directly to the alternate factory when setting `useFactory` with `deps`',
      () => {
        const files = {
          app: {
@@ -219,8 +219,8 @@ describe('compiler compliance: dependency injection', () => {
        const factory = `
           MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
             token: MyService,
-            factory: function() {
-              return MyAlternateService.ngFactoryDef();
+            factory: function(t) {
+              return MyAlternateService.ngFactoryDef(t);
             },
             providedIn: null
           });
@@ -272,7 +272,7 @@ describe('compiler compliance: dependency injection', () => {
        expectEmit(result.source, factory, 'Incorrect factory definition');
      });
 
-  it('should unwrap forward refs when delegating to a different factory', () => {
+  it('should unwrap forward refs when delegating to a different class', () => {
     const files = {
       app: {
         'spec.ts': `
@@ -292,8 +292,8 @@ describe('compiler compliance: dependency injection', () => {
     const factory = `
       SomeProvider.ngInjectableDef = $r3$.ɵɵdefineInjectable({
         token: SomeProvider,
-        factory: function() {
-          return SomeProviderImpl.ngFactoryDef();
+        factory: function(t) {
+          return SomeProviderImpl.ngFactoryDef(t);
         },
         providedIn: 'root'
       });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -135,10 +135,10 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('Service.ngInjectableDef =');
-      expect(jsContents).toContain('(r = new t());');
-      expect(jsContents).toContain('(r = (function () { return new Service(); })());');
-      expect(jsContents).toContain('factory: function Service_Factory(t) { var r = null; if (t) {');
-      expect(jsContents).toContain('return r; }, providedIn: \'root\' });');
+      expect(jsContents)
+          .toContain('factory: function () { return (function () { return new Service(); })(); }');
+      expect(jsContents).toContain('Service_Factory(t) { return new (t || Service)(); }');
+      expect(jsContents).toContain(', providedIn: \'root\' });');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
@@ -164,7 +164,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('Service.ngInjectableDef =');
       expect(jsContents).toContain('factory: function Service_Factory(t) { var r = null; if (t) {');
-      expect(jsContents).toContain('(r = new t(i0.ɵɵinject(Dep)));');
+      expect(jsContents).toContain('return new (t || Service)(i0.ɵɵinject(Dep));');
       expect(jsContents)
           .toContain('(r = (function (dep) { return new Service(dep); })(i0.ɵɵinject(Dep)));');
       expect(jsContents).toContain('return r; }, providedIn: \'root\' });');
@@ -1291,7 +1291,7 @@ runInEachFileSystem(os => {
 
              env.driveMain();
              const jsContents = env.getContents('test.js');
-             expect(jsContents).toMatch(/if \(t\).*throw new Error.* else .* '42'/ms);
+             expect(jsContents).toMatch(/function Test_Factory\(t\) { throw new Error\(/ms);
            });
       });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -67,6 +67,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Dep>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with a generic service', () => {
@@ -83,6 +85,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('Store.ngInjectableDef =');
       const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Store<any>>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Store<any>>;');
     });
 
@@ -106,11 +109,15 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('Dep.ngInjectableDef =');
       expect(jsContents).toContain('Service.ngInjectableDef =');
       expect(jsContents)
-          .toContain('return new (t || Service)(i0.ɵɵinject(Dep)); }, providedIn: \'root\' });');
+          .toContain(
+              'Service.ngFactoryDef = function Service_Factory(t) { return new (t || Service)(i0.ɵɵinject(Dep)); };');
+      expect(jsContents).toContain('providedIn: \'root\' })');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Dep>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with providedIn and factory without errors', () => {
@@ -135,6 +142,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with providedIn and factory with deps without errors', () => {
@@ -163,6 +171,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile @Injectable with an @Optional dependency', () => {
@@ -1290,33 +1299,35 @@ runInEachFileSystem(os => {
         it('should compile an @Injectable on a class with a non-injectable constructor', () => {
           env.tsconfig({strictInjectionParameters: false});
           env.write('test.ts', `
-          import {Injectable} from '@angular/core';
+            import {Injectable} from '@angular/core';
 
-          @Injectable()
-          export class Test {
-            constructor(private notInjectable: string) {}
-          }
-        `);
+            @Injectable()
+            export class Test {
+              constructor(private notInjectable: string) {}
+            }
+          `);
 
           env.driveMain();
           const jsContents = env.getContents('test.js');
-          expect(jsContents).toContain('factory: function Test_Factory(t) { throw new Error(');
+          expect(jsContents)
+              .toContain('Test.ngFactoryDef = function Test_Factory(t) { throw new Error(');
         });
 
         it('should compile an @Injectable provided in the root on a class with a non-injectable constructor',
            () => {
              env.tsconfig({strictInjectionParameters: false});
              env.write('test.ts', `
-            import {Injectable} from '@angular/core';
-            @Injectable({providedIn: 'root'})
-            export class Test {
-              constructor(private notInjectable: string) {}
-            }
-          `);
+              import {Injectable} from '@angular/core';
+              @Injectable({providedIn: 'root'})
+              export class Test {
+                constructor(private notInjectable: string) {}
+              }
+            `);
 
              env.driveMain();
              const jsContents = env.getContents('test.js');
-             expect(jsContents).toContain('factory: function Test_Factory(t) { throw new Error(');
+             expect(jsContents)
+                 .toContain('Test.ngFactoryDef = function Test_Factory(t) { throw new Error(');
            });
 
       });

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -40,8 +40,7 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
-      isPipe?: boolean): any;
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
@@ -93,7 +92,6 @@ export interface R3InjectableMetadataFacade {
   name: string;
   type: any;
   typeArgumentCount: number;
-  ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
   useClass?: any;
   useFactory?: any;
@@ -169,7 +167,7 @@ export interface R3FactoryDefMetadataFacade {
   typeArgumentCount: number;
   deps: R3DependencyMetadataFacade[]|null;
   injectFn: 'directiveInject'|'inject';
-  isPipe?: boolean;
+  isPipe: boolean;
 }
 
 export type ViewEncapsulation = number;

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -40,8 +40,7 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
-      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
       isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
@@ -88,7 +87,6 @@ export interface R3PipeMetadataFacade {
   pipeName: string;
   deps: R3DependencyMetadataFacade[]|null;
   pure: boolean;
-  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3InjectableMetadataFacade {
@@ -97,7 +95,6 @@ export interface R3InjectableMetadataFacade {
   typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
-  injectFn: 'directiveInject'|'inject';
   useClass?: any;
   useFactory?: any;
   useExisting?: any;
@@ -141,7 +138,6 @@ export interface R3DirectiveMetadataFacade {
   exportAs: string[]|null;
   providers: Provider[]|null;
   viewQueries: R3QueryMetadataFacade[];
-  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
@@ -165,6 +161,15 @@ export interface R3BaseMetadataFacade {
   outputs?: {[key: string]: string};
   queries?: R3QueryMetadataFacade[];
   viewQueries?: R3QueryMetadataFacade[];
+}
+
+export interface R3FactoryDefMetadataFacade {
+  name: string;
+  type: any;
+  typeArgumentCount: number;
+  deps: R3DependencyMetadataFacade[]|null;
+  injectFn: 'directiveInject'|'inject';
+  isPipe?: boolean;
 }
 
 export type ViewEncapsulation = number;

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -40,8 +40,8 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
-      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
+      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
       isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
@@ -88,6 +88,7 @@ export interface R3PipeMetadataFacade {
   pipeName: string;
   deps: R3DependencyMetadataFacade[]|null;
   pure: boolean;
+  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3InjectableMetadataFacade {
@@ -96,6 +97,7 @@ export interface R3InjectableMetadataFacade {
   typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
+  injectFn: 'directiveInject'|'inject';
   useClass?: any;
   useFactory?: any;
   useExisting?: any;
@@ -139,6 +141,7 @@ export interface R3DirectiveMetadataFacade {
   exportAs: string[]|null;
   providers: Provider[]|null;
   viewQueries: R3QueryMetadataFacade[];
+  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {

--- a/packages/compiler/src/identifiers.ts
+++ b/packages/compiler/src/identifiers.ts
@@ -63,6 +63,7 @@ export class Identifiers {
 
   };
   static inject: o.ExternalReference = {name: 'ɵɵinject', moduleName: CORE};
+  static directiveInject: o.ExternalReference = {name: 'ɵɵdirectiveInject', moduleName: CORE};
   static INJECTOR: o.ExternalReference = {name: 'INJECTOR', moduleName: CORE};
   static Injector: o.ExternalReference = {name: 'Injector', moduleName: CORE};
   static ɵɵdefineInjectable: o.ExternalReference = {name: 'ɵɵdefineInjectable', moduleName: CORE};

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectFlags} from './core';
 import {Identifiers} from './identifiers';
 import * as o from './output/output_ast';
-import {R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata, compileFactoryFunction} from './render3/r3_factory';
+import {R3DependencyMetadata, R3FactoryDelegateType, compileFactoryFunction} from './render3/r3_factory';
 import {mapToMapExpression, typeWithParameters} from './render3/util';
 
 export interface InjectableDef {
@@ -95,7 +94,11 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
       expression: o.importExpr(Identifiers.inject).callFn([meta.useExisting]),
     });
   } else {
-    result = compileFactoryFunction(factoryMeta);
+    // factory: () => meta.type.ngFactoryDef()
+    result = {
+      statements: [],
+      factory: o.fn([], [new o.ReturnStatement(meta.type.callMethod('ngFactoryDef', []))])
+    };
   }
 
   const token = meta.type;

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -117,7 +117,8 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
 function delegateToFactory(type: o.Expression) {
   return {
     statements: [],
-    // () => meta.type.ngFactoryDef()
-    factory: o.fn([], [new o.ReturnStatement(type.callMethod('ngFactoryDef', []))])
+    // () => meta.type.ngFactoryDef(t)
+    factory: o.fn([new o.FnParam('t', o.DYNAMIC_TYPE)], [new o.ReturnStatement(type.callMethod(
+                                                            'ngFactoryDef', [o.variable('t')]))])
   };
 }

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -60,7 +60,6 @@ export class CompilerFacadeImpl implements CompilerFacade {
       useFactory: wrapExpression(facade, USE_FACTORY),
       useValue: wrapExpression(facade, USE_VALUE),
       useExisting: wrapExpression(facade, USE_EXISTING),
-      ctorDeps: convertR3DependencyMetadataArray(facade.ctorDeps),
       userDeps: convertR3DependencyMetadataArray(facade.userDeps) || undefined,
     });
 
@@ -155,16 +154,15 @@ export class CompilerFacadeImpl implements CompilerFacade {
   }
 
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
-      isPipe = false) {
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade) {
     const factoryRes = compileFactoryFromMetadata({
       name: meta.name,
       type: new WrappedNodeExpr(meta.type),
       typeArgumentCount: meta.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(meta.deps),
-      injectFn:
-          meta.injectFn === 'directiveInject' ? Identifiers.directiveInject : Identifiers.inject,
-      isPipe
+      injectFn: meta.injectFn === 'directiveInject' ? Identifiers.directiveInject :
+                                                      Identifiers.inject,
+      isPipe: meta.isPipe
     });
     return this.jitExpression(
         factoryRes.factory, angularCoreEnv, sourceMapUrl, factoryRes.statements);

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -10,6 +10,7 @@
 import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, R3BaseMetadataFacade, R3ComponentMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
 import {ConstantPool} from './constant_pool';
 import {HostBinding, HostListener, Input, Output, Type} from './core';
+import {Identifiers} from './identifiers';
 import {compileInjectable} from './injectable_compiler_2';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/interpolation_config';
 import {DeclareVarStmt, Expression, LiteralExpr, Statement, StmtModifier, WrappedNodeExpr} from './output/output_ast';
@@ -154,14 +155,23 @@ export class CompilerFacadeImpl implements CompilerFacade {
   }
 
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
-      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
+      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
       isPipe = false) {
     const factoryRes = compileFactoryFromMetadata({
       name: meta.name,
       type: new WrappedNodeExpr(meta.type),
       typeArgumentCount: meta.typeArgumentCount,
-      deps: convertR3DependencyMetadataArray(meta.deps), isPipe
+      deps: convertR3DependencyMetadataArray(
+          (meta as R3InjectableMetadataFacade).ctorDeps ||
+          (meta as R3PipeMetadataFacade | R3DirectiveMetadataFacade | R3ComponentMetadataFacade)
+              .deps),
+      // TODO(crisbeto): passing in the identifiers as string feels dirty and should not be in the
+      // final changes, but I couldn't figure out how to access the identifiers inside `jit`.
+      // Bring this up during code review.
+      injectFn:
+          meta.injectFn === 'directiveInject' ? Identifiers.directiveInject : Identifiers.inject,
+      isPipe
     });
     return this.jitExpression(
         factoryRes.factory, angularCoreEnv, sourceMapUrl, factoryRes.statements);

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, R3BaseMetadataFacade, R3ComponentMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
+import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, R3BaseMetadataFacade, R3ComponentMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3FactoryDefMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
 import {ConstantPool} from './constant_pool';
 import {HostBinding, HostListener, Input, Output, Type} from './core';
 import {Identifiers} from './identifiers';
@@ -155,20 +155,13 @@ export class CompilerFacadeImpl implements CompilerFacade {
   }
 
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
-      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
       isPipe = false) {
     const factoryRes = compileFactoryFromMetadata({
       name: meta.name,
       type: new WrappedNodeExpr(meta.type),
       typeArgumentCount: meta.typeArgumentCount,
-      deps: convertR3DependencyMetadataArray(
-          (meta as R3InjectableMetadataFacade).ctorDeps ||
-          (meta as R3PipeMetadataFacade | R3DirectiveMetadataFacade | R3ComponentMetadataFacade)
-              .deps),
-      // TODO(crisbeto): passing in the identifiers as string feels dirty and should not be in the
-      // final changes, but I couldn't figure out how to access the identifiers inside `jit`.
-      // Bring this up during code review.
+      deps: convertR3DependencyMetadataArray(meta.deps),
       injectFn:
           meta.injectFn === 'directiveInject' ? Identifiers.directiveInject : Identifiers.inject,
       isPipe

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -86,7 +86,8 @@ export interface R3FactoryDefMetadata {
   name: string;
   type: o.Expression;
   typeArgumentCount: number;
-  deps: R3DependencyMetadata[]|null;
+  deps: R3DependencyMetadata[]|'invalid'|null;
+  injectFn: o.ExternalReference;
   isPipe?: boolean;
 }
 
@@ -267,8 +268,7 @@ export function compileFactoryFromMetadata(meta: R3FactoryDefMetadata): R3Factor
         type: meta.type,
         deps: meta.deps,
         typeArgumentCount: meta.typeArgumentCount,
-        // TODO(crisbeto): this should be refactored once we start using it for injectables.
-        injectFn: R3.directiveInject,
+        injectFn: meta.injectFn,
       },
       meta.isPipe);
 }

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -89,7 +89,8 @@ export function compilePipeFromRender2(
     pure: pipe.pure,
   };
   const res = compilePipeFromMetadata(metadata);
-  const factoryRes = compileFactoryFromMetadata({...metadata, isPipe: true});
+  const factoryRes =
+      compileFactoryFromMetadata({...metadata, injectFn: R3.directiveInject, isPipe: true});
   const definitionField = outputCtx.constantPool.propertyNameOf(DefinitionKind.Pipe);
   const ngFactoryDefStatement = new o.ClassStmt(
       /* name */ name,

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -325,7 +325,7 @@ export function compileDirectiveFromRender2(
 
   const meta = directiveMetadataFromGlobalMetadata(directive, outputCtx, reflector);
   const res = compileDirectiveFromMetadata(meta, outputCtx.constantPool, bindingParser);
-  const factoryRes = compileFactoryFromMetadata(meta);
+  const factoryRes = compileFactoryFromMetadata({...meta, injectFn: R3.directiveInject});
   const ngFactoryDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(
@@ -378,7 +378,7 @@ export function compileComponentFromRender2(
     i18nUseExternalIds: true,
   };
   const res = compileComponentFromMetadata(meta, outputCtx.constantPool, bindingParser);
-  const factoryRes = compileFactoryFromMetadata(meta);
+  const factoryRes = compileFactoryFromMetadata({...meta, injectFn: R3.directiveInject});
   const ngFactoryDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -40,8 +40,7 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
-      isPipe?: boolean): any;
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
@@ -93,7 +92,6 @@ export interface R3InjectableMetadataFacade {
   name: string;
   type: any;
   typeArgumentCount: number;
-  ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
   useClass?: any;
   useFactory?: any;
@@ -169,7 +167,7 @@ export interface R3FactoryDefMetadataFacade {
   typeArgumentCount: number;
   deps: R3DependencyMetadataFacade[]|null;
   injectFn: 'directiveInject'|'inject';
-  isPipe?: boolean;
+  isPipe: boolean;
 }
 
 export type ViewEncapsulation = number;

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -40,8 +40,7 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
-      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade,
       isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
@@ -88,7 +87,6 @@ export interface R3PipeMetadataFacade {
   pipeName: string;
   deps: R3DependencyMetadataFacade[]|null;
   pure: boolean;
-  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3InjectableMetadataFacade {
@@ -97,7 +95,6 @@ export interface R3InjectableMetadataFacade {
   typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
-  injectFn: 'directiveInject'|'inject';
   useClass?: any;
   useFactory?: any;
   useExisting?: any;
@@ -141,7 +138,6 @@ export interface R3DirectiveMetadataFacade {
   exportAs: string[]|null;
   providers: Provider[]|null;
   viewQueries: R3QueryMetadataFacade[];
-  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
@@ -165,6 +161,15 @@ export interface R3BaseMetadataFacade {
   outputs?: {[key: string]: string};
   queries?: R3QueryMetadataFacade[];
   viewQueries?: R3QueryMetadataFacade[];
+}
+
+export interface R3FactoryDefMetadataFacade {
+  name: string;
+  type: any;
+  typeArgumentCount: number;
+  deps: R3DependencyMetadataFacade[]|null;
+  injectFn: 'directiveInject'|'inject';
+  isPipe?: boolean;
 }
 
 export type ViewEncapsulation = number;

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -40,8 +40,8 @@ export interface CompilerFacade {
   compileBase(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3BaseMetadataFacade):
       any;
   compileFactory(
-      angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
-      meta: R3PipeMetadataFacade|R3DirectiveMetadataFacade|R3ComponentMetadataFacade,
+      angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade|
+      R3DirectiveMetadataFacade|R3ComponentMetadataFacade|R3InjectableMetadataFacade,
       isPipe?: boolean): any;
 
   createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
@@ -88,6 +88,7 @@ export interface R3PipeMetadataFacade {
   pipeName: string;
   deps: R3DependencyMetadataFacade[]|null;
   pure: boolean;
+  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3InjectableMetadataFacade {
@@ -96,6 +97,7 @@ export interface R3InjectableMetadataFacade {
   typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
+  injectFn: 'directiveInject'|'inject';
   useClass?: any;
   useFactory?: any;
   useExisting?: any;
@@ -139,6 +141,7 @@ export interface R3DirectiveMetadataFacade {
   exportAs: string[]|null;
   providers: Provider[]|null;
   viewQueries: R3QueryMetadataFacade[];
+  injectFn: 'directiveInject'|'inject';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -46,9 +46,15 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
     Object.defineProperty(type, NG_FACTORY_DEF, {
       get: () => {
         if (ngFactoryDef === null) {
+          const metadata = getInjectableMetadata(type, srcMeta);
           ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreDiEnv, `ng:///${type.name}/ngFactoryDef.js`,
-              getInjectableMetadata(type, srcMeta));
+              angularCoreDiEnv, `ng:///${type.name}/ngFactoryDef.js`, {
+                name: metadata.name,
+                type: metadata.type,
+                typeArgumentCount: metadata.typeArgumentCount,
+                deps: metadata.ctorDeps,
+                injectFn: 'inject'
+              });
         }
         return ngFactoryDef;
       },
@@ -87,7 +93,6 @@ function getInjectableMetadata(type: Type<any>, srcMeta?: Injectable): R3Injecta
     providedIn: meta.providedIn,
     ctorDeps: reflectDependencies(type),
     userDeps: undefined,
-    injectFn: 'inject'
   };
   if ((isUseClassProvider(meta) || isUseFactoryProvider(meta)) && meta.deps !== undefined) {
     compilerMeta.userDeps = convertDependencies(meta.deps);

--- a/packages/core/src/r3_symbols.ts
+++ b/packages/core/src/r3_symbols.ts
@@ -25,6 +25,7 @@ export {ɵɵinject} from './di/injector_compatibility';
 export {ɵɵInjectableDef, ɵɵInjectorDef, ɵɵdefineInjectable, ɵɵdefineInjector} from './di/interface/defs';
 export {NgModuleDef, ɵɵNgModuleDefWithMeta} from './metadata/ng_module';
 export {ɵɵdefineNgModule} from './render3/definition';
+export {ɵɵFactoryDef} from './render3/interfaces/definition';
 export {setClassMetadata} from './render3/metadata';
 export {NgModuleFactory} from './render3/ng_module_ref';
 

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -753,11 +753,11 @@ export function getBaseDef<T>(type: any): ɵɵBaseDef<T>|null {
 export function getFactoryDef<T>(type: any, throwNotFound: true): FactoryFn<T>;
 export function getFactoryDef<T>(type: any): FactoryFn<T>|null;
 export function getFactoryDef<T>(type: any, throwNotFound?: boolean): FactoryFn<T>|null {
-  const factoryFn = type[NG_FACTORY_DEF] || null;
-  if (!factoryFn && throwNotFound === true && ngDevMode) {
+  const hasFactoryDef = type.hasOwnProperty(NG_FACTORY_DEF);
+  if (!hasFactoryDef && throwNotFound === true && ngDevMode) {
     throw new Error(`Type ${stringify(type)} does not have 'ngFactoryDef' property.`);
   }
-  return factoryFn;
+  return hasFactoryDef ? type[NG_FACTORY_DEF] : null;
 }
 
 export function getNgModuleDef<T>(type: any, throwNotFound: true): NgModuleDef<T>;

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -642,9 +642,11 @@ export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
     }) as any;
   }
 
-  // TODO(crisbeto): unify injectable factories with getFactory.
-  const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
-  const factory = def && def.factory || getFactoryDef<T>(typeAny);
+  let factory = getFactoryDef<T>(typeAny);
+  if (factory === null) {
+    const injectorDef = getInjectorDef<T>(typeAny);
+    factory = injectorDef && injectorDef.factory;
+  }
   return factory || null;
 }
 

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -16,7 +16,7 @@ import {Type} from '../interface/type';
 import {assertDefined, assertEqual} from '../util/assert';
 
 import {getFactoryDef} from './definition';
-import {NG_ELEMENT_ID} from './fields';
+import {NG_ELEMENT_ID, NG_FACTORY_DEF} from './fields';
 import {DirectiveDef, FactoryFn} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
 import {AttributeMarker, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType} from './interfaces/node';
@@ -655,7 +655,7 @@ export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
  */
 export function ɵɵgetInheritedFactory<T>(type: Type<any>): (type: Type<T>) => T {
   const proto = Object.getPrototypeOf(type.prototype).constructor as Type<any>;
-  const factory = ɵɵgetFactoryOf<T>(proto);
+  const factory = (proto as any)[NG_FACTORY_DEF] || ɵɵgetFactoryOf<T>(proto);
   if (factory !== null) {
     return factory;
   } else {

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -161,21 +161,19 @@ function getDirectiveMetadata(type: Type<any>, metadata: Directive) {
 function addDirectiveFactoryDef(type: Type<any>, metadata: Directive | Component) {
   let ngFactoryDef: any = null;
 
-  if (!type.hasOwnProperty(NG_FACTORY_DEF)) {
-    Object.defineProperty(type, NG_FACTORY_DEF, {
-      get: () => {
-        if (ngFactoryDef === null) {
-          const meta = getDirectiveMetadata(type, metadata);
-          ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreEnv, `ng:///${type.name}/ngFactoryDef.js`,
-              {...meta.metadata, injectFn: 'directiveInject'});
-        }
-        return ngFactoryDef;
-      },
-      // Make the property configurable in dev mode to allow overriding in tests
-      configurable: !!ngDevMode,
-    });
-  }
+  Object.defineProperty(type, NG_FACTORY_DEF, {
+    get: () => {
+      if (ngFactoryDef === null) {
+        const meta = getDirectiveMetadata(type, metadata);
+        ngFactoryDef = getCompilerFacade().compileFactory(
+            angularCoreEnv, `ng:///${type.name}/ngFactoryDef.js`,
+            {...meta.metadata, injectFn: 'directiveInject', isPipe: false});
+      }
+      return ngFactoryDef;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
 }
 
 export function extendsDirectlyFromObject(type: Type<any>): boolean {

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -167,7 +167,8 @@ function addDirectiveFactoryDef(type: Type<any>, metadata: Directive | Component
         if (ngFactoryDef === null) {
           const meta = getDirectiveMetadata(type, metadata);
           ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreEnv, `ng:///${type.name}/ngFactoryDef.js`, meta.metadata);
+              angularCoreEnv, `ng:///${type.name}/ngFactoryDef.js`,
+              {...meta.metadata, injectFn: 'directiveInject'});
         }
         return ngFactoryDef;
       },
@@ -205,8 +206,7 @@ export function directiveMetadata(type: Type<any>, metadata: Directive): R3Direc
     usesInheritance: !extendsDirectlyFromObject(type),
     exportAs: extractExportAs(metadata.exportAs),
     providers: metadata.providers || null,
-    viewQueries: extractQueriesMetadata(type, propMetadata, isViewQuery),
-    injectFn: 'directiveInject'
+    viewQueries: extractQueriesMetadata(type, propMetadata, isViewQuery)
   };
 }
 

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -18,22 +18,19 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
   let ngPipeDef: any = null;
   let ngFactoryDef: any = null;
 
-  // if NG_FACTORY_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_FACTORY_DEF)) {
-    Object.defineProperty(type, NG_FACTORY_DEF, {
-      get: () => {
-        if (ngFactoryDef === null) {
-          const metadata = getPipeMetadata(type, meta);
-          ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreEnv, `ng:///${metadata.name}/ngFactoryDef.js`,
-              {...metadata, injectFn: 'directiveInject'}, true);
-        }
-        return ngFactoryDef;
-      },
-      // Make the property configurable in dev mode to allow overriding in tests
-      configurable: !!ngDevMode,
-    });
-  }
+  Object.defineProperty(type, NG_FACTORY_DEF, {
+    get: () => {
+      if (ngFactoryDef === null) {
+        const metadata = getPipeMetadata(type, meta);
+        ngFactoryDef = getCompilerFacade().compileFactory(
+            angularCoreEnv, `ng:///${metadata.name}/ngFactoryDef.js`,
+            {...metadata, injectFn: 'directiveInject', isPipe: true});
+      }
+      return ngFactoryDef;
+    },
+    // Make the property configurable in dev mode to allow overriding in tests
+    configurable: !!ngDevMode,
+  });
 
   Object.defineProperty(type, NG_PIPE_DEF, {
     get: () => {

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -25,7 +25,8 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
         if (ngFactoryDef === null) {
           const metadata = getPipeMetadata(type, meta);
           ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreEnv, `ng:///${metadata.name}/ngFactoryDef.js`, metadata, true);
+              angularCoreEnv, `ng:///${metadata.name}/ngFactoryDef.js`,
+              {...metadata, injectFn: 'directiveInject'}, true);
         }
         return ngFactoryDef;
       },
@@ -55,7 +56,6 @@ function getPipeMetadata(type: Type<any>, meta: Pipe): R3PipeMetadataFacade {
     name: type.name,
     deps: reflectDependencies(type),
     pipeName: meta.name,
-    pure: meta.pure !== undefined ? meta.pure : true,
-    injectFn: 'directiveInject'
+    pure: meta.pure !== undefined ? meta.pure : true
   };
 }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -951,6 +951,37 @@ describe('di', () => {
             `This will become an error in v10. Please add @Injectable() to the "SubSubClass" class.`);
       }
     });
+
+    it('should instantiate correct class when undecorated class extends an injectable', () => {
+      @Injectable()
+      class MyService {
+        id = 1;
+      }
+
+      class MyRootService extends MyService {
+        id = 2;
+      }
+
+      @Component({template: ''})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App], providers: [MyRootService]});
+      const warnSpy = spyOn(console, 'warn');
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const provider = TestBed.inject(MyRootService);
+
+      expect(provider instanceof MyRootService).toBe(true);
+      expect(provider.id).toBe(2);
+
+      if (ivyEnabled) {
+        expect(warnSpy).toHaveBeenCalledWith(
+            `DEPRECATED: DI is instantiating a token "MyRootService" that inherits its @Injectable decorator but does not provide one itself.\n` +
+            `This will become an error in v10. Please add @Injectable() to the "MyRootService" class.`);
+      }
+    });
   });
 
   describe('inject', () => {


### PR DESCRIPTION
With #31953 we moved the factories for components, directives and pipes into a new field called `ngFactoryDef`, however I decided not to do it for injectables, because they needed some extra logic. These changes set up the `ngFactoryDef` for injectables as well.

For reference, the extra logic mentioned above is that for injectables we have two code paths:

1. For injectables that don't configure how they should be instantiated, we create a `factory` that proxies to `ngFactoryDef`:

```
// Source
@Injectable()
class Service {}

// Output
class Service {
  static ngInjectableDef = defineInjectable({
    factory: () => Service.ngFactoryFn(),
  });

  static ngFactoryFn: (t) => new (t || Service)();
}
```

2. For injectables that do configure how they're created, we keep the `ngFactoryDef` and generate the factory based on the metadata:

```
// Source
@Injectable({
  useValue: DEFAULT_IMPL,
})
class Service {}

// Output
export class Service {
  static ngInjectableDef = defineInjectable({
    factory: () => DEFAULT_IMPL,
  });

  static ngFactoryFn: (t) => new (t || Service)();
}
```
