### PR TITLE
refactor(compiler): add details while throw error during expression c…

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -551,7 +551,10 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
           this.usesImplicitReceiver = prevUsesImplicitReceiver;
         } else {
           // Otherwise it's an error.
-          throw new Error('Cannot assign to a reference or variable!');
+          const receiver = ast.name;
+          const value = (ast.value instanceof cdAst.PropertyRead) ? ast.value.name : undefined;
+          throw new Error(
+              `Cannot assign value "${value}" to template variable "${receiver}". Template variables are read-only.`);
         }
       }
     }

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -662,9 +662,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
            }));
 
         it('should throw when trying to assign to a local', fakeAsync(() => {
-             expect(() => {
-               _bindSimpleProp('(event)="$event=1"');
-             }).toThrowError(new RegExp('Cannot assign to a reference or variable!'));
+             expect(() => { _bindSimpleProp('(event)="$event=1"'); })
+                 .toThrowError(new RegExp(
+                     'Cannot assign value (.*) to template variable (.*). Template variables are read-only.'));
            }));
 
         it('should support short-circuiting', fakeAsync(() => {


### PR DESCRIPTION
…onvert

Fixes #32759

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32760 


## What is the new behavior?

Now there is details in error message with variable names in template expression, which causes prod build failing.

There is example error message: 

>ERROR in ReadPropExpr expected but PropertyWrite found with receiver "myVarTitle" and value "changedTitle"


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
