### PR TITLE
Post styling perf 2019 09 17

### DIFF
--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -47,7 +47,7 @@ ts_devserver(
         "@npm//:node_modules/zone.js/dist/zone.js",
     ],
     deps = [
-        ":bundle.min.js",
+        ":bundle.min_debug.es2015.js",
     ],
 )
 

--- a/packages/core/src/render3/styling_next/bindings.ts
+++ b/packages/core/src/render3/styling_next/bindings.ts
@@ -712,25 +712,37 @@ export function setStylingMapsSyncFn(fn: SyncStylingMapsFn) {
  */
 export const setStyle: ApplyStylingFn =
     (renderer: Renderer3 | null, native: RElement, prop: string, value: string | null) => {
-      // the reason why this may be `null` is either because
-      // it's a container element or it's a part of a test
-      // environment that doesn't have styling. In either
-      // case it's safe not to apply styling to the element.
-      const nativeStyle = native.style;
-      if (value) {
-        // opacity, z-index and flexbox all have number values
-        // and these need to be converted into strings so that
-        // they can be assigned properly.
-        value = value.toString();
-        ngDevMode && ngDevMode.rendererSetStyle++;
-        renderer && isProceduralRenderer(renderer) ?
-            renderer.setStyle(native, prop, value, RendererStyleFlags3.DashCase) :
-            (nativeStyle && nativeStyle.setProperty(prop, value));
-      } else {
-        ngDevMode && ngDevMode.rendererRemoveStyle++;
-        renderer && isProceduralRenderer(renderer) ?
-            renderer.removeStyle(native, prop, RendererStyleFlags3.DashCase) :
-            (nativeStyle && nativeStyle.removeProperty(prop));
+      if (renderer !== null) {
+        if (value) {
+          // opacity, z-index and flexbox all have number values
+          // and these need to be converted into strings so that
+          // they can be assigned properly.
+          value = value.toString();
+          ngDevMode && ngDevMode.rendererSetStyle++;
+          if (isProceduralRenderer(renderer)) {
+            renderer.setStyle(native, prop, value, RendererStyleFlags3.DashCase);
+          } else {
+            // The reason why native style may be `null` is either because
+            // it's a container element or it's a part of a test
+            // environment that doesn't have styling. In either
+            // case it's safe not to apply styling to the element.
+            const nativeStyle = native.style;
+            if (nativeStyle != null) {
+              nativeStyle.setProperty(prop, value);
+            }
+          }
+        } else {
+          ngDevMode && ngDevMode.rendererRemoveStyle++;
+
+          if (isProceduralRenderer(renderer)) {
+            renderer.removeStyle(native, prop, RendererStyleFlags3.DashCase);
+          } else {
+            const nativeStyle = native.style;
+            if (nativeStyle != null) {
+              nativeStyle.removeProperty(prop);
+            }
+          }
+        }
       }
     };
 
@@ -739,20 +751,31 @@ export const setStyle: ApplyStylingFn =
  */
 export const setClass: ApplyStylingFn =
     (renderer: Renderer3 | null, native: RElement, className: string, value: any) => {
-      if (className !== '') {
-        // the reason why this may be `null` is either because
-        // it's a container element or it's a part of a test
-        // environment that doesn't have styling. In either
-        // case it's safe not to apply styling to the element.
-        const classList = native.classList;
+      if (renderer !== null && className !== '') {
         if (value) {
           ngDevMode && ngDevMode.rendererAddClass++;
-          renderer && isProceduralRenderer(renderer) ? renderer.addClass(native, className) :
-                                                       (classList && classList.add(className));
+          if (isProceduralRenderer(renderer)) {
+            renderer.addClass(native, className);
+          } else {
+            // the reason why classList may be `null` is either because
+            // it's a container element or it's a part of a test
+            // environment that doesn't have styling. In either
+            // case it's safe not to apply styling to the element.
+            const classList = native.classList;
+            if (classList != null) {
+              classList.add(className);
+            }
+          }
         } else {
           ngDevMode && ngDevMode.rendererRemoveClass++;
-          renderer && isProceduralRenderer(renderer) ? renderer.removeClass(native, className) :
-                                                       (classList && classList.remove(className));
+          if (isProceduralRenderer(renderer)) {
+            renderer.removeClass(native, className);
+          } else {
+            const classList = native.classList;
+            if (classList != null) {
+              classList.remove(className);
+            }
+          }
         }
       }
     };


### PR DESCRIPTION
This PR removes unnecessary DOM reads (`classList` / `style`) in the most common case of using a procedural renderer. This simple change removes the most expensive function(s) (self time) from the profiller's radar.

Before:

![setClass before](https://user-images.githubusercontent.com/973550/65043570-6a4a0d00-d95b-11e9-9a6b-fa1a6926e188.png)

After:

![setClass after](https://user-images.githubusercontent.com/973550/65043593-78982900-d95b-11e9-8f89-5cb473b40f7e.png)
