### PR TITLE
fix(router): support lazy loading for named outlets

### DIFF
--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -462,6 +462,27 @@ describe('applyRedirects', () => {
             expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
           });
     });
+
+    it('should load the configuration of empty root path if the entry point is an auxiliary outlet',
+       () => {
+         const loadedConfig =
+             new LoadedRouterConfig([{path: '', component: ComponentA}], testModule);
+         const loader = {
+           load: (injector: any, p: any) => {
+             return of(loadedConfig);
+           }
+         };
+
+         const config: Routes = [
+           {path: '', loadChildren: 'root'}, {path: 'modal', loadChildren: 'aux', outlet: 'popup'}
+         ];
+
+         applyRedirects(testModule.injector, <any>loader, serializer, tree('(popup:modal)'), config)
+             .forEach(r => {
+               expectTreeToBe(r, '/(popup:modal)');
+               expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
+             });
+       });
   });
 
   describe('empty paths', () => {

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -491,6 +491,32 @@ describe('applyRedirects', () => {
          tick(100);
          expect(loaded).toEqual(['root', 'aux']);
        }));
+
+    it('loads only the first match when two Routes with the same outlet have the same path',
+      fakeAsync(() => {
+        const loadedConfig =
+          new LoadedRouterConfig([{path: '', component: ComponentA}], testModule);
+        let loadCalls = 0;
+        let loaded: string[] = [];
+        const loader = {
+          load: (injector: any, p: Route) => {
+            loadCalls++;
+            return of(loadedConfig)
+              .pipe(
+                tap(() => loaded.push(p.loadChildren! as string)),
+              );
+          }
+        };
+
+        const config: Routes =
+          [{path: 'a', loadChildren: 'first'}, {path: 'a', loadChildren: 'second'}];
+
+        applyRedirects(testModule.injector, <any>loader, serializer, tree('a'), config)
+          .subscribe();
+        expect(loadCalls).toBe(1);
+        tick();
+        expect(loaded).toEqual(['first']);
+      }))
   });
 
   describe('empty paths', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
**This is correct implementation and replacement of #25483**

This PR is avoid problem appear in #25483: the same error occurs when you have lazy-loaded default route and routes with empty path and named outlet before it.

---

Given the following route configuration:

```
[
    {path: '', loadChildren: 'children'},
    {path: 'a', loadChildren: 'otherChildren', outlet: 'aux'}
]
```
With this configuration, using the outlet as an entry point to the application, the root module will not load properly and results in the following error:

`TypeError: Cannot read property 'routes' of undefined at getChildConfig (router.js:3041)`

The `_loadedConfig` property of the route remains `undefined` as the `expandSegmentAgainstRoute()` isn't executed.

This issue is only present if the root has a lazy loaded module, works fine with a component or even with a lazy loaded module if the root path is not empty.

**Issue Number:** #12842


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
