### PR TITLE
ci: use automatic strategy selection for AngularTemplateCompile and TypeScriptCompile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -146,11 +146,6 @@ build --incompatible_list_based_execution_strategy_selection=false
 test --incompatible_list_based_execution_strategy_selection=false
 run --incompatible_list_based_execution_strategy_selection=false
 
-# Use workers for tsc and ngc when building locally.
-# This config is overwritten on CI to as the worker strategy causes flakes on CI.
-build --strategy=AngularTemplateCompile=worker
-build --strategy=TypeScriptCompile=worker
-
 ####################################################
 # User bazel configuration
 # NOTE: This needs to be the *last* entry in the config.

--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -13,8 +13,3 @@ test --flaky_test_attempts=2
 
 # More details on failures
 build --verbose_failures=true
-
-# Utilize remote strategy for AngularTemplateCompile and TypeScriptCompile to take
-# advantage of caching of outputs
-build --strategy=AngularTemplateCompile=remote
-build --strategy=TypeScriptCompile=remote

--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -14,13 +14,7 @@ test --flaky_test_attempts=2
 # More details on failures
 build --verbose_failures=true
 
-# We have seen some flakiness in using TS workers on CircleCI
-# https://angular-team.slack.com/archives/C07DT5M6V/p1562693245183400
-# > failures like `ERROR: /home/circleci/ng/packages/core/test/BUILD.bazel:5:1:
-# > Compiling TypeScript (devmode) //packages/core/test:test_lib failed: Worker process did not return a WorkResponse:`
-# > I saw that issue a couple times today.
-# > Example job: https://circleci.com/gh/angular/angular/385517
-# We expect that TypeScript compilations will parallelize wider than the number of local cores anyway
-# so we should saturate remote workers with TS compilations
-build --strategy=AngularTemplateCompile=local
-build --strategy=TypeScriptCompile=local
+# Utilize remote strategy for AngularTemplateCompile and TypeScriptCompile to take
+# advantage of caching of outputs
+build --strategy=AngularTemplateCompile=remote
+build --strategy=TypeScriptCompile=remote

--- a/modules/playground/src/relative_assets/BUILD.bazel
+++ b/modules/playground/src/relative_assets/BUILD.bazel
@@ -6,6 +6,10 @@ package(default_visibility = ["//modules/playground:__subpackages__"])
 ng_module(
     name = "relative_assets",
     srcs = glob(["**/*.ts"]),
+    assets = [
+        "app/style.css",
+        "app/tpl.html",
+    ],
     # This example demonstrates how external resources can be loaded relatively, so we
     # need to disable resource inlining.
     inline_resources = False,

--- a/modules/playground/src/todo/BUILD.bazel
+++ b/modules/playground/src/todo/BUILD.bazel
@@ -6,7 +6,10 @@ package(default_visibility = ["//modules/playground:__subpackages__"])
 ng_module(
     name = "todo",
     srcs = glob(["**/*.ts"]),
-    assets = ["todo.html"],
+    assets = [
+        "todo.html",
+        "css/base.css",
+    ],
     tsconfig = "//modules/playground:tsconfig-build.json",
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,


### PR DESCRIPTION
Removes the selection strategies for `AngularTemplateCompile` and `TypeScriptCompile` causing them to use the automatic selection strategies instead.


For `test_ivy_aot`
Before change:
`1919 processes: 1223 remote cache hit, 463 local, 233 remote`
After change:
`1919 processes: 1651 remote cache hit, 31 local, 237 remote`