### PR TITLE
test(language-service): Remove MockTypescriptHost.readFileContent()

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -88,12 +88,12 @@ describe('completions', () => {
         } catch (e) {
           // Emit enough diagnostic information to reproduce the error.
           console.error(
-              `Position: ${position}\nContent: "${mockHost.getFileContent(fileName)}"\nStack:\n${e.stack}`);
+              `Position: ${position}\nContent: "${mockHost.readFile(fileName)}"\nStack:\n${e.stack}`);
           throw e;
         }
       }
 
-      const originalContent = mockHost.getFileContent(fileName) !;
+      const originalContent = mockHost.readFile(fileName) !;
 
       // For each character in the file, add it to the file and request a completion after it.
       for (let index = 0, len = originalContent.length; index < len; index++) {

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -155,7 +155,7 @@ describe('definitions', () => {
     expect(def.fileName).toBe(refFileName);
     expect(def.name).toBe('TestComponent');
     expect(def.kind).toBe('component');
-    const content = mockHost.getFileContent(refFileName) !;
+    const content = mockHost.readFile(refFileName) !;
     const begin = '/*BeginTestComponent*/ ';
     const start = content.indexOf(begin) + begin.length;
     const end = content.indexOf(' /*EndTestComponent*/');
@@ -192,7 +192,7 @@ describe('definitions', () => {
     expect(def.fileName).toBe(refFileName);
     expect(def.name).toBe('testEvent');
     expect(def.kind).toBe('event');
-    const content = mockHost.getFileContent(refFileName) !;
+    const content = mockHost.readFile(refFileName) !;
     const ref = `@Output('test') testEvent = new EventEmitter();`;
     expect(def.textSpan).toEqual({
       start: content.indexOf(ref),
@@ -230,7 +230,7 @@ describe('definitions', () => {
     expect(def.fileName).toBe(refFileName);
     expect(def.name).toBe('name');
     expect(def.kind).toBe('property');
-    const content = mockHost.getFileContent(refFileName) !;
+    const content = mockHost.readFile(refFileName) !;
     const ref = `@Input('tcName') name = 'test';`;
     expect(def.textSpan).toEqual({
       start: content.indexOf(ref),

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -109,7 +109,7 @@ describe('diagnostics', () => {
     expect(messageText)
         .toBe(
             `Component 'MyComponent' is not included in a module and will not be available inside a template. Consider adding it to a NgModule declaration.`);
-    const content = mockHost.getFileContent(fileName) !;
+    const content = mockHost.readFile(fileName) !;
     const keyword = '@Component';
     expect(start).toBe(content.lastIndexOf(keyword) + 1);  // exclude leading '@'
     expect(length).toBe(keyword.length - 1);               // exclude leading '@'

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -149,7 +149,7 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
   }
 
   getScriptSnapshot(fileName: string): ts.IScriptSnapshot|undefined {
-    const content = this.getFileContent(fileName);
+    const content = this.readFile(fileName);
     if (content) return ts.ScriptSnapshot.fromString(content);
     return undefined;
   }
@@ -172,7 +172,12 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
 
   fileExists(fileName: string): boolean { return this.getRawFileContent(fileName) != null; }
 
-  readFile(path: string): string|undefined { return this.getRawFileContent(path); }
+  readFile(fileName: string): string|undefined {
+    const content = this.getRawFileContent(fileName);
+    if (content) {
+      return removeReferenceMarkers(removeLocationMarkers(content));
+    }
+  }
 
   getMarkerLocations(fileName: string): {[name: string]: number}|undefined {
     let content = this.getRawFileContent(fileName);
@@ -186,11 +191,6 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     if (content) {
       return getReferenceMarkers(content);
     }
-  }
-
-  getFileContent(fileName: string): string|undefined {
-    const content = this.getRawFileContent(fileName);
-    if (content) return removeReferenceMarkers(removeLocationMarkers(content));
   }
 
   /**
@@ -269,7 +269,7 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
    */
   addCode(code: string) {
     const fileName = '/app/app.component.ts';
-    const originalContent = this.getFileContent(fileName);
+    const originalContent = this.readFile(fileName);
     const newContent = originalContent + code;
     this.override(fileName, newContent);
     return fileName;

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -62,8 +62,8 @@ describe('TypeScriptServiceHost', () => {
     expect(ngLSHost.getAnalyzedModules().ngModules).toEqual([]);
     // Now add a script, this would change the program
     const fileName = '/app/main.ts';
-    const content = (tsLSHost as MockTypescriptHost).getFileContent(fileName) !;
-    (tsLSHost as MockTypescriptHost).addScript(fileName, content);
+    const content = tsLSHost.readFile(fileName) !;
+    tsLSHost.addScript(fileName, content);
     // If the caches are not cleared, we would get back an empty array.
     // But if the caches are cleared then the analyzed modules will be non-empty.
     expect(ngLSHost.getAnalyzedModules().ngModules.length).not.toEqual(0);


### PR DESCRIPTION
readFileContent() has the exact same functionality as readFile(), but it
is not actually part of ts.LanguageServiceHost interface.
It's not actually needed, so replace it with readFile() instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
