### PR TITLE
feat(language-service): add script to rebuild, refresh Angular dist

### DIFF
--- a/integration/language_service_plugin/README.md
+++ b/integration/language_service_plugin/README.md
@@ -7,9 +7,9 @@ To use the tests:
 
 - Use `yarn install` to install all dependencies in this directory and in the Angular repo root
     directory.
-- From the Angular repo root directory, build Angular in the `dist/packages-dist` folder with
-    `./scripts/build-packages-dist.sh`.
-- In this directory, run the tests with `yarn test`.
+- Build an Angular distribution with `yarn build-dist`. This needs to be done after changes to
+    Angular, but not after changes to integration tests. This is an expensive build.
+- In this directory, run the integration tests with `yarn test`.
 
 ## Update golden files
 

--- a/integration/language_service_plugin/package.json
+++ b/integration/language_service_plugin/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build-dist": "../../scripts/build-packages-dist.sh && yarn install --check-files",
     "cleanup": "rm -rf ti-*.log tsserver.log",
     "golden": "yarn build && node generate.js",
     "test": "yarn cleanup && yarn build && jasmine test.js"


### PR DESCRIPTION
The Language Service integration tests should reinstall the Angular
distribution every time it is built. Adds a `yarn build-dist`
convinience script so building the distribution doesn't have to
happen on the repo root. This new script also refreshes the installed
modules. Building is expensive, so it is not bundled with testing
scripts.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information