### PR TITLE
fix(language-service): add closing quote in invalid test template

### DIFF
--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -130,7 +130,7 @@ describe('TypeScriptServiceHost', () => {
       import {Component} from '@angular/core';
 
       @Component({
-        template: '<div>Hello</div>
+        template: '<div>Hello</div>',
       })
       export class HelloComponent {}
     `);


### PR DESCRIPTION
Fixes an invalid TypeScript code in the language service tests. I must
have missed this while reviewing previously; sorry about that!

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
