### PR TITLE
build: generate CODEOWNERS from rules in each package

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,7 +1,6 @@
 .git
 node_modules
 dist
-aio/content
 aio/node_modules
 aio/tools/examples/shared/node_modules
 integration/bazel

--- a/.circleci/BUILD.bazel
+++ b/.circleci/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)

--- a/.github/BUILD.bazel
+++ b/.github/BUILD.bazel
@@ -1,0 +1,139 @@
+load("//tools:defaults.bzl", "codeowners")
+load("@rules_codeowners//tools:codeowners.bzl", "generate_codeowners")
+load("@build_bazel_rules_nodejs//internal/golden_file_test:golden_file_test.bzl", "golden_file_test")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.CODEOWNERS",
+    no_docs_parent = True,
+    pattern = "CODEOWNERS",
+    teams = [
+        "@IgorMinar",
+    ],
+)
+
+generate_codeowners(
+    name = "generate_codeowners",
+    # do not sort
+    owners = [
+        "//:OWNERS",
+        "//packages/animations:OWNERS",
+        "//packages/platform-browser/animations:OWNERS",
+        "//aio/content:OWNERS.animations",
+        "//packages/bazel:OWNERS",
+        "//aio/content:OWNERS.bazel",
+        "//packages/compiler:OWNERS",
+        "//packages/examples/compiler:OWNERS",
+        "//packages/compiler-cli:OWNERS",
+        "//aio/content:OWNERS.compiler",
+        "//packages/compiler-cli/ngcc:OWNERS",
+        "//packages/compiler-cli:OWNERS.ngtools",
+        "//aio/content:OWNERS.cli",
+        "//packages/core:OWNERS",
+        "//packages/examples/core:OWNERS",
+        "//packages/common:OWNERS",
+        "//packages/platform-browser:OWNERS",
+        "//packages/examples/platform-browser:OWNERS",
+        "//packages/platform-browser-dynamic:OWNERS",
+        "//packages/platform-webworker:OWNERS",
+        "//packages/platform-webworker-dynamic:OWNERS",
+        "//packages/examples/common:OWNERS",
+        "//packages/docs:OWNERS",
+        "//aio/content:OWNERS.core",
+        "//packages/common/http:OWNERS",
+        "//packages/http:OWNERS",
+        "//packages/examples/http:OWNERS",
+        "//aio/content:OWNERS.http",
+        "//packages/elements:OWNERS",
+        "//aio/content:OWNERS.elements",
+        "//packages/forms:OWNERS",
+        "//packages/examples/forms:OWNERS",
+        "//aio/content:OWNERS.forms",
+        "//packages/language-service:OWNERS",
+        "//aio/content:OWNERS.language-service",
+        "//packages/platform-server:OWNERS",
+        "//aio/content:OWNERS.server",
+        "//packages/router:OWNERS",
+        "//packages/examples/router:OWNERS",
+        "//aio/content:OWNERS.router",
+        "//packages/service-worker:OWNERS",
+        "//packages/examples/service-worker:OWNERS",
+        "//aio/content:OWNERS.service-worker",
+        "//packages/upgrade:OWNERS",
+        "//packages/common/upgrade:OWNERS",
+        "//packages/examples/upgrade:OWNERS",
+        "//aio/content:OWNERS.upgrade",
+        "//:OWNERS.testing",
+        "//aio/content:OWNERS.testing",
+        "//packages/core:OWNERS.i18n",
+        "//packages/common:OWNERS.i18n",
+        "//packages/compiler:OWNERS.i18n",
+        "//packages/compiler-cli:OWNERS.i18n",
+        "//packages/localize:OWNERS",
+        "//aio/content:OWNERS.i18n",
+        "//packages/core:OWNERS.security",
+        "//packages/compiler:OWNERS.security",
+        "//packages/platform-browser:OWNERS.security",
+        "//aio/content:OWNERS.security",
+        "//packages/zone.js:OWNERS",
+        "//packages/benchpress:OWNERS",
+        "//integration:OWNERS",
+        "//aio:OWNERS",
+        "//aio/content:OWNERS.docs-infra",
+        "//aio/content:OWNERS.docs-intro",
+        "//aio/content:OWNERS.docs-observables",
+        "//aio/content:OWNERS.docs-packaging",
+        "//aio/content:OWNERS.docs-libraries",
+        "//aio/content:OWNERS.docs-schematics",
+        "//aio/content:OWNERS.docs-marketing",
+        "//:OWNERS.star",
+        "//.circleci:OWNERS",
+        "//:OWNERS.devcontainer",
+        ":OWNERS",
+        "//:OWNERS.vscode",
+        "//:OWNERS.bazel",
+        "//packages:OWNERS",
+        "//packages/examples/test-utils:OWNERS",
+        "//packages/private:OWNERS",
+        "//scripts:OWNERS",
+        "//third_party:OWNERS",
+        "//tools:OWNERS",
+        "//:OWNERS.bzl",
+        "//tools:OWNERS.core",
+        "//tools:OWNERS.public-api",
+        "//aio/content:OWNERS.public-api",
+        "//aio/content:OWNERS.static-query",
+        ":OWNERS.CODEOWNERS",
+    ],
+)
+
+# Normalize unimportant formatting
+# - remove comments
+# - remove blank lines
+# - collapse multiple whitespace to one
+# This is useful while getting to zero-delta
+_SCRUB_CMD = "grep -v \"^#\" $< | awk 'NF' | tr -s ' ' > $@"
+
+genrule(
+    name = "scrub_golden",
+    srcs = ["CODEOWNERS"],
+    outs = ["CODEOWNERS.scrubbed"],
+    cmd = _SCRUB_CMD,
+)
+
+genrule(
+    name = "scrub_actual",
+    srcs = ["generate_codeowners"],
+    outs = ["codeowners.gen"],
+    cmd = _SCRUB_CMD,
+)
+
+golden_file_test(
+    name = "test",
+    actual = "scrub_actual",
+    golden = "scrub_golden",
+)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -885,7 +885,6 @@ testing/**                                                      @angular/fw-test
 # ================================================
 
 /*                                                              @angular/dev-infra-framework
-/.buildkite/**                                                  @angular/dev-infra-framework
 /.circleci/**                                                   @angular/dev-infra-framework
 /.devcontainer/**                                               @angular/dev-infra-framework
 /.github/**                                                     @angular/dev-infra-framework

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "karma_web_test")
+load("//tools:defaults.bzl", "codeowners", "karma_web_test")
 
 exports_files([
     "LICENSE",
@@ -8,6 +8,53 @@ exports_files([
     "karma-js.conf.js",
     "browser-providers.conf.js",
 ])
+
+codeowners(
+    no_docs_parent = True,
+    pattern = "*",
+    team = "@IgorMinar",
+)
+
+codeowners(
+    name = "OWNERS.star",
+    no_parent = True,
+    pattern = "/*",
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.vscode",
+    no_parent = True,
+    pattern = "/.vscode/**",
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.bazel",
+    no_parent = True,
+    pattern = "/docs/BAZEL.md",
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.testing",
+    pattern = "testing/**",
+    team = "@angular/fw-testing",
+)
+
+codeowners(
+    name = "OWNERS.bzl",
+    no_parent = True,
+    pattern = "*.bzl",
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.devcontainer",
+    no_parent = True,
+    pattern = "/.devcontainer/**",
+    team = "@angular/dev-infra-framework",
+)
 
 alias(
     name = "tsconfig.json",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,3 +155,14 @@ rbe_autoconfig(
     # a specific Linux kernel that comes with "libx11" in order to run headless browser tests.
     repository = "google/rbe-ubuntu16-04-webtest",
 )
+
+RULES_CODEOWNERS_VERSION = "56e551f5ae6d37975889291ab26e4aa2494468db"
+
+RULES_CODEOWNERS_SHA = "be8280b139df5237e85942a606b3f532d9b7cf506a47fc8f5e9bb62fc2c2b24e"
+
+http_archive(
+    name = "rules_codeowners",
+    sha256 = RULES_CODEOWNERS_SHA,
+    strip_prefix = "rules_codeowners-%s" % RULES_CODEOWNERS_VERSION,
+    url = "https://github.com/zegl/rules_codeowners/archive/%s.zip" % RULES_CODEOWNERS_VERSION,
+)

--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_docs_parent = True,
+    patterns = [
+        "*",
+        "aio-builds-setup/**",
+        "content/examples/*",
+        "scripts/**",
+        "src/**",
+        "tests/**",
+        "tools/**",
+    ],
+    team = "@angular/docs-infra",
+)

--- a/aio/content/BUILD.bazel
+++ b/aio/content/BUILD.bazel
@@ -1,0 +1,396 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    name = "OWNERS.animations",
+    patterns = [
+        "guide/animations.md",
+        "examples/animations/**",
+        "images/guide/animations/**",
+        "guide/complex-animation-sequences.md",
+        "guide/reusable-animations.md",
+        "guide/route-animations.md",
+        "guide/transition-and-triggers.md",
+    ],
+    team = "@angular/fw-animations",
+)
+
+codeowners(
+    name = "OWNERS.bazel",
+    pattern = "guide/bazel.md",
+    team = "@angular/tools-bazel",
+)
+
+codeowners(
+    name = "OWNERS.compiler",
+    patterns = [
+        "guide/angular-compiler-options.md",
+        "guide/aot-compiler.md",
+        "guide/aot-metadata-errors.md",
+    ],
+    team = "@angular/fw-compiler",
+)
+
+codeowners(
+    name = "OWNERS.cli",
+    patterns = [
+        "guide/cli-builder.md",
+        "guide/ivy.md",
+        "guide/web-worker.md",
+    ],
+    team = "@angular/tools-cli",
+)
+
+codeowners(
+    name = "OWNERS.core",
+    patterns = [
+        "guide/accessibility.md",
+        "examples/accessibility/**",
+        "guide/architecture-components.md",
+        "guide/architecture-modules.md",
+        "guide/architecture-next-steps.md",
+        "guide/architecture-services.md",
+        "guide/architecture.md",
+        "examples/architecture/**",
+        "images/guide/architecture/**",
+        "guide/attribute-directives.md",
+        "examples/attribute-directives/**",
+        "images/guide/attribute-directives/**",
+        "guide/bootstrapping.md",
+        "examples/bootstrapping/**",
+        "guide/cheatsheet.md",
+        "guide/component-interaction.md",
+        "examples/component-interaction/**",
+        "images/guide/component-interaction/**",
+        "guide/component-styles.md",
+        "examples/component-styles/**",
+        "guide/dependency-injection.md",
+        "examples/dependency-injection/**",
+        "images/guide/dependency-injection/**",
+        "guide/dependency-injection-in-action.md",
+        "examples/dependency-injection-in-action/**",
+        "images/guide/dependency-injection-in-action/**",
+        "guide/dependency-injection-navtree.md",
+        "guide/dependency-injection-providers.md",
+        "guide/displaying-data.md",
+        "examples/displaying-data/**",
+        "images/guide/displaying-data/**",
+        "guide/dynamic-component-loader.md",
+        "examples/dynamic-component-loader/**",
+        "images/guide/dynamic-component-loader/**",
+        "guide/entry-components.md",
+        "guide/feature-modules.md",
+        "examples/feature-modules/**",
+        "images/guide/feature-modules/**",
+        "guide/frequent-ngmodules.md",
+        "images/guide/frequent-ngmodules/**",
+        "guide/hierarchical-dependency-injection.md",
+        "examples/hierarchical-dependency-injection/**",
+        "examples/providers-viewproviders/**",
+        "examples/resolution-modifiers/**",
+        "guide/lazy-loading-ngmodules.md",
+        "examples/lazy-loading-ngmodules/**",
+        "images/guide/lazy-loading-ngmodules/**",
+        "guide/lifecycle-hooks.md",
+        "examples/lifecycle-hooks/**",
+        "images/guide/lifecycle-hooks/**",
+        "examples/ngcontainer/**",
+        "guide/ngmodules.md",
+        "examples/ngmodules/**",
+        "guide/ngmodule-api.md",
+        "guide/ngmodule-faq.md",
+        "examples/ngmodule-faq/**",
+        "guide/ngmodule-vs-jsmodule.md",
+        "guide/module-types.md",
+        "guide/template-syntax.md",
+        "examples/built-in-template-functions/**",
+        "examples/event-binding/**",
+        "examples/interpolation/**",
+        "examples/template-syntax/**",
+        "images/guide/template-syntax/**",
+        "examples/binding-syntax/**",
+        "examples/property-binding/**",
+        "examples/attribute-binding/**",
+        "examples/two-way-binding/**",
+        "examples/built-in-directives/**",
+        "images/guide/built-in-directives/**",
+        "examples/template-reference-variables/**",
+        "examples/inputs-outputs/**",
+        "images/guide/inputs-outputs/**",
+        "examples/template-expression-operators/**",
+        "guide/pipes.md",
+        "examples/pipes/**",
+        "images/guide/pipes/**",
+        "guide/providers.md",
+        "examples/providers/**",
+        "guide/singleton-services.md",
+        "guide/set-document-title.md",
+        "examples/set-document-title/**",
+        "images/guide/set-document-title/**",
+        "guide/sharing-ngmodules.md",
+        "guide/structural-directives.md",
+        "examples/structural-directives/**",
+        "images/guide/structural-directives/**",
+        "guide/user-input.md",
+        "examples/user-input/**",
+        "images/guide/user-input/**",
+    ],
+    team = "@angular/fw-core",
+)
+
+codeowners(
+    name = "OWNERS.http",
+    patterns = [
+        "guide/http.md",
+        "examples/http/**",
+        "images/guide/http/**",
+    ],
+    team = "@angular/fw-http",
+)
+
+codeowners(
+    name = "OWNERS.elements",
+    patterns = [
+        "examples/elements/**",
+        "images/guide/elements/**",
+        "guide/elements.md",
+    ],
+    team = "@angular/fw-elements",
+)
+
+codeowners(
+    name = "OWNERS.forms",
+    patterns = [
+        "guide/forms.md",
+        "examples/forms/**",
+        "images/guide/forms/**",
+        "guide/forms-overview.md",
+        "examples/forms-overview/**",
+        "images/guide/forms-overview/**",
+        "guide/form-validation.md",
+        "examples/form-validation/**",
+        "images/guide/form-validation/**",
+        "guide/dynamic-form.md",
+        "examples/dynamic-form/**",
+        "images/guide/dynamic-form/**",
+        "guide/reactive-forms.md",
+        "examples/reactive-forms/**",
+        "images/guide/reactive-forms/**",
+    ],
+    team = "@angular/fw-forms",
+)
+
+codeowners(
+    name = "OWNERS.language-service",
+    patterns = [
+        "guide/language-service.md",
+        "images/guide/language-service/**",
+    ],
+    team = "@angular/tools-language-service",
+)
+
+codeowners(
+    name = "OWNERS.server",
+    patterns = [
+        "guide/universal.md",
+        "examples/universal/**",
+    ],
+    team = "@angular/fw-server",
+)
+
+codeowners(
+    name = "OWNERS.router",
+    patterns = [
+        "guide/router.md",
+        "examples/router/**",
+        "images/guide/router/**",
+    ],
+    team = "@angular/fw-router",
+)
+
+codeowners(
+    name = "OWNERS.service-worker",
+    patterns = [
+        "guide/service-worker-getting-started.md",
+        "examples/service-worker-getting-started/**",
+        "guide/app-shell.md",
+        "guide/service-worker-communications.md",
+        "guide/service-worker-config.md",
+        "guide/service-worker-devops.md",
+        "guide/service-worker-intro.md",
+        "images/guide/service-worker/**",
+    ],
+    team = "@angular/fw-service-worker",
+)
+
+codeowners(
+    name = "OWNERS.upgrade",
+    patterns = [
+        "guide/upgrade.md",
+        "examples/upgrade-lazy-load-ajs/**",
+        "examples/upgrade-module/**",
+        "images/guide/upgrade/**",
+        "examples/upgrade-phonecat-1-typescript/**",
+        "examples/upgrade-phonecat-2-hybrid/**",
+        "examples/upgrade-phonecat-3-final/**",
+        "guide/upgrade-performance.md",
+        "guide/upgrade-setup.md",
+        "guide/ajs-quick-reference.md",
+        "examples/ajs-quick-reference/**",
+    ],
+    team = "@angular/fw-upgrade",
+)
+
+codeowners(
+    name = "OWNERS.testing",
+    patterns = [
+        "guide/testing.md",
+        "examples/testing/**",
+        "images/guide/testing/**",
+    ],
+    team = "@angular/fw-testing",
+)
+
+codeowners(
+    name = "OWNERS.i18n",
+    patterns = [
+        "guide/i18n.md",
+        "examples/i18n/**",
+    ],
+    team = "@angular/fw-i18n",
+)
+
+codeowners(
+    name = "OWNERS.security",
+    patterns = [
+        "guide/security.md",
+        "examples/security/**",
+        "images/guide/security/**",
+    ],
+    team = "@angular/fw-security",
+)
+
+codeowners(
+    name = "OWNERS.docs-infra",
+    no_docs_parent = True,
+    patterns = [
+        "guide/docs-style-guide.md",
+        "examples/docs-style-guide/**",
+        "images/guide/docs-style-guide/**",
+        "guide/visual-studio-2015.md",
+        "examples/visual-studio-2015/**",
+    ],
+    team = "@angular/docs-infra",
+)
+
+codeowners(
+    name = "OWNERS.docs-intro",
+    patterns = [
+        "guide/setup-local.md",
+        "images/guide/setup-local/**",
+        "tutorial/**",
+        "images/guide/toh/**",
+        "examples/toh-pt0/**",
+        "examples/toh-pt1/**",
+        "examples/toh-pt2/**",
+        "examples/toh-pt3/**",
+        "examples/toh-pt4/**",
+        "examples/toh-pt5/**",
+        "examples/toh-pt6/**",
+        "examples/getting-started-v0/**",
+        "examples/getting-started/**",
+        "start/**",
+        "images/guide/start/**",
+    ],
+    team = "@angular/fw-docs-intro",
+)
+
+codeowners(
+    name = "OWNERS.docs-observables",
+    patterns = [
+        "guide/observables.md",
+        "examples/observables/**",
+        "guide/comparing-observables.md",
+        "guide/observables-in-angular.md",
+        "examples/observables-in-angular/**",
+        "guide/practical-observable-usage.md",
+        "examples/practical-observable-usage/**",
+        "guide/rx-library.md",
+        "examples/rx-library/**",
+    ],
+    team = "@angular/fw-docs-observables",
+)
+
+codeowners(
+    name = "OWNERS.docs-packaging",
+    patterns = [
+        "guide/npm-packages.md",
+        "guide/browser-support.md",
+        "guide/typescript-configuration.md",
+        "examples/setup/**",
+        "guide/build.md",
+        "images/guide/build/**",
+        "guide/deployment.md",
+        "images/guide/deployment/**",
+        "guide/file-structure.md",
+        "guide/releases.md",
+        "guide/updating.md",
+        "guide/workspace-config.md",
+        "guide/deprecations.md",
+        "guide/migration-renderer.md",
+        "guide/migration-undecorated-classes.md",
+        "guide/migration-dynamic-flag.md",
+    ],
+    team = "@angular/fw-docs-packaging",
+)
+
+codeowners(
+    name = "OWNERS.docs-libraries",
+    patterns = [
+        "guide/creating-libraries.md",
+        "guide/libraries.md",
+        "guide/using-libraries.md",
+    ],
+    team = "@angular/tools-docs-libraries",
+)
+
+codeowners(
+    name = "OWNERS.docs-schematics",
+    patterns = [
+        "guide/schematics.md",
+        "guide/schematics-authoring.md",
+        "guide/schematics-for-libraries.md",
+        "images/guide/schematics/**",
+        "examples/schematics-for-libraries/**",
+    ],
+    team = "@angular/tools-docs-schematics",
+)
+
+codeowners(
+    name = "OWNERS.docs-marketing",
+    patterns = [
+        "marketing/**",
+        "images/bios/**",
+        "images/marketing/**",
+        "navigation.json",
+        "license.md",
+    ],
+    team = "@angular/fw-docs-marketing",
+)
+
+codeowners(
+    name = "OWNERS.public-api",
+    no_parent = True,
+    patterns = [
+        "guide/glossary.md",
+        "guide/styleguide.md",
+        "examples/styleguide/**",
+        "images/guide/styleguide/**",
+    ],
+    team = "@angular/fw-public-api",
+)
+
+codeowners(
+    name = "OWNERS.static-query",
+    pattern = "guide/static-query-migration.md",
+    team = "@kara",
+)

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_docs_parent = True,
+    team = "@angular/fw-integration",
+)

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "tslint-eslint-rules": "4.1.1",
     "tslint-no-toplevel-property-access": "0.0.2",
     "tsutils": "2.27.2",
+    "unidiff": "^1.0.2",
     "universal-analytics": "0.4.15",
     "vlq": "0.2.2",
     "vrsource-tslint-rules": "5.1.1",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -6,7 +6,13 @@ exports_files([
 ])
 
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ts_library")
+
+codeowners(
+    no_parent = True,
+    pattern = "*",
+    team = "@angular/dev-infra-framework",
+)
 
 ts_library(
     name = "types",

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-animations")
 
 ng_module(
     name = "animations",

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -1,4 +1,6 @@
-load("//tools:defaults.bzl", "npm_package")
+load("//tools:defaults.bzl", "codeowners", "npm_package")
+
+codeowners(team = "@angular/tools-bazel")
 
 npm_package(
     name = "npm_package",

--- a/packages/benchpress/BUILD.bazel
+++ b/packages/benchpress/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "npm_package", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "npm_package", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/tools-benchpress")
 
 ts_library(
     name = "benchpress",

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -1,6 +1,21 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
+
+codeowners(
+    name = "OWNERS.i18n",
+    patterns = [
+        "locales/**",
+        "src/i18n/**",
+        "src/pipes/date_pipe.ts",
+        "src/pipes/i18n_plural_pipe.ts",
+        "src/pipes/i18n_select_pipe.ts",
+        "src/pipes/number_pipe.ts",
+    ],
+    team = "@angular/fw-i18n",
+)
 
 ng_module(
     name = "common",

--- a/packages/common/http/BUILD.bazel
+++ b/packages/common/http/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "codeowners", "ng_module")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-http")
 
 exports_files(["package.json"])
 

--- a/packages/common/upgrade/BUILD.bazel
+++ b/packages/common/upgrade/BUILD.bazel
@@ -1,8 +1,10 @@
+load("//tools:defaults.bzl", "codeowners", "ng_module")
+
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["package.json"])
+codeowners(team = "@angular/fw-upgrade")
 
-load("//tools:defaults.bzl", "ng_module")
+exports_files(["package.json"])
 
 ng_module(
     name = "upgrade",

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -1,7 +1,22 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "npm_package", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "npm_package", "ts_library")
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
+
+codeowners(team = "@angular/fw-compiler")
+
+codeowners(
+    name = "OWNERS.i18n",
+    pattern = "src/extract_i18n.ts",
+    team = "@angular/fw-i18n",
+)
+
+codeowners(
+    name = "OWNERS.ngtools",
+    no_docs_parent = True,
+    pattern = "src/ngtools/**",
+    team = "@angular/tools-cli",
+)
 
 ts_config(
     name = "tsconfig",

--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -1,6 +1,11 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(
+    no_docs_parent = True,
+    team = "@angular/fw-ngcc",
+)
 
 ts_library(
     name = "ngcc",

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -1,6 +1,24 @@
-load("//tools:defaults.bzl", "ng_package", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ng_package", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-compiler")
+
+codeowners(
+    name = "OWNERS.i18n",
+    patterns = [
+        "src/i18n/**",
+        "src/render3/view/i18n/**",
+    ],
+    team = "@angular/fw-i18n",
+)
+
+codeowners(
+    name = "OWNERS.security",
+    no_parent = True,
+    pattern = "src/schema/**",
+    team = "@angular/fw-security",
+)
 
 ts_library(
     name = "compiler",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -1,6 +1,29 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
+
+codeowners(
+    name = "OWNERS.i18n",
+    patterns = [
+        "src/i18n/**",
+        "src/render3/i18n.ts",
+        "src/render3/i18n.md",
+        "src/render3/interfaces/i18n.ts",
+    ],
+    team = "@angular/fw-i18n",
+)
+
+codeowners(
+    name = "OWNERS.security",
+    no_parent = True,
+    patterns = [
+        "src/sanitization/**",
+        "test/linker/security_integration_spec.ts",
+    ],
+    team = "@angular/fw-security",
+)
 
 ng_module(
     name = "core",

--- a/packages/docs/BUILD.bazel
+++ b/packages/docs/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(team = "@angular/fw-core")

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-elements")
 
 ng_module(
     name = "elements",

--- a/packages/examples/common/BUILD.bazel
+++ b/packages/examples/common/BUILD.bazel
@@ -1,8 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ts_library")
 load("@npm_bazel_protractor//:index.bzl", "protractor_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "common_examples",

--- a/packages/examples/compiler/BUILD.bazel
+++ b/packages/examples/compiler/BUILD.bazel
@@ -1,6 +1,8 @@
+load("//tools:defaults.bzl", "codeowners", "ng_module")
+
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module")
+codeowners(team = "@angular/fw-compiler")
 
 ng_module(
     name = "compiler_examples",

--- a/packages/examples/core/BUILD.bazel
+++ b/packages/examples/core/BUILD.bazel
@@ -1,8 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "jasmine_node_test", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "jasmine_node_test", "ng_module", "ts_library")
 load("@npm_bazel_protractor//:index.bzl", "protractor_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "core_examples",

--- a/packages/examples/forms/BUILD.bazel
+++ b/packages/examples/forms/BUILD.bazel
@@ -1,8 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ts_library")
 load("@npm_bazel_protractor//:index.bzl", "protractor_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
+
+codeowners(team = "@angular/fw-forms")
 
 ng_module(
     name = "forms_examples",

--- a/packages/examples/http/BUILD.bazel
+++ b/packages/examples/http/BUILD.bazel
@@ -1,1 +1,5 @@
+load("//tools:defaults.bzl", "codeowners")
+
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-http")

--- a/packages/examples/platform-browser/BUILD.bazel
+++ b/packages/examples/platform-browser/BUILD.bazel
@@ -1,6 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "codeowners", "ng_module")
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "platform_browser_examples",

--- a/packages/examples/router/BUILD.bazel
+++ b/packages/examples/router/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(team = "@angular/fw-router")

--- a/packages/examples/service-worker/BUILD.bazel
+++ b/packages/examples/service-worker/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(team = "@angular/fw-service-worker")

--- a/packages/examples/test-utils/BUILD.bazel
+++ b/packages/examples/test-utils/BUILD.bazel
@@ -1,6 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ts_library")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)
 
 ts_library(
     name = "test-utils",

--- a/packages/examples/upgrade/BUILD.bazel
+++ b/packages/examples/upgrade/BUILD.bazel
@@ -1,3 +1,7 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(team = "@angular/fw-upgrade")
+
 exports_files([
     "tsconfig-build.json",
     "start-server.js",

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-forms")
 
 ng_module(
     name = "forms",

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-http")
 
 ng_module(
     name = "http",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -1,6 +1,11 @@
-load("//tools:defaults.bzl", "npm_package", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "npm_package", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(
+    no_docs_parent = True,
+    team = "@angular/tools-language-service",
+)
 
 ts_library(
     name = "language-service",

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_package", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ng_package", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-i18n")
 
 ts_library(
     name = "localize",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "platform-browser-dynamic",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -1,6 +1,15 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
+
+codeowners(
+    name = "OWNERS.security",
+    no_parent = True,
+    pattern = "src/security/**",
+    team = "@angular/fw-security",
+)
 
 ng_module(
     name = "platform-browser",

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -1,8 +1,10 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "codeowners", "ng_module")
 
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["package.json"])
+
+codeowners(team = "@angular/fw-animations")
 
 ng_module(
     name = "animations",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-server")
 
 ng_module(
     name = "platform-server",

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "platform-webworker-dynamic",

--- a/packages/platform-webworker/BUILD.bazel
+++ b/packages/platform-webworker/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-core")
 
 ng_module(
     name = "platform-webworker",

--- a/packages/private/BUILD.bazel
+++ b/packages/private/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-router")
 
 ng_module(
     name = "router",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-service-worker")
 
 ng_module(
     name = "service-worker",

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "codeowners", "ng_module", "ng_package")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/fw-upgrade")
 
 ng_module(
     name = "upgrade",

--- a/packages/zone.js/BUILD.bazel
+++ b/packages/zone.js/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
 load("//packages/zone.js:bundles.bzl", "ES2015_BUNDLES", "ES5_BUNDLES", "ES5_GLOBAL_BUNDLES")
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(team = "@angular/fw-zones")
 
 exports_files([
     "tsconfig.json",

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools:defaults.bzl", "codeowners")
+
+codeowners(
+    no_parent = True,
+    team = "@angular/dev-infra-framework",
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,6 +1,45 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//tools:defaults.bzl", "codeowners")
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
+
+codeowners(
+    no_parent = True,
+    patterns = [
+        "build/**",
+        "cjs-jasmine/**",
+        "gulp-tasks/**",
+        "ngcontainer/**",
+        "npm/**",
+        "npm_workspace/**",
+        "public_api_guard/**",
+        "rxjs/**",
+        "size-tracking/**",
+        "source-map-test/**",
+        "symbol-extractor/**",
+        "testing/**",
+        "ts-api-guardian/**",
+        "tslint/**",
+        "validate-commit-message/**",
+        "yarn/**",
+        "*",
+    ],
+    team = "@angular/dev-infra-framework",
+)
+
+codeowners(
+    name = "OWNERS.core",
+    no_docs_parent = True,
+    pattern = "material-ci/**",
+    team = "@angular/fw-core",
+)
+
+codeowners(
+    name = "OWNERS.public-api",
+    no_parent = True,
+    pattern = "public_api_guard/**",
+    team = "@angular/fw-public-api",
+)
 
 exports_files([
     "tsconfig.json",

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -1,6 +1,8 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "codeowners", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
+
+codeowners(team = "@angular/dev-infra-framework")
 
 ts_library(
     name = "browser",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,7 +3276,7 @@ didyoumean@^1.2.1:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
   integrity sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=
 
-diff@^2.0.2:
+diff@^2.0.2, diff@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
   integrity sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=
@@ -11223,6 +11223,13 @@ unicoderegexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/unicoderegexp/-/unicoderegexp-0.4.1.tgz#afb10e4ef1eeddc711417bbb652bc885da9d4171"
   integrity sha1-r7EOTvHu3ccRQXu7ZSvIhdqdQXE=
+
+unidiff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unidiff/-/unidiff-1.0.2.tgz#8706eb36e4aa182a6ca699ecd2f8877f4b906ce0"
+  integrity sha512-2sbEzki5fBmjgAqoafwxRenfMcumMlmVAoJDwYJa3CI4ZVugkdR6qjTw5sVsl29/4JfBBXhWEAd5ars8nRdqXg==
+  dependencies:
+    diff "^2.2.2"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This introduces a test `//.github:test` that asserts we generate an identical CODEOWNERS file as today.

Once we are happy with this setup (maybe during review of this PR) we can clobber the CODEOWNERS file with the generated output.