### PR TITLE
perf(ivy): initialise TNode inputs / outputs on the first creation pass

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -23,7 +23,7 @@ import {getInitialStylingValue, hasClassInput, hasStyleInput} from '../styling_n
 import {setUpAttributes} from '../util/attrs_utils';
 import {getNativeByTNode, getTNode} from '../util/view_utils';
 
-import {createDirectivesInstances, elementCreate, executeContentQueries, getOrCreateTNode, initializeTNodeInputs, renderInitialStyling, resolveDirectives, saveResolvedLocalsInData, setInputsForProperty} from './shared';
+import {createDirectivesInstances, elementCreate, executeContentQueries, getOrCreateTNode, renderInitialStyling, resolveDirectives, saveResolvedLocalsInData, setInputsForProperty} from './shared';
 
 
 
@@ -84,13 +84,14 @@ export function ɵɵelementStart(
     ngDevMode && ngDevMode.firstTemplatePass++;
     resolveDirectives(tView, lView, tNode, localRefs || null);
 
-    const inputData = initializeTNodeInputs(tView, tNode);
-    if (inputData && inputData.hasOwnProperty('class')) {
-      tNode.flags |= TNodeFlags.hasClassInput;
-    }
-
-    if (inputData && inputData.hasOwnProperty('style')) {
-      tNode.flags |= TNodeFlags.hasStyleInput;
+    const inputData = tNode.inputs;
+    if (inputData != null) {
+      if (inputData.hasOwnProperty('class')) {
+        tNode.flags |= TNodeFlags.hasClassInput;
+      }
+      if (inputData.hasOwnProperty('style')) {
+        tNode.flags |= TNodeFlags.hasStyleInput;
+      }
     }
 
     if (tView.queries !== null) {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -423,7 +423,7 @@
     "name": "initNodeFlags"
   },
   {
-    "name": "initializeTNodeInputs"
+    "name": "initializeInputAndOutputAliases"
   },
   {
     "name": "insertBloom"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -936,7 +936,7 @@
     "name": "initNodeFlags"
   },
   {
-    "name": "initializeTNodeInputs"
+    "name": "initializeInputAndOutputAliases"
   },
   {
     "name": "injectElementRef"


### PR DESCRIPTION
This perf-focused refactoring moves the TNode's input / output initialization
logic to the first template pass - close to the place where directives are
matched and resolved.

This code change makes it possible to update-mode checks for both property
bindings and listeners registration.
