### PR TITLE
fix(ivy): ensure `window.ng.getDebugNode` returns debug info for component elements

### DIFF
--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -358,7 +358,7 @@ export function toDebugNodes(tNode: TNode | null, lView: LView): DebugNode[]|nul
     const debugNodes: DebugNode[] = [];
     let tNodeCursor: TNode|null = tNode;
     while (tNodeCursor) {
-      debugNodes.push(buildDebugNode(tNodeCursor, lView));
+      debugNodes.push(buildDebugNode(tNodeCursor, lView, tNodeCursor.index));
       tNodeCursor = tNodeCursor.next;
     }
     return debugNodes;
@@ -367,8 +367,8 @@ export function toDebugNodes(tNode: TNode | null, lView: LView): DebugNode[]|nul
   }
 }
 
-export function buildDebugNode(tNode: TNode, lView: LView): DebugNode {
-  const rawValue = lView[tNode.index];
+export function buildDebugNode(tNode: TNode, lView: LView, nodeIndex: number): DebugNode {
+  const rawValue = lView[nodeIndex];
   const native = unwrapRNode(rawValue);
   const componentLViewDebug = toDebug(readLViewValue(rawValue));
   const styles = isStylingContext(tNode.styles) ?

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {CommonModule} from '@angular/common';
-import {Component, Directive, InjectionToken, ViewChild} from '@angular/core';
+import {Component, Directive, HostBinding, InjectionToken, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {onlyInIvy} from '@angular/private/testing';
 
@@ -428,6 +428,40 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils deprecated', () =>
 
       expect(parentDebug.native).toBe(parent);
       expect(childDebug.native).toBe(child);
+    });
+
+    it('should be able to pull debug information for a component host element', () => {
+      @Component({
+        selector: 'child-comp',
+        template: `
+          child comp
+        `
+      })
+      class ChildComp {
+        @HostBinding('style') public styles = {width: '200px', height: '400px'};
+      }
+
+      @Component({
+        template: `
+          <child-comp></child-comp>
+        `
+      })
+      class Comp {
+      }
+
+      TestBed.configureTestingModule({declarations: [Comp, ChildComp]});
+      const fixture = TestBed.createComponent(Comp);
+      fixture.detectChanges();
+
+      const child = fixture.nativeElement.querySelector('child-comp') !;
+      const childDebug = getDebugNode(child) !;
+
+      expect(childDebug.native).toBe(child);
+      expect(childDebug.styles).toBeTruthy();
+
+      const styles = childDebug.styles !.values;
+      expect(styles['width']).toEqual('200px');
+      expect(styles['height']).toEqual('400px');
     });
   });
 });


### PR DESCRIPTION
Prior to this patch the `window.ng.getDebugNode` method would fail to
return the debug information for an element that is a host element to
a component.
