### PR TITLE
ci: update schedule for locking inactive issues

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,4 +1,4 @@
-name: Lock Inactive Issues
+name: Lock closed inactive issues
 
 on:
   schedule:

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,17 +1,14 @@
-name: Lock issues that are closed and inactive
+name: Lock Inactive Issues
 
 on:
   schedule:
-    # Run at the 20th and 50th minute of every hour, we are running with high
-    # frequency while clearing the backlog of inactive locked issues/prs.  Long
-    # term we will run this task once per day.
-    - cron: '20,50 * * * *'
+    # Run at 16:00 every day
+    - cron: '0 16 * * *'
 
 jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@a4fd924
+      - uses: angular/dev-infra/github-actions/lock-closed@66462f6
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
-          locks-per-execution: 100


### PR DESCRIPTION
Closes #32499

Now that we have worked through the backlog of inactive closed issues. We will move to automatically locking issues once per day.
