### PR TITLE
build: temporarily disable dynamic queries migration

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -34,11 +34,6 @@
       "version": "9-beta",
       "description": "Adds an Angular decorator to undecorated classes that have decorated fields",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
-    },
-    "migration-v9-dynamic-queries": {
-      "version": "9-beta",
-      "description": "Removes the `static` flag from dynamic queries.",
-      "factory": "./migrations/dynamic-queries/index"
     }
   }
 }

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
+        "test-migrations.json",
         "//packages/core/schematics:migrations.json",
     ],
     deps = [

--- a/packages/core/schematics/test/dynamic_queries_migration_spec.ts
+++ b/packages/core/schematics/test/dynamic_queries_migration_spec.ts
@@ -20,7 +20,7 @@ describe('dynamic queries migration', () => {
   let previousWorkingDir: string;
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('./test-migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 

--- a/packages/core/schematics/test/test-migrations.json
+++ b/packages/core/schematics/test/test-migrations.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "migration-v9-dynamic-queries": {
+      "version": "9-beta",
+      "description": "Removes the `static` flag from dynamic queries.",
+      "factory": "../migrations/dynamic-queries/index"
+    }
+  }
+}


### PR DESCRIPTION
Disables the dynamic queries migration until we can land the relevant framework changes (#32686 and #32720).
