### PR TITLE
Correct default in API doc for Router ExtraOptions.initialNavigation

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -229,16 +229,17 @@ export function provideRoutes(routes: Routes): any {
  * Allowed values in an `ExtraOptions` object that configure
  * when the router performs the initial navigation operation.
  *
- * * 'enabled' (Default) The initial navigation starts before the root component is created.
- * The bootstrap is blocked until the initial navigation is complete.
+ * * 'enabled' - The initial navigation starts before the root component is created.
+ * The bootstrap is blocked until the initial navigation is complete. This value is required
+ * for [server-side rendering](guide/universal) to work.
  * * 'disabled' - The initial navigation is not performed. The location listener is set up before
  * the root component gets created. Use if there is a reason to have
  * more control over when the router starts its initial navigation due to some complex
  * initialization logic.
- * * 'legacy_enabled'- The initial navigation starts after the root component has been created.
+ * * 'legacy_enabled'- (Default, for compatibility.) The initial navigation starts after the root component has been created.
  * The bootstrap is not blocked until the initial navigation is complete. @deprecated
  * * 'legacy_disabled'- The initial navigation is not performed. The location listener is set up
- * after the root component gets created. @deprecated
+ * after the root component gets created. @deprecated since v4
  * * `true` - same as 'legacy_enabled'. @deprecated since v4
  * * `false` - same as 'legacy_disabled'. @deprecated since v4
  *
@@ -271,11 +272,24 @@ export interface ExtraOptions {
   useHash?: boolean;
 
   /**
-   * One of `enabled` (the default) or `disabled`.
-   * By default, the initial navigation starts before the root component is created.
-   * The bootstrap is blocked until the initial navigation is complete.
+   * One of `enabled` or `disabled`.
+   * When set to `enabled`, the initial navigation starts before the root component is created.
+   * The bootstrap is blocked until the initial navigation is complete. This value is required for
+   * [server-side rendering](guide/universal) to work.
    * When set to `disabled`, the initial navigation is not performed.
    * The location listener is set up before the root component gets created.
+   * Use if there is a reason to have more control over when the router
+   * starts its initial navigation due to some complex initialization logic.
+   *
+   * Legacy values are deprecated since v4 and should not be used for new applications:
+   *
+   * * `legacy_enabled` - Default for compatibility.
+   * The initial navigation starts after the root component has been created,
+   * but the bootstrap is not blocked until the initial navigation is complete.
+   * * `legacy_disabled` - The initial navigation is not performed.
+   * The location listener is set up after the root component gets created.
+   * * `true` - same as `legacy_enabled`.
+   * * `false` - same as `legacy_disabled`.
    */
   initialNavigation?: InitialNavigation;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Fix default, mention SSR requirement. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
* https://angular.io/api/router/ExtraOptions#initialNavigation incorrectly identifies default value as `enabled` instead of `legacy_enabled`
* The `InitialNavigation` type does not appear in API doc (and the source doc also incorrectly identifies the default).

Issue Number:  https://github.com/angular/angular/issues/32571

## What is the new behavior?
Corrected doc for 
https://angular.io/api/router/ExtraOptions#initialNavigation  and the `InitialNavigation` type

TBD: `InitialNavigation` type  should appear in API doc 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
