### PR TITLE
feat(router): remove deprecated initialNavigation options and change default

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -229,27 +229,18 @@ export function provideRoutes(routes: Routes): any {
  * Allowed values in an `ExtraOptions` object that configure
  * when the router performs the initial navigation operation.
  *
- * * 'enabled' (Default) The initial navigation starts before the root component is created.
+ * * 'enabled' (Default) - The initial navigation starts before the root component is created.
  * The bootstrap is blocked until the initial navigation is complete.
  * * 'disabled' - The initial navigation is not performed. The location listener is set up before
  * the root component gets created. Use if there is a reason to have
  * more control over when the router starts its initial navigation due to some complex
  * initialization logic.
- * * 'legacy_enabled'- The initial navigation starts after the root component has been created.
- * The bootstrap is not blocked until the initial navigation is complete. @deprecated
- * * 'legacy_disabled'- The initial navigation is not performed. The location listener is set up
- * after the root component gets created. @deprecated
- * * `true` - same as 'legacy_enabled'. @deprecated since v4
- * * `false` - same as 'legacy_disabled'. @deprecated since v4
- *
- * The 'legacy_enabled' and 'legacy_disabled' should not be used for new applications.
  *
  * @see `forRoot()`
  *
  * @publicApi
  */
-export type InitialNavigation =
-    true | false | 'enabled' | 'disabled' | 'legacy_enabled' | 'legacy_disabled';
+export type InitialNavigation = 'enabled' | 'disabled';
 
 /**
  * A set of configuration options for a router module, provided in the
@@ -272,7 +263,7 @@ export interface ExtraOptions {
 
   /**
    * One of `enabled` (the default) or `disabled`.
-   * By default, the initial navigation starts before the root component is created.
+   * If enabled (the default), the initial navigation starts before the root component is created.
    * The bootstrap is blocked until the initial navigation is complete.
    * When set to `disabled`, the initial navigation is not performed.
    * The location listener is set up before the root component gets created.
@@ -497,14 +488,10 @@ export class RouterInitializer {
       const router = this.injector.get(Router);
       const opts = this.injector.get(ROUTER_CONFIGURATION);
 
-      if (this.isLegacyDisabled(opts) || this.isLegacyEnabled(opts)) {
-        resolve(true);
-
-      } else if (opts.initialNavigation === 'disabled') {
+      if (opts.initialNavigation === 'disabled') {
         router.setUpLocationChangeListener();
         resolve(true);
-
-      } else if (opts.initialNavigation === 'enabled') {
+      } else {
         router.hooks.afterPreactivation = () => {
           // only the initial navigation should be delayed
           if (!this.initNavigation) {
@@ -518,9 +505,6 @@ export class RouterInitializer {
           }
         };
         router.initialNavigation();
-
-      } else {
-        throw new Error(`Invalid initialNavigation options: '${opts.initialNavigation}'`);
       }
 
       return res;
@@ -538,26 +522,11 @@ export class RouterInitializer {
       return;
     }
 
-    if (this.isLegacyEnabled(opts)) {
-      router.initialNavigation();
-    } else if (this.isLegacyDisabled(opts)) {
-      router.setUpLocationChangeListener();
-    }
-
     preloader.setUpPreloading();
     routerScroller.init();
     router.resetRootComponentType(ref.componentTypes[0]);
     this.resultOfPreactivationDone.next(null !);
     this.resultOfPreactivationDone.complete();
-  }
-
-  private isLegacyEnabled(opts: ExtraOptions): boolean {
-    return opts.initialNavigation === 'legacy_enabled' || opts.initialNavigation === true ||
-        opts.initialNavigation === undefined;
-  }
-
-  private isLegacyDisabled(opts: ExtraOptions): boolean {
-    return opts.initialNavigation === 'legacy_disabled' || opts.initialNavigation === false;
   }
 }
 

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -92,48 +92,6 @@ describe('bootstrap', () => {
     });
   });
 
-  it('should NOT wait for resolvers to complete when initialNavigation = legacy_enabled',
-     (done) => {
-       @Component({selector: 'test', template: 'test'})
-       class TestCmpLegacyEnabled {
-       }
-
-       @NgModule({
-         imports: [
-           BrowserModule,
-           RouterModule.forRoot(
-               [{path: '**', component: TestCmpLegacyEnabled, resolve: {test: TestResolver}}],
-               {useHash: true, initialNavigation: 'legacy_enabled'})
-         ],
-         declarations: [RootCmp, TestCmpLegacyEnabled],
-         bootstrap: [RootCmp],
-         providers: [...testProviders, TestResolver],
-         schemas: [CUSTOM_ELEMENTS_SCHEMA]
-       })
-       class TestModule {
-         constructor(router: Router) {
-           log.push('TestModule');
-           router.events.subscribe(e => log.push(e.constructor.name));
-         }
-       }
-
-       platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
-         const router: Router = res.injector.get(Router);
-         expect(router.routerState.snapshot.root.firstChild).toBeNull();
-         // ResolveEnd has not been emitted yet because bootstrap returned too early
-         expect(log).toEqual([
-           'TestModule', 'RootCmp', 'NavigationStart', 'RoutesRecognized', 'GuardsCheckStart',
-           'ChildActivationStart', 'ActivationStart', 'GuardsCheckEnd', 'ResolveStart'
-         ]);
-
-         router.events.subscribe((e) => {
-           if (e instanceof NavigationEnd) {
-             done();
-           }
-         });
-       });
-     });
-
   it('should not run navigation when initialNavigation = disabled', (done) => {
     @Component({selector: 'test', template: 'test'})
     class TestCmpDiabled {
@@ -146,37 +104,6 @@ describe('bootstrap', () => {
                            {useHash: true, initialNavigation: 'disabled'})
       ],
       declarations: [RootCmp, TestCmpDiabled],
-      bootstrap: [RootCmp],
-      providers: [...testProviders, TestResolver],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    })
-    class TestModule {
-      constructor(router: Router) {
-        log.push('TestModule');
-        router.events.subscribe(e => log.push(e.constructor.name));
-      }
-    }
-
-    platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
-      const router = res.injector.get(Router);
-      expect(log).toEqual(['TestModule', 'RootCmp']);
-      done();
-    });
-  });
-
-  it('should not run navigation when initialNavigation = legacy_disabled', (done) => {
-    @Component({selector: 'test', template: 'test'})
-    class TestCmpLegacyDisabled {
-    }
-
-    @NgModule({
-      imports: [
-        BrowserModule,
-        RouterModule.forRoot(
-            [{path: '**', component: TestCmpLegacyDisabled, resolve: {test: TestResolver}}],
-            {useHash: true, initialNavigation: 'legacy_disabled'})
-      ],
-      declarations: [RootCmp, TestCmpLegacyDisabled],
       bootstrap: [RootCmp],
       providers: [...testProviders, TestResolver],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]


### PR DESCRIPTION
BREAKING CHANGE:
* Default for `initialNavigation` is now `enabled` (formerly `legacy_enabled`)
* Values of `true`, `false`, `legacy_enabled`, and `legacy_disabled` are
  no longer valid options for `initialNavigation`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
