### PR TITLE
refactor: re-enable dynamic queries migration

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -86,7 +86,7 @@ export * from './schema/dom_element_schema_registry';
 export * from './selector';
 export * from './style_compiler';
 export * from './template_parser/template_parser';
-export {ViewCompiler, findStaticQueryIds, staticViewQueryIds} from './view_compiler/view_compiler';
+export {ViewCompiler} from './view_compiler/view_compiler';
 export {getParseErrors, isSyntaxError, syntaxError, Version} from './util';
 export {SourceMap} from './output/source_map';
 export * from './injectable_compiler_2';

--- a/packages/compiler/src/view_compiler/view_compiler.ts
+++ b/packages/compiler/src/view_compiler/view_compiler.ts
@@ -1013,57 +1013,6 @@ function callUnwrapValue(nodeIndex: number, bindingIdx: number, expr: o.Expressi
   ]);
 }
 
-interface StaticAndDynamicQueryIds {
-  staticQueryIds: Set<number>;
-  dynamicQueryIds: Set<number>;
-}
-
-
-export function findStaticQueryIds(
-    nodes: TemplateAst[], result = new Map<TemplateAst, StaticAndDynamicQueryIds>()):
-    Map<TemplateAst, StaticAndDynamicQueryIds> {
-  nodes.forEach((node) => {
-    const staticQueryIds = new Set<number>();
-    const dynamicQueryIds = new Set<number>();
-    let queryMatches: QueryMatch[] = undefined !;
-    if (node instanceof ElementAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child) !;
-        childData.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    } else if (node instanceof EmbeddedTemplateAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child) !;
-        childData.staticQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    }
-    if (queryMatches) {
-      queryMatches.forEach((match) => staticQueryIds.add(match.queryId));
-    }
-    dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
-    result.set(node, {staticQueryIds, dynamicQueryIds});
-  });
-  return result;
-}
-
-export function staticViewQueryIds(nodeStaticQueryIds: Map<TemplateAst, StaticAndDynamicQueryIds>):
-    StaticAndDynamicQueryIds {
-  const staticQueryIds = new Set<number>();
-  const dynamicQueryIds = new Set<number>();
-  Array.from(nodeStaticQueryIds.values()).forEach((entry) => {
-    entry.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
-    entry.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-  });
-  dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
-  return {staticQueryIds, dynamicQueryIds};
-}
-
 function elementEventNameAndTarget(
     eventAst: BoundEventAst, dirAst: DirectiveAst | null): {name: string, target: string | null} {
   if (eventAst.isAnimation) {

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -34,6 +34,11 @@
       "version": "9-beta",
       "description": "Adds an Angular decorator to undecorated classes that have decorated fields",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
+    },
+    "migration-v9-dynamic-queries": {
+      "version": "9-beta",
+      "description": "Removes the `static` flag from dynamic queries.",
+      "factory": "./migrations/dynamic-queries/index"
     }
   }
 }

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -5,7 +5,6 @@ ts_library(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
-        "test-migrations.json",
         "//packages/core/schematics:migrations.json",
     ],
     deps = [

--- a/packages/core/schematics/test/dynamic_queries_migration_spec.ts
+++ b/packages/core/schematics/test/dynamic_queries_migration_spec.ts
@@ -20,7 +20,7 @@ describe('dynamic queries migration', () => {
   let previousWorkingDir: string;
 
   beforeEach(() => {
-    runner = new SchematicTestRunner('test', require.resolve('./test-migrations.json'));
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
 

--- a/packages/core/schematics/test/test-migrations.json
+++ b/packages/core/schematics/test/test-migrations.json
@@ -1,9 +1,0 @@
-{
-  "schematics": {
-    "migration-v9-dynamic-queries": {
-      "version": "9-beta",
-      "description": "Removes the `static` flag from dynamic queries.",
-      "factory": "../migrations/dynamic-queries/index"
-    }
-  }
-}


### PR DESCRIPTION
Re-enables the dynamic queries migration, now that we have all of the necessary framework changes in place.

Also moves the logic that identifies static queries out of the compiler and into the static queries migration, because that's the only place left that's using it.
