### PR TITLE
fix(ivy): unable to override ComponentFactoryResolver provider in tests

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -119,12 +119,12 @@ export class R3Injector {
     // Start off by creating Records for every provider declared in every InjectorType
     // included transitively in `def`.
     const dedupStack: InjectorType<any>[] = [];
-    deepForEach([def], injectorDef => this.processInjectorType(injectorDef, [], dedupStack));
 
     additionalProviders && deepForEach(
                                additionalProviders, provider => this.processProvider(
                                                         provider, def, additionalProviders));
 
+    deepForEach([def], injectorDef => this.processInjectorType(injectorDef, [], dedupStack));
 
     // Make sure the INJECTOR token provides this injector.
     this.records.set(INJECTOR, makeRecord(undefined, this));

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -116,10 +116,11 @@ export class R3Injector {
   constructor(
       def: InjectorType<any>, additionalProviders: StaticProvider[]|null, readonly parent: Injector,
       source: string|null = null) {
-    // Start off by creating Records for every provider declared in every InjectorType
-    // included transitively in `def`.
     const dedupStack: InjectorType<any>[] = [];
 
+    // Start off by creating Records for every provider declared in every InjectorType
+    // included transitively in additional providers then do the same for `def`. This order is
+    // important because `def` may include providers that override ones in additionalProviders.
     additionalProviders && deepForEach(
                                additionalProviders, provider => this.processProvider(
                                                         provider, def, additionalProviders));

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -1049,13 +1049,3 @@ Did you run and wait for 'resolveComponentResources()'?` :
     });
   });
 }
-describe('override', () => {
-
-  it('defined in core - injectable providedIn', () => {
-    const sanitizerMock = jasmine.createSpyObj('sanitizer', ['sanitize']);
-    TestBed.overrideProvider(Sanitizer, {useValue: sanitizerMock});
-    expect(TestBed.get(Sanitizer)).toEqual(sanitizerMock);
-  });
-
-
-});

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompilerConfig, ResourceLoader} from '@angular/compiler';
-import {CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, Inject, Injectable, InjectionToken, Injector, Input, NgModule, Optional, Pipe, SkipSelf, ɵstringify as stringify} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, ComponentFactoryResolver, Directive, Inject, Injectable, InjectionToken, Injector, Input, NgModule, Optional, Pipe, SkipSelf, ɵstringify as stringify} from '@angular/core';
 import {TestBed, async, fakeAsync, getTestBed, inject, tick, withModule} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ivyEnabled, modifiedInIvy, obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
@@ -418,6 +418,16 @@ const bTok = new InjectionToken<string>('b');
       });
 
       describe('overriding providers', () => {
+
+        describe('in core', () => {
+          it('ComponentFactoryResolver', () => {
+            const componentFactoryMock =
+                jasmine.createSpyObj('componentFactory', ['resolveComponentFactory']);
+            TestBed.overrideProvider(ComponentFactoryResolver, {useValue: componentFactoryMock});
+            expect(TestBed.get(ComponentFactoryResolver)).toEqual(componentFactoryMock);
+          });
+        });
+
         describe('in NgModules', () => {
 
           it('should support useValue', () => {
@@ -1039,3 +1049,13 @@ Did you run and wait for 'resolveComponentResources()'?` :
     });
   });
 }
+describe('override', () => {
+
+  it('defined in core - injectable providedIn', () => {
+    const sanitizerMock = jasmine.createSpyObj('sanitizer', ['sanitize']);
+    TestBed.overrideProvider(Sanitizer, {useValue: sanitizerMock});
+    expect(TestBed.get(Sanitizer)).toEqual(sanitizerMock);
+  });
+
+
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Cannot override ComponentFactoryResolver in TestBed tests. The test added in this PR was failing in Ivy without the change in r3_injector
