### PR TITLE
refactor(ivy): migrate component ref spec from render

### DIFF
--- a/packages/core/test/acceptance/component_ref_spec.ts
+++ b/packages/core/test/acceptance/component_ref_spec.ts
@@ -6,33 +6,45 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModuleRef, ViewEncapsulation} from '../../src/core';
-import {ComponentFactory} from '../../src/linker/component_factory';
-import {RendererFactory2} from '../../src/render/api';
-import {injectComponentFactoryResolver} from '../../src/render3/component_ref';
-import {ɵɵdefineComponent} from '../../src/render3/index';
-import {domRendererFactory3} from '../../src/render3/interfaces/renderer';
-import {Sanitizer} from '../../src/sanitization/sanitizer';
+import {Component, ComponentFactory, ComponentFactoryResolver, EventEmitter, Injector, Input, NgModule, NgModuleRef, Output, RendererFactory2, Sanitizer, Type, ViewEncapsulation} from '@angular/core';
+import {injectComponentFactoryResolver} from '@angular/core/src/render3';
+import {domRendererFactory3} from '@angular/core/src/render3/interfaces/renderer';
+import {TestBed} from '@angular/core/testing';
+import {beforeEach} from '@angular/core/testing/src/testing_internal';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
 
 describe('ComponentFactory', () => {
-  const cfr = injectComponentFactoryResolver();
 
   describe('constructor()', () => {
-    it('should correctly populate default properties', () => {
-      class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
-        static ngComponentDef = ɵɵdefineComponent({
-          type: TestComponent,
-          selectors: [['test', 'foo'], ['bar']],
-          consts: 0,
-          vars: 0,
-          template: () => undefined,
-        });
+
+    /**
+     * Ivy tests don't need this,
+     * but VE tests need the component to be in an NgModule
+     * to be used with `ComponentFactoryResolver`
+     * @param componentType The component to add to the TestingModule
+     */
+    function setupModuleForViewEngineTest<T>(componentType: Type<T>) {
+      @NgModule({entryComponents: [componentType], declarations: [componentType]})
+      class TestModule {
       }
 
+      TestBed.configureTestingModule({imports: [TestModule]});
+    }
+
+    it('should correctly populate default properties', () => {
+      @Component({selector: 'test[foo],bar', template: ''})
+      class TestComponent {
+      }
+
+      if (!ivyEnabled) {
+        setupModuleForViewEngineTest(TestComponent);
+      }
+
+      const cfr = TestBed.inject(ComponentFactoryResolver);
       const cf = cfr.resolveComponentFactory(TestComponent);
 
-      expect(cf.selector).toBe('test');
+      expect(cf.selector).toBe('test[foo],bar');
       expect(cf.componentType).toBe(TestComponent);
       expect(cf.ngContentSelectors).toEqual([]);
       expect(cf.inputs).toEqual([]);
@@ -40,27 +52,24 @@ describe('ComponentFactory', () => {
     });
 
     it('should correctly populate defined properties', () => {
+      @Component({
+        selector: 'test',
+        template:
+            '<ng-content select="*"></ng-content><ng-content select="a"></ng-content><ng-content select="b"></ng-content>',
+        encapsulation: ViewEncapsulation.None
+      })
       class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
-        static ngComponentDef = ɵɵdefineComponent({
-          type: TestComponent,
-          encapsulation: ViewEncapsulation.None,
-          selectors: [['test', 'foo'], ['bar']],
-          consts: 0,
-          vars: 0,
-          template: () => undefined,
-          ngContentSelectors: ['*', 'a', 'b'],
-          inputs: {
-            in1: 'in1',
-            in2: ['input-attr-2', 'in2'],
-          },
-          outputs: {
-            out1: 'out1',
-            out2: 'output-attr-2',
-          },
-        });
+        @Input() in1 = '';
+        @Input('input-attr-2') in2 = '';
+        @Output() out1 = new EventEmitter();
+        @Output('output-attr-2') out2 = new EventEmitter();
       }
 
+      if (!ivyEnabled) {
+        setupModuleForViewEngineTest(TestComponent);
+      }
+
+      const cfr = TestBed.inject(ComponentFactoryResolver);
       const cf = cfr.resolveComponentFactory(TestComponent);
 
       expect(cf.componentType).toBe(TestComponent);
@@ -68,46 +77,41 @@ describe('ComponentFactory', () => {
       expect(cf.selector).toBe('test');
 
       expect(cf.inputs).toEqual([
-        {propName: 'in1', templateName: 'in1'},
-        {propName: 'in2', templateName: 'input-attr-2'},
+        {propName: 'in1', templateName: 'in1'}, {propName: 'in2', templateName: 'input-attr-2'}
       ]);
       expect(cf.outputs).toEqual([
         {propName: 'out1', templateName: 'out1'},
-        {propName: 'out2', templateName: 'output-attr-2'},
+        {propName: 'out2', templateName: 'output-attr-2'}
       ]);
     });
   });
 
-  describe('create()', () => {
+  onlyInIvy('renderer3 is available only in Ivy').describe('create()', () => {
+
     let createRenderer2Spy: jasmine.Spy;
     let createRenderer3Spy: jasmine.Spy;
     let cf: ComponentFactory<any>;
 
     beforeEach(() => {
       createRenderer2Spy =
-          jasmine.createSpy('RendererFactory2#createRenderer').and.returnValue(document),
+          jasmine.createSpy('RendererFactory2#createRenderer').and.returnValue(document);
       createRenderer3Spy = spyOn(domRendererFactory3, 'createRenderer').and.callThrough();
 
+      @Component({selector: 'test', template: ''})
       class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
-        static ngComponentDef = ɵɵdefineComponent({
-          type: TestComponent,
-          encapsulation: ViewEncapsulation.None,
-          selectors: [['test']],
-          consts: 0,
-          vars: 0,
-          template: () => undefined,
-        });
       }
 
+      const cfr = injectComponentFactoryResolver();
       cf = cfr.resolveComponentFactory(TestComponent);
     });
 
     describe('(when `ngModuleRef` is not provided)', () => {
+
       it('should retrieve `RendererFactory2` from the specified injector', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
-        ]);
+        const injector = Injector.create({
+          providers:
+              [{provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}}]
+        });
 
         cf.create(injector);
 
@@ -116,7 +120,7 @@ describe('ComponentFactory', () => {
       });
 
       it('should fall back to `domRendererFactory3` if `RendererFactory2` is not provided', () => {
-        const injector = Injector.create([]);
+        const injector = Injector.create({providers: []});
 
         cf.create(injector);
 
@@ -126,9 +130,8 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the specified injector', () => {
         const sanitizerFactorySpy = jasmine.createSpy('sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: Sanitizer, useFactory: sanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create(
+            {providers: [{provide: Sanitizer, useFactory: sanitizerFactorySpy, deps: []}]});
 
         cf.create(injector);
 
@@ -138,12 +141,14 @@ describe('ComponentFactory', () => {
 
     describe('(when `ngModuleRef` is provided)', () => {
       it('should retrieve `RendererFactory2` from the specified injector first', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
-        ]);
-        const mInjector = Injector.create([
-          {provide: RendererFactory2, useValue: {createRenderer: createRenderer3Spy}},
-        ]);
+        const injector = Injector.create({
+          providers:
+              [{provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}}]
+        });
+        const mInjector = Injector.create({
+          providers:
+              [{provide: RendererFactory2, useValue: {createRenderer: createRenderer3Spy}}]
+        });
 
         cf.create(injector, undefined, undefined, { injector: mInjector } as NgModuleRef<any>);
 
@@ -153,10 +158,11 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `RendererFactory2` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
-           const mInjector = Injector.create([
-             {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
-           ]);
+           const injector = Injector.create({providers: []});
+           const mInjector = Injector.create({
+             providers:
+                 [{provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}}]
+           });
 
            cf.create(injector, undefined, undefined, { injector: mInjector } as NgModuleRef<any>);
 
@@ -165,8 +171,8 @@ describe('ComponentFactory', () => {
          });
 
       it('should fall back to `domRendererFactory3` if `RendererFactory2` is not provided', () => {
-        const injector = Injector.create([]);
-        const mInjector = Injector.create([]);
+        const injector = Injector.create({providers: []});
+        const mInjector = Injector.create({providers: []});
 
         cf.create(injector, undefined, undefined, { injector: mInjector } as NgModuleRef<any>);
 
@@ -177,15 +183,13 @@ describe('ComponentFactory', () => {
       it('should retrieve `Sanitizer` from the specified injector first', () => {
         const iSanitizerFactorySpy =
             jasmine.createSpy('Injector#sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create(
+            {providers: [{provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []}]});
 
         const mSanitizerFactorySpy =
             jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
-        const mInjector = Injector.create([
-          {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-        ]);
+        const mInjector = Injector.create(
+            {providers: [{provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []}]});
 
         cf.create(injector, undefined, undefined, { injector: mInjector } as NgModuleRef<any>);
 
@@ -195,14 +199,12 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
 
            const mSanitizerFactorySpy =
                jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
-           const mInjector = Injector.create([
-             {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-           ]);
-
+           const mInjector = Injector.create(
+               {providers: [{provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []}]});
 
            cf.create(injector, undefined, undefined, { injector: mInjector } as NgModuleRef<any>);
 
@@ -212,13 +214,15 @@ describe('ComponentFactory', () => {
 
     describe('(when the factory is bound to a `ngModuleRef`)', () => {
       it('should retrieve `RendererFactory2` from the specified injector first', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
-        ]);
+        const injector = Injector.create({
+          providers:
+              [{provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}}]
+        });
         (cf as any).ngModule = {
-          injector: Injector.create([
-            {provide: RendererFactory2, useValue: {createRenderer: createRenderer3Spy}},
-          ])
+          injector: Injector.create({
+            providers:
+                [{provide: RendererFactory2, useValue: {createRenderer: createRenderer3Spy}}]
+          })
         };
 
         cf.create(injector);
@@ -229,11 +233,12 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `RendererFactory2` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
            (cf as any).ngModule = {
-             injector: Injector.create([
-               {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
-             ])
+             injector: Injector.create({
+               providers:
+                   [{provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}}]
+             })
            };
 
            cf.create(injector);
@@ -243,8 +248,8 @@ describe('ComponentFactory', () => {
          });
 
       it('should fall back to `domRendererFactory3` if `RendererFactory2` is not provided', () => {
-        const injector = Injector.create([]);
-        (cf as any).ngModule = {injector: Injector.create([])};
+        const injector = Injector.create({providers: []});
+        (cf as any).ngModule = {injector: Injector.create({providers: []})};
 
         cf.create(injector);
 
@@ -255,16 +260,14 @@ describe('ComponentFactory', () => {
       it('should retrieve `Sanitizer` from the specified injector first', () => {
         const iSanitizerFactorySpy =
             jasmine.createSpy('Injector#sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create(
+            {providers: [{provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []}]});
 
         const mSanitizerFactorySpy =
             jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
         (cf as any).ngModule = {
-          injector: Injector.create([
-            {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-          ])
+          injector: Injector.create(
+              {providers: [{provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []}]})
         };
 
         cf.create(injector);
@@ -275,16 +278,14 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
 
            const mSanitizerFactorySpy =
                jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
            (cf as any).ngModule = {
-             injector: Injector.create([
-               {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-             ])
+             injector: Injector.create(
+                 {providers: [{provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []}]})
            };
-
 
            cf.create(injector);
 
@@ -292,4 +293,5 @@ describe('ComponentFactory', () => {
          });
     });
   });
+
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Migrates `component_ref_spec.ts` from `render3` to `acceptance`.
Some tests are focused on Renderer3 and have been marked as `onlyInIvy`.
Also note that the `Injector.create` calls are now using the non-deprecated version.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
