### PR TITLE
Fix component selector typo

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -254,7 +254,7 @@ We're going to create a new alert feature. The alert feature will take a product
 
     1. Open `product-list.component.html`.
     
-    1. To include the new component, use its selector (`app-product-alert`) as you would an HTML element. 
+    1. To include the new component, use its selector (`app-product-alerts`) as you would an HTML element. 
     
     1. Pass the current product as input to the component using property binding. 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Section 5 of Input (Getting Started - Your First App) references an incorrect selector for the product-alerts component.

```
To include the new component, use its selector (app-product-alert) as you would an HTML element.
```

Issue Number: N/A


## What is the new behavior?
Guide now references *app-product-alerts* selector instead of app-product-alert.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
