### PR TITLE
feat(common): make `HttpParameterCodec` injectable

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1,11 +1,13 @@
 export declare const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
 
+export declare const HTTP_PARAMETER_CODEC: InjectionToken<HttpParameterCodec>;
+
 export declare abstract class HttpBackend implements HttpHandler {
     abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
 export declare class HttpClient {
-    constructor(handler: HttpHandler);
+    constructor(handler: HttpHandler, httpParamCodec?: HttpParameterCodec | undefined);
     delete(url: string, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -34,7 +34,7 @@ export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInterceptingHandler as ɵHttpInterceptingHandler} from './src/module';
-export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
+export {HTTP_PARAMETER_CODEC, HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {HttpXhrBackend} from './src/xhr';

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -6,16 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Inject, Injectable, Optional} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions} from './params';
+import {HTTP_PARAMETER_CODEC, HttpParameterCodec, HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
+
 
 
 /**
@@ -109,7 +110,9 @@ function addBody<T>(
  */
 @Injectable()
 export class HttpClient {
-  constructor(private handler: HttpHandler) {}
+  constructor(
+      private handler: HttpHandler,
+      @Optional() @Inject(HTTP_PARAMETER_CODEC) private httpParamCodec?: HttpParameterCodec) {}
 
   /**
    * Sends an `HttpRequest` and returns a stream of `HttpEvent`s.
@@ -519,7 +522,11 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({fromObject: options.params} as HttpParamsOptions);
+          const paramOptions: HttpParamsOptions = {fromObject: options.params};
+          if (!!this.httpParamCodec) {
+            paramOptions.encoder = this.httpParamCodec;
+          }
+          params = new HttpParams(paramOptions);
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -5,6 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {InjectionToken} from '@angular/core';
+
 
 /**
  * A codec for encoding and decoding parameters in URLs.
@@ -20,6 +22,14 @@ export interface HttpParameterCodec {
   decodeKey(key: string): string;
   decodeValue(value: string): string;
 }
+
+/**
+ * @description
+ * Provide this token to change entire app's parameter encoding
+ *
+ * @publicApi
+ */
+export const HTTP_PARAMETER_CODEC = new InjectionToken<HttpParameterCodec>('HttpParameterCodec');
 
 /**
  * Provides encoding and decoding of URL parameter and query-string values.


### PR DESCRIPTION
You can inject custom `HttpParameterCodec` to not use default parameter encoder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Specific API server can't accept character. '+' so we need to encode that.

https://github.com/angular/angular/blob/5298b2bda34a8766b28c8425e447f94598b23901/packages/common/http/src/params.ts#L64

But angular's standard encoder decode that.

So developer needs to add custom encoder every http method invokes. and it's very annoying.

Related Issue Numbers: #19710, #23157 #18261, #18719, #11058

## What is the new behavior?

User can provide default custom http parameter codec.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
