### PR TITLE
Library doc: libs built differently from apps.

### DIFF
--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -193,3 +193,18 @@ Incremental builds can be run as a background process in your dev environment. T
 <code-example language="bash">
 ng build my-lib --watch
 </code-example>
+
+<div class="alert is-important">
+
+The CLI `build` command uses a different builder and invokes a different build tool for libraries than it does for applications.
+
+* The  build system for apps, `@angular-devkit/build-angular`, is based on `webpack`, and is included in all new Angular CLI projects.
+* The build system for libraries is based on `ng-packagr`. It is only added to your dependencies when you add a library using `ng generate library my-lib`.
+
+The two build systems support different things, and even where they support the same things, they do those things differently.
+This means that the TypeScript source can result in different JavaScript code in a built library than it would in a built application.
+
+For this reason, an app that depends on a library should only use TypeScript path mappings that point to the *built library*.
+TypeScript path mappings should *not* point to the library source `.ts` files.
+
+</div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://angular.io/guide/creating-libraries
does not make it clear that a lib code is transpiled differently by a different builder than apps.
This means that an app should not point to source TS files, but should only point to the built JS files.

cf https://angular-team.slack.com/archives/C08M4JKNH/p1569923719206100

Issue Number: N/A


## What is the new behavior?
Add note on differing build schematics to https://angular.io/guide/creating-libraries

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
