### PR TITLE
docs: change "patchMatch" to "pathMatch"

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -312,7 +312,7 @@ export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParam
  * the router would apply the redirect even when navigating to the redirect destination,
  * creating an endless loop.
  *
- * In the following example, supplying the 'full' `patchMatch` strategy ensures
+ * In the following example, supplying the 'full' `pathMatch` strategy ensures
  * that the router applies the redirect if and only if navigating to '/'.
  *
  * ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the current live version of docs of the Angular router page, `pathMatch` has been misspelt as `patchMatch`.

Link: https://angular.io/api/router/Route#matching-strategy

Issue Number: N/A


## What is the new behavior?
This PR fixes the typo for the Router's Matching Behaviour section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
