### PR TITLE
docs(forms): expand e-mail validation description

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -57,6 +57,34 @@ export const NG_VALIDATORS = new InjectionToken<Array<Validator|Function>>('NgVa
 export const NG_ASYNC_VALIDATORS =
     new InjectionToken<Array<Validator|Function>>('NgAsyncValidators');
 
+/**
+ * At a high level, this regexp matches e-mail addresses of the format `local-part@tld`, where:
+ * - `local-part` consists of one or more of the allowed characters (alphanumeric and some
+ *   punctuation symbols).
+ * - `local-part` cannot begin or end with a period (`.`).
+ * - `local-part` cannot be longer than 64 characters.
+ * - `tld` consistst of one or more `labels` separated by periods (`.`). E.g. `localhost` or
+ *   `foo.com`.
+ * - A `label` consists of one or more of the allowed characters (alphanumeric, dashes (`-`) and
+ *   periods (`.`)).
+ * - A `label` cannot begin or end with a dash (`-`) or a period (`.`).
+ * - A `label` cannot be longer than 63 characters.
+ * - The whole address cannot be longer than 254 characters.
+ *
+ * ## Implementation background
+ *
+ * This regexp was ported over from AngularJS (see there for git history):
+ * https://github.com/angular/angular.js/blob/c133ef836/src/ng/directive/input.js#L27
+ * It is based on the
+ * [WHATWG version](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address) with
+ * some enhancements to incorporate more RFC rules (e.g. related to domain names and the lengths of
+ * different parts of the address). The main differences from the WHATWG version are:
+ *   - Disallow `local-part` to begin or end with a period (`.`).
+ *   - Disallow `local-part` length to exceed 64 characters.
+ *   - Disallow total address length to exceed 254 characters.
+ *
+ * See [this commit](https://github.com/angular/angular.js/commit/f3f5cf72e) for more details.
+ */
 const EMAIL_REGEXP =
     /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
@@ -190,6 +218,20 @@ export class Validators {
   /**
    * @description
    * Validator that requires the control's value pass an email validation test.
+   *
+   * Tests the value using a [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
+   * pattern suitable for common usecases. The pattern is based on the definition of a valid email
+   * address in the [WHATWG HTML specification](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
+   * with some enhancements to incorporate more RFC rules (e.g. related to domain names and the
+   * lengths of different parts of the address).
+   *
+   * The differences from the WHATWG version include:
+   * - Disallow `local-part` (the part before the `@` symbol) to begin or end with a period (`.`).
+   * - Disallow `local-part` to be longer than 64 characters.
+   * - Disallow the whole address to be longer than 254 characters.
+   *
+   * If this pattern does not satisfy your business needs, you can use `Validators.pattern()` to
+   * validate the value against a different pattern.
    *
    * @usageNotes
    *

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -86,7 +86,7 @@ export const NG_ASYNC_VALIDATORS =
  * See [this commit](https://github.com/angular/angular.js/commit/f3f5cf72e) for more details.
  */
 const EMAIL_REGEXP =
-    /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
+    /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 /**
  * @description

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -58,12 +58,14 @@ export const NG_ASYNC_VALIDATORS =
     new InjectionToken<Array<Validator|Function>>('NgAsyncValidators');
 
 /**
+ * A regular expression that matches valid e-mail addresses.
+ *
  * At a high level, this regexp matches e-mail addresses of the format `local-part@tld`, where:
  * - `local-part` consists of one or more of the allowed characters (alphanumeric and some
  *   punctuation symbols).
  * - `local-part` cannot begin or end with a period (`.`).
  * - `local-part` cannot be longer than 64 characters.
- * - `tld` consistst of one or more `labels` separated by periods (`.`). E.g. `localhost` or
+ * - `tld` consists of one or more `labels` separated by periods (`.`). For example `localhost` or
  *   `foo.com`.
  * - A `label` consists of one or more of the allowed characters (alphanumeric, dashes (`-`) and
  *   periods (`.`)).
@@ -77,8 +79,8 @@ export const NG_ASYNC_VALIDATORS =
  * https://github.com/angular/angular.js/blob/c133ef836/src/ng/directive/input.js#L27
  * It is based on the
  * [WHATWG version](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address) with
- * some enhancements to incorporate more RFC rules (e.g. related to domain names and the lengths of
- * different parts of the address). The main differences from the WHATWG version are:
+ * some enhancements to incorporate more RFC rules (such as rules related to domain names and the
+ * lengths of different parts of the address). The main differences from the WHATWG version are:
  *   - Disallow `local-part` to begin or end with a period (`.`).
  *   - Disallow `local-part` length to exceed 64 characters.
  *   - Disallow total address length to exceed 254 characters.
@@ -222,8 +224,8 @@ export class Validators {
    * Tests the value using a [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
    * pattern suitable for common usecases. The pattern is based on the definition of a valid email
    * address in the [WHATWG HTML specification](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
-   * with some enhancements to incorporate more RFC rules (e.g. related to domain names and the
-   * lengths of different parts of the address).
+   * with some enhancements to incorporate more RFC rules (such as rules related to domain names and
+   * the lengths of different parts of the address).
    *
    * The differences from the WHATWG version include:
    * - Disallow `local-part` (the part before the `@` symbol) to begin or end with a period (`.`).


### PR DESCRIPTION
Previously, there was no documentation of what `Validators.email()` expects as a valid e-mail address, making it difficult for people to determine whether it covers their requirements or not. Even more so that the used pattern slightly deviates from the [WHATWG version](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address). One's only option was to look at the source code and try to decipher the regexp pattern.

This PR adds a high-level description of the validator and mentions its similarity to and differences from the WHATWG version. It also adds a brief explanation of the regexp's behavior and references for more information in the source code to provide more context to maintainers/users trying to understand the implementation in the future.

Finally, this PR also refactors `EMAIL_REGEXP (without changing its behavior) to make it more closely match the format of WHATWG version, so that it is easier for people to compare it against the WHATWG one and understand the differences.

Fixes #18985, fixes #25186, closes #32747.