### PR TITLE
Content changes in Component Class section description

### DIFF
--- a/aio/content/guide/ajs-quick-reference.md
+++ b/aio/content/guide/ajs-quick-reference.md
@@ -1150,7 +1150,7 @@ The Angular code is shown using TypeScript.
 
       In Angular, you create a component class.
 
-      NOTE: If you are using TypeScript with AngularJS, you must use the `export` keyword to export the component class.
+      NOTE: If you are using TypeScript with Angular, you must use the `export` keyword to export the component class.
 
       For more information, see the [Components](guide/architecture#components)
       section of the [Architecture Overview](guide/architecture) page.


### PR DESCRIPTION
In the Component Class section, the reference of angular in relation to typescript should be angular instead of angularJS.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Content changes.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No code, just content mistake.

Issue Number: N/A


## What is the new behavior?
No code, just content mistake.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
