### PR TITLE
ci: run ts-api-guardian test remotely on CI

### DIFF
--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -80,7 +80,6 @@ jasmine_node_test(
         # TODO: remove this once the boostrap.js workaround has been removed.
         ":package.json",
     ],
-    tags = ["local"],
 )
 # END-INTERNAL
 


### PR DESCRIPTION
By running the ts-api-guardian tests remotely, we allow them to be cached and prevent having to run the tests on every run.