### PR TITLE
ci: pin docker images by ID for hermeticity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,14 @@
 # needed for jobs that run tests without Bazel. Bazel runs tests with browsers that will be
 # fetched by the Webtesting rules. Therefore for jobs that run tests with Bazel, we don't need a
 # docker image with browsers pre-installed.
-# **NOTE 1**: If you change the version of the `*-browsers` docker image, make sure the
+# **NOTE 1**: Pin to exact images using an ID (SHA). See https://circleci.com/docs/2.0/circleci-images/#using-a-docker-image-id-to-pin-an-image-to-a-fixed-version.
+#             (Using the tag in not necessary when pinning by ID, but include it anyway for documentation purposes.)
+# **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
+# **NOTE 3**: If you change the version of the `*-browsers` docker image, make sure the
 #             `CI_CHROMEDRIVER_VERSION_ARG` env var (in `.circleci/env.sh`) points to a ChromeDriver
 #             version that is compatible with the Chrome version in the image.
-# **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
-var_1: &default_docker_image circleci/node:10.16
-var_2: &browsers_docker_image circleci/node:10.16-browsers
+var_1: &default_docker_image circleci/node:10.16@sha256:75c05084fff4afa3683a03c5a04a4a3ad95c536ff2439d8fe14e7e1f5c58b09a
+var_2: &browsers_docker_image circleci/node:10.16-browsers@sha256:d2a96fe1cbef51257ee626b5f645e64dade3e886f00ba9cb7e8ea65b4efe8db1
 # We don't want to include the current branch name in the cache key because that would prevent
 # PRs from being able to restore the cache since the branch names are always different for PRs.
 # The cache key should only consist of dynamic values that change whenever something in the


### PR DESCRIPTION
Previously, the docker images used on CI where specified by a tag (`10.16` and `10.16-browsers`). Since tags are not immutable, this only pins specific characteristics of the environment (e.g. the OS type and the Node.js version), but not others. Especially when using a tag that does not specify the patch version (e.g. `10.16` instead of `10.16.0`), it is inevitable that the image will change at some point, potentially leading to unrelated failures due to changes in the environment.

One source of such failures can be the Chrome version used in tests. Since we install a specific ChromeDriver version (that is only compatible with specific Chrome version ranges), unexpectedly updating to a newer Chrome version may break the tests if the new version falls outside the range of supported version for our pinned ChromeDriver.

Using a tag that specifies the patch version (e.g. `10.16.0`) or even the OS version (e.g. `10.16.0-buster`) is safer (i.e. has a lower probability of introducing the kind of breakages described above), but is still not fully hermetic.

This commit prevents such breakages by pinning the docker images by ID. Image IDs are based on the image's digest (SHA256) and are thus immutable, ensuring that all CI jobs will be running on the exact same image.

See [here][1] for more info on pre-built CircleCI docker images and more specifically [pinning images by ID][2].

[1]: https://circleci.com/docs/2.0/circleci-images
[2]: https://circleci.com/docs/2.0/circleci-images#using-a-docker-image-id-to-pin-an-image-to-a-fixed-version