### PR TITLE
feat(service-worker): remove deprecated `versionedFiles` option

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -404,7 +404,7 @@ The following APIs have been removed starting with version 8.0.0:
 | `@angular/platform-browser` | [`DOCUMENT`](https://v7.angular.io/api/platform-browser/DOCUMENT) | [`DOCUMENT` in `@angular/common`](api/common/DOCUMENT) | Updating to version 8 with [`ng update`](cli/update) changes this automatically.  |
 | `@angular/core/testing` | [`TestBed.deprecatedOverrideProvider()`](https://v7.angular.io/api/core/testing/TestBed#deprecatedoverrideprovider) | [`TestBed.overrideProvider()`](api/core/testing/TestBed#overrideprovider) | none |
 | `@angular/core/testing` | [`TestBedStatic.deprecatedOverrideProvider()`](https://v7.angular.io/api/core/testing/TestBedStatic#deprecatedoverrideprovider) | [`TestBedStatic.overrideProvider()`](api/core/testing/TestBedStatic#overrideprovider) | none |
-
+| `@angular/service-worker` | `versionedFiles` | `files` | In the service worker configuration file `ngsw-config.json`, replace `versionedFiles` with `files`. See [Service Worker Configuration](guide/service-worker-config#assetgroups). |
 
 
 <!-- The following anchor is used by redirects from the removed API pages. Do not change or remove. -->

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -52,7 +52,6 @@ v8 - v11
 | `@angular/upgrade` | [`setAngularLib`](#upgrade-static) | <!--v8--> v9 |
 | template syntax | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector) | <!--v7--> unspecified |
 | template syntax | [`<template`>](#template-tag) | <!--v7--> v9 |
-| service worker | [`versionedFiles` setting](#sw-versionedfiles)| v9 |
 | polyfills | [reflect-metadata](#reflect-metadata) | <!--v8--> v9 |
 | `@angular/core` | [`defineInjectable`](#core) | v11 |
 | `@angular/router` | [`loadChildren` string syntax](#loadChildren) | v11 |
@@ -209,14 +208,6 @@ The [`NgFormSelectorWarning`](api/forms/NgFormSelectorWarning) directive is sole
 Support for using the `ngModel` input property and `ngModelChange` event with reactive form directives was deprecated in version 6.
 
 For more information, see the usage notes for [`FormControlDirective`](api/forms/FormControlDirective#use-with-ngmodel) and [`FormControlName`](api/forms/FormControlName#use-with-ngmodel).
-
-
-{@a sw-versionedfiles}
-### Service worker versionedFiles
-
-In the service worker configuration file `ngsw-config.json`, `versionedFiles` and `files` have the same behavior. As of v6, `versionedFiles` is deprecated; use `files` instead.
-
-For more information, see [Service Worker Configuration](guide/service-worker-config#assetgroups).
 
 
 {@a reflectiveinjector}

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -71,8 +71,6 @@ interface AssetGroup {
   updateMode?: 'prefetch' | 'lazy';
   resources: {
     files?: string[];
-    /** @deprecated As of v6 `versionedFiles` and `files` options have the same behavior. Use `files` instead. */
-    versionedFiles?: string[];
     urls?: string[];
   };
 }
@@ -104,11 +102,9 @@ Defaults to the value `installMode` is set to.
 
 ### `resources`
 
-This section describes the resources to cache, broken up into three groups.
+This section describes the resources to cache, broken up into the following groups:
 
 * `files` lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.
-
-* `versionedFiles` has been deprecated. As of v6 `versionedFiles` and `files` options have the same behavior. Use `files` instead.
 
 * `urls` includes both URLs and URL patterns that will be matched at runtime. These resources are not fetched directly and do not have content hashes, but they will be cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service.<br>
   _(Negative glob patterns are not supported and `?` will be matched literally; i.e. it will not match any character other than `?`.)_

--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -45,26 +45,13 @@ export class Generator {
       Promise<Object[]> {
     const seenMap = new Set<string>();
     return Promise.all((config.assetGroups || []).map(async(group) => {
-      if (group.resources.versionedFiles) {
-        console.warn(
-            `Asset-group '${group.name}' in 'ngsw-config.json' uses the 'versionedFiles' option.\n` +
-            'As of v6 \'versionedFiles\' and \'files\' options have the same behavior. ' +
-            'Use \'files\' instead.');
-      }
-
       const fileMatcher = globListToMatcher(group.resources.files || []);
-      const versionedMatcher = globListToMatcher(group.resources.versionedFiles || []);
-
       const allFiles = await this.fs.list('/');
 
-      const plainFiles = allFiles.filter(fileMatcher).filter(file => !seenMap.has(file));
-      plainFiles.forEach(file => seenMap.add(file));
-
-      const versionedFiles = allFiles.filter(versionedMatcher).filter(file => !seenMap.has(file));
-      versionedFiles.forEach(file => seenMap.add(file));
+      const matchedFiles = allFiles.filter(fileMatcher).filter(file => !seenMap.has(file)).sort();
+      matchedFiles.forEach(file => seenMap.add(file));
 
       // Add the hashes.
-      const matchedFiles = [...plainFiles, ...versionedFiles].sort();
       await matchedFiles.reduce(async(previous, file) => {
         await previous;
         const hash = await this.fs.hash(file);

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -38,13 +38,7 @@ export interface AssetGroup {
   name: string;
   installMode?: 'prefetch'|'lazy';
   updateMode?: 'prefetch'|'lazy';
-  resources: {
-    files?: Glob[];
-    /** @deprecated As of v6 `versionedFiles` and `files` options have the same behavior. Use
-       `files` instead. */
-    versionedFiles?: Glob[];
-    urls?: Glob[];
-  };
+  resources: {files?: Glob[]; urls?: Glob[];};
 }
 
 /**

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -35,8 +35,6 @@ describe('Generator', () => {
             '/**/*.html',
             '/**/*.?s',
             '!/ignored/**',
-          ],
-          versionedFiles: [
             '/**/*.txt',
           ],
           urls: [

--- a/tools/public_api_guard/service-worker/config.d.ts
+++ b/tools/public_api_guard/service-worker/config.d.ts
@@ -3,7 +3,6 @@ export interface AssetGroup {
     name: string;
     resources: {
         files?: Glob[];
-        /** @deprecated */ versionedFiles?: Glob[];
         urls?: Glob[];
     };
     updateMode?: 'prefetch' | 'lazy';


### PR DESCRIPTION
BREAKING CHANGE:

Remove deprecated option `versionedFiles` from service worker asset group configuration in `ngsw-config.json`

Before
```json
"assetGroups": [
  {
    "name": "test",
    "resources": {
      "versionedFiles": [
        "/**/*.txt"
      ]
    }
  }
]
```

After
```json
"assetGroups": [
  {
    "name": "test",
    "resources": {
      "files": [
        "/**/*.txt"
      ]
    }
  }
]
```