### PR TITLE
feat(bazel): support ts_library targets as entry-points for ng_package

### DIFF
--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -33,6 +33,11 @@ load("//packages/bazel/src:external.bzl", "FLAT_DTS_FILE_SUFFIX")
 load("//packages/bazel/src:esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "flatten_esm5")
 load("//packages/bazel/src/ng_package:collect-type-definitions.bzl", "collect_type_definitions")
 
+# Prints a debug message if "--define=VERBOSE_LOGS=true" is specified.
+def _debug(vars, *args):
+    if "VERBOSE_LOGS" in vars.keys():
+        print("[ng_package.bzl]", *args)
+
 _DEFAULT_NG_PACKAGER = "@npm//@angular/bazel/bin:packager"
 
 # Convert from some-dash-case to someCamelCase
@@ -254,6 +259,11 @@ def _ng_package_impl(ctx):
             typings_path = ng_module_metadata.typings_file.path
             metadata_file = ng_module_metadata.metadata_file
             guessed_paths = False
+            _debug(
+                ctx.var,
+                "entry-point %s is built using a flat module bundle." % dep,
+                "using %s as main file of the entry-point" % index_file,
+            )
         else:
             # In case the dependency is built through the "ts_library" rule, or the "ng_module"
             # rule does not generate a flat module bundle, we determine the index file and
@@ -273,6 +283,11 @@ def _ng_package_impl(ctx):
             typings_path = "%s/index.d.ts" % output_dir
             metadata_file = None
             guessed_paths = True
+            _debug(
+                ctx.var,
+                "entry-point %s does not have flat module metadata." % dep,
+                "guessing %s as main file of the entry-point" % index_file,
+            )
 
         # Store the collected entry point in a list of all entry-points. This
         # can be later passed to the packager as a manifest.

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -98,7 +98,7 @@ WELL_KNOWN_GLOBALS = {p: _global_name(p) for p in [
 # TODO(gregmagolan): clean this up
 _DEPSET_TYPE = "depset"
 
-def _rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output, format = "es", package_name = "", include_tslib = False):
+def _rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output, format = "es", module_name = "", include_tslib = False):
     map_output = ctx.actions.declare_file(js_output.basename + ".map", sibling = js_output)
 
     args = ctx.actions.args()
@@ -107,9 +107,9 @@ def _rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output, for
     args.add("--input", entry_point)
     args.add("--output.file", js_output)
     args.add("--output.format", format)
-    if package_name:
-        args.add("--output.name", _global_name(package_name))
-        args.add("--amd.id", package_name)
+    if module_name:
+        args.add("--output.name", _global_name(module_name))
+        args.add("--amd.id", module_name)
 
     # After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
     # which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.
@@ -228,22 +228,60 @@ def _ng_package_impl(ctx):
     # - ng_module rules in the deps (they have an "angular" provider)
     # - in this package or a subpackage
     # - those that have a module_name attribute (they produce flat module metadata)
-    flat_module_metadata = []
+    collected_entry_points = []
 
-    # Name given in the package.json name field, eg. @angular/core/testing
-    package_name = ""
     deps_in_package = [d for d in ctx.attr.deps if d.label.package.startswith(ctx.label.package)]
     for dep in deps_in_package:
+        # Module name of the current entry-point. eg. @angular/core/testing
+        module_name = ""
+
         # Intentionally evaluates to empty string for the main entry point
         entry_point = dep.label.package[len(ctx.label.package) + 1:]
+
+        # Extract the "module_name" from either "ts_library" or "ng_module". Both
+        # set the "module_name" in the provider struct.
         if hasattr(dep, "module_name"):
-            package_name = dep.module_name
+            module_name = dep.module_name
+
         if hasattr(dep, "angular") and hasattr(dep.angular, "flat_module_metadata"):
-            flat_module_metadata.append(dep.angular.flat_module_metadata)
-            flat_module_out_file = dep.angular.flat_module_metadata.flat_module_out_file + ".js"
+            # For dependencies which are built using the "ng_module" with flat module bundles
+            # enabled, we determine the module name, the flat module index file, the metadata
+            # file and the typings entry point from the flat module metadata which is set by
+            # the "ng_module" rule.
+            ng_module_metadata = dep.angular.flat_module_metadata
+            module_name = ng_module_metadata.module_name
+            index_file = ng_module_metadata.flat_module_out_file + ".js"
+            typings_path = ng_module_metadata.typings_file.path
+            metadata_file = ng_module_metadata.metadata_file
+            guessed_paths = False
         else:
+            # In case the dependency is built through the "ts_library" rule, or the "ng_module"
+            # rule does not generate a flat module bundle, we determine the index file and
+            # typings entry-point through the most reasonable defaults (i.e. "package/index").
+            output_dir = "/".join([
+                p
+                for p in [
+                    ctx.bin_dir.path,
+                    ctx.label.package,
+                    entry_point,
+                ]
+                if p
+            ])
+
             # fallback to a reasonable default
-            flat_module_out_file = "index.js"
+            index_file = "index.js"
+            typings_path = "%s/index.d.ts" % output_dir
+            metadata_file = None
+            guessed_paths = True
+
+        # Store the collected entry point in a list of all entry-points. This
+        # can be later passed to the packager as a manifest.
+        collected_entry_points.append(struct(
+            module_name = module_name,
+            typings_path = typings_path,
+            metadata_file = metadata_file,
+            guessed_paths = guessed_paths,
+        ))
 
         if hasattr(dep, "dts_bundles"):
             bundled_type_definitions += dep.dts_bundles
@@ -258,8 +296,8 @@ def _ng_package_impl(ctx):
             ).to_list()
 
         if len(type_definitions) > 0 and len(bundled_type_definitions) > 0:
-            # bundle_dts needs to be enabled/disabled for all ng module packages.
-            fail("Expected all or none of the 'ng_module' dependencies to have 'bundle_dts' enabled.")
+            # bundle_dts needs to be enabled/disabled for all entry points.
+            fail("Expected all or none of the entry points to have 'bundle_dts' enabled.")
 
         es2015_entry_point = "/".join([p for p in [
             ctx.bin_dir.path,
@@ -267,13 +305,13 @@ def _ng_package_impl(ctx):
             _esm2015_root_dir(ctx),
             ctx.label.package,
             entry_point,
-            flat_module_out_file,
+            index_file,
         ] if p])
 
         es5_entry_point = "/".join([p for p in [
             ctx.label.package,
             entry_point,
-            flat_module_out_file,
+            index_file,
         ] if p])
 
         if entry_point:
@@ -314,8 +352,8 @@ def _ng_package_impl(ctx):
                 es5_entry_point,
                 esm5_rollup_inputs,
                 umd_output,
+                module_name = module_name,
                 format = "umd",
-                package_name = package_name,
                 include_tslib = True,
             ),
         )
@@ -349,12 +387,17 @@ def _ng_package_impl(ctx):
     # Marshal the metadata into a JSON string so we can parse the data structure
     # in the TypeScript program easily.
     metadata_arg = {}
-    for m in flat_module_metadata:
-        packager_inputs.extend([m.metadata_file])
+    for m in collected_entry_points:
+        if m.metadata_file:
+            packager_inputs.extend([m.metadata_file])
         metadata_arg[m.module_name] = {
-            "index": m.typings_file.path.replace(".d.ts", ".js"),
-            "typings": m.typings_file.path,
-            "metadata": m.metadata_file.path,
+            "index": m.typings_path.replace(".d.ts", ".js"),
+            "typings": m.typings_path,
+            # Metadata can be undefined if entry point is built with "ts_library".
+            "metadata": m.metadata_file.path if m.metadata_file else "",
+            # If the paths for that entry-point were guessed (e.g. "ts_library" rule or
+            # "ng_module" without flat module bundle), we pass this information to the packager.
+            "guessedPaths": "true" if m.guessed_paths else "",
         }
     packager_args.add(str(metadata_arg))
 

--- a/packages/bazel/test/ng_package/BUILD.bazel
+++ b/packages/bazel/test/ng_package/BUILD.bazel
@@ -62,7 +62,9 @@ jasmine_node_test(
     srcs = [":example_spec_lib"],
     data = [
         "example_package.golden",
+        "example_with_ts_library_package.golden",
         "//packages/bazel/test/ng_package/example:npm_package",
+        "//packages/bazel/test/ng_package/example-with-ts-library:npm_package",
     ],
     # We don't want to run the example_package golden test with Ivy yet. Currently the golden
     # file is based on non-ivy output and therefore won't work for ngc and Ivy at the same time.
@@ -76,8 +78,10 @@ nodejs_binary(
     testonly = True,
     data = [
         "example_package.golden",
+        "example_with_ts_library_package.golden",
         ":example_spec_lib",
         "//packages/bazel/test/ng_package/example:npm_package",
+        "//packages/bazel/test/ng_package/example-with-ts-library:npm_package",
         "@npm//diff",
     ],
     entry_point = ":example_package.spec.ts",

--- a/packages/bazel/test/ng_package/example-with-ts-library/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example-with-ts-library/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//tools:defaults.bzl", "ng_package", "ts_library")
+
+package(default_visibility = ["//packages/bazel/test:__subpackages__"])
+
+ts_library(
+    name = "example",
+    srcs = glob(["*.ts"]),
+    module_name = "example",
+    deps = [],
+)
+
+ng_package(
+    name = "npm_package",
+    srcs = [
+        "package.json",
+    ],
+    entry_point = ":index.ts",
+    deps = [
+        ":example",
+        "//packages/bazel/test/ng_package/example-with-ts-library/portal",
+        "//packages/bazel/test/ng_package/example-with-ts-library/utils",
+    ],
+)

--- a/packages/bazel/test/ng_package/example-with-ts-library/index.ts
+++ b/packages/bazel/test/ng_package/example-with-ts-library/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const VERSION = '0.0.0';

--- a/packages/bazel/test/ng_package/example-with-ts-library/package.json
+++ b/packages/bazel/test/ng_package/example-with-ts-library/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "example",
+  "version": "0.0.0-PLACEHOLDER",
+  "main": "./bundles/example.umd.js",
+  "fesm5": "./fesm5/example.js",
+  "fesm2015": "./fesm2015/example.js",
+  "esm5": "./esm5/index.js",
+  "esm2015": "./esm2015/index.js",
+  "typings": "./index.d.ts",
+  "module": "./fesm5/example.js",
+  "es2015": "./fesm2015/example.js",
+  "schematics": "Custom property that should be preserved."
+}

--- a/packages/bazel/test/ng_package/example-with-ts-library/portal/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example-with-ts-library/portal/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//packages/bazel/test:__subpackages__"])
+
+ng_module(
+    name = "portal",
+    srcs = glob(["*.ts"]),
+    bundle_dts = False,
+    module_name = "example/portal",
+    deps = [
+        "//packages/core",
+        "@npm//@types",
+    ],
+)

--- a/packages/bazel/test/ng_package/example-with-ts-library/portal/index.ts
+++ b/packages/bazel/test/ng_package/example-with-ts-library/portal/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './portal-module';

--- a/packages/bazel/test/ng_package/example-with-ts-library/portal/portal-module.ts
+++ b/packages/bazel/test/ng_package/example-with-ts-library/portal/portal-module.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+
+@NgModule({})
+export class PortalModule {
+}
+
+export const a = 1;

--- a/packages/bazel/test/ng_package/example-with-ts-library/utils/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example-with-ts-library/utils/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//packages/bazel/test:__subpackages__"])
+
+ts_library(
+    name = "utils",
+    srcs = glob(["*.ts"]),
+    module_name = "example/utils",
+)

--- a/packages/bazel/test/ng_package/example-with-ts-library/utils/index.ts
+++ b/packages/bazel/test/ng_package/example-with-ts-library/utils/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './testing';

--- a/packages/bazel/test/ng_package/example-with-ts-library/utils/testing.ts
+++ b/packages/bazel/test/ng_package/example-with-ts-library/utils/testing.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export function dispatchFakeEvent(el: HTMLElement, ev: Event) {
+  el.dispatchEvent(ev);
+}

--- a/packages/bazel/test/ng_package/example_package.spec.ts
+++ b/packages/bazel/test/ng_package/example_package.spec.ts
@@ -24,6 +24,15 @@ const packagesToTest: TestPackage[] = [
         require.resolve('angular/packages/bazel/test/ng_package/example/npm_package/package.json')),
     goldenFilePath: require.resolve('./example_package.golden')
   },
+  {
+    displayName: 'Example with ts_library NPM package',
+    // Resolve the "npm_package" directory by using the runfile resolution. Note that we need to
+    // resolve the "package.json" of the package since otherwise NodeJS would resolve the "main"
+    // file, which is not necessarily at the root of the "npm_package".
+    packagePath: path.dirname(require.resolve(
+        'angular/packages/bazel/test/ng_package/example-with-ts-library/npm_package/package.json')),
+    goldenFilePath: require.resolve('./example_with_ts_library_package.golden')
+  },
 ];
 
 /**

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -1,0 +1,961 @@
+README.md
+bundles
+  bundles/example-with-ts-library-portal.umd.js
+  bundles/example-with-ts-library-portal.umd.js.map
+  bundles/example-with-ts-library-portal.umd.min.js
+  bundles/example-with-ts-library-portal.umd.min.js.map
+  bundles/example-with-ts-library-utils.umd.js
+  bundles/example-with-ts-library-utils.umd.js.map
+  bundles/example-with-ts-library-utils.umd.min.js
+  bundles/example-with-ts-library-utils.umd.min.js.map
+  bundles/example-with-ts-library.umd.js
+  bundles/example-with-ts-library.umd.js.map
+  bundles/example-with-ts-library.umd.min.js
+  bundles/example-with-ts-library.umd.min.js.map
+esm2015
+  esm2015/example.externs.js
+  esm2015/index.js
+  esm2015/portal
+    esm2015/portal/index.js
+    esm2015/portal/portal-module.js
+    esm2015/portal/portal.externs.js
+    esm2015/portal/portal.js
+  esm2015/utils
+    esm2015/utils/index.js
+    esm2015/utils/testing.js
+    esm2015/utils/utils.externs.js
+esm5
+  esm5/index.js
+  esm5/portal
+    esm5/portal/index.js
+    esm5/portal/portal-module.js
+    esm5/portal/portal.js
+  esm5/utils
+    esm5/utils/index.js
+    esm5/utils/testing.js
+fesm2015
+  fesm2015/example-with-ts-library.js
+  fesm2015/example-with-ts-library.js.map
+  fesm2015/portal.js
+  fesm2015/portal.js.map
+  fesm2015/utils.js
+  fesm2015/utils.js.map
+fesm5
+  fesm5/example-with-ts-library.js
+  fesm5/example-with-ts-library.js.map
+  fesm5/portal.js
+  fesm5/portal.js.map
+  fesm5/utils.js
+  fesm5/utils.js.map
+index.d.ts
+package.json
+portal
+  portal/index.d.ts
+  portal/package.json
+  portal/portal-module.d.ts
+  portal/portal.d.ts
+  portal/portal.metadata.json
+portal.d.ts
+portal.metadata.json
+utils
+  utils/index.d.ts
+  utils/package.json
+  utils/testing.d.ts
+utils.d.ts
+--- README.md ---
+
+Angular
+=======
+
+The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
+
+License: MIT
+
+
+--- bundles/example-with-ts-library-portal.umd.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
+    typeof define === 'function' && define.amd ? define('example/portal', ['exports', '@angular/core'], factory) :
+    (global = global || self, factory((global.example = global.example || {}, global.example.portal = {}), global.ng.core));
+}(this, function (exports, core) { 'use strict';
+
+    /*! *****************************************************************************
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain a copy of the
+    License at http://www.apache.org/licenses/LICENSE-2.0
+
+    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+    MERCHANTABLITY OR NON-INFRINGEMENT.
+
+    See the Apache Version 2.0 License for specific language governing permissions
+    and limitations under the License.
+    ***************************************************************************** */
+    /* global Reflect, Promise */
+
+    var extendStatics = function(d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+
+    function __extends(d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    }
+
+    var __assign = function() {
+        __assign = Object.assign || function __assign(t) {
+            for (var s, i = 1, n = arguments.length; i < n; i++) {
+                s = arguments[i];
+                for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+            }
+            return t;
+        };
+        return __assign.apply(this, arguments);
+    };
+
+    function __rest(s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+            t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+                t[p[i]] = s[p[i]];
+        return t;
+    }
+
+    function __decorate(decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    }
+
+    function __param(paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    }
+
+    function __metadata(metadataKey, metadataValue) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+    }
+
+    function __awaiter(thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    }
+
+    function __generator(thisArg, body) {
+        var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+        return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_) try {
+                if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+                if (y = 0, t) op = [op[0] & 2, t.value];
+                switch (op[0]) {
+                    case 0: case 1: t = op; break;
+                    case 4: _.label++; return { value: op[1], done: false };
+                    case 5: _.label++; y = op[1]; op = [0]; continue;
+                    case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                    default:
+                        if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                        if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                        if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                        if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                        if (t[2]) _.ops.pop();
+                        _.trys.pop(); continue;
+                }
+                op = body.call(thisArg, _);
+            } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+            if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    }
+
+    function __exportStar(m, exports) {
+        for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+    }
+
+    function __values(o) {
+        var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
+        if (m) return m.call(o);
+        return {
+            next: function () {
+                if (o && i >= o.length) o = void 0;
+                return { value: o && o[i++], done: !o };
+            }
+        };
+    }
+
+    function __read(o, n) {
+        var m = typeof Symbol === "function" && o[Symbol.iterator];
+        if (!m) return o;
+        var i = m.call(o), r, ar = [], e;
+        try {
+            while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+        }
+        catch (error) { e = { error: error }; }
+        finally {
+            try {
+                if (r && !r.done && (m = i["return"])) m.call(i);
+            }
+            finally { if (e) throw e.error; }
+        }
+        return ar;
+    }
+
+    function __spread() {
+        for (var ar = [], i = 0; i < arguments.length; i++)
+            ar = ar.concat(__read(arguments[i]));
+        return ar;
+    }
+
+    function __await(v) {
+        return this instanceof __await ? (this.v = v, this) : new __await(v);
+    }
+
+    function __asyncGenerator(thisArg, _arguments, generator) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var g = generator.apply(thisArg, _arguments || []), i, q = [];
+        return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+        function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+        function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+        function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r); }
+        function fulfill(value) { resume("next", value); }
+        function reject(value) { resume("throw", value); }
+        function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+    }
+
+    function __asyncDelegator(o) {
+        var i, p;
+        return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+        function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; } : f; }
+    }
+
+    function __asyncValues(o) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var m = o[Symbol.asyncIterator], i;
+        return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+        function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+        function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+    }
+
+    function __makeTemplateObject(cooked, raw) {
+        if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+        return cooked;
+    };
+
+    function __importStar(mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+        result.default = mod;
+        return result;
+    }
+
+    function __importDefault(mod) {
+        return (mod && mod.__esModule) ? mod : { default: mod };
+    }
+
+    /**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+    var PortalModule = /** @class */ (function () {
+        function PortalModule() {
+        }
+        PortalModule = __decorate([
+            core.NgModule({})
+        ], PortalModule);
+        return PortalModule;
+    }());
+    var a = 1;
+
+    /**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+
+    /**
+     * Generated bundle index. Do not edit.
+     */
+
+    exports.PortalModule = PortalModule;
+    exports.a = a;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+}));
+//# sourceMappingURL=example-with-ts-library-portal.umd.js.map
+
+
+--- bundles/example-with-ts-library-portal.umd.min.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports,require("@angular/core")):"function"==typeof define&&define.amd?define("example/portal",["exports","@angular/core"],t):t(((e=e||self).example=e.example||{},e.example.portal={}),e.ng.core)}(this,function(e,t){"use strict";
+/**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+var o=function(){return function o(e,t,r,n){var f,l=arguments.length,c=l<3?t:null===n?n=Object.getOwnPropertyDescriptor(t,r):n;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)c=Reflect.decorate(e,t,r,n);else for(var u=e.length-1;u>=0;u--)(f=e[u])&&(c=(l<3?f(c):l>3?f(t,r,c):f(t,r))||c);return l>3&&c&&Object.defineProperty(t,r,c),c}([t.NgModule({})],function e(){})}();
+/**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+e.PortalModule=o,e.a=1,Object.defineProperty(e,"__esModule",{value:!0})});
+
+--- bundles/example-with-ts-library-utils.umd.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define('example/utils', ['exports'], factory) :
+    (global = global || self, factory((global.example = global.example || {}, global.example.utils = {})));
+}(this, function (exports) { 'use strict';
+
+    /**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+    function dispatchFakeEvent(el, ev) {
+        el.dispatchEvent(ev);
+    }
+
+    /**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+
+    exports.dispatchFakeEvent = dispatchFakeEvent;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+}));
+//# sourceMappingURL=example-with-ts-library-utils.umd.js.map
+
+
+--- bundles/example-with-ts-library-utils.umd.min.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports):"function"==typeof define&&define.amd?define("example/utils",["exports"],t):t(((e=e||self).example=e.example||{},e.example.utils={}))}(this,function(e){"use strict";
+/**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+/**
+     * @license
+     * Copyright Google Inc. All Rights Reserved.
+     *
+     * Use of this source code is governed by an MIT-style license that can be
+     * found in the LICENSE file at https://angular.io/license
+     */
+e.dispatchFakeEvent=function t(e,n){e.dispatchEvent(n)},Object.defineProperty(e,"__esModule",{value:!0})});
+
+--- bundles/example-with-ts-library.umd.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define('example', ['exports'], factory) :
+	(global = global || self, factory(global.example = {}));
+}(this, function (exports) { 'use strict';
+
+	/**
+	 * @license
+	 * Copyright Google Inc. All Rights Reserved.
+	 *
+	 * Use of this source code is governed by an MIT-style license that can be
+	 * found in the LICENSE file at https://angular.io/license
+	 */
+	var VERSION = '0.0.0';
+
+	exports.VERSION = VERSION;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+}));
+//# sourceMappingURL=example-with-ts-library.umd.js.map
+
+
+--- bundles/example-with-ts-library.umd.min.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports):"function"==typeof define&&define.amd?define("example",["exports"],t):t((e=e||self).example={})}(this,function(e){"use strict";
+/**
+	 * @license
+	 * Copyright Google Inc. All Rights Reserved.
+	 *
+	 * Use of this source code is governed by an MIT-style license that can be
+	 * found in the LICENSE file at https://angular.io/license
+	 */e.VERSION="0.0.0",Object.defineProperty(e,"__esModule",{value:!0})});
+
+--- esm2015/example.externs.js ---
+
+
+
+--- esm2015/index.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export const VERSION = '0.0.0';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvaW5kZXgudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7OztHQU1HO0FBRUgsTUFBTSxDQUFDLE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogQGxpY2Vuc2VcbiAqIENvcHlyaWdodCBHb29nbGUgSW5jLiBBbGwgUmlnaHRzIFJlc2VydmVkLlxuICpcbiAqIFVzZSBvZiB0aGlzIHNvdXJjZSBjb2RlIGlzIGdvdmVybmVkIGJ5IGFuIE1JVC1zdHlsZSBsaWNlbnNlIHRoYXQgY2FuIGJlXG4gKiBmb3VuZCBpbiB0aGUgTElDRU5TRSBmaWxlIGF0IGh0dHBzOi8vYW5ndWxhci5pby9saWNlbnNlXG4gKi9cblxuZXhwb3J0IGNvbnN0IFZFUlNJT04gPSAnMC4wLjAnO1xuIl19
+
+--- esm2015/portal/index.js ---
+
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export { PortalModule, a } from './portal-module';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvcG9ydGFsL2luZGV4LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7Ozs7O0FBUUEsZ0NBQWMsaUJBQWlCLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCAqIGZyb20gJy4vcG9ydGFsLW1vZHVsZSc7XG4iXX0=
+
+--- esm2015/portal/portal-module.js ---
+
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { NgModule } from '@angular/core';
+export class PortalModule {
+}
+PortalModule.decorators = [
+    { type: NgModule, args: [{},] }
+];
+/** @type {?} */
+export const a = 1;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGFsLW1vZHVsZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uL3BhY2thZ2VzL2JhemVsL3Rlc3QvbmdfcGFja2FnZS9leGFtcGxlLXdpdGgtdHMtbGlicmFyeS9wb3J0YWwvcG9ydGFsLW1vZHVsZS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7OztBQVFBLE9BQU8sRUFBQyxRQUFRLEVBQUMsTUFBTSxlQUFlLENBQUM7QUFHdkMsTUFBTSxPQUFPLFlBQVk7OztZQUR4QixRQUFRLFNBQUMsRUFBRTs7O0FBSVosTUFBTSxPQUFPLENBQUMsR0FBRyxDQUFDIiwic291cmNlc0NvbnRlbnQiOlsiLyoqXG4gKiBAbGljZW5zZVxuICogQ29weXJpZ2h0IEdvb2dsZSBJbmMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQuXG4gKlxuICogVXNlIG9mIHRoaXMgc291cmNlIGNvZGUgaXMgZ292ZXJuZWQgYnkgYW4gTUlULXN0eWxlIGxpY2Vuc2UgdGhhdCBjYW4gYmVcbiAqIGZvdW5kIGluIHRoZSBMSUNFTlNFIGZpbGUgYXQgaHR0cHM6Ly9hbmd1bGFyLmlvL2xpY2Vuc2VcbiAqL1xuXG5pbXBvcnQge05nTW9kdWxlfSBmcm9tICdAYW5ndWxhci9jb3JlJztcblxuQE5nTW9kdWxlKHt9KVxuZXhwb3J0IGNsYXNzIFBvcnRhbE1vZHVsZSB7XG59XG5cbmV4cG9ydCBjb25zdCBhID0gMTtcbiJdfQ==
+
+--- esm2015/portal/portal.externs.js ---
+
+/** @externs */
+/**
+ * @externs
+ * @suppress {duplicate,checkTypes}
+ */
+// NOTE: generated by tsickle, do not edit.
+
+
+--- esm2015/portal/portal.js ---
+
+/**
+ * Generated bundle index. Do not edit.
+ */
+export * from './index';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGFsLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vcGFja2FnZXMvYmF6ZWwvdGVzdC9uZ19wYWNrYWdlL2V4YW1wbGUtd2l0aC10cy1saWJyYXJ5L3BvcnRhbC9wb3J0YWwudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7O0dBRUc7QUFFSCxjQUFjLFNBQVMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogR2VuZXJhdGVkIGJ1bmRsZSBpbmRleC4gRG8gbm90IGVkaXQuXG4gKi9cblxuZXhwb3J0ICogZnJvbSAnLi9pbmRleCc7XG4iXX0=
+
+--- esm2015/utils/index.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './testing';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvdXRpbHMvaW5kZXgudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7OztHQU1HO0FBRUgsY0FBYyxXQUFXLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCAqIGZyb20gJy4vdGVzdGluZyc7XG4iXX0=
+
+--- esm2015/utils/testing.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export function dispatchFakeEvent(el, ev) {
+    el.dispatchEvent(ev);
+}
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdGluZy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uL3BhY2thZ2VzL2JhemVsL3Rlc3QvbmdfcGFja2FnZS9leGFtcGxlLXdpdGgtdHMtbGlicmFyeS91dGlscy90ZXN0aW5nLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBOzs7Ozs7R0FNRztBQUVILE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxFQUFlLEVBQUUsRUFBUztJQUMxRCxFQUFFLENBQUMsYUFBYSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0FBQ3ZCLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCBmdW5jdGlvbiBkaXNwYXRjaEZha2VFdmVudChlbDogSFRNTEVsZW1lbnQsIGV2OiBFdmVudCkge1xuICBlbC5kaXNwYXRjaEV2ZW50KGV2KTtcbn1cbiJdfQ==
+
+--- esm2015/utils/utils.externs.js ---
+
+
+
+--- esm5/index.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export var VERSION = '0.0.0';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvaW5kZXgudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7OztHQU1HO0FBRUgsTUFBTSxDQUFDLElBQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogQGxpY2Vuc2VcbiAqIENvcHlyaWdodCBHb29nbGUgSW5jLiBBbGwgUmlnaHRzIFJlc2VydmVkLlxuICpcbiAqIFVzZSBvZiB0aGlzIHNvdXJjZSBjb2RlIGlzIGdvdmVybmVkIGJ5IGFuIE1JVC1zdHlsZSBsaWNlbnNlIHRoYXQgY2FuIGJlXG4gKiBmb3VuZCBpbiB0aGUgTElDRU5TRSBmaWxlIGF0IGh0dHBzOi8vYW5ndWxhci5pby9saWNlbnNlXG4gKi9cblxuZXhwb3J0IGNvbnN0IFZFUlNJT04gPSAnMC4wLjAnO1xuIl19
+
+--- esm5/portal/index.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './portal-module';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvcG9ydGFsL2luZGV4LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBOzs7Ozs7R0FNRztBQUVILGNBQWMsaUJBQWlCLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCAqIGZyb20gJy4vcG9ydGFsLW1vZHVsZSc7XG4iXX0=
+
+--- esm5/portal/portal-module.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as tslib_1 from "tslib";
+import { NgModule } from '@angular/core';
+var PortalModule = /** @class */ (function () {
+    function PortalModule() {
+    }
+    PortalModule = tslib_1.__decorate([
+        NgModule({})
+    ], PortalModule);
+    return PortalModule;
+}());
+export { PortalModule };
+export var a = 1;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGFsLW1vZHVsZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uL3BhY2thZ2VzL2JhemVsL3Rlc3QvbmdfcGFja2FnZS9leGFtcGxlLXdpdGgtdHMtbGlicmFyeS9wb3J0YWwvcG9ydGFsLW1vZHVsZS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTs7Ozs7O0dBTUc7O0FBRUgsT0FBTyxFQUFDLFFBQVEsRUFBQyxNQUFNLGVBQWUsQ0FBQztBQUd2QztJQUFBO0lBQ0EsQ0FBQztJQURZLFlBQVk7UUFEeEIsUUFBUSxDQUFDLEVBQUUsQ0FBQztPQUNBLFlBQVksQ0FDeEI7SUFBRCxtQkFBQztDQUFBLEFBREQsSUFDQztTQURZLFlBQVk7QUFHekIsTUFBTSxDQUFDLElBQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogQGxpY2Vuc2VcbiAqIENvcHlyaWdodCBHb29nbGUgSW5jLiBBbGwgUmlnaHRzIFJlc2VydmVkLlxuICpcbiAqIFVzZSBvZiB0aGlzIHNvdXJjZSBjb2RlIGlzIGdvdmVybmVkIGJ5IGFuIE1JVC1zdHlsZSBsaWNlbnNlIHRoYXQgY2FuIGJlXG4gKiBmb3VuZCBpbiB0aGUgTElDRU5TRSBmaWxlIGF0IGh0dHBzOi8vYW5ndWxhci5pby9saWNlbnNlXG4gKi9cblxuaW1wb3J0IHtOZ01vZHVsZX0gZnJvbSAnQGFuZ3VsYXIvY29yZSc7XG5cbkBOZ01vZHVsZSh7fSlcbmV4cG9ydCBjbGFzcyBQb3J0YWxNb2R1bGUge1xufVxuXG5leHBvcnQgY29uc3QgYSA9IDE7XG4iXX0=
+
+--- esm5/portal/portal.js ---
+
+/**
+ * Generated bundle index. Do not edit.
+ */
+export * from './index';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGFsLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vcGFja2FnZXMvYmF6ZWwvdGVzdC9uZ19wYWNrYWdlL2V4YW1wbGUtd2l0aC10cy1saWJyYXJ5L3BvcnRhbC9wb3J0YWwudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7O0dBRUc7QUFFSCxjQUFjLFNBQVMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogR2VuZXJhdGVkIGJ1bmRsZSBpbmRleC4gRG8gbm90IGVkaXQuXG4gKi9cblxuZXhwb3J0ICogZnJvbSAnLi9pbmRleCc7XG4iXX0=
+
+--- esm5/utils/index.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './testing';
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi8uLi9wYWNrYWdlcy9iYXplbC90ZXN0L25nX3BhY2thZ2UvZXhhbXBsZS13aXRoLXRzLWxpYnJhcnkvdXRpbHMvaW5kZXgudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7OztHQU1HO0FBRUgsY0FBYyxXQUFXLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCAqIGZyb20gJy4vdGVzdGluZyc7XG4iXX0=
+
+--- esm5/utils/testing.js ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export function dispatchFakeEvent(el, ev) {
+    el.dispatchEvent(ev);
+}
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdGluZy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uL3BhY2thZ2VzL2JhemVsL3Rlc3QvbmdfcGFja2FnZS9leGFtcGxlLXdpdGgtdHMtbGlicmFyeS91dGlscy90ZXN0aW5nLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBOzs7Ozs7R0FNRztBQUVILE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxFQUFlLEVBQUUsRUFBUztJQUMxRCxFQUFFLENBQUMsYUFBYSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0FBQ3ZCLENBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cbiAqXG4gKiBVc2Ugb2YgdGhpcyBzb3VyY2UgY29kZSBpcyBnb3Zlcm5lZCBieSBhbiBNSVQtc3R5bGUgbGljZW5zZSB0aGF0IGNhbiBiZVxuICogZm91bmQgaW4gdGhlIExJQ0VOU0UgZmlsZSBhdCBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZVxuICovXG5cbmV4cG9ydCBmdW5jdGlvbiBkaXNwYXRjaEZha2VFdmVudChlbDogSFRNTEVsZW1lbnQsIGV2OiBFdmVudCkge1xuICBlbC5kaXNwYXRjaEV2ZW50KGV2KTtcbn1cbiJdfQ==
+
+--- fesm2015/example-with-ts-library.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const VERSION = '0.0.0';
+
+export { VERSION };
+//# sourceMappingURL=example-with-ts-library.js.map
+
+
+--- fesm2015/portal.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+import { NgModule } from '@angular/core';
+
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+class PortalModule {
+}
+PortalModule.decorators = [
+    { type: NgModule, args: [{},] }
+];
+/** @type {?} */
+const a = 1;
+
+/**
+ * @fileoverview added by tsickle
+ * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+ */
+
+/**
+ * Generated bundle index. Do not edit.
+ */
+
+export { PortalModule, a };
+//# sourceMappingURL=portal.js.map
+
+
+--- fesm2015/utils.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+function dispatchFakeEvent(el, ev) {
+    el.dispatchEvent(ev);
+}
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export { dispatchFakeEvent };
+//# sourceMappingURL=utils.js.map
+
+
+--- fesm5/example-with-ts-library.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+var VERSION = '0.0.0';
+
+export { VERSION };
+//# sourceMappingURL=example-with-ts-library.js.map
+
+
+--- fesm5/portal.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+import { __decorate } from 'tslib';
+import { NgModule } from '@angular/core';
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+var PortalModule = /** @class */ (function () {
+    function PortalModule() {
+    }
+    PortalModule = __decorate([
+        NgModule({})
+    ], PortalModule);
+    return PortalModule;
+}());
+var a = 1;
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Generated bundle index. Do not edit.
+ */
+
+export { PortalModule, a };
+//# sourceMappingURL=portal.js.map
+
+
+--- fesm5/utils.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+function dispatchFakeEvent(el, ev) {
+    el.dispatchEvent(ev);
+}
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export { dispatchFakeEvent };
+//# sourceMappingURL=utils.js.map
+
+
+--- index.d.ts ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export declare const VERSION = "0.0.0";
+
+
+--- package.json ---
+
+{
+  "name": "example",
+  "version": "0.0.0",
+  "main": "./bundles/example.umd.js",
+  "fesm5": "./fesm5/example.js",
+  "fesm2015": "./fesm2015/example.js",
+  "esm5": "./esm5/index.js",
+  "esm2015": "./esm2015/index.js",
+  "typings": "./index.d.ts",
+  "module": "./fesm5/example.js",
+  "es2015": "./fesm2015/example.js",
+  "schematics": "Custom property that should be preserved."
+}
+
+--- portal/index.d.ts ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './portal-module';
+
+
+--- portal/package.json ---
+
+{
+  "name": "example/portal",
+  "main": "../bundles/example-portal.umd.js",
+  "fesm5": "../fesm5/portal.js",
+  "fesm2015": "../fesm2015/portal.js",
+  "esm5": "../esm5/portal/portal.js",
+  "esm2015": "../esm2015/portal/portal.js",
+  "typings": "./portal.d.ts",
+  "module": "../fesm5/portal.js",
+  "es2015": "../fesm2015/portal.js"
+}
+
+--- portal/portal-module.d.ts ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export declare class PortalModule {
+}
+export declare const a = 1;
+
+
+--- portal/portal.d.ts ---
+
+/**
+ * Generated bundle index. Do not edit.
+ */
+export * from './index';
+
+
+--- portal/portal.metadata.json ---
+
+{"__symbolic":"module","version":4,"metadata":{"PortalModule":{"__symbolic":"class","decorators":[{"__symbolic":"call","expression":{"__symbolic":"reference","module":"@angular/core","name":"NgModule","line":10,"character":1},"arguments":[{}]}],"members":{}},"a":1},"origins":{"PortalModule":"./portal-module","a":"./portal-module"},"importAs":"example/portal"}
+
+--- portal.d.ts ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+export * from './portal/portal';
+
+
+--- portal.metadata.json ---
+
+{"__symbolic":"module","version":3,"metadata":{},"exports":[{"from":"./portal/portal"}],"flatModuleIndexRedirect":true,"importAs":"example/portal"}
+
+
+--- utils/index.d.ts ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './testing';
+
+
+--- utils/package.json ---
+
+{
+  "name": "example/utils",
+  "main": "../bundles/example-utils.umd.js",
+  "fesm5": "../fesm5/utils.js",
+  "fesm2015": "../fesm2015/utils.js",
+  "esm5": "../esm5/utils/index.js",
+  "esm2015": "../esm2015/utils/index.js",
+  "typings": "./index.d.ts",
+  "module": "../fesm5/utils.js",
+  "es2015": "../fesm2015/utils.js"
+}
+
+--- utils/testing.d.ts ---
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export declare function dispatchFakeEvent(el: HTMLElement, ev: Event): void;
+
+
+--- utils.d.ts ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2019 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+export * from './utils/index';
+


### PR DESCRIPTION
Within an Angular package, it can happen that there are
entry-points which do not contain features that belong into
an `@NgModule` or need metadata files to be generated.

For example: the `cdk`, `cdk/testing` and `cdk/coercion`
entry-points. Besides other entry-points in the `cdk`
package, those entry-points do not need metadata to
be generated and no not use the `ng_module` rule.

Currently the "ng_package" rule properly picks up such
entry-points and builds bundles, does downleveling etc.
The only thing it misses is that no `package.json` files
are generated for the entry-point. This means that consumers
will not be able to use these entry-points built with "ts_library"
(except accessing the individual bundlings explicitly).

The "ng_package" rule should follow the full APF specification
for such entry-points. Partially building bundles and doing the
downleveling is confusing and a breaking issue.

---

The motifivation of supporting this (besides making the
rule behavior consistent; the incomplete output is not
acceptable), is that using the "ng_module" rule does
not make sense to be used for non-Angular entry-points.

Especially since it depends on Angular packages to
be specified as Bazel action inputs just to compile
vanilla TypeScript with `@angular/compiler-cli`.