### PR TITLE
fix(ivy): i18n - do not generate jsdoc comments for `$localize`

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -194,10 +194,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_0$ = $MSG_EXTERNAL_idA$$APP_SPEC_TS_1$;
         }
         else {
-          /**
-           * @desc descA
-           * @meaning meaningA
-           */
           $I18N_0$ = $localize \`Content A\`;
         }
         const $_c2$ = [${AttributeMarker.I18n}, "title"];
@@ -211,10 +207,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_3$ = $MSG_EXTERNAL_idB$$APP_SPEC_TS_4$;
         }
         else {
-          /**
-           * @desc descB
-           * @meaning meaningB
-           */
           $I18N_3$ = $localize \`Title B\`;
         }
         const $_c5$ = ["title", $I18N_3$];
@@ -227,9 +219,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_7$ = $MSG_EXTERNAL_4978592519614169666$$APP_SPEC_TS_8$;
         }
         else {
-          /**
-           * @desc meaningC
-           */
           $I18N_7$ = $localize \`Title C\`;
         }
         const $_c9$ = ["title", $I18N_7$];
@@ -243,10 +232,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_11$ = $MSG_EXTERNAL_5200291527729162531$$APP_SPEC_TS_12$;
         }
         else {
-          /**
-           * @desc descD
-           * @meaning meaningD
-           */
           $I18N_11$ = $localize \`Title D\`;
         }
         const $_c13$ = ["title", $I18N_11$];
@@ -259,9 +244,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_15$ = $MSG_EXTERNAL_idE$$APP_SPEC_TS_16$;
         }
         else {
-          /**
-           * @desc meaningE
-           */
           $I18N_15$ = $localize \`Title E\`;
         }
         const $_c17$ = ["title", $I18N_15$];
@@ -283,9 +265,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
         }
         else {
-          /**
-           * @desc [BACKUP_MESSAGE_ID:idH]desc
-           */
           $I18N_23$ = $localize \`Title G\`;
         }
         const $_c25$ = ["title", $I18N_23$];
@@ -386,10 +365,6 @@ describe('i18n support in the view compiler', () => {
           $I18N_1$ = $MSG_EXTERNAL_8809028065680254561$$APP_SPEC_TS_1$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_1$ = $localize \`introduction\`;
         }
         const $_c1$ = ["title", $I18N_1$];
@@ -441,10 +416,6 @@ describe('i18n support in the view compiler', () => {
           $I18N_2$ = $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_2$ = $localize \`intro $` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -460,10 +431,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_3$ = $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$;
         }
         else {
-          /**
-           * @desc d1
-           * @meaning m1
-           */
           $I18N_3$ = $localize \`$` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -485,10 +452,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_6$ = $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$;
         }
         else {
-          /**
-           * @desc d2
-           * @meaning m2
-           */
           $I18N_6$ = $localize \`$` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation: and $` +
           String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: and again $` +
@@ -554,10 +517,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_1$ = $MSG_EXTERNAL_8977039798304050198$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_1$ = $localize \`intro $` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -601,10 +560,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_1$ = $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__1$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_1$ = $localize \`different scope $` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -679,10 +634,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_2$ = $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_2$ = $localize \`intro $` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -698,10 +649,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_3$ = $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$;
         }
         else {
-          /**
-           * @desc d1
-           * @meaning m1
-           */
           $I18N_3$ = $localize \`$` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -723,10 +670,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_6$ = $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$;
         }
         else {
-          /**
-           * @desc d2
-           * @meaning m2
-           */
           $I18N_6$ = $localize \`$` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation: and $` +
           String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: and again $` +
@@ -795,10 +738,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_2$ = $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__3$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_2$ = $localize \`different scope $` +
           String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
         }
@@ -852,10 +791,6 @@ describe('i18n support in the view compiler', () => {
             $I18N_0$ = $MSG_EXTERNAL_7727043314656808423$$APP_SPEC_TS_0$;
         }
         else {
-          /**
-           * @desc d
-           * @meaning m
-           */
           $I18N_0$ = $localize \`Element title\`;
         }
         const $_c1$ = ["title", $I18N_0$];

--- a/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
@@ -25,7 +25,10 @@ export function createGoogleGetMsgStatements(
     args.push(mapLiteral(params, true));
   }
 
-  // /** Description and meaning of message */
+  // /**
+  //  * @desc description of message
+  //  * @meaning meaning of message
+  //  */
   // const MSG_... = goog.getMsg(..);
   // I18N_X = MSG_...;
   const statements = [];

--- a/packages/compiler/src/render3/view/i18n/localize_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/localize_utils.ts
@@ -17,10 +17,13 @@ export function createLocalizeStatements(
     params: {[name: string]: o.Expression}): o.Statement[] {
   const statements = [];
 
-  const jsdocComment = i18nMetaToDocStmt(metaFromI18nMessage(message));
-  if (jsdocComment !== null) {
-    statements.push(jsdocComment);
-  }
+  // TODO: re-enable these comments when we have a plan on how to make them work so that Closure
+  // compiler doesn't complain about the JSDOC comments.
+
+  // const jsdocComment = i18nMetaToDocStmt(metaFromI18nMessage(message));
+  // if (jsdocComment !== null) {
+  //   statements.push(jsdocComment);
+  // }
 
   const {messageParts, placeHolders} = serializeI18nMessageForLocalize(message);
   statements.push(new o.ExpressionStatement(variable.set(


### PR DESCRIPTION
Previously the compiler would generate the same jsdoc comment
block for `$localize` as for `goog.getMsg()`. But it turns out that
the closure compiler will complain if the `@desc` and `@meaning`
tags are used for non-`getMsg()` calls. So we now generate custom
jsdoc tags (`@i18nDesc` and `@i18nMeaning`) that for the
`$localize` calls.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
