### PR TITLE
feat(forms): add touchedStateChanges observable to forms

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -310,6 +310,11 @@ export abstract class AbstractControl {
   public readonly statusChanges !: Observable<any>;
 
   /**
+   * A multicasting observable that emits an event every time the control is touched or untouched
+   */
+  public readonly touchedStateChanges !: Observable<any>;
+
+  /**
    * Reports the update strategy of the `AbstractControl` (meaning
    * the event on which the control updates itself).
    * Possible values: `'change'` | `'blur'` | `'submit'`
@@ -376,6 +381,7 @@ export abstract class AbstractControl {
    */
   markAsTouched(opts: {onlySelf?: boolean} = {}): void {
     (this as{touched: boolean}).touched = true;
+    (this.touchedStateChanges as EventEmitter<any>).emit(this.touched);
 
     if (this._parent && !opts.onlySelf) {
       this._parent.markAsTouched(opts);
@@ -410,6 +416,7 @@ export abstract class AbstractControl {
   markAsUntouched(opts: {onlySelf?: boolean} = {}): void {
     (this as{touched: boolean}).touched = false;
     this._pendingTouched = false;
+    (this.touchedStateChanges as EventEmitter<any>).emit(this.touched);
 
     this._forEachChild(
         (control: AbstractControl) => { control.markAsUntouched({onlySelf: true}); });
@@ -804,6 +811,7 @@ export abstract class AbstractControl {
   _initObservables() {
     (this as{valueChanges: Observable<any>}).valueChanges = new EventEmitter();
     (this as{statusChanges: Observable<any>}).statusChanges = new EventEmitter();
+    (this as{touchedStateChanges: Observable<any>}).touchedStateChanges = new EventEmitter();
   }
 
 

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -452,6 +452,35 @@ import {FormArray} from '@angular/forms/src/model';
       });
     });
 
+    describe('touchedChanges', () => {
+      let g: FormGroup, c: FormControl, logger: any[];
+      beforeEach(() => {
+        c = new FormControl('oldValue');
+        g = new FormGroup({'one': c});
+        logger = [];
+      });
+
+      it('should emit true when touched', () => {
+        c.touchedStateChanges.subscribe((arg) => logger.push(arg));
+        c.markAsTouched();
+        expect(logger).toEqual([true]);
+      });
+
+      it('should emit true when touched and false when untouched', () => {
+        c.touchedStateChanges.subscribe((arg) => logger.push(arg));
+        c.markAsTouched();
+        c.markAsUntouched();
+        expect(logger).toEqual([true, false]);
+      });
+
+      it('should emit true as child when parent is touched', () => {
+        c.touchedStateChanges.subscribe((arg) => logger.push(arg));
+        g.markAllAsTouched();
+        expect(logger).toEqual([true]);
+      });
+
+    });
+
     describe('setValue', () => {
       let g: FormGroup, c: FormControl;
       beforeEach(() => {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -12,6 +12,7 @@ export declare abstract class AbstractControl {
     readonly status: string;
     readonly statusChanges: Observable<any>;
     readonly touched: boolean;
+    readonly touchedStateChanges: Observable<any>;
     readonly untouched: boolean;
     readonly updateOn: FormHooks;
     readonly valid: boolean;


### PR DESCRIPTION
add touchedStateChanges property to AbstractControl which emits events when control is touched/untouched

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is current no way to subscribe to touched changes on a form.

## What is the new behavior?
The new behaviour lets you subscribe to touchedStateChanges which will emit a boolean when the form is touched/untouched.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
