### PR TITLE
fix(ivy): R3TestBed should clean up registered modules after each test

### DIFF
--- a/packages/core/src/linker/ng_module_factory_registration.ts
+++ b/packages/core/src/linker/ng_module_factory_registration.ts
@@ -54,7 +54,7 @@ export function registerNgModuleType(ngModuleType: NgModuleType) {
   }
 }
 
-export function clearModulesForTest(): void {
+export function clearModuleRegistry(): void {
   modules.clear();
 }
 

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -17,7 +17,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {modifiedInIvy, obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
-import {clearModulesForTest} from '../../src/linker/ng_module_factory_registration';
+import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
 import {stringify} from '../../src/util/stringify';
 
 class Engine {}
@@ -294,7 +294,10 @@ function declareTests(config?: {useJit: boolean}) {
     describe('id', () => {
       const token = 'myid';
 
-      afterEach(() => clearModulesForTest());
+      // Ivy TestBed clears module registry in resetTestingModule so this afterEach is not needed for Ivy
+      if (!ivyEnabled) {
+        afterEach(() => clearModuleRegistry());
+      }
 
       it('should register loaded modules', () => {
         @NgModule({id: token})

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -294,7 +294,8 @@ function declareTests(config?: {useJit: boolean}) {
     describe('id', () => {
       const token = 'myid';
 
-      // Ivy TestBed clears module registry in resetTestingModule so this afterEach is not needed for Ivy
+      // Ivy TestBed clears module registry in resetTestingModule so this afterEach is not needed
+      // for Ivy
       if (!ivyEnabled) {
         afterEach(() => clearModuleRegistry());
       }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Input, ModuleWithProviders, NgModule, Optional, Pipe, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
+import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Input, ModuleWithProviders, NgModule, Optional, Pipe, getModuleFactory, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -729,5 +729,18 @@ describe('TestBed', () => {
              expect((ComponentWithProvider as any).ngComponentDef.providersResolver)
                  .toEqual(originalResolver);
            });
+      });
+
+  onlyInIvy('Ivy module registration happens when NgModuleFactory is created')
+      .it('cleans up registered modules', async() => {
+        @NgModule({id: 'my_module'})
+        class MyModule {
+        }
+
+        expect(() => getModuleFactory('my_module')).toThrowError();
+        await TestBed.inject(Compiler).compileModuleAsync(MyModule);
+        expect(() => getModuleFactory('my_module')).not.toThrowError();
+        TestBed.resetTestingModule();
+        expect(() => getModuleFactory('my_module')).toThrowError();
       });
 });

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -35,6 +35,7 @@ import {MetadataOverride} from './metadata_override';
 import {TestBed} from './test_bed';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
 import {R3TestBedCompiler} from './r3_test_bed_compiler';
+import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
 
 let _nextRootElementId = 0;
 
@@ -229,6 +230,7 @@ export class TestBedRender3 implements TestBed {
   }
 
   resetTestingModule(): void {
+    clearModuleRegistry();
     this.checkGlobalCompilationFinished();
     resetCompiledComponents();
     if (this._compiler !== null) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

TestBed does not reset the registered modules after each test. Some tests can fail if they are depending on some custom deferred loading module system that: 1. attempts to load the module and if it fails, force compilation and 2. overrideProviders on the module with different values in different tests. The current behavior is that after the first registration, the module is never reregistered so its overrides don't work after the first run.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
