### PR TITLE
fix(language-service): create StaticReflector once only

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -86,6 +86,22 @@ export class StaticReflector implements CompileReflector {
     return this.symbolResolver.getResourcePath(staticSymbol);
   }
 
+  /**
+   * Invalidate the specified `symbols` on program change.
+   * @param symbols
+   */
+  invalidateSymbols(symbols: StaticSymbol[]) {
+    for (const symbol of symbols) {
+      this.annotationCache.delete(symbol);
+      this.shallowAnnotationCache.delete(symbol);
+      this.propertyCache.delete(symbol);
+      this.parameterCache.delete(symbol);
+      this.methodCache.delete(symbol);
+      this.staticCache.delete(symbol);
+      this.conversionMap.delete(symbol);
+    }
+  }
+
   resolveExternalReference(ref: o.ExternalReference, containingFile?: string): StaticSymbol {
     let key: string|undefined = undefined;
     if (!containingFile) {

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
@@ -280,7 +280,7 @@ export class UndecoratedClassesTransform {
         return [{
           node,
           message: `Class cannot be migrated as the inherited metadata from ` +
-              `${identifier.getText()} cannot be converted into a decorator. Please manually 
+              `${identifier.getText()} cannot be converted into a decorator. Please manually
             decorate the class.`,
         }];
       }
@@ -431,7 +431,7 @@ export class UndecoratedClassesTransform {
     // future calls to "StaticReflector#annotations" are based on metadata files.
     this.symbolResolver['_resolveSymbolFromSummary'] = () => null;
     this.symbolResolver['resolvedSymbols'].clear();
-    this.symbolResolver['resolvedFilePaths'].clear();
+    this.symbolResolver['symbolFromFile'].clear();
     this.compiler.reflector['annotationCache'].clear();
 
     // Original summary resolver used by the AOT compiler.

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -51,22 +51,24 @@ describe('TypeScriptServiceHost', () => {
     expect(analyzedModules.files.length).toBe(0);
     expect(analyzedModules.ngModules.length).toBe(0);
     expect(analyzedModules.ngModuleByPipeOrDirective.size).toBe(0);
-    expect(analyzedModules.symbolsMissingModule).toBeUndefined();
+    expect(analyzedModules.symbolsMissingModule).toEqual([]);
   });
 
-  it('should clear the caches if program changes', () => {
+  it('should clear the caches if new script is added', () => {
     // First create a TypescriptHost with empty script names
     const tsLSHost = new MockTypescriptHost([]);
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
-    expect(ngLSHost.getAnalyzedModules().ngModules).toEqual([]);
+    const oldModules = ngLSHost.getAnalyzedModules();
+    expect(oldModules.ngModules).toEqual([]);
     // Now add a script, this would change the program
     const fileName = '/app/main.ts';
     const content = tsLSHost.readFile(fileName) !;
     tsLSHost.addScript(fileName, content);
     // If the caches are not cleared, we would get back an empty array.
     // But if the caches are cleared then the analyzed modules will be non-empty.
-    expect(ngLSHost.getAnalyzedModules().ngModules.length).not.toEqual(0);
+    const newModules = ngLSHost.getAnalyzedModules();
+    expect(newModules.ngModules.length).toBeGreaterThan(0);
   });
 
   it('should throw if getSourceFile is called on non-TS file', () => {


### PR DESCRIPTION
The creation of `StaticReflector` in `createMetadataResolver()` is a very expensive operation because it involves numerous module resolutions (on the order of hundreds) to initialize core Angular symbols.
Since the API of the Reflector does not provide the ability to invalidate its internal caches, `StaticReflector` has to be destroyed and recreated on *every* program change.
This has a HUGE impact on performance.
This PR fixes this problem by carefully invalidating all StaticSymbols in a file that has changed, thereby greatly reducing the overhead of recomputation on program change.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
