### PR TITLE
ci: work around `CIRCLE_COMPARE_URL` not being available wih CircleCI Pipelines

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -19,16 +19,20 @@ setPublicVar PROJECT_ROOT "$projectDir";
 setPublicVar CI_AIO_MIN_PWA_SCORE "95";
 # This is the branch being built; e.g. `pull/12345` for PR builds.
 setPublicVar CI_BRANCH "$CIRCLE_BRANCH";
+setPublicVar CI_BUILD_URL "$CIRCLE_BUILD_URL";
 # ChromeDriver version compatible with the Chrome version included in the docker image used in
 # `.circleci/config.yml`. See http://chromedriver.chromium.org/downloads for a list of versions.
 # This variable is intended to be passed as an arg to the `webdriver-manager update` command (e.g.
 # `"postinstall": "webdriver-manager update $CI_CHROMEDRIVER_VERSION_ARG"`).
 setPublicVar CI_CHROMEDRIVER_VERSION_ARG "--versions.chrome 75.0.3770.90";
 setPublicVar CI_COMMIT "$CIRCLE_SHA1";
-# `CI_COMMIT_RANGE` will only be available when `CIRCLE_COMPARE_URL` is also available (or can be
-# retrieved via `get-compare-url.js`), i.e. on push builds (a.k.a. non-PR, non-scheduled builds and
-# rerun workflows of such builds). That is fine, since we only need it in push builds.
-setPublicVar CI_COMMIT_RANGE "`[[ ${CIRCLE_PR_NUMBER:-false} != false ]] && echo "" || node $getCommitRangePath "$CIRCLE_BUILD_NUM" "$CIRCLE_COMPARE_URL"`";
+# `CI_COMMIT_RANGE` is only used on push builds (a.k.a. non-PR, non-scheduled builds and rerun
+# workflows of such builds).
+# NOTE: With [CircleCI Pipelines](https://circleci.com/docs/2.0/build-processing) enabled,
+#       `CIRCLE_COMPARE_URL` is no longer available and the commit range cannot be reliably
+#       detected. Fall back to only considering the last commit (which is accurate in the majority
+#       of cases for push builds).
+setPublicVar CI_COMMIT_RANGE "`[[ ${CIRCLE_PR_NUMBER:-false} != false ]] && echo "" || echo "$CIRCLE_SHA1~1...$CIRCLE_SHA1"`";
 setPublicVar CI_PULL_REQUEST "${CIRCLE_PR_NUMBER:-false}";
 setPublicVar CI_REPO_NAME "$CIRCLE_PROJECT_REPONAME";
 setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";

--- a/.circleci/get-commit-range.js
+++ b/.circleci/get-commit-range.js
@@ -10,6 +10,13 @@
  * format of the `CIRCLE_COMPARE_URL` environment variable, or by retrieving the equivalent of
  * `CIRCLE_COMPARE_URL` for jobs that are part of a rerun workflow and extracting it from there.
  *
+ * > !!! WARNING !!!
+ * > !!
+ * > !! When [CircleCI Pipelines](https://circleci.com/docs/2.0/build-processing) is enabled, the
+ * > !! `CIRCLE_COMPARE_URL` environment variable is not available at all and this script does not
+ * > !! work.
+ * > !!!!!!!!!!!!!!!
+ *
  * **Context:**
  * CircleCI sets the `CIRCLE_COMPARE_URL` environment variable (from which we can extract the commit
  * range) on push builds (a.k.a. non-PR, non-scheduled builds). Yet, when a workflow is rerun
@@ -21,7 +28,7 @@
  * (undocumented) fact that the workspace ID happens to be the same as the workflow ID that first
  * created it.
  *
- * For example, for a job on push build workflow, the CircleCI API will return data that look like:
+ * For example, for a job on push build workflows, the CircleCI API will return data that look like:
  * ```js
  * {
  *   compare: 'THE_COMPARE_URL_WE_ARE_LOOKING_FOR',

--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -51,6 +51,15 @@ addTimestamp() {
   payloadData="$payloadData\"timestamp\": $timestamp, "
 }
 
+# Write the current CI build URL to global variable `$payloadData`.
+# This allows mapping the data stored in the database to the CI build job that generated it, which
+# might contain more info/context.
+#   $1: string - The CI build URL.
+addBuildUrl() {
+  buildUrl="$1"
+  payloadData="$payloadData\"buildUrl\": \"$buildUrl\", "
+}
+
 # Write the commit message for the current CI commit range to global variable `$payloadData`.
 #   $1: string - The commit range for this build (in `<SHA-1>...<SHA-2>` format).
 addMessage() {
@@ -142,6 +151,7 @@ trackPayloadSize() {
       addChangeType $CI_COMMIT_RANGE
     fi
     addTimestamp
+    addBuildUrl $CI_BUILD_URL
     addMessage $CI_COMMIT_RANGE
     uploadData $name
   fi


### PR DESCRIPTION
The commit range that is associated with a CI build is used for a couple of things (mostly related to payload-size tracking):
- Determine whether a size change was caused by application code or dependencies (or both).
- Add the messages of the commits associated with the build (and thus the payload-size change).

NOTE: The commit range is only used on push builds.

Previously, the commit range was computed based on the `CIRCLE_COMPARE_URL` environment variable. With [CircleCI Pipelines][1] enabled, `CIRCLE_COMPARE_URL` is no longer available and the commit range cannot be reliably detected.

This commit switches `CI_COMMIT_RANGE` to only include the last commit. This can be less accurate in some rare cases, but is true in the majority of cases (on push builds). Additionally, it stores the CircleCI build URL in the database along with the payload data, so the relevant info can be retrieved when needed.

[1]: https://circleci.com/docs/2.0/build-processing