### PR TITLE
Fix/26040 null routerlink overrides href

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -215,7 +215,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   // the url displayed on the anchor element.
   // TODO(issue/24571): remove '!'.
-  @HostBinding() href !: string;
+  @HostBinding('attr.href') @Input() href !: string;
 
   constructor(
       private router: Router, private route: ActivatedRoute,
@@ -267,7 +267,9 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    if (this.commands.length || this.href === undefined || this.href === '') {
+      this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    }
   }
 
   get urlTree(): UrlTree {

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -321,7 +321,7 @@ export class ActivatedRouteSnapshot {
   }
 
   toString(): string {
-    const url = this.url.map(segment => segment.toString()).join('/');
+    const url = this.url ? this.url.map(segment => segment.toString()).join('/') : '';
     const matched = this.routeConfig ? this.routeConfig.path : '';
     return `Route(url:'${url}', path:'${matched}')`;
   }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1804,6 +1804,42 @@ describe('Integration', () => {
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 
+    it('should not change href if routerLink is null', fakeAsync(() => {
+         @Component({
+           selector: 'someCmp',
+           template: `<router-outlet></router-outlet><a href="link" [routerLink]="null">Link</a>`
+         })
+         class CmpWithLink {
+         }
+
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
+         const router: Router = TestBed.get(Router);
+
+         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+
+         advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('link');
+       }));
+
+    it('should set href to current location if routerLink is null', fakeAsync(() => {
+         @Component({
+           selector: 'someCmp',
+           template: `<router-outlet></router-outlet><a [routerLink]="null">Link</a>`
+         })
+         class CmpWithLink {
+         }
+
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
+         const router: Router = TestBed.get(Router);
+
+         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+
+         advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/');
+       }));
+
     it('should not throw when commands is null', fakeAsync(() => {
          @Component({
            selector: 'someCmp',
@@ -5119,7 +5155,6 @@ class RootCmpWithNamedOutlet {
 class ThrowingCmp {
   constructor() { throw new Error('Throwing Cmp'); }
 }
-
 
 
 function advance(fixture: ComponentFixture<any>, millis?: number): void {


### PR DESCRIPTION
Fix a bug where a null value passed to routerLink directive overrides the existing href.

fixes #26040

Previous PR: https://github.com/angular/angular/pull/27347 (but I guess it has been left aside).


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature


## What is the current behavior?
Description and full Stackblitz example are in the issue below: 

Issue Number: #26040 


## What is the new behavior?
If a `null` value is passed to `routerLink` directive and if an `href` attribute is defined and not empty, `href` will remain unchanged. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
