### PR TITLE
perf(ivy): run tree benchmark with bundles and ngDevMode off

### DIFF
--- a/modules/benchmarks/src/tree/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_rollup_bundle")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
 load("//modules/benchmarks:benchmark_test.bzl", "benchmark_test")
 
@@ -22,25 +22,28 @@ ng_module(
     ],
 )
 
+ng_rollup_bundle(
+    name = "bundle",
+    entry_point = ":index_aot.ts",
+    deps = [
+        ":ng2",
+        "@npm//rxjs",
+    ],
+)
+
 ts_devserver(
-    name = "devserver",
-    entry_module = "angular/modules/benchmarks/src/tree/ng2/index",
+    name = "prodserver",
     index_html = "index.html",
     port = 4200,
-    scripts = [
-        "@npm//:node_modules/tslib/tslib.js",
-        "//tools/rxjs:rxjs_umd_modules",
-    ],
     static_files = [
+        ":bundle.min_debug.es2015.js",
         "@npm//:node_modules/zone.js/dist/zone.js",
-        "@npm//:node_modules/reflect-metadata/Reflect.js",
     ],
-    deps = [":ng2"],
 )
 
 benchmark_test(
     name = "perf",
-    server = ":devserver",
+    server = ":prodserver",
     deps = [
         "//modules/benchmarks/src/tree:perf_detect_changes_lib",
         "//modules/benchmarks/src/tree:perf_lib",


### PR DESCRIPTION
Before this change the tree benchmark was running with the un-bundled version, without `ngDevMode` tree-shaken away. This was very slow setup for ngIvy as we were essentially running in the dev mode. 