### PR TITLE
feat(language-service): expose determining the NgModule of a Directive

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -442,12 +442,11 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   }
 
   /**
-   * Gets the StaticSymbol of a TypeScript node.
-   * @param node TypeScript node to get static symbol of
-   * @return Angular StaticSymbol of the TypeScript node, if any
+   * Gets a StaticSymbol from a file and symbol name.
+   * @return Angular StaticSymbol matching the file and name, if any
    */
-  getNodeStaticSymbol(node: ts.Node): StaticSymbol|undefined {
-    return this.reflector.getStaticSymbol(node.getSourceFile().fileName, node.getText());
+  getStaticSymbol(file: string, name: string): StaticSymbol|undefined {
+    return this.reflector.getStaticSymbol(file, name);
   }
 
   /**

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -442,18 +442,12 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   }
 
   /**
-   * Gets the NgModule of a Directive.
-   * @param directive directive TypeScript declaration or Angular StaticSymbol
-   * @return NgModule the directive belongs to, if any
+   * Gets the StaticSymbol of a TypeScript node.
+   * @param node TypeScript node to get static symbol of
+   * @return Angular StaticSymbol of the TypeScript node, if any
    */
-  getDirectiveModule(directive: ts.ClassDeclaration|StaticSymbol): CompileNgModuleMetadata
-      |undefined {
-    if (!(directive instanceof StaticSymbol)) {
-      if (!directive.name) return;
-      directive =
-          this.reflector.getStaticSymbol(directive.getSourceFile().fileName, directive.name.text);
-    }
-    return this.analyzedModules.ngModuleByPipeOrDirective.get(directive);
+  getNodeStaticSymbol(node: ts.Node): StaticSymbol|undefined {
+    return this.reflector.getStaticSymbol(node.getSourceFile().fileName, node.getText());
   }
 
   /**
@@ -468,8 +462,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       schemas: [] as SchemaMetadata[],
     };
     // First find which NgModule the directive belongs to.
-    const ngModule =
-        this.getDirectiveModule(classSymbol) || findSuitableDefaultModule(this.analyzedModules);
+    const ngModule = this.analyzedModules.ngModuleByPipeOrDirective.get(classSymbol) ||
+        findSuitableDefaultModule(this.analyzedModules);
     if (!ngModule) {
       return result;
     }

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -171,40 +171,21 @@ describe('TypeScriptServiceHost', () => {
     expect(newModules).toBe(oldModules);
   });
 
-  describe('getting the NgModule of a Directive', () => {
-    it('should get the correct NgModule for a Directive StaticSymbol', () => {
-      const tsLSHost = new MockTypescriptHost(['/app/app.component.ts', '/app/main.ts'], toh);
-      const tsLS = ts.createLanguageService(tsLSHost);
-      const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
-      ngLSHost.getAnalyzedModules();  // modules are analyzed lazily
-      const declarations = ngLSHost.getDeclarations('/app/app.component.ts');
-
-      const directive = declarations.find(d => d.type.name === 'AppComponent');
-      expect(directive).toBeDefined();
-      const ngModule = ngLSHost.getDirectiveModule(directive !.type);
-      expect(ngModule).toBeDefined();
-      const ngModuleRef = ngModule !.type.reference;
-      expect(ngModuleRef.constructor.name).toBe('StaticSymbol');
-      expect(ngModuleRef.name).toBe('AppModule');
+  it('should get the correct StaticSymbol for a Directive', () => {
+    const tsLSHost = new MockTypescriptHost(['/app/app.component.ts', '/app/main.ts'], toh);
+    const tsLS = ts.createLanguageService(tsLSHost);
+    const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+    ngLSHost.getAnalyzedModules();  // modules are analyzed lazily
+    const sf = ngLSHost.getSourceFile('/app/app.component.ts');
+    expect(sf).toBeDefined();
+    const directiveDecl = sf !.forEachChild(n => {
+      if (ts.isClassDeclaration(n) && n.name && n.name.text === 'AppComponent') return n;
     });
 
-    it('should get the correct NgModule for a Directive class declaration', () => {
-      const tsLSHost = new MockTypescriptHost(['/app/app.component.ts', '/app/main.ts'], toh);
-      const tsLS = ts.createLanguageService(tsLSHost);
-      const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
-      ngLSHost.getAnalyzedModules();  // modules are analyzed lazily
-      const sf = ngLSHost.getSourceFile('/app/app.component.ts');
-      expect(sf).toBeDefined();
-      const directiveDecl = sf !.forEachChild(n => {
-        if (ts.isClassDeclaration(n) && n.name && n.name.text === 'AppComponent') return n;
-      });
-
-      expect(directiveDecl).toBeDefined();
-      const ngModule = ngLSHost.getDirectiveModule(directiveDecl !);
-      expect(ngModule).toBeDefined();
-      const ngModuleRef = ngModule !.type.reference;
-      expect(ngModuleRef.constructor.name).toBe('StaticSymbol');
-      expect(ngModuleRef.name).toBe('AppModule');
-    });
+    expect(directiveDecl).toBeDefined();
+    expect(directiveDecl !.name).toBeDefined();
+    const directiveSymbol = ngLSHost.getNodeStaticSymbol(directiveDecl !.name !);
+    expect(directiveSymbol).toBeDefined();
+    expect(directiveSymbol !.name).toBe('AppComponent');
   });
 });

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -184,7 +184,9 @@ describe('TypeScriptServiceHost', () => {
 
     expect(directiveDecl).toBeDefined();
     expect(directiveDecl !.name).toBeDefined();
-    const directiveSymbol = ngLSHost.getNodeStaticSymbol(directiveDecl !.name !);
+    const fileName = directiveDecl !.getSourceFile().fileName;
+    const symbolName = directiveDecl !.name !.getText();
+    const directiveSymbol = ngLSHost.getStaticSymbol(fileName, symbolName);
     expect(directiveSymbol).toBeDefined();
     expect(directiveSymbol !.name).toBe('AppComponent');
   });

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -170,4 +170,41 @@ describe('TypeScriptServiceHost', () => {
     const newModules = ngLSHost.getAnalyzedModules();
     expect(newModules).toBe(oldModules);
   });
+
+  describe('getting the NgModule of a Directive', () => {
+    it('should get the correct NgModule for a Directive StaticSymbol', () => {
+      const tsLSHost = new MockTypescriptHost(['/app/app.component.ts', '/app/main.ts'], toh);
+      const tsLS = ts.createLanguageService(tsLSHost);
+      const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+      ngLSHost.getAnalyzedModules();  // modules are analyzed lazily
+      const declarations = ngLSHost.getDeclarations('/app/app.component.ts');
+
+      const directive = declarations.find(d => d.type.name === 'AppComponent');
+      expect(directive).toBeDefined();
+      const ngModule = ngLSHost.getDirectiveModule(directive !.type);
+      expect(ngModule).toBeDefined();
+      const ngModuleRef = ngModule !.type.reference;
+      expect(ngModuleRef.constructor.name).toBe('StaticSymbol');
+      expect(ngModuleRef.name).toBe('AppModule');
+    });
+
+    it('should get the correct NgModule for a Directive class declaration', () => {
+      const tsLSHost = new MockTypescriptHost(['/app/app.component.ts', '/app/main.ts'], toh);
+      const tsLS = ts.createLanguageService(tsLSHost);
+      const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
+      ngLSHost.getAnalyzedModules();  // modules are analyzed lazily
+      const sf = ngLSHost.getSourceFile('/app/app.component.ts');
+      expect(sf).toBeDefined();
+      const directiveDecl = sf !.forEachChild(n => {
+        if (ts.isClassDeclaration(n) && n.name && n.name.text === 'AppComponent') return n;
+      });
+
+      expect(directiveDecl).toBeDefined();
+      const ngModule = ngLSHost.getDirectiveModule(directiveDecl !);
+      expect(ngModule).toBeDefined();
+      const ngModuleRef = ngModule !.type.reference;
+      expect(ngModuleRef.constructor.name).toBe('StaticSymbol');
+      expect(ngModuleRef.name).toBe('AppModule');
+    });
+  });
 });


### PR DESCRIPTION
This sets up the Language Service to support #32565.
This PR exposes a `getDirectiveModule` method on `TypeScriptServiceHost`
that returns the NgModule owning a Directive given the Directive's
TypeScript node or its Angular `StaticSymbol`. Both types are supported
to reduce extraneous helper methods.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No