### PR TITLE
fix(router): lazy loaded empty root path loads with auxiliary outlet

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -149,15 +149,12 @@ class ApplyRedirects {
                  ngModule, segmentGroup, routes, r, segments, outlet, allowRedirects);
              return expanded$.pipe(catchError((e: any) => {
                if (e instanceof NoMatch) {
-                 // TODO(i): this return type doesn't match the declared Observable<UrlSegmentGroup>
-                 // -
-                 // talk to Jason
-                 return of (null) as any as Observable<UrlSegmentGroup>;
+                 return of (new UrlSegmentGroup([], {}));
                }
                throw e;
              }));
            }))
-        .pipe(map(x => x.find((s: any) => !!s) as UrlSegmentGroup), catchError((e: any, _: any) => {
+        .pipe(map(x => x.find((s: any) => !!s) || new UrlSegmentGroup([], {})), catchError((e: any, _: any) => {
                 if (e instanceof EmptyError || e.name === 'EmptyError') {
                   if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
                     return of (new UrlSegmentGroup([], {}));

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, NgModuleRef} from '@angular/core';
-import {EmptyError, Observable, Observer, from, of, combineLatest } from 'rxjs';
+import {EmptyError, Observable, Observer, combineLatest, from, of } from 'rxjs';
 import {catchError, concatAll, every, first, map, mergeMap} from 'rxjs/operators';
 
 import {LoadedRouterConfig, Route, Routes} from './config';
@@ -145,25 +145,27 @@ class ApplyRedirects {
       segments: UrlSegment[], outlet: string,
       allowRedirects: boolean): Observable<UrlSegmentGroup> {
     return combineLatest(routes.map((r: any) => {
-          const expanded$ = this.expandSegmentAgainstRoute(
-              ngModule, segmentGroup, routes, r, segments, outlet, allowRedirects);
-          return expanded$.pipe(catchError((e: any) => {
-            if (e instanceof NoMatch) {
-              // TODO(i): this return type doesn't match the declared Observable<UrlSegmentGroup> -
-              // talk to Jason
-              return of (null) as any;
-            }
-            throw e;
-          }));
-        })).pipe(map(x => x.find((s: any) => !!s)), catchError((e: any, _: any) => {
-          if (e instanceof EmptyError || e.name === 'EmptyError') {
-            if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
-              return of (new UrlSegmentGroup([], {}));
-            }
-            throw new NoMatch(segmentGroup);
-          }
-          throw e;
-        }));
+             const expanded$ = this.expandSegmentAgainstRoute(
+                 ngModule, segmentGroup, routes, r, segments, outlet, allowRedirects);
+             return expanded$.pipe(catchError((e: any) => {
+               if (e instanceof NoMatch) {
+                 // TODO(i): this return type doesn't match the declared Observable<UrlSegmentGroup>
+                 // -
+                 // talk to Jason
+                 return of (null) as any;
+               }
+               throw e;
+             }));
+           }))
+        .pipe(map(x => x.find((s: any) => !!s)), catchError((e: any, _: any) => {
+                if (e instanceof EmptyError || e.name === 'EmptyError') {
+                  if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
+                    return of (new UrlSegmentGroup([], {}));
+                  }
+                  throw new NoMatch(segmentGroup);
+                }
+                throw e;
+              }));
   }
 
   private noLeftoversInUrl(segmentGroup: UrlSegmentGroup, segments: UrlSegment[], outlet: string):

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -154,15 +154,17 @@ class ApplyRedirects {
                throw e;
              }));
            }))
-        .pipe(map(x => x.find((s: any) => !!s) || new UrlSegmentGroup([], {})), catchError((e: any, _: any) => {
-                if (e instanceof EmptyError || e.name === 'EmptyError') {
-                  if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
-                    return of (new UrlSegmentGroup([], {}));
-                  }
-                  throw new NoMatch(segmentGroup);
+        .pipe(
+            map(x => x.find((s: any) => !!s) || new UrlSegmentGroup([], {})),
+            catchError((e: any, _: any) => {
+              if (e instanceof EmptyError || e.name === 'EmptyError') {
+                if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
+                  return of (new UrlSegmentGroup([], {}));
                 }
-                throw e;
-              }));
+                throw new NoMatch(segmentGroup);
+              }
+              throw e;
+            }));
   }
 
   private noLeftoversInUrl(segmentGroup: UrlSegmentGroup, segments: UrlSegment[], outlet: string):

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -152,12 +152,12 @@ class ApplyRedirects {
                  // TODO(i): this return type doesn't match the declared Observable<UrlSegmentGroup>
                  // -
                  // talk to Jason
-                 return of (null) as any;
+                 return of (null) as any as Observable<UrlSegmentGroup>;
                }
                throw e;
              }));
            }))
-        .pipe(map(x => x.find((s: any) => !!s)), catchError((e: any, _: any) => {
+        .pipe(map(x => x.find((s: any) => !!s) as UrlSegmentGroup), catchError((e: any, _: any) => {
                 if (e instanceof EmptyError || e.name === 'EmptyError') {
                   if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
                     return of (new UrlSegmentGroup([], {}));

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,8 +7,8 @@
  */
 
 import {Injector, NgModuleRef} from '@angular/core';
-import {EmptyError, Observable, Observer, combineLatest, from, of } from 'rxjs';
-import {catchError, concatAll, every, first, map, mergeMap} from 'rxjs/operators';
+import {Observable, Observer, combineLatest, from, of } from 'rxjs';
+import {catchError, concatAll, every, map, mergeMap} from 'rxjs/operators';
 
 import {LoadedRouterConfig, Route, Routes} from './config';
 import {CanLoadFn} from './interfaces';
@@ -154,24 +154,16 @@ class ApplyRedirects {
                throw e;
              }));
            }))
-        .pipe(
-            map(x => {
-              const match = x.find((s: any) => !!s);
-              if (match) {
-                return match;
-              } else {
-                throw new EmptyError();
-              }
-            }),
-            catchError((e: any, _: any) => {
-              if (e instanceof EmptyError || e.name === 'EmptyError') {
-                if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
-                  return of (new UrlSegmentGroup([], {}));
-                }
-                throw new NoMatch(segmentGroup);
-              }
-              throw e;
-            }));
+        .pipe(map(x => {
+          const match = x.find((s: any) => !!s);
+          if (!match) {
+            if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
+              return of (new UrlSegmentGroup([], {}));
+            }
+            throw new NoMatch(segmentGroup);
+          }
+          return match;
+        }));
   }
 
   private noLeftoversInUrl(segmentGroup: UrlSegmentGroup, segments: UrlSegment[], outlet: string):

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -158,7 +158,7 @@ class ApplyRedirects {
           const match = x.find((s: any) => !!s);
           if (!match) {
             if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
-              return of (new UrlSegmentGroup([], {}));
+              return new UrlSegmentGroup([], {});
             }
             throw new NoMatch(segmentGroup);
           }

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -149,13 +149,20 @@ class ApplyRedirects {
                  ngModule, segmentGroup, routes, r, segments, outlet, allowRedirects);
              return expanded$.pipe(catchError((e: any) => {
                if (e instanceof NoMatch) {
-                 return of (new UrlSegmentGroup([], {}));
+                 return of (null);
                }
                throw e;
              }));
            }))
         .pipe(
-            map(x => x.find((s: any) => !!s) || new UrlSegmentGroup([], {})),
+            map(x => {
+              const match = x.find((s: any) => !!s);
+              if (match) {
+                return match;
+              } else {
+                throw new EmptyError();
+              }
+            }),
             catchError((e: any, _: any) => {
               if (e instanceof EmptyError || e.name === 'EmptyError') {
                 if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -144,8 +144,7 @@ class ApplyRedirects {
       ngModule: NgModuleRef<any>, segmentGroup: UrlSegmentGroup, routes: Route[],
       segments: UrlSegment[], outlet: string,
       allowRedirects: boolean): Observable<UrlSegmentGroup> {
-    return of (...routes).pipe(
-        map((r: any) => {
+    return combineLatest(routes.map((r: any) => {
           const expanded$ = this.expandSegmentAgainstRoute(
               ngModule, segmentGroup, routes, r, segments, outlet, allowRedirects);
           return expanded$.pipe(catchError((e: any) => {
@@ -156,8 +155,7 @@ class ApplyRedirects {
             }
             throw e;
           }));
-        }),
-        concatAll(), first((s: any) => !!s), catchError((e: any, _: any) => {
+        })).pipe(map(x => x.find((s: any) => !!s)), catchError((e: any, _: any) => {
           if (e instanceof EmptyError || e.name === 'EmptyError') {
             if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
               return of (new UrlSegmentGroup([], {}));

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, NgModuleRef} from '@angular/core';
-import {EmptyError, Observable, Observer, from, of } from 'rxjs';
+import {EmptyError, Observable, Observer, from, of, combineLatest } from 'rxjs';
 import {catchError, concatAll, every, first, map, mergeMap} from 'rxjs/operators';
 
 import {LoadedRouterConfig, Route, Routes} from './config';

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -423,6 +423,23 @@ describe('applyRedirects', () => {
       applyRedirects(testModule.injector, <any>loader, serializer, tree('xyz'), config)
           .forEach(r => { expect((config[0] as any)._loadedConfig).toBe(loadedConfig); });
     });
+
+    it('should load the configuration of empty root path if the entry point is an auxiliary outlet',
+       () => {
+         const loadedConfig =
+             new LoadedRouterConfig([{path: '', component: ComponentA}], testModule);
+         const loader = {load: (injector: any, p: any) => { return of (loadedConfig); }};
+
+         const config: Routes = [
+           {path: '', loadChildren: 'root'}, {path: 'modal', loadChildren: 'aux', outlet: 'popup'}
+         ];
+
+         applyRedirects(testModule.injector, <any>loader, serializer, tree('(popup:modal)'), config)
+             .forEach(r => {
+               expectTreeToBe(r, '/(popup:modal)');
+               expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
+             });
+       });
   });
 
   describe('empty paths', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
**This is correct implementation and replacement of #25483**

Given the following route configuration:

```
[
    {path: '', loadChildren: 'children'},
    {path: 'a', loadChildren: 'otherChildren', outlet: 'aux'}
]
```
With this configuration, using the outlet as an entry point to the application, the root module will not load properly and results in the following error:

`TypeError: Cannot read property 'routes' of undefined at getChildConfig (router.js:3041)`

The `_loadedConfig` property of the route remains `undefined` as the `expandSegmentAgainstRoute()` isn't executed.

This issue is only present if the root has a lazy loaded module, works fine with a component or even with a lazy loaded module if the root path is not empty.

Issue Number: #12842


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
