### PR TITLE
fix(ngcc): consistently use outer declaration for classes

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -14,10 +14,9 @@ import {FileSystem, LogicalFileSystem, absoluteFrom, dirname, resolve} from '../
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../../src/ngtsc/imports';
 import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, LocalMetadataRegistry} from '../../../src/ngtsc/metadata';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
-import {ClassSymbol} from '../../../src/ngtsc/reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../src/ngtsc/scope';
 import {CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
-import {NgccReflectionHost} from '../host/ngcc_host';
+import {NgccClassSymbol, NgccReflectionHost} from '../host/ngcc_host';
 import {Migration, MigrationHost} from '../migrations/migration';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {isDefined} from '../utils';
@@ -128,7 +127,7 @@ export class DecorationAnalyzer {
     return analyzedClasses.length ? {sourceFile, analyzedClasses} : undefined;
   }
 
-  protected analyzeClass(symbol: ClassSymbol): AnalyzedClass|null {
+  protected analyzeClass(symbol: NgccClassSymbol): AnalyzedClass|null {
     const decorators = this.reflectionHost.getDecoratorsOfSymbol(symbol);
     const analyzedClass = analyzeDecorators(symbol, decorators, this.handlers);
     if (analyzedClass !== null && analyzedClass.diagnostics !== undefined) {

--- a/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
@@ -80,7 +80,7 @@ export class ModuleWithProvidersAnalyzer {
     let dtsFn: ts.Declaration|null = null;
     const containerClass = fn.container && this.host.getClassSymbol(fn.container);
     if (containerClass) {
-      const dtsClass = this.host.getDtsDeclaration(containerClass.valueDeclaration);
+      const dtsClass = this.host.getDtsDeclaration(containerClass.declaration.valueDeclaration);
       // Get the declaration of the matching static method
       dtsFn = dtsClass && ts.isClassDeclaration(dtsClass) ?
           dtsClass.members

--- a/packages/compiler-cli/ngcc/src/analysis/util.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/util.ts
@@ -20,9 +20,9 @@ export function isWithinPackage(packagePath: AbsoluteFsPath, sourceFile: ts.Sour
 }
 
 export function analyzeDecorators(
-    symbol: NgccClassSymbol, decorators: Decorator[] | null,
+    classSymbol: NgccClassSymbol, decorators: Decorator[] | null,
     handlers: DecoratorHandler<any, any>[]): AnalyzedClass|null {
-  const declaration = symbol.valueDeclaration;
+  const declaration = classSymbol.declaration.valueDeclaration;
   const matchingHandlers = handlers
                                .map(handler => {
                                  const detected = handler.detect(declaration, decorators);
@@ -78,7 +78,7 @@ export function analyzeDecorators(
     }
   }
   return {
-    name: symbol.name,
+    name: classSymbol.name,
     declaration,
     decorators,
     matches,

--- a/packages/compiler-cli/ngcc/src/analysis/util.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/util.ts
@@ -9,8 +9,9 @@ import * as ts from 'typescript';
 
 import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
 import {AbsoluteFsPath, absoluteFromSourceFile, relative} from '../../../src/ngtsc/file_system';
-import {ClassSymbol, Decorator} from '../../../src/ngtsc/reflection';
+import {Decorator} from '../../../src/ngtsc/reflection';
 import {DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
+import {NgccClassSymbol} from '../host/ngcc_host';
 
 import {AnalyzedClass, MatchingHandler} from './types';
 
@@ -19,7 +20,7 @@ export function isWithinPackage(packagePath: AbsoluteFsPath, sourceFile: ts.Sour
 }
 
 export function analyzeDecorators(
-    symbol: ClassSymbol, decorators: Decorator[] | null,
+    symbol: NgccClassSymbol, decorators: Decorator[] | null,
     handlers: DecoratorHandler<any, any>[]): AnalyzedClass|null {
   const declaration = symbol.valueDeclaration;
   const matchingHandlers = handlers

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -64,7 +64,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     if (esm5HelperCalls.length > 0) {
       return esm5HelperCalls;
     } else {
-      const sourceFile = classSymbol.valueDeclaration.getSourceFile();
+      const sourceFile = classSymbol.declaration.valueDeclaration.getSourceFile();
       return this.getTopLevelHelperCalls(sourceFile, helperName);
     }
   }

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -8,12 +8,13 @@
 
 import * as ts from 'typescript';
 import {absoluteFrom} from '../../../src/ngtsc/file_system';
-import {ClassSymbol, Declaration, Import} from '../../../src/ngtsc/reflection';
+import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
 import {isDefined} from '../utils';
 
 import {Esm5ReflectionHost} from './esm5_host';
+import {NgccClassSymbol} from './ngcc_host';
 
 export class CommonJsReflectionHost extends Esm5ReflectionHost {
   protected commonJsExports = new Map<ts.SourceFile, Map<string, Declaration>|null>();
@@ -57,7 +58,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
    * @param helperName the name of the helper (e.g. `__decorate`) whose calls we are interested in.
    * @returns an array of nodes of calls to the helper with the given name.
    */
-  protected getHelperCallsForClass(classSymbol: ClassSymbol, helperName: string):
+  protected getHelperCallsForClass(classSymbol: NgccClassSymbol, helperName: string):
       ts.CallExpression[] {
     const esm5HelperCalls = super.getHelperCallsForClass(classSymbol, helperName);
     if (esm5HelperCalls.length > 0) {

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -191,7 +191,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected createClassSymbol(
       outerDeclaration: ClassDeclaration, innerDeclaration: ClassDeclaration|null): NgccClassSymbol
       |undefined {
-    const declarationSymbol = this.checker.getSymbolAtLocation(outerDeclaration.name);
+    const declarationSymbol =
+        this.checker.getSymbolAtLocation(outerDeclaration.name) as ClassSymbol | undefined;
     if (declarationSymbol === undefined) {
       return undefined;
     }
@@ -205,7 +206,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
     return {
       name: declarationSymbol.name,
-      declaration: declarationSymbol as ClassSymbol,
+      declaration: declarationSymbol,
       implementation: implementationSymbol,
     };
   }

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,12 +8,11 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Parameter, TsHelperFn, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
-import {isFromDtsFile} from '../../../src/ngtsc/util/src/typescript';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, Parameter, TsHelperFn, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {getNameText, hasNameIdentifier, stripDollarSuffix} from '../utils';
 
 import {Esm2015ReflectionHost, ParamInfo, getPropertyValueFromSymbol, isAssignmentStatement} from './esm2015_host';
-import {ClassSymbol, NgccClassSymbol} from './ngcc_host';
+import {NgccClassSymbol} from './ngcc_host';
 
 
 
@@ -92,16 +91,16 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * whose value is assigned to a variable (which represents the class to the rest of the program).
    * So we might need to dig around to get hold of the "class" declaration.
    *
-   * This method extracts a `NgccClassSymbol` if `node` is the outer variable which is assigned the
-   * result of the IIFE. Otherwise, undefined is returned.
+   * This method extracts a `NgccClassSymbol` if `declaration` is the outer variable which is
+   * assigned the result of the IIFE. Otherwise, undefined is returned.
    *
    * @param declaration the declaration whose symbol we are finding.
    * @returns the symbol for the node or `undefined` if it is not a "class" or has no symbol.
    */
   protected getClassSymbolFromOuterDeclaration(declaration: ts.Node): NgccClassSymbol|undefined {
-    const superSymbol = super.getClassSymbolFromOuterDeclaration(declaration);
-    if (superSymbol !== undefined) {
-      return superSymbol;
+    const classSymbol = super.getClassSymbolFromOuterDeclaration(declaration);
+    if (classSymbol !== undefined) {
+      return classSymbol;
     }
 
     if (!isNamedVariableDeclaration(declaration)) {
@@ -121,16 +120,16 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * whose value is assigned to a variable (which represents the class to the rest of the program).
    * So we might need to dig around to get hold of the "class" declaration.
    *
-   * This method extracts a `NgccClassSymbol` if `node` is the function declaration inside the IIFE.
-   * Otherwise, undefined is returned.
+   * This method extracts a `NgccClassSymbol` if `declaration` is the function declaration inside
+   * the IIFE. Otherwise, undefined is returned.
    *
    * @param declaration the declaration whose symbol we are finding.
    * @returns the symbol for the node or `undefined` if it is not a "class" or has no symbol.
    */
   protected getClassSymbolFromInnerDeclaration(declaration: ts.Node): NgccClassSymbol|undefined {
-    const superSymbol = super.getClassSymbolFromInnerDeclaration(declaration);
-    if (superSymbol !== undefined) {
-      return superSymbol;
+    const classSymbol = super.getClassSymbolFromInnerDeclaration(declaration);
+    if (classSymbol !== undefined) {
+      return classSymbol;
     }
 
     if (!ts.isFunctionDeclaration(declaration) || !hasNameIdentifier(declaration)) {

--- a/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassSymbol, ConcreteDeclaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ConcreteDeclaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
 
 export const PRE_R3_MARKER = '__PRE_R3__';
 export const POST_R3_MARKER = '__POST_R3__';
@@ -44,6 +44,12 @@ export interface ModuleWithProvidersFunction {
 }
 
 /**
+ * The symbol corresponding to a "class" declaration. I.e. a `ts.Symbol` whose `valueDeclaration` is
+ * a `ClassDeclaration`.
+ */
+export type NgccClassSymbol = ts.Symbol & {valueDeclaration: ClassDeclaration};
+
+/**
  * A reflection host that has extra methods for looking at non-Typescript package formats
  */
 export interface NgccReflectionHost extends ReflectionHost {
@@ -53,7 +59,7 @@ export interface NgccReflectionHost extends ReflectionHost {
    * @returns the symbol for the declaration or `undefined` if it is not
    * a "class" or has no symbol.
    */
-  getClassSymbol(node: ts.Node): ClassSymbol|undefined;
+  getClassSymbol(node: ts.Node): NgccClassSymbol|undefined;
 
   /**
    * Search the given module for variable declarations in which the initializer
@@ -68,14 +74,14 @@ export interface NgccReflectionHost extends ReflectionHost {
    * @param symbol Class symbol that can refer to a declaration which can hold decorators.
    * @returns An array of decorators or null if none are declared.
    */
-  getDecoratorsOfSymbol(symbol: ClassSymbol): Decorator[]|null;
+  getDecoratorsOfSymbol(symbol: NgccClassSymbol): Decorator[]|null;
 
   /**
    * Retrieves all class symbols of a given source file.
    * @param sourceFile The source file to search for classes.
    * @returns An array of found class symbols.
    */
-  findClassSymbols(sourceFile: ts.SourceFile): ClassSymbol[];
+  findClassSymbols(sourceFile: ts.SourceFile): NgccClassSymbol[];
 
   /**
    * Search the given source file for exported functions and static class methods that return

--- a/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
@@ -47,7 +47,32 @@ export interface ModuleWithProvidersFunction {
  * The symbol corresponding to a "class" declaration. I.e. a `ts.Symbol` whose `valueDeclaration` is
  * a `ClassDeclaration`.
  */
-export type NgccClassSymbol = ts.Symbol & {valueDeclaration: ClassDeclaration};
+export type ClassSymbol = ts.Symbol & {valueDeclaration: ClassDeclaration};
+
+/**
+ * A representation of a class that accounts for the potential existence of two `ClassSymbol`s for a
+ * given class, as the compiled JavaScript bundles that ngcc reflects on can have two declarations.
+ */
+export interface NgccClassSymbol {
+  /**
+   * The name of the class.
+   */
+  name: string;
+
+  /**
+   * Represents the symbol corresponding with the outer declaration of the class. This should be
+   * considered the public class symbol, i.e. its declaration is visible to the rest of the program.
+   */
+  declaration: ClassSymbol;
+
+  /**
+   * Represents the symbol corresponding with the inner declaration of the class, referred to as its
+   * "implementation". This is not necessarily a `ClassSymbol` but rather just a `ts.Symbol`, as the
+   * inner declaration does not need to satisfy the requirements imposed on a publicly visible class
+   * declaration.
+   */
+  implementation: ts.Symbol;
+}
 
 /**
  * A reflection host that has extra methods for looking at non-Typescript package formats
@@ -59,7 +84,7 @@ export interface NgccReflectionHost extends ReflectionHost {
    * @returns the symbol for the declaration or `undefined` if it is not
    * a "class" or has no symbol.
    */
-  getClassSymbol(node: ts.Node): NgccClassSymbol|undefined;
+  getClassSymbol(declaration: ts.Node): NgccClassSymbol|undefined;
 
   /**
    * Search the given module for variable declarations in which the initializer

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -79,7 +79,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
     if (!classSymbol) {
       throw new Error(`Compiled class does not have a valid symbol: ${compiledClass.name}`);
     }
-    const insertionPoint = classSymbol.valueDeclaration !.getEnd();
+    const insertionPoint = classSymbol.declaration.valueDeclaration !.getEnd();
     output.appendLeft(insertionPoint, '\n' + definitions);
   }
 

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -6,15 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ErrorCode} from '../../../src/ngtsc/diagnostics';
-import {ClassDeclaration, ClassSymbol, Decorator} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
 import {DefaultMigrationHost} from '../../src/analysis/migration_host';
 import {AnalyzedClass, AnalyzedFile} from '../../src/analysis/types';
+import {NgccClassSymbol} from '../../src/host/ngcc_host';
 
 describe('DefaultMigrationHost', () => {
   describe('injectSyntheticDecorator()', () => {
     const mockHost: any = {
-      getClassSymbol: (node: any): ClassSymbol | undefined =>
+      getClassSymbol: (node: any): NgccClassSymbol | undefined =>
                           ({ valueDeclaration: node, name: node.name.text } as any),
     };
     const mockMetadata: any = {};

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -15,8 +15,14 @@ import {NgccClassSymbol} from '../../src/host/ngcc_host';
 describe('DefaultMigrationHost', () => {
   describe('injectSyntheticDecorator()', () => {
     const mockHost: any = {
-      getClassSymbol: (node: any): NgccClassSymbol | undefined =>
-                          ({ valueDeclaration: node, name: node.name.text } as any),
+      getClassSymbol: (node: any): NgccClassSymbol | undefined => {
+        const symbol = { valueDeclaration: node, name: node.name.text } as any;
+        return {
+          name: node.name.text,
+          declaration: symbol,
+          implementation: symbol,
+        };
+      },
     };
     const mockMetadata: any = {};
     const mockEvaluator: any = {};

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -13,8 +13,7 @@ import {ClassMemberKind, CtorParameter, Import, InlineDeclaration, isNamedClassD
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
-import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
-import {Esm5ReflectionHost, getIifeBody} from '../../src/host/esm5_host';
+import {getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
 import {getRootFiles, makeTestBundleProgram, makeTestDtsBundleProgram} from '../helpers/utils';
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -14,7 +14,7 @@ import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
-import {getIifeBody} from '../../src/host/esm5_host';
+import {Esm5ReflectionHost, getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
 import {getRootFiles, makeTestBundleProgram, makeTestDtsBundleProgram} from '../helpers/utils';
 
@@ -1712,19 +1712,22 @@ exports.ExternalModule = ExternalModule;
           const classSymbol = host.getClassSymbol(node);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(node);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(node);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(node);
         });
 
         it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
           const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const node = getDeclaration(
+          const outerNode = getDeclaration(
               program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-          const classSymbol = host.getClassSymbol(node);
+          const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+          const classSymbol = host.getClassSymbol(outerNode);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(node);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
         });
 
         it('should return the class symbol for an ES5 class (inner function declaration)', () => {
@@ -1737,7 +1740,8 @@ exports.ExternalModule = ExternalModule;
           const classSymbol = host.getClassSymbol(innerNode);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
         });
 
         it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
@@ -1751,7 +1755,10 @@ exports.ExternalModule = ExternalModule;
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
 
-             expect(host.getClassSymbol(innerNode)).toBe(host.getClassSymbol(outerNode));
+             const innerSymbol = host.getClassSymbol(innerNode) !;
+             const outerSymbol = host.getClassSymbol(outerNode) !;
+             expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
+             expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
            });
 
         it('should return undefined if node is not an ES5 class', () => {
@@ -1764,46 +1771,67 @@ exports.ExternalModule = ExternalModule;
 
           expect(classSymbol).toBeUndefined();
         });
+
+        it('should return undefined if variable declaration is not initialized using an IIFE',
+           () => {
+             const testFile = {
+               name: _('/test.js'),
+               contents: `var MyClass = null;`,
+             };
+             loadTestFiles([testFile]);
+             const {program, host: compilerHost} = makeTestBundleProgram(testFile.name);
+             const host =
+                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const node =
+                 getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+             const classSymbol = host.getClassSymbol(node);
+
+             expect(classSymbol).toBeUndefined();
+           });
       });
 
       describe('isClass()', () => {
-        let host: CommonJsReflectionHost;
-        let mockNode: ts.Node;
-        let getClassDeclarationSpy: jasmine.Spy;
-        let superGetClassDeclarationSpy: jasmine.Spy;
-
-        beforeEach(() => {
-          loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          mockNode = {} as any;
-
-          getClassDeclarationSpy = spyOn(CommonJsReflectionHost.prototype, 'getClassDeclaration');
-          superGetClassDeclarationSpy =
-              spyOn(Esm2015ReflectionHost.prototype, 'getClassDeclaration');
+        it('should return true if a given node is a TS class declaration', () => {
+          loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
+          const {program, host: compilerHost} =
+              makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const node = getDeclaration(
+              program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+          expect(host.isClass(node)).toBe(true);
         });
 
-        it('should return true if superclass returns true', () => {
-          superGetClassDeclarationSpy.and.returnValue(true);
-          getClassDeclarationSpy.and.callThrough();
+        it('should return true if a given node is the outer variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const node = getDeclaration(
+                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+             expect(host.isClass(node)).toBe(true);
+           });
 
-          expect(host.isClass(mockNode)).toBe(true);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-          expect(superGetClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-        });
+        it('should return true if a given node is the inner variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const outerNode = getDeclaration(
+                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+             const innerNode =
+                 getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+             expect(host.isClass(innerNode)).toBe(true);
+           });
 
-        it('should return true if it can find a declaration for the class', () => {
-          getClassDeclarationSpy.and.returnValue(true);
-
-          expect(host.isClass(mockNode)).toBe(true);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-        });
-
-        it('should return false if it cannot find a declaration for the class', () => {
-          getClassDeclarationSpy.and.returnValue(false);
-
-          expect(host.isClass(mockNode)).toBe(false);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
+        it('should return false if a given node is a function declaration', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const node =
+              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          expect(host.isClass(node)).toBe(false);
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1783,19 +1783,22 @@ runInEachFileSystem(() => {
           const classSymbol = host.getClassSymbol(node);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(node);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(node);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(node);
         });
 
         it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
           const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-          const node = getDeclaration(
+          const outerNode = getDeclaration(
               program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-          const classSymbol = host.getClassSymbol(node);
+          const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+          const classSymbol = host.getClassSymbol(outerNode);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(node);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
         });
 
         it('should return the class symbol for an ES5 class (inner function declaration)', () => {
@@ -1808,7 +1811,8 @@ runInEachFileSystem(() => {
           const classSymbol = host.getClassSymbol(innerNode);
 
           expect(classSymbol).toBeDefined();
-          expect(classSymbol !.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
+          expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
         });
 
         it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
@@ -1821,7 +1825,10 @@ runInEachFileSystem(() => {
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
 
-             expect(host.getClassSymbol(innerNode)).toBe(host.getClassSymbol(outerNode));
+             const innerSymbol = host.getClassSymbol(innerNode) !;
+             const outerSymbol = host.getClassSymbol(outerNode) !;
+             expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
+             expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
            });
 
         it('should return undefined if node is not an ES5 class', () => {
@@ -1834,46 +1841,64 @@ runInEachFileSystem(() => {
 
           expect(classSymbol).toBeUndefined();
         });
+
+        it('should return undefined if variable declaration is not initialized using an IIFE',
+           () => {
+             const testFile = {
+               name: _('/test.js'),
+               contents: `var MyClass = null;`,
+             };
+             loadTestFiles([testFile]);
+             const {program, host: compilerHost} = makeTestBundleProgram(testFile.name);
+             const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+             const node =
+                 getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+             const classSymbol = host.getClassSymbol(node);
+
+             expect(classSymbol).toBeUndefined();
+           });
       });
 
       describe('isClass()', () => {
-        let host: UmdReflectionHost;
-        let mockNode: ts.Node;
-        let getClassDeclarationSpy: jasmine.Spy;
-        let superGetClassDeclarationSpy: jasmine.Spy;
-
-        beforeEach(() => {
-          loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-          mockNode = {} as any;
-
-          getClassDeclarationSpy = spyOn(UmdReflectionHost.prototype, 'getClassDeclaration');
-          superGetClassDeclarationSpy =
-              spyOn(Esm2015ReflectionHost.prototype, 'getClassDeclaration');
+        it('should return true if a given node is a TS class declaration', () => {
+          loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
+          const {program, host: compilerHost} =
+              makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const node = getDeclaration(
+              program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+          expect(host.isClass(node)).toBe(true);
         });
 
-        it('should return true if superclass returns true', () => {
-          superGetClassDeclarationSpy.and.returnValue(true);
-          getClassDeclarationSpy.and.callThrough();
+        it('should return true if a given node is the outer variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+             const node = getDeclaration(
+                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+             expect(host.isClass(node)).toBe(true);
+           });
 
-          expect(host.isClass(mockNode)).toBe(true);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-          expect(superGetClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-        });
+        it('should return true if a given node is the inner variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+             const outerNode = getDeclaration(
+                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+             const innerNode =
+                 getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+             expect(host.isClass(innerNode)).toBe(true);
+           });
 
-        it('should return true if it can find a declaration for the class', () => {
-          getClassDeclarationSpy.and.returnValue(true);
-
-          expect(host.isClass(mockNode)).toBe(true);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
-        });
-
-        it('should return false if it cannot find a declaration for the class', () => {
-          getClassDeclarationSpy.and.returnValue(false);
-
-          expect(host.isClass(mockNode)).toBe(false);
-          expect(getClassDeclarationSpy).toHaveBeenCalledWith(mockNode);
+        it('should return false if a given node is a function declaration', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const node =
+              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          expect(host.isClass(node)).toBe(false);
         });
       });
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -71,12 +71,6 @@ export function isDecoratorIdentifier(exp: ts.Expression): exp is DecoratorIdent
 export type ClassDeclaration<T extends ts.Declaration = ts.Declaration> = T & {name: ts.Identifier};
 
 /**
- * The symbol corresponding to a "class" declaration. I.e. a `ts.Symbol` whose `valueDeclaration` is
- * a `ClassDeclaration`.
- */
-export type ClassSymbol = ts.Symbol & {valueDeclaration: ClassDeclaration};
-
-/**
  * An enumeration of possible kinds of class members.
  */
 export enum ClassMemberKind {


### PR DESCRIPTION
In ngcc's reflection hosts for compiled JS bundles, such as ESM2015,
special care needs to be taken for classes as there may be an outer
declaration (referred to as "declaration") and an inner declaration
(referred to as "implementation") for a given class. Therefore, there
will also be two `ts.Symbol`s bound per class, and ngcc needs to switch
between those declarations and symbols depending on where certain
information can be found.

Prior to this commit, the `NgccReflectionHost` interface had methods
`getClassSymbol` and `findClassSymbols` that would return a `ts.Symbol`.
These class symbols would be used to kick off compilation of components
using ngtsc, so it is important for these symbols to correspond with the
publicly visible outer declaration of the class. However, the ESM2015
reflection host used to return the `ts.Symbol` for the inner
declaration, if the class was declared as follows:

```javascript
var MyClass = class MyClass {};
```

For the above code, `Esm2015ReflectionHost.getClassSymbol` would return
the `ts.Symbol` corresponding with the `class MyClass {}` declaration,
whereas it should have corresponded with the `var MyClass` declaration.
As a consequence, no `NgModule` could be resolved for the component, so
no components/directives would be in scope for the component. This
resulted in errors during runtime.

This commit resolves the issue by introducing a `NgccClassSymbol` that
contains references to both the outer and inner `ts.Symbol`, instead of
just a single `ts.Symbol`. This avoids the unclarity of whether a
`ts.Symbol` corresponds with the outer or inner declaration.

More details can be found here: https://hackmd.io/7nkgWOFWQlSRAuIW_8KPPw

Fixes #32078
Closes FW-1507