### PR TITLE
fix(docs-infra): show hamburger button on getting started guide

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -49,8 +49,8 @@ aio-shell.page-resources mat-toolbar.mat-toolbar {
 aio-shell.folder-api mat-toolbar.mat-toolbar,
 aio-shell.folder-cli mat-toolbar.mat-toolbar,
 aio-shell.folder-docs mat-toolbar.mat-toolbar,
-aio-shell.folder-getting-started mat-toolbar.mat-toolbar,
 aio-shell.folder-guide mat-toolbar.mat-toolbar,
+aio-shell.folder-start mat-toolbar.mat-toolbar,
 aio-shell.folder-tutorial mat-toolbar.mat-toolbar {
   @media (min-width: 992px) {
     .hamburger.mat-button {


### PR DESCRIPTION
In 1c3ee4190, the `getting-started` guide/tutorial was renamed to `start`, but the corresponding CSS class that controls the display of the top-left hamburger (and it automatically derived based on the URL) was not updated.

This commit updates the class to ensure that the hamburger is not hidden when navigating to the getting started guide.
