### PR TITLE
Clarify static name attribute in RouterOutlet API doc

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -18,14 +18,17 @@ import {PRIMARY_OUTLET} from '../shared';
  *
  * Acts as a placeholder that Angular dynamically fills based on the current router state.
  *
+ * Each outlet can have a unique name, determined by the optional `name` attribute.
+ * The name cannot be set or changed dynamically. If not set, default value is "primary".
+ *
  * ```
  * <router-outlet></router-outlet>
  * <router-outlet name='left'></router-outlet>
  * <router-outlet name='right'></router-outlet>
  * ```
  *
- * A router outlet will emit an activate event any time a new component is being instantiated,
- * and a deactivate event when it is being destroyed.
+ * A router outlet emits an activate event when a new component is instantiated,
+ * and a deactivate event when a component is destroyed.
  *
  * ```
  * <router-outlet


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Updates API doc for `RouterOutlet`
https://angular.io/api/router/RouterOutlet#description

<!-- Please check the one that applies to this PR using "x". -->
- [x] Documentation content changes

## What is the current behavior?
Not clear that `name` is a static attribute that cannot be set or changed dynamically.

Issue Number: https://github.com/angular/angular/issues/24720
https://github.com/angular/angular/issues/12522


## What is the new behavior?
Clarifies status of `RouterOutlet` naming.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No