### PR TITLE
fix(ivy): ensure that ivy-specific code for ngStyle/ngClass is tree-shaken away properly

### DIFF
--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -24,12 +24,12 @@ import {NgClassImpl, NgClassImplProvider} from './ng_class_impl';
  */
 
 // used when the VE is present
-export const ngClassDirectiveDef__PRE_R3__ = () => {};
+const ngClassDirectiveDef__PRE_R3__ = () => {};
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
 // base class)
-export function ngClassDirectiveDef__POST_R3__() {
+function ngClassDirectiveDef__POST_R3__() {
   return ɵɵdefineDirective({
     type: function() {} as any,
     selectors: null as any,
@@ -44,11 +44,10 @@ export function ngClassDirectiveDef__POST_R3__() {
   });
 }
 
-export const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
-
-export const ngClassFactoryDef__PRE_R3__ = undefined;
-export const ngClassFactoryDef__POST_R3__ = function() {};
-export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
+const ngClassFactoryDef__PRE_R3__ = undefined;
+const ngClassFactoryDef__POST_R3__ = function() {};
+const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
+const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgClass.

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -24,23 +24,25 @@ import {NgClassImpl, NgClassImplProvider} from './ng_class_impl';
  */
 
 // used when the VE is present
-export const ngClassDirectiveDef__PRE_R3__ = undefined;
+export const ngClassDirectiveDef__PRE_R3__ = () => {};
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
 // base class)
-export const ngClassDirectiveDef__POST_R3__ = ɵɵdefineDirective({
-  type: function() {} as any,
-  selectors: null as any,
-  hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
-    if (rf & ɵRenderFlags.Create) {
-      ɵɵallocHostVars(1);
+export function ngClassDirectiveDef__POST_R3__() {
+  return ɵɵdefineDirective({
+    type: function() {} as any,
+    selectors: null as any,
+    hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
+      if (rf & ɵRenderFlags.Create) {
+        ɵɵallocHostVars(1);
+      }
+      if (rf & ɵRenderFlags.Update) {
+        ɵɵclassMap(ctx.getValue());
+      }
     }
-    if (rf & ɵRenderFlags.Update) {
-      ɵɵclassMap(ctx.getValue());
-    }
-  }
-});
+  });
+}
 
 export const ngClassDirectiveDef = ngClassDirectiveDef__PRE_R3__;
 
@@ -63,7 +65,7 @@ export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
  * @publicApi
  */
 export class NgClassBase {
-  static ɵdir: any = ngClassDirectiveDef;
+  static ɵdir: any = ngClassDirectiveDef();
   static ɵfac: any = ngClassFactoryDef;
 
   constructor(protected _delegate: NgClassImpl) {}

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -24,24 +24,26 @@ import {NgStyleImpl, NgStyleImplProvider} from './ng_style_impl';
  */
 
 // used when the VE is present
-export const ngStyleDirectiveDef__PRE_R3__ = undefined;
+export const ngStyleDirectiveDef__PRE_R3__ = () => {};
 export const ngStyleFactoryDef__PRE_R3__ = undefined;
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
 // base class)
-export const ngStyleDirectiveDef__POST_R3__ = ɵɵdefineDirective({
-  type: function() {} as any,
-  selectors: null as any,
-  hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
-    if (rf & ɵRenderFlags.Create) {
-      ɵɵallocHostVars(1);
+export function ngStyleDirectiveDef__POST_R3__() {
+  return ɵɵdefineDirective({
+    type: function() {} as any,
+    selectors: null as any,
+    hostBindings: function(rf: ɵRenderFlags, ctx: any, elIndex: number) {
+      if (rf & ɵRenderFlags.Create) {
+        ɵɵallocHostVars(1);
+      }
+      if (rf & ɵRenderFlags.Update) {
+        ɵɵstyleMap(ctx.getValue());
+      }
     }
-    if (rf & ɵRenderFlags.Update) {
-      ɵɵstyleMap(ctx.getValue());
-    }
-  }
-});
+  });
+}
 
 export const ngStyleFactoryDef__POST_R3__ = function() {};
 
@@ -63,7 +65,7 @@ export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
  * @publicApi
  */
 export class NgStyleBase {
-  static ɵdir: any = ngStyleDirectiveDef;
+  static ɵdir: any = ngStyleDirectiveDef();
   static ɵfac: any = ngStyleFactoryDef;
 
   constructor(protected _delegate: NgStyleImpl) {}

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -24,13 +24,13 @@ import {NgStyleImpl, NgStyleImplProvider} from './ng_style_impl';
  */
 
 // used when the VE is present
-export const ngStyleDirectiveDef__PRE_R3__ = () => {};
-export const ngStyleFactoryDef__PRE_R3__ = undefined;
+const ngStyleDirectiveDef__PRE_R3__ = () => {};
+const ngStyleFactoryDef__PRE_R3__ = undefined;
 
 // used when the VE is not present (note the directive will
 // never be instantiated normally because it is apart of a
 // base class)
-export function ngStyleDirectiveDef__POST_R3__() {
+function ngStyleDirectiveDef__POST_R3__() {
   return ɵɵdefineDirective({
     type: function() {} as any,
     selectors: null as any,
@@ -45,10 +45,9 @@ export function ngStyleDirectiveDef__POST_R3__() {
   });
 }
 
-export const ngStyleFactoryDef__POST_R3__ = function() {};
-
-export const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
-export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
+const ngStyleFactoryDef__POST_R3__ = function() {};
+const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
+const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
 
 /**
  * Serves as the base non-VE container for NgStyle.

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ngClassDirectiveDef__POST_R3__ as ɵngClassDirectiveDef__POST_R3__, ngClassFactoryDef__POST_R3__ as ɵngClassFactoryDef__POST_R3__} from './directives/ng_class';
 export {NgClassImpl as ɵNgClassImpl, NgClassImplProvider__POST_R3__ as ɵNgClassImplProvider__POST_R3__, NgClassR2Impl as ɵNgClassR2Impl} from './directives/ng_class_impl';
-export {ngStyleDirectiveDef__POST_R3__ as ɵngStyleDirectiveDef__POST_R3__, ngStyleFactoryDef__POST_R3__ as ɵngStyleFactoryDef__POST_R3__} from './directives/ng_style';
 export {NgStyleImpl as ɵNgStyleImpl, NgStyleImplProvider__POST_R3__ as ɵNgStyleImplProvider__POST_R3__, NgStyleR2Impl as ɵNgStyleR2Impl} from './directives/ng_style_impl';
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';


### PR DESCRIPTION
Prior to this fix all of the ivy code that lived inside of ngClass and
ngStyle would be loaded even when ivy was not present. This is because
the `defineDirective` code was being called on the top-level which means
that it is impossible to tree-shake it away. This patch fixes that
issue.
