### PR TITLE
docs: correct matcher description

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -42,12 +42,12 @@ export type UrlMatchResult = {
 /**
  * A function for matching a route against URLs. Implement a custom URL matcher
  * for `Route.matcher` when a combination of `path` and `pathMatch`
- * is not expressive enough.
+ * is not expressive enough. Cannot be used together with `path` and `pathMatch`.
  *
  * @param segments An array of URL segments.
  * @param group A segment group.
  * @param route The route to match against.
- * @returns The match-result,
+ * @returns The match-result.
  *
  * @usageNotes
  *
@@ -386,9 +386,11 @@ export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParam
  */
 export interface Route {
   /**
-   * The path to match against, a URL string that uses router matching notation.
+   * The path to match against. Cannot be used together with a custom `matcher` function.
+   * A URL string that uses router matching notation.
    * Can be a wild card (`**`) that matches any URL (see Usage Notes below).
    * Default is "/" (the root path).
+   *
    */
   path?: string;
   /**
@@ -408,8 +410,7 @@ export interface Route {
    */
   pathMatch?: string;
   /**
-   * A URL-matching function to use as a custom strategy for path matching.
-   * If present, supersedes `path` and `pathMatch`.
+   * A custom URL-matching function. Cannot be used together with `path`.
    */
   matcher?: UrlMatcher;
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Fixes description of `Route.matcher` property in API doc.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## What is the current behavior?
API doc incorrectly states that `matcher` supersedes `path/pathMatch`
Issue Number: https://github.com/angular/angular/issues/31862


## What is the new behavior?
API doc correctly states that `matcher` cannot be used together with `path/pathMatch`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
