### PR TITLE
fix(ivy): ensure multiple map-based bindings do not skip intermediate values

### DIFF
--- a/packages/core/src/render3/styling/bindings.ts
+++ b/packages/core/src/render3/styling/bindings.ts
@@ -173,7 +173,7 @@ function renderHostBindingsAsStale(
     context: TStylingContext, data: LStylingData, prop: string | null): void {
   const valuesCount = getValuesCount(context);
 
-  if (prop && hasConfig(context, TStylingConfig.HasPropBindings)) {
+  if (prop !== null && hasConfig(context, TStylingConfig.HasPropBindings)) {
     const itemsPerRow = TStylingContextIndex.BindingsStartOffset + valuesCount;
 
     let i = TStylingContextIndex.ValuesStartPosition;

--- a/packages/core/src/render3/styling/map_based_bindings.ts
+++ b/packages/core/src/render3/styling/map_based_bindings.ts
@@ -280,7 +280,7 @@ function resolveInnerMapMode(
     currentMode: number, valueIsDefined: boolean, isTargetPropMatched: boolean): number {
   let innerMode = currentMode;
 
-  // the statements below figure out whether or not an inner styling map
+  // the statements below figures out whether or not an inner styling map
   // is allowed to apply its value or not. The main thing to keep note
   // of is that if the target prop isn't matched then its expected that
   // all values before it are allowed to be applied so long as "apply all values"

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1995,6 +1995,46 @@ describe('styling', () => {
        expect(readyHost).toBeTruthy();
        expect(readyChild).toBeTruthy();
      });
+
+  onlyInIvy('only ivy allows for multiple styles/classes to be balanaced across directives')
+      .it('should allow various duplicate properties to be defined in various styling maps within the template and directive styling bindings',
+          () => {
+            @Component({
+              template: `
+           <div [style.width]="w"
+                [style.height]="h"
+                [style]="s1"
+                [dir-with-styling]="s2">
+         `
+            })
+            class Cmp {
+              h = '100px';
+              w = '100px';
+              s1: any = {border: '10px solid black', width: '200px'};
+              s2: any = {border: '10px solid red', width: '300px'};
+            }
+
+            @Directive({selector: '[dir-with-styling]'})
+            class DirectiveExpectingStyling {
+              @Input('dir-with-styling') @HostBinding('style') public styles: any = null;
+            }
+
+            TestBed.configureTestingModule({declarations: [Cmp, DirectiveExpectingStyling]});
+            const fixture = TestBed.createComponent(Cmp);
+            fixture.detectChanges();
+
+            const element = fixture.nativeElement.querySelector('div');
+            expect(element.style.border).toEqual('10px solid black');
+            expect(element.style.width).toEqual('100px');
+            expect(element.style.height).toEqual('100px');
+
+            fixture.componentInstance.s1 = null;
+            fixture.detectChanges();
+
+            expect(element.style.border).toEqual('10px solid red');
+            expect(element.style.width).toEqual('100px');
+            expect(element.style.height).toEqual('100px');
+          });
 });
 
 function getDebugNode(element: Node): DebugNode|null {


### PR DESCRIPTION
This patch fixes a bug where the map-based cursor moves too far and
skips intermediate values when the correct combination of single-prop
bindings and map-based bindings are used together.