### PR TITLE
test: fix ivy ts_devserver tests under /packages/core/test/bunding/

### DIFF
--- a/packages/core/test/bundling/todo/BUILD.bazel
+++ b/packages/core/test/bundling/todo/BUILD.bazel
@@ -89,8 +89,13 @@ genrule(
 
 ts_devserver(
     name = "devserver",
-    entry_module = "angular/packages/core/test/bundling/todo/index",
-    serving_path = "/bundle.min.js",
+    entry_module = "@angular/core/test/bundling/todo",
+    scripts = [
+        "//tools/rxjs:rxjs_umd_modules",
+    ],
+    # Use a serving_path that matches the common static index.html used
+    # in both devserver & prodserver
+    serving_path = "/bundle.min.js.br",
     static_files = [
         "index.html",
         ":tslib",

--- a/packages/core/test/bundling/todo/index.html
+++ b/packages/core/test/bundling/todo/index.html
@@ -38,20 +38,6 @@
       (document.location.search.endsWith('debug') ? '/bundle.min_debug.js' : '/bundle.min.js.br') +
       '"></' + 'script>');
   </script>
-  <script>
-    if (typeof define === "function" && define.amd) {
-      // If `define` is defined that we are in devserver mode. Dev server concatenates all of the 
-      // source files and than loads them using `require`. There is an issue with the way 
-      // `@angular/core` imports are generated which results in both `@angular/core` as well as `@angular/core/index`
-      // This hack makes both of the exports available to the application.
-      define("@angular/core", ["require", "exports", "tslib", "@angular/core/index"], function (require, exports) {
-        "use strict";
-        Object.defineProperty(exports, "__esModule", { value: true });
-        var tslib = require("tslib");
-        tslib.__exportStar(require("@angular/core/index"), exports);
-      });
-    }
-  </script>
 </body>
 
 </html>

--- a/packages/core/test/bundling/todo_i18n/BUILD.bazel
+++ b/packages/core/test/bundling/todo_i18n/BUILD.bazel
@@ -83,8 +83,13 @@ genrule(
 
 ts_devserver(
     name = "devserver",
-    entry_module = "angular/packages/core/test/bundling/todo_i18n/index",
-    serving_path = "/bundle.min.js",
+    entry_module = "@angular/core/test/bundling/todo_i18n",
+    scripts = [
+        "//tools/rxjs:rxjs_umd_modules",
+    ],
+    # Use a serving_path that matches the common static index.html used
+    # in both devserver & prodserver
+    serving_path = "/bundle.min.js.br",
     static_files = [
         "index.html",
         ":tslib",

--- a/packages/core/test/bundling/todo_i18n/index.html
+++ b/packages/core/test/bundling/todo_i18n/index.html
@@ -38,20 +38,6 @@
       (document.location.search.endsWith('debug') ? '/bundle.min_debug.js' : '/bundle.min.js.br') +
       '"></' + 'script>');
   </script>
-  <script>
-    if (typeof define === "function" && define.amd) {
-      // If `define` is defined that we are in devserver mode. Dev server concatenates all of the
-      // source files and than loads them using `require`. There is an issue with the way
-      // `@angular/core` imports are generated which results in both `@angular/core` as well as `@angular/core/index`
-      // This hack makes both of the exports available to the application.
-      define("@angular/core", ["require", "exports", "tslib", "@angular/core/index"], function (require, exports) {
-        "use strict";
-        Object.defineProperty(exports, "__esModule", { value: true });
-        var tslib = require("tslib");
-        tslib.__exportStar(require("@angular/core/index"), exports);
-      });
-    }
-  </script>
 </body>
 
 </html>

--- a/packages/core/test/bundling/todo_r2/BUILD.bazel
+++ b/packages/core/test/bundling/todo_r2/BUILD.bazel
@@ -84,8 +84,13 @@ genrule(
 
 ts_devserver(
     name = "devserver",
-    entry_module = "angular/packages/core/test/bundling/todo_r2/index",
-    serving_path = "/bundle.min.js",
+    entry_module = "@angular/core/test/bundling/todo_r2",
+    scripts = [
+        "//tools/rxjs:rxjs_umd_modules",
+    ],
+    # Use a serving_path that matches the common static index.html used
+    # in both devserver & prodserver
+    serving_path = "/bundle.min.js.br",
     static_files = [
         "index.html",
         ":tslib",

--- a/packages/core/test/bundling/todo_r2/index.html
+++ b/packages/core/test/bundling/todo_r2/index.html
@@ -38,20 +38,6 @@
       (document.location.search.endsWith('debug') ? '/bundle.min_debug.js' : '/bundle.min.js.br') +
       '"></' + 'script>');
   </script>
-  <script>
-    if (typeof define === "function" && define.amd) {
-      // If `define` is defined that we are in devserver mode. Dev server concatenates all of the 
-      // source files and than loads them using `require`. There is an issue with the way 
-      // `@angular/core` imports are generated which results in both `@angular/core` as well as `@angular/core/index`
-      // This hack makes both of the exports available to the application.
-      define("@angular/core", ["require", "exports", "tslib", "@angular/core/index"], function (require, exports) {
-        "use strict";
-        Object.defineProperty(exports, "__esModule", { value: true });
-        var tslib = require("tslib");
-        tslib.__exportStar(require("@angular/core/index"), exports);
-      });
-    }
-  </script>
 </body>
 
 </html>

--- a/packages/core/test/bundling/util/BUILD.bazel
+++ b/packages/core/test/bundling/util/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         ":metadata_switch",
     ],
     module_name = "@angular/core/test/bundling/util/src/reflect_metadata",
+    module_root = "src/reflect_metadata",
     deps = ["@npm//reflect-metadata"],
 )
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Ivy ts_devserver targets under /packages/core/test/bunding/ out of date and not working.

## What is the new behavior?
Fixed Ivy ts_devserver targets `//packages/core/test/bundling/todo:devserver`, `//packages/core/test/bundling/todo_r2:devserver`, `//packages/core/test/bundling/todo_i18n:devserver`.

Run with `bazel run --define=compile=aot packages/core/test/bundling/todo_i18n:devserver`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
