### PR TITLE
Perf set changing prop

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -839,17 +839,23 @@ export function generatePropertyAliases(
 
 /**
  * Mapping between attributes names that don't correspond to their element property names.
+ *
+ * Performance note: this function is written as a series of if checks (instead of, say, a property
+ * object lookup) for performance reasons - the series of `if` checks seems to be the fastest way of
+ * mapping property names. Do NOT change without benchmarking.
+ *
  * Note: this mapping has to be kept in sync with the equally named mapping in the template
  * type-checking machinery of ngtsc.
  */
-const ATTR_TO_PROP: {[name: string]: string} = {
-  'class': 'className',
-  'for': 'htmlFor',
-  'formaction': 'formAction',
-  'innerHtml': 'innerHTML',
-  'readonly': 'readOnly',
-  'tabindex': 'tabIndex',
-};
+function mapPropName(name: string): string {
+  if (name === 'class') return 'className';
+  if (name === 'for') return 'htmlFor';
+  if (name === 'formaction') return 'formAction';
+  if (name === 'innerHtml') return 'innerHTML';
+  if (name === 'readonly') return 'readOnly';
+  if (name === 'tabindex') return 'tabIndex';
+  return name;
+}
 
 export function elementPropertyInternal<T>(
     index: number, propName: string, value: T, sanitizer?: SanitizerFn | null, nativeOnly?: boolean,
@@ -882,7 +888,7 @@ export function elementPropertyInternal<T>(
       }
     }
   } else if (tNode.type === TNodeType.Element) {
-    propName = ATTR_TO_PROP[propName] || propName;
+    propName = mapPropName(propName);
 
     if (ngDevMode) {
       validateAgainstEventProperties(propName);

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -6,9 +6,6 @@
     "name": "ANIMATION_PROP_PREFIX"
   },
   {
-    "name": "ATTR_TO_PROP"
-  },
-  {
     "name": "BINDING_INDEX"
   },
   {
@@ -1084,6 +1081,9 @@
   },
   {
     "name": "makeParamDecorator"
+  },
+  {
+    "name": "mapPropName"
   },
   {
     "name": "markAsComponentHost"

--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -46,6 +46,14 @@ ng_rollup_bundle(
 )
 
 ng_rollup_bundle(
+    name = "property_binding_update",
+    entry_point = ":property_binding_update/index.ts",
+    deps = [
+        ":perf_lib",
+    ],
+)
+
+ng_rollup_bundle(
     name = "style_binding",
     entry_point = ":style_binding/index.ts",
     deps = [

--- a/packages/core/test/render3/perf/property_binding_update/index.ts
+++ b/packages/core/test/render3/perf/property_binding_update/index.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ɵɵadvance} from '../../../../src/render3/instructions/advance';
+import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
+import {ɵɵproperty} from '../../../../src/render3/instructions/property';
+import {refreshView} from '../../../../src/render3/instructions/shared';
+import {RenderFlags} from '../../../../src/render3/interfaces/definition';
+import {TVIEW} from '../../../../src/render3/interfaces/view';
+import {createBenchmark} from '../micro_bench';
+import {setupRootViewWithEmbeddedViews} from '../setup';
+
+`<div>
+    <button [title]="'title1'"></button>
+    <button [title]="'title2'"></button>
+    <button [title]="'title3'"></button>
+    <button [title]="'title4'"></button>
+    <button [title]="'title5'"></button>
+    <button [title]="'title6'"></button>
+    <button [title]="'title7'"></button>
+    <button [title]="'title8'"></button>
+    <button [title]="'title9'"></button>
+    <button [title]="'title10'"></button>
+  </div>
+</ng-template>`;
+function TestInterpolationComponent_ng_template_0_Template(rf: RenderFlags, ctx: {value: string}) {
+  if (rf & 1) {
+    ɵɵelementStart(0, 'div');
+    ɵɵelement(1, 'button');
+    ɵɵelement(2, 'button');
+    ɵɵelement(3, 'button');
+    ɵɵelement(4, 'button');
+    ɵɵelement(5, 'button');
+    ɵɵelement(6, 'button');
+    ɵɵelement(7, 'button');
+    ɵɵelement(8, 'button');
+    ɵɵelement(9, 'button');
+    ɵɵelement(10, 'button');
+    ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    ɵɵadvance(1);
+    ɵɵproperty('prop1', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop2', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop3', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop4', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop5', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop6', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop7', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop8', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop9', ctx.value);
+    ɵɵadvance(1);
+    ɵɵproperty('prop10', ctx.value);
+  }
+}
+
+const ctx = {
+  value: 'value'
+};
+
+const rootLView = setupRootViewWithEmbeddedViews(
+    TestInterpolationComponent_ng_template_0_Template, 11, 10, 1000, ctx);
+const rootTView = rootLView[TVIEW];
+
+
+// scenario to benchmark
+const propertyBindingBenchmark = createBenchmark('property binding', 2000, 20);
+const updateTime = propertyBindingBenchmark('update');
+
+// run change detection where each binding value changes
+console.profile('element property update');
+while (updateTime.run()) {
+  let i = 0;
+  while (updateTime()) {
+    ctx.value = `value${i++}`;
+    refreshView(rootLView, rootTView, null, ctx);
+  }
+}
+console.profileEnd();
+
+propertyBindingBenchmark.report();

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -23,8 +23,8 @@ export function createAndRenderLView(
 }
 
 export function setupRootViewWithEmbeddedViews(
-    templateFn: ComponentTemplate<any>| null, consts: number, vars: number,
-    noOfViews: number): LView {
+    templateFn: ComponentTemplate<any>| null, consts: number, vars: number, noOfViews: number,
+    embeddedViewContext: any = {}): LView {
   // Create a root view with a container
   const rootTView = createTView(-1, null, 1, 0, null, null, null, null);
   const tContainerNode = getOrCreateTNode(rootTView, null, 0, TNodeType.Container, null, null);
@@ -44,7 +44,7 @@ export function setupRootViewWithEmbeddedViews(
   // create embedded views and add them to the container
   for (let i = 0; i < noOfViews; i++) {
     const embeddedLView = createLView(
-        rootLView, embeddedTView, {}, LViewFlags.CheckAlways, null, viewTNode,
+        rootLView, embeddedTView, embeddedViewContext, LViewFlags.CheckAlways, null, viewTNode,
         new NoopRendererFactory(), new NoopRenderer());
     renderView(embeddedLView, embeddedTView, null);
     insertView(embeddedLView, lContainer, i);


### PR DESCRIPTION
This PR introduces a new benchmark that focuses on performance of property updates. It also contain a fix where by removing a megamorphic access we can speed up this new benchmark by ~30%. 

Review commit by commit and check individual commit message for more details.