### PR TITLE
feat(language-service): allow retreiving synchronized analyzed NgModules

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -152,12 +152,13 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
    * and templateReferences.
    * In addition to returning information about NgModules, this method plays the
    * same role as 'synchronizeHostData' in tsserver.
-   * @param ensureSynchronized if true, returns the set of analyzedModules that is already cached.
-   *   This is useful if the project must not be reanalyzed, even if its file watchers (which are
-   *   disjoint from the TypeScriptServiceHost)detect an update.
+   * @param ensureSynchronized whether or not the Language Service should make sure analyzedModules
+   *   are synced to the last update of the project. If false, returns the set of analyzedModules
+   *   that is already cached. This is useful if the project must not be reanalyzed, even if its
+   *   file watchers (which are disjoint from the TypeScriptServiceHost) detect an update.
    */
-  getAnalyzedModules(ensureSynchronized = false): NgAnalyzedModules {
-    if (ensureSynchronized || this.upToDate()) {
+  getAnalyzedModules(ensureSynchronized = true): NgAnalyzedModules {
+    if (!ensureSynchronized || this.upToDate()) {
       return this.analyzedModules;
     }
 

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -152,9 +152,12 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
    * and templateReferences.
    * In addition to returning information about NgModules, this method plays the
    * same role as 'synchronizeHostData' in tsserver.
+   * @param ensureSynchronized if true, returns the set of analyzedModules that is already cached.
+   *   This is useful if the project must not be reanalyzed, even if its file watchers (which are
+   *   disjoint from the TypeScriptServiceHost)detect an update.
    */
-  getAnalyzedModules(): NgAnalyzedModules {
-    if (this.upToDate()) {
+  getAnalyzedModules(ensureSynchronized = false): NgAnalyzedModules {
+    if (ensureSynchronized || this.upToDate()) {
       return this.analyzedModules;
     }
 

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -209,7 +209,7 @@ describe('TypeScriptServiceHost', () => {
       export class HelloComponent {}
     `);
     // Make sure synchronized modules match the original state
-    const syncModules = ngLSHost.getAnalyzedModules(true);
+    const syncModules = ngLSHost.getAnalyzedModules(false);
     expect(originalModules).toEqual(syncModules);
 
     // Now, get modules for the updated project, which should not be synchronized


### PR DESCRIPTION
Sometimes modules retreived from the language service need to be
synchronized to the last time they were updated, and not updated
on-the-fly. This PR adds a flag to
`TypeScriptServiceHost#getAnalyzedModules` that retreives cached
analyzed NgModules rather than potentially recomputing them.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No