### PR TITLE
fix(common): ensures hash location strategy includes current path fro…

### DIFF
--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -61,22 +61,20 @@ export class HashLocationStrategy extends LocationStrategy {
 
   prepareExternalUrl(internal: string): string {
     const url = joinWithSlash(this._baseHref, internal);
-    return url.length > 0 ? ('#' + url) : url;
+    const path = this._platformLocation.pathname;
+
+    return url.length > 0 ? (path + '#' + url) : path;
   }
 
   pushState(state: any, title: string, path: string, queryParams: string) {
-    let url: string|null = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
-    if (url.length == 0) {
-      url = this._platformLocation.pathname;
-    }
+    let url = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
+
     this._platformLocation.pushState(state, title, url);
   }
 
   replaceState(state: any, title: string, path: string, queryParams: string) {
     let url = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
-    if (url.length == 0) {
-      url = this._platformLocation.pathname;
-    }
+
     this._platformLocation.replaceState(state, title, url);
   }
 

--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -61,9 +61,12 @@ export class HashLocationStrategy extends LocationStrategy {
 
   prepareExternalUrl(internal: string): string {
     const url = joinWithSlash(this._baseHref, internal);
-    const path = this._platformLocation.pathname;
+    // equivalnt to location.origin + location.pathname
+    const baseUrl = this._platformLocation.protocol + '//' + this._platformLocation.hostname +
+        (!!this._platformLocation.port ? ':' + this._platformLocation.port : '') +
+        this._platformLocation.pathname + this._platformLocation.search;
 
-    return url.length > 0 ? (path + '#' + url) : path;
+    return url.length > 0 ? baseUrl + '#' + url : baseUrl;
   }
 
   pushState(state: any, title: string, path: string, queryParams: string) {

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -139,7 +139,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
     if (supportsState()) {
       this._history.pushState(state, title, url);
     } else {
-      this.location.hash = url;
+      this.location.assign(url);
     }
   }
 
@@ -147,7 +147,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
     if (supportsState()) {
       this._history.replaceState(state, title, url);
     } else {
-      this.location.hash = url;
+      this.location.replace(url);
     }
   }
 


### PR DESCRIPTION
…m window.location.pathname

Previously with HashLocationStrategy, any url updates were only made with the hash, for example when the routerLink directives updates the href on anchor tags or in calls to history.pushState or history.replaceState. In the case that a base href is set though, the browser will actually update the url path in the address bar with the path included in the base href. During client side hash routing, this causes unexpected behavior. By always including the current location.pathname in history updates, this ensures that HashRouting will never cause a change to anything before the hash, which is what one would expect.

Fixes #33000

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #33000

## What is the new behavior?

When using HashRouting, the url before the hash will not be modified

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No
