### PR TITLE
fix(language-service): use tsLSHost to do module resolution

### DIFF
--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -7,8 +7,11 @@
  */
 
 import * as path from 'path';
+import * as ts from 'typescript';
 
+import {createLanguageService} from '../src/language_service';
 import {ReflectorHost} from '../src/reflector_host';
+import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
 import {MockTypescriptHost} from './test_utils';
@@ -19,7 +22,7 @@ describe('reflector_host_spec', () => {
   it('should be able to find angular under windows', () => {
     const originalJoin = path.join;
     const originalPosixJoin = path.posix.join;
-    let mockHost =
+    const mockHost =
         new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh, 'node_modules', {
           ...path,
           join: (...args: string[]) => originalJoin.apply(path, args),
@@ -36,5 +39,47 @@ describe('reflector_host_spec', () => {
 
     const result = reflectorHost.moduleNameToFileName('@angular/core');
     expect(result).not.toBeNull('could not find @angular/core using path.win32');
+  });
+
+  it('should use module resolution cache', () => {
+    const mockHost = new MockTypescriptHost(['/app/main.ts'], toh);
+    // TypeScript relies on `ModuleResolutionHost.fileExists()` to perform
+    // module resolution, and ReflectorHost uses
+    // `LanguageServiceHost.getScriptSnapshot()` to implement `fileExists()`,
+    // so spy on this method to determine how many times it's called.
+    const spy = spyOn(mockHost, 'getScriptSnapshot').and.callThrough();
+
+    const tsLS = ts.createLanguageService(mockHost);
+
+    // First count is due to the instantiation of StaticReflector, which
+    // performs resolutions of core Angular symbols, like `NgModule`.
+    // TODO: Reduce this count to zero doing lazy instantiation.
+    const ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
+    const firstCount = spy.calls.count();
+    expect(firstCount).toBeGreaterThan(20);
+    expect(firstCount).toBeLessThan(50);
+    spy.calls.reset();
+
+    // Second count is due to resolution of the Tour of Heroes (toh) project.
+    // This resolves all Angular directives in the project.
+    ngLSHost.getAnalyzedModules();
+    const secondCount = spy.calls.count();
+    expect(secondCount).toBeGreaterThan(500);
+    expect(secondCount).toBeLessThan(600);
+    spy.calls.reset();
+
+    // Third count is due to recompution after the program changes.
+    mockHost.addCode('');  // this will mark project as dirty
+    ngLSHost.getAnalyzedModules();
+    const thirdCount = spy.calls.count();
+    expect(thirdCount).toBeGreaterThan(50);
+    expect(thirdCount).toBeLessThan(100);
+
+    // Summary
+    // |               | First Count | Second Count | Third Count |
+    // |---------------|-------------|--------------|-------------|
+    // | Without Cache | 2581        | 6291         | 257         |
+    // | With Cache    | 26          | 550          | 84          |
+    // | Improvement   | ~100x       | ~10x         | ~3x         |
   });
 });


### PR DESCRIPTION
This PR fixes a critical performance issue where the language
service makes a MASSIVE number of filesystem calls when performing
module resolution.
This is because there is no caching. To make matters worse, module
resolution is performed for **every** program change (which means every
few keystrokes trigger a massive number of fs calls).

There are two solutions here:
1. Provide a cache to ts.resolveModuleName()
2. Use ts.LanguageServiceHost.resolveModuleNames()

Since every Project (and by extension ConfiguredProject) implements
ts.LanguageServiceHost interface, (2) is the preferred solution here.
i.e. the TypeScript LanguageServiceHost always has the
resolveModuleNames() defined even though it's optional in the interface.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information