### PR TITLE
fix(ngcc): make the build-marker error more clear

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/build_marker.ts
+++ b/packages/compiler-cli/ngcc/src/packages/build_marker.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, dirname} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, basename, dirname, isRoot} from '../../../src/ngtsc/file_system';
 import {PackageJsonUpdater} from '../writing/package_json_updater';
 import {EntryPointPackageJson, PackageJsonFormatProperties} from './entry_point';
 
@@ -31,9 +31,13 @@ export function hasBeenProcessed(
   }
   if (Object.keys(packageJson.__processed_by_ivy_ngcc__)
           .some(property => packageJson.__processed_by_ivy_ngcc__ ![property] !== NGCC_VERSION)) {
+    let nodeModulesFolderPath = entryPointPath;
+    while (!isRoot(nodeModulesFolderPath) && basename(nodeModulesFolderPath) !== 'node_modules') {
+      nodeModulesFolderPath = dirname(nodeModulesFolderPath);
+    }
     throw new Error(
-        'The ngcc compiler has changed since the last ngcc build.\n' +
-        `Please completely remove the "node_modules" folder containing "${entryPointPath}" and try again.`);
+        `The ngcc compiler has changed since the last ngcc build.\n` +
+        `Please remove "${isRoot(nodeModulesFolderPath) ? entryPointPath : nodeModulesFolderPath}" and try again.`);
   }
 
   return packageJson.__processed_by_ivy_ngcc__[format] === NGCC_VERSION;

--- a/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/build_marker_spec.ts
@@ -178,8 +178,12 @@ runInEachFileSystem(() => {
 
     describe('hasBeenProcessed', () => {
       let entryPointPath: AbsoluteFsPath;
+      let nodeModulesPath: AbsoluteFsPath;
 
-      beforeEach(() => entryPointPath = _('/node_modules/test'));
+      beforeEach(() => {
+        entryPointPath = _('/node_modules/test');
+        nodeModulesPath = _('/node_modules');
+      });
 
       it('should return true if the marker exists for the given format property', () => {
         expect(hasBeenProcessed(
@@ -187,14 +191,17 @@ runInEachFileSystem(() => {
                    'fesm2015', entryPointPath))
             .toBe(true);
       });
+
       it('should return false if the marker does not exist for the given format property', () => {
         expect(hasBeenProcessed(
                    {name: 'test', __processed_by_ivy_ngcc__: {'fesm2015': '0.0.0-PLACEHOLDER'}},
                    'module', entryPointPath))
             .toBe(false);
       });
+
       it('should return false if no markers exist',
          () => { expect(hasBeenProcessed({name: 'test'}, 'module', entryPointPath)).toBe(false); });
+
       it('should throw an Error if the format has been compiled with a different version.', () => {
         expect(
             () => hasBeenProcessed(
@@ -202,8 +209,9 @@ runInEachFileSystem(() => {
                 entryPointPath))
             .toThrowError(
                 'The ngcc compiler has changed since the last ngcc build.\n' +
-                `Please completely remove the "node_modules" folder containing "${entryPointPath}" and try again.`);
+                `Please remove "${nodeModulesPath}" and try again.`);
       });
+
       it('should throw an Error if any format has been compiled with a different version.', () => {
         expect(
             () => hasBeenProcessed(
@@ -211,7 +219,7 @@ runInEachFileSystem(() => {
                 entryPointPath))
             .toThrowError(
                 'The ngcc compiler has changed since the last ngcc build.\n' +
-                `Please completely remove the "node_modules" folder containing "${entryPointPath}" and try again.`);
+                `Please remove "${nodeModulesPath}" and try again.`);
         expect(
             () => hasBeenProcessed(
                 {
@@ -221,7 +229,7 @@ runInEachFileSystem(() => {
                 'module', entryPointPath))
             .toThrowError(
                 'The ngcc compiler has changed since the last ngcc build.\n' +
-                `Please completely remove the "node_modules" folder containing "${entryPointPath}" and try again.`);
+                `Please remove "${nodeModulesPath}" and try again.`);
         expect(
             () => hasBeenProcessed(
                 {
@@ -231,8 +239,35 @@ runInEachFileSystem(() => {
                 'fesm2015', entryPointPath))
             .toThrowError(
                 'The ngcc compiler has changed since the last ngcc build.\n' +
-                `Please completely remove the "node_modules" folder containing "${entryPointPath}" and try again.`);
+                `Please remove "${nodeModulesPath}" and try again.`);
       });
+
+      it('should throw an Error, with the appropriate path to remove, if the format has been compiled with a different version',
+         () => {
+           expect(
+               () => hasBeenProcessed(
+                   {name: 'test', __processed_by_ivy_ngcc__: {'fesm2015': '8.0.0'}}, 'fesm2015',
+                   _('/node_modules/test')))
+               .toThrowError(
+                   'The ngcc compiler has changed since the last ngcc build.\n' +
+                   `Please remove "${_('/node_modules')}" and try again.`);
+
+           expect(
+               () => hasBeenProcessed(
+                   {name: 'nested', __processed_by_ivy_ngcc__: {'fesm2015': '8.0.0'}}, 'fesm2015',
+                   _('/node_modules/test/node_modules/nested')))
+               .toThrowError(
+                   'The ngcc compiler has changed since the last ngcc build.\n' +
+                   `Please remove "${_('/node_modules/test/node_modules')}" and try again.`);
+
+           expect(
+               () => hasBeenProcessed(
+                   {name: 'test', __processed_by_ivy_ngcc__: {'fesm2015': '8.0.0'}}, 'fesm2015',
+                   _('/dist/test')))
+               .toThrowError(
+                   'The ngcc compiler has changed since the last ngcc build.\n' +
+                   `Please remove "${_('/dist/test')}" and try again.`);
+         });
     });
   });
 });


### PR DESCRIPTION
The previous message was confusing as it could be
interpreted as only deleting the package mentioned.

Now we compute and display the actual node_modules
path to remove.

See https://github.com/angular/angular/issues/31354#issuecomment-532080537

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
