### PR TITLE
fix(router): fix issue 16710

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1075,6 +1075,10 @@ export class Router {
         lastNavigation.rawUrl.toString() === rawUrl.toString()) {
       return Promise.resolve(true);  // return value is not used
     }
+    // Fix issue 16710 (https://github.com/angular/angular/issues/16710)
+    if (source !== 'imperative' && this.location.path(true) !== rawUrl.toString()) {
+      return Promise.resolve(true);  // return value is not used
+    }
 
     let resolve: any = null;
     let reject: any = null;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -924,7 +924,7 @@ describe('Integration', () => {
          // - the first location change gets canceled, the URL gets reset to '/'
          // - the second location change gets finished, the URL should be reset to '/simple'
          (<any>location).simulateUrlPop('/simple');
-         (<any>location).simulateUrlPop('/simple');
+         (<any>location).simulateHashChange('/simple');
 
          tick(2000);
          advance(fixture);


### PR DESCRIPTION
Fix issue 16710. Navigation events are called twice when using HashLocationStrategy. When user change url manually in browser URL.
ex: Router A(component A) using navigateByUrl(in guard) to redirect to Router B(Component B). When user enter router A in browser URL. That follow will be call twice. Detail in issue 16710

https://github.com/angular/angular/issues/16710

## PR Checklist
Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
* [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16710


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
* [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
