### PR TITLE
fix(core): improve the "missing `$localize`" error message

### DIFF
--- a/integration/side-effects/snapshots/core/esm2015.js
+++ b/integration/side-effects/snapshots/core/esm2015.js
@@ -13,5 +13,5 @@ const __global = "undefined" !== typeof global && global;
 const _global = __globalThis || __global || __window || __self;
 
 if (ngDevMode) _global.$localize = _global.$localize || function() {
-    throw new Error("The global function `$localize` is missing. Please add `import '@angular/localize';` to your polyfills.ts file.");
+    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please add `import '@angular/localize';` to your polyfills.ts file.");
 };

--- a/integration/side-effects/snapshots/core/esm5.js
+++ b/integration/side-effects/snapshots/core/esm5.js
@@ -15,5 +15,5 @@ var __global = "undefined" !== typeof global && global;
 var _global = __globalThis || __global || __window || __self;
 
 if (ngDevMode) _global.$localize = _global.$localize || function() {
-    throw new Error("The global function `$localize` is missing. Please add `import '@angular/localize';` to your polyfills.ts file.");
+    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please add `import '@angular/localize';` to your polyfills.ts file.");
 };

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -45,6 +45,8 @@ if (ngDevMode) {
   // tslint:disable-next-line: no-toplevel-property-access
   global.$localize = global.$localize || function() {
     throw new Error(
-        'The global function `$localize` is missing. Please add `import \'@angular/localize\';` to your polyfills.ts file.');
+        'It looks like your application or one of its dependencies is using i18n.\n' +
+        'Angular 9 introduced a global `$localize()` function that needs to be loaded.\n' +
+        'Please add `import \'@angular/localize\';` to your polyfills.ts file.');
   };
 }


### PR DESCRIPTION
We need to be clearer to developers who upgrade to v9 (next) and get this
error, why they have a problem and what they have to do about it.

Once we have a better CLI schematics story, where this import will be
included by default in new applications and a CLI migration will add it
when upgrading apps to v9, we could simplify or remove this error message.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
