### PR TITLE
fix(ivy): include `ngProjectAs` into attributes array

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1376,7 +1376,7 @@ describe('compiler compliance', () => {
         const SimpleComponentDefinition = `
           const $_c0$ = [[["", "title", ""]]];
           const $_c1$ = ["[title]"];
-          const $_c2$ = [5, ["", "title", ""]];
+          const $_c2$ = ["ngProjectAs", "[title]", 5, ["", "title", ""]];
           …
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,
@@ -1428,7 +1428,7 @@ describe('compiler compliance', () => {
         const SimpleComponentDefinition = `
           const $_c0$ = [[["", "title", ""]]];
           const $_c1$ = ["[title]"];
-          const $_c2$ = [5, ["", "title", ""]];
+          const $_c2$ = ["ngProjectAs", "[title],[header]", 5, ["", "title", ""]];
           …
           MyApp.ngComponentDef = $r3$.ɵɵdefineComponent({
             type: MyApp,

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1025,6 +1025,36 @@ describe('projection', () => {
     expect(fixture.nativeElement.textContent).not.toContain('Title content');
   });
 
+  it('should preserve ngProjectAs and other attributes on projected element', () => {
+    @Component({
+      selector: 'projector',
+      template: `<ng-content select="projectMe"></ng-content>`,
+    })
+    class Projector {
+    }
+
+    @Component({
+      template: `
+        <projector>
+          <div ngProjectAs="projectMe" title="some title"></div>
+        </projector>
+      `
+    })
+    class Root {
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [Root, Projector],
+    });
+    const fixture = TestBed.createComponent(Root);
+    fixture.detectChanges();
+
+    const projectedElement = fixture.debugElement.query(By.css('div'));
+    const {ngProjectAs, title} = projectedElement.attributes;
+    expect(ngProjectAs).toBe('projectMe');
+    expect(title).toBe('some title');
+  });
+
   describe('on inline templates (e.g.  *ngIf)', () => {
     it('should work when matching the element name', () => {
       let divDirectives = 0;


### PR DESCRIPTION
Prior to this commit, the `ngProjectAs` attribute was only included with a special flag and in a parsed format. As a result, projected node was missing `ngProjectAs` attribute as well as other attributes added after `ngProjectAs` one. This is problematic since app code might rely on the presence of `ngProjectAs` attribute (for example in CSS). This commit fixes the problem by including `ngProjectAs` into attributes array as a regular attribute and also makes sure that the parsed version of the `ngProjectAs` attribute with a special marker is added after regular attributes (thus we set them correctly at runtime). This change also aligns View Engine and Ivy behavior.

This PR resolves FW-1562.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No