### PR TITLE
fix(ivy): ensure TestBed restores fields to the most original value

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -700,7 +700,8 @@ describe('TestBed', () => {
              expect((Module as any).ngInjectorDef.providers).toEqual([Token]);
            });
 
-        it('should clean up overridden providers on components whose modules are compiled more than once', async() => {
+        it('should clean up overridden providers on components whose modules are compiled more than once',
+           async() => {
              @Injectable()
              class SomeInjectable {
                id: string|undefined;

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -513,7 +513,10 @@ export class R3TestBedCompiler {
   }
 
   restoreOriginalState(): void {
-    for (const op of this.defCleanupOps) {
+    // Process cleanup ops in reverse order so the field's original value is restored correctly (in
+    // case there were multiple overrides for the same field).
+    for (let i = this.defCleanupOps.length - 1; i >= 0; i--) {
+      const op = this.defCleanupOps[i];
       op.def[op.field] = op.original;
     }
     // Restore initial component/directive/pipe defs

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -515,10 +515,9 @@ export class R3TestBedCompiler {
   restoreOriginalState(): void {
     // Process cleanup ops in reverse order so the field's original value is restored correctly (in
     // case there were multiple overrides for the same field).
-    for (let i = this.defCleanupOps.length - 1; i >= 0; i--) {
-      const op = this.defCleanupOps[i];
+    forEachRight(this.defCleanupOps, (op: CleanupOperation) => {
       op.def[op.field] = op.original;
-    }
+    });
     // Restore initial component/directive/pipe defs
     this.initialNgDefs.forEach(
         (value: [string, PropertyDescriptor | undefined], type: Type<any>) => {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -515,9 +515,7 @@ export class R3TestBedCompiler {
   restoreOriginalState(): void {
     // Process cleanup ops in reverse order so the field's original value is restored correctly (in
     // case there were multiple overrides for the same field).
-    forEachRight(this.defCleanupOps, (op: CleanupOperation) => {
-      op.def[op.field] = op.original;
-    });
+    forEachRight(this.defCleanupOps, (op: CleanupOperation) => { op.def[op.field] = op.original; });
     // Restore initial component/directive/pipe defs
     this.initialNgDefs.forEach(
         (value: [string, PropertyDescriptor | undefined], type: Type<any>) => {


### PR DESCRIPTION
If `TestBed.applyProviderOverrides` is called multiple times in a single test (happens if someone calls `compileModuleAsync` or `compileModuleSync`), the original fields for `ngComponentDef` are not restored correctly. Subsequent tests will get old versions of overridden providers in these cases. 