### PR TITLE
fix(core): update migration descriptions with links to AIO documentation

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -17,22 +17,22 @@
     },
     "migration-v9-renderer-to-renderer2": {
       "version": "9-beta",
-      "description": "Migrates usages of Renderer to Renderer2",
+      "description": "The Renderer class has been marked as deprecated since Angular version 4. This migration converts usage of Renderer to Renderer2. For additional information please see: https://v9.angular.io/guide/migration-renderer",
       "factory": "./migrations/renderer-to-renderer2/index"
     },
     "migration-v9-missing-injectable": {
       "version": "9-beta",
-      "description": "Decorates all declared undecorated provider classes with @Injectable",
+      "description": "Decorates all declared undecorated provider classes with @Injectable.",
       "factory": "./migrations/missing-injectable/index"
     },
     "migration-v9-undecorated-classes-with-di": {
       "version": "9-beta",
-      "description": "Decorates undecorated base classes of directives/components that use dependency injection. Copies metadata from base classes to derived directives/components/pipes that are not decorated.",
+      "description": "Adds an Angular decorator to undecorated base classes of directives/components that use dependency injection. Copies metadata from base classes to derived directives/components/pipes that are not decorated. For additional information please see: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-di/index"
     },
     "migration-v9-undecorated-classes-with-decorated-fields": {
       "version": "9-beta",
-      "description": "Adds an Angular decorator to undecorated classes that have decorated fields",
+      "description": "Adds an Angular decorator to undecorated classes that have decorated fields.",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
     }
   }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -1,37 +1,37 @@
 {
   "schematics": {
     "migration-v8-move-document": {
-      "version": "8-beta",
+      "version": "8.0.0-beta",
       "description": "Migrates DOCUMENT Injection token from platform-browser imports to common import",
       "factory": "./migrations/move-document/index"
     },
     "migration-v8-static-queries": {
-      "version": "8-beta",
+      "version": "8.0.0-beta",
       "description": "Migrates ViewChild and ContentChild to explicit query timing",
       "factory": "./migrations/static-queries/index"
     },
     "migration-v8-template-local-variables": {
-      "version": "8-beta",
+      "version": "8.0.0-beta",
       "description": "Warns developers if values are assigned to template variables",
       "factory": "./migrations/template-var-assignment/index"
     },
     "migration-v9-renderer-to-renderer2": {
-      "version": "9-beta",
+      "version": "9.0.0-beta",
       "description": "The Renderer class has been marked as deprecated since Angular version 4. This migration converts usage of Renderer to Renderer2. For additional information please see: https://v9.angular.io/guide/migration-renderer",
       "factory": "./migrations/renderer-to-renderer2/index"
     },
     "migration-v9-missing-injectable": {
-      "version": "9-beta",
+      "version": "9.0.0-beta",
       "description": "Decorates all declared undecorated provider classes with @Injectable.",
       "factory": "./migrations/missing-injectable/index"
     },
     "migration-v9-undecorated-classes-with-di": {
-      "version": "9-beta",
+      "version": "9.0.0-beta",
       "description": "Adds an Angular decorator to undecorated base classes of directives/components that use dependency injection. Copies metadata from base classes to derived directives/components/pipes that are not decorated. For additional information please see: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-di/index"
     },
     "migration-v9-undecorated-classes-with-decorated-fields": {
-      "version": "9-beta",
+      "version": "9.0.0-beta",
       "description": "Adds an Angular decorator to undecorated classes that have decorated fields.",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

9.0 migrations did not contain references to the AIO documentation describing the migrations.


## What is the new behavior?

9.0 migrations that have accompanying documentation now have links to the aforementioned documentation.  The versions for the migration schematics were also corrected to use a valid semver version.

## Does this PR introduce a breaking change?

- [X] No

## Other information
