### PR TITLE
fix(router): do not add hash when fragment is empty

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -290,8 +290,9 @@ export class DefaultUrlSerializer implements UrlSerializer {
   serialize(tree: UrlTree): string {
     const segment = `/${serializeSegment(tree.root, true)}`;
     const query = serializeQueryParams(tree.queryParams);
-    const fragment =
-        typeof tree.fragment === `string` ? `#${encodeUriFragment(tree.fragment !)}` : '';
+    const fragment = typeof tree.fragment === `string` && tree.fragment ?
+        `#${encodeUriFragment(tree.fragment !)}` :
+        '';
 
     return `${segment}${query}${fragment}`;
   }

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -183,7 +183,7 @@ describe('url serializer', () => {
   it('should parse empty fragment', () => {
     const tree = url.parse('/one#');
     expect(tree.fragment).toEqual('');
-    expect(url.serialize(tree)).toEqual('/one#');
+    expect(url.serialize(tree)).toEqual('/one');
   });
 
   describe('encoding/decoding', () => {


### PR DESCRIPTION
Closes #29683

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: [29683](https://github.com/angular/angular/issues/29683)


## What is the new behavior?
Won't add hash to URL when fragment is empty.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
