### PR TITLE
build: remove localize as a CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -739,7 +739,6 @@ testing/**                                                      @angular/fw-test
 /packages/compiler/src/i18n/**                                  @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/compiler/src/render3/view/i18n/**                     @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /packages/compiler-cli/src/extract_i18n.ts                      @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
-/packages/localize/**                                           @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/i18n.md                                      @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/examples/i18n/**                                   @angular/fw-i18n @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 


### PR DESCRIPTION
With v544eb89198304846c8a9c488da6790a1672cac64 the CODEOWNERS file
was amended to include an entry for the `localize` angular package.
This package exists in master, but not in the `8.x` branch. This patch
removes the entry from the file so that CI will work for `8.x`.