### PR TITLE
fix(ivy): maintain coalesced listeners order

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -149,9 +149,13 @@ function listenerInternal(
         existingListener = findExistingListener(lView, eventName, tNode.index);
       }
       if (existingListener !== null) {
-        // Attach a new listener at the head of the coalesced listeners list.
-        (<any>listenerFn).__ngNextListenerFn__ = (<any>existingListener).__ngNextListenerFn__;
-        (<any>existingListener).__ngNextListenerFn__ = listenerFn;
+        // Attach a new listener to coalesced listeners list, maintaining the order in which
+        // listeners are registered. For performance reasons, we keep a reference to the last
+        // listener in that list (in `__ngLastListenerFn__` field), so we can avoid going through
+        // the entire set each time we need to add a new listener.
+        const lastListenerFn = (<any>existingListener).__ngLastListenerFn__ || existingListener;
+        lastListenerFn.__ngNextListenerFn__ = listenerFn;
+        (<any>existingListener).__ngLastListenerFn__ = listenerFn;
         processOutputs = false;
       } else {
         // The first argument of `listen` function in Procedural Renderer is:

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -238,5 +238,38 @@ describe('event listeners', () => {
       expect(componentInstance.count).toEqual(1);
       expect(componentInstance.someValue).toEqual(42);
     });
+
+    it('should maintain the order in which listeners are registered', () => {
+      const log: string[] = [];
+      @Component({
+        selector: 'my-comp',
+        template: '<button dirA dirB (click)="count()">Click me!</button>',
+      })
+      class MyComp {
+        counter = 0;
+        count() { log.push('component.click'); }
+      }
+
+      @Directive({selector: '[dirA]'})
+      class DirA {
+        @HostListener('click')
+        count() { log.push('dirA.click'); }
+      }
+
+      @Directive({selector: '[dirB]'})
+      class DirB {
+        @HostListener('click')
+        count() { log.push('dirB.click'); }
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComp, DirA, DirB]});
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.firstChild;
+      button.click();
+
+      expect(log).toEqual(['dirA.click', 'dirB.click', 'component.click']);
+    });
   });
 });

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -240,44 +240,6 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         const form = fixture.debugElement.query(By.css('form'));
         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
       });
-
-      it('should fire `ngModelChange` event before `input` event', () => {
-        const log: string[] = [];
-        @Component({
-          selector: 'my-comp',
-          template: `
-            <input
-              type="number"
-              [(ngModel)]="myField"
-              (input)="handleInput($event)"
-            />
-          `
-        })
-        class MyComp {
-          private _myField: any = 1;
-
-          get myField() { return this._myField; }
-          set myField(value: any) {
-            this._myField = value;
-            log.push('ngModel');
-          }
-
-          handleInput() { log.push('input'); }
-        }
-
-        const fixture = initTest(MyComp);
-        fixture.detectChanges();
-
-        log.length = 0;
-
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        input.value = 2;
-        dispatchEvent(input, 'input');
-        fixture.detectChanges();
-
-        expect(log).toEqual(['ngModel', 'input']);
-        expect(fixture.componentInstance.myField).toEqual(2);
-      });
     });
 
     describe('name and ngModelOptions', () => {

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -272,7 +272,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 2;
-        input.dispatchEvent(new Event('input'));
+        dispatchEvent(input, 'input');
         fixture.detectChanges();
 
         expect(log).toEqual(['ngModel', 'input']);

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -240,6 +240,44 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         const form = fixture.debugElement.query(By.css('form'));
         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
       });
+
+      it('should fire `ngModelChange` event before `input` event', () => {
+        const log: string[] = [];
+        @Component({
+          selector: 'my-comp',
+          template: `
+            <input
+              type="number"
+              [(ngModel)]="myField"
+              (input)="handleInput($event)"
+            />
+          `
+        })
+        class MyComp {
+          private _myField: any = 1;
+
+          get myField() { return this._myField; }
+          set myField(value: any) {
+            this._myField = value;
+            log.push('ngModel');
+          }
+
+          handleInput() { log.push('input'); }
+        }
+
+        const fixture = initTest(MyComp);
+        fixture.detectChanges();
+
+        log.length = 0;
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 2;
+        input.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+
+        expect(log).toEqual(['ngModel', 'input']);
+        expect(fixture.componentInstance.myField).toEqual(2);
+      });
     });
 
     describe('name and ngModelOptions', () => {


### PR DESCRIPTION
Prior to this commit, listeners order was not preserved in case we coalesce them to avoid triggering unnecessary change detection cycles. For performance reasons we were attaching listeners to existing events at head (always using first listener as an anchor), to avoid going through the list, thus breaking the order in which listeners are registered. In some scenarios this order might be important (for example with `ngModelChange` and `input` listeners), so this commit updates the logic to put new listeners at the end of the list. In order to avoid performance implications, we keep a pointer to the last listener in the list, so adding a new listener takes constant amount of time.

This PR resolves FW-1528.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No