### PR TITLE
Revert "feat(core): make static query flag optional (#32686)"

### DIFF
--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -29,7 +29,7 @@ export interface Query {
   read: any;
   isViewQuery: boolean;
   selector: any;
-  static?: boolean;
+  static: boolean;
 }
 
 export const createContentChildren = makeMetadataFactory<Query>(

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -101,7 +101,7 @@ export interface Query {
   read: any;
   isViewQuery: boolean;
   selector: any;
-  static?: boolean;
+  static: boolean;
 }
 
 /**
@@ -222,8 +222,8 @@ export interface ContentChildDecorator {
    *
    * @Annotation
    */
-  (selector: Type<any>|Function|string, opts?: {read?: any, static?: boolean}): any;
-  new (selector: Type<any>|Function|string, opts?: {read?: any, static?: boolean}): ContentChild;
+  (selector: Type<any>|Function|string, opts: {read?: any, static: boolean}): any;
+  new (selector: Type<any>|Function|string, opts: {read?: any, static: boolean}): ContentChild;
 }
 
 /**
@@ -348,8 +348,8 @@ export interface ViewChildDecorator {
    *
    * @Annotation
    */
-  (selector: Type<any>|Function|string, opts?: {read?: any, static?: boolean}): any;
-  new (selector: Type<any>|Function|string, opts?: {read?: any, static?: boolean}): ViewChild;
+  (selector: Type<any>|Function|string, opts: {read?: any, static: boolean}): any;
+  new (selector: Type<any>|Function|string, opts: {read?: any, static: boolean}): ViewChild;
 }
 
 /**

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -177,13 +177,13 @@ export interface ConstructorSansProvider {
 export declare type ContentChild = Query;
 
 export interface ContentChildDecorator {
-    (selector: Type<any> | Function | string, opts?: {
+    (selector: Type<any> | Function | string, opts: {
         read?: any;
-        static?: boolean;
+        static: boolean;
     }): any;
-    new (selector: Type<any> | Function | string, opts?: {
+    new (selector: Type<any> | Function | string, opts: {
         read?: any;
-        static?: boolean;
+        static: boolean;
     }): ContentChild;
 }
 
@@ -1151,7 +1151,7 @@ export interface Query {
     isViewQuery: boolean;
     read: any;
     selector: any;
-    static?: boolean;
+    static: boolean;
 }
 
 export declare abstract class Query {
@@ -1445,13 +1445,13 @@ export declare const VERSION: Version;
 export declare type ViewChild = Query;
 
 export interface ViewChildDecorator {
-    (selector: Type<any> | Function | string, opts?: {
+    (selector: Type<any> | Function | string, opts: {
         read?: any;
-        static?: boolean;
+        static: boolean;
     }): any;
-    new (selector: Type<any> | Function | string, opts?: {
+    new (selector: Type<any> | Function | string, opts: {
         read?: any;
-        static?: boolean;
+        static: boolean;
     }): ViewChild;
 }
 


### PR DESCRIPTION
This reverts commit 25219baeb4ae037527fc367f37ff6453e352d4a1.
We should run global presubmits as well (only blueprint presubmits were run)