### PR TITLE
refactor(core): add `createMigrationCompilerHost`

### DIFF
--- a/packages/core/schematics/migrations/move-document/index.ts
+++ b/packages/core/schematics/migrations/move-document/index.ts
@@ -11,9 +11,12 @@ import {dirname, relative} from 'path';
 import * as ts from 'typescript';
 
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationCompilerHost} from '../../utils/typescript/compiler_host';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
+
 import {COMMON_IMPORT, DOCUMENT_TOKEN_NAME, DocumentImportVisitor, ResolvedDocumentImport} from './document_import_visitor';
 import {addToImport, createImport, removeFromImport} from './move-import';
+
 
 
 /** Entry point for the V8 move-document migration. */
@@ -40,19 +43,7 @@ export default function(): Rule {
  */
 function runMoveDocumentMigration(tree: Tree, tsconfigPath: string, basePath: string) {
   const parsed = parseTsconfigFile(tsconfigPath, dirname(tsconfigPath));
-  const host = ts.createCompilerHost(parsed.options, true);
-
-  // We need to overwrite the host "readFile" method, as we want the TypeScript
-  // program to be based on the file contents in the virtual file tree. Otherwise
-  // if we run the migration for multiple tsconfig files which have intersecting
-  // source files, it can end up updating query definitions multiple times.
-  host.readFile = fileName => {
-    const buffer = tree.read(relative(basePath, fileName));
-    // Strip BOM as otherwise TSC methods (Ex: getWidth) will return an offset which
-    // which breaks the CLI UpdateRecorder.
-    // See: https://github.com/angular/angular/pull/30719
-    return buffer ? buffer.toString().replace(/^\uFEFF/, '') : undefined;
-  };
+  const host = createMigrationCompilerHost(tree, parsed.options, basePath);
 
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -13,6 +13,7 @@ import * as ts from 'typescript';
 
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationCompilerHost} from '../../utils/typescript/compiler_host';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
 
 import {analyzeResolvedTemplate} from './analyze_template';
@@ -47,18 +48,7 @@ export default function(): Rule {
 function runTemplateVariableAssignmentCheck(
     tree: Tree, tsconfigPath: string, basePath: string, logger: Logger) {
   const parsed = parseTsconfigFile(tsconfigPath, dirname(tsconfigPath));
-  const host = ts.createCompilerHost(parsed.options, true);
-
-  // We need to overwrite the host "readFile" method, as we want the TypeScript
-  // program to be based on the file contents in the virtual file tree.
-  host.readFile = fileName => {
-    const buffer = tree.read(relative(basePath, fileName));
-    // Strip BOM as otherwise TSC methods (Ex: getWidth) will return an offset which
-    // which breaks the CLI UpdateRecorder.
-    // See: https://github.com/angular/angular/pull/30719
-    return buffer ? buffer.toString().replace(/^\uFEFF/, '') : undefined;
-  };
-
+  const host = createMigrationCompilerHost(tree, parsed.options, basePath);
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const templateVisitor = new NgComponentTemplateVisitor(typeChecker);

--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
@@ -9,8 +9,8 @@
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {dirname, relative} from 'path';
 import * as ts from 'typescript';
-
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationCompilerHost} from '../../utils/typescript/compiler_host';
 import {parseTsconfigFile} from '../../utils/typescript/parse_tsconfig';
 import {FALLBACK_DECORATOR, addImport, getNamedImports, getUndecoratedClassesWithDecoratedFields, hasNamedImport} from './utils';
 
@@ -44,20 +44,7 @@ export default function(): Rule {
 
 function runUndecoratedClassesMigration(tree: Tree, tsconfigPath: string, basePath: string) {
   const parsed = parseTsconfigFile(tsconfigPath, dirname(tsconfigPath));
-  const host = ts.createCompilerHost(parsed.options, true);
-
-  // We need to overwrite the host "readFile" method, as we want the TypeScript
-  // program to be based on the file contents in the virtual file tree. Otherwise
-  // if we run the migration for multiple tsconfig files which have intersecting
-  // source files, it can end up updating them multiple times.
-  host.readFile = fileName => {
-    const buffer = tree.read(relative(basePath, fileName));
-    // Strip BOM as otherwise TSC methods (Ex: getWidth) will return an offset which
-    // which breaks the CLI UpdateRecorder.
-    // See: https://github.com/angular/angular/pull/30719
-    return buffer ? buffer.toString().replace(/^\uFEFF/, '') : undefined;
-  };
-
+  const host = createMigrationCompilerHost(tree, parsed.options, basePath);
   const program = ts.createProgram(parsed.fileNames, parsed.options, host);
   const typeChecker = program.getTypeChecker();
   const printer = ts.createPrinter();

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -148,10 +148,8 @@ function gracefullyCreateProgram(
     tree: Tree, basePath: string, tsconfigPath: string,
     logger: logging.LoggerApi): {compiler: AotCompiler, program: ts.Program}|null {
   try {
-    const {ngcProgram, host, program, compiler} = createNgcProgram((options) => {
-      const tsHost = createMigrationCompilerHost(tree, options, basePath);
-      return createCompilerHost({options, tsHost});
-    }, tsconfigPath);
+    const {ngcProgram, host, program, compiler} = createNgcProgram(
+        (options) => createMigrationCompilerHost(tree, options, basePath), tsconfigPath);
     const syntacticDiagnostics = ngcProgram.getTsSyntacticDiagnostics();
     const structuralDiagnostics = ngcProgram.getNgStructuralDiagnostics();
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -9,6 +9,7 @@
 import {logging} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {AotCompiler} from '@angular/compiler';
+import {createCompilerHost} from '@angular/compiler-cli';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {relative} from 'path';
@@ -147,8 +148,10 @@ function gracefullyCreateProgram(
     tree: Tree, basePath: string, tsconfigPath: string,
     logger: logging.LoggerApi): {compiler: AotCompiler, program: ts.Program}|null {
   try {
-    const {ngcProgram, host, program, compiler} = createNgcProgram(
-        (options) => createMigrationCompilerHost(tree, options, basePath), tsconfigPath);
+    const {ngcProgram, host, program, compiler} = createNgcProgram((options) => {
+      const tsHost = createMigrationCompilerHost(tree, options, basePath);
+      return createCompilerHost({options, tsHost});
+    }, tsconfigPath);
     const syntacticDiagnostics = ngcProgram.getTsSyntacticDiagnostics();
     const structuralDiagnostics = ngcProgram.getNgStructuralDiagnostics();
 

--- a/packages/core/schematics/utils/BUILD.bazel
+++ b/packages/core/schematics/utils/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     visibility = ["//packages/core/schematics:__subpackages__"],
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
         "@npm//@schematics/angular",

--- a/packages/core/schematics/utils/BUILD.bazel
+++ b/packages/core/schematics/utils/BUILD.bazel
@@ -7,7 +7,6 @@ ts_library(
     visibility = ["//packages/core/schematics:__subpackages__"],
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
         "@npm//@schematics/angular",

--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -15,8 +15,8 @@ export function createMigrationCompilerHost(
 
   // We need to overwrite the host "readFile" method, as we want the TypeScript
   // program to be based on the file contents in the virtual file tree. Otherwise
-  // if we run the migration for multiple tsconfig files which have intersecting
-  // source files, it can end up updating query definitions multiple times.
+  // if we run multiple migrations we might have intersecting changes and
+  // source files.
   host.readFile = fileName => {
     const buffer = tree.read(relative(basePath, fileName));
     // Strip BOM as otherwise TSC methods (Ex: getWidth) will return an offset which

--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Tree} from '@angular-devkit/schematics';
-import {CompilerHost, createCompilerHost} from '@angular/compiler-cli';
 import {relative} from 'path';
 import * as ts from 'typescript';
 
 export function createMigrationCompilerHost(
-    tree: Tree, options: ts.CompilerOptions, basePath: string): CompilerHost {
-  const host = createCompilerHost({options});
+    tree: Tree, options: ts.CompilerOptions, basePath: string): ts.CompilerHost {
+  const host = ts.createCompilerHost(options, true);
 
   // We need to overwrite the host "readFile" method, as we want the TypeScript
   // program to be based on the file contents in the virtual file tree. Otherwise

--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Tree} from '@angular-devkit/schematics';
+import {CompilerHost, createCompilerHost} from '@angular/compiler-cli';
+import {relative} from 'path';
+import * as ts from 'typescript';
+
+export function createMigrationCompilerHost(
+    tree: Tree, options: ts.CompilerOptions, basePath: string): CompilerHost {
+  const host = createCompilerHost({options});
+
+  // We need to overwrite the host "readFile" method, as we want the TypeScript
+  // program to be based on the file contents in the virtual file tree. Otherwise
+  // if we run the migration for multiple tsconfig files which have intersecting
+  // source files, it can end up updating query definitions multiple times.
+  host.readFile = fileName => {
+    const buffer = tree.read(relative(basePath, fileName));
+    // Strip BOM as otherwise TSC methods (Ex: getWidth) will return an offset which
+    // which breaks the CLI UpdateRecorder.
+    // See: https://github.com/angular/angular/pull/30719
+    return buffer ? buffer.toString().replace(/^\uFEFF/, '') : undefined;
+  };
+
+  return host;
+}


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Current we need to create and override certain compiler host methods in every schematic because schematics use a virtual fs. We this change we extract this logic to a common util.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
