### PR TITLE
docs: fix typo in deployment guide

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -304,7 +304,7 @@ Configure the Angular Router to defer loading of all other modules (and their as
 or by [_lazy loading_](guide/router#asynchronous-routing "Lazy loading")
 them on demand.
 
-<div class="callout is-helpful>
+<div class="callout is-helpful">
 
 <header>Don't eagerly import something from a lazy-loaded module</header>
 


### PR DESCRIPTION
The typo causes most of the callout to not appear on the page. The issue 
appears at the bottom of the "Lazy loading" section on the live site:
https://angular.io/guide/deployment#lazy-loading

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Callout is mangled due to missing quote. Visible at bottom of lazy-loading section here:
https://angular.io/guide/deployment#lazy-loading

and here:
https://github.com/angular/angular/blob/9bbe67f28622438a295b3a7a3cb914972ce3829d/aio/content/guide/deployment.md#lazy-loading

Issue Number: N/A


## What is the new behavior?

Callout is visible: https://github.com/jetpack/angular/blob/jetpack-docstypo/aio/content/guide/deployment.md#lazy-loading

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
