### PR TITLE
docs(router): make `InitialNavigation` part of the public API

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,7 +16,7 @@ export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router} from './router';
 export {ROUTES} from './router_config_loader';
-export {ExtraOptions, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
+export {ExtraOptions, InitialNavigation, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
 export {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
 export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} from './router_preloader';
 export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -313,24 +313,24 @@ export interface ExtraOptions {
    *
    * ```typescript
    * class AppModule {
-    *   constructor(router: Router, viewportScroller: ViewportScroller) {
-    *     router.events.pipe(
-    *       filter((e: Event): e is Scroll => e instanceof Scroll)
-    *     ).subscribe(e => {
-    *       if (e.position) {
-    *         // backward navigation
-    *         viewportScroller.scrollToPosition(e.position);
-    *       } else if (e.anchor) {
-    *         // anchor navigation
-    *         viewportScroller.scrollToAnchor(e.anchor);
-    *       } else {
-    *         // forward navigation
-    *         viewportScroller.scrollToPosition([0, 0]);
-    *       }
-    *     });
-    *   }
-    * }
-    * ```
+   *   constructor(router: Router, viewportScroller: ViewportScroller) {
+   *     router.events.pipe(
+   *       filter((e: Event): e is Scroll => e instanceof Scroll)
+   *     ).subscribe(e => {
+   *       if (e.position) {
+   *         // backward navigation
+   *         viewportScroller.scrollToPosition(e.position);
+   *       } else if (e.anchor) {
+   *         // anchor navigation
+   *         viewportScroller.scrollToAnchor(e.anchor);
+   *       } else {
+   *         // forward navigation
+   *         viewportScroller.scrollToPosition([0, 0]);
+   *       }
+   *     });
+   *   }
+   * }
+   * ```
    */
   scrollPositionRestoration?: 'disabled'|'enabled'|'top';
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -148,6 +148,9 @@ export declare class GuardsCheckStart extends RouterEvent {
     toString(): string;
 }
 
+/** @deprecated */
+export declare type InitialNavigation = true | false | 'enabled' | 'disabled' | 'legacy_enabled' | 'legacy_disabled';
+
 export declare type LoadChildren = LoadChildrenCallback | DeprecatedLoadChildren;
 
 export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any> | any>;


### PR DESCRIPTION
`InitialNavigation` is used in `ExtraOptions`, which is already part of the public API. Thus, `InitialNavigation` should be too. Not publicly exporting it from `router/index.ts` seems an omission, since the type is already annotated with the `@publicApi` JSDoc tag.

By publicly exporting `InitialNavigation`, it will also correctly appear in the API docs on angular.io.
