### PR TITLE
Improve performance of attributes setting 

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -33,7 +33,7 @@ import {isNodeMatchingSelectorList} from '../node_selector_matcher';
 import {ActiveElementFlags, executeElementExitFn, getBindingsEnabled, getCheckNoChangesMode, getIsParent, getPreviousOrParentTNode, getSelectedIndex, hasActiveElementFlag, incrementActiveDirectiveId, namespaceHTMLInternal, selectView, setActiveHostElement, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setPreviousOrParentTNode, setSelectedIndex} from '../state';
 import {renderStylingMap} from '../styling/bindings';
 import {NO_CHANGE} from '../tokens';
-import {ANIMATION_PROP_PREFIX, isAnimationProp} from '../util/attrs_utils';
+import {isAnimationProp} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
 import {getLViewParent} from '../util/view_traversal_utils';
 import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isCreationMode, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
@@ -974,8 +974,7 @@ function validateProperty(
   // The property is considered valid if the element matches the schema, it exists on the element
   // or it is synthetic, and we are in a browser context (web worker nodes should be skipped).
   return matchingSchemas(hostView, tNode.tagName) || propName in element ||
-      propName[0] === ANIMATION_PROP_PREFIX || typeof Node !== 'function' ||
-      !(element instanceof Node);
+      isAnimationProp(propName) || typeof Node !== 'function' || !(element instanceof Node);
 }
 
 function matchingSchemas(hostView: LView, tagName: string | null): boolean {

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -100,8 +100,9 @@ export function isNameOnlyAttributeMarker(marker: string | AttributeMarker | Css
       marker === AttributeMarker.I18n;
 }
 
-export const ANIMATION_PROP_PREFIX = '@';
-
 export function isAnimationProp(name: string): boolean {
-  return name[0] === ANIMATION_PROP_PREFIX;
+  // Perf note: accessing charCodeAt to check for the first character of a string is faster as
+  // compared to accessing a character at index 0 (ex. name[0]). The main reason for this is that
+  // charCodeAt doesn't allocate memory to return a substring.
+  return name.charCodeAt(0) === 64;  // @
 }

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -3,9 +3,6 @@
     "name": "ACTIVE_INDEX"
   },
   {
-    "name": "ANIMATION_PROP_PREFIX"
-  },
-  {
     "name": "BINDING_INDEX"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -3,9 +3,6 @@
     "name": "ACTIVE_INDEX"
   },
   {
-    "name": "ANIMATION_PROP_PREFIX"
-  },
-  {
     "name": "BINDING_INDEX"
   },
   {

--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -14,6 +14,9 @@ import {resetComponentState} from '../../../../src/render3/state';
 import {createBenchmark} from '../micro_bench';
 import {createAndRenderLView} from '../setup';
 
+const attrs =
+    ['name1', 'value1', 'name2', 'value2', 'name3', 'value3', 'name4', 'value4', 'name5', 'value5'];
+
 `<div>
     <button>0</button>
     <button>1</button>
@@ -30,34 +33,34 @@ import {createAndRenderLView} from '../setup';
 function testTemplate(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelementStart(0, 'div');
-    ɵɵelementStart(1, 'button');
+    ɵɵelementStart(1, 'button', attrs);
     ɵɵtext(2, '0');
     ɵɵelementEnd();
-    ɵɵelementStart(3, 'button');
+    ɵɵelementStart(3, 'button', attrs);
     ɵɵtext(4, '1');
     ɵɵelementEnd();
-    ɵɵelementStart(5, 'button');
+    ɵɵelementStart(5, 'button', attrs);
     ɵɵtext(6, '2');
     ɵɵelementEnd();
-    ɵɵelementStart(7, 'button');
+    ɵɵelementStart(7, 'button', attrs);
     ɵɵtext(8, '3');
     ɵɵelementEnd();
-    ɵɵelementStart(9, 'button');
+    ɵɵelementStart(9, 'button', attrs);
     ɵɵtext(10, '4');
     ɵɵelementEnd();
-    ɵɵelementStart(11, 'button');
+    ɵɵelementStart(11, 'button', attrs);
     ɵɵtext(12, '5');
     ɵɵelementEnd();
-    ɵɵelementStart(13, 'button');
+    ɵɵelementStart(13, 'button', attrs);
     ɵɵtext(14, '6');
     ɵɵelementEnd();
-    ɵɵelementStart(15, 'button');
+    ɵɵelementStart(15, 'button', attrs);
     ɵɵtext(16, '7');
     ɵɵelementEnd();
-    ɵɵelementStart(17, 'button');
+    ɵɵelementStart(17, 'button', attrs);
     ɵɵtext(18, '8');
     ɵɵelementEnd();
-    ɵɵelementStart(19, 'button');
+    ɵɵelementStart(19, 'button', attrs);
     ɵɵtext(20, '9');
     ɵɵelementEnd();
     ɵɵelementEnd();

--- a/packages/core/test/render3/perf/noop_renderer.ts
+++ b/packages/core/test/render3/perf/noop_renderer.ts
@@ -32,11 +32,8 @@ export class NoopRenderer implements ProceduralRenderer3 {
   parentNode(node: RNode): RElement|null { throw new Error('Method not implemented.'); }
   nextSibling(node: RNode): RNode|null { throw new Error('Method not implemented.'); }
   setAttribute(el: RElement, name: string, value: string, namespace?: string|null|undefined): void {
-    throw new Error('Method not implemented.');
   }
-  removeAttribute(el: RElement, name: string, namespace?: string|null|undefined): void {
-    throw new Error('Method not implemented.');
-  }
+  removeAttribute(el: RElement, name: string, namespace?: string|null|undefined): void {}
   addClass(el: RElement, name: string): void {}
   removeClass(el: RElement, name: string): void {}
   setStyle(el: RElement, style: string, value: any, flags?: RendererStyleFlags3|undefined): void {}


### PR DESCRIPTION
Accessing a string's character at index allocates a new, single character string.
A better (faster) check is to use `charCodeAt` that doesn't trigger allocation.

This simple change speeds up the element_text_create benchmark by ~7%.