### PR TITLE
perf(language-service): keep analyzedModules cache when source files don't change

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -275,12 +275,14 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
 
     // Invalidate file that have changed in the static symbol resolver
     const seen = new Set<string>();
+    let hasChanges = false;
     for (const sourceFile of program.getSourceFiles()) {
       const fileName = sourceFile.fileName;
       seen.add(fileName);
       const version = this.tsLsHost.getScriptVersion(fileName);
       const lastVersion = this.fileVersions.get(fileName);
       if (version !== lastVersion) {
+        hasChanges = true;
         this.fileVersions.set(fileName, version);
         this.staticSymbolResolver.invalidateFile(fileName);
       }
@@ -295,7 +297,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
 
     this.lastProgram = program;
 
-    return false;
+    return missing.length === 0 && !hasChanges;
   }
 
   /**

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -148,4 +148,14 @@ describe('TypeScriptServiceHost', () => {
     expect(newModules.ngModuleByPipeOrDirective.has(helloComp)).toBe(true);
     expect(newModules.ngModuleByPipeOrDirective.has(appComp)).toBe(false);
   });
+
+  it('should not clear caches when external template changes', () => {
+    const tsLSHost = new MockTypescriptHost(['/app/main.ts'], toh);
+    const tsLS = ts.createLanguageService(tsLSHost);
+    const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+    const oldModules = ngLSHost.getAnalyzedModules();
+    tsLSHost.override('/app/test.ng', '<div></div>');
+    const newModules = ngLSHost.getAnalyzedModules();
+    expect(newModules).toBe(oldModules);
+  });
 });


### PR DESCRIPTION
This change will improve performance of language service when working in external templates.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
