### PR TITLE
ci: add @josephperrott to global approvers in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@
 #  (secret team to avoid review requests, it also doesn't inherit from @angular/framework because nested teams can't be secret)
 #
 #   - IgorMinar
+#   - josephperrott
 #   - kara
 #   - mhevery
 


### PR DESCRIPTION
This change aims to align the documented members in `CODEOWNERS` with the actual members of the secret `framework-global-approvers` GitHub team.
