### PR TITLE
fix(compiler-cli): don't set `emitDecoratorMetadata` to `true` when not using tsickle

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -74,27 +74,29 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
   if (!transformDecorators && !transformTypesToClosure) {
     return undefined;
   }
-  if (transformDecorators) {
-    // This is needed as a workaround for https://github.com/angular/tsickle/issues/635
-    // Otherwise tsickle might emit references to non imported values
-    // as TypeScript elided the import.
-    options.emitDecoratorMetadata = true;
-  }
-  const tsickleHost: Pick<
-      tsickle.TsickleHost, 'shouldSkipTsickleProcessing'|'pathToModuleName'|
-      'shouldIgnoreWarningsForPath'|'fileNameToModuleId'|'googmodule'|'untyped'|
-      'convertIndexImportShorthand'|'transformDecorators'|'transformTypesToClosure'> = {
-    shouldSkipTsickleProcessing: (fileName) =>
-                                     /\.d\.ts$/.test(fileName) || GENERATED_FILES.test(fileName),
-    pathToModuleName: (context, importPath) => '',
-    shouldIgnoreWarningsForPath: (filePath) => false,
-    fileNameToModuleId: (fileName) => fileName,
-    googmodule: false,
-    untyped: true,
-    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
-  };
 
   if (options.annotateForClosureCompiler || options.annotationsAs === 'static fields') {
+    if (transformDecorators) {
+      // This is needed as a workaround for https://github.com/angular/tsickle/issues/635
+      // Otherwise tsickle might emit references to non imported values
+      // as TypeScript elided the import.
+      options.emitDecoratorMetadata = true;
+    }
+
+    const tsickleHost: Pick<
+        tsickle.TsickleHost, 'shouldSkipTsickleProcessing'|'pathToModuleName'|
+        'shouldIgnoreWarningsForPath'|'fileNameToModuleId'|'googmodule'|'untyped'|
+        'convertIndexImportShorthand'|'transformDecorators'|'transformTypesToClosure'> = {
+      shouldSkipTsickleProcessing: (fileName) =>
+                                       /\.d\.ts$/.test(fileName) || GENERATED_FILES.test(fileName),
+      pathToModuleName: (_context, _importPath) => '',
+      shouldIgnoreWarningsForPath: (_filePath) => false,
+      fileNameToModuleId: (fileName) => fileName,
+      googmodule: false,
+      untyped: true,
+      convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
+    };
+
     return ({
              program,
              targetSourceFile,
@@ -112,19 +114,9 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
               beforeTs: customTransformers.before,
               afterTs: customTransformers.after,
             });
-  } else {
-    return ({
-             program,
-             targetSourceFile,
-             writeFile,
-             cancellationToken,
-             emitOnlyDtsFiles,
-             customTransformers = {},
-           }) =>
-               program.emit(
-                   targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles,
-                   {after: customTransformers.after, before: customTransformers.before});
   }
+
+  return undefined;
 }
 
 export interface NgcParsedConfiguration extends ParsedConfiguration { watch?: boolean; }


### PR DESCRIPTION
fix(compiler-cli): don't set `emitDecoratorMetadata` to `true` when not using tsickle

Currently, in the `createEmitCallback` we are always setting `emitDecoratorMetadata` to true, even if this is only needed for when using tsickle not to elide imports.

In ng-packagr, we have a copy of `createEmitCallback` (https://github.com/ng-packagr/ng-packagr/blob/master/src/lib/ngc/create-emit-callback.ts) and we discovered that we will always emit `__metadata` helpers even when we don't want. Such such case if when using the ctor transformer which is a workaround for the `forwardRef` temporary dead zone (TDZ)

Also, this PR remove the redundant else part of the emit.