### PR TITLE
fix(compiler): do not throw error if localExpr is instanceof ReadVarExpr

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -535,11 +535,11 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     const receiver: o.Expression = this._visit(ast.receiver, _Mode.Expression);
     const prevUsesImplicitReceiver = this.usesImplicitReceiver;
 
-    let varExpr: o.ReadPropExpr|null = null;
+    let varExpr: o.ReadPropExpr|o.ReadVarExpr|null = null;
     if (receiver === this._implicitReceiver) {
       const localExpr = this._getLocal(ast.name);
       if (localExpr) {
-        if (localExpr instanceof o.ReadPropExpr) {
+        if (localExpr instanceof o.ReadPropExpr || localExpr instanceof o.ReadVarExpr) {
           // If the local variable is a property read expression, it's a reference
           // to a 'context.property' value and will be used as the target of the
           // write expression.


### PR DESCRIPTION
Fixes #32761

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32761 


## What is the new behavior?

`ng build --prod` doesn't fails.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There is also one more PR with adding details to error message in this case: #32760 