### PR TITLE
perf(ivy): replace select instruction with advance

### DIFF
--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵRenderFlags, ɵrenderComponent as renderComponent, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineComponent, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵstyleProp, ɵɵstyling, ɵɵstylingApply, ɵɵtext, ɵɵtextInterpolate1} from '@angular/core';
+import {ɵRenderFlags, ɵrenderComponent as renderComponent, ɵɵadvance, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵdefineComponent, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵstyleProp, ɵɵstyling, ɵɵstylingApply, ɵɵtext, ɵɵtextInterpolate1} from '@angular/core';
 
 import {bindAction, profile} from '../../util';
 import {createDom, destroyDom, detectChanges} from '../render3/tree';
@@ -48,10 +48,10 @@ export function TreeTpl(rf: ɵRenderFlags, ctx: TreeNode) {
     ɵɵelementEnd();
   }
   if (rf & ɵRenderFlags.Update) {
-    ɵɵselect(1);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', ctx.depth % 2 ? '' : 'grey');
     ɵɵstylingApply();
-    ɵɵselect(2);
+    ɵɵadvance(1);
     ɵɵtextInterpolate1(' ', ctx.value, ' ');
     ɵɵcontainerRefreshStart(3);
     {

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -774,7 +774,7 @@ describe('compiler compliance', () => {
           if (rf & 2) {
             const $myComp$ = $r3$.ɵɵnextContext();
             const $foo$ = $r3$.ɵɵreference(1);
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵtextInterpolate2("", $myComp$.salutation, " ", $foo$, "");
           }
         }
@@ -1275,7 +1275,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵproperty("ngIf", ctx.visible);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("ngIf", ctx.visible);
             }
           }
@@ -2032,7 +2032,7 @@ describe('compiler compliance', () => {
                 }
                 if (rf & 2) {
                   $r3$.ɵɵtextInterpolate($r3$.ɵɵpipeBind2(1, 3, $r3$.ɵɵpipeBind2(2, 6, ctx.name, ctx.size), ctx.size));
-                  $r3$.ɵɵselect(4);
+                  $r3$.ɵɵadvance(4);
                   $r3$.ɵɵtextInterpolate2("", $r3$.ɵɵpipeBindV(5, 9, $r3$.ɵɵpureFunction1(18, $c0$, ctx.name)), " ", ctx.name ? 1 : $r3$.ɵɵpipeBind1(6, 16, 2), "");
                 }
               },
@@ -2216,7 +2216,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $user$ = $r3$.ɵɵreference(1);
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(2);
               $r3$.ɵɵtextInterpolate1("Hello ", $user$.value, "!");
             }
           },
@@ -2279,7 +2279,7 @@ describe('compiler compliance', () => {
             $r3$.ɵɵnextContext();
             const $foo$ = $r3$.ɵɵreference(1);
             const $baz$ = $r3$.ɵɵreference(5);
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵtextInterpolate3("", $foo$, "-", $bar$, "-", $baz$, "");
           }
         }
@@ -2295,7 +2295,7 @@ describe('compiler compliance', () => {
             const $bar$ = $r3$.ɵɵreference(4);
             $r3$.ɵɵnextContext();
             const $foo$ = $r3$.ɵɵreference(1);
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵtextInterpolate2(" ", $foo$, "-", $bar$, " ");
           }
         }
@@ -2314,7 +2314,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $foo$ = $r3$.ɵɵreference(1);
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(2);
               $r3$.ɵɵtextInterpolate1(" ", $foo$, " ");
             }
           },
@@ -2365,7 +2365,7 @@ describe('compiler compliance', () => {
         if (rf & 2) {
           const $item$ = $i0$.ɵɵnextContext().$implicit;
           const $foo$ = $i0$.ɵɵreference(2);
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate2(" ", $foo$, " - ", $item$, " ");
         }
       }
@@ -2379,7 +2379,7 @@ describe('compiler compliance', () => {
         }
         if (rf & 2) {
           const $app$ = $i0$.ɵɵnextContext();
-          $r3$.ɵɵselect(3);
+          $r3$.ɵɵadvance(3);
           $i0$.ɵɵproperty("ngIf", $app$.showing);
         }
       }
@@ -2469,7 +2469,7 @@ describe('compiler compliance', () => {
               }
               if (rf & 2) {
                 $r3$.ɵɵproperty("name", ctx.name1);
-                $r3$.ɵɵselect(1);
+                $r3$.ɵɵadvance(1);
                 $r3$.ɵɵproperty("name", ctx.name2);
               }
             },
@@ -2602,7 +2602,7 @@ describe('compiler compliance', () => {
                     $r3$.ɵɵelementEnd();
                   }
                   if (rf & 2) {
-                    $r3$.ɵɵselect(1);
+                    $r3$.ɵɵadvance(1);
                     $r3$.ɵɵproperty("forOf", ctx.items);
                   }
                 },
@@ -2670,7 +2670,7 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $item$ = ctx.$implicit;
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵtextInterpolate($item$.name);
             }
           }
@@ -2687,7 +2687,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵelementEnd();
               }
               if (rf & 2) {
-                $r3$.ɵɵselect(1);
+                $r3$.ɵɵadvance(1);
                 $r3$.ɵɵproperty("forOf", ctx.items);
               }
             },
@@ -2753,7 +2753,7 @@ describe('compiler compliance', () => {
             if (rf & 2) {
               const $info$ = ctx.$implicit;
               const $item$ = $r3$.ɵɵnextContext().$implicit;
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵtextInterpolate2(" ", $item$.name, ": ", $info$.description, " ");
             }
           }
@@ -2771,9 +2771,9 @@ describe('compiler compliance', () => {
             }
             if (rf & 2) {
               const $item$ = ctx.$implicit;
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(2);
               $r3$.ɵɵtextInterpolate(IDENT.name);
-              $r3$.ɵɵselect(4);
+              $r3$.ɵɵadvance(2);
               $r3$.ɵɵproperty("forOf", IDENT.infos);
             }
           }
@@ -2791,7 +2791,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵelementEnd();
               }
               if (rf & 2) {
-                $r3$.ɵɵselect(1);
+                $r3$.ɵɵadvance(1);
                 $r3$.ɵɵproperty("forOf", ctx.items);
               }
             },

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -44,7 +44,7 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵɵelementEnd();
         }
         if (rf & 2) {
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate1("Hello ", $ctx$.name, "");
         }
       }`;
@@ -360,9 +360,9 @@ describe('compiler compliance: bindings', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵproperty("title", ctx.myTitle)("id", ctx.buttonId)("tabindex", 1);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("id", 1)("title", "hello")("someProp", 1 + 2);
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("prop", "one")("otherProp", 2);
             }
           }
@@ -397,7 +397,7 @@ describe('compiler compliance: bindings', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵproperty("title", ctx.myTitle)("id", ctx.buttonId)("tabindex", 1);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("id", 1)("title", "hello")("someProp", 1 + 2);
             }
           }
@@ -566,9 +566,9 @@ describe('compiler compliance: bindings', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵattribute("title", ctx.myTitle)("id", ctx.buttonId)("tabindex", 1);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵattribute("id", 1)("title", "hello")("some-attr", 1 + 2);
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵattribute("some-attr", "one")("some-other-attr", 2);
             }
           }
@@ -603,7 +603,7 @@ describe('compiler compliance: bindings', () => {
             …
             if (rf & 2) {
               $r3$.ɵɵattribute("title", ctx.myTitle)("id", ctx.buttonId)("tabindex", 1);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵattribute("id", 1)("title", "hello")("some-attr", 1 + 2);
             }
           }
@@ -1173,23 +1173,23 @@ describe('compiler compliance: bindings', () => {
       …
         if (rf & 2) {
           i0.ɵɵpropertyInterpolateV("title", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
-          i0.ɵɵselect(1);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate8("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
-          i0.ɵɵselect(2);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate7("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
-          i0.ɵɵselect(3);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate6("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
-          i0.ɵɵselect(4);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate5("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
-          i0.ɵɵselect(5);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate4("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
-          i0.ɵɵselect(6);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate3("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
-          i0.ɵɵselect(7);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate2("title", "a", ctx.one, "b", ctx.two, "c");
-          i0.ɵɵselect(8);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate1("title", "a", ctx.one, "b");
-          i0.ɵɵselect(9);
+          i0.ɵɵadvance(1);
           i0.ɵɵpropertyInterpolate("title", ctx.one);
       }
       …
@@ -1217,23 +1217,23 @@ describe('compiler compliance: bindings', () => {
       …
         if (rf & 2) {
           i0.ɵɵattributeInterpolateV("title", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
-          i0.ɵɵselect(1);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate8("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
-          i0.ɵɵselect(2);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate7("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
-          i0.ɵɵselect(3);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate6("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
-          i0.ɵɵselect(4);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate5("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
-          i0.ɵɵselect(5);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate4("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
-          i0.ɵɵselect(6);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate3("title", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
-          i0.ɵɵselect(7);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate2("title", "a", ctx.one, "b", ctx.two, "c");
-          i0.ɵɵselect(8);
+          i0.ɵɵadvance(1);
           i0.ɵɵattributeInterpolate1("title", "a", ctx.one, "b");
-          i0.ɵɵselect(9);
+          i0.ɵɵadvance(1);
           i0.ɵɵattribute("title", ctx.one);
       }
       …
@@ -1267,7 +1267,7 @@ describe('compiler compliance: bindings', () => {
           }
           if (rf & 2) {
             const $_r0$ = $i0$.ɵɵreference(1);
-            $r3$.ɵɵselect(4);
+            $r3$.ɵɵadvance(4);
             $i0$.ɵɵtextInterpolate1(" ", $_r0$.id, " ");
           }
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -488,7 +488,7 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(1, 6, ctx.valueA))(ctx.valueB);
             $r3$.ɵɵi18nApply(2);
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB)(ctx.valueA + ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(4);
           }
@@ -575,7 +575,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, $outer_r1$));
             $r3$.ɵɵi18nApply(3);
           }
@@ -746,7 +746,7 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(1, 6, ctx.valueA))(ctx.valueB);
             $r3$.ɵɵi18nApply(2);
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB)(ctx.valueA + ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(4);
           }
@@ -793,7 +793,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, $outer_r1$));
             $r3$.ɵɵi18nApply(3);
           }
@@ -1046,7 +1046,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1081,7 +1081,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.valueA);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1126,7 +1126,7 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             var $tmp_2_0$ = null;
             const $currVal_2$ = ($tmp_2_0$ = ctx.valueA.getRawValue()) == null ? null : $tmp_2_0$.getTitle();
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 3, ctx.valueA))(ctx.valueA == null ? null : ctx.valueA.a == null ? null : ctx.valueA.a.b)($currVal_2$);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1193,13 +1193,13 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.one);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(4, 3, ctx.two));
             $r3$.ɵɵi18nApply(3);
-            $r3$.ɵɵselect(6);
+            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.three + ctx.four + ctx.five);
             $r3$.ɵɵi18nApply(6);
           }
@@ -1289,10 +1289,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.one);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵselect(4);
+            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(5, 3, ctx.two))(ctx.nestedInBlockTwo);
             $r3$.ɵɵi18nApply(4);
           }
@@ -1398,12 +1398,12 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp(ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(3);
             $r3$.ɵɵi18nExp(ctx.valueA);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵselect(7);
+            $r3$.ɵɵadvance(6);
             $r3$.ɵɵi18nExp(ctx.valueE);
             $r3$.ɵɵi18nApply(8);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(6, 5, ctx.valueD));
@@ -1463,7 +1463,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r0$.valueA)($r3$.ɵɵpipeBind1(4, 2, $ctx_r0$.valueB));
             $r3$.ɵɵi18nApply(2);
           }
@@ -1479,7 +1479,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
           }
         }
@@ -1539,9 +1539,9 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(2, MyComponent_img_2_Template, 2, 1, "img", $_c2$);
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
           }
         }
@@ -1604,7 +1604,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵselect(4);
+            $r3$.ɵɵadvance(4);
             $r3$.ɵɵproperty("ngIf", $ctx_r0$.exists);
             $r3$.ɵɵi18nExp($ctx_r0$.valueA)($r3$.ɵɵpipeBind1(3, 3, $ctx_r0$.valueB));
             $r3$.ɵɵi18nApply(0);
@@ -1683,9 +1683,9 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", !ctx.visible);
           }
         }
@@ -1727,7 +1727,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
               const $ctx_r0$ = $r3$.ɵɵnextContext();
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵi18nExp($ctx_r0$.valueA);
               $r3$.ɵɵi18nApply(1);
           }
@@ -1833,7 +1833,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1958,7 +1958,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, ctx.valueA));
             $r3$.ɵɵi18nApply(1);
           }
@@ -2063,7 +2063,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(4, 1, ctx.valueB));
             $r3$.ɵɵi18nApply(1);
           }
@@ -2123,7 +2123,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp(ctx.age);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2278,7 +2278,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 1, 1, "ng-template");
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2554,7 +2554,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2667,7 +2667,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r0$.age);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2695,7 +2695,7 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r1$.count)($ctx_r1$.count);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2712,12 +2712,12 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", $_c1$);
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", ctx.available);
           }
         }
@@ -2752,7 +2752,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age)(ctx.other);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2828,7 +2828,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2866,7 +2866,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.ageA + ctx.ageB + ctx.ageC);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2929,7 +2929,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3035,7 +3035,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(3);
+            $r3$.ɵɵadvance(3);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.gender);
             $r3$.ɵɵi18nApply(1);
@@ -3091,7 +3091,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age)(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3140,7 +3140,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.name)(ctx.count)(ctx.count);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3225,7 +3225,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵproperty("ngIf", ctx.ageVisible);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
@@ -3314,7 +3314,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(2);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵproperty("ngIf", ctx.ageVisible);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.weight)(ctx.height);
             $r3$.ɵɵi18nApply(1);
@@ -3361,7 +3361,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵselect(1);
+            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.weight)(ctx.height)(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -488,7 +488,6 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(1, 6, ctx.valueA))(ctx.valueB);
             $r3$.ɵɵi18nApply(2);
-            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB)(ctx.valueA + ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(4);
           }
@@ -575,7 +574,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, $outer_r1$));
             $r3$.ɵɵi18nApply(3);
           }
@@ -746,7 +744,6 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(1, 6, ctx.valueA))(ctx.valueB);
             $r3$.ɵɵi18nApply(2);
-            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB)(ctx.valueA + ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(4);
           }
@@ -793,7 +790,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $outer_r1$ = ctx.$implicit;
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, $outer_r1$));
             $r3$.ɵɵi18nApply(3);
           }
@@ -1046,7 +1042,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.valueA)(ctx.valueB);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1081,7 +1076,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.valueA);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1126,7 +1120,6 @@ describe('i18n support in the template compiler', () => {
           if (rf & 2) {
             var $tmp_2_0$ = null;
             const $currVal_2$ = ($tmp_2_0$ = ctx.valueA.getRawValue()) == null ? null : $tmp_2_0$.getTitle();
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 3, ctx.valueA))(ctx.valueA == null ? null : ctx.valueA.a == null ? null : ctx.valueA.a.b)($currVal_2$);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1193,13 +1186,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.one);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(4, 3, ctx.two));
             $r3$.ɵɵi18nApply(3);
-            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp(ctx.three + ctx.four + ctx.five);
             $r3$.ɵɵi18nApply(6);
           }
@@ -1289,10 +1279,8 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.one);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵadvance(3);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(5, 3, ctx.two))(ctx.nestedInBlockTwo);
             $r3$.ɵɵi18nApply(4);
           }
@@ -1398,12 +1386,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp(ctx.valueB)(ctx.valueC);
             $r3$.ɵɵi18nApply(3);
             $r3$.ɵɵi18nExp(ctx.valueA);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵadvance(6);
             $r3$.ɵɵi18nExp(ctx.valueE);
             $r3$.ɵɵi18nApply(8);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(6, 5, ctx.valueD));
@@ -1463,7 +1449,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r0$.valueA)($r3$.ɵɵpipeBind1(4, 2, $ctx_r0$.valueB));
             $r3$.ɵɵi18nApply(2);
           }
@@ -1727,7 +1712,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
               const $ctx_r0$ = $r3$.ɵɵnextContext();
-              $r3$.ɵɵadvance(1);
               $r3$.ɵɵi18nExp($ctx_r0$.valueA);
               $r3$.ɵɵi18nApply(1);
           }
@@ -1833,7 +1817,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }
@@ -1958,7 +1941,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 1, ctx.valueA));
             $r3$.ɵɵi18nApply(1);
           }
@@ -2063,7 +2045,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(4, 1, ctx.valueB));
             $r3$.ɵɵi18nApply(1);
           }
@@ -2123,7 +2104,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp(ctx.age);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2278,7 +2258,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 1, 1, "ng-template");
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2554,7 +2533,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2667,7 +2645,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r0$.age);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2695,7 +2672,6 @@ describe('i18n support in the template compiler', () => {
           }
           if (rf & 2) {
             const $ctx_r1$ = $r3$.ɵɵnextContext();
-            $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($ctx_r1$.count)($ctx_r1$.count);
             $r3$.ɵɵi18nApply(2);
           }
@@ -2712,10 +2688,9 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", $_c1$);
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
-            $r3$.ɵɵadvance(1);
+            $r3$.ɵɵadvance(2);
             $r3$.ɵɵproperty("ngIf", ctx.visible);
             $r3$.ɵɵadvance(1);
             $r3$.ɵɵproperty("ngIf", ctx.available);
@@ -2752,7 +2727,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age)(ctx.other);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2828,7 +2802,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2866,7 +2839,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.ageA + ctx.ageB + ctx.ageC);
             $r3$.ɵɵi18nApply(1);
           }
@@ -2929,7 +2901,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3091,7 +3062,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.age)(ctx.gender);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3140,7 +3110,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.name)(ctx.count)(ctx.count);
             $r3$.ɵɵi18nApply(1);
           }
@@ -3361,7 +3330,6 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            $r3$.ɵɵadvance(1);
             $r3$.ɵɵi18nExp(ctx.gender)(ctx.weight)(ctx.height)(ctx.age);
             $r3$.ɵɵi18nApply(1);
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -221,9 +221,9 @@ describe('compiler compliance: styling', () => {
             }
             if (rf & 2) {
               $r3$.ɵɵproperty("@foo", ctx.exp);
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("@bar", undefined);
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵproperty("@baz", undefined);
             }
           },
@@ -955,7 +955,7 @@ describe('compiler compliance: styling', () => {
               $r3$.ɵɵstyleProp("baz", $r3$.ɵɵpipeBind2(3, 12, $ctx$.bazExp, 4000));
               $r3$.ɵɵclassProp("foo", $r3$.ɵɵpipeBind2(4, 15, $ctx$.fooExp, 2000));
               $r3$.ɵɵstylingApply();
-              $r3$.ɵɵselect(5);
+              $r3$.ɵɵadvance(5);
               $r3$.ɵɵtextInterpolate1(" ", $ctx$.item, "");
             }
           }
@@ -1000,13 +1000,13 @@ describe('compiler compliance: styling', () => {
             if (rf & 2) {
               $r3$.ɵɵstyleProp("width", $ctx$.w1);
               $r3$.ɵɵstylingApply();
-              $r3$.ɵɵselect(1);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵstyleProp("height", $ctx$.h1);
               $r3$.ɵɵstylingApply();
-              $r3$.ɵɵselect(2);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵclassProp("active", $ctx$.a1);
               $r3$.ɵɵstylingApply();
-              $r3$.ɵɵselect(3);
+              $r3$.ɵɵadvance(1);
               $r3$.ɵɵclassProp("removed", $ctx$.r1);
               $r3$.ɵɵstylingApply();
             }
@@ -1337,31 +1337,31 @@ describe('compiler compliance: styling', () => {
         if (rf & 2) {
           $r3$.ɵɵclassMapInterpolateV(["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate8("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(2);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate7("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(3);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate6("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(4);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate5("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(5);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate4("a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(6);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate3("a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(7);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate2("a", ctx.one, "b", ctx.two, "c");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(8);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMapInterpolate1("a", ctx.one, "b");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(9);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵclassMap(ctx.one);
           $r3$.ɵɵstylingApply();
       }
@@ -1439,31 +1439,31 @@ describe('compiler compliance: styling', () => {
         if (rf & 2) {
           $r3$.ɵɵstylePropInterpolateV("color", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate8("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(2);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate7("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(3);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate6("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(4);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate5("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(5);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate4("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(6);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate3("color", "a", ctx.one, "b", ctx.two, "c", ctx.three, "d");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(7);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate2("color", "a", ctx.one, "b", ctx.two, "c");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(8);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstylePropInterpolate1("color", "a", ctx.one, "b");
           $r3$.ɵɵstylingApply();
-          $r3$.ɵɵselect(9);
+          $r3$.ɵɵadvance(1);
           $r3$.ɵɵstyleProp("color", ctx.one);
           $r3$.ɵɵstylingApply();
       }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -76,7 +76,7 @@ describe('compiler compliance: template', () => {
           const $outer1$ = $i0$.ɵɵnextContext().$implicit;
           const $myComp1$ = $i0$.ɵɵnextContext();
           $i0$.ɵɵproperty("title", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component));
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate1(" ", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component), " ");
         }
       }
@@ -89,7 +89,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $myComp2$ = $i0$.ɵɵnextContext(2);
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵproperty("ngForOf", $myComp2$.items);
         }
       }
@@ -102,7 +102,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $outer2$ = ctx.$implicit;
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵproperty("ngForOf", $outer2$.items);
         }
       }
@@ -192,7 +192,7 @@ describe('compiler compliance: template', () => {
             \`
           })
           export class MyComponent {
-            greet(val: any) {} 
+            greet(val: any) {}
           }
 
           @NgModule({declarations: [MyComponent]})
@@ -263,7 +263,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $item$ = ctx.$implicit;
           const $i$ = ctx.index;
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate2(" ", $i$, " - ", $item$, " ");
         }
       }
@@ -319,7 +319,7 @@ describe('compiler compliance: template', () => {
           const $div$ = $i0$.ɵɵnextContext();
           const $i$ = $div$.index;
           const $item$ = $div$.$implicit;
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate2(" ", $i$, " - ", $item$, " ");
         }
       }
@@ -332,7 +332,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $app$ = $i0$.ɵɵnextContext();
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵproperty("ngIf", $app$.showing);
         }
       }
@@ -389,7 +389,7 @@ describe('compiler compliance: template', () => {
         if (rf & 2) {
           const $middle$ = $i0$.ɵɵnextContext().$implicit;
           const $myComp$ = $i0$.ɵɵnextContext(2);
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵtextInterpolate2(" ", $middle$.value, " - ", $myComp$.name, " ");
         }
       }
@@ -402,7 +402,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $middle$ = ctx.$implicit;
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵproperty("ngForOf", $middle$.items);
         }
       }
@@ -415,7 +415,7 @@ describe('compiler compliance: template', () => {
         }
         if (rf & 2) {
           const $outer$ = ctx.$implicit;
-          $r3$.ɵɵselect(1);
+          $r3$.ɵɵadvance(1);
           $i0$.ɵɵproperty("ngForOf", $outer$.items);
         }
       }

--- a/packages/compiler/design/architecture.md
+++ b/packages/compiler/design/architecture.md
@@ -92,7 +92,7 @@ GreetComponent.ngComponentDef = i0.ɵɵdefineComponent({
             i0.ɵɵelementEnd();
         }
         if (rf & RenderFlags.Update) {
-            i0.ɵɵselect(1);
+            i0.ɵɵadvance(1);
             i0.ɵɵtextInterpolate1('Hello ', ctx.name, '!');
         }
     }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -30,6 +30,7 @@ export class Identifiers {
   static elementEnd: o.ExternalReference = {name: 'ɵɵelementEnd', moduleName: CORE};
 
   static select: o.ExternalReference = {name: 'ɵɵselect', moduleName: CORE};
+  static advance: o.ExternalReference = {name: 'ɵɵadvance', moduleName: CORE};
 
   static updateSyntheticHostBinding:
       o.ExternalReference = {name: 'ɵɵupdateSyntheticHostBinding', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -148,6 +148,7 @@ export {
   ɵɵelementHostAttrs,
 
   ɵɵselect,
+  ɵɵadvance,
   ɵɵtemplate,
   ɵɵembeddedViewEnd,
   store as ɵstore,

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -98,9 +98,8 @@ class MyApp {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵselect(0);
         ɵɵproperty('title', ctx.name);
-        ɵɵselect(1);
+        ɵɵadvance(1);
         ɵɵtextInterpolate1('Hello ', ctx.name, '!');
       }
       ...

--- a/packages/core/src/render3/features/providers_feature.ts
+++ b/packages/core/src/render3/features/providers_feature.ts
@@ -29,7 +29,6 @@ import {DirectiveDef} from '../interfaces/definition';
  *        ɵɵtext(0);
  *      }
  *      if (fs & RenderFlags.Update) {
- *        ɵɵselect(0);
  *        ɵɵtextInterpolate(ctx.greeter.greet());
  *      }
  *    },

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -97,7 +97,9 @@ export {
 
   ɵɵreference,
 
+  // TODO: remove `select` once we're refactored all of the tests not to use it.
   ɵɵselect,
+  ɵɵadvance,
   ɵɵstyleMap,
 
   ɵɵstyleProp,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -42,7 +42,7 @@ export * from './next_context';
 export * from './projection';
 export * from './property';
 export * from './property_interpolation';
-export * from './select';
+export * from './advance';
 export * from '../styling_next/instructions';
 export * from './text';
 export * from './text_interpolation';

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -37,8 +37,8 @@ import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../ut
 import {getLViewParent} from '../util/view_traversal_utils';
 import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isCreationMode, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
 
+import {selectIndexInternal} from './advance';
 import {LCleanup, LViewBlueprint, MatchesArray, TCleanup, TNodeConstructor, TNodeInitialData, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor, attachLContainerDebug, attachLViewDebug, cloneToLView, cloneToTViewData} from './lview_debug';
-import {selectInternal} from './select';
 
 
 
@@ -494,9 +494,9 @@ function executeTemplate<T>(
   try {
     setActiveHostElement(null);
     if (rf & RenderFlags.Update && lView.length > HEADER_OFFSET) {
-      // When we're updating, have an inherent ɵɵselect(0) so we don't have to generate that
-      // instruction for most update blocks
-      selectInternal(lView, 0, getCheckNoChangesMode());
+      // When we're updating, inherently select 0 so we don't
+      // have to generate that instruction for most update blocks.
+      selectIndexInternal(lView, 0, getCheckNoChangesMode());
     }
     templateFn(rf, context);
   } finally {

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -132,6 +132,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵstylingApply': r3.ɵɵstylingApply,
        'ɵɵclassProp': r3.ɵɵclassProp,
        'ɵɵselect': r3.ɵɵselect,
+       'ɵɵadvance': r3.ɵɵadvance,
        'ɵɵtemplate': r3.ɵɵtemplate,
        'ɵɵtext': r3.ɵɵtext,
        'ɵɵtextInterpolate': r3.ɵɵtextInterpolate,

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -594,7 +594,7 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "selectInternal"
+    "name": "selectIndexInternal"
   },
   {
     "name": "selectView"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -432,7 +432,7 @@
     "name": "resetStylingState"
   },
   {
-    "name": "selectInternal"
+    "name": "selectIndexInternal"
   },
   {
     "name": "selectView"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -1,8 +1,5 @@
 [
   {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
     "name": "CIRCULAR"
   },
   {
@@ -13,6 +10,9 @@
   },
   {
     "name": "INJECTOR"
+  },
+  {
+    "name": "INJECTOR_SCOPE"
   },
   {
     "name": "Inject"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1248,7 +1248,7 @@
     "name": "searchTokensOnInjector"
   },
   {
-    "name": "selectInternal"
+    "name": "selectIndexInternal"
   },
   {
     "name": "selectView"
@@ -1395,6 +1395,9 @@
     "name": "wrapListener"
   },
   {
+    "name": "ɵɵadvance"
+  },
+  {
     "name": "ɵɵclassProp"
   },
   {
@@ -1435,9 +1438,6 @@
   },
   {
     "name": "ɵɵrestoreView"
-  },
-  {
-    "name": "ɵɵselect"
   },
   {
     "name": "ɵɵstyling"

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -10,7 +10,7 @@ import {withBody} from '@angular/private/testing';
 
 import {ChangeDetectionStrategy, DoCheck} from '../../src/core';
 import {whenRendered} from '../../src/render3/component';
-import {LifecycleHooksFeature, getRenderedText, ɵɵdefineComponent, ɵɵgetCurrentView, ɵɵproperty, ɵɵselect, ɵɵtextInterpolate1, ɵɵtextInterpolate2} from '../../src/render3/index';
+import {LifecycleHooksFeature, getRenderedText, ɵɵadvance, ɵɵdefineComponent, ɵɵgetCurrentView, ɵɵproperty, ɵɵtextInterpolate1, ɵɵtextInterpolate2} from '../../src/render3/index';
 import {detectChanges, markDirty, tick, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵlistener, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -38,7 +38,7 @@ describe('change detection', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(1);
+            ɵɵadvance(1);
             ɵɵtextInterpolate(ctx.value);
           }
         }
@@ -121,7 +121,6 @@ describe('change detection', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵtextInterpolate2('', ctx.doCheckCount, ' - ', ctx.name, '');
           }
         },
@@ -165,7 +164,6 @@ describe('change detection', () => {
               ɵɵelementEnd();
             }
             if (rf & RenderFlags.Update) {
-              ɵɵselect(0);
               ɵɵtextInterpolate2('', ctx.doCheckCount, ' - ', ctx.name, '');
             }
           },
@@ -189,7 +187,6 @@ describe('change detection', () => {
               ɵɵelement(0, 'manual-comp');
             }
             if (rf & RenderFlags.Update) {
-              ɵɵselect(0);
               ɵɵproperty('name', ctx.name);
             }
 
@@ -246,7 +243,6 @@ describe('change detection', () => {
                    ɵɵelement(1, 'manual-comp');
                  }
                  if (rf & RenderFlags.Update) {
-                   ɵɵselect(0);
                    ɵɵtextInterpolate1('', ctx.doCheckCount, ' - ');
                  }
                },
@@ -322,7 +318,6 @@ describe('change detection', () => {
             ɵɵtext(0);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵtextInterpolate(ctx.value);
           }
         }

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -8,7 +8,7 @@
 
 import {ViewEncapsulation, ɵɵdefineInjectable, ɵɵdefineInjector} from '../../src/core';
 import {createInjector} from '../../src/di/r3_injector';
-import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
+import {AttributeMarker, ComponentFactory, LifecycleHooksFeature, getRenderedText, markDirty, ɵɵadvance, ɵɵdefineComponent, ɵɵdirectiveInject, ɵɵproperty, ɵɵselect, ɵɵtemplate} from '../../src/render3/index';
 import {tick, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵnextContext, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {ComponentDef, RenderFlags} from '../../src/render3/interfaces/definition';
 
@@ -33,7 +33,6 @@ describe('component', () => {
           ɵɵtext(0);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵselect(0);
           ɵɵtextInterpolate(ctx.count);
         }
       },
@@ -84,7 +83,6 @@ describe('component', () => {
             ɵɵtext(0);
           }
           if (fs & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵtextInterpolate(ctx.myService.value);
           }
         }
@@ -128,7 +126,6 @@ describe('component', () => {
             ɵɵtext(0);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵtextInterpolate(ctx.name);
           }
         },
@@ -143,7 +140,7 @@ describe('component', () => {
         ɵɵelement(4097, 'comp');
       }
       if (rf & RenderFlags.Update) {
-        ɵɵselect(4097);
+        ɵɵadvance(4097);
         ɵɵproperty('name', ctx.name);
       }
     }, 4098, 1, [Comp]);
@@ -197,7 +194,7 @@ it('should not invoke renderer destroy method for embedded views', () => {
               2, MyComponent_div_Template_2, 2, 0, 'div', [AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵselect(2);
+          ɵɵadvance(2);
           ɵɵproperty('ngIf', ctx.visible);
         }
       }
@@ -280,7 +277,6 @@ describe('component with a container', () => {
       ɵɵelement(0, 'wrapper');
     }
     if (rf & RenderFlags.Update) {
-      ɵɵselect(0);
       ɵɵproperty('items', ctx.items);
     }
   }
@@ -342,7 +338,6 @@ describe('recursive components', () => {
           ɵɵcontainer(2);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵselect(0);
           ɵɵtextInterpolate(ctx.data.value);
           ɵɵcontainerRefreshStart(1);
           {
@@ -414,11 +409,10 @@ describe('recursive components', () => {
               [AttributeMarker.Bindings, 'data', AttributeMarker.Template, 'ngIf']);
         }
         if (rf & RenderFlags.Update) {
-          ɵɵselect(0);
           ɵɵtextInterpolate(ctx.data.value);
-          ɵɵselect(1);
+          ɵɵadvance(1);
           ɵɵproperty('ngIf', ctx.data.left);
-          ɵɵselect(2);
+          ɵɵadvance(1);
           ɵɵproperty('ngIf', ctx.data.right);
         }
 
@@ -434,7 +428,6 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵselect(0);
       ɵɵproperty('data', parent.data.left);
     }
   }
@@ -446,7 +439,6 @@ describe('recursive components', () => {
     }
     if (rf & RenderFlags.Update) {
       const parent = ɵɵnextContext();
-      ɵɵselect(0);
       ɵɵproperty('data', parent.data.right);
     }
   }

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -9,6 +9,7 @@
 import {ɵɵdefineComponent} from '../../src/render3/definition';
 import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵselect, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
+
 import {ComponentFixture, TemplateFixture, createComponent} from './render_util';
 
 describe('JS control flow', () => {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -8,8 +8,8 @@
 
 import {RendererType2} from '../../src/render/api';
 import {getLContext} from '../../src/render3/context_discovery';
-import {AttributeMarker, ɵɵattribute, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵhostProperty, ɵɵproperty} from '../../src/render3/index';
-import {ɵɵallocHostVars, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
+import {AttributeMarker, ɵɵadvance, ɵɵattribute, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵhostProperty, ɵɵproperty} from '../../src/render3/index';
+import {ɵɵallocHostVars, ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵstyling, ɵɵstylingApply, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {MONKEY_PATCH_KEY_NAME} from '../../src/render3/interfaces/context';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -69,7 +69,6 @@ describe('render3 integration test', () => {
               ɵɵtext(0);
             }
             if (rf1 & RenderFlags.Update) {
-              ɵɵselect(0);
               ɵɵtextInterpolate(ctx.label);
             }
             ɵɵembeddedViewEnd();
@@ -160,7 +159,6 @@ describe('render3 integration test', () => {
         ɵɵelementEnd();
       }
       if (rf & RenderFlags.Update) {
-        ɵɵselect(0);
         ɵɵproperty('beforeTree', ctx.beforeTree);
         ɵɵproperty('afterTree', ctx.afterTree);
         ɵɵcontainerRefreshStart(1);
@@ -287,7 +285,6 @@ describe('component animations', () => {
             ɵɵelement(0, 'div', [AttributeMarker.Bindings, '@fooAnimation']);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵattribute('@fooAnimation', ctx.animationValue);
           }
         }
@@ -494,7 +491,7 @@ describe('element discovery', () => {
             ɵɵelementEnd();
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(1);
+            ɵɵadvance(1);
             ɵɵproperty('ngIf', true);
           }
         }
@@ -1085,7 +1082,6 @@ describe('sanitization', () => {
             ɵɵelement(0, 'a');
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵproperty('href', ctx.href, ɵɵsanitizeUrl);
           }
         }
@@ -1121,12 +1117,11 @@ describe('sanitization', () => {
       static ngDirectiveDef = ɵɵdefineDirective({
         type: UnsafeUrlHostBindingDir,
         selectors: [['', 'unsafeUrlHostBindingDir', '']],
-        hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: any) => {
           if (rf & RenderFlags.Create) {
             ɵɵallocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(elementIndex);
             ɵɵhostProperty('cite', ctx.cite, ɵɵsanitizeUrl);
           }
         }

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ComponentTemplate, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵproperty} from '../../src/render3/index';
-import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵselect, ɵɵtext} from '../../src/render3/instructions/all';
+import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵprojection, ɵɵprojectionDef, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {NgIf} from './common_with_def';
 import {ComponentFixture, createComponent} from './render_util';
@@ -20,7 +20,6 @@ describe('lifecycles', () => {
         ɵɵelement(0, name);
       }
       if (rf & RenderFlags.Update) {
-        ɵɵselect(0);
         ɵɵproperty('val', ctx.val);
       }
     };

--- a/packages/core/test/render3/perf/interpolation/index.ts
+++ b/packages/core/test/render3/perf/interpolation/index.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {ɵɵselect} from '../../../../src/render3/instructions/select';
 import {refreshView} from '../../../../src/render3/instructions/shared';
 import {ɵɵtext} from '../../../../src/render3/instructions/text';
 import {ɵɵtextInterpolate} from '../../../../src/render3/instructions/text_interpolation';
@@ -63,25 +63,25 @@ function TestInterpolationComponent_ng_template_0_Template(rf: RenderFlags, ctx:
     ɵɵelementEnd();
   }
   if (rf & 2) {
-    ɵɵselect(2);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('0');
-    ɵɵselect(4);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('1');
-    ɵɵselect(6);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('2');
-    ɵɵselect(8);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('3');
-    ɵɵselect(10);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('4');
-    ɵɵselect(12);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('5');
-    ɵɵselect(14);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('6');
-    ɵɵselect(16);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('7');
-    ɵɵselect(18);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('8');
-    ɵɵselect(20);
+    ɵɵadvance(2);
     ɵɵtextInterpolate('9');
   }
 }

--- a/packages/core/test/render3/perf/map_based_style_and_class_bindings/index.ts
+++ b/packages/core/test/render3/perf/map_based_style_and_class_bindings/index.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {ɵɵselect} from '../../../../src/render3/instructions/select';
 import {refreshView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TVIEW} from '../../../../src/render3/interfaces/view';
@@ -63,43 +63,43 @@ function testTemplate(rf: RenderFlags, ctx: any) {
     ɵɵelementEnd();
   }
   if (rf & 2) {
-    ɵɵselect(1);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '0px', height: '0px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(2);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '10px', height: '100px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(3);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '20px', height: '200px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(4);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '30px', height: '300px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(5);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '40px', height: '400px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(6);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '50px', height: '500px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(7);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '60px', height: '600px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(8);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '70px', height: '700px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(9);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '80px', height: '800px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();
-    ɵɵselect(10);
+    ɵɵadvance(1);
     ɵɵstyleMap({width: '90px', height: '900px'});
     ɵɵclassMap('one two');
     ɵɵstylingApply();

--- a/packages/core/test/render3/perf/property_binding/index.ts
+++ b/packages/core/test/render3/perf/property_binding/index.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
 import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
 import {ɵɵproperty} from '../../../../src/render3/instructions/property';
-import {ɵɵselect} from '../../../../src/render3/instructions/select';
 import {refreshView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TVIEW} from '../../../../src/render3/interfaces/view';
@@ -42,25 +42,25 @@ function TestInterpolationComponent_ng_template_0_Template(rf: RenderFlags, ctx:
     ɵɵelementEnd();
   }
   if (rf & 2) {
-    ɵɵselect(1);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title1');
-    ɵɵselect(2);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title2');
-    ɵɵselect(3);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title3');
-    ɵɵselect(4);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title4');
-    ɵɵselect(5);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title5');
-    ɵɵselect(6);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title6');
-    ɵɵselect(7);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title7');
-    ɵɵselect(8);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title8');
-    ɵɵselect(9);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title9');
-    ɵɵselect(10);
+    ɵɵadvance(1);
     ɵɵproperty('title', 'title10');
   }
 }

--- a/packages/core/test/render3/perf/style_and_class_bindings/index.ts
+++ b/packages/core/test/render3/perf/style_and_class_bindings/index.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {ɵɵselect} from '../../../../src/render3/instructions/select';
 import {refreshView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {AttributeMarker} from '../../../../src/render3/interfaces/node';
@@ -74,43 +74,43 @@ function testTemplate(rf: RenderFlags, ctx: any) {
     ɵɵelementEnd();
   }
   if (rf & 2) {
-    ɵɵselect(1);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '0px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(2);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '100px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(3);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '200px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(4);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '300px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(5);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '400px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(6);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '500px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(7);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '600px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(8);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '700px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(9);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '800px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();
-    ɵɵselect(10);
+    ɵɵadvance(1);
     ɵɵstyleProp('width', '900px');
     ɵɵclassProp('scale', true);
     ɵɵstylingApply();

--- a/packages/core/test/render3/perf/style_binding/index.ts
+++ b/packages/core/test/render3/perf/style_binding/index.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {ɵɵselect} from '../../../../src/render3/instructions/select';
 import {refreshView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TVIEW} from '../../../../src/render3/interfaces/view';
@@ -15,16 +15,16 @@ import {setupRootViewWithEmbeddedViews} from '../setup';
 
 `<ng-template>
   <div>
-    <button [style.backgroundColor]="'color1'"></button>              
-    <button [style.backgroundColor]="'color2'"></button>              
-    <button [style.backgroundColor]="'color3'"></button>              
-    <button [style.backgroundColor]="'color4'"></button>              
-    <button [style.backgroundColor]="'color5'"></button>              
-    <button [style.backgroundColor]="'color6'"></button>              
-    <button [style.backgroundColor]="'color7'"></button>              
-    <button [style.backgroundColor]="'color8'"></button>              
-    <button [style.backgroundColor]="'color9'"></button>              
-    <button [style.backgroundColor]="'color10'"></button>              
+    <button [style.backgroundColor]="'color1'"></button>
+    <button [style.backgroundColor]="'color2'"></button>
+    <button [style.backgroundColor]="'color3'"></button>
+    <button [style.backgroundColor]="'color4'"></button>
+    <button [style.backgroundColor]="'color5'"></button>
+    <button [style.backgroundColor]="'color6'"></button>
+    <button [style.backgroundColor]="'color7'"></button>
+    <button [style.backgroundColor]="'color8'"></button>
+    <button [style.backgroundColor]="'color9'"></button>
+    <button [style.backgroundColor]="'color10'"></button>
   </div>
 </ng-template>`;
 function testTemplate(rf: RenderFlags, ctx: any) {
@@ -63,34 +63,34 @@ function testTemplate(rf: RenderFlags, ctx: any) {
     ɵɵelementEnd();
   }
   if (rf & 2) {
-    ɵɵselect(1);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color1');
     ɵɵstylingApply();
-    ɵɵselect(2);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color2');
     ɵɵstylingApply();
-    ɵɵselect(3);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color3');
     ɵɵstylingApply();
-    ɵɵselect(4);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color4');
     ɵɵstylingApply();
-    ɵɵselect(5);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color5');
     ɵɵstylingApply();
-    ɵɵselect(6);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color6');
     ɵɵstylingApply();
-    ɵɵselect(7);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color7');
     ɵɵstylingApply();
-    ɵɵselect(8);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color8');
     ɵɵstylingApply();
-    ɵɵselect(9);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color9');
     ɵɵstylingApply();
-    ɵɵselect(10);
+    ɵɵadvance(1);
     ɵɵstyleProp('background-color', 'color10');
     ɵɵstylingApply();
   }

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -9,7 +9,7 @@
 import {Directive as _Directive, Pipe as _Pipe, PipeTransform, WrappedValue, ɵɵdefinePipe} from '@angular/core';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {ɵɵselect, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/instructions/all';
+import {ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/instructions/all';
 import {ɵɵpipe, ɵɵpipeBind1} from '../../src/render3/pipe';
 
 import {TemplateFixture} from './render_util';
@@ -38,10 +38,7 @@ describe('pipe', () => {
       ɵɵpipe(1, 'wrappingPipe');
     }
 
-    function updateTemplate() {
-      ɵɵselect(0);
-      ɵɵtextInterpolate1('', ɵɵpipeBind1(1, 1, null), '');
-    }
+    function updateTemplate() { ɵɵtextInterpolate1('', ɵɵpipeBind1(1, 1, null), ''); }
 
     it('should unwrap', () => {
       const fixture =

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -9,11 +9,12 @@
 import {Component as _Component, ComponentFactoryResolver, ElementRef, InjectFlags, Injectable as _Injectable, InjectionToken, InjectorType, Provider, RendererFactory2, ViewContainerRef, ɵNgModuleDef as NgModuleDef, ɵɵdefineInjectable, ɵɵdefineInjector, ɵɵinject} from '../../src/core';
 import {forwardRef} from '../../src/di/forward_ref';
 import {createInjector} from '../../src/di/r3_injector';
-import {injectComponentFactoryResolver, ɵɵProvidersFeature, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵselect, ɵɵtextInterpolate1} from '../../src/render3/index';
+import {injectComponentFactoryResolver, ɵɵProvidersFeature, ɵɵadvance, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵtextInterpolate1} from '../../src/render3/index';
 import {ɵɵcontainer, ɵɵcontainerRefreshEnd, ɵɵcontainerRefreshStart, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵembeddedViewEnd, ɵɵembeddedViewStart, ɵɵtext, ɵɵtextInterpolate} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {NgModuleFactory} from '../../src/render3/ng_module_ref';
 import {getInjector} from '../../src/render3/util/discovery_utils';
+
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture} from './render_util';
 
@@ -880,9 +881,8 @@ describe('providers', () => {
               ɵɵtext(1);
             }
             if (fs & RenderFlags.Update) {
-              ɵɵselect(0);
               ɵɵtextInterpolate(ctx.s);
-              ɵɵselect(1);
+              ɵɵadvance(1);
               ɵɵtextInterpolate(ctx.n);
             }
           }
@@ -967,9 +967,8 @@ describe('providers', () => {
               ɵɵtext(1);
             }
             if (fs & RenderFlags.Update) {
-              ɵɵselect(0);
               ɵɵtextInterpolate(ctx.s);
-              ɵɵselect(1);
+              ɵɵadvance(1);
               ɵɵtextInterpolate(ctx.n);
             }
           },
@@ -1050,7 +1049,6 @@ describe('providers', () => {
             ɵɵtext(0);
           }
           if (rf & RenderFlags.Update) {
-            ɵɵselect(0);
             ɵɵtextInterpolate1('', cmp.s, '');
           }
         }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -677,6 +677,8 @@ export interface OutputDecorator {
     new (bindingPropertyName?: string): any;
 }
 
+export declare function ɵɵadvance(delta: number): void;
+
 export declare function ɵɵallocHostVars(count: number): void;
 
 export declare function ɵɵattribute(name: string, value: any, sanitizer?: SanitizerFn | null, namespace?: string): TsickleIssue1009;
@@ -1033,6 +1035,7 @@ export declare function ɵɵsanitizeUrl(unsafeUrl: any): string;
 
 export declare function ɵɵsanitizeUrlOrResourceUrl(unsafeUrl: any, tag: string, prop: string): any;
 
+/** @deprecated */
 export declare function ɵɵselect(index: number): void;
 
 export declare function ɵɵsetComponentScope(type: ComponentType<any>, directives: Type<any>[], pipes: Type<any>[]): void;


### PR DESCRIPTION
Replaces the `select` instruction with a new one called `advance`. Instead of the jumping to a specific index, the new instruction goes forward X amount of elements. The advantage of doing this is that it should generate code that compresses better.
