### PR TITLE
ci: check code-ownership on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ jobs:
               (echo -e "\n.bzl files have lint errors. Please run ''yarn bazel:lint-fix''"; exit 1)'
 
       - run: yarn gulp lint
+      - run: node tools/verify-codeownership
 
   test:
     <<: *job_defaults

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -408,6 +408,7 @@
 # ================================================
 
 /packages/bazel/**                                              @angular/tools-bazel @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/bazel.md                                     @angular/tools-bazel @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
 
@@ -419,7 +420,9 @@
 /packages/compiler/**                                           @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/examples/compiler/**                                  @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/compiler-cli/**                                       @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/angular-compiler-options.md                  @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/aot-compiler.md                              @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/aot-metadata-errors.md                       @angular/fw-compiler @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
 
@@ -438,6 +441,7 @@
 # ================================================
 
 /packages/compiler-cli/src/ngtools/**                           @angular/tools-cli @angular/framework-global-approvers
+/aio/content/guide/cli-builder.md                               @angular/tools-cli @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/ivy.md                                       @angular/tools-cli @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/web-worker.md                                @angular/tools-cli @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
@@ -461,6 +465,10 @@
 /packages/platform-webworker/**                                 @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/platform-webworker-dynamic/**                         @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/examples/common/**                                    @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/packages/docs/**                                               @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+
+/aio/content/guide/accessibility.md                             @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/examples/accessibility/**                          @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 /aio/content/guide/architecture-components.md                   @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/architecture-modules.md                      @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
@@ -558,7 +566,6 @@
 /aio/content/examples/inputs-outputs/**                         @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/images/guide/inputs-outputs/**                     @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/examples/template-expression-operators/**          @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
-
 
 /aio/content/guide/pipes.md                                     @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/examples/pipes/**                                  @angular/fw-core @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
@@ -886,7 +893,7 @@ testing/**                                                      @angular/fw-test
 
 
 # ================================================
-#  Build & CI Owners
+#  Build, CI & Dev-infra Owners
 # ================================================
 
 /*                                                              @angular/dev-infra-framework
@@ -898,6 +905,7 @@ testing/**                                                      @angular/fw-test
 /docs/BAZEL.md                                                  @angular/dev-infra-framework
 /packages/*                                                     @angular/dev-infra-framework
 /packages/examples/test-utils/**                                @angular/dev-infra-framework
+/packages/private/**                                            @angular/dev-infra-framework
 /scripts/**                                                     @angular/dev-infra-framework
 /third_party/**                                                 @angular/dev-infra-framework
 /tools/build/**                                                 @angular/dev-infra-framework
@@ -937,6 +945,14 @@ testing/**                                                      @angular/fw-test
 /aio/content/guide/styleguide.md                                @angular/fw-public-api
 /aio/content/examples/styleguide/**                             @angular/fw-public-api
 /aio/content/images/guide/styleguide/**                         @angular/fw-public-api
+
+
+
+# ================================================
+#  Special cases
+# ================================================
+
+/aio/content/guide/static-query-migration.md                    @kara @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
 

--- a/aio/scripts/verify-codeownership.js
+++ b/aio/scripts/verify-codeownership.js
@@ -1,4 +1,25 @@
+#!/usr/bin/env node
 'use strict';
+
+/**
+ * **Usage:**
+ * ```
+ * node aio/scripts/verify-codeownership
+ * ```
+ *
+ * Verify whether there are directories in the codebase that don't have a codeowner (in `.github/CODEOWNERS`) and vice
+ * versa (that there are no patterns in `CODEOWNERS` that do not correspond to actual directories).
+ *
+ * The script does not aim to be exhaustive and highly accurate, checking all files and directories (since that would be
+ * too complicated). Instead, it does a coarse check on some important (or frequently changing) directories.
+ *
+ * Currently, it checks the following:
+ * - **Packages**: Top-level directories in `packages/`.
+ * - **API docs examples**: Top-level directories in `packages/examples/`.
+ * - **Guides**: Top-level files in `aio/content/guide/`.
+ * - **Guide images**: Top-level directories in `aio/content/images/guide/`.
+ * - **Guide examples**: Top-level directories in `aio/content/examples/`.
+ */
 
 // Imports
 const fs = require('fs');
@@ -7,44 +28,53 @@ const path = require('path');
 // Constants
 const PROJECT_ROOT_DIR = path.resolve(__dirname, '../..');
 const CODEOWNERS_PATH = path.resolve(PROJECT_ROOT_DIR, '.github/CODEOWNERS');
-const PKG_EXAMPLES_DIR = path.resolve(PROJECT_ROOT_DIR, 'packages/examples');
+const PKG_DIR = path.resolve(PROJECT_ROOT_DIR, 'packages');
+const PKG_EXAMPLES_DIR = path.resolve(PKG_DIR, 'examples');
 const AIO_CONTENT_DIR = path.resolve(PROJECT_ROOT_DIR, 'aio/content');
 const AIO_GUIDES_DIR = path.resolve(AIO_CONTENT_DIR, 'guide');
 const AIO_GUIDE_IMAGES_DIR = path.resolve(AIO_CONTENT_DIR, 'images/guide');
 const AIO_GUIDE_EXAMPLES_DIR = path.resolve(AIO_CONTENT_DIR, 'examples');
+const IGNORED_PKG_DIRS = new Set([
+  // Examples are checked separately.
+  'examples',
+]);
 
 // Run
 _main();
 
 // Functions - Definitions
 function _main() {
-  const {examples: pkgExamplePaths} = getPathsFromPkgExamples();
+  const {packages: pkgPackagePaths, examples: pkgExamplePaths} = getPathsFromPkg();
   const {guides: aioGuidePaths, images: aioGuideImagesPaths, examples: aioExamplePaths} = getPathsFromAioContent();
   const {
+    pkgPackages: coPkgPackagePaths,
+    pkgExamples: coPkgExamplePaths,
     aioGuides: coAioGuidePaths,
     aioImages: coAioGuideImagesPaths,
     aioExamples: coAioExamplePaths,
-    pkgExamples: coPkgExamplePaths,
   } = getPathsFromCodeowners();
 
+  const pkgPackagesDiff = arrayDiff(pkgPackagePaths, coPkgPackagePaths);
+  const pkgExamplesDiff = arrayDiff(pkgExamplePaths, coPkgExamplePaths);
   const aioGuidesDiff = arrayDiff(aioGuidePaths, coAioGuidePaths);
   const aioImagesDiff = arrayDiff(aioGuideImagesPaths, coAioGuideImagesPaths);
   const aioExamplesDiff = arrayDiff(aioExamplePaths, coAioExamplePaths);
-  const pkgExamplesDiff = arrayDiff(pkgExamplePaths, coPkgExamplePaths);
-  const hasDiff = (aioGuidesDiff.diffCount > 0) || (aioImagesDiff.diffCount> 0) || (aioExamplesDiff.diffCount > 0) ||
-                  (pkgExamplesDiff.diffCount > 0);
+  const hasDiff = (pkgPackagesDiff.diffCount > 0) || (pkgExamplesDiff.diffCount > 0) ||
+                  (aioGuidesDiff.diffCount > 0) || (aioImagesDiff.diffCount> 0) || (aioExamplesDiff.diffCount > 0);
 
   if (hasDiff) {
+    const expectedPkgPackagesSrc = path.relative(PROJECT_ROOT_DIR, PKG_DIR);
+    const expectedPkgExamplesSrc = path.relative(PROJECT_ROOT_DIR, PKG_EXAMPLES_DIR);
     const expectedAioGuidesSrc = path.relative(PROJECT_ROOT_DIR, AIO_GUIDES_DIR);
     const expectedAioImagesSrc = path.relative(PROJECT_ROOT_DIR, AIO_GUIDE_IMAGES_DIR);
     const expectedAioExamplesSrc = path.relative(PROJECT_ROOT_DIR, AIO_GUIDE_EXAMPLES_DIR);
-    const expectedPkgExamplesSrc = path.relative(PROJECT_ROOT_DIR, PKG_EXAMPLES_DIR);
     const actualSrc = path.relative(PROJECT_ROOT_DIR, CODEOWNERS_PATH);
 
+    reportDiff(pkgPackagesDiff, expectedPkgPackagesSrc, actualSrc);
+    reportDiff(pkgExamplesDiff, expectedPkgExamplesSrc, actualSrc);
     reportDiff(aioGuidesDiff, expectedAioGuidesSrc, actualSrc);
     reportDiff(aioImagesDiff, expectedAioImagesSrc, actualSrc);
     reportDiff(aioExamplesDiff, expectedAioExamplesSrc, actualSrc);
-    reportDiff(pkgExamplesDiff, expectedPkgExamplesSrc, actualSrc);
   }
 
   process.exit(hasDiff ? 1 : 0);
@@ -57,6 +87,11 @@ function arrayDiff(expected, actual) {
   return {missing, extra, diffCount: missing.length + extra.length};
 }
 
+function findDirectories(parentDir) {
+  return fs.readdirSync(parentDir).
+    filter(name => fs.statSync(`${parentDir}/${name}`).isDirectory());
+}
+
 function getPathsFromAioContent() {
   return {
     guides: fs.readdirSync(AIO_GUIDES_DIR),
@@ -67,20 +102,22 @@ function getPathsFromAioContent() {
 }
 
 function getPathsFromCodeowners() {
+  const pkgPackagesPathRe = /^\/packages\/([^\s\*/]+)\/\*?\*\s/;
+  const pkgExamplesPathRe = /^\/packages\/examples\/([^\s\*/]+)/;
   // Use capturing groups for `images/` and `examples` to be able to differentiate between the
   // different kinds of matches (guide, image, example) later (see `isImage`/`isExample` below).
-  const aioGuidesOrImagesPathRe = /^\/aio\/content\/(?:(images\/)?guide|(examples))\/([^\s\*/]+)/;
-  const pkgExamplesPathRe = /^\/packages\/examples\/([^\s\*/]+)/;
+  const aioGuidesImagesExamplesPathRe = /^\/aio\/content\/(?:(images\/)?guide|(examples))\/([^\s\*/]+)/;
   const manualGlobExpansions = {
     // `CODEOWNERS` has a glob to match all `testing/` directories, so no specific glob for
     // `packages/examples/testing/` is necessary.
     'testing/**': ['/packages/examples/testing/**'],
   };
 
+  const pkgPackages = [];
+  const pkgExamples = [];
   const aioGuides = [];
   const aioImages = [];
   const aioExamples = [];
-  const pkgExamples = [];
 
   // Read `CODEOWNERS` and split into lines.
   const lines = fs.
@@ -96,9 +133,21 @@ function getPathsFromCodeowners() {
     }
   }
 
+  // Collect packages (`packages/`).
+  lines.
+    map(l => l.match(pkgPackagesPathRe)).
+    filter(m => m).
+    forEach(([, path]) => pkgPackages.push(path));
+
+  // Collect API docs examples (`packages/examples/`).
+  lines.
+    map(l => l.match(pkgExamplesPathRe)).
+    filter(m => m).
+    forEach(([, path]) => pkgExamples.push(path));
+
   // Collect `aio/` guides/images/examples.
   lines.
-    map(l => l.match(aioGuidesOrImagesPathRe)).
+    map(l => l.match(aioGuidesImagesExamplesPathRe)).
     filter(m => m).
     forEach(([, isImage, isExample, path]) => {
       const list = isExample ? aioExamples :
@@ -107,19 +156,13 @@ function getPathsFromCodeowners() {
       list.push(path);
     });
 
-  // Collect API docs examples (`packages/examples/`).
-  lines.
-    map(l => l.match(pkgExamplesPathRe)).
-    filter(m => m).
-    forEach(([, path]) => pkgExamples.push(path));
-
-  return {aioGuides, aioImages, aioExamples, pkgExamples};
+  return {pkgPackages, pkgExamples, aioGuides, aioImages, aioExamples};
 }
 
-function getPathsFromPkgExamples() {
+function getPathsFromPkg() {
   return {
-    examples: fs.readdirSync(PKG_EXAMPLES_DIR).
-      filter(name => fs.statSync(`${PKG_EXAMPLES_DIR}/${name}`).isDirectory()),
+    packages: findDirectories(PKG_DIR).filter(name => !IGNORED_PKG_DIRS.has(name)),
+    examples: findDirectories(PKG_EXAMPLES_DIR),
   };
 }
 

--- a/tools/verify-codeownership.js
+++ b/tools/verify-codeownership.js
@@ -91,7 +91,11 @@ function _main() {
     reportDiff(aioExamplesDiff, expectedAioExamplesSrc, actualSrc);
 
     // tslint:disable-next-line: no-console
-    console.log(chalk.red('\nCode-ownership verification failed.'));
+    console.log(chalk.red(
+      '\nCode-ownership verification failed.\n' +
+      'Please update \'.github/CODEOWNERS\' to ensure that all necessary files/directories have ' +
+      'code-owners and all patterns that appear in the file correspond to actual ' +
+      'files/directories in the repo.'));
   } else {
     // tslint:disable-next-line: no-console
     console.log(chalk.green('\nCode-ownership verification succeeded!'));

--- a/tools/verify-codeownership.js
+++ b/tools/verify-codeownership.js
@@ -30,6 +30,7 @@
 'use strict';
 
 // Imports
+const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 
@@ -46,10 +47,6 @@ const IGNORED_PKG_DIRS = new Set([
   // Examples are checked separately.
   'examples',
 ]);
-
-// Helpers
-const green = input => `\u001b[32m${input}\u001b[39m`;
-const red = input => `\u001b[31m${input}\u001b[39m`;
 
 // Run
 _main();
@@ -94,10 +91,10 @@ function _main() {
     reportDiff(aioExamplesDiff, expectedAioExamplesSrc, actualSrc);
 
     // tslint:disable-next-line: no-console
-    console.log(red('\nCode-ownership verification failed.'));
+    console.log(chalk.red('\nCode-ownership verification failed.'));
   } else {
     // tslint:disable-next-line: no-console
-    console.log(green('\nCode-ownership verification succeeded!'));
+    console.log(chalk.green('\nCode-ownership verification succeeded!'));
   }
 
   process.exit(hasDiff ? 1 : 0);

--- a/tools/verify-codeownership.js
+++ b/tools/verify-codeownership.js
@@ -92,10 +92,10 @@ function _main() {
 
     // tslint:disable-next-line: no-console
     console.log(chalk.red(
-      '\nCode-ownership verification failed.\n' +
-      'Please update \'.github/CODEOWNERS\' to ensure that all necessary files/directories have ' +
-      'code-owners and all patterns that appear in the file correspond to actual ' +
-      'files/directories in the repo.'));
+        '\nCode-ownership verification failed.\n' +
+        'Please update \'.github/CODEOWNERS\' to ensure that all necessary files/directories ' +
+        'have code-owners and all patterns that appear in the file correspond to actual ' +
+        'files/directories in the repo.'));
   } else {
     // tslint:disable-next-line: no-console
     console.log(chalk.green('\nCode-ownership verification succeeded!'));

--- a/tools/verify-codeownership.js
+++ b/tools/verify-codeownership.js
@@ -1,17 +1,24 @@
-#!/usr/bin/env node
-'use strict';
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 
 /**
  * **Usage:**
  * ```
- * node aio/scripts/verify-codeownership
+ * node tools/verify-codeownership
  * ```
  *
- * Verify whether there are directories in the codebase that don't have a codeowner (in `.github/CODEOWNERS`) and vice
- * versa (that there are no patterns in `CODEOWNERS` that do not correspond to actual directories).
+ * Verify whether there are directories in the codebase that don't have a codeowner (in
+ * `.github/CODEOWNERS`) and vice versa (that there are no patterns in `CODEOWNERS` that do not
+ * correspond to actual directories).
  *
- * The script does not aim to be exhaustive and highly accurate, checking all files and directories (since that would be
- * too complicated). Instead, it does a coarse check on some important (or frequently changing) directories.
+ * The script does not aim to be exhaustive and highly accurate, checking all files and directories
+ * (since that would be too complicated). Instead, it does a coarse check on some important (or
+ * frequently changing) directories.
  *
  * Currently, it checks the following:
  * - **Packages**: Top-level directories in `packages/`.
@@ -20,13 +27,14 @@
  * - **Guide images**: Top-level directories in `aio/content/images/guide/`.
  * - **Guide examples**: Top-level directories in `aio/content/examples/`.
  */
+'use strict';
 
 // Imports
 const fs = require('fs');
 const path = require('path');
 
 // Constants
-const PROJECT_ROOT_DIR = path.resolve(__dirname, '../..');
+const PROJECT_ROOT_DIR = path.resolve(__dirname, '..');
 const CODEOWNERS_PATH = path.resolve(PROJECT_ROOT_DIR, '.github/CODEOWNERS');
 const PKG_DIR = path.resolve(PROJECT_ROOT_DIR, 'packages');
 const PKG_EXAMPLES_DIR = path.resolve(PKG_DIR, 'examples');
@@ -39,13 +47,21 @@ const IGNORED_PKG_DIRS = new Set([
   'examples',
 ]);
 
+// Helpers
+const green = input => `\u001b[32m${input}\u001b[39m`;
+const red = input => `\u001b[31m${input}\u001b[39m`;
+
 // Run
 _main();
 
 // Functions - Definitions
 function _main() {
   const {packages: pkgPackagePaths, examples: pkgExamplePaths} = getPathsFromPkg();
-  const {guides: aioGuidePaths, images: aioGuideImagesPaths, examples: aioExamplePaths} = getPathsFromAioContent();
+  const {
+    guides: aioGuidePaths,
+    images: aioGuideImagesPaths,
+    examples: aioExamplePaths,
+  } = getPathsFromAioContent();
   const {
     pkgPackages: coPkgPackagePaths,
     pkgExamples: coPkgExamplePaths,
@@ -60,7 +76,8 @@ function _main() {
   const aioImagesDiff = arrayDiff(aioGuideImagesPaths, coAioGuideImagesPaths);
   const aioExamplesDiff = arrayDiff(aioExamplePaths, coAioExamplePaths);
   const hasDiff = (pkgPackagesDiff.diffCount > 0) || (pkgExamplesDiff.diffCount > 0) ||
-                  (aioGuidesDiff.diffCount > 0) || (aioImagesDiff.diffCount> 0) || (aioExamplesDiff.diffCount > 0);
+      (aioGuidesDiff.diffCount > 0) || (aioImagesDiff.diffCount > 0) ||
+      (aioExamplesDiff.diffCount > 0);
 
   if (hasDiff) {
     const expectedPkgPackagesSrc = path.relative(PROJECT_ROOT_DIR, PKG_DIR);
@@ -75,6 +92,12 @@ function _main() {
     reportDiff(aioGuidesDiff, expectedAioGuidesSrc, actualSrc);
     reportDiff(aioImagesDiff, expectedAioImagesSrc, actualSrc);
     reportDiff(aioExamplesDiff, expectedAioExamplesSrc, actualSrc);
+
+    // tslint:disable-next-line: no-console
+    console.log(red('\nCode-ownership verification failed.'));
+  } else {
+    // tslint:disable-next-line: no-console
+    console.log(green('\nCode-ownership verification succeeded!'));
   }
 
   process.exit(hasDiff ? 1 : 0);
@@ -88,16 +111,16 @@ function arrayDiff(expected, actual) {
 }
 
 function findDirectories(parentDir) {
-  return fs.readdirSync(parentDir).
-    filter(name => fs.statSync(`${parentDir}/${name}`).isDirectory());
+  return fs.readdirSync(parentDir).filter(
+      name => fs.statSync(`${parentDir}/${name}`).isDirectory());
 }
 
 function getPathsFromAioContent() {
   return {
     guides: fs.readdirSync(AIO_GUIDES_DIR),
     images: fs.readdirSync(AIO_GUIDE_IMAGES_DIR),
-    examples: fs.readdirSync(AIO_GUIDE_EXAMPLES_DIR).
-      filter(name => fs.statSync(`${AIO_GUIDE_EXAMPLES_DIR}/${name}`).isDirectory()),
+    examples: fs.readdirSync(AIO_GUIDE_EXAMPLES_DIR)
+                  .filter(name => fs.statSync(`${AIO_GUIDE_EXAMPLES_DIR}/${name}`).isDirectory()),
   };
 }
 
@@ -106,7 +129,8 @@ function getPathsFromCodeowners() {
   const pkgExamplesPathRe = /^\/packages\/examples\/([^\s\*/]+)/;
   // Use capturing groups for `images/` and `examples` to be able to differentiate between the
   // different kinds of matches (guide, image, example) later (see `isImage`/`isExample` below).
-  const aioGuidesImagesExamplesPathRe = /^\/aio\/content\/(?:(images\/)?guide|(examples))\/([^\s\*/]+)/;
+  const aioGuidesImagesExamplesPathRe =
+      /^\/aio\/content\/(?:(images\/)?guide|(examples))\/([^\s\*/]+)/;
   const manualGlobExpansions = {
     // `CODEOWNERS` has a glob to match all `testing/` directories, so no specific glob for
     // `packages/examples/testing/` is necessary.
@@ -120,10 +144,7 @@ function getPathsFromCodeowners() {
   const aioExamples = [];
 
   // Read `CODEOWNERS` and split into lines.
-  const lines = fs.
-    readFileSync(CODEOWNERS_PATH, 'utf8').
-    split('\n').
-    map(l => l.trim());
+  const lines = fs.readFileSync(CODEOWNERS_PATH, 'utf8').split('\n').map(l => l.trim());
 
   // Manually expand globs to known matching patterns.
   for (const [glob, expansions] of Object.entries(manualGlobExpansions)) {
@@ -134,27 +155,22 @@ function getPathsFromCodeowners() {
   }
 
   // Collect packages (`packages/`).
-  lines.
-    map(l => l.match(pkgPackagesPathRe)).
-    filter(m => m).
-    forEach(([, path]) => pkgPackages.push(path));
+  lines.map(l => l.match(pkgPackagesPathRe)).filter(m => m).forEach(([
+                                                                      , path
+                                                                    ]) => pkgPackages.push(path));
 
   // Collect API docs examples (`packages/examples/`).
-  lines.
-    map(l => l.match(pkgExamplesPathRe)).
-    filter(m => m).
-    forEach(([, path]) => pkgExamples.push(path));
+  lines.map(l => l.match(pkgExamplesPathRe)).filter(m => m).forEach(([
+                                                                      , path
+                                                                    ]) => pkgExamples.push(path));
 
   // Collect `aio/` guides/images/examples.
-  lines.
-    map(l => l.match(aioGuidesImagesExamplesPathRe)).
-    filter(m => m).
-    forEach(([, isImage, isExample, path]) => {
-      const list = isExample ? aioExamples :
-                   isImage   ? aioImages :
-                               aioGuides;
-      list.push(path);
-    });
+  lines.map(l => l.match(aioGuidesImagesExamplesPathRe))
+      .filter(m => m)
+      .forEach(([, isImage, isExample, path]) => {
+        const list = isExample ? aioExamples : isImage ? aioImages : aioGuides;
+        list.push(path);
+      });
 
   return {pkgPackages, pkgExamples, aioGuides, aioImages, aioExamples};
 }


### PR DESCRIPTION
This PR adds support for checking code-ownership (for some important/frequently changing directories) on CI with the purpose of preventing overloading @IgorMinar (who is the "fall-back" code-owner and will get review requests for all code that is not explicitly assigned an different owner).

See individual commits for details.