### PR TITLE
fix(compiler-cli): fix typo in diagnostic template info

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
@@ -238,7 +238,7 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
               'The template context does not have an implicit value', spanOf(ast.sourceSpan));
         } else {
           this.reportError(
-              `The template context does not defined a member called '${ast.value}'`,
+              `The template context does not define a member called '${ast.value}'`,
               spanOf(ast.sourceSpan));
         }
       }

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -166,7 +166,7 @@ describe('plugin', () => {
             'Identifier \'people_1\' is not defined. The component declaration, template variable declarations, and element references do not contain such a member');
       });
       it('should report an unknown context reference', () => {
-        expectError('even_1', 'The template context does not defined a member called \'even_1\'');
+        expectError('even_1', 'The template context does not define a member called \'even_1\'');
       });
       it('should report an unknown value in a key expression', () => {
         expectError(
@@ -179,8 +179,7 @@ describe('plugin', () => {
         expectSemanticError('app/ng-if-cases.ts', locationMarker, message);
       }
       it('should report an implicit context reference', () => {
-        expectError(
-            'implicit', 'The template context does not defined a member called \'unknown\'');
+        expectError('implicit', 'The template context does not define a member called \'unknown\'');
       });
     });
 


### PR DESCRIPTION


Closes #32662.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 32662


## What is the new behavior?
Explicit context reference error now reads
`The template context does not define a member called`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
