### PR TITLE
fix(language-service): use tsLSHost to do module resolution

### DIFF
--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -20,7 +20,7 @@ describe('reflector_host_spec', () => {
     const originalJoin = path.join;
     const originalPosixJoin = path.posix.join;
     let mockHost =
-        new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh, 'app/node_modules', {
+        new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh, 'node_modules', {
           ...path,
           join: (...args: string[]) => originalJoin.apply(path, args),
           posix:


### PR DESCRIPTION
This is a patch PR for https://github.com/angular/angular/pull/32479

This PR fixes a critical performance issue where the language
service makes a MASSIVE number of filesystem calls when performing
module resolution.
This is because there is no caching. To make matters worse, module
resolution is performed for every program change (which means every
few keystrokes trigger a massive number of fs calls).

There are two solutions here:

Provide a cache to ts.resolveModuleName()
Use ts.LanguageServiceHost.resolveModuleNames()
Since every Project (and by extension ConfiguredProject) implements
ts.LanguageServiceHost interface, (2) is the preferred solution here.
i.e. the TypeScript LanguageServiceHost always has the
resolveModuleNames() defined even though it's optional in the interface.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
