### PR TITLE
fix(core): meta addTag() adds incorrect attribute

### DIFF
--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -180,7 +180,8 @@ export class Meta {
   }
 
   private _setMetaElementAttributes(tag: MetaDefinition, el: HTMLMetaElement): HTMLMetaElement {
-    Object.keys(tag).forEach((prop: string) => el.setAttribute(prop, tag[prop]));
+    Object.keys(tag).forEach(
+        (prop: string) => el.setAttribute(this._getMetaKeyMap(prop), tag[prop]));
     return el;
   }
 
@@ -190,6 +191,18 @@ export class Meta {
   }
 
   private _containsAttributes(tag: MetaDefinition, elem: HTMLMetaElement): boolean {
-    return Object.keys(tag).every((key: string) => elem.getAttribute(key) === tag[key]);
+    return Object.keys(tag).every(
+        (key: string) => elem.getAttribute(this._getMetaKeyMap(key)) === tag[key]);
+  }
+
+  private _getMetaKeyMap(prop: string): string {
+    return META_KEYS_MAP[prop] || prop;
   }
 }
+
+/**
+ * Mapping for MetaDefinition properties with their correct meta attribute names
+ */
+const META_KEYS_MAP: {[prop: string]: string;} = {
+  httpEquiv: 'http-equiv'
+};

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -126,6 +126,18 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       metaService.removeTagElement(actual);
     });
 
+    it('should add httpEquiv meta tag as http-equiv', () => {
+      metaService.addTag({httpEquiv: 'refresh', content: '3;url=http://test'});
+
+      const actual = metaService.getTag('http-equiv')!;
+      expect(actual).not.toBeNull();
+      expect(actual.getAttribute('http-equiv')).toEqual('refresh');
+      expect(actual.getAttribute('content')).toEqual('3;url=http://test');
+
+      // clean up
+      metaService.removeTagElement(actual);
+    });
+
     it('should add multiple new meta tags', () => {
       const nameSelector = 'name="twitter:title"';
       const propertySelector = 'property="og:title"';


### PR DESCRIPTION
Meta::addTag() adds a meta tag with httpEquiv instead of http-equiv when
MetaDefinition contains httpEquiv property.

closes #31525

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently when we use the addTag() or addTags() method with a MetaDefinition containing httpEquiv property a meta tag with an incorrect attribute httpequiv will be added instead of the correct http-equiv attribute.

Issue Number: #31525

## What is the new behavior?
The changes will add meta tags with the correct attribute.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Creating this PR instead of an old one that I messed up while fixing a conflict: https://github.com/angular/angular/pull/31542
