### PR TITLE
fix(ivy): avoid exposing `ng` with Closure Compiler enhanced optimizations

### DIFF
--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -61,13 +61,19 @@ export declare type GlobalDevModeContainer = {
  * used from the browser console when an application is not in production.
  */
 export function publishGlobalUtil(name: string, fn: Function): void {
-  const w = global as any as GlobalDevModeContainer;
-  ngDevMode && assertDefined(fn, 'function not defined');
-  if (w) {
-    let container = w[GLOBAL_PUBLISH_EXPANDO_KEY];
-    if (!container) {
-      container = w[GLOBAL_PUBLISH_EXPANDO_KEY] = {};
+  if (typeof COMPILED === 'undefined' || !COMPILED) {
+    // Note: we can't export `ng` when using closure enhanced optimization as:
+    // - closure declares globals itself for minified names, which sometimes clobber our `ng` global
+    // - we can't declare a closure extern as the namespace `ng` is already used within Google
+    //   for typings for AngularJS (via `goog.provide('ng....')`).
+    const w = global as any as GlobalDevModeContainer;
+    ngDevMode && assertDefined(fn, 'function not defined');
+    if (w) {
+      let container = w[GLOBAL_PUBLISH_EXPANDO_KEY];
+      if (!container) {
+        container = w[GLOBAL_PUBLISH_EXPANDO_KEY] = {};
+      }
+      container[name] = fn;
     }
-    container[name] = fn;
   }
 }


### PR DESCRIPTION
Prior to this commit, `ng` was exposed in global namespace, which turned out to be problematic when minifying code with Closure, since it sometimes clobber our `ng` global. This commit aligns Ivy debugging tools behavior with existing logic in "platform-browser" package (packages/platform-browser/src/dom/util.ts#L31) by avoiding `ng` in global namespace when Closure Compiler is used.

Similar change was originally introduced in https://github.com/angular/angular/commit/a7798f2.

Note: if we want to expose debugging tools in Closure at some point in the future, we should be able to do that using a different namespace (like `ngDevTools`).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No