### PR TITLE
fix(ivy): adding `ng` to externs list

### DIFF
--- a/packages/core/src/core.externs.js
+++ b/packages/core/src/core.externs.js
@@ -22,3 +22,9 @@ var wtf;
  * about the global variable.
  */
 var $localize;
+
+/**
+ * This is needed to prevent Closure from using `ng` while minifying scripts, to avoid collisions
+ * with `window.ng` that is used to expose debug utilities in dev mode.
+ */
+var ng;


### PR DESCRIPTION
Prior to this commit, Closure Compiler may accidentally use `ng` during minification process, which conflicts with `window.ng` that is exposed in dev mode for debugging. This commit adds `ng` into externs file to avoid such collisions.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No