### PR TITLE
fix(platform-browser): remove jasmine custom matcher for Maps

### DIFF
--- a/packages/core/test/testing_internal_spec.ts
+++ b/packages/core/test/testing_internal_spec.ts
@@ -78,6 +78,21 @@ class TestObj {
         m2.set('b', 2);
         expect(m1).not.toEqual(m2);
       });
+
+      it('should detect equality for non-primitive keys', () => {
+        const key = {x: 1};
+        const m1 = new Map<{x: number}, number>([[key, 2]]);
+        const m2 = new Map<{x: number}, number>([[key, 2]]);
+
+        expect(m1).toEqual(m2);
+      });
+
+      it('should detect inequality for non-primitive keys', () => {
+        const m1 = new Map<{x: number}, number>([[{x: 1}, 2]]);
+        const m2 = new Map<{x: number}, number>([[{x: 1}, 2]]);
+
+        expect(m1).not.toEqual(m2);
+      });
     });
 
     describe('spy objects', () => {

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -128,22 +128,6 @@ export const expect: <T = any>(actual: T) => NgMatchers<T> = _global.expect;
 };
 
 _global.beforeEach(function() {
-  // Custom handler for Map as we use Jasmine 2.4, and support for maps is not
-  // added until Jasmine 2.6.
-  jasmine.addCustomEqualityTester(function compareMap(actual: any, expected: any): boolean {
-    if (actual instanceof Map) {
-      let pass = actual.size === expected.size;
-      if (pass) {
-        actual.forEach((v: any, k: any) => {
-          pass = pass && jasmine.matchersUtil.equals(v, expected.get(k));
-        });
-      }
-      return pass;
-    } else {
-      // TODO(misko): we should change the return, but jasmine.d.ts is not null safe
-      return undefined !;
-    }
-  });
   jasmine.addMatchers({
     toBePromise: function() {
       return {


### PR DESCRIPTION
Angular's Jasmine custom equality checks for Maps is broken. A proper one is now actually provided by default by Jasmine 3.x so that the Angular one can be removed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No