### PR TITLE
fix(ivy): template compiler should render correct $localize placeholder names

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -417,7 +417,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_3$;
         if (ngI18nClosureMode) {
@@ -432,7 +432,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_3$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c1$ = [
           "aria-roledescription", $I18N_1$,
@@ -453,9 +453,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_6$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: and again $` +
-          String.raw `{"\uFFFD2\uFFFD"}:interpolation_2:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
+          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
         }
         var $I18N_7$;
         if (ngI18nClosureMode) {
@@ -466,7 +466,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = [
           "title", $I18N_6$,
@@ -518,7 +518,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_1$ = $localize \`intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = ["title", $I18N_1$];
         …
@@ -561,7 +561,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_1$ = $localize \`different scope $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c2$ = ["title", $I18N_1$];
         function MyComponent_div_0_Template(rf, ctx) {
@@ -612,7 +612,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: title\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: title\`;
         }
         const $_c3$ = ["title", $I18N_1$];
         …
@@ -675,7 +675,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_3$;
         if (ngI18nClosureMode) {
@@ -690,7 +690,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_3$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c1$ = [
           "aria-roledescription", $I18N_1$,
@@ -711,9 +711,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_6$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: and again $` +
-          String.raw `{"\uFFFD2\uFFFD"}:interpolation_2:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
+          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
         }
         var $I18N_7$;
         if (ngI18nClosureMode) {
@@ -724,7 +724,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = [
           "title", $I18N_6$,
@@ -779,7 +779,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`different scope $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         function MyComponent_div_0_Template(rf, ctx) {
@@ -1033,8 +1033,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` Named interpolation: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:phA: Named interpolation with spaces: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:phB: \`;
+          String.raw `{"\uFFFD0\uFFFD"}:PH_A: Named interpolation with spaces: $` +
+          String.raw `{"\uFFFD1\uFFFD"}:PH_B: \`;
         }
         …
         consts: 2,
@@ -1071,7 +1071,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -1111,9 +1111,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: $` +
-          String.raw `{"\uFFFD2\uFFFD"}:interpolation_2: \`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2: \`;
         }
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -1152,7 +1152,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_1$;
         if (ngI18nClosureMode) {
@@ -1163,7 +1163,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_2$;
         if (ngI18nClosureMode) {
@@ -1174,7 +1174,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         consts: 7,
@@ -1239,9 +1239,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:startTagSpan:Plain text in nested element$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:closeTagSpan:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:Plain text in nested element$` +
+          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         var $I18N_1$;
         if (ngI18nClosureMode) {
@@ -1257,14 +1257,14 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \` My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` +
-          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:startTagDiv:$` +
-          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:startTagDiv:$` + String.raw
-      `{"\uFFFD#8\uFFFD"}:startTagSpan: More bindings in more nested element: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: $` +
-          String.raw `{"\uFFFD/#8\uFFFD"}:closeTagSpan:$` +
-          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:closeTagDiv:$` +
-          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:closeTagDiv:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` +
+          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` + String.raw
+      `{"\uFFFD#8\uFFFD"}:START_TAG_SPAN: More bindings in more nested element: $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw `{"\uFFFD/#8\uFFFD"}:CLOSE_TAG_SPAN:$` +
+          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:$` +
+          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:\`;
         }
         $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$);
         …
@@ -1330,8 +1330,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`Span title $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         var $I18N_0$;
@@ -1345,9 +1345,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` My i18n block #1 with value: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` + String.raw
-      `{"\uFFFD#2\uFFFD"}:startTagSpan: Plain text in nested element (block #1) $` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:closeTagSpan:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
+      `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #1) $` +
+          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         var $I18N_7$;
         if (ngI18nClosureMode) {
@@ -1358,7 +1358,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`Span title $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c9$ = ["title", $I18N_7$];
         var $I18N_6$;
@@ -1372,9 +1372,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_6$ = $localize \` My i18n block #2 with value $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` + String.raw
-      `{"\uFFFD#7\uFFFD"}:startTagSpan: Plain text in nested element (block #2) $` +
-          String.raw `{"\uFFFD/#7\uFFFD"}:closeTagSpan:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
+      `{"\uFFFD#7\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #2) $` +
+          String.raw `{"\uFFFD/#7\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         …
         consts: 9,
@@ -1444,10 +1444,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \` Some other content $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation: $` +
-          String.raw `{"\uFFFD#3\uFFFD"}:startTagDiv: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1\uFFFD"}:interpolation_1: $` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:closeTagDiv:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_DIV: More nested levels with bindings $` +
+          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
         }
         …
         function MyComponent_div_2_Template(rf, ctx) {
@@ -1514,7 +1514,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`App logo #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         function MyComponent_img_2_Template(rf, ctx) {
@@ -1630,29 +1630,29 @@ describe('i18n support in the template compiler', () => {
         else {
             $I18N_0$ = $localize \` Some content $` +
           String.raw
-      `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:startTagDiv_2: Some other content $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:interpolation: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:startTagDiv: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1:1\uFFFD"}:interpolation_1: $` + String.raw
-      `{"\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD"}:startTagDiv_1: Content inside sub-template $` +
-          String.raw `{"\uFFFD0:2\uFFFD"}:interpolation_2: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:startTagDiv: Bottom level element $` +
-          String.raw `{"\uFFFD1:2\uFFFD"}:interpolation_3: $` + String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:$` +
+      `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_2: Some other content $` +
+          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
+      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
+          String.raw `{"\uFFFD1:1\uFFFD"}:INTERPOLATION_1: $` + String.raw
+      `{"\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD"}:START_TAG_DIV_1: Content inside sub-template $` +
+          String.raw `{"\uFFFD0:2\uFFFD"}:INTERPOLATION_2: $` + String.raw
+      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: Bottom level element $` +
+          String.raw `{"\uFFFD1:2\uFFFD"}:INTERPOLATION_3: $` + String.raw
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:$` +
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:$` +
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:$` +
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
-      `{"\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD"}:startTagDiv_3: Some other content $` +
-          String.raw `{"\uFFFD0:3\uFFFD"}:interpolation_4: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:startTagDiv: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1:3\uFFFD"}:interpolation_5: $` + String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:$` +
+      `{"\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD"}:START_TAG_DIV_3: Some other content $` +
+          String.raw `{"\uFFFD0:3\uFFFD"}:INTERPOLATION_4: $` + String.raw
+      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
+          String.raw `{"\uFFFD1:3\uFFFD"}:INTERPOLATION_5: $` + String.raw
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:closeTagDiv:\`;
+      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:\`;
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$);
         function MyComponent_div_3_Template(rf, ctx) {
@@ -1712,9 +1712,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`Some other content $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:startTagSpan:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:closeTagSpan:\`;
+          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:$` +
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:$` +
+          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         …
         function MyComponent_div_0_Template(rf, ctx) {
@@ -1945,7 +1945,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \`Some content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         consts: 3,
@@ -1983,7 +1983,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`Some content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation:\`;
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
@@ -2031,12 +2031,12 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD*2:1\uFFFD"}:startTagNgTemplate:Template content: $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:interpolation:$` +
-          String.raw `{"\uFFFD/*2:1\uFFFD"}:closeTagNgTemplate:$` +
-          String.raw `{"\uFFFD#3\uFFFD"}:startTagNgContainer:Container content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:interpolation_1:$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:closeTagNgContainer:\`;
+          String.raw `{"\uFFFD*2:1\uFFFD"}:START_TAG_NG_TEMPLATE:Template content: $` +
+          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION:$` +
+          String.raw `{"\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_NG_TEMPLATE:$` +
+          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_NG_CONTAINER:Container content: $` +
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION_1:$` +
+          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
@@ -2185,17 +2185,17 @@ describe('i18n support in the template compiler', () => {
         else {
             $I18N_0$ = $localize \`$` +
           String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:startTagNgTemplate: Template A: $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:interpolation: $` + String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:startTagNgTemplate: Template B: $` +
-          String.raw `{"\uFFFD0:2\uFFFD"}:interpolation_1: $` + String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:startTagNgTemplate: Template C: $` +
-          String.raw `{"\uFFFD0:3\uFFFD"}:interpolation_2: $` + String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:closeTagNgTemplate:$` +
+      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template A: $` +
+          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
+      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template B: $` +
+          String.raw `{"\uFFFD0:2\uFFFD"}:INTERPOLATION_1: $` + String.raw
+      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template C: $` +
+          String.raw `{"\uFFFD0:3\uFFFD"}:INTERPOLATION_2: $` + String.raw
+      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
           String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:closeTagNgTemplate:$` +
+      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
           String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:closeTagNgTemplate:\`;
+      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:\`;
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$);
         function MyComponent_ng_template_2_Template(rf, ctx) {
@@ -2309,7 +2309,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"}:tagImg: is my logo #1 \`;
+          String.raw `{"\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"}:TAG_IMG: is my logo #1 \`;
         }
         var $I18N_2$;
         if (ngI18nClosureMode) {
@@ -2320,7 +2320,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`$` +
-          String.raw `{"\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"}:tagImg: is my logo #2 \`;
+          String.raw `{"\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"}:TAG_IMG: is my logo #2 \`;
         }
         function MyComponent_ng_template_3_Template(rf, ctx) {
           if (rf & 1) {
@@ -2367,8 +2367,8 @@ describe('i18n support in the template compiler', () => {
         else {
             $I18N_0$ = $localize \` Root content $` +
           String.raw
-      `{"\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD"}:startTagNgContainer: Nested content $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"}:closeTagNgContainer:\`;
+      `{"\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_NG_CONTAINER: Nested content $` +
+          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         …
       `;
@@ -2423,8 +2423,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \` Hello $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:startTagNgContainer:there$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:closeTagNgContainer:\`;
+          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there$` +
+          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         …
         consts: 3,
@@ -2459,10 +2459,10 @@ describe('i18n support in the template compiler', () => {
           }
           else {
             $I18N_0$ = $localize \` Hello $` +
-             String.raw `{"\uFFFD#2\uFFFD"}:startTagNgContainer:there $` +
-             String.raw `{"\uFFFD#3\uFFFD"}:startTagStrong:!$` +
-             String.raw `{"\uFFFD/#3\uFFFD"}:closeTagStrong:$` +
-             String.raw `{"\uFFFD/#2\uFFFD"}:closeTagNgContainer:\`;
+             String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there $` +
+             String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_STRONG:!$` +
+             String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_STRONG:$` +
+             String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
           }
           …
           consts: 4,
@@ -2505,8 +2505,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`\n          Some text\n          $` +
-          String.raw `{"\uFFFD#3\uFFFD"}:startTagSpan:Text inside span$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:closeTagSpan:\n        \`;
+          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_SPAN:Text inside span$` +
+          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_SPAN:\n        \`;
         }
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -2805,13 +2805,13 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:icu: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:startBoldText:Other content$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:closeBoldText:$` +
-          String.raw `{"\uFFFD#3\uFFFD"}:startTagDiv:$` +
-          String.raw `{"\uFFFD#4\uFFFD"}:startItalicText:Another content$` +
-          String.raw `{"\uFFFD/#4\uFFFD"}:closeItalicText:$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:closeTagDiv:\`;
+          String.raw `{$I18N_1$}:ICU: $` +
+          String.raw `{"\uFFFD#2\uFFFD"}:START_BOLD_TEXT:Other content$` +
+          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_BOLD_TEXT:$` +
+          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_DIV:$` +
+          String.raw `{"\uFFFD#4\uFFFD"}:START_ITALIC_TEXT:Another content$` +
+          String.raw `{"\uFFFD/#4\uFFFD"}:CLOSE_ITALIC_TEXT:$` +
+          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
         }
         …
         consts: 5,
@@ -2917,7 +2917,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:icu: $` + String.raw `{$I18N_2$}:icu_1: \`;
+          String.raw `{$I18N_1$}:ICU: $` + String.raw `{$I18N_2$}:ICU_1: \`;
         }
         …
         consts: 2,
@@ -2999,13 +2999,13 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:icu: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:startTagDiv: $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:icu: $` + String.raw
-      `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:closeTagDiv:$` +
-          String.raw `{"\uFFFD*3:1\uFFFD\uFFFD#1:1\uFFFD"}:startTagDiv_1: $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:icu: $` + String.raw
-      `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:closeTagDiv:\`;
+          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` +
+          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_DIV: $` +
+          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
+      `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:CLOSE_TAG_DIV:$` +
+          String.raw `{"\uFFFD*3:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_1: $` +
+          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
+      `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:CLOSE_TAG_DIV:\`;
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
           "ICU": [$I18N_1$, $I18N_2$, $I18N_4$]
@@ -3080,7 +3080,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:icu: \`;
+          String.raw `{$I18N_1$}:ICU: \`;
         }        …
         consts: 2,
         vars: 2,
@@ -3196,10 +3196,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:icu: $` +
-          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:startTagSpan: $` +
-          String.raw `{$I18N_3$}:icu_1: $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:closeTagSpan:\`;
+          String.raw `{$I18N_1$}:ICU: $` +
+          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
+          String.raw `{$I18N_3$}:ICU_1: $` +
+          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
@@ -3285,10 +3285,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{I18N_1}:icu: $` +
-          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:startTagSpan: $` +
-          String.raw `{I18N_4}:icu_1: $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:closeTagSpan:\`;
+          String.raw `{I18N_1}:ICU: $` +
+          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
+          String.raw `{I18N_4}:ICU_1: $` +
+          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {

--- a/packages/compiler/src/render3/view/i18n/localize_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/localize_utils.ts
@@ -9,7 +9,6 @@ import * as i18n from '../../../i18n/i18n_ast';
 import * as o from '../../../output/output_ast';
 
 import {serializeIcuNode} from './icu_serializer';
-import {i18nMetaToDocStmt, metaFromI18nMessage} from './meta';
 import {formatI18nPlaceholderName} from './util';
 
 export function createLocalizeStatements(
@@ -37,7 +36,7 @@ class MessagePiece {
 }
 class LiteralPiece extends MessagePiece {}
 class PlaceholderPiece extends MessagePiece {
-  constructor(name: string) { super(formatI18nPlaceholderName(name)); }
+  constructor(name: string) { super(formatI18nPlaceholderName(name, /* useCamelCase */ false)); }
 }
 
 /**

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -2021,13 +2021,15 @@ export function getTranslationDeclStmts(
     message: i18n.Message, variable: o.ReadVarExpr, closureVar: o.ReadVarExpr,
     params: {[name: string]: o.Expression} = {},
     transformFn?: (raw: o.ReadVarExpr) => o.Expression): o.Statement[] {
-  const formattedParams = i18nFormatPlaceholderNames(params, /* useCamelCase */ true);
   const statements: o.Statement[] = [
     declareI18nVariable(variable),
     o.ifStmt(
         o.variable(NG_I18N_CLOSURE_MODE),
-        createGoogleGetMsgStatements(variable, message, closureVar, formattedParams),
-        createLocalizeStatements(variable, message, formattedParams)),
+        createGoogleGetMsgStatements(
+            variable, message, closureVar,
+            i18nFormatPlaceholderNames(params, /* useCamelCase */ true)),
+        createLocalizeStatements(
+            variable, message, i18nFormatPlaceholderNames(params, /* useCamelCase */ false))),
   ];
 
   if (transformFn) {

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -232,6 +232,11 @@ describe('serializeI18nMessageForGetMsg', () => {
         .toEqual('Some text {$interpolation} and {$interpolation_1}');
   });
 
+  it('should serialize interpolation with named placeholder for `GetMsg()`', () => {
+    expect(serialize('{{ valueB + valueC // i18n(ph="PLACEHOLDER NAME") }}'))
+        .toEqual('{$placeholderName}');
+  });
+
   it('should serialize content with HTML tags for `GetMsg()`', () => {
     expect(serialize('A <span>B<div>C</div></span> D'))
         .toEqual('A {$startTagSpan}B{$startTagDiv}C{$closeTagDiv}{$closeTagSpan} D');
@@ -277,14 +282,14 @@ describe('serializeI18nMessageForLocalize', () => {
   it('should serialize text with interpolation for `$localize()`', () => {
     expect(serialize('Some text {{ valueA }} and {{ valueB + valueC }} done')).toEqual({
       messageParts: ['Some text ', ' and ', ' done'],
-      placeHolders: ['interpolation', 'interpolation_1']
+      placeHolders: ['INTERPOLATION', 'INTERPOLATION_1']
     });
   });
 
   it('should serialize text with interpolation at start for `$localize()`', () => {
     expect(serialize('{{ valueA }} and {{ valueB + valueC }} done')).toEqual({
       messageParts: ['', ' and ', ' done'],
-      placeHolders: ['interpolation', 'interpolation_1']
+      placeHolders: ['INTERPOLATION', 'INTERPOLATION_1']
     });
   });
 
@@ -292,21 +297,27 @@ describe('serializeI18nMessageForLocalize', () => {
   it('should serialize text with interpolation at end for `$localize()`', () => {
     expect(serialize('Some text {{ valueA }} and {{ valueB + valueC }}')).toEqual({
       messageParts: ['Some text ', ' and ', ''],
-      placeHolders: ['interpolation', 'interpolation_1']
+      placeHolders: ['INTERPOLATION', 'INTERPOLATION_1']
     });
   });
 
 
   it('should serialize only interpolation for `$localize()`', () => {
     expect(serialize('{{ valueB + valueC }}'))
-        .toEqual({messageParts: ['', ''], placeHolders: ['interpolation']});
+        .toEqual({messageParts: ['', ''], placeHolders: ['INTERPOLATION']});
+  });
+
+
+  it('should serialize interpolation with named placeholder for `$localize()`', () => {
+    expect(serialize('{{ valueB + valueC // i18n(ph="PLACEHOLDER NAME") }}'))
+        .toEqual({messageParts: ['', ''], placeHolders: ['PLACEHOLDER_NAME']});
   });
 
 
   it('should serialize content with HTML tags for `$localize()`', () => {
     expect(serialize('A <span>B<div>C</div></span> D')).toEqual({
       messageParts: ['A ', 'B', 'C', '', ' D'],
-      placeHolders: ['startTagSpan', 'startTagDiv', 'closeTagDiv', 'closeTagSpan']
+      placeHolders: ['START_TAG_SPAN', 'START_TAG_DIV', 'CLOSE_TAG_DIV', 'CLOSE_TAG_SPAN']
     });
   });
 
@@ -346,7 +357,7 @@ describe('serializeI18nMessageForLocalize', () => {
             '{gender, select, male {male} female {female} other {other}}<div>{gender, select, male {male} female {female} other {other}}</div>'))
         .toEqual({
           messageParts: ['', '', '', '', ''],
-          placeHolders: ['icu', 'startTagDiv', 'icu', 'closeTagDiv']
+          placeHolders: ['ICU', 'START_TAG_DIV', 'ICU', 'CLOSE_TAG_DIV']
         });
   });
 });

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -17,149 +17,155 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {onlyInIvy} from '@angular/private/testing';
 
 
-onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [AppComp, DirectiveWithTplRef, UppercasePipe]});
-  });
+onlyInIvy('Ivy i18n logic')
+    .describe(
+        'runtime i18n', () => {
+          beforeEach(() => {
+            TestBed.configureTestingModule(
+                {declarations: [AppComp, DirectiveWithTplRef, UppercasePipe]});
+          });
 
-  afterEach(() => { setDelayProjection(false); });
+          afterEach(() => { setDelayProjection(false); });
 
-  it('should translate text', () => {
-    loadTranslations({'text': 'texte'});
-    const fixture = initWithTemplate(AppComp, `<div i18n>text</div>`);
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div>texte</div>`);
-  });
+          it('should translate text', () => {
+            loadTranslations({'text': 'texte'});
+            const fixture = initWithTemplate(AppComp, `<div i18n>text</div>`);
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div>texte</div>`);
+          });
 
-  it('should support interpolations', () => {
-    loadTranslations({'Hello {$interpolation}!': 'Bonjour {$interpolation}!'});
-    const fixture = initWithTemplate(AppComp, `<div i18n>Hello {{name}}!</div>`);
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div>Bonjour Angular!</div>`);
-    fixture.componentRef.instance.name = `John`;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div>Bonjour John!</div>`);
-  });
+          it('should support interpolations', () => {
+            loadTranslations({'Hello {$INTERPOLATION}!': 'Bonjour {$INTERPOLATION}!'});
+            const fixture = initWithTemplate(AppComp, `<div i18n>Hello {{name}}!</div>`);
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div>Bonjour Angular!</div>`);
+            fixture.componentRef.instance.name = `John`;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div>Bonjour John!</div>`);
+          });
 
-  it('should support named interpolations', () => {
-    loadTranslations({
-      ' Hello {$userName}! Emails: {$amountOfEmailsReceived} ':
-          ' Bonjour {$userName}! Emails: {$amountOfEmailsReceived} '
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support named interpolations', () => {
+            loadTranslations({
+              ' Hello {$USER_NAME}! Emails: {$AMOUNT_OF_EMAILS_RECEIVED} ':
+                  ' Bonjour {$USER_NAME}! Emails: {$AMOUNT_OF_EMAILS_RECEIVED} '
+            });
+            const fixture = initWithTemplate(AppComp, `
       <div i18n>
         Hello {{ name // i18n(ph="user_name") }}!
         Emails: {{ count // i18n(ph="amount of emails received") }}
       </div>
     `);
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div> Bonjour Angular! Emails: 0 </div>`);
-    fixture.componentRef.instance.name = `John`;
-    fixture.componentRef.instance.count = 5;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div> Bonjour John! Emails: 5 </div>`);
-  });
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div> Bonjour Angular! Emails: 0 </div>`);
+            fixture.componentRef.instance.name = `John`;
+            fixture.componentRef.instance.count = 5;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div> Bonjour John! Emails: 5 </div>`);
+          });
 
-  it('should support interpolations with custom interpolation config', () => {
-    loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
-    const interpolation = ['{%', '%}'] as[string, string];
-    TestBed.overrideComponent(AppComp, {set: {interpolation}});
-    const fixture = initWithTemplate(AppComp, `<div i18n>Hello {% name %}</div>`);
+          it('should support interpolations with custom interpolation config', () => {
+            loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+            const interpolation = ['{%', '%}'] as[string, string];
+            TestBed.overrideComponent(AppComp, {set: {interpolation}});
+            const fixture = initWithTemplate(AppComp, `<div i18n>Hello {% name %}</div>`);
 
-    expect(fixture.nativeElement.innerHTML).toBe('<div>Bonjour Angular</div>');
-  });
+            expect(fixture.nativeElement.innerHTML).toBe('<div>Bonjour Angular</div>');
+          });
 
-  it('should support &ngsp; in translatable sections', () => {
-    // note: the `` unicode symbol represents the `&ngsp;` in translations
-    loadTranslations({'text ||': 'texte ||'});
-    const fixture = initWithTemplate(AppCompWithWhitespaces, `<div i18n>text |&ngsp;|</div>`);
+          it('should support &ngsp; in translatable sections', () => {
+            // note: the `` unicode symbol represents the `&ngsp;` in translations
+            loadTranslations({'text ||': 'texte ||'});
+            const fixture =
+                initWithTemplate(AppCompWithWhitespaces, `<div i18n>text |&ngsp;|</div>`);
 
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div>texte | |</div>`);
-  });
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div>texte | |</div>`);
+          });
 
-  it('should support interpolations with complex expressions', () => {
-    loadTranslations({
-      ' {$interpolation} - {$interpolation_1} - {$interpolation_2} ':
-          ' {$interpolation} - {$interpolation_1} - {$interpolation_2} (fr) '
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support interpolations with complex expressions', () => {
+            loadTranslations({
+              ' {$INTERPOLATION} - {$INTERPOLATION_1} - {$INTERPOLATION_2} ':
+                  ' {$INTERPOLATION} - {$INTERPOLATION_1} - {$INTERPOLATION_2} (fr) '
+            });
+            const fixture = initWithTemplate(AppComp, `
       <div i18n>
         {{ name | uppercase }} -
         {{ obj?.a?.b }} -
         {{ obj?.getA()?.b }}
       </div>
     `);
-    // the `obj` field is not yet defined, so 2nd and 3rd interpolations return empty strings
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div> ANGULAR -  -  (fr) </div>`);
+            // the `obj` field is not yet defined, so 2nd and 3rd interpolations return empty
+            // strings
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div> ANGULAR -  -  (fr) </div>`);
 
-    fixture.componentRef.instance.obj = {
-      a: {b: 'value 1'},
-      getA: () => ({b: 'value 2'}),
-    };
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div> ANGULAR - value 1 - value 2 (fr) </div>`);
-  });
+            fixture.componentRef.instance.obj = {
+              a: {b: 'value 1'},
+              getA: () => ({b: 'value 2'}),
+            };
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div> ANGULAR - value 1 - value 2 (fr) </div>`);
+          });
 
-  it('should support elements', () => {
-    loadTranslations({
-      'Hello {$startTagSpan}world{$closeTagSpan} and {$startTagDiv}universe{$closeTagDiv}!':
-          'Bonjour {$startTagSpan}monde{$closeTagSpan} et {$startTagDiv}univers{$closeTagDiv}!'
-    });
-    const fixture = initWithTemplate(
-        AppComp, `<div i18n>Hello <span>world</span> and <div>universe</div>!</div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div>Bonjour <span>monde</span> et <div>univers</div>!</div>`);
-  });
+          it('should support elements', () => {
+            loadTranslations({
+              'Hello {$START_TAG_SPAN}world{$CLOSE_TAG_SPAN} and {$START_TAG_DIV}universe{$CLOSE_TAG_DIV}!':
+                  'Bonjour {$START_TAG_SPAN}monde{$CLOSE_TAG_SPAN} et {$START_TAG_DIV}univers{$CLOSE_TAG_DIV}!'
+            });
+            const fixture = initWithTemplate(
+                AppComp, `<div i18n>Hello <span>world</span> and <div>universe</div>!</div>`);
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div>Bonjour <span>monde</span> et <div>univers</div>!</div>`);
+          });
 
-  it('should support removing elements', () => {
-    loadTranslations({
-      'Hello {$startBoldText}my{$closeBoldText}{$startTagSpan}world{$closeTagSpan}':
-          'Bonjour {$startTagSpan}monde{$closeTagSpan}'
-    });
-    const fixture =
-        initWithTemplate(AppComp, `<div i18n>Hello <b>my</b><span>world</span></div><div>!</div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div>Bonjour <span>monde</span></div><div>!</div>`);
-  });
+          it('should support removing elements', () => {
+            loadTranslations({
+              'Hello {$START_BOLD_TEXT}my{$CLOSE_BOLD_TEXT}{$START_TAG_SPAN}world{$CLOSE_TAG_SPAN}':
+                  'Bonjour {$START_TAG_SPAN}monde{$CLOSE_TAG_SPAN}'
+            });
+            const fixture = initWithTemplate(
+                AppComp, `<div i18n>Hello <b>my</b><span>world</span></div><div>!</div>`);
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div>Bonjour <span>monde</span></div><div>!</div>`);
+          });
 
-  it('should support moving elements', () => {
-    loadTranslations({
-      'Hello {$startTagSpan}world{$closeTagSpan} and {$startTagDiv}universe{$closeTagDiv}!':
-          'Bonjour {$startTagDiv}univers{$closeTagDiv} et {$startTagSpan}monde{$closeTagSpan}!'
-    });
-    const fixture = initWithTemplate(
-        AppComp, `<div i18n>Hello <span>world</span> and <div>universe</div>!</div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div>Bonjour <div>univers</div> et <span>monde</span>!</div>`);
-  });
+          it('should support moving elements', () => {
+            loadTranslations({
+              'Hello {$START_TAG_SPAN}world{$CLOSE_TAG_SPAN} and {$START_TAG_DIV}universe{$CLOSE_TAG_DIV}!':
+                  'Bonjour {$START_TAG_DIV}univers{$CLOSE_TAG_DIV} et {$START_TAG_SPAN}monde{$CLOSE_TAG_SPAN}!'
+            });
+            const fixture = initWithTemplate(
+                AppComp, `<div i18n>Hello <span>world</span> and <div>universe</div>!</div>`);
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div>Bonjour <div>univers</div> et <span>monde</span>!</div>`);
+          });
 
-  it('should support template directives', () => {
-    loadTranslations({
-      'Content: {$startTagDiv}before{$startTagSpan}middle{$closeTagSpan}after{$closeTagDiv}!':
-          'Contenu: {$startTagDiv}avant{$startTagSpan}milieu{$closeTagSpan}après{$closeTagDiv}!'
-    });
-    const fixture = initWithTemplate(
-        AppComp,
-        `<div i18n>Content: <div *ngIf="visible">before<span>middle</span>after</div>!</div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div>Contenu: <div>avant<span>milieu</span>après</div><!--bindings={
+          it('should support template directives', () => {
+            loadTranslations({
+              'Content: {$START_TAG_DIV}before{$START_TAG_SPAN}middle{$CLOSE_TAG_SPAN}after{$CLOSE_TAG_DIV}!':
+                  'Contenu: {$START_TAG_DIV}avant{$START_TAG_SPAN}milieu{$CLOSE_TAG_SPAN}après{$CLOSE_TAG_DIV}!'
+            });
+            const fixture = initWithTemplate(
+                AppComp,
+                `<div i18n>Content: <div *ngIf="visible">before<span>middle</span>after</div>!</div>`);
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(`<div>Contenu: <div>avant<span>milieu</span>après</div><!--bindings={
   "ng-reflect-ng-if": "true"
 }-->!</div>`);
 
-    fixture.componentRef.instance.visible = false;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div>Contenu: <!--bindings={
+            fixture.componentRef.instance.visible = false;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div>Contenu: <!--bindings={
   "ng-reflect-ng-if": "false"
 }-->!</div>`);
-  });
+          });
 
-  it('should support multiple i18n blocks', () => {
-    loadTranslations({
-      'trad {$interpolation}': 'traduction {$interpolation}',
-      'start {$interpolation} middle {$interpolation_1} end':
-          'start {$interpolation_1} middle {$interpolation} end',
-      '{$startTagC}trad{$closeTagC}{$startTagD}{$closeTagD}{$startTagE}{$closeTagE}':
-          '{$startTagE}{$closeTagE}{$startTagC}traduction{$closeTagC}'
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support multiple i18n blocks', () => {
+            loadTranslations({
+              'trad {$INTERPOLATION}': 'traduction {$INTERPOLATION}',
+              'start {$INTERPOLATION} middle {$INTERPOLATION_1} end':
+                  'start {$INTERPOLATION_1} middle {$INTERPOLATION} end',
+              '{$START_TAG_C}trad{$CLOSE_TAG_C}{$START_TAG_D}{$CLOSE_TAG_D}{$START_TAG_E}{$CLOSE_TAG_E}':
+                  '{$START_TAG_E}{$CLOSE_TAG_E}{$START_TAG_C}traduction{$CLOSE_TAG_C}'
+            });
+            const fixture = initWithTemplate(AppComp, `
       <div>
         <a i18n>trad {{name}}</a>
         hello
@@ -169,132 +175,137 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
           <e></e>
         </b>
       </div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(
-            `<div><a>traduction Angular</a> hello <b title="start Angular middle 0 end"><e></e><c>traduction</c></b></div>`);
-  });
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<div><a>traduction Angular</a> hello <b title="start Angular middle 0 end"><e></e><c>traduction</c></b></div>`);
+          });
 
-  it('should support multiple sibling i18n blocks', () => {
-    loadTranslations({
-      'Section 1': 'Section un',
-      'Section 2': 'Section deux',
-      'Section 3': 'Section trois',
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support multiple sibling i18n blocks', () => {
+            loadTranslations({
+              'Section 1': 'Section un',
+              'Section 2': 'Section deux',
+              'Section 3': 'Section trois',
+            });
+            const fixture = initWithTemplate(AppComp, `
       <div>
         <div i18n>Section 1</div>
         <div i18n>Section 2</div>
         <div i18n>Section 3</div>
       </div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(`<div><div>Section un</div><div>Section deux</div><div>Section trois</div></div>`);
-  });
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<div><div>Section un</div><div>Section deux</div><div>Section trois</div></div>`);
+          });
 
-  it('should support multiple sibling i18n blocks inside of a template directive', () => {
-    loadTranslations({
-      'Section 1': 'Section un',
-      'Section 2': 'Section deux',
-      'Section 3': 'Section trois',
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support multiple sibling i18n blocks inside of a template directive', () => {
+            loadTranslations({
+              'Section 1': 'Section un',
+              'Section 2': 'Section deux',
+              'Section 3': 'Section trois',
+            });
+            const fixture = initWithTemplate(AppComp, `
       <ul *ngFor="let item of [1,2,3]">
         <li i18n>Section 1</li>
         <li i18n>Section 2</li>
         <li i18n>Section 3</li>
       </ul>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(
-            `<ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><!--bindings={
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><ul><li>Section un</li><li>Section deux</li><li>Section trois</li></ul><!--bindings={
   "ng-reflect-ng-for-of": "1,2,3"
 }-->`);
-  });
+          });
 
-  it('should properly escape quotes in content', () => {
-    loadTranslations({
-      '\'Single quotes\' and "Double quotes"': '\'Guillemets simples\' et "Guillemets doubles"'
-    });
-    const fixture =
-        initWithTemplate(AppComp, `<div i18n>'Single quotes' and "Double quotes"</div>`);
+          it('should properly escape quotes in content', () => {
+            loadTranslations({
+              '\'Single quotes\' and "Double quotes"':
+                  '\'Guillemets simples\' et "Guillemets doubles"'
+            });
+            const fixture =
+                initWithTemplate(AppComp, `<div i18n>'Single quotes' and "Double quotes"</div>`);
 
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual('<div>\'Guillemets simples\' et "Guillemets doubles"</div>');
-  });
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual('<div>\'Guillemets simples\' et "Guillemets doubles"</div>');
+          });
 
-  it('should correctly bind to context in nested template', () => {
-    loadTranslations({'Item {$interpolation}': 'Article {$interpolation}'});
-    const fixture = initWithTemplate(AppComp, `
+          it('should correctly bind to context in nested template', () => {
+            loadTranslations({'Item {$INTERPOLATION}': 'Article {$INTERPOLATION}'});
+            const fixture = initWithTemplate(AppComp, `
           <div *ngFor='let id of items'>
             <div i18n>Item {{ id }}</div>
           </div>
         `);
 
-    const element = fixture.nativeElement;
-    for (let i = 0; i < element.children.length; i++) {
-      const child = element.children[i];
-      expect(child).toHaveText(`Article ${i + 1}`);
-    }
-  });
+            const element = fixture.nativeElement;
+            for (let i = 0; i < element.children.length; i++) {
+              const child = element.children[i];
+              expect(child).toHaveText(`Article ${i + 1}`);
+            }
+          });
 
-  it('should ignore i18n attributes on self-closing tags', () => {
-    const fixture = initWithTemplate(AppComp, '<img src="logo.png" i18n>');
-    expect(fixture.nativeElement.innerHTML).toBe(`<img src="logo.png">`);
-  });
+          it('should ignore i18n attributes on self-closing tags', () => {
+            const fixture = initWithTemplate(AppComp, '<img src="logo.png" i18n>');
+            expect(fixture.nativeElement.innerHTML).toBe(`<img src="logo.png">`);
+          });
 
-  it('should handle i18n attribute with directives', () => {
-    loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
-    const fixture = initWithTemplate(AppComp, `<div *ngIf="visible" i18n>Hello {{ name }}</div>`);
-    expect(fixture.nativeElement.firstChild).toHaveText('Bonjour Angular');
-  });
+          it('should handle i18n attribute with directives', () => {
+            loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+            const fixture =
+                initWithTemplate(AppComp, `<div *ngIf="visible" i18n>Hello {{ name }}</div>`);
+            expect(fixture.nativeElement.firstChild).toHaveText('Bonjour Angular');
+          });
 
-  it('should work correctly with event listeners', () => {
-    loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
+          it('should work correctly with event listeners', () => {
+            loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
 
-    @Component(
-        {selector: 'app-comp', template: `<div i18n (click)="onClick()">Hello {{ name }}</div>`})
-    class ListenerComp {
-      name = `Angular`;
-      clicks = 0;
+            @Component({
+              selector: 'app-comp',
+              template: `<div i18n (click)="onClick()">Hello {{ name }}</div>`
+            })
+            class ListenerComp {
+              name = `Angular`;
+              clicks = 0;
 
-      onClick() { this.clicks++; }
-    }
+              onClick() { this.clicks++; }
+            }
 
-    TestBed.configureTestingModule({declarations: [ListenerComp]});
-    const fixture = TestBed.createComponent(ListenerComp);
-    fixture.detectChanges();
+            TestBed.configureTestingModule({declarations: [ListenerComp]});
+            const fixture = TestBed.createComponent(ListenerComp);
+            fixture.detectChanges();
 
-    const element = fixture.nativeElement.firstChild;
-    const instance = fixture.componentInstance;
+            const element = fixture.nativeElement.firstChild;
+            const instance = fixture.componentInstance;
 
-    expect(element).toHaveText('Bonjour Angular');
-    expect(instance.clicks).toBe(0);
+            expect(element).toHaveText('Bonjour Angular');
+            expect(instance.clicks).toBe(0);
 
-    element.click();
-    expect(instance.clicks).toBe(1);
-  });
+            element.click();
+            expect(instance.clicks).toBe(1);
+          });
 
-  describe('ng-container and ng-template support', () => {
-    it('should support ng-container', () => {
-      loadTranslations({'text': 'texte'});
-      const fixture = initWithTemplate(AppComp, `<ng-container i18n>text</ng-container>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`texte<!--ng-container-->`);
-    });
+          describe('ng-container and ng-template support', () => {
+            it('should support ng-container', () => {
+              loadTranslations({'text': 'texte'});
+              const fixture = initWithTemplate(AppComp, `<ng-container i18n>text</ng-container>`);
+              expect(fixture.nativeElement.innerHTML).toEqual(`texte<!--ng-container-->`);
+            });
 
-    it('should handle single translation message within ng-template', () => {
-      loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
-      const fixture =
-          initWithTemplate(AppComp, `<ng-template i18n tplRef>Hello {{ name }}</ng-template>`);
+            it('should handle single translation message within ng-template', () => {
+              loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+              const fixture = initWithTemplate(
+                  AppComp, `<ng-template i18n tplRef>Hello {{ name }}</ng-template>`);
 
-      const element = fixture.nativeElement;
-      expect(element).toHaveText('Bonjour Angular');
-    });
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('Bonjour Angular');
+            });
 
-    it('should be able to act as child elements inside i18n block (plain text content)', () => {
-      loadTranslations({
+            it('should be able to act as child elements inside i18n block (plain text content)', () => {
+              loadTranslations({
 
-        '{$startTagNgTemplate} Hello {$closeTagNgTemplate}{$startTagNgContainer} Bye {$closeTagNgContainer}':
-            '{$startTagNgTemplate} Bonjour {$closeTagNgTemplate}{$startTagNgContainer} Au revoir {$closeTagNgContainer}'
-      });
-      const fixture = initWithTemplate(AppComp, `
+                '{$START_TAG_NG_TEMPLATE} Hello {$CLOSE_TAG_NG_TEMPLATE}{$START_TAG_NG_CONTAINER} Bye {$CLOSE_TAG_NG_CONTAINER}':
+                    '{$START_TAG_NG_TEMPLATE} Bonjour {$CLOSE_TAG_NG_TEMPLATE}{$START_TAG_NG_CONTAINER} Au revoir {$CLOSE_TAG_NG_CONTAINER}'
+              });
+              const fixture = initWithTemplate(AppComp, `
         <div i18n>
           <ng-template tplRef>
             Hello
@@ -305,17 +316,17 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         </div>
       `);
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.textContent.replace(/\s+/g, ' ').trim()).toBe('Bonjour Au revoir');
-    });
+              const element = fixture.nativeElement.firstChild;
+              expect(element.textContent.replace(/\s+/g, ' ').trim()).toBe('Bonjour Au revoir');
+            });
 
-    it('should be able to act as child elements inside i18n block (text + tags)', () => {
-      loadTranslations({
+            it('should be able to act as child elements inside i18n block (text + tags)', () => {
+              loadTranslations({
 
-        '{$startTagNgTemplate}{$startTagSpan}Hello{$closeTagSpan}{$closeTagNgTemplate}{$startTagNgContainer}{$startTagSpan}Hello{$closeTagSpan}{$closeTagNgContainer}':
-            '{$startTagNgTemplate}{$startTagSpan}Bonjour{$closeTagSpan}{$closeTagNgTemplate}{$startTagNgContainer}{$startTagSpan}Bonjour{$closeTagSpan}{$closeTagNgContainer}'
-      });
-      const fixture = initWithTemplate(AppComp, `
+                '{$START_TAG_NG_TEMPLATE}{$START_TAG_SPAN}Hello{$CLOSE_TAG_SPAN}{$CLOSE_TAG_NG_TEMPLATE}{$START_TAG_NG_CONTAINER}{$START_TAG_SPAN}Hello{$CLOSE_TAG_SPAN}{$CLOSE_TAG_NG_CONTAINER}':
+                    '{$START_TAG_NG_TEMPLATE}{$START_TAG_SPAN}Bonjour{$CLOSE_TAG_SPAN}{$CLOSE_TAG_NG_TEMPLATE}{$START_TAG_NG_CONTAINER}{$START_TAG_SPAN}Bonjour{$CLOSE_TAG_SPAN}{$CLOSE_TAG_NG_CONTAINER}'
+              });
+              const fixture = initWithTemplate(AppComp, `
         <div i18n>
           <ng-template tplRef>
             <span>Hello</span>
@@ -326,42 +337,44 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         </div>
       `);
 
-      const element = fixture.nativeElement;
-      const spans = element.getElementsByTagName('span');
-      for (let i = 0; i < spans.length; i++) {
-        expect(spans[i]).toHaveText('Bonjour');
-      }
-    });
+              const element = fixture.nativeElement;
+              const spans = element.getElementsByTagName('span');
+              for (let i = 0; i < spans.length; i++) {
+                expect(spans[i]).toHaveText('Bonjour');
+              }
+            });
 
-    it('should be able to act as child elements inside i18n block (text + pipes)', () => {
-      // Note: for some reason keeping this key inline causes clang to reformat the entire file
-      // in a very weird way. Keeping it separated like this seems to make it happy.
-      const key = '{$startTagNgTemplate}Hello {$interpolation}{$closeTagNgTemplate}' +
-          '{$startTagNgContainer}Bye {$interpolation}{$closeTagNgContainer}';
+            it('should be able to act as child elements inside i18n block (text + pipes)', () => {
+              // Note: for some reason keeping this key inline causes clang to reformat the entire
+              // file
+              // in a very weird way. Keeping it separated like this seems to make it happy.
+              const key = '{$START_TAG_NG_TEMPLATE}Hello {$INTERPOLATION}{$CLOSE_TAG_NG_TEMPLATE}' +
+                  '{$START_TAG_NG_CONTAINER}Bye {$INTERPOLATION}{$CLOSE_TAG_NG_CONTAINER}';
 
-      loadTranslations({
+              loadTranslations({
 
-        [key]:
-            '{$startTagNgTemplate}Hej {$interpolation}{$closeTagNgTemplate}{$startTagNgContainer}Vi ses {$interpolation}{$closeTagNgContainer}'
-      });
-      const fixture = initWithTemplate(AppComp, `
+                [key]:
+                    '{$START_TAG_NG_TEMPLATE}Hej {$INTERPOLATION}{$CLOSE_TAG_NG_TEMPLATE}{$START_TAG_NG_CONTAINER}Vi ses {$INTERPOLATION}{$CLOSE_TAG_NG_CONTAINER}'
+              });
+              const fixture = initWithTemplate(AppComp, `
         <div i18n>
           <ng-template tplRef>Hello {{name | uppercase}}</ng-template>
           <ng-container>Bye {{name | uppercase}}</ng-container>
         </div>
       `);
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.textContent.replace(/\s+/g, ' ').trim()).toBe('Hej ANGULARVi ses ANGULAR');
-    });
+              const element = fixture.nativeElement.firstChild;
+              expect(element.textContent.replace(/\s+/g, ' ').trim())
+                  .toBe('Hej ANGULARVi ses ANGULAR');
+            });
 
-    it('should be able to handle deep nested levels with templates', () => {
-      loadTranslations({
+            it('should be able to handle deep nested levels with templates', () => {
+              loadTranslations({
 
-        '{$startTagSpan} Hello - 1 {$closeTagSpan}{$startTagSpan_1} Hello - 2 {$startTagSpan_1} Hello - 3 {$startTagSpan_1} Hello - 4 {$closeTagSpan}{$closeTagSpan}{$closeTagSpan}{$startTagSpan} Hello - 5 {$closeTagSpan}':
-            '{$startTagSpan} Bonjour - 1 {$closeTagSpan}{$startTagSpan_1} Bonjour - 2 {$startTagSpan_1} Bonjour - 3 {$startTagSpan_1} Bonjour - 4 {$closeTagSpan}{$closeTagSpan}{$closeTagSpan}{$startTagSpan} Bonjour - 5 {$closeTagSpan}'
-      });
-      const fixture = initWithTemplate(AppComp, `
+                '{$START_TAG_SPAN} Hello - 1 {$CLOSE_TAG_SPAN}{$START_TAG_SPAN_1} Hello - 2 {$START_TAG_SPAN_1} Hello - 3 {$START_TAG_SPAN_1} Hello - 4 {$CLOSE_TAG_SPAN}{$CLOSE_TAG_SPAN}{$CLOSE_TAG_SPAN}{$START_TAG_SPAN} Hello - 5 {$CLOSE_TAG_SPAN}':
+                    '{$START_TAG_SPAN} Bonjour - 1 {$CLOSE_TAG_SPAN}{$START_TAG_SPAN_1} Bonjour - 2 {$START_TAG_SPAN_1} Bonjour - 3 {$START_TAG_SPAN_1} Bonjour - 4 {$CLOSE_TAG_SPAN}{$CLOSE_TAG_SPAN}{$CLOSE_TAG_SPAN}{$START_TAG_SPAN} Bonjour - 5 {$CLOSE_TAG_SPAN}'
+              });
+              const fixture = initWithTemplate(AppComp, `
         <div i18n>
           <span>
             Hello - 1
@@ -381,21 +394,21 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         </div>
       `);
 
-      const element = fixture.nativeElement;
-      const spans = element.getElementsByTagName('span');
-      for (let i = 0; i < spans.length; i++) {
-        expect(spans[i].innerHTML).toContain(`Bonjour - ${i + 1}`);
-      }
-    });
+              const element = fixture.nativeElement;
+              const spans = element.getElementsByTagName('span');
+              for (let i = 0; i < spans.length; i++) {
+                expect(spans[i].innerHTML).toContain(`Bonjour - ${i + 1}`);
+              }
+            });
 
-    it('should handle self-closing tags as content', () => {
-      loadTranslations({
+            it('should handle self-closing tags as content', () => {
+              loadTranslations({
 
-        '{$startTagSpan}My logo{$tagImg}{$closeTagSpan}':
-            '{$startTagSpan}Mon logo{$tagImg}{$closeTagSpan}'
-      });
-      const content = `My logo<img src="logo.png" title="Logo">`;
-      const fixture = initWithTemplate(AppComp, `
+                '{$START_TAG_SPAN}My logo{$TAG_IMG}{$CLOSE_TAG_SPAN}':
+                    '{$START_TAG_SPAN}Mon logo{$TAG_IMG}{$CLOSE_TAG_SPAN}'
+              });
+              const content = `My logo<img src="logo.png" title="Logo">`;
+              const fixture = initWithTemplate(AppComp, `
         <ng-container i18n>
           <span>${content}</span>
         </ng-container>
@@ -404,23 +417,24 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         </ng-template>
       `);
 
-      const element = fixture.nativeElement;
-      const spans = element.getElementsByTagName('span');
-      for (let i = 0; i < spans.length; i++) {
-        const child = spans[i];
-        expect(child).toHaveText('Mon logo');
-      }
-    });
+              const element = fixture.nativeElement;
+              const spans = element.getElementsByTagName('span');
+              for (let i = 0; i < spans.length; i++) {
+                const child = spans[i];
+                expect(child).toHaveText('Mon logo');
+              }
+            });
 
-    it('should correctly find context for an element inside i18n section in <ng-template>', () => {
-      @Directive({selector: '[myDir]'})
-      class Dir {
-        condition = true;
-      }
+            it('should correctly find context for an element inside i18n section in <ng-template>',
+               () => {
+                 @Directive({selector: '[myDir]'})
+                 class Dir {
+                   condition = true;
+                 }
 
-      @Component({
-        selector: 'my-cmp',
-        template: `
+                 @Component({
+                   selector: 'my-cmp',
+                   template: `
               <div *ngIf="isLogged; else notLoggedIn">
                 <span>Logged in</span>
               </div>
@@ -428,181 +442,187 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
                 <a myDir>Not logged in</a>
               </ng-template>
             `,
-      })
-      class Cmp {
-        isLogged = false;
-      }
+                 })
+                 class Cmp {
+                   isLogged = false;
+                 }
 
-      TestBed.configureTestingModule({
-        declarations: [Cmp, Dir],
-      });
-      const fixture = TestBed.createComponent(Cmp);
-      fixture.detectChanges();
+                 TestBed.configureTestingModule({
+                   declarations: [Cmp, Dir],
+                 });
+                 const fixture = TestBed.createComponent(Cmp);
+                 fixture.detectChanges();
 
-      const a = fixture.debugElement.query(By.css('a'));
-      const dir = a.injector.get(Dir);
-      expect(dir.condition).toEqual(true);
-    });
-  });
+                 const a = fixture.debugElement.query(By.css('a'));
+                 const dir = a.injector.get(Dir);
+                 expect(dir.condition).toEqual(true);
+               });
+          });
 
-  describe('should support ICU expressions', () => {
-    it('with no root node', () => {
-      loadTranslations({
+          describe('should support ICU expressions', () => {
+            it('with no root node', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
-            '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
-      });
-      const fixture =
-          initWithTemplate(AppComp, `{count, select, 10 {ten} 20 {twenty} other {other}}`);
+                '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
+                    '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
+              });
+              const fixture =
+                  initWithTemplate(AppComp, `{count, select, 10 {ten} 20 {twenty} other {other}}`);
 
-      const element = fixture.nativeElement;
-      expect(element).toHaveText('autre');
-    });
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('autre');
+            });
 
-    it('with no i18n tag', () => {
-      loadTranslations({
+            it('with no i18n tag', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
-            '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
-      });
-      const fixture = initWithTemplate(
-          AppComp, `<div>{count, select, 10 {ten} 20 {twenty} other {other}}</div>`);
+                '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
+                    '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
+              });
+              const fixture = initWithTemplate(
+                  AppComp, `<div>{count, select, 10 {ten} 20 {twenty} other {other}}</div>`);
 
-      const element = fixture.nativeElement;
-      expect(element).toHaveText('autre');
-    });
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('autre');
+            });
 
-    it('multiple', () => {
-      loadTranslations({
+            it('multiple', () => {
+              loadTranslations({
 
-        '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
-            '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
-        '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
-      });
-      const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
+                '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
+                    '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
+                '{VAR_SELECT, select, other {(name)}}':
+                    '{VAR_SELECT, select, other {({$INTERPOLATION})}}'
+              });
+              const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
         =0 {no <b>emails</b>!}
         =1 {one <i>email</i>}
         other {{{count}} <span title="{{name}}">emails</span>}
       } - {name, select,
         other {({{name}})}
       }</div>`);
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>aucun <b>email</b>!<!--ICU 7--> - (Angular)<!--ICU 13--></div>`);
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div>aucun <b>email</b>!<!--ICU 7--> - (Angular)<!--ICU 13--></div>`);
 
-      fixture.componentRef.instance.count = 4;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div>4 <span title="Angular">emails</span><!--ICU 7--> - (Angular)<!--ICU 13--></div>`);
+              fixture.componentRef.instance.count = 4;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div>4 <span title="Angular">emails</span><!--ICU 7--> - (Angular)<!--ICU 13--></div>`);
 
-      fixture.componentRef.instance.count = 0;
-      fixture.componentRef.instance.name = 'John';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>aucun <b>email</b>!<!--ICU 7--> - (John)<!--ICU 13--></div>`);
-    });
+              fixture.componentRef.instance.count = 0;
+              fixture.componentRef.instance.name = 'John';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div>aucun <b>email</b>!<!--ICU 7--> - (John)<!--ICU 13--></div>`);
+            });
 
-    it('with custom interpolation config', () => {
-      loadTranslations({
+            it('with custom interpolation config', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, 10 {ten} other {{$interpolation}}}':
-            '{VAR_SELECT, select, 10 {dix} other {{$interpolation}}}'
-      });
-      const interpolation = ['{%', '%}'] as[string, string];
-      TestBed.overrideComponent(AppComp, {set: {interpolation}});
-      const fixture =
-          initWithTemplate(AppComp, `<div i18n>{count, select, 10 {ten} other {{% name %}}}</div>`);
+                '{VAR_SELECT, select, 10 {ten} other {{$INTERPOLATION}}}':
+                    '{VAR_SELECT, select, 10 {dix} other {{$INTERPOLATION}}}'
+              });
+              const interpolation = ['{%', '%}'] as[string, string];
+              TestBed.overrideComponent(AppComp, {set: {interpolation}});
+              const fixture = initWithTemplate(
+                  AppComp, `<div i18n>{count, select, 10 {ten} other {{% name %}}}</div>`);
 
-      expect(fixture.nativeElement).toHaveText(`Angular`);
-    });
+              expect(fixture.nativeElement).toHaveText(`Angular`);
+            });
 
-    it('inside HTML elements', () => {
-      loadTranslations({
+            it('inside HTML elements', () => {
+              loadTranslations({
 
-        '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
-            '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
-        '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
-      });
-      const fixture = initWithTemplate(AppComp, `<div i18n><span>{count, plural,
+                '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}':
+                    '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} {START_TAG_SPAN}emails{CLOSE_TAG_SPAN}}}',
+                '{VAR_SELECT, select, other {(name)}}':
+                    '{VAR_SELECT, select, other {({$INTERPOLATION})}}'
+              });
+              const fixture = initWithTemplate(AppComp, `<div i18n><span>{count, plural,
         =0 {no <b>emails</b>!}
         =1 {one <i>email</i>}
         other {{{count}} <span title="{{name}}">emails</span>}
       }</span> - <span>{name, select,
         other {({{name}})}
       }</span></div>`);
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div><span>aucun <b>email</b>!<!--ICU 9--></span> - <span>(Angular)<!--ICU 15--></span></div>`);
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><span>aucun <b>email</b>!<!--ICU 9--></span> - <span>(Angular)<!--ICU 15--></span></div>`);
 
-      fixture.componentRef.instance.count = 4;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div><span>4 <span title="Angular">emails</span><!--ICU 9--></span> - <span>(Angular)<!--ICU 15--></span></div>`);
+              fixture.componentRef.instance.count = 4;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><span>4 <span title="Angular">emails</span><!--ICU 9--></span> - <span>(Angular)<!--ICU 15--></span></div>`);
 
-      fixture.componentRef.instance.count = 0;
-      fixture.componentRef.instance.name = 'John';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div><span>aucun <b>email</b>!<!--ICU 9--></span> - <span>(John)<!--ICU 15--></span></div>`);
-    });
+              fixture.componentRef.instance.count = 0;
+              fixture.componentRef.instance.name = 'John';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><span>aucun <b>email</b>!<!--ICU 9--></span> - <span>(John)<!--ICU 15--></span></div>`);
+            });
 
-    it('inside template directives', () => {
-      loadTranslations({
+            it('inside template directives', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
-      });
-      const fixture = initWithTemplate(AppComp, `<div i18n><span *ngIf="visible">{name, select,
+                '{VAR_SELECT, select, other {(name)}}':
+                    '{VAR_SELECT, select, other {({$INTERPOLATION})}}'
+              });
+              const fixture =
+                  initWithTemplate(AppComp, `<div i18n><span *ngIf="visible">{name, select,
         other {({{name}})}
       }</span></div>`);
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div><span>(Angular)<!--ICU 4--></span><!--bindings={
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div><span>(Angular)<!--ICU 4--></span><!--bindings={
   "ng-reflect-ng-if": "true"
 }--></div>`);
 
-      fixture.componentRef.instance.visible = false;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div><!--bindings={
+              fixture.componentRef.instance.visible = false;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div><!--bindings={
   "ng-reflect-ng-if": "false"
 }--></div>`);
-    });
+            });
 
-    it('inside ng-container', () => {
-      loadTranslations({
+            it('inside ng-container', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, other {(name)}}': '{VAR_SELECT, select, other {({$interpolation})}}'
-      });
-      const fixture = initWithTemplate(AppComp, `<ng-container i18n>{name, select,
+                '{VAR_SELECT, select, other {(name)}}':
+                    '{VAR_SELECT, select, other {({$INTERPOLATION})}}'
+              });
+              const fixture = initWithTemplate(AppComp, `<ng-container i18n>{name, select,
         other {({{name}})}
       }</ng-container>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`(Angular)<!--ICU 4--><!--ng-container-->`);
-    });
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`(Angular)<!--ICU 4--><!--ng-container-->`);
+            });
 
-    it('inside <ng-template>', () => {
-      loadTranslations({
+            it('inside <ng-template>', () => {
+              loadTranslations({
 
-        '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
-            '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
-      });
-      const fixture = initWithTemplate(
-          AppComp, `
+                '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
+                    '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autre}}'
+              });
+              const fixture = initWithTemplate(
+                  AppComp, `
         <ng-template i18n tplRef>` +
-              `{count, select, 10 {ten} 20 {twenty} other {other}}` +
-              `</ng-template>
+                      `{count, select, 10 {ten} 20 {twenty} other {other}}` +
+                      `</ng-template>
       `);
 
-      const element = fixture.nativeElement;
-      expect(element).toHaveText('autre');
-    });
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('autre');
+            });
 
-    it('nested', () => {
-      loadTranslations({
+            it('nested', () => {
+              loadTranslations({
 
-        '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}}!}}':
-            '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {chats} dog {chients} other {animaux}}!}}'
-      });
-      const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
+                '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}}!}}':
+                    '{VAR_PLURAL, plural, =0 {zero} other {{INTERPOLATION} {VAR_SELECT, select, cat {chats} dog {chients} other {animaux}}!}}'
+              });
+              const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
         =0 {zero}
         other {{{count}} {name, select,
                        cat {cats}
@@ -610,24 +630,25 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
                        other {animals}
                      }!}
       }</div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 5--></div>`);
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 5--></div>`);
 
-      fixture.componentRef.instance.count = 4;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>4 animaux<!--nested ICU 0-->!<!--ICU 5--></div>`);
-    });
+              fixture.componentRef.instance.count = 4;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div>4 animaux<!--nested ICU 0-->!<!--ICU 5--></div>`);
+            });
 
-    it('nested with interpolations in "other" blocks', () => {
-      // Note: for some reason long string causing clang to reformat the entire file.
-      const key = '{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, ' +
-          'cat {cats} dog {dogs} other {animals}}!} other {other - {INTERPOLATION}}}';
-      const translation =
-          '{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, ' +
-          'cat {chats} dog {chients} other {animaux}}!} other {other - {INTERPOLATION}}}';
-      loadTranslations({[key]: translation});
+            it('nested with interpolations in "other" blocks', () => {
+              // Note: for some reason long string causing clang to reformat the entire file.
+              const key =
+                  '{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, ' +
+                  'cat {cats} dog {dogs} other {animals}}!} other {other - {INTERPOLATION}}}';
+              const translation =
+                  '{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, ' +
+                  'cat {chats} dog {chients} other {animaux}}!} other {other - {INTERPOLATION}}}';
+              loadTranslations({[key]: translation});
 
-      const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
+              const fixture = initWithTemplate(AppComp, `<div i18n>{count, plural,
         =0 {zero}
         =2 {{{count}} {name, select,
                        cat {cats}
@@ -636,24 +657,25 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
                      }!}
         other {other - {{count}}}
       }</div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 5--></div>`);
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 5--></div>`);
 
-      fixture.componentRef.instance.count = 2;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>2 animaux<!--nested ICU 0-->!<!--ICU 5--></div>`);
+              fixture.componentRef.instance.count = 2;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div>2 animaux<!--nested ICU 0-->!<!--ICU 5--></div>`);
 
-      fixture.componentRef.instance.count = 4;
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>other - 4<!--ICU 5--></div>`);
-    });
+              fixture.componentRef.instance.count = 4;
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div>other - 4<!--ICU 5--></div>`);
+            });
 
-    it('should return the correct plural form for ICU expressions when using a specific locale',
-       () => {
-         registerLocaleData(localeRo);
-         TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'ro'}]});
-         // We could also use `TestBed.overrideProvider(LOCALE_ID, {useValue: 'ro'});`
-         const fixture = initWithTemplate(AppComp, `
+            it('should return the correct plural form for ICU expressions when using a specific locale',
+               () => {
+                 registerLocaleData(localeRo);
+                 TestBed.configureTestingModule(
+                     {providers: [{provide: LOCALE_ID, useValue: 'ro'}]});
+                 // We could also use `TestBed.overrideProvider(LOCALE_ID, {useValue: 'ro'});`
+                 const fixture = initWithTemplate(AppComp, `
           {count, plural,
             =0 {no email}
             =one {one email}
@@ -661,93 +683,94 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
             =other {lots of emails}
           }`);
 
-         expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
+                 expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
 
-         // Change detection cycle, no model changes
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
+                 // Change detection cycle, no model changes
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
 
-         fixture.componentInstance.count = 3;
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 2-->');
+                 fixture.componentInstance.count = 3;
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 2-->');
 
-         fixture.componentInstance.count = 1;
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 2-->');
+                 fixture.componentInstance.count = 1;
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 2-->');
 
-         fixture.componentInstance.count = 10;
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 2-->');
+                 fixture.componentInstance.count = 10;
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 2-->');
 
-         fixture.componentInstance.count = 20;
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 2-->');
+                 fixture.componentInstance.count = 20;
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 2-->');
 
-         fixture.componentInstance.count = 0;
-         fixture.detectChanges();
-         expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
-       });
+                 fixture.componentInstance.count = 0;
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 2-->');
+               });
 
-    it('projection', () => {
-      @Component({selector: 'child', template: '<div><ng-content></ng-content></div>'})
-      class Child {
-      }
+            it('projection', () => {
+              @Component({selector: 'child', template: '<div><ng-content></ng-content></div>'})
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template: `
+              @Component({
+                selector: 'parent',
+                template: `
       <child i18n>{
         value // i18n(ph = "blah"),
         plural,
          =1 {one}
         other {at least {{value}} .}
       }</child>`
-      })
-      class Parent {
-        value = 3;
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({});
+              })
+              class Parent {
+                value = 3;
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({});
 
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
 
-      expect(fixture.nativeElement.innerHTML).toContain('at least');
-    });
+              expect(fixture.nativeElement.innerHTML).toContain('at least');
+            });
 
-    it('with empty values', () => {
-      const fixture = initWithTemplate(AppComp, `{count, select, 10 {} 20 {twenty} other {other}}`);
+            it('with empty values', () => {
+              const fixture =
+                  initWithTemplate(AppComp, `{count, select, 10 {} 20 {twenty} other {other}}`);
 
-      const element = fixture.nativeElement;
-      expect(element).toHaveText('other');
-    });
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('other');
+            });
 
-    it('inside a container when creating a view via vcr.createEmbeddedView', () => {
-      @Directive({
-        selector: '[someDir]',
-      })
-      class Dir {
-        constructor(
-            private readonly viewContainerRef: ViewContainerRef,
-            private readonly templateRef: TemplateRef<any>) {}
+            it('inside a container when creating a view via vcr.createEmbeddedView', () => {
+              @Directive({
+                selector: '[someDir]',
+              })
+              class Dir {
+                constructor(
+                    private readonly viewContainerRef: ViewContainerRef,
+                    private readonly templateRef: TemplateRef<any>) {}
 
-        ngOnInit() { this.viewContainerRef.createEmbeddedView(this.templateRef); }
-      }
+                ngOnInit() { this.viewContainerRef.createEmbeddedView(this.templateRef); }
+              }
 
-      @Component({
-        selector: 'my-cmp',
-        template: `
+              @Component({
+                selector: 'my-cmp',
+                template: `
               <div *someDir>
                 <ng-content></ng-content>
               </div>
             `,
-      })
-      class Cmp {
-      }
+              })
+              class Cmp {
+              }
 
-      @Component({
-        selector: 'my-app',
-        template: `
+              @Component({
+                selector: 'my-app',
+                template: `
             <my-cmp i18n="test" *ngIf="condition">{
               count,
               plural,
@@ -755,68 +778,70 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               other {OTHER}
             }</my-cmp>
           `,
-      })
-      class App {
-        count = 1;
-        condition = true;
-      }
+              })
+              class App {
+                count = 1;
+                condition = true;
+              }
 
-      TestBed.configureTestingModule({
-        declarations: [App, Cmp, Dir],
-      });
-      const fixture = TestBed.createComponent(App);
-      fixture.detectChanges();
-      expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>ONE<!--ICU 13--></div><!--container--></my-cmp>');
+              TestBed.configureTestingModule({
+                declarations: [App, Cmp, Dir],
+              });
+              const fixture = TestBed.createComponent(App);
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement.innerHTML)
+                  .toContain('<my-cmp><div>ONE<!--ICU 13--></div><!--container--></my-cmp>');
 
-      fixture.componentRef.instance.count = 2;
-      fixture.detectChanges();
-      expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>OTHER<!--ICU 13--></div><!--container--></my-cmp>');
+              fixture.componentRef.instance.count = 2;
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement.innerHTML)
+                  .toContain('<my-cmp><div>OTHER<!--ICU 13--></div><!--container--></my-cmp>');
 
-      // destroy component
-      fixture.componentInstance.condition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.nativeElement.textContent).toBe('');
+              // destroy component
+              fixture.componentInstance.condition = false;
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement.textContent).toBe('');
 
-      // render it again and also change ICU case
-      fixture.componentInstance.condition = true;
-      fixture.componentInstance.count = 1;
-      fixture.detectChanges();
-      expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>ONE<!--ICU 13--></div><!--container--></my-cmp>');
-    });
+              // render it again and also change ICU case
+              fixture.componentInstance.condition = true;
+              fixture.componentInstance.count = 1;
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement.innerHTML)
+                  .toContain('<my-cmp><div>ONE<!--ICU 13--></div><!--container--></my-cmp>');
+            });
 
-    it('with nested ICU expression and inside a container when creating a view via vcr.createEmbeddedView',
-       () => {
-         let dir: Dir|null = null;
-         @Directive({
-           selector: '[someDir]',
-         })
-         class Dir {
-           constructor(
-               private readonly viewContainerRef: ViewContainerRef,
-               private readonly templateRef: TemplateRef<any>) {
-             dir = this;
-           }
+            it('with nested ICU expression and inside a container when creating a view via vcr.createEmbeddedView',
+               () => {
+                 let dir: Dir|null = null;
+                 @Directive({
+                   selector: '[someDir]',
+                 })
+                 class Dir {
+                   constructor(
+                       private readonly viewContainerRef: ViewContainerRef,
+                       private readonly templateRef: TemplateRef<any>) {
+                     dir = this;
+                   }
 
-           attachEmbeddedView() { this.viewContainerRef.createEmbeddedView(this.templateRef); }
-         }
+                   attachEmbeddedView() {
+                     this.viewContainerRef.createEmbeddedView(this.templateRef);
+                   }
+                 }
 
-         @Component({
-           selector: 'my-cmp',
-           template: `
+                 @Component({
+                   selector: 'my-cmp',
+                   template: `
               <div *someDir>
                 <ng-content></ng-content>
               </div>
             `,
-         })
-         class Cmp {
-         }
+                 })
+                 class Cmp {
+                 }
 
-         @Component({
-           selector: 'my-app',
-           template: `
+                 @Component({
+                   selector: 'my-app',
+                   template: `
             <my-cmp i18n="test">{
               count,
               plural,
@@ -828,36 +853,36 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               }!}
             }</my-cmp>
           `,
-         })
-         class App {
-           count = 1;
-         }
+                 })
+                 class App {
+                   count = 1;
+                 }
 
-         TestBed.configureTestingModule({
-           declarations: [App, Cmp, Dir],
-         });
-         const fixture = TestBed.createComponent(App);
-         fixture.componentRef.instance.count = 2;
-         fixture.detectChanges();
-         expect(fixture.debugElement.nativeElement.innerHTML)
-             .toBe('<my-cmp><!--container--></my-cmp>');
+                 TestBed.configureTestingModule({
+                   declarations: [App, Cmp, Dir],
+                 });
+                 const fixture = TestBed.createComponent(App);
+                 fixture.componentRef.instance.count = 2;
+                 fixture.detectChanges();
+                 expect(fixture.debugElement.nativeElement.innerHTML)
+                     .toBe('<my-cmp><!--container--></my-cmp>');
 
-         dir !.attachEmbeddedView();
-         fixture.detectChanges();
-         expect(fixture.debugElement.nativeElement.innerHTML)
-             .toBe(
-                 '<my-cmp><div>2 animals<!--nested ICU 0-->!<!--ICU 15--></div><!--container--></my-cmp>');
+                 dir !.attachEmbeddedView();
+                 fixture.detectChanges();
+                 expect(fixture.debugElement.nativeElement.innerHTML)
+                     .toBe(
+                         '<my-cmp><div>2 animals<!--nested ICU 0-->!<!--ICU 15--></div><!--container--></my-cmp>');
 
-         fixture.componentRef.instance.count = 1;
-         fixture.detectChanges();
-         expect(fixture.debugElement.nativeElement.innerHTML)
-             .toBe('<my-cmp><div>ONE<!--ICU 15--></div><!--container--></my-cmp>');
-       });
+                 fixture.componentRef.instance.count = 1;
+                 fixture.detectChanges();
+                 expect(fixture.debugElement.nativeElement.innerHTML)
+                     .toBe('<my-cmp><div>ONE<!--ICU 15--></div><!--container--></my-cmp>');
+               });
 
-    it('with nested containers', () => {
-      @Component({
-        selector: 'comp',
-        template: `
+            it('with nested containers', () => {
+              @Component({
+                selector: 'comp',
+                template: `
         <ng-container [ngSwitch]="visible">
           <ng-container *ngSwitchCase="isVisible()" i18n>
             {type, select, A { A } B { B } other { C }}
@@ -867,31 +892,31 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
           </ng-container>
         </ng-container>
       `,
-      })
-      class Comp {
-        type = 'A';
-        visible = true;
-        isVisible() { return true; }
-      }
+              })
+              class Comp {
+                type = 'A';
+                visible = true;
+                isVisible() { return true; }
+              }
 
-      TestBed.configureTestingModule({declarations: [Comp]});
+              TestBed.configureTestingModule({declarations: [Comp]});
 
-      const fixture = TestBed.createComponent(Comp);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(Comp);
+              fixture.detectChanges();
 
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('A');
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('A');
 
-      fixture.componentInstance.visible = false;
-      fixture.detectChanges();
+              fixture.componentInstance.visible = false;
+              fixture.detectChanges();
 
-      expect(fixture.debugElement.nativeElement.innerHTML).not.toContain('A');
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('C1');
-    });
+              expect(fixture.debugElement.nativeElement.innerHTML).not.toContain('A');
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('C1');
+            });
 
-    it('with named interpolations', () => {
-      @Component({
-        selector: 'comp',
-        template: `
+            it('with named interpolations', () => {
+              @Component({
+                selector: 'comp',
+                template: `
           <ng-container i18n>{
             type,
             select,
@@ -900,32 +925,32 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               other {other - {{ typeC // i18n(ph="PH WITH SPACES") }}}
           }</ng-container>
         `,
-      })
-      class Comp {
-        type = 'A';
-        typeA = 'Type A';
-        typeB = 'Type B';
-        typeC = 'Type C';
-      }
+              })
+              class Comp {
+                type = 'A';
+                typeA = 'Type A';
+                typeB = 'Type B';
+                typeC = 'Type C';
+              }
 
-      TestBed.configureTestingModule({declarations: [Comp]});
+              TestBed.configureTestingModule({declarations: [Comp]});
 
-      const fixture = TestBed.createComponent(Comp);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(Comp);
+              fixture.detectChanges();
 
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('A - Type A');
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('A - Type A');
 
-      fixture.componentInstance.type = 'C';  // trigger "other" case
-      fixture.detectChanges();
+              fixture.componentInstance.type = 'C';  // trigger "other" case
+              fixture.detectChanges();
 
-      expect(fixture.debugElement.nativeElement.innerHTML).not.toContain('A - Type A');
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('other - Type C');
-    });
+              expect(fixture.debugElement.nativeElement.innerHTML).not.toContain('A - Type A');
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('other - Type C');
+            });
 
-    it('should work inside an ngTemplateOutlet inside an ngFor', () => {
-      @Component({
-        selector: 'app',
-        template: `
+            it('should work inside an ngTemplateOutlet inside an ngFor', () => {
+              @Component({
+                selector: 'app',
+                template: `
           <ng-template #myTemp i18n let-type>{
             type,
             select,
@@ -940,171 +965,176 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
             </ng-container>
           </div>
         `
-      })
-      class AppComponent {
-        types = ['A', 'B', 'C'];
-      }
+              })
+              class AppComponent {
+                types = ['A', 'B', 'C'];
+              }
 
-      TestBed.configureTestingModule({declarations: [AppComponent]});
+              TestBed.configureTestingModule({declarations: [AppComponent]});
 
-      const fixture = TestBed.createComponent(AppComponent);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(AppComponent);
+              fixture.detectChanges();
 
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('A');
-      expect(fixture.debugElement.nativeElement.innerHTML).toContain('B');
-    });
-  });
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('A');
+              expect(fixture.debugElement.nativeElement.innerHTML).toContain('B');
+            });
+          });
 
-  describe('should support attributes', () => {
-    it('text', () => {
-      loadTranslations({'text': 'texte'});
-      const fixture = initWithTemplate(AppComp, `<div i18n i18n-title title="text"></div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="texte"></div>`);
-    });
+          describe('should support attributes', () => {
+            it('text', () => {
+              loadTranslations({'text': 'texte'});
+              const fixture = initWithTemplate(AppComp, `<div i18n i18n-title title="text"></div>`);
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div title="texte"></div>`);
+            });
 
-    it('interpolations', () => {
-      loadTranslations({'hello {$interpolation}': 'bonjour {$interpolation}'});
-      const fixture =
-          initWithTemplate(AppComp, `<div i18n i18n-title title="hello {{name}}"></div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour Angular"></div>`);
+            it('interpolations', () => {
+              loadTranslations({'hello {$INTERPOLATION}': 'bonjour {$INTERPOLATION}'});
+              const fixture =
+                  initWithTemplate(AppComp, `<div i18n i18n-title title="hello {{name}}"></div>`);
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div title="bonjour Angular"></div>`);
 
-      fixture.componentRef.instance.name = 'John';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour John"></div>`);
-    });
+              fixture.componentRef.instance.name = 'John';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour John"></div>`);
+            });
 
-    it('with pipes', () => {
-      loadTranslations({'hello {$interpolation}': 'bonjour {$interpolation}'});
-      const fixture = initWithTemplate(
-          AppComp, `<div i18n i18n-title title="hello {{name | uppercase}}"></div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour ANGULAR"></div>`);
-    });
+            it('with pipes', () => {
+              loadTranslations({'hello {$INTERPOLATION}': 'bonjour {$INTERPOLATION}'});
+              const fixture = initWithTemplate(
+                  AppComp, `<div i18n i18n-title title="hello {{name | uppercase}}"></div>`);
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<div title="bonjour ANGULAR"></div>`);
+            });
 
-    it('multiple attributes', () => {
-      loadTranslations({'hello {$interpolation}': 'bonjour {$interpolation}'});
-      const fixture = initWithTemplate(
-          AppComp,
-          `<input i18n i18n-title title="hello {{name}}" i18n-placeholder placeholder="hello {{name}}">`);
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<input title="bonjour Angular" placeholder="bonjour Angular">`);
+            it('multiple attributes', () => {
+              loadTranslations({'hello {$INTERPOLATION}': 'bonjour {$INTERPOLATION}'});
+              const fixture = initWithTemplate(
+                  AppComp,
+                  `<input i18n i18n-title title="hello {{name}}" i18n-placeholder placeholder="hello {{name}}">`);
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<input title="bonjour Angular" placeholder="bonjour Angular">`);
 
-      fixture.componentRef.instance.name = 'John';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<input title="bonjour John" placeholder="bonjour John">`);
-    });
+              fixture.componentRef.instance.name = 'John';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<input title="bonjour John" placeholder="bonjour John">`);
+            });
 
-    it('on removed elements', () => {
-      loadTranslations({'text': 'texte', '{$startTagSpan}content{$closeTagSpan}': 'contenu'});
-      const fixture =
-          initWithTemplate(AppComp, `<div i18n><span i18n-title title="text">content</span></div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>contenu</div>`);
-    });
+            it('on removed elements', () => {
+              loadTranslations(
+                  {'text': 'texte', '{$START_TAG_SPAN}content{$CLOSE_TAG_SPAN}': 'contenu'});
+              const fixture = initWithTemplate(
+                  AppComp, `<div i18n><span i18n-title title="text">content</span></div>`);
+              expect(fixture.nativeElement.innerHTML).toEqual(`<div>contenu</div>`);
+            });
 
-    it('with custom interpolation config', () => {
-      loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
-      const interpolation = ['{%', '%}'] as[string, string];
-      TestBed.overrideComponent(AppComp, {set: {interpolation}});
-      const fixture =
-          initWithTemplate(AppComp, `<div i18n-title="m|d" title="Hello {% name %}"></div>`);
+            it('with custom interpolation config', () => {
+              loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+              const interpolation = ['{%', '%}'] as[string, string];
+              TestBed.overrideComponent(AppComp, {set: {interpolation}});
+              const fixture = initWithTemplate(
+                  AppComp, `<div i18n-title="m|d" title="Hello {% name %}"></div>`);
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe('Bonjour Angular');
-    });
+              const element = fixture.nativeElement.firstChild;
+              expect(element.title).toBe('Bonjour Angular');
+            });
 
-    it('in nested template', () => {
-      loadTranslations({'Item {$interpolation}': 'Article {$interpolation}'});
-      const fixture = initWithTemplate(AppComp, `
+            it('in nested template', () => {
+              loadTranslations({'Item {$INTERPOLATION}': 'Article {$INTERPOLATION}'});
+              const fixture = initWithTemplate(AppComp, `
           <div *ngFor='let item of [1,2,3]'>
             <div i18n-title='m|d' title='Item {{ item }}'></div>
           </div>`);
 
-      const element = fixture.nativeElement;
-      for (let i = 0; i < element.children.length; i++) {
-        const child = element.children[i];
-        expect((child as any).innerHTML).toBe(`<div title="Article ${i + 1}"></div>`);
-      }
-    });
+              const element = fixture.nativeElement;
+              for (let i = 0; i < element.children.length; i++) {
+                const child = element.children[i];
+                expect((child as any).innerHTML).toBe(`<div title="Article ${i + 1}"></div>`);
+              }
+            });
 
-    it('should add i18n attributes on self-closing tags', () => {
-      loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}'});
-      const fixture =
-          initWithTemplate(AppComp, `<img src="logo.png" i18n-title title="Hello {{ name }}">`);
+            it('should add i18n attributes on self-closing tags', () => {
+              loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+              const fixture = initWithTemplate(
+                  AppComp, `<img src="logo.png" i18n-title title="Hello {{ name }}">`);
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe('Bonjour Angular');
-    });
+              const element = fixture.nativeElement.firstChild;
+              expect(element.title).toBe('Bonjour Angular');
+            });
 
-    it('should apply i18n attributes during second template pass', () => {
-      @Directive({
-        selector: '[test]',
-        inputs: ['test'],
-        exportAs: 'dir',
-      })
-      class Dir {
-      }
+            it('should apply i18n attributes during second template pass', () => {
+              @Directive({
+                selector: '[test]',
+                inputs: ['test'],
+                exportAs: 'dir',
+              })
+              class Dir {
+              }
 
-      @Component({
-        selector: 'other',
-        template: `<div i18n #ref="dir" test="Set" i18n-test="This is also a test"></div>`
-      })
-      class Other {
-      }
+              @Component({
+                selector: 'other',
+                template: `<div i18n #ref="dir" test="Set" i18n-test="This is also a test"></div>`
+              })
+              class Other {
+              }
 
-      @Component({
-        selector: 'blah',
-        template: `
+              @Component({
+                selector: 'blah',
+                template: `
           <other></other>
           <other></other>
         `
-      })
-      class Cmp {
-      }
+              })
+              class Cmp {
+              }
 
-      TestBed.configureTestingModule({
-        declarations: [Dir, Cmp, Other],
-      });
+              TestBed.configureTestingModule({
+                declarations: [Dir, Cmp, Other],
+              });
 
-      const fixture = TestBed.createComponent(Cmp);
-      fixture.detectChanges();
-      expect(fixture.debugElement.children[0].children[0].references.ref.test).toBe('Set');
-      expect(fixture.debugElement.children[1].children[0].references.ref.test).toBe('Set');
-    });
+              const fixture = TestBed.createComponent(Cmp);
+              fixture.detectChanges();
+              expect(fixture.debugElement.children[0].children[0].references.ref.test).toBe('Set');
+              expect(fixture.debugElement.children[1].children[0].references.ref.test).toBe('Set');
+            });
 
-    it('with complex expressions', () => {
-      loadTranslations({
-        '{$interpolation} - {$interpolation_1} - {$interpolation_2}':
-            '{$interpolation} - {$interpolation_1} - {$interpolation_2} (fr)'
-      });
-      const fixture = initWithTemplate(AppComp, `
+            it('with complex expressions', () => {
+              loadTranslations({
+                '{$INTERPOLATION} - {$INTERPOLATION_1} - {$INTERPOLATION_2}':
+                    '{$INTERPOLATION} - {$INTERPOLATION_1} - {$INTERPOLATION_2} (fr)'
+              });
+              const fixture = initWithTemplate(AppComp, `
         <div i18n-title title="{{ name | uppercase }} - {{ obj?.a?.b }} - {{ obj?.getA()?.b }}"></div>
       `);
-      // the `obj` field is not yet defined, so 2nd and 3rd interpolations return empty strings
-      expect(fixture.nativeElement.firstChild.title).toEqual(`ANGULAR -  -  (fr)`);
+              // the `obj` field is not yet defined, so 2nd and 3rd interpolations return empty
+              // strings
+              expect(fixture.nativeElement.firstChild.title).toEqual(`ANGULAR -  -  (fr)`);
 
-      fixture.componentRef.instance.obj = {
-        a: {b: 'value 1'},
-        getA: () => ({b: 'value 2'}),
-      };
-      fixture.detectChanges();
-      expect(fixture.nativeElement.firstChild.title).toEqual(`ANGULAR - value 1 - value 2 (fr)`);
-    });
-  });
+              fixture.componentRef.instance.obj = {
+                a: {b: 'value 1'},
+                getA: () => ({b: 'value 2'}),
+              };
+              fixture.detectChanges();
+              expect(fixture.nativeElement.firstChild.title)
+                  .toEqual(`ANGULAR - value 1 - value 2 (fr)`);
+            });
+          });
 
-  it('should work with directives and host bindings', () => {
-    let directiveInstances: ClsDir[] = [];
+          it('should work with directives and host bindings', () => {
+            let directiveInstances: ClsDir[] = [];
 
-    @Directive({selector: '[test]'})
-    class ClsDir {
-      @HostBinding('className')
-      klass = 'foo';
+            @Directive({selector: '[test]'})
+            class ClsDir {
+              @HostBinding('className')
+              klass = 'foo';
 
-      constructor() { directiveInstances.push(this); }
-    }
+              constructor() { directiveInstances.push(this); }
+            }
 
-    @Component({
-      selector: `my-app`,
-      template: `
+            @Component({
+              selector: `my-app`,
+              template: `
       <div i18n test i18n-title title="start {{exp1}} middle {{exp2}} end">
          trad: {exp1, plural,
               =0 {no <b title="none">emails</b>!}
@@ -1112,80 +1142,81 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               other {{{exp1}} emails}
          }
       </div><div test></div>`
-    })
-    class MyApp {
-      exp1 = 1;
-      exp2 = 2;
-    }
+            })
+            class MyApp {
+              exp1 = 1;
+              exp2 = 2;
+            }
 
-    TestBed.configureTestingModule({declarations: [ClsDir, MyApp]});
-    loadTranslations({
-      // Not that this translation switches the order of the expressions!
-      'start {$interpolation} middle {$interpolation_1} end':
-          'début {$interpolation_1} milieu {$interpolation} fin',
-      '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}':
-          '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}',
-      ' trad: {$icu} ': ' traduction: {$icu} '
-    });
-    const fixture = TestBed.createComponent(MyApp);
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(
-            `<div test="" title="début 2 milieu 1 fin" class="foo"> traduction: un <i>email</i><!--ICU 20--> ` +
-            `</div><div test="" class="foo"></div>`);
+            TestBed.configureTestingModule({declarations: [ClsDir, MyApp]});
+            loadTranslations({
+              // Not that this translation switches the order of the expressions!
+              'start {$INTERPOLATION} middle {$INTERPOLATION_1} end':
+                  'début {$INTERPOLATION_1} milieu {$INTERPOLATION} fin',
+              '{VAR_PLURAL, plural, =0 {no {START_BOLD_TEXT}emails{CLOSE_BOLD_TEXT}!} =1 {one {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}':
+                  '{VAR_PLURAL, plural, =0 {aucun {START_BOLD_TEXT}email{CLOSE_BOLD_TEXT}!} =1 {un {START_ITALIC_TEXT}email{CLOSE_ITALIC_TEXT}} other {{INTERPOLATION} emails}}',
+              ' trad: {$ICU} ': ' traduction: {$ICU} '
+            });
+            const fixture = TestBed.createComponent(MyApp);
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<div test="" title="début 2 milieu 1 fin" class="foo"> traduction: un <i>email</i><!--ICU 20--> ` +
+                    `</div><div test="" class="foo"></div>`);
 
-    directiveInstances.forEach(instance => instance.klass = 'bar');
-    fixture.componentRef.instance.exp1 = 2;
-    fixture.componentRef.instance.exp2 = 3;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(
-            `<div test="" title="début 3 milieu 2 fin" class="bar"> traduction: 2 emails<!--ICU 20--> ` +
-            `</div><div test="" class="bar"></div>`);
-  });
+            directiveInstances.forEach(instance => instance.klass = 'bar');
+            fixture.componentRef.instance.exp1 = 2;
+            fixture.componentRef.instance.exp2 = 3;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<div test="" title="début 3 milieu 2 fin" class="bar"> traduction: 2 emails<!--ICU 20--> ` +
+                    `</div><div test="" class="bar"></div>`);
+          });
 
-  it('should handle i18n attribute with directive inputs', () => {
-    let calledTitle = false;
-    let calledValue = false;
-    @Component({selector: 'my-comp', template: ''})
-    class MyComp {
-      t !: string;
-      @Input()
-      get title() { return this.t; }
-      set title(title) {
-        calledTitle = true;
-        this.t = title;
-      }
+          it('should handle i18n attribute with directive inputs', () => {
+            let calledTitle = false;
+            let calledValue = false;
+            @Component({selector: 'my-comp', template: ''})
+            class MyComp {
+              t !: string;
+              @Input()
+              get title() { return this.t; }
+              set title(title) {
+                calledTitle = true;
+                this.t = title;
+              }
 
-      @Input()
-      get value() { return this.val; }
-      set value(value: string) {
-        calledValue = true;
-        this.val = value;
-      }
-      val !: string;
-    }
+              @Input()
+              get value() { return this.val; }
+              set value(value: string) {
+                calledValue = true;
+                this.val = value;
+              }
+              val !: string;
+            }
 
-    TestBed.configureTestingModule({declarations: [AppComp, MyComp]});
-    loadTranslations({'Hello {$interpolation}': 'Bonjour {$interpolation}', 'works': 'fonctionne'});
-    const fixture = initWithTemplate(
-        AppComp,
-        `<my-comp i18n i18n-title title="works" i18n-value="hi" value="Hello {{name}}"></my-comp>`);
-    fixture.detectChanges();
+            TestBed.configureTestingModule({declarations: [AppComp, MyComp]});
+            loadTranslations(
+                {'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}', 'works': 'fonctionne'});
+            const fixture = initWithTemplate(
+                AppComp,
+                `<my-comp i18n i18n-title title="works" i18n-value="hi" value="Hello {{name}}"></my-comp>`);
+            fixture.detectChanges();
 
-    const directive = fixture.debugElement.children[0].injector.get(MyComp);
-    expect(calledValue).toEqual(true);
-    expect(calledTitle).toEqual(true);
-    expect(directive.value).toEqual(`Bonjour Angular`);
-    expect(directive.title).toEqual(`fonctionne`);
-  });
+            const directive = fixture.debugElement.children[0].injector.get(MyComp);
+            expect(calledValue).toEqual(true);
+            expect(calledTitle).toEqual(true);
+            expect(directive.value).toEqual(`Bonjour Angular`);
+            expect(directive.title).toEqual(`fonctionne`);
+          });
 
-  it('should support adding/moving/removing nodes', () => {
-    loadTranslations({
-      '{$startTagDiv2}{$closeTagDiv2}{$startTagDiv3}{$closeTagDiv3}{$startTagDiv4}{$closeTagDiv4}{$startTagDiv5}{$closeTagDiv5}{$startTagDiv6}{$closeTagDiv6}{$startTagDiv7}{$closeTagDiv7}{$startTagDiv8}{$closeTagDiv8}':
-          '{$startTagDiv2}{$closeTagDiv2}{$startTagDiv8}{$closeTagDiv8}{$startTagDiv4}{$closeTagDiv4}{$startTagDiv5}{$closeTagDiv5}Bonjour monde{$startTagDiv3}{$closeTagDiv3}{$startTagDiv7}{$closeTagDiv7}'
-    });
-    const fixture = initWithTemplate(AppComp, `
+          it('should support adding/moving/removing nodes', () => {
+            loadTranslations({
+              '{$START_TAG_DIV2}{$CLOSE_TAG_DIV2}{$START_TAG_DIV3}{$CLOSE_TAG_DIV3}{$START_TAG_DIV4}{$CLOSE_TAG_DIV4}{$START_TAG_DIV5}{$CLOSE_TAG_DIV5}{$START_TAG_DIV6}{$CLOSE_TAG_DIV6}{$START_TAG_DIV7}{$CLOSE_TAG_DIV7}{$START_TAG_DIV8}{$CLOSE_TAG_DIV8}':
+                  '{$START_TAG_DIV2}{$CLOSE_TAG_DIV2}{$START_TAG_DIV8}{$CLOSE_TAG_DIV8}{$START_TAG_DIV4}{$CLOSE_TAG_DIV4}{$START_TAG_DIV5}{$CLOSE_TAG_DIV5}Bonjour monde{$START_TAG_DIV3}{$CLOSE_TAG_DIV3}{$START_TAG_DIV7}{$CLOSE_TAG_DIV7}'
+            });
+            const fixture = initWithTemplate(AppComp, `
       <div i18n>
         <div2></div2>
         <div3></div3>
@@ -1195,20 +1226,20 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         <div7></div7>
         <div8></div8>
       </div>`);
-    expect(fixture.nativeElement.innerHTML)
-        .toEqual(
-            `<div><div2></div2><div8></div8><div4></div4><div5></div5>Bonjour monde<div3></div3><div7></div7></div>`);
-  });
+            expect(fixture.nativeElement.innerHTML)
+                .toEqual(
+                    `<div><div2></div2><div8></div8><div4></div4><div5></div5>Bonjour monde<div3></div3><div7></div7></div>`);
+          });
 
-  describe('projection', () => {
-    it('should project the translations', () => {
-      @Component({selector: 'child', template: '<p><ng-content></ng-content></p>'})
-      class Child {
-      }
+          describe('projection', () => {
+            it('should project the translations', () => {
+              @Component({selector: 'child', template: '<p><ng-content></ng-content></p>'})
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template: `
+              @Component({
+                selector: 'parent',
+                template: `
             <div i18n>
               <child>I am projected from
                 <b i18n-title title="Child of {{name}}">{{name}}<remove-me-1></remove-me-1></b>
@@ -1216,32 +1247,32 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               </child>
               <remove-me-3></remove-me-3>
             </div>`
-      })
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              })
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Child of {$interpolation}': 'Enfant de {$interpolation}',
-        '{$startTagChild}I am projected from {$startBoldText}{$interpolation}{$startTagRemoveMe_1}{$closeTagRemoveMe_1}{$closeBoldText}{$startTagRemoveMe_2}{$closeTagRemoveMe_2}{$closeTagChild}{$startTagRemoveMe_3}{$closeTagRemoveMe_3}':
-            '{$startTagChild}Je suis projeté depuis {$startBoldText}{$interpolation}{$closeBoldText}{$closeTagChild}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div><child><p>Je suis projeté depuis <b title="Enfant de Parent">Parent</b></p></child></div>`);
-    });
+                'Child of {$INTERPOLATION}': 'Enfant de {$INTERPOLATION}',
+                '{$START_TAG_CHILD}I am projected from {$START_BOLD_TEXT}{$INTERPOLATION}{$START_TAG_REMOVE_ME_1}{$CLOSE_TAG_REMOVE_ME_1}{$CLOSE_BOLD_TEXT}{$START_TAG_REMOVE_ME_2}{$CLOSE_TAG_REMOVE_ME_2}{$CLOSE_TAG_CHILD}{$START_TAG_REMOVE_ME_3}{$CLOSE_TAG_REMOVE_ME_3}':
+                    '{$START_TAG_CHILD}Je suis projeté depuis {$START_BOLD_TEXT}{$INTERPOLATION}{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_CHILD}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><child><p>Je suis projeté depuis <b title="Enfant de Parent">Parent</b></p></child></div>`);
+            });
 
-    it('should project a translated i18n block', () => {
-      @Component({selector: 'child', template: '<p><ng-content></ng-content></p>'})
-      class Child {
-      }
+            it('should project a translated i18n block', () => {
+              @Component({selector: 'child', template: '<p><ng-content></ng-content></p>'})
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template: `
+              @Component({
+                selector: 'parent',
+                template: `
           <div>
             <child>
               <any></any>
@@ -1249,360 +1280,381 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
               <any></any>
             </child>
           </div>`
-      })
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              })
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Child of {$interpolation}': 'Enfant de {$interpolation}',
-        'I am projected from {$interpolation}': 'Je suis projeté depuis {$interpolation}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<div><child><p><any></any><b title="Enfant de Parent">Je suis projeté depuis Parent</b><any></any></p></child></div>`);
+                'Child of {$INTERPOLATION}': 'Enfant de {$INTERPOLATION}',
+                'I am projected from {$INTERPOLATION}': 'Je suis projeté depuis {$INTERPOLATION}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><child><p><any></any><b title="Enfant de Parent">Je suis projeté depuis Parent</b><any></any></p></child></div>`);
 
-      // it should be able to render a new component with the same template code
-      const fixture2 = TestBed.createComponent(Parent);
-      fixture2.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(fixture2.nativeElement.innerHTML);
+              // it should be able to render a new component with the same template code
+              const fixture2 = TestBed.createComponent(Parent);
+              fixture2.detectChanges();
+              expect(fixture.nativeElement.innerHTML).toEqual(fixture2.nativeElement.innerHTML);
 
-      fixture2.componentRef.instance.name = 'Parent 2';
-      fixture2.detectChanges();
-      expect(fixture2.nativeElement.innerHTML)
-          .toEqual(
-              `<div><child><p><any></any><b title="Enfant de Parent 2">Je suis projeté depuis Parent 2</b><any></any></p></child></div>`);
+              fixture2.componentRef.instance.name = 'Parent 2';
+              fixture2.detectChanges();
+              expect(fixture2.nativeElement.innerHTML)
+                  .toEqual(
+                      `<div><child><p><any></any><b title="Enfant de Parent 2">Je suis projeté depuis Parent 2</b><any></any></p></child></div>`);
 
-      // The first fixture should not have changed
-      expect(fixture.nativeElement.innerHTML).not.toEqual(fixture2.nativeElement.innerHTML);
-    });
+              // The first fixture should not have changed
+              expect(fixture.nativeElement.innerHTML).not.toEqual(fixture2.nativeElement.innerHTML);
+            });
 
-    it('should re-project translations when multiple projections', () => {
-      @Component({selector: 'grand-child', template: '<div><ng-content></ng-content></div>'})
-      class GrandChild {
-      }
+            it('should re-project translations when multiple projections', () => {
+              @Component(
+                  {selector: 'grand-child', template: '<div><ng-content></ng-content></div>'})
+              class GrandChild {
+              }
 
-      @Component(
-          {selector: 'child', template: '<grand-child><ng-content></ng-content></grand-child>'})
-      class Child {
-      }
+              @Component({
+                selector: 'child',
+                template: '<grand-child><ng-content></ng-content></grand-child>'
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child i18n><b>Hello</b> World!</child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
+              @Component({selector: 'parent', template: `<child i18n><b>Hello</b> World!</child>`})
+              class Parent {
+                name: string = 'Parent';
+              }
 
-      TestBed.configureTestingModule({declarations: [Parent, Child, GrandChild]});
-      loadTranslations({
+              TestBed.configureTestingModule({declarations: [Parent, Child, GrandChild]});
+              loadTranslations({
 
-        '{$startBoldText}Hello{$closeBoldText} World!':
-            '{$startBoldText}Bonjour{$closeBoldText} monde!'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual('<child><grand-child><div><b>Bonjour</b> monde!</div></grand-child></child>');
-    });
+                '{$START_BOLD_TEXT}Hello{$CLOSE_BOLD_TEXT} World!':
+                    '{$START_BOLD_TEXT}Bonjour{$CLOSE_BOLD_TEXT} monde!'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      '<child><grand-child><div><b>Bonjour</b> monde!</div></grand-child></child>');
+            });
 
-    it('should be able to remove projected placeholders', () => {
-      @Component({selector: 'grand-child', template: '<div><ng-content></ng-content></div>'})
-      class GrandChild {
-      }
+            it('should be able to remove projected placeholders', () => {
+              @Component(
+                  {selector: 'grand-child', template: '<div><ng-content></ng-content></div>'})
+              class GrandChild {
+              }
 
-      @Component(
-          {selector: 'child', template: '<grand-child><ng-content></ng-content></grand-child>'})
-      class Child {
-      }
+              @Component({
+                selector: 'child',
+                template: '<grand-child><ng-content></ng-content></grand-child>'
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child i18n><b>Hello</b> World!</child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
+              @Component({selector: 'parent', template: `<child i18n><b>Hello</b> World!</child>`})
+              class Parent {
+                name: string = 'Parent';
+              }
 
-      TestBed.configureTestingModule({declarations: [Parent, Child, GrandChild]});
-      loadTranslations({'{$startBoldText}Hello{$closeBoldText} World!': 'Bonjour monde!'});
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual('<child><grand-child><div>Bonjour monde!</div></grand-child></child>');
-    });
+              TestBed.configureTestingModule({declarations: [Parent, Child, GrandChild]});
+              loadTranslations(
+                  {'{$START_BOLD_TEXT}Hello{$CLOSE_BOLD_TEXT} World!': 'Bonjour monde!'});
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual('<child><grand-child><div>Bonjour monde!</div></grand-child></child>');
+            });
 
-    it('should project translations with selectors', () => {
-      @Component({selector: 'child', template: `<ng-content select="span"></ng-content>`})
-      class Child {
-      }
+            it('should project translations with selectors', () => {
+              @Component({selector: 'child', template: `<ng-content select="span"></ng-content>`})
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template: `
+              @Component({
+                selector: 'parent',
+                template: `
           <child i18n>
             <span title="keepMe"></span>
             <span title="deleteMe"></span>
           </child>
         `
-      })
-      class Parent {
-      }
+              })
+              class Parent {
+              }
 
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        '{$startTagSpan}{$closeTagSpan}{$startTagSpan_1}{$closeTagSpan}':
-            '{$startTagSpan}Contenu{$closeTagSpan}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual('<child><span title="keepMe">Contenu</span></child>');
-    });
+                '{$START_TAG_SPAN}{$CLOSE_TAG_SPAN}{$START_TAG_SPAN_1}{$CLOSE_TAG_SPAN}':
+                    '{$START_TAG_SPAN}Contenu{$CLOSE_TAG_SPAN}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual('<child><span title="keepMe">Contenu</span></child>');
+            });
 
-    it('should project content in i18n blocks', () => {
-      @Component({
-        selector: 'child',
-        template: `<div i18n>Content projected from <ng-content></ng-content></div>`
-      })
-      class Child {
-      }
+            it('should project content in i18n blocks', () => {
+              @Component({
+                selector: 'child',
+                template: `<div i18n>Content projected from <ng-content></ng-content></div>`
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child>{{name}}</child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              @Component({selector: 'parent', template: `<child>{{name}}</child>`})
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Content projected from {$startTagNgContent}{$closeTagNgContent}':
-            'Contenu projeté depuis {$startTagNgContent}{$closeTagNgContent}'
-      });
+                'Content projected from {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}':
+                    'Contenu projeté depuis {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}'
+              });
 
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<child><div>Contenu projeté depuis Parent</div></child>`);
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<child><div>Contenu projeté depuis Parent</div></child>`);
 
-      fixture.componentRef.instance.name = 'Parent component';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<child><div>Contenu projeté depuis Parent component</div></child>`);
-    });
+              fixture.componentRef.instance.name = 'Parent component';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<child><div>Contenu projeté depuis Parent component</div></child>`);
+            });
 
-    it('should project content in i18n blocks with placeholders', () => {
-      @Component({
-        selector: 'child',
-        template: `<div i18n>Content projected from <ng-content></ng-content></div>`
-      })
-      class Child {
-      }
+            it('should project content in i18n blocks with placeholders', () => {
+              @Component({
+                selector: 'child',
+                template: `<div i18n>Content projected from <ng-content></ng-content></div>`
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child><b>{{name}}</b></child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              @Component({selector: 'parent', template: `<child><b>{{name}}</b></child>`})
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Content projected from {$startTagNgContent}{$closeTagNgContent}':
-            '{$startTagNgContent}{$closeTagNgContent} a projeté le contenu'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<child><div><b>Parent</b> a projeté le contenu</div></child>`);
-    });
+                'Content projected from {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}':
+                    '{$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT} a projeté le contenu'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<child><div><b>Parent</b> a projeté le contenu</div></child>`);
+            });
 
-    it('should project translated content in i18n blocks', () => {
-      @Component(
-          {selector: 'child', template: `<div i18n>Child content <ng-content></ng-content></div>`})
-      class Child {
-      }
+            it('should project translated content in i18n blocks', () => {
+              @Component({
+                selector: 'child',
+                template: `<div i18n>Child content <ng-content></ng-content></div>`
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child i18n>and projection from {{name}}</child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              @Component({
+                selector: 'parent',
+                template: `<child i18n>and projection from {{name}}</child>`
+              })
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Child content {$startTagNgContent}{$closeTagNgContent}':
-            'Contenu enfant {$startTagNgContent}{$closeTagNgContent}',
-        'and projection from {$interpolation}': 'et projection depuis {$interpolation}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<child><div>Contenu enfant et projection depuis Parent</div></child>`);
-    });
+                'Child content {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}':
+                    'Contenu enfant {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}',
+                'and projection from {$INTERPOLATION}': 'et projection depuis {$INTERPOLATION}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<child><div>Contenu enfant et projection depuis Parent</div></child>`);
+            });
 
-    it('should project bare ICU expressions', () => {
-      @Component({selector: 'child', template: '<div><ng-content></ng-content></div>'})
-      class Child {
-      }
+            it('should project bare ICU expressions', () => {
+              @Component({selector: 'child', template: '<div><ng-content></ng-content></div>'})
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template: `
+              @Component({
+                selector: 'parent',
+                template: `
       <child i18n>{
         value // i18n(ph = "blah"),
         plural,
          =1 {one}
         other {at least {{value}} .}
       }</child>`
-      })
-      class Parent {
-        value = 3;
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({});
+              })
+              class Parent {
+                value = 3;
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({});
 
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
 
-      expect(fixture.nativeElement.innerHTML).toContain('at least');
-    });
+              expect(fixture.nativeElement.innerHTML).toContain('at least');
+            });
 
-    it('should project ICUs in i18n blocks', () => {
-      @Component(
-          {selector: 'child', template: `<div i18n>Child content <ng-content></ng-content></div>`})
-      class Child {
-      }
+            it('should project ICUs in i18n blocks', () => {
+              @Component({
+                selector: 'child',
+                template: `<div i18n>Child content <ng-content></ng-content></div>`
+              })
+              class Child {
+              }
 
-      @Component({
-        selector: 'parent',
-        template:
-            `<child i18n>and projection from {name, select, angular {Angular} other {{{name}}}}</child>`
-      })
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              @Component({
+                selector: 'parent',
+                template:
+                    `<child i18n>and projection from {name, select, angular {Angular} other {{{name}}}}</child>`
+              })
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Child content {$startTagNgContent}{$closeTagNgContent}':
-            'Contenu enfant {$startTagNgContent}{$closeTagNgContent}',
-        'and projection from {$icu}': 'et projection depuis {$icu}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<child><div>Contenu enfant et projection depuis Parent<!--ICU 15--></div></child>`);
+                'Child content {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}':
+                    'Contenu enfant {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}',
+                'and projection from {$ICU}': 'et projection depuis {$ICU}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<child><div>Contenu enfant et projection depuis Parent<!--ICU 15--></div></child>`);
 
-      fixture.componentRef.instance.name = 'angular';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual(
-              `<child><div>Contenu enfant et projection depuis Angular<!--ICU 15--></div></child>`);
-    });
+              fixture.componentRef.instance.name = 'angular';
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(
+                      `<child><div>Contenu enfant et projection depuis Angular<!--ICU 15--></div></child>`);
+            });
 
-    it(`shouldn't project deleted projections in i18n blocks`, () => {
-      @Component(
-          {selector: 'child', template: `<div i18n>Child content <ng-content></ng-content></div>`})
-      class Child {
-      }
+            it(`shouldn't project deleted projections in i18n blocks`, () => {
+              @Component({
+                selector: 'child',
+                template: `<div i18n>Child content <ng-content></ng-content></div>`
+              })
+              class Child {
+              }
 
-      @Component({selector: 'parent', template: `<child i18n>and projection from {{name}}</child>`})
-      class Parent {
-        name: string = 'Parent';
-      }
-      TestBed.configureTestingModule({declarations: [Parent, Child]});
-      loadTranslations({
+              @Component({
+                selector: 'parent',
+                template: `<child i18n>and projection from {{name}}</child>`
+              })
+              class Parent {
+                name: string = 'Parent';
+              }
+              TestBed.configureTestingModule({declarations: [Parent, Child]});
+              loadTranslations({
 
-        'Child content {$startTagNgContent}{$closeTagNgContent}': 'Contenu enfant',
-        'and projection from {$interpolation}': 'et projection depuis {$interpolation}'
-      });
-      const fixture = TestBed.createComponent(Parent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<child><div>Contenu enfant</div></child>`);
-    });
+                'Child content {$START_TAG_NG_CONTENT}{$CLOSE_TAG_NG_CONTENT}': 'Contenu enfant',
+                'and projection from {$INTERPOLATION}': 'et projection depuis {$INTERPOLATION}'
+              });
+              const fixture = TestBed.createComponent(Parent);
+              fixture.detectChanges();
+              expect(fixture.nativeElement.innerHTML)
+                  .toEqual(`<child><div>Contenu enfant</div></child>`);
+            });
 
-    it('should display/destroy projected i18n content', () => {
+            it('should display/destroy projected i18n content', () => {
 
-      @Component({
-        selector: 'app',
-        template: `
+              @Component({
+                selector: 'app',
+                template: `
             <ng-container>(<ng-content></ng-content>)</ng-container>
         `
-      })
-      class MyContentApp {
-      }
+              })
+              class MyContentApp {
+              }
 
-      @Component({
-        selector: 'my-app',
-        template: `
+              @Component({
+                selector: 'my-app',
+                template: `
           <app i18n *ngIf="condition">{type, select, A {A} B {B} other {other}}</app>
         `
-      })
-      class MyApp {
-        type = 'A';
-        condition = true;
-      }
+              })
+              class MyApp {
+                type = 'A';
+                condition = true;
+              }
 
-      TestBed.configureTestingModule({declarations: [MyApp, MyContentApp]});
+              TestBed.configureTestingModule({declarations: [MyApp, MyContentApp]});
 
-      const fixture = TestBed.createComponent(MyApp);
-      fixture.detectChanges();
+              const fixture = TestBed.createComponent(MyApp);
+              fixture.detectChanges();
 
-      expect(fixture.nativeElement.textContent).toContain('(A)');
+              expect(fixture.nativeElement.textContent).toContain('(A)');
 
-      // change `condition` to remove <app>
-      fixture.componentInstance.condition = false;
-      fixture.detectChanges();
+              // change `condition` to remove <app>
+              fixture.componentInstance.condition = false;
+              fixture.detectChanges();
 
-      // should not contain 'A'
-      expect(fixture.nativeElement.textContent).toBe('');
+              // should not contain 'A'
+              expect(fixture.nativeElement.textContent).toBe('');
 
-      // display <app> again
-      fixture.componentInstance.type = 'B';
-      fixture.componentInstance.condition = true;
-      fixture.detectChanges();
+              // display <app> again
+              fixture.componentInstance.type = 'B';
+              fixture.componentInstance.condition = true;
+              fixture.detectChanges();
 
-      // expect that 'B' is now displayed
-      expect(fixture.nativeElement.textContent).toContain('(B)');
-    });
-  });
+              // expect that 'B' is now displayed
+              expect(fixture.nativeElement.textContent).toContain('(B)');
+            });
+          });
 
-  describe('queries', () => {
-    function toHtml(element: Element): string {
-      return element.innerHTML.replace(/\sng-reflect-\S*="[^"]*"/g, '')
-          .replace(/<!--bindings=\{(\W.*\W\s*)?\}-->/g, '');
-    }
+          describe('queries', () => {
+            function toHtml(element: Element): string {
+              return element.innerHTML.replace(/\sng-reflect-\S*="[^"]*"/g, '')
+                  .replace(/<!--bindings=\{(\W.*\W\s*)?\}-->/g, '');
+            }
 
-    it('detached nodes should still be part of query', () => {
-      @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
-      class TextDirective {
-        // TODO(issue/24571): remove '!'.
-        text !: string;
-        constructor() {}
-      }
+            it('detached nodes should still be part of query', () => {
+              @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
+              class TextDirective {
+                // TODO(issue/24571): remove '!'.
+                text !: string;
+                constructor() {}
+              }
 
-      @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
-      class DivQuery {
-        // TODO(issue/24571): remove '!'.
-        @ContentChild(TemplateRef, {static: true}) template !: TemplateRef<any>;
+              @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
+              class DivQuery {
+                // TODO(issue/24571): remove '!'.
+                @ContentChild(TemplateRef, {static: true}) template !: TemplateRef<any>;
 
-        // TODO(issue/24571): remove '!'.
-        @ViewChild('vc', {read: ViewContainerRef, static: true})
-        vc !: ViewContainerRef;
+                // TODO(issue/24571): remove '!'.
+                @ViewChild('vc', {read: ViewContainerRef, static: true})
+                vc !: ViewContainerRef;
 
-        // TODO(issue/24571): remove '!'.
-        @ContentChildren(TextDirective, {descendants: true})
-        query !: QueryList<TextDirective>;
+                // TODO(issue/24571): remove '!'.
+                @ContentChildren(TextDirective, {descendants: true})
+                query !: QueryList<TextDirective>;
 
-        create() { this.vc.createEmbeddedView(this.template); }
+                create() { this.vc.createEmbeddedView(this.template); }
 
-        destroy() { this.vc.clear(); }
-      }
+                destroy() { this.vc.clear(); }
+              }
 
-      TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
-      loadTranslations({
+              TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
+              loadTranslations({
 
-        '{$startTagNgTemplate}{$startTagDiv_1}{$startTagDiv}{$startTagSpan}Content{$closeTagSpan}{$closeTagDiv}{$closeTagDiv}{$closeTagNgTemplate}':
-            '{$startTagNgTemplate}Contenu{$closeTagNgTemplate}'
-      });
-      const fixture = initWithTemplate(AppComp, `
+                '{$START_TAG_NG_TEMPLATE}{$START_TAG_DIV_1}{$START_TAG_DIV}{$START_TAG_SPAN}Content{$CLOSE_TAG_SPAN}{$CLOSE_TAG_DIV}{$CLOSE_TAG_DIV}{$CLOSE_TAG_NG_TEMPLATE}':
+                    '{$START_TAG_NG_TEMPLATE}Contenu{$CLOSE_TAG_NG_TEMPLATE}'
+              });
+              const fixture = initWithTemplate(AppComp, `
           <div-query #q i18n>
             <ng-template>
               <div>
@@ -1613,28 +1665,28 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
             </ng-template>
           </div-query>
         `);
-      const q = fixture.debugElement.children[0].references.q;
-      expect(q.query.length).toEqual(0);
+              const q = fixture.debugElement.children[0].references.q;
+              expect(q.query.length).toEqual(0);
 
-      // Create embedded view
-      q.create();
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(1);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query>Contenu<!--ng-container--></div-query>`);
+              // Create embedded view
+              q.create();
+              fixture.detectChanges();
+              expect(q.query.length).toEqual(1);
+              expect(toHtml(fixture.nativeElement))
+                  .toEqual(`<div-query>Contenu<!--ng-container--></div-query>`);
 
-      // Disable ng-if
-      fixture.componentInstance.visible = false;
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(0);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query>Contenu<!--ng-container--></div-query>`);
-    });
-  });
+              // Disable ng-if
+              fixture.componentInstance.visible = false;
+              fixture.detectChanges();
+              expect(q.query.length).toEqual(0);
+              expect(toHtml(fixture.nativeElement))
+                  .toEqual(`<div-query>Contenu<!--ng-container--></div-query>`);
+            });
+          });
 
-  it('should not alloc expando slots when there is no new variable to create', () => {
-    @Component({
-      template: `
+          it('should not alloc expando slots when there is no new variable to create', () => {
+            @Component({
+              template: `
       <div dialog i18n>
           <div *ngIf="data">
               Some content
@@ -1642,20 +1694,21 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       </div>
       <button [close]="true">Button label</button>
   `
-    })
-    class ContentElementDialog {
-      data = false;
-    }
+            })
+            class ContentElementDialog {
+              data = false;
+            }
 
-    TestBed.configureTestingModule({declarations: [DialogDir, CloseBtn, ContentElementDialog]});
+            TestBed.configureTestingModule(
+                {declarations: [DialogDir, CloseBtn, ContentElementDialog]});
 
-    const fixture = TestBed.createComponent(ContentElementDialog);
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML).toEqual(`<div dialog=""><!--bindings={
+            const fixture = TestBed.createComponent(ContentElementDialog);
+            fixture.detectChanges();
+            expect(fixture.nativeElement.innerHTML).toEqual(`<div dialog=""><!--bindings={
   "ng-reflect-ng-if": "false"
 }--></div><button ng-reflect-dialog-result="true" title="Close dialog">Button label</button>`);
-  });
-});
+          });
+        });
 
 function initWithTemplate(compType: Type<any>, template: string) {
   TestBed.overrideComponent(compType, {set: {template}});

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -20,10 +20,10 @@ describe('ViewContainerRef', () => {
 
   const TRANSLATIONS: any = {
     'Bar': 'o',
-    '{$startTagBefore}{$closeTagBefore}{$startTagDiv}{$startTagInside}{$closeTagInside}{$closeTagDiv}{$startTagAfter}{$closeTagAfter}':
-        'F{$startTagDiv}{$closeTagDiv}o',
-    '{$startTagBefore}{$closeTagBefore}{$startTagDiv}{$startTagIn}{$closeTagIn}{$closeTagDiv}{$startTagAfter}{$closeTagAfter}':
-        '{$startTagDiv}{$closeTagDiv}{$startTagBefore}{$closeTagBefore}'
+    '{$START_TAG_BEFORE}{$CLOSE_TAG_BEFORE}{$START_TAG_DIV}{$START_TAG_INSIDE}{$CLOSE_TAG_INSIDE}{$CLOSE_TAG_DIV}{$START_TAG_AFTER}{$CLOSE_TAG_AFTER}':
+        'F{$START_TAG_DIV}{$CLOSE_TAG_DIV}o',
+    '{$START_TAG_BEFORE}{$CLOSE_TAG_BEFORE}{$START_TAG_DIV}{$START_TAG_IN}{$CLOSE_TAG_IN}{$CLOSE_TAG_DIV}{$START_TAG_AFTER}{$CLOSE_TAG_AFTER}':
+        '{$START_TAG_DIV}{$CLOSE_TAG_DIV}{$START_TAG_BEFORE}{$CLOSE_TAG_BEFORE}'
   };
 
   /**

--- a/packages/core/test/bundling/todo_i18n/translations.ts
+++ b/packages/core/test/bundling/todo_i18n/translations.ts
@@ -10,12 +10,12 @@ import {loadTranslations} from '@angular/localize/run_time';
 
 export const translations = {
   'What needs to be done?': `Qu'y a-t-il à faire ?`,
-  '{$startHeadingLevel1}todos{$closeHeadingLevel1}{$tagInput}':
-      '{$startHeadingLevel1}liste de tâches{$closeHeadingLevel1}{$tagInput}',
+  '{$START_HEADING_LEVEL1}todos{$CLOSE_HEADING_LEVEL1}{$TAG_INPUT}':
+      '{$START_HEADING_LEVEL1}liste de tâches{$CLOSE_HEADING_LEVEL1}{$TAG_INPUT}',
   '{VAR_PLURAL, plural, =1 {item left} other {items left}}':
       '{VAR_PLURAL, plural, =1 {tâche restante} other {tâches restantes}}',
-  '{$startTagStrong}{$interpolation}{$closeTagStrong}{$icu}':
-      '{$startTagStrong}{$interpolation}{$closeTagStrong} {$icu}',
+  '{$START_TAG_STRONG}{$INTERPOLATION}{$CLOSE_TAG_STRONG}{$ICU}':
+      '{$START_TAG_STRONG}{$INTERPOLATION}{$CLOSE_TAG_STRONG} {$ICU}',
   ' Clear completed ': ' Effacer terminés ',
   'Demonstrate Components': 'Démontrer les components',
   'Demonstrate Structural Directives': 'Démontrer les directives structurelles',


### PR DESCRIPTION

The `goog.getMsg()` function requires placeholder names to be camelCased.

This is not the case for `$localize`. Here placeholder names need
match what is serialized to translation files.

Specifically such placeholder names keep their casing but have all characters
that are not in `a-z`, `A-Z`, `0-9` and `_` converted to `_`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
