### PR TITLE
fix(router): fix undefined transition value

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -775,7 +775,7 @@ export class Router {
   }
 
   private getTransition(): NavigationTransition {
-    const transition = this.transitions.value;
+    const transition = this.transitions.getValue();
     // This value needs to be set. Other values such as extractedUrl are set on initial navigation
     // but the urlAfterRedirects may not get set if we aren't processing the new URL *and* not
     // processing the previous URL.


### PR DESCRIPTION
Transition now gets correct value from the BehaviorSubject, so browserUrlTree can be assigned to transition.urlAfterRedirects without getting urlAfterRedirects of undefined error.