### PR TITLE
fix(ivy): avoid unnecessary i18n instructions generation for <ng-template> with structural directives

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -2516,7 +2516,7 @@ describe('i18n support in the template compiler', () => {
           }
         }
       `;
-      verify(input, output, {verbose: true});
+      verify(input, output);
     });
   });
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -2462,6 +2462,8 @@ describe('i18n support in the template compiler', () => {
          verify(input, output);
        });
 
+    // Note: applying structural directives to <ng-template> is typically user error, but it is
+    // technically allowed, so we need to support it.
     it('should handle structural directives', () => {
       const input = `
         <ng-template *ngIf="someFlag" i18n>Content A</ng-template>

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -2462,6 +2462,62 @@ describe('i18n support in the template compiler', () => {
          verify(input, output);
        });
 
+    it('should handle structural directives', () => {
+      const input = `
+        <ng-template *ngIf="someFlag" i18n>Content A</ng-template>
+        <ng-container *ngIf="someFlag" i18n>Content B</ng-container>
+      `;
+
+      const output = String.raw `
+        const $_c0$ = [4, "ngIf"];
+        var $I18N_1$;
+        if (ngI18nClosureMode) {
+            const $MSG_EXTERNAL_3308216566145348998$$APP_SPEC_TS___2$ = goog.getMsg("Content A");
+            $I18N_1$ = $MSG_EXTERNAL_3308216566145348998$$APP_SPEC_TS___2$;
+        } else {
+            $I18N_1$ = $localize \`Content A\`;
+        }
+        function MyComponent_0_ng_template_0_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵɵi18n(0, $I18N_1$);
+          }
+        }
+        function MyComponent_0_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 1, 0, "ng-template");
+          }
+        }
+        var $I18N_3$;
+        if (ngI18nClosureMode) {
+            const $MSG_EXTERNAL_8349021389088127654$$APP_SPEC_TS__4$ = goog.getMsg("Content B");
+            $I18N_3$ = $MSG_EXTERNAL_8349021389088127654$$APP_SPEC_TS__4$;
+        } else {
+            $I18N_3$ = $localize \`Content B\`;
+        }
+        function MyComponent_ng_container_1_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵɵelementContainerStart(0);
+            $r3$.ɵɵi18n(1, $I18N_3$);
+            $r3$.ɵɵelementContainerEnd();
+          }
+        }
+        …
+        consts: 2,
+        vars: 2,
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵɵtemplate(0, MyComponent_0_Template, 1, 0, undefined, $_c0$);
+            $r3$.ɵɵtemplate(1, MyComponent_ng_container_1_Template, 2, 0, "ng-container", $_c0$);
+          }
+          if (rf & 2) {
+            $r3$.ɵɵproperty("ngIf", ctx.someFlag);
+            $r3$.ɵɵadvance(1);
+            $r3$.ɵɵproperty("ngIf", ctx.someFlag);
+          }
+        }
+      `;
+      verify(input, output, {verbose: true});
+    });
   });
 
   describe('whitespace preserving mode', () => {

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -18,7 +18,7 @@ import {PreparsedElementType, preparseElement} from '../template_parser/template
 import {syntaxError} from '../util';
 
 import * as t from './r3_ast';
-import {I18N_ICU_VAR_PREFIX} from './view/i18n/util';
+import {I18N_ICU_VAR_PREFIX, isI18nRootNode} from './view/i18n/util';
 
 const BIND_NAME_REGEXP =
     /^(?:(?:(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.+))|\[\(([^\)]+)\)\]|\[([^\]]+)\]|\(([^\)]+)\))$/;
@@ -205,12 +205,18 @@ class HtmlAstToIvyAst implements html.Visitor {
             outputs: parsedElement.outputs,
           } :
           {attributes: [], inputs: [], outputs: []};
+
+      // For <ng-template>s with structural directives on them, avoid passing i18n information to
+      // the wrapping template to prevent unnecessary i18n instructions from being generated. The
+      // necessary i18n meta information will be extracted from child elements.
+      const i18n = isTemplateElement && isI18nRootNode(element.i18n) ? undefined : element.i18n;
+
       // TODO(pk): test for this case
       parsedElement = new t.Template(
           (parsedElement as t.Element).name, hoistedAttrs.attributes, hoistedAttrs.inputs,
           hoistedAttrs.outputs, templateAttrs, [parsedElement], [/* no references */],
           templateVariables, element.sourceSpan, element.startSourceSpan, element.endSourceSpan,
-          element.i18n);
+          i18n);
     }
     return parsedElement;
   }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -199,12 +199,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     variables.forEach(v => this.registerContextVariables(v));
 
     // Initiate i18n context in case:
-    // - this template has parent i18n context
-    // - or the template has i18n meta associated with it,
-    //   but it's not initiated by the Element (e.g. <ng-template i18n>)
-    const initI18nContext =
-        this.i18nContext || (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
-                             !(isSingleElementTemplate(nodes) && nodes[0].i18n === i18n));
+    // - it's *not* a template-only content
+    // - this template has parent i18n context (i.e. it's inside i18n block) or the template has
+    // i18n meta associated with it, but it's not initiated by the Element (e.g. <ng-template i18n>)
+    const initI18nContext = !isSingleTemplateNode(nodes) &&
+        (this.i18nContext || (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
+                              !(isSingleElementNode(nodes) && nodes[0].i18n === i18n)));
     const selfClosingI18nInstruction = hasTextChildrenOnly(nodes);
     if (initI18nContext) {
       this.i18nStart(null, i18n !, selfClosingI18nInstruction);
@@ -1984,8 +1984,12 @@ export function resolveSanitizationFn(context: core.SecurityContext, isAttribute
   }
 }
 
-function isSingleElementTemplate(children: t.Node[]): children is[t.Element] {
+function isSingleElementNode(children: t.Node[]): children is[t.Element] {
   return children.length === 1 && children[0] instanceof t.Element;
+}
+
+function isSingleTemplateNode(children: t.Node[]): children is[t.Template] {
+  return children.length === 1 && children[0] instanceof t.Template;
 }
 
 function isTextNode(node: t.Node): boolean {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -199,12 +199,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     variables.forEach(v => this.registerContextVariables(v));
 
     // Initiate i18n context in case:
-    // - it's *not* a template-only content
-    // - this template has parent i18n context (i.e. it's inside i18n block) or the template has
-    // i18n meta associated with it, but it's not initiated by the Element (e.g. <ng-template i18n>)
-    const initI18nContext = !isSingleTemplateNode(nodes) &&
-        (this.i18nContext || (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
-                              !(isSingleElementNode(nodes) && nodes[0].i18n === i18n)));
+    // - this template has parent i18n context
+    // - or the template has i18n meta associated with it,
+    //   but it's not initiated by the Element (e.g. <ng-template i18n>)
+    const initI18nContext =
+        this.i18nContext || (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
+                             !(isSingleElementTemplate(nodes) && nodes[0].i18n === i18n));
     const selfClosingI18nInstruction = hasTextChildrenOnly(nodes);
     if (initI18nContext) {
       this.i18nStart(null, i18n !, selfClosingI18nInstruction);
@@ -1984,12 +1984,8 @@ export function resolveSanitizationFn(context: core.SecurityContext, isAttribute
   }
 }
 
-function isSingleElementNode(children: t.Node[]): children is[t.Element] {
+function isSingleElementTemplate(children: t.Node[]): children is[t.Element] {
   return children.length === 1 && children[0] instanceof t.Element;
-}
-
-function isSingleTemplateNode(children: t.Node[]): children is[t.Template] {
-  return children.length === 1 && children[0] instanceof t.Template;
 }
 
 function isTextNode(node: t.Node): boolean {

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -301,6 +301,8 @@ onlyInIvy('Ivy i18n logic')
               expect(element).toHaveText('Bonjour Angular');
             });
 
+            // Note: applying structural directives to <ng-template> is typically user error, but it
+            // is technically allowed, so we need to support it.
             it('should handle structural directives on ng-template', () => {
               loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
               const fixture = initWithTemplate(

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -301,6 +301,15 @@ onlyInIvy('Ivy i18n logic')
               expect(element).toHaveText('Bonjour Angular');
             });
 
+            it('should handle structural directives on ng-template', () => {
+              loadTranslations({'Hello {$INTERPOLATION}': 'Bonjour {$INTERPOLATION}'});
+              const fixture = initWithTemplate(
+                  AppComp, `<ng-template *ngIf="name" i18n tplRef>Hello {{ name }}</ng-template>`);
+
+              const element = fixture.nativeElement;
+              expect(element).toHaveText('Bonjour Angular');
+            });
+
             it('should be able to act as child elements inside i18n block (plain text content)', () => {
               loadTranslations({
 


### PR DESCRIPTION
If an <ng-template> contains a structural directive (for example *ngIf), Ngtsc generates extra template function with 1 template instruction call. When <ng-template> tag also contains i18n attribute on it, we generate i18nStart and i18nEnd instructions around it, which is unnecessary and breaking runtime. This commit adds a logic to make sure we do not generate i18n instructions in case only `template` is present.

This PR resolves FW-1553.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No