### PR TITLE
docs(core): update static flag documentation

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -205,12 +205,7 @@ export interface ContentChildDecorator {
    * * **selector** - The directive type or the name used for querying.
    * * **read** - True to read a different token from the queried element.
    * * **static** - True to resolve query results before change detection runs,
-   * false to resolve after change detection.
-   *
-   * When `static` is not provided, uses the query results to determine the timing of query
-   * resolution. If any query results are inside a nested view (such as `*ngIf`), the query is
-   * resolved after change detection runs. Otherwise, it is resolved before change detection
-   * runs.
+   * false to resolve after change detection. Defaults to false.
    *
    * @usageNotes
    *
@@ -320,12 +315,9 @@ export interface ViewChildDecorator {
    *
    * * **selector** - The directive type or the name used for querying.
    * * **read** - True to read a different token from the queried elements.
-   * * **static** - True to resolve query results before change detection runs
+   * * **static** - True to resolve query results before change detection runs,
+   * false to resolve after change detection. Defaults to false.
    *
-   * When `static` is not provided, uses query results to determine the timing of query
-   * resolution. If any query results are inside a nested view (such as `*ngIf`), the query is
-   * resolved after change detection runs. Otherwise, it is resolved before change detection
-   * runs.
    *
    * The following selectors are supported.
    *   * Any class with the `@Component` or `@Directive` decorator


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Followup to #32720 that removed the logic that statically determines whether a query is dynamic.

## What is the new behavior?

This updates the docs to reflect that, and mentions that the flag now defaults to false.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
