### PR TITLE
fix(ivy): refresh child components before executing ViewQuery function

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -430,15 +430,15 @@ export function refreshView<T>(
 
     setHostBindings(tView, lView);
 
-    const viewQuery = tView.viewQuery;
-    if (viewQuery !== null) {
-      executeViewQueryFn(RenderFlags.Update, viewQuery, context);
-    }
-
     // Refresh child component views.
     const components = tView.components;
     if (components !== null) {
       refreshChildComponents(lView, components);
+    }
+
+    const viewQuery = tView.viewQuery;
+    if (viewQuery !== null) {
+      executeViewQueryFn(RenderFlags.Update, viewQuery, context);
     }
 
     // execute view hooks (AfterViewInit, AfterViewChecked)

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -436,6 +436,9 @@ export function refreshView<T>(
       refreshChildComponents(lView, components);
     }
 
+    // View queries must execute after refreshing child components because a template in this view
+    // could be inserted in a child component. If the view query executes before child component
+    // refresh, the template might not yet be inserted.
     const viewQuery = tView.viewQuery;
     if (viewQuery !== null) {
       executeViewQueryFn(RenderFlags.Update, viewQuery, context);

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -266,7 +266,7 @@ describe('query logic', () => {
     });
 
     it('should support ViewChild query where template is inserted in child component', () => {
-      @Directive({selector: '[required]'})
+      @Component({selector: 'required', template: ''})
       class Required {
       }
 
@@ -275,15 +275,15 @@ describe('query logic', () => {
         template: `<ng-container [ngTemplateOutlet]="content"></ng-container>`
       })
       class Insertion {
-        @Input() content!: TemplateRef<{}>;
+        @Input() content !: TemplateRef<{}>;
       }
 
       @Component({
         template: `
-          <ng-template #findMe>
-            <div required>required</div>
+          <ng-template #template>
+            <required></required>
           </ng-template>
-          <insertion [content]="findMe"></insertion>
+          <insertion [content]="template"></insertion>
           `
       })
       class App {

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -288,17 +288,17 @@ describe('query logic', () => {
       })
       class App {
         @ViewChild(Required, {static: false}) requiredEl !: Required;
+        viewChildAvailableInAfterViewInit?: boolean;
 
         ngAfterViewInit() {
-          if (this.requiredEl === undefined) {
-            throw Error('can\'t find required element');
-          }
+          this.viewChildAvailableInAfterViewInit = this.requiredEl !== undefined;
         }
       }
 
       const fixture = TestBed.configureTestingModule({declarations: [App, Insertion, Required]})
                           .createComponent(App);
-      expect(() => fixture.detectChanges()).not.toThrow();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.viewChildAvailableInAfterViewInit).toBe(true);
     });
 
   });

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -265,6 +265,42 @@ describe('query logic', () => {
       expect(fixture.componentInstance.foo.length).toBe(2);
     });
 
+    it('should support ViewChild query where template is inserted in child component', () => {
+      @Directive({selector: '[required]'})
+      class Required {
+      }
+
+      @Component({
+        selector: 'insertion',
+        template: `<ng-container [ngTemplateOutlet]="content"></ng-container>`
+      })
+      class Insertion {
+        @Input() content!: TemplateRef<{}>;
+      }
+
+      @Component({
+        template: `
+          <ng-template #findMe>
+            <div required>required</div>
+          </ng-template>
+          <insertion [content]="findMe"></insertion>
+          `
+      })
+      class App {
+        @ViewChild(Required, {static: false}) requiredEl !: Required;
+
+        ngAfterViewInit() {
+          if (this.requiredEl === undefined) {
+            throw Error('can\'t find required element');
+          }
+        }
+      }
+
+      const fixture = TestBed.configureTestingModule({declarations: [App, Insertion, Required]})
+                          .createComponent(App);
+      expect(() => fixture.detectChanges()).not.toThrow();
+    });
+
   });
 
   describe('content queries', () => {


### PR DESCRIPTION
Child component refresh must happen before executing the ViewQueryFn because
child components could insert a template from the host that contains the result
of the ViewQuery function (see related test added in this PR).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
