### PR TITLE
refactor(ivy): simplify property binding metadata

### DIFF
--- a/packages/core/src/render3/instructions/interpolation.ts
+++ b/packages/core/src/render3/instructions/interpolation.ts
@@ -8,10 +8,9 @@
 
 import {assertEqual, assertLessThan} from '../../util/assert';
 import {bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4} from '../bindings';
-import {BINDING_INDEX, LView, TVIEW} from '../interfaces/view';
+import {BINDING_INDEX, LView} from '../interfaces/view';
 import {NO_CHANGE} from '../tokens';
 import {renderStringify} from '../util/misc_utils';
-import {storeBindingMetadata} from './shared';
 
 
 
@@ -31,23 +30,13 @@ export function interpolationV(lView: LView, values: any[]): string|NO_CHANGE {
   ngDevMode && assertLessThan(2, values.length, 'should have at least 3 values');
   ngDevMode && assertEqual(values.length % 2, 1, 'should have an odd number of values');
   let isBindingUpdated = false;
-  const tData = lView[TVIEW].data;
   let bindingIndex = lView[BINDING_INDEX];
-
-  if (tData[bindingIndex] == null) {
-    // 2 is the index of the first static interstitial value (ie. not prefix)
-    for (let i = 2; i < values.length; i += 2) {
-      tData[bindingIndex++] = values[i];
-    }
-    bindingIndex = lView[BINDING_INDEX];
-  }
 
   for (let i = 1; i < values.length; i += 2) {
     // Check if bindings (odd indexes) have changed
     isBindingUpdated = bindingUpdated(lView, bindingIndex++, values[i]) || isBindingUpdated;
   }
   lView[BINDING_INDEX] = bindingIndex;
-  storeBindingMetadata(lView, values[0], values[values.length - 1]);
 
   if (!isBindingUpdated) {
     return NO_CHANGE;
@@ -72,7 +61,6 @@ export function interpolationV(lView: LView, values: any[]): string|NO_CHANGE {
 export function interpolation1(lView: LView, prefix: string, v0: any, suffix: string): string|
     NO_CHANGE {
   const different = bindingUpdated(lView, lView[BINDING_INDEX]++, v0);
-  ngDevMode && storeBindingMetadata(lView, prefix, suffix);
   return different ? prefix + renderStringify(v0) + suffix : NO_CHANGE;
 }
 
@@ -84,14 +72,6 @@ export function interpolation2(
   const bindingIndex = lView[BINDING_INDEX];
   const different = bindingUpdated2(lView, bindingIndex, v0, v1);
   lView[BINDING_INDEX] += 2;
-
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      lView[TVIEW].data[bindingIndex] = i0;
-    }
-  }
 
   return different ? prefix + renderStringify(v0) + i0 + renderStringify(v1) + suffix : NO_CHANGE;
 }
@@ -105,16 +85,6 @@ export function interpolation3(
   const bindingIndex = lView[BINDING_INDEX];
   const different = bindingUpdated3(lView, bindingIndex, v0, v1, v2);
   lView[BINDING_INDEX] += 3;
-
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-    }
-  }
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + suffix :
@@ -130,17 +100,6 @@ export function interpolation4(
   const bindingIndex = lView[BINDING_INDEX];
   const different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   lView[BINDING_INDEX] += 4;
-
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-      tData[bindingIndex + 2] = i2;
-    }
-  }
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -159,18 +118,6 @@ export function interpolation5(
   different = bindingUpdated(lView, bindingIndex + 4, v4) || different;
   lView[BINDING_INDEX] += 5;
 
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-      tData[bindingIndex + 2] = i2;
-      tData[bindingIndex + 3] = i3;
-    }
-  }
-
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
           renderStringify(v3) + i3 + renderStringify(v4) + suffix :
@@ -187,19 +134,6 @@ export function interpolation6(
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated2(lView, bindingIndex + 4, v4, v5) || different;
   lView[BINDING_INDEX] += 6;
-
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-      tData[bindingIndex + 2] = i2;
-      tData[bindingIndex + 3] = i3;
-      tData[bindingIndex + 4] = i4;
-    }
-  }
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -219,20 +153,6 @@ export function interpolation7(
   different = bindingUpdated3(lView, bindingIndex + 4, v4, v5, v6) || different;
   lView[BINDING_INDEX] += 7;
 
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-      tData[bindingIndex + 2] = i2;
-      tData[bindingIndex + 3] = i3;
-      tData[bindingIndex + 4] = i4;
-      tData[bindingIndex + 5] = i5;
-    }
-  }
-
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
           renderStringify(v3) + i3 + renderStringify(v4) + i4 + renderStringify(v5) + i5 +
@@ -251,21 +171,6 @@ export function interpolation8(
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated4(lView, bindingIndex + 4, v4, v5, v6, v7) || different;
   lView[BINDING_INDEX] += 8;
-
-  if (ngDevMode) {
-    // Only set static strings the first time (data will be null subsequent runs).
-    const data = storeBindingMetadata(lView, prefix, suffix);
-    if (data) {
-      const tData = lView[TVIEW].data;
-      tData[bindingIndex] = i0;
-      tData[bindingIndex + 1] = i1;
-      tData[bindingIndex + 2] = i2;
-      tData[bindingIndex + 3] = i3;
-      tData[bindingIndex + 4] = i4;
-      tData[bindingIndex + 5] = i5;
-      tData[bindingIndex + 6] = i6;
-    }
-  }
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -118,8 +118,7 @@ export const TNodeConstructor = class TNode implements ITNode {
       public injectorIndex: number,                                            //
       public directiveStart: number,                                           //
       public directiveEnd: number,                                             //
-      public propertyMetadataStartIndex: number,                               //
-      public propertyMetadataEndIndex: number,                                 //
+      public propertyBindings: number[]|null,                                  //
       public flags: TNodeFlags,                                                //
       public providerIndexes: TNodeProviderIndexes,                            //
       public tagName: string|null,                                             //

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -7,11 +7,11 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX, LView} from '../interfaces/view';
+import {BINDING_INDEX, LView, TVIEW} from '../interfaces/view';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
-import {TsickleIssue1009, elementPropertyInternal, storeBindingMetadata} from './shared';
+import {TsickleIssue1009, elementPropertyInternal, storePropertyBindingMetadata} from './shared';
 
 
 /**
@@ -35,9 +35,11 @@ import {TsickleIssue1009, elementPropertyInternal, storeBindingMetadata} from '.
 export function ɵɵproperty<T>(
     propName: string, value: T, sanitizer?: SanitizerFn | null): TsickleIssue1009 {
   const lView = getLView();
-  const bindReconciledValue = bind(lView, value);
-  if (bindReconciledValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, bindReconciledValue, sanitizer);
+  const bindingIndex = lView[BINDING_INDEX]++;
+  if (bindingUpdated(lView, bindingIndex, value)) {
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, value, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
   }
   return ɵɵproperty;
 }
@@ -49,7 +51,5 @@ export function ɵɵproperty<T>(
  * @param value Value to diff
  */
 export function bind<T>(lView: LView, value: T): T|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX]++;
-  ngDevMode && storeBindingMetadata(lView);
-  return bindingUpdated(lView, bindingIndex, value) ? value : NO_CHANGE;
+  return bindingUpdated(lView, lView[BINDING_INDEX]++, value) ? value : NO_CHANGE;
 }

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {SanitizerFn} from '../interfaces/sanitization';
+import {BINDING_INDEX, TVIEW} from '../interfaces/view';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
-import {TsickleIssue1009, elementPropertyInternal} from './shared';
+import {TsickleIssue1009, elementPropertyInternal, storePropertyBindingMetadata} from './shared';
 
 
 
@@ -81,9 +82,13 @@ export function ɵɵpropertyInterpolate(
 export function ɵɵpropertyInterpolate1(
     propName: string, prefix: string, v0: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolation1(getLView(), prefix, v0, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, getSelectedIndex(), propName, lView[BINDING_INDEX] - 1,
+                     prefix, suffix);
   }
   return ɵɵpropertyInterpolate1;
 }
@@ -121,9 +126,14 @@ export function ɵɵpropertyInterpolate1(
 export function ɵɵpropertyInterpolate2(
     propName: string, prefix: string, v0: any, i0: string, v1: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolation2(getLView(), prefix, v0, i0, v1, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode &&
+        storePropertyBindingMetadata(
+            lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 2, prefix, i0, suffix);
   }
   return ɵɵpropertyInterpolate2;
 }
@@ -164,9 +174,14 @@ export function ɵɵpropertyInterpolate2(
 export function ɵɵpropertyInterpolate3(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolation3(getLView(), prefix, v0, i0, v1, i1, v2, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 3, prefix, i0,
+                     i1, suffix);
   }
   return ɵɵpropertyInterpolate3;
 }
@@ -209,9 +224,14 @@ export function ɵɵpropertyInterpolate3(
 export function ɵɵpropertyInterpolate4(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolation4(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
+  const lView = getLView();
+  const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 4, prefix, i0,
+                     i1, i2, suffix);
   }
   return ɵɵpropertyInterpolate4;
 }
@@ -256,10 +276,15 @@ export function ɵɵpropertyInterpolate4(
 export function ɵɵpropertyInterpolate5(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue =
-      interpolation5(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
+      interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 5, prefix, i0,
+                     i1, i2, i3, suffix);
   }
   return ɵɵpropertyInterpolate5;
 }
@@ -307,10 +332,15 @@ export function ɵɵpropertyInterpolate6(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue =
-      interpolation6(getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
+      interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 6, prefix, i0,
+                     i1, i2, i3, i4, suffix);
   }
   return ɵɵpropertyInterpolate6;
 }
@@ -360,10 +390,15 @@ export function ɵɵpropertyInterpolate7(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, suffix: string,
     sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolation7(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
+  const lView = getLView();
+  const interpolatedValue =
+      interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 7, prefix, i0,
+                     i1, i2, i3, i4, i5, suffix);
   }
   return ɵɵpropertyInterpolate7;
 }
@@ -415,10 +450,15 @@ export function ɵɵpropertyInterpolate8(
     propName: string, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string, sanitizer?: SanitizerFn): TsickleIssue1009 {
+  const lView = getLView();
   const interpolatedValue = interpolation8(
-      getLView(), prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
+      lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    ngDevMode && storePropertyBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 8, prefix, i0,
+                     i1, i2, i3, i4, i5, i6, suffix);
   }
   return ɵɵpropertyInterpolate8;
 }
@@ -455,9 +495,20 @@ export function ɵɵpropertyInterpolate8(
  */
 export function ɵɵpropertyInterpolateV(
     propName: string, values: any[], sanitizer?: SanitizerFn): TsickleIssue1009 {
-  const interpolatedValue = interpolationV(getLView(), values);
+  const lView = getLView();
+  const interpolatedValue = interpolationV(lView, values);
   if (interpolatedValue !== NO_CHANGE) {
-    elementPropertyInternal(getSelectedIndex(), propName, interpolatedValue, sanitizer);
+    const nodeIndex = getSelectedIndex();
+    elementPropertyInternal(nodeIndex, propName, interpolatedValue, sanitizer);
+    if (ngDevMode) {
+      const interpolationInBetween = [values[0]];  // prefix
+      for (let i = 2; i < values.length; i += 2) {
+        interpolationInBetween.push(values[i]);
+      }
+      storePropertyBindingMetadata(
+          lView[TVIEW].data, nodeIndex, propName,
+          lView[BINDING_INDEX] - interpolationInBetween.length + 1, ...interpolationInBetween);
+    }
   }
   return ɵɵpropertyInterpolateV;
 }

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -260,19 +260,13 @@ export interface TNode {
   directiveEnd: number;
 
   /**
-   * Stores the first index where property binding metadata is stored for
-   * this node.
+   * Stores indexes of property bindings. This field is only set in the ngDevMode and holds indexes
+   * of property bindings so TestBed can get bound property metadata for a given node.
    */
-  propertyMetadataStartIndex: number;
+  propertyBindings: number[]|null;
 
   /**
-   * Stores the exclusive final index where property binding metadata is
-   * stored for this node.
-   */
-  propertyMetadataEndIndex: number;
-
-  /**
-   * Stores if Node isComponent, isProjected, hasContentQuery, hasClassInput and hasStyleInput
+   * Stores if Node isComponent, isProjected, hasContentQuery, hasClassInput and hasStyleInput etc.
    */
   flags: TNodeFlags;
 

--- a/packages/core/src/render3/util/misc_utils.ts
+++ b/packages/core/src/render3/util/misc_utils.ts
@@ -83,14 +83,6 @@ export function ɵɵresolveBody(element: RElement & {ownerDocument: Document}) {
 export const INTERPOLATION_DELIMITER = `�`;
 
 /**
- * Determines whether or not the given string is a property metadata string.
- * See storeBindingMetadata().
- */
-export function isPropMetadataString(str: string): boolean {
-  return str.indexOf(INTERPOLATION_DELIMITER) >= 0;
-}
-
-/**
  * Unwrap a value which might be behind a closure (for forward declaration reasons).
  */
 export function maybeUnwrapFn<T>(value: T | (() => T)): T {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -489,9 +489,6 @@
     "name": "baseResolveDirective"
   },
   {
-    "name": "bind"
-  },
-  {
     "name": "bindingUpdated"
   },
   {

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -33,6 +33,11 @@ class MessageDir {
   set message(newMessage: string) { this.logger.add(newMessage); }
 }
 
+@Directive({selector: '[with-title]', inputs: ['title']})
+class WithTitleDir {
+  title = '';
+}
+
 @Component({
   selector: 'child-comp',
   template: `<div class="child" message="child">
@@ -211,6 +216,23 @@ class TestCmptWithPropBindings {
   title = 'hello';
 }
 
+@Component({
+  template: `
+  <button title="{{0}}"></button>
+  <button title="a{{1}}b"></button>
+  <button title="a{{1}}b{{2}}c"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e{{5}}f"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e{{5}}f{{6}}g"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e{{5}}f{{6}}g{{7}}h"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e{{5}}f{{6}}g{{7}}h{{8}}i"></button>
+  <button title="a{{1}}b{{2}}c{{3}}d{{4}}e{{5}}f{{6}}g{{7}}h{{8}}i{{9}}j"></button>
+`
+})
+class TestCmptWithPropInterpolation {
+}
+
 {
   describe('debug element', () => {
     let fixture: ComponentFixture<any>;
@@ -235,6 +257,8 @@ class TestCmptWithPropBindings {
           TestCmptWithViewContainerRef,
           SimpleContentComp,
           TestCmptWithPropBindings,
+          TestCmptWithPropInterpolation,
+          WithTitleDir,
         ],
         providers: [Logger],
         schemas: [NO_ERRORS_SCHEMA],
@@ -718,6 +742,35 @@ class TestCmptWithPropBindings {
 
       const button = fixture.debugElement.query(By.css('button'));
       expect(button.properties).toEqual({disabled: true, tabIndex: 1337, title: 'hello'});
+    });
+
+    it('should include interpolated properties in the properties map', () => {
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.children;
+
+      expect(buttons.length).toBe(10);
+      expect(buttons[0].properties.title).toBe('0');
+      expect(buttons[1].properties.title).toBe('a1b');
+      expect(buttons[2].properties.title).toBe('a1b2c');
+      expect(buttons[3].properties.title).toBe('a1b2c3d');
+      expect(buttons[4].properties.title).toBe('a1b2c3d4e');
+      expect(buttons[5].properties.title).toBe('a1b2c3d4e5f');
+      expect(buttons[6].properties.title).toBe('a1b2c3d4e5f6g');
+      expect(buttons[7].properties.title).toBe('a1b2c3d4e5f6g7h');
+      expect(buttons[8].properties.title).toBe('a1b2c3d4e5f6g7h8i');
+      expect(buttons[9].properties.title).toBe('a1b2c3d4e5f6g7h8i9j');
+    });
+
+    it('should not include directive-shadowed properties in the properties map', () => {
+      TestBed.overrideTemplate(
+          TestCmptWithPropInterpolation, `<button with-title [title]="'goes to input'"></button>`);
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
+      fixture.detectChanges();
+
+      const button = fixture.debugElement.query(By.css('button'));
+      expect(button.properties.title).toBeUndefined();
     });
 
     it('should trigger events registered via Renderer2', () => {


### PR DESCRIPTION
Since property binding metadata storage is guarded with the ngDevMode now
and several instructions were merged together, we can simplify the way we
store and read property binding metadata. 

The the most important change in this PR is that now we can store binding metadata in one field in the `TView.data` (previously meta-data for an interpolated bound property would be spread over multiple `TView.data` entries). This greatly simplifies property binding metadata retrieval (we just need to look it up at one index) and lets us to remove chunks of code / logic (`getFirstBindingIndex ` can go away). Also regular and host binding properties gets unified (`collectHostPropertyBindings` can be removed). 

To know where property bindings are located for a given `TNode` we can remove 2 fields from `TNode` (`propertyMetadataStartIndex ` / `propertyMetadataEndIndex `) and replace it with just one  (`propertyBindings`) filled in the `ngDevMode` only.

Finally, property binding metadata are stored for properties only and there is no processing for attribute bindings.

I believe that this refactoring removes code, simplifies logic and opens up possibilities of other refactorings (perf-motivated goal here is to get rid of the `bind` function).
