### PR TITLE
feat(core): add postinstall ngcc migration

### DIFF
--- a/aio/content/guide/ivy.md
+++ b/aio/content/guide/ivy.md
@@ -6,21 +6,21 @@ The previous compilation and rendering pipeline, View Engine, is deprecated in v
 You can choose to opt out of Ivy and continue using View Engine while making the transition.
 
 To opt out of Ivy and continue using View Engine for an existing project, set the `enableIvy` option in the `angularCompilerOptions` in your project's `tsconfig.json` to `false`.
-```json
+<code-example language="json" header="tsconfig.json">
 {
   "compilerOptions": { ... },
   "angularCompilerOptions": {
     "enableIvy": false
   }
 }
-```
+</code-example>
 
 AOT compilation with Ivy is faster than with View Engine, and can be used for development. 
 If you opt out of Ivy, AOT compilation will be slower, and should not be used for development in large projects. 
 When Ivy is disabled for a large project, make sure that the `aot` build option in that project configuration is 
 set to `false` and it's only set to `true` in the `production` configuration.
 
-```json
+<code-example language="json" header="angular.json">
 {
   "projects": {
     "my-existing-project": {
@@ -41,4 +41,15 @@ set to `false` and it's only set to `true` in the `production` configuration.
     }
   }
 }
-```
+</code-example>
+
+Ivy projects usually contain a `postinstall` script in the `scripts` section of `package.json` that converts packages in `node_modules` to use Ivy as well.
+When you opt out of Ivy, remove this script. Remove the following line in package.json.
+
+<code-example language="json" header="package.json">
+{
+  "scripts": {
+    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+  }
+}
+</code-example>

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -13,6 +13,7 @@ npm_package(
         "//packages/core/schematics/migrations/dynamic-queries",
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/move-document",
+        "//packages/core/schematics/migrations/postinstall-ngcc",
         "//packages/core/schematics/migrations/renderer-to-renderer2",
         "//packages/core/schematics/migrations/static-queries",
         "//packages/core/schematics/migrations/template-var-assignment",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -39,6 +39,11 @@
       "version": "9-beta",
       "description": "Removes the `static` flag from dynamic queries.",
       "factory": "./migrations/dynamic-queries/index"
+    },
+    "migration-v9-postinstall-ngcc": {
+      "version": "9-beta",
+      "description": "Adds an ngcc call as a postinstall hook in package.json",
+      "factory": "./migrations/postinstall-ngcc/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/postinstall-ngcc/BUILD.bazel
+++ b/packages/core/schematics/migrations/postinstall-ngcc/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "postinstall-ngcc",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "@npm//@angular-devkit/core",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@schematics/angular",
+    ],
+)

--- a/packages/core/schematics/migrations/postinstall-ngcc/README.md
+++ b/packages/core/schematics/migrations/postinstall-ngcc/README.md
@@ -1,0 +1,22 @@
+## Postinstall ngcc migration
+
+Automatically adds a postinstall script to `package.json` to run `ngcc`.
+If a postinstall script is already there and does not call `ngcc`, the call will be prepended.
+
+#### Before
+```json
+{
+  "scripts": {
+    "postinstall": "do-something"
+  }
+}
+```
+
+#### After
+```json
+{
+  "scripts": {
+    "postinstall": "ngcc ... && do-something"
+  }
+}
+```

--- a/packages/core/schematics/migrations/postinstall-ngcc/index.ts
+++ b/packages/core/schematics/migrations/postinstall-ngcc/index.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {JsonParseMode, parseJsonAst} from '@angular-devkit/core';
+import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
+import {appendPropertyInAstObject, findPropertyInAstObject, insertPropertyInAstObjectInOrder} from '@schematics/angular/utility/json-utils';
+
+
+/**
+ * Runs the ngcc postinstall migration for the current CLI workspace.
+ */
+export default function(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    addPackageJsonScript(
+        tree, 'postinstall',
+        'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points');
+    context.addTask(new NodePackageInstallTask());
+  };
+}
+
+function addPackageJsonScript(tree: Tree, scriptName: string, script: string): void {
+  const pkgJsonPath = '/package.json';
+
+  // Read package.json and turn it into an AST.
+  const buffer = tree.read(pkgJsonPath);
+  if (buffer === null) {
+    throw new SchematicsException('Could not read package.json.');
+  }
+  const content = buffer.toString();
+
+  const packageJsonAst = parseJsonAst(content, JsonParseMode.Strict);
+  if (packageJsonAst.kind != 'object') {
+    throw new SchematicsException('Invalid package.json. Was expecting an object.');
+  }
+
+  // Begin recording changes.
+  const recorder = tree.beginUpdate(pkgJsonPath);
+  const scriptsNode = findPropertyInAstObject(packageJsonAst, 'scripts');
+
+  if (!scriptsNode) {
+    // Haven't found the scripts key, add it to the root of the package.json.
+    appendPropertyInAstObject(
+        recorder, packageJsonAst, 'scripts', {
+          [scriptName]: script,
+        },
+        2);
+  } else if (scriptsNode.kind === 'object') {
+    // Check if the script is already there.
+    const scriptNode = findPropertyInAstObject(scriptsNode, scriptName);
+
+    if (!scriptNode) {
+      // Script not found, add it.
+      insertPropertyInAstObjectInOrder(recorder, scriptsNode, scriptName, script, 4);
+    } else {
+      // Script found, prepend the new script with &&.
+      const currentScript = scriptNode.value;
+      if (typeof currentScript == 'string') {
+        // Only add script if there's no ngcc call there already.
+        if (!currentScript.includes('ngcc')) {
+          const {start, end} = scriptNode;
+          recorder.remove(start.offset, end.offset - start.offset);
+          recorder.insertRight(start.offset, JSON.stringify(`${script} && ${currentScript}`));
+        }
+      } else {
+        throw new SchematicsException(
+            'Invalid postinstall script in package.json. Was expecting a string.');
+      }
+    }
+  }
+
+  // Write the changes.
+  tree.commitUpdate(recorder);
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//packages/core/schematics/migrations/dynamic-queries",
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/move-document",
+        "//packages/core/schematics/migrations/postinstall-ngcc",
         "//packages/core/schematics/migrations/renderer-to-renderer2",
         "//packages/core/schematics/migrations/static-queries",
         "//packages/core/schematics/migrations/template-var-assignment",

--- a/packages/core/schematics/test/postinstall_ngcc_spec.ts
+++ b/packages/core/schematics/test/postinstall_ngcc_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EmptyTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+
+
+describe('postinstall ngcc migration', () => {
+  let runner: SchematicTestRunner;
+  let tree: UnitTestTree;
+  const pkgJsonPath = '/package.json';
+  const ngccPostinstall =
+      `"postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"`;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    tree = new UnitTestTree(new EmptyTree());
+  });
+
+  it(`should add postinstall if scripts object is missing`, async() => {
+    tree.create(pkgJsonPath, JSON.stringify({}, null, 2));
+    await runMigration();
+    expect(tree.readContent(pkgJsonPath)).toContain(ngccPostinstall);
+  });
+
+  it(`should add postinstall if the script is missing`, async() => {
+    tree.create(pkgJsonPath, JSON.stringify({scripts: {}}, null, 2));
+    await runMigration();
+    expect(tree.readContent(pkgJsonPath)).toContain(ngccPostinstall);
+  });
+
+  it(`should prepend to postinstall if script already exists`, async() => {
+    tree.create(pkgJsonPath, JSON.stringify({scripts: {postinstall: 'do-something'}}, null, 2));
+    await runMigration();
+    expect(tree.readContent(pkgJsonPath))
+        .toContain(
+            `"postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points && do-something"`);
+  });
+
+  it(`should not prepend to postinstall if script contains ngcc`, async() => {
+    tree.create(pkgJsonPath, JSON.stringify({scripts: {postinstall: 'ngcc --something'}}, null, 2));
+    await runMigration();
+    expect(tree.readContent(pkgJsonPath)).toContain(`"postinstall": "ngcc --something"`);
+    expect(tree.readContent(pkgJsonPath)).not.toContain(ngccPostinstall);
+    expect(tree.readContent(pkgJsonPath))
+        .not.toContain(
+            `ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points`);
+  });
+
+  function runMigration() {
+    return runner.runSchematicAsync('migration-v9-postinstall-ngcc', {}, tree).toPromise();
+  }
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe: 


## What is the current behavior?
Projects updating via `ng update` to Angular version 9 will take longer on the first build due to running `ivy-ngcc` automatically during the build step.


## What is the new behavior?
A postinstall script ensures `ivy-ngcc` is run when installing dependencies instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
https://angular-team.atlassian.net/browse/TOOL-1076