### PR TITLE
fix(language-service): Lazily instantiate MetadataResolver

### DIFF
--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -51,13 +51,11 @@ describe('reflector_host_spec', () => {
 
     const tsLS = ts.createLanguageService(mockHost);
 
-    // First count is due to the instantiation of StaticReflector, which
-    // performs resolutions of core Angular symbols, like `NgModule`.
-    // TODO: Reduce this count to zero doing lazy instantiation.
+    // First count is zero due to lazy instantiation of the StaticReflector
+    // and MetadataResolver.
     const ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
     const firstCount = spy.calls.count();
-    expect(firstCount).toBeGreaterThan(20);
-    expect(firstCount).toBeLessThan(50);
+    expect(firstCount).toBe(0);
     spy.calls.reset();
 
     // Second count is due to resolution of the Tour of Heroes (toh) project.


### PR DESCRIPTION
The instantiation of the resolver also requires instantiation of the
StaticReflector, and the latter requires resolution of core Angular symbols.
Module resolution should not be done during instantiation to avoid potential
cyclic dependency between the plugin and the containing Project, so the
Singleton pattern is used to create the resolver.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
