### PR TITLE
build: enforce proper compile mode for size-tracking test

### DIFF
--- a/packages/core/test/bundling/core_all/BUILD.bazel
+++ b/packages/core/test/bundling/core_all/BUILD.bazel
@@ -32,10 +32,14 @@ js_size_tracking_test(
         ":bundle",
         ":bundle.golden_size_map.json",
     ],
-    goldenFile = "angular/packages/core/test/bundling/core_all/bundle.golden_size_map.json",
-    maxByteDiff = 250,
-    maxPercentageDiff = 15,
-    sourceMap = "angular/packages/core/test/bundling/core_all/bundle.min.js.map",
+    golden_file = "angular/packages/core/test/bundling/core_all/bundle.golden_size_map.json",
+    max_byte_diff = 250,
+    max_percentage_diff = 15,
+    # Ensures that this target runs with "--define=compile=aot" (aka Ivy). This is necessary
+    # because we don't run this test on CI currently, but if we run it manually, we need to
+    # ensure that it runs with Ivy for proper size comparisons.
+    required_compile_mode = "aot",
+    source_map = "angular/packages/core/test/bundling/core_all/bundle.min.js.map",
     tags = [
         "ivy-only",
         "manual",

--- a/tools/size-tracking/index.bzl
+++ b/tools/size-tracking/index.bzl
@@ -14,10 +14,11 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
 def js_size_tracking_test(
         name,
         src,
-        sourceMap,
-        goldenFile,
-        maxPercentageDiff,
-        maxByteDiff,
+        source_map,
+        golden_file,
+        max_percentage_diff,
+        max_byte_diff,
+        required_compile_mode = "",
         data = [],
         **kwargs):
     all_data = data + [
@@ -32,7 +33,15 @@ def js_size_tracking_test(
         data = all_data,
         entry_point = entry_point,
         configuration_env_vars = ["compile"],
-        templated_args = [src, sourceMap, goldenFile, "%d" % maxPercentageDiff, "%d" % maxByteDiff, "false"],
+        templated_args = [
+            src,
+            source_map,
+            golden_file,
+            "%d" % max_percentage_diff,
+            "%d" % max_byte_diff,
+            "false",
+            required_compile_mode,
+        ],
         **kwargs
     )
 
@@ -42,6 +51,6 @@ def js_size_tracking_test(
         data = all_data,
         entry_point = entry_point,
         configuration_env_vars = ["compile"],
-        templated_args = [src, sourceMap, goldenFile, "0", "0", "true"],
+        templated_args = [src, source_map, golden_file, "0", "0", "true", required_compile_mode],
         **kwargs
     )

--- a/tools/size-tracking/index.ts
+++ b/tools/size-tracking/index.ts
@@ -14,24 +14,33 @@ import {FileSizeData} from './file_size_data';
 
 if (require.main === module) {
   const
-      [filePath, sourceMapPath, goldenPath, maxPercentageDiffArg, maxSizeDiffArg, writeGoldenArg] =
-          process.argv.slice(2);
+      [filePath, sourceMapPath, goldenPath, maxPercentageDiffArg, maxSizeDiffArg, writeGoldenArg,
+       requiredCompileMode] = process.argv.slice(2);
   const status = main(
       require.resolve(filePath), require.resolve(sourceMapPath), require.resolve(goldenPath),
-      writeGoldenArg === 'true', parseInt(maxPercentageDiffArg), parseInt(maxSizeDiffArg));
+      writeGoldenArg === 'true', parseInt(maxPercentageDiffArg), parseInt(maxSizeDiffArg),
+      requiredCompileMode);
 
   process.exit(status ? 0 : 1);
 }
 
 export function main(
     filePath: string, sourceMapPath: string, goldenSizeMapPath: string, writeGolden: boolean,
-    maxPercentageDiff: number, maxByteDiff: number): boolean {
+    maxPercentageDiff: number, maxByteDiff: number, requiredCompileMode: string): boolean {
   const {sizeResult} = new SizeTracker(filePath, sourceMapPath);
+  const compileMode = process.env['compile'];
+
+  if (requiredCompileMode && compileMode !== requiredCompileMode) {
+    console.error(chalk.red(
+        `Expected the size-tracking tool to be run with: ` +
+        `--define=compile=${requiredCompileMode}`));
+    return false;
+  }
 
   if (writeGolden) {
     writeFileSync(goldenSizeMapPath, JSON.stringify(sizeResult, null, 2));
     console.error(chalk.green(`Updated golden size data in ${goldenSizeMapPath}`));
-    return;
+    return true;
   }
 
   const expectedSizeData = <FileSizeData>JSON.parse(readFileSync(goldenSizeMapPath, 'utf8'));
@@ -50,10 +59,10 @@ export function main(
     console.error(chalk.red(`    ${failurePrefix}${message}`));
   });
 
-  const compile = process.env['compile'];
-  const defineFlag = (compile !== 'legacy') ? `--define=compile=${compile} ` : '';
   const bazelTargetName = process.env['TEST_TARGET'];
+  const defineFlag = (compileMode !== 'legacy') ? `--define=compile=${compileMode} ` : '';
 
   console.error(`\nThe golden file can be updated with the following command:`);
   console.error(`    yarn bazel run ${defineFlag}${bazelTargetName}.accept`);
+  return false;
 }


### PR DESCRIPTION
Ensures that the `core_all:size_test` target runs with `--define=compile=aot`.
This is necessary because we don't run this test on CI currently, but if we run
it manually, we need to ensure that it runs with Ivy for proper size comparisons.