### PR TITLE
fix(ngcc): support UMD global factory in comma lists

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -204,13 +204,19 @@ function isAmdConditional(value: ts.Node): value is AmdConditional {
  */
 function isGlobalFactoryCall(value: ts.Node): value is ts.CallExpression {
   if (ts.isCallExpression(value) && !!value.parent) {
+    // Be resilient to the value being part of a comma list
+    value = isCommaExpression(value.parent) ? value.parent : value;
     // Be resilient to the value being inside parentheses
-    const expression = ts.isParenthesizedExpression(value.parent) ? value.parent : value;
-    return !!expression.parent && ts.isConditionalExpression(expression.parent) &&
-        expression.parent.whenFalse === expression;
+    value = ts.isParenthesizedExpression(value.parent) ? value.parent : value;
+    return !!value.parent && ts.isConditionalExpression(value.parent) &&
+        value.parent.whenFalse === value;
   } else {
     return false;
   }
+}
+
+function isCommaExpression(value: ts.Node): value is ts.BinaryExpression {
+  return ts.isBinaryExpression(value) && value.operatorToken.kind === ts.SyntaxKind.CommaToken;
 }
 
 function getGlobalIdentifier(i: Import) {


### PR DESCRIPTION
Previously we were looking for a global factory call that looks like:

```ts
(factory((global.ng = global.ng || {}, global.ng.common = {}), global.ng.core))"
```

but in some cases it looks like:

```ts
(global = global || self, factory((global.ng = global.ng || {}, global.ng.common = {}), global.ng.core))"
```

Note the `global = global || self` at the start of the statement.

This commit makes the test when finding the global factory
function call resilient to being in a comma list.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
