### PR TITLE
fix(forms): include null in return types of .parent of abstract control

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -6,7 +6,7 @@ export declare abstract class AbstractControl {
     get enabled(): boolean;
     readonly errors: ValidationErrors | null;
     get invalid(): boolean;
-    get parent(): FormGroup | FormArray;
+    get parent(): FormGroup | FormArray | null;
     get pending(): boolean;
     readonly pristine: boolean;
     get root(): AbstractControl;

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -173,8 +173,7 @@ export abstract class AbstractControl {
   // TODO(issue/24571): remove '!'.
   _updateOn!: FormHooks;
 
-  // TODO(issue/24571): remove '!'.
-  private _parent!: FormGroup|FormArray;
+  private _parent: FormGroup|FormArray|null = null;
   private _asyncValidationSubscription: any;
 
   /**
@@ -267,7 +266,7 @@ export abstract class AbstractControl {
   /**
    * The parent control.
    */
-  get parent(): FormGroup|FormArray {
+  get parent(): FormGroup|FormArray|null {
     return this._parent;
   }
 
@@ -1018,7 +1017,7 @@ export abstract class AbstractControl {
    */
   private _parentMarkedDirty(onlySelf?: boolean): boolean {
     const parentDirty = this._parent && this._parent.dirty;
-    return !onlySelf && parentDirty && !this._parent._anyControlsDirty();
+    return !onlySelf && !!parentDirty && !this._parent!._anyControlsDirty();
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`AbstractControl#parent` returns a defined value.

Issue Number: https://github.com/angular/angular/issues/16999


## What is the new behavior?

`AbstractControl#parent` can return `undefined`.


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Technically yes since we're changing the public API but then again, we're fixing a lie we told users before.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
