### PR TITLE
fix(ivy): DebugNode throws exceptions when querying some properties

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -19,7 +19,7 @@ import {isStylingContext} from '../render3/styling_next/util';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from '../render3/util/misc_utils';
 import {findComponentView} from '../render3/util/view_traversal_utils';
-import {getComponentViewByIndex, getNativeByTNodeOrNull, readPatchedData} from '../render3/util/view_utils';
+import {getComponentViewByIndex, getNativeByTNodeOrNull, hasPatchedData} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
@@ -220,38 +220,35 @@ class DebugNode__POST_R3__ implements DebugNode {
   }
 
   get injector(): Injector {
-    return this.hasPatchedData(this.nativeNode) ? getInjector(this.nativeNode) : Injector.NULL;
+    return hasPatchedData(this.nativeNode) ? getInjector(this.nativeNode) : Injector.NULL;
   }
 
   get componentInstance(): any {
     const nativeElement = this.nativeNode;
-    return this.hasPatchedData(nativeElement) ?
+    return hasPatchedData(nativeElement) ?
         (getComponent(nativeElement as Element) || getViewComponent(nativeElement)) :
         null;
   }
 
   get context(): any {
-    return this.hasPatchedData(this.nativeNode) ?
+    return hasPatchedData(this.nativeNode) ?
         getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element) :
         null;
   }
 
   get listeners(): DebugEventListener[] {
-    return this.hasPatchedData(this.nativeNode) ?
+    return hasPatchedData(this.nativeNode) ?
         getListeners(this.nativeNode as Element).filter(isBrowserEvents) :
         [];
   }
 
   get references(): {[key: string]: any;} {
-    return this.hasPatchedData(this.nativeNode) ? getLocalRefs(this.nativeNode) : {};
+    return hasPatchedData(this.nativeNode) ? getLocalRefs(this.nativeNode) : {};
   }
 
   get providerTokens(): any[] {
-    return this.hasPatchedData(this.nativeNode) ? getInjectionTokens(this.nativeNode as Element) :
-                                                  [];
+    return hasPatchedData(this.nativeNode) ? getInjectionTokens(this.nativeNode as Element) : [];
   }
-
-  private hasPatchedData(target: any) { return target && readPatchedData(target) !== null; }
 }
 
 class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugElement {

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -19,7 +19,7 @@ import {isStylingContext} from '../render3/styling_next/util';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from '../render3/util/misc_utils';
 import {findComponentView} from '../render3/util/view_traversal_utils';
-import {getComponentViewByIndex, getNativeByTNodeOrNull, hasPatchedData} from '../render3/util/view_utils';
+import {getComponentViewByIndex, getNativeByTNodeOrNull} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
@@ -88,7 +88,6 @@ export interface DebugElement extends DebugNode {
   queryAllNodes(predicate: Predicate<DebugNode>): DebugNode[];
   triggerEventHandler(eventName: string, eventObj: any): void;
 }
-
 export class DebugElement__PRE_R3__ extends DebugNode__PRE_R3__ implements DebugElement {
   readonly name !: string;
   readonly properties: {[key: string]: any} = {};
@@ -208,7 +207,6 @@ function _queryNodeChildren(
     });
   }
 }
-
 class DebugNode__POST_R3__ implements DebugNode {
   readonly nativeNode: Node;
 
@@ -219,36 +217,24 @@ class DebugNode__POST_R3__ implements DebugNode {
     return parent ? new DebugElement__POST_R3__(parent) : null;
   }
 
-  get injector(): Injector {
-    return hasPatchedData(this.nativeNode) ? getInjector(this.nativeNode) : Injector.NULL;
-  }
+  get injector(): Injector { return getInjector(this.nativeNode); }
 
   get componentInstance(): any {
     const nativeElement = this.nativeNode;
-    return hasPatchedData(nativeElement) ?
-        (getComponent(nativeElement as Element) || getViewComponent(nativeElement)) :
-        null;
+    return nativeElement &&
+        (getComponent(nativeElement as Element) || getViewComponent(nativeElement));
   }
-
   get context(): any {
-    return hasPatchedData(this.nativeNode) ?
-        getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element) :
-        null;
+    return getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element);
   }
 
   get listeners(): DebugEventListener[] {
-    return hasPatchedData(this.nativeNode) ?
-        getListeners(this.nativeNode as Element).filter(isBrowserEvents) :
-        [];
+    return getListeners(this.nativeNode as Element).filter(isBrowserEvents);
   }
 
-  get references(): {[key: string]: any;} {
-    return hasPatchedData(this.nativeNode) ? getLocalRefs(this.nativeNode) : {};
-  }
+  get references(): {[key: string]: any;} { return getLocalRefs(this.nativeNode); }
 
-  get providerTokens(): any[] {
-    return hasPatchedData(this.nativeNode) ? getInjectionTokens(this.nativeNode as Element) : [];
-  }
+  get providerTokens(): any[] { return getInjectionTokens(this.nativeNode as Element); }
 }
 
 class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugElement {

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -19,7 +19,7 @@ import {isStylingContext} from '../render3/styling_next/util';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from '../render3/util/misc_utils';
 import {findComponentView} from '../render3/util/view_traversal_utils';
-import {getComponentViewByIndex, getNativeByTNodeOrNull} from '../render3/util/view_utils';
+import {getComponentViewByIndex, getNativeByTNodeOrNull, readPatchedData} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
@@ -88,6 +88,7 @@ export interface DebugElement extends DebugNode {
   queryAllNodes(predicate: Predicate<DebugNode>): DebugNode[];
   triggerEventHandler(eventName: string, eventObj: any): void;
 }
+
 export class DebugElement__PRE_R3__ extends DebugNode__PRE_R3__ implements DebugElement {
   readonly name !: string;
   readonly properties: {[key: string]: any} = {};
@@ -207,6 +208,7 @@ function _queryNodeChildren(
     });
   }
 }
+
 class DebugNode__POST_R3__ implements DebugNode {
   readonly nativeNode: Node;
 
@@ -217,24 +219,39 @@ class DebugNode__POST_R3__ implements DebugNode {
     return parent ? new DebugElement__POST_R3__(parent) : null;
   }
 
-  get injector(): Injector { return getInjector(this.nativeNode); }
+  get injector(): Injector {
+    return this.hasPatchedData(this.nativeNode) ? getInjector(this.nativeNode) : Injector.NULL;
+  }
 
   get componentInstance(): any {
     const nativeElement = this.nativeNode;
-    return nativeElement &&
-        (getComponent(nativeElement as Element) || getViewComponent(nativeElement));
+    return this.hasPatchedData(nativeElement) ?
+        (getComponent(nativeElement as Element) || getViewComponent(nativeElement)) :
+        null;
   }
+
   get context(): any {
-    return getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element);
+    return this.hasPatchedData(this.nativeNode) ?
+        getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element) :
+        null;
   }
 
   get listeners(): DebugEventListener[] {
-    return getListeners(this.nativeNode as Element).filter(isBrowserEvents);
+    return this.hasPatchedData(this.nativeNode) ?
+        getListeners(this.nativeNode as Element).filter(isBrowserEvents) :
+        [];
   }
 
-  get references(): {[key: string]: any;} { return getLocalRefs(this.nativeNode); }
+  get references(): {[key: string]: any;} {
+    return this.hasPatchedData(this.nativeNode) ? getLocalRefs(this.nativeNode) : {};
+  }
 
-  get providerTokens(): any[] { return getInjectionTokens(this.nativeNode as Element); }
+  get providerTokens(): any[] {
+    return this.hasPatchedData(this.nativeNode) ? getInjectionTokens(this.nativeNode as Element) :
+                                                  [];
+  }
+
+  private hasPatchedData(target: any) { return target && readPatchedData(target) !== null; }
 }
 
 class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugElement {

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -42,6 +42,7 @@ import {unwrapRNode} from './view_utils';
  * @publicApi
  */
 export function getComponent<T = {}>(element: Element): T|null {
+  if (!(element instanceof Node)) throw new Error('Expecting instance of DOM Node');
   const context = loadLContext(element, false);
   if (context === null) return null;
 
@@ -74,6 +75,7 @@ export function getComponent<T = {}>(element: Element): T|null {
  * @publicApi
  */
 export function getContext<T = {}>(element: Element): T|null {
+  if (!(element instanceof Node)) throw new Error('Expecting instance of DOM Node');
   const context = loadLContext(element, false);
   if (context === null) return null;
 
@@ -294,6 +296,7 @@ export function isBrowserEvents(listener: Listener): boolean {
  * @publicApi
  */
 export function getListeners(element: Element): Listener[] {
+  if (!(element instanceof Node)) throw new Error('Expecting instance of DOM Node');
   const lContext = loadLContext(element, false);
   if (lContext === null) return [];
 

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -42,7 +42,9 @@ import {unwrapRNode} from './view_utils';
  * @publicApi
  */
 export function getComponent<T = {}>(element: Element): T|null {
-  const context = loadLContextFromNode(element);
+  const context = loadLContext(element, false);
+  if (context === null) return null;
+
 
   if (context.component === undefined) {
     context.component = getComponentAtNodeIndex(context.nodeIndex, context.lView);
@@ -72,7 +74,9 @@ export function getComponent<T = {}>(element: Element): T|null {
  * @publicApi
  */
 export function getContext<T = {}>(element: Element): T|null {
-  const context = loadLContextFromNode(element) !;
+  const context = loadLContext(element, false);
+  if (context === null) return null;
+
   return context.lView[CONTEXT] as T;
 }
 
@@ -97,7 +101,9 @@ export function getContext<T = {}>(element: Element): T|null {
  * @publicApi
  */
 export function getViewComponent<T = {}>(element: Element | {}): T|null {
-  const context = loadLContext(element) !;
+  const context = loadLContext(element, false);
+  if (context === null) return null;
+
   let lView = context.lView;
   let parent: LView|null;
   ngDevMode && assertLView(lView);
@@ -129,7 +135,9 @@ export function getRootComponents(target: {}): any[] {
  * @publicApi
  */
 export function getInjector(target: {}): Injector {
-  const context = loadLContext(target);
+  const context = loadLContext(target, false);
+  if (context === null) return Injector.NULL;
+
   const tNode = context.lView[TVIEW].data[context.nodeIndex] as TElementNode;
   return new NodeInjector(tNode, context.lView);
 }
@@ -142,7 +150,7 @@ export function getInjector(target: {}): Injector {
  */
 export function getInjectionTokens(element: Element): any[] {
   const context = loadLContext(element, false);
-  if (!context) return [];
+  if (context === null) return [];
   const lView = context.lView;
   const tView = lView[TVIEW];
   const tNode = tView.data[context.nodeIndex] as TNode;
@@ -207,7 +215,8 @@ export function loadLContext(target: {}, throwOnNotFound: boolean = true): LCont
  * @publicApi
  */
 export function getLocalRefs(target: {}): {[key: string]: any} {
-  const context = loadLContext(target) !;
+  const context = loadLContext(target, false);
+  if (context === null) return {};
 
   if (context.localRefs === undefined) {
     context.localRefs = discoverLocalRefs(context.lView, context.nodeIndex);
@@ -285,7 +294,9 @@ export function isBrowserEvents(listener: Listener): boolean {
  * @publicApi
  */
 export function getListeners(element: Element): Listener[] {
-  const lContext = loadLContextFromNode(element);
+  const lContext = loadLContext(element, false);
+  if (lContext === null) return [];
+
   const lView = lContext.lView;
   const tView = lView[TVIEW];
   const lCleanup = lView[CLEANUP];

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -154,11 +154,6 @@ export function readPatchedData(target: any): LView|LContext|null {
   return target[MONKEY_PATCH_KEY_NAME] || null;
 }
 
-/** Checks whether a target has monkey-patched LView or LContext data. */
-export function hasPatchedData(target: any): boolean {
-  return !!target && target.hasOwnProperty[MONKEY_PATCH_KEY_NAME];
-}
-
 export function readPatchedLView(target: any): LView|null {
   const value = readPatchedData(target);
   if (value) {

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -151,7 +151,7 @@ export function getComponentViewByIndex(nodeIndex: number, hostView: LView): LVi
  */
 export function readPatchedData(target: any): LView|LContext|null {
   ngDevMode && assertDefined(target, 'Target expected');
-  return target[MONKEY_PATCH_KEY_NAME];
+  return target[MONKEY_PATCH_KEY_NAME] || null;
 }
 
 export function readPatchedLView(target: any): LView|null {

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -154,6 +154,11 @@ export function readPatchedData(target: any): LView|LContext|null {
   return target[MONKEY_PATCH_KEY_NAME] || null;
 }
 
+/** Checks whether a target has monkey-patched LView or LContext data. */
+export function hasPatchedData(target: any): boolean {
+  return !!target && target.hasOwnProperty[MONKEY_PATCH_KEY_NAME];
+}
+
 export function readPatchedLView(target: any): LView|null {
   const value = readPatchedData(target);
   if (value) {

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -639,6 +639,30 @@ class TestCmptWithPropInterpolation {
       it('when searching for elements by their properties', () => {
         expect(() => el.query(e => e.properties['any prop'] === 'any value')).not.toThrow();
       });
+
+      it('when searching by componentInstance', () => {
+        expect(() => el.query(e => e.componentInstance === null)).not.toThrow();
+      });
+
+      it('when searching by context', () => {
+        expect(() => el.query(e => e.context === null)).not.toThrow();
+      });
+
+      it('when searching by listeners', () => {
+        expect(() => el.query(e => e.listeners.length === 0)).not.toThrow();
+      });
+
+      it('when searching by references', () => {
+        expect(() => el.query(e => e.references === null)).not.toThrow();
+      });
+
+      it('when searching by providerTokens', () => {
+        expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow();
+      });
+
+      it('when searching by injector', () => {
+        expect(() => el.query(e => e.injector === null)).not.toThrow();
+      });
     });
 
     it('DebugElement.queryAll should pick up both elements inserted via the view and through Renderer2',

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -640,29 +640,23 @@ class TestCmptWithPropInterpolation {
         expect(() => el.query(e => e.properties['any prop'] === 'any value')).not.toThrow();
       });
 
-      it('when searching by componentInstance', () => {
-        expect(() => el.query(e => e.componentInstance === null)).not.toThrow();
-      });
+      it('when searching by componentInstance',
+         () => { expect(() => el.query(e => e.componentInstance === null)).not.toThrow(); });
 
-      it('when searching by context', () => {
-        expect(() => el.query(e => e.context === null)).not.toThrow();
-      });
+      it('when searching by context',
+         () => { expect(() => el.query(e => e.context === null)).not.toThrow(); });
 
-      it('when searching by listeners', () => {
-        expect(() => el.query(e => e.listeners.length === 0)).not.toThrow();
-      });
+      it('when searching by listeners',
+         () => { expect(() => el.query(e => e.listeners.length === 0)).not.toThrow(); });
 
-      it('when searching by references', () => {
-        expect(() => el.query(e => e.references === null)).not.toThrow();
-      });
+      it('when searching by references',
+         () => { expect(() => el.query(e => e.references === null)).not.toThrow(); });
 
-      it('when searching by providerTokens', () => {
-        expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow();
-      });
+      it('when searching by providerTokens',
+         () => { expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow(); });
 
-      it('when searching by injector', () => {
-        expect(() => el.query(e => e.injector === null)).not.toThrow();
-      });
+      it('when searching by injector',
+         () => { expect(() => el.query(e => e.injector === null)).not.toThrow(); });
     });
 
     it('DebugElement.queryAll should pick up both elements inserted via the view and through Renderer2',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)



## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

In Ivy, DebugElement.query throws exceptions when querying some properties because it encounters elements created outside Angular's context.

Issue Number: N/A


## What is the new behavior?

No exceptions are thrown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
DebugElement.injector still throws an exception because the interface doesn't support returning null.