### PR TITLE
docs: added missing word in managing data guide

### DIFF
--- a/aio/content/start/data.md
+++ b/aio/content/start/data.md
@@ -20,7 +20,7 @@ Services are the place where you share data between parts of your application. F
 
 Up to this point, users can view product information, and simulate sharing and being notified about product changes. They cannot, however, buy products.
 
-In this section, you'll add a "Buy" button the product details page.
+In this section, you'll add a "Buy" button to the product details page.
 You'll also set up a cart service to store information about products in the cart.
 
 <div class="alert is-helpful">


### PR DESCRIPTION
Added a missing "to" in the following sentence: 
"In this section, you'll add a "Buy" button **to** the product details page."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Missing the word "to" in a sentence within the docs.

Issue Number: N/A


## What is the new behavior?
Added the missing word "to"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
