### PR TITLE
fix(ngcc): handle presence of both `ctorParameters` and `__decorate`

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -660,6 +660,26 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     if (decoratorInfo === null) {
       // If none were present, use the `__decorate` helper calls instead.
       decoratorInfo = this.computeDecoratorInfoFromHelperCalls(classSymbol);
+    } else {
+      // If there was decorator information in static properties, it may be the case that only
+      // constructor parameters (`ctorParameters`) were present as static property and additional
+      // decorator info is represented using `__decorate` helper calls. Therefore, also inspect
+      // `__decorate` helpers and attach the class and member decorators it may contain to the
+      // computed decorator info.
+      //
+      // Note that the helper calls may also provide information about constructor parameters, if
+      // `emitDecoratorMetadata` was enabled for the published library. We can safely disregard this
+      // information from the helper calls, as the extracted information from the `ctorParameters`
+      // static property is fully complete by itself.
+      //
+      // Refer to https://github.com/ng-packagr/ng-packagr/pull/1401 where the static property
+      // transform of constructor parameters was ported from tsickle to ng-packagr.
+      if (decoratorInfo.classDecorators === null && decoratorInfo.memberDecorators.size === 0) {
+        const helperCallInfo = this.computeDecoratorInfoFromHelperCalls(classSymbol);
+
+        decoratorInfo.classDecorators = helperCallInfo.classDecorators;
+        decoratorInfo.memberDecorators = helperCallInfo.memberDecorators;
+      }
     }
 
     this.decoratorCache.set(decl, decoratorInfo);

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -79,6 +79,43 @@ runInEachFileSystem(() => {
   `,
         },
         {
+          name: _('/some_directive_ctor_parameters.js'),
+          contents: `
+  import * as tslib_1 from 'tslib';
+  import { Directive, Inject, InjectionToken, Input } from '@angular/core';
+  var INJECTED_TOKEN = new InjectionToken('injected');
+  var ViewContainerRef = /** @class */ (function () {
+      function ViewContainerRef() {
+      }
+      return ViewContainerRef;
+  }());
+  var TemplateRef = /** @class */ (function () {
+      function TemplateRef() {
+      }
+      return TemplateRef;
+  }());
+  var SomeDirective = /** @class */ (function () {
+      function SomeDirective(_viewContainer, _template, injected) {
+          this.input1 = '';
+      }
+      SomeDirective.ctorParameters = function() { return [
+        { type: ViewContainerRef, },
+        { type: TemplateRef, },
+        { type: undefined, decorators: [{ type: Inject, args: [INJECTED_TOKEN,] },] },
+      ]; };
+      tslib_1.__decorate([
+          Input(),
+      ], SomeDirective.prototype, "input1", void 0);
+      SomeDirective = tslib_1.__decorate([
+          Directive({ selector: '[someDirective]' }),
+          tslib_1.__param(2, Inject(INJECTED_TOKEN)),
+      ], SomeDirective);
+      return SomeDirective;
+  }());
+  export { SomeDirective };
+  `,
+        },
+        {
           name: _('/node_modules/@angular/core/some_directive.js'),
           contents: `
   import * as tslib_1 from 'tslib';
@@ -172,6 +209,28 @@ export { SomeDirective };
             ]);
           });
 
+          it('should find the decorators on a class when mixing `ctorParameters` and `__decorate`',
+             () => {
+               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host =
+                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const classNode = getDeclaration(
+                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   isNamedVariableDeclaration);
+               const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+               expect(decorators).toBeDefined();
+               expect(decorators.length).toEqual(1);
+
+               const decorator = decorators[0];
+               expect(decorator.name).toEqual('Directive');
+               expect(decorator.identifier.getText()).toEqual('Directive');
+               expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+               expect(decorator.args !.map(arg => arg.getText())).toEqual([
+                 '{ selector: \'[someDirective]\' }',
+               ]);
+             });
+
           it('should support decorators being used inside @angular/core', () => {
             const {program} =
                 makeTestBundleProgram(_('/node_modules/@angular/core/some_directive.js'));
@@ -212,6 +271,22 @@ export { SomeDirective };
             expect(input2.isStatic).toEqual(false);
             expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
           });
+
+          it('should find decorated members on a class when mixing `ctorParameters` and `__decorate`',
+             () => {
+               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host =
+                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const classNode = getDeclaration(
+                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   isNamedVariableDeclaration);
+               const members = host.getMembersOfClass(classNode);
+
+               const input1 = members.find(member => member.name === 'input1') !;
+               expect(input1.kind).toEqual(ClassMemberKind.Property);
+               expect(input1.isStatic).toEqual(false);
+               expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+             });
 
           it('should find non decorated properties on a class', () => {
             const {program} = makeTestBundleProgram(_('/some_directive.js'));
@@ -287,6 +362,27 @@ export { SomeDirective };
               'String',
             ]);
           });
+
+          it('should find the decorated constructor parameters when mixing `ctorParameters` and `__decorate`',
+             () => {
+               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host =
+                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const classNode = getDeclaration(
+                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   isNamedVariableDeclaration);
+               const parameters = host.getConstructorParameters(classNode);
+
+               expect(parameters).toBeDefined();
+               expect(parameters !.map(parameter => parameter.name)).toEqual([
+                 '_viewContainer', '_template', 'injected'
+               ]);
+               expectTypeValueReferencesForParameters(parameters !, [
+                 'ViewContainerRef',
+                 'TemplateRef',
+                 null,
+               ]);
+             });
 
           describe('(returned parameters `decorators`)', () => {
             it('should have import information on decorators', () => {


### PR DESCRIPTION
Recently ng-packagr was updated to include a transform that used to be
done in tsickle (https://github.com/ng-packagr/ng-packagr/pull/1401),
where only constructor parameter decorators are emitted in tsickle's
format, not any of the other decorators.

ngcc used to extract decorators from only a single format, so once it 
saw the `ctorParameters` static property it assumed the library is using
the tsickle format. Therefore, none of the `__decorate` calls were
considered. This resulted in missing decorator information, preventing 
proper processing of a package.

This commit changes how decorators are extracted by always looking at 
both the static properties and the `__decorate` calls, merging these 
sources appropriately.

Resolves FW-1573