### PR TITLE
test: clean up explicit dynamic query usages

### DIFF
--- a/aio/content/examples/binding-syntax/src/app/app.component.ts
+++ b/aio/content/examples/binding-syntax/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { Component, ViewChild, ElementRef } from '@angular/core';
 })
 export class AppComponent {
 
-  @ViewChild('bindingInput', { static: false }) bindingInput: ElementRef;
+  @ViewChild('bindingInput') bindingInput: ElementRef;
 
   isUnchanged = true;
 

--- a/aio/content/examples/component-interaction/src/app/countdown-parent.component.ts
+++ b/aio/content/examples/component-interaction/src/app/countdown-parent.component.ts
@@ -39,7 +39,7 @@ export class CountdownLocalVarParentComponent { }
 })
 export class CountdownViewChildParentComponent implements AfterViewInit {
 
-  @ViewChild(CountdownTimerComponent, {static: false})
+  @ViewChild(CountdownTimerComponent)
   private timerComponent: CountdownTimerComponent;
 
   seconds() { return 0; }

--- a/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
@@ -34,7 +34,7 @@ export class AfterContentComponent implements AfterContentChecked, AfterContentI
   comment = '';
 
   // Query for a CONTENT child of type `ChildComponent`
-  @ContentChild(ChildComponent, {static: false}) contentChild: ChildComponent;
+  @ContentChild(ChildComponent) contentChild: ChildComponent;
 
 // #enddocregion hooks
   constructor(private logger: LoggerService) {

--- a/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
@@ -35,7 +35,7 @@ export class AfterViewComponent implements  AfterViewChecked, AfterViewInit {
   private prevHero = '';
 
   // Query for a VIEW child of type `ChildViewComponent`
-  @ViewChild(ChildViewComponent, {static: false}) viewChild: ChildViewComponent;
+  @ViewChild(ChildViewComponent) viewChild: ChildViewComponent;
 
 // #enddocregion hooks
   constructor(private logger: LoggerService) {

--- a/aio/content/examples/lifecycle-hooks/src/app/do-check.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/do-check.component.ts
@@ -81,7 +81,7 @@ export class DoCheckParentComponent {
   hero: Hero;
   power: string;
   title = 'DoCheck';
-  @ViewChild(DoCheckComponent, {static: false}) childView: DoCheckComponent;
+  @ViewChild(DoCheckComponent) childView: DoCheckComponent;
 
   constructor() { this.reset(); }
 

--- a/aio/content/examples/lifecycle-hooks/src/app/on-changes.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/on-changes.component.ts
@@ -55,7 +55,7 @@ export class OnChangesParentComponent {
   hero: Hero;
   power: string;
   title = 'OnChanges';
-  @ViewChild(OnChangesComponent, {static: false}) childView: OnChangesComponent;
+  @ViewChild(OnChangesComponent) childView: OnChangesComponent;
 
   constructor() {
     this.reset();

--- a/aio/content/examples/template-reference-variables/src/app/app.component.ts
+++ b/aio/content/examples/template-reference-variables/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { NgForm } from '@angular/forms';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  @ViewChild('itemForm', { static: false }) form: NgForm;
+  @ViewChild('itemForm') form: NgForm;
 
   private _submitMessage = '';
 

--- a/aio/content/examples/template-syntax/src/app/hero-form.component.ts
+++ b/aio/content/examples/template-syntax/src/app/hero-form.component.ts
@@ -13,7 +13,7 @@ import { Hero } from './hero';
 })
 export class HeroFormComponent {
   @Input() hero: Hero;
-  @ViewChild('heroForm', {static: false}) form: NgForm;
+  @ViewChild('heroForm') form: NgForm;
 
   // tslint:disable-next-line:variable-name
   private _submitMessage = '';

--- a/aio/content/examples/testing/src/app/shared/canvas.component.ts
+++ b/aio/content/examples/testing/src/app/shared/canvas.component.ts
@@ -6,7 +6,7 @@ import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 })
 export class CanvasComponent implements AfterViewInit {
   blobSize: number;
-  @ViewChild('sampleCanvas', {static: false}) sampleCanvas: ElementRef;
+  @ViewChild('sampleCanvas') sampleCanvas: ElementRef;
 
   constructor() { }
 

--- a/integration/dynamic-compiler/src/app.component.ts
+++ b/integration/dynamic-compiler/src/app.component.ts
@@ -10,7 +10,7 @@ declare var System: any;
   `,
 })
 export class AppComponent implements AfterViewInit {
-  @ViewChild('vc', {read: ViewContainerRef, static: false}) container: ViewContainerRef;
+  @ViewChild('vc', {read: ViewContainerRef}) container: ViewContainerRef;
 
   constructor(private compiler: Compiler) {}
 

--- a/modules/benchmarks/src/expanding_rows/expanding_row_summary.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_row_summary.ts
@@ -48,7 +48,7 @@ export class ExpandingRowSummary implements OnDestroy {
    * reference to compute collapsed height of the row. We also use this
    * reference for focus and blur methods below.
    */
-  @ViewChild('expandingRowSummaryMainElement', {static: false})
+  @ViewChild('expandingRowSummaryMainElement')
   mainElementRef !: ElementRef;
 
   /** Subscription for changes in parent isExpanded property. */

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1624,7 +1624,7 @@ describe('compiler compliance', () => {
             })
             export class ViewQueryComponent {
               @ViewChild(SomeDirective, {static: true}) someDir !: SomeDirective;
-              @ViewChild('foo', {static: false}) foo !: ElementRef;
+              @ViewChild('foo') foo !: ElementRef;
             }
 
             @NgModule({declarations: [SomeDirective, ViewQueryComponent]})
@@ -1742,7 +1742,7 @@ describe('compiler compliance', () => {
               \`
             })
             export class ContentQueryComponent {
-              @ContentChild(SomeDirective, {static: false}) someDir: SomeDirective;
+              @ContentChild(SomeDirective) someDir: SomeDirective;
               @ContentChildren(SomeDirective) someDirList !: QueryList<SomeDirective>;
             }
 
@@ -1811,7 +1811,7 @@ describe('compiler compliance', () => {
               \`
             })
             export class ContentQueryComponent {
-              @ContentChild('myRef', {static: false}) myRef: any;
+              @ContentChild('myRef') myRef: any;
               @ContentChildren('myRef1, myRef2, myRef3') myRefs: QueryList<any>;
             }
             @NgModule({declarations: [ContentQueryComponent]})
@@ -1862,7 +1862,7 @@ describe('compiler compliance', () => {
             })
             export class ContentQueryComponent {
               @ContentChild(SomeDirective, {static: true}) someDir !: SomeDirective;
-              @ContentChild('foo', {static: false}) foo !: ElementRef;
+              @ContentChild('foo') foo !: ElementRef;
             }
 
             @Component({
@@ -1933,9 +1933,9 @@ describe('compiler compliance', () => {
               \`
             })
             export class ContentQueryComponent {
-              @ContentChild('myRef', {read: TemplateRef, static: false}) myRef: TemplateRef;
+              @ContentChild('myRef', {read: TemplateRef}) myRef: TemplateRef;
               @ContentChildren('myRef1, myRef2, myRef3', {read: ElementRef}) myRefs: QueryList<ElementRef>;
-              @ContentChild(SomeDirective, {read: ElementRef, static: false}) someDir: ElementRef;
+              @ContentChild(SomeDirective, {read: ElementRef}) someDir: ElementRef;
               @ContentChildren(SomeDirective, {read: TemplateRef}) someDirs: QueryList<TemplateRef>;
             }
             @NgModule({declarations: [ContentQueryComponent]})
@@ -3213,7 +3213,7 @@ describe('compiler compliance', () => {
           'spec.ts': `
             import {Component, NgModule, ContentChild} from '@angular/core';
             export class BaseClass {
-              @ContentChild('something', {static: false}) something: any;
+              @ContentChild('something') something: any;
             }
 
             @Component({

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1096,7 +1096,7 @@ runInEachFileSystem(os => {
           template: '<ng-content></ng-content>'
         })
         export class TestCmp {
-          @Input() @ContentChild('foo', {static: false}) foo: any;
+          @Input() @ContentChild('foo') foo: any;
         }
       `);
 
@@ -1118,7 +1118,7 @@ runInEachFileSystem(os => {
         })
         export class TestCmp {
           @ContentChild('bar', {static: true})
-          @ContentChild('foo', {static: false})
+          @ContentChild('foo')
           foo: any;
         }
       `);
@@ -1140,7 +1140,7 @@ runInEachFileSystem(os => {
           template: '...'
         })
         export class TestCmp {
-          @ContentChild('foo', {static: false})
+          @ContentChild('foo')
           private someFn() {}
         }
       `);
@@ -1656,10 +1656,10 @@ runInEachFileSystem(os => {
           }
         })
         class FooCmp {
-          @ContentChild('bar', {read: TemplateRef, static: false}) child: any;
+          @ContentChild('bar', {read: TemplateRef}) child: any;
           @ContentChildren(TemplateRef) children: any;
           get aview(): any { return null; }
-          @ViewChild('accessor', {static: false}) set aview(value: any) {}
+          @ViewChild('accessor') set aview(value: any) {}
         }
     `);
 
@@ -1687,7 +1687,7 @@ runInEachFileSystem(os => {
           }
         })
         class FooCmp {
-          @ContentChild('bar', {read: TemplateRef, static: false}) child: any;
+          @ContentChild('bar', {read: TemplateRef}) child: any;
           @ContentChildren(TemplateRef) children: any;
           get aview(): any { return null; }
           @ViewChild('accessor') set aview(value: any) {}
@@ -1718,11 +1718,11 @@ runInEachFileSystem(os => {
           template: '<div #foo></div>',
         })
         class FooCmp {
-          @ContentChild(forwardRef(() => TemplateRef), {static: false}) child: any;
+          @ContentChild(forwardRef(() => TemplateRef)) child: any;
 
-          @ContentChild(forwardRef(function() { return ViewContainerRef; }), {static: false}) child2: any;
+          @ContentChild(forwardRef(function() { return ViewContainerRef; })) child2: any;
 
-          @ContentChild((forwardRef((function() { return 'parens'; }) as any)), {static: false}) childInParens: any;
+          @ContentChild((forwardRef((function() { return 'parens'; }) as any))) childInParens: any;
         }
     `);
 

--- a/packages/compiler/test/core_spec.ts
+++ b/packages/compiler/test/core_spec.ts
@@ -27,11 +27,10 @@ import * as core from '@angular/core';
       typeExtends<compilerCore.Query, core.Query>();
       typeExtends<core.Query, compilerCore.Query>();
       compareRuntimeShape(
-          new core.ContentChild('someSelector', {static: false}),
-          compilerCore.createContentChild('someSelector', {static: false}));
+          new core.ContentChild('someSelector'), compilerCore.createContentChild('someSelector'));
       compareRuntimeShape(
-          new core.ContentChild('someSelector', {read: 'someRead', static: false}),
-          compilerCore.createContentChild('someSelector', {read: 'someRead', static: false}));
+          new core.ContentChild('someSelector', {read: 'someRead'}),
+          compilerCore.createContentChild('someSelector', {read: 'someRead'}));
       compareRuntimeShape(
           new core.ContentChildren('someSelector'),
           compilerCore.createContentChildren('someSelector'));
@@ -40,11 +39,10 @@ import * as core from '@angular/core';
           compilerCore.createContentChildren(
               'someSelector', {read: 'someRead', descendants: false}));
       compareRuntimeShape(
-          new core.ViewChild('someSelector', {static: false}),
-          compilerCore.createViewChild('someSelector', {static: false}));
+          new core.ViewChild('someSelector'), compilerCore.createViewChild('someSelector'));
       compareRuntimeShape(
-          new core.ViewChild('someSelector', {read: 'someRead', static: false}),
-          compilerCore.createViewChild('someSelector', {read: 'someRead', static: false}));
+          new core.ViewChild('someSelector', {read: 'someRead'}),
+          compilerCore.createViewChild('someSelector', {read: 'someRead'}));
       compareRuntimeShape(
           new core.ViewChildren('someSelector'), compilerCore.createViewChildren('someSelector'));
       compareRuntimeShape(

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -68,15 +68,15 @@ class SomeDirectiveWithViewChildren {
   c: any;
 }
 
-@Directive({selector: 'someDirective', queries: {'c': new ContentChild('c', {static: false})}})
+@Directive({selector: 'someDirective', queries: {'c': new ContentChild('c')}})
 class SomeDirectiveWithContentChild {
-  @ContentChild('a', {static: false}) a: any;
+  @ContentChild('a') a: any;
   c: any;
 }
 
-@Directive({selector: 'someDirective', queries: {'c': new ViewChild('c', {static: false})}})
+@Directive({selector: 'someDirective', queries: {'c': new ViewChild('c')}})
 class SomeDirectiveWithViewChild {
-  @ViewChild('a', {static: false}) a: any;
+  @ViewChild('a') a: any;
   c: any;
 }
 
@@ -408,41 +408,37 @@ class SomeDirectiveWithoutMetadata {}
 
       it('should append ContentChild', () => {
         const directiveMetadata = resolver.resolve(SomeDirectiveWithContentChild);
-        expect(directiveMetadata.queries).toEqual({
-          'c': new ContentChild('c', {static: false}),
-          'a': new ContentChild('a', {static: false})
-        });
+        expect(directiveMetadata.queries)
+            .toEqual({'c': new ContentChild('c'), 'a': new ContentChild('a')});
       });
 
       it('should append ViewChild', () => {
         const directiveMetadata = resolver.resolve(SomeDirectiveWithViewChild);
-        expect(directiveMetadata.queries).toEqual({
-          'c': new ViewChild('c', {static: false}),
-          'a': new ViewChild('a', {static: false})
-        });
+        expect(directiveMetadata.queries)
+            .toEqual({'c': new ViewChild('c'), 'a': new ViewChild('a')});
       });
 
       it('should support inheriting queries', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @ContentChild('p1', {static: false})
+          @ContentChild('p1')
           p1: any;
-          @ContentChild('p21', {static: false})
+          @ContentChild('p21')
           p2: any;
         }
 
         class Child extends Parent {
-          @ContentChild('p22', {static: false})
+          @ContentChild('p22')
           p2: any;
-          @ContentChild('p3', {static: false})
+          @ContentChild('p3')
           p3: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);
         expect(directiveMetadata.queries).toEqual({
-          'p1': new ContentChild('p1', {static: false}),
-          'p2': new ContentChild('p22', {static: false}),
-          'p3': new ContentChild('p3', {static: false})
+          'p1': new ContentChild('p1'),
+          'p2': new ContentChild('p22'),
+          'p3': new ContentChild('p3')
         });
       });
     });

--- a/packages/core/schematics/test/google3/undecorated_classes_with_decorated_fields_spec.ts
+++ b/packages/core/schematics/test/google3/undecorated_classes_with_decorated_fields_spec.ts
@@ -183,7 +183,7 @@ describe('Google3 undecorated classes with decorated fields TSLint rule', () => 
       import { ViewChild, ElementRef } from '@angular/core';
 
       export class Base {
-        @ViewChild('button', { static: false }) button: ElementRef<HTMLElement>;
+        @ViewChild('button') button: ElementRef<HTMLElement>;
       }
     `);
 
@@ -209,7 +209,7 @@ describe('Google3 undecorated classes with decorated fields TSLint rule', () => 
       import { ContentChild, ElementRef } from '@angular/core';
 
       export class Base {
-        @ContentChild('button', { static: false }) button: ElementRef<HTMLElement>;
+        @ContentChild('button') button: ElementRef<HTMLElement>;
       }
     `);
 

--- a/packages/core/schematics/test/undecorated_classes_with_decorated_fields_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_decorated_fields_migration_spec.ts
@@ -159,7 +159,7 @@ describe('Undecorated classes with decorated fields migration', () => {
       import { ViewChild, ElementRef } from '@angular/core';
 
       export class Base {
-        @ViewChild('button', { static: false }) button: ElementRef<HTMLElement>;
+        @ViewChild('button') button: ElementRef<HTMLElement>;
       }
     `);
 
@@ -185,7 +185,7 @@ describe('Undecorated classes with decorated fields migration', () => {
       import { ContentChild, ElementRef } from '@angular/core';
 
       export class Base {
-        @ContentChild('button', { static: false }) button: ElementRef<HTMLElement>;
+        @ContentChild('button') button: ElementRef<HTMLElement>;
       }
     `);
 

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -80,7 +80,7 @@ describe('change detection', () => {
       })
       class TestCmpt {
         counter = 0;
-        @ViewChild('vc', {read: ViewContainerRef, static: false}) vcRef !: ViewContainerRef;
+        @ViewChild('vc', {read: ViewContainerRef}) vcRef !: ViewContainerRef;
 
         constructor(private _cfr: ComponentFactoryResolver) {}
 
@@ -146,7 +146,7 @@ describe('change detection', () => {
 
     @Component({selector: 'my-app', template: '<my-comp [name]="name"></my-comp>'})
     class MyApp {
-      @ViewChild(MyComponent, {static: false}) comp !: MyComponent;
+      @ViewChild(MyComponent) comp !: MyComponent;
       name: string = 'Nancy';
     }
 
@@ -238,7 +238,7 @@ describe('change detection', () => {
         template: '<my-comp></my-comp><button id="parent" (click)="noop()"></button>'
       })
       class ButtonParent {
-        @ViewChild(MyComponent, {static: false}) comp !: MyComponent;
+        @ViewChild(MyComponent) comp !: MyComponent;
         noop() {}
       }
 
@@ -264,7 +264,7 @@ describe('change detection', () => {
         changeDetection: ChangeDetectionStrategy.OnPush
       })
       class ButtonParent implements DoCheck {
-        @ViewChild(MyComponent, {static: false}) comp !: MyComponent;
+        @ViewChild(MyComponent) comp !: MyComponent;
         noop() {}
 
         doCheckCount = 0;
@@ -273,7 +273,7 @@ describe('change detection', () => {
 
       @Component({selector: 'my-button-app', template: '<button-parent></button-parent>'})
       class MyButtonApp {
-        @ViewChild(ButtonParent, {static: false}) parent !: ButtonParent;
+        @ViewChild(ButtonParent) parent !: ButtonParent;
       }
 
       TestBed.configureTestingModule({declarations: [MyButtonApp, MyComponent, ButtonParent]});
@@ -326,7 +326,7 @@ describe('change detection', () => {
 
       @Component({selector: 'parent-comp', template: `{{ doCheckCount}} - <my-comp></my-comp>`})
       class ParentComp implements DoCheck {
-        @ViewChild(MyComp, {static: false}) myComp !: MyComp;
+        @ViewChild(MyComp) myComp !: MyComp;
 
         doCheckCount = 0;
 
@@ -411,8 +411,8 @@ describe('change detection', () => {
       it('should check component view when called by directive on component node', () => {
         @Component({template: '<my-comp dir></my-comp>'})
         class MyApp {
-          @ViewChild(MyComp, {static: false}) myComp !: MyComp;
-          @ViewChild(Dir, {static: false}) dir !: Dir;
+          @ViewChild(MyComp) myComp !: MyComp;
+          @ViewChild(Dir) dir !: Dir;
         }
 
         TestBed.configureTestingModule({declarations: [MyComp, Dir, MyApp]});
@@ -429,8 +429,8 @@ describe('change detection', () => {
       it('should check host component when called by directive on element node', () => {
         @Component({template: '{{ value }}<div dir></div>'})
         class MyApp {
-          @ViewChild(MyComp, {static: false}) myComp !: MyComp;
-          @ViewChild(Dir, {static: false}) dir !: Dir;
+          @ViewChild(MyComp) myComp !: MyComp;
+          @ViewChild(Dir) dir !: Dir;
           value = '';
         }
 
@@ -450,7 +450,7 @@ describe('change detection', () => {
       it('should check the host component when called from EmbeddedViewRef', () => {
         @Component({template: '{{ name }}<div *ngIf="showing" dir></div>'})
         class MyApp {
-          @ViewChild(Dir, {static: false}) dir !: Dir;
+          @ViewChild(Dir) dir !: Dir;
           showing = true;
           name = 'Amelia';
         }
@@ -601,7 +601,7 @@ describe('change detection', () => {
                 '<ng-template #foo let-ctx="ctx">{{ ctx.value }}</ng-template><structural-comp [tmp]="foo"></structural-comp>'
           })
           class App {
-            @ViewChild(StructuralComp, {static: false}) structuralComp !: StructuralComp;
+            @ViewChild(StructuralComp) structuralComp !: StructuralComp;
           }
 
           TestBed.configureTestingModule({declarations: [App, StructuralComp]});
@@ -630,7 +630,7 @@ describe('change detection', () => {
             template: '<ng-template #foo>Template text</ng-template><structural-comp [tmp]="foo">'
           })
           class App {
-            @ViewChild(StructuralComp, {static: false}) structuralComp !: StructuralComp;
+            @ViewChild(StructuralComp) structuralComp !: StructuralComp;
           }
 
           TestBed.configureTestingModule({declarations: [App, StructuralComp]});
@@ -661,7 +661,7 @@ describe('change detection', () => {
 
       @Component({template: '<detached-comp></detached-comp>'})
       class MyApp {
-        @ViewChild(DetachedComp, {static: false}) comp !: DetachedComp;
+        @ViewChild(DetachedComp) comp !: DetachedComp;
 
         constructor(public cdr: ChangeDetectorRef) {}
       }
@@ -772,7 +772,7 @@ describe('change detection', () => {
 
         @Component({template: '<on-push-comp [value]="value"></on-push-comp>'})
         class OnPushApp {
-          @ViewChild(OnPushComp, {static: false}) onPushComp !: OnPushComp;
+          @ViewChild(OnPushComp) onPushComp !: OnPushComp;
           value = '';
         }
 
@@ -819,7 +819,7 @@ describe('change detection', () => {
         changeDetection: ChangeDetectionStrategy.OnPush
       })
       class OnPushParent {
-        @ViewChild(OnPushComp, {static: false}) comp !: OnPushComp;
+        @ViewChild(OnPushComp) comp !: OnPushComp;
         value = 'one';
       }
 
@@ -881,7 +881,7 @@ describe('change detection', () => {
           changeDetection: ChangeDetectionStrategy.OnPush
         })
         class EmbeddedViewParent {
-          @ViewChild(OnPushComp, {static: false}) comp !: OnPushComp;
+          @ViewChild(OnPushComp) comp !: OnPushComp;
           value = 'one';
           showing = true;
         }

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -239,7 +239,7 @@ describe('component', () => {
       encapsulation: ViewEncapsulation.Emulated,
     })
     class Parent {
-      @ViewChild(Child, {static: false}) childInstance !: Child;
+      @ViewChild(Child) childInstance !: Child;
       constructor(public renderer: Renderer2) {}
     }
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -405,7 +405,7 @@ describe('di', () => {
          </div>`
         })
         class MyComp {
-          @ViewChild(StructuralDirective, {static: false}) structuralDir !: StructuralDirective;
+          @ViewChild(StructuralDirective) structuralDir !: StructuralDirective;
         }
 
         TestBed.configureTestingModule(
@@ -449,8 +449,8 @@ describe('di', () => {
           </div>`
         })
         class MyApp {
-          @ViewChild(HostBindingDirective, {static: false}) hostBindingDir !: HostBindingDirective;
-          @ViewChild(DirectiveA, {static: false}) dirA !: DirectiveA;
+          @ViewChild(HostBindingDirective) hostBindingDir !: HostBindingDirective;
+          @ViewChild(DirectiveA) dirA !: DirectiveA;
         }
 
         TestBed.configureTestingModule(
@@ -563,7 +563,7 @@ describe('di', () => {
 
           @Component({template: '<div dirA></div>'})
           class MyComp {
-            @ViewChild(DirectiveA, {static: false}) dirA !: DirectiveA;
+            @ViewChild(DirectiveA) dirA !: DirectiveA;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
@@ -583,7 +583,7 @@ describe('di', () => {
 
           @Component({template: '<div dirC></div>'})
           class MyComp {
-            @ViewChild(DirectiveC, {static: false}) dirC !: DirectiveC;
+            @ViewChild(DirectiveC) dirC !: DirectiveC;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveC, MyComp]});
@@ -603,7 +603,7 @@ describe('di', () => {
 
           @Component({template: '<div dirB></div><div dirC></div>'})
           class MyComp {
-            @ViewChild(DirectiveC, {static: false}) dirC !: DirectiveC;
+            @ViewChild(DirectiveC) dirC !: DirectiveC;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveB, DirectiveC, MyComp]});
@@ -624,12 +624,12 @@ describe('di', () => {
 
         @Component({selector: 'my-comp', template: '<div dirA dirB="self"></div>'})
         class MyComp {
-          @ViewChild(DirectiveA, {static: false}) dirA !: DirectiveA;
+          @ViewChild(DirectiveA) dirA !: DirectiveA;
         }
 
         @Component({template: '<my-comp dirB="parent"></my-comp>'})
         class MyApp {
-          @ViewChild(MyComp, {static: false}) myComp !: MyComp;
+          @ViewChild(MyComp) myComp !: MyComp;
         }
 
         TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp, MyApp]});
@@ -674,12 +674,12 @@ describe('di', () => {
             viewProviders: [{provide: String, useValue: 'Foo'}]
           })
           class MyComp {
-            @ViewChild(DirectiveString, {static: false}) dirString !: DirectiveString;
+            @ViewChild(DirectiveString) dirString !: DirectiveString;
           }
 
           @Component({template: '<my-comp></my-comp>'})
           class MyApp {
-            @ViewChild(MyComp, {static: false}) myComp !: MyComp;
+            @ViewChild(MyComp) myComp !: MyComp;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveString, MyComp, MyApp]});
@@ -698,12 +698,12 @@ describe('di', () => {
 
           @Component({selector: 'my-comp', template: '<div dirComp></div>'})
           class MyComp {
-            @ViewChild(DirectiveComp, {static: false}) dirComp !: DirectiveComp;
+            @ViewChild(DirectiveComp) dirComp !: DirectiveComp;
           }
 
           @Component({template: '<my-comp></my-comp>'})
           class MyApp {
-            @ViewChild(MyComp, {static: false}) myComp !: MyComp;
+            @ViewChild(MyComp) myComp !: MyComp;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveComp, MyComp, MyApp]});
@@ -762,7 +762,7 @@ describe('di', () => {
 
               @Component({template: '<my-comp dirB></my-comp>'})
               class MyApp {
-                @ViewChild(MyComp, {static: false}) myComp !: MyComp;
+                @ViewChild(MyComp) myComp !: MyComp;
               }
 
               TestBed.configureTestingModule(
@@ -779,8 +779,8 @@ describe('di', () => {
           @Component({template: '<div dirB><div *ngIf="showing" dirA></div></div>'})
           class MyApp {
             showing = false;
-            @ViewChild(DirectiveA, {static: false}) dirA !: DirectiveA;
-            @ViewChild(DirectiveB, {static: false}) dirB !: DirectiveB;
+            @ViewChild(DirectiveA) dirA !: DirectiveA;
+            @ViewChild(DirectiveB) dirB !: DirectiveB;
           }
 
           TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyApp]});
@@ -1042,8 +1042,8 @@ describe('di', () => {
 
         @Component({template: '<div injectorDir otherInjectorDir></div>'})
         class MyComp {
-          @ViewChild(InjectorDir, {static: false}) injectorDir !: InjectorDir;
-          @ViewChild(OtherInjectorDir, {static: false}) otherInjectorDir !: OtherInjectorDir;
+          @ViewChild(InjectorDir) injectorDir !: InjectorDir;
+          @ViewChild(OtherInjectorDir) otherInjectorDir !: OtherInjectorDir;
         }
 
         TestBed.configureTestingModule({declarations: [InjectorDir, OtherInjectorDir, MyComp]});
@@ -1068,7 +1068,7 @@ describe('di', () => {
 
         @Component({template: '<div injectorDir></div>'})
         class MyComp {
-          @ViewChild(InjectorDir, {static: false}) injectorDir !: InjectorDir;
+          @ViewChild(InjectorDir) injectorDir !: InjectorDir;
         }
 
         TestBed.configureTestingModule({declarations: [InjectorDir, MyComp]});
@@ -1105,8 +1105,8 @@ describe('di', () => {
 
         @Component({template: '<div dir otherDir></div>'})
         class MyComp {
-          @ViewChild(MyDir, {static: false}) directive !: MyDir;
-          @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+          @ViewChild(MyDir) directive !: MyDir;
+          @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
         }
 
         TestBed.configureTestingModule({declarations: [MyDir, MyOtherDir, MyComp]});
@@ -1137,7 +1137,7 @@ describe('di', () => {
 
            @Component({template: '<ng-template dir></ng-template>'})
            class MyComp {
-             @ViewChild(MyDir, {static: false}) directive !: MyDir;
+             @ViewChild(MyDir) directive !: MyDir;
            }
 
            TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1172,7 +1172,7 @@ describe('di', () => {
           template: `<div id="test-id" dir></div>`,
         })
         class ChildComp {
-          @ViewChild(DirectiveA, {static: false}) directive !: DirectiveA;
+          @ViewChild(DirectiveA) directive !: DirectiveA;
         }
 
         @Component({
@@ -1238,8 +1238,8 @@ describe('di', () => {
               template: '<ng-template dir otherDir #dir="dir" #otherDir="otherDir"></ng-template>'
             })
             class MyComp {
-              @ViewChild(MyDir, {static: false}) directive !: MyDir;
-              @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+              @ViewChild(MyDir) directive !: MyDir;
+              @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
             }
 
             TestBed.configureTestingModule({declarations: [MyDir, MyOtherDir, MyComp]});
@@ -1282,7 +1282,7 @@ describe('di', () => {
         }
         @Component({template: '<div optionalDir></div>'})
         class MyComp {
-          @ViewChild(OptionalDir, {static: false}) directive !: OptionalDir;
+          @ViewChild(OptionalDir) directive !: OptionalDir;
         }
 
         TestBed.configureTestingModule({declarations: [OptionalDir, MyComp]});
@@ -1311,8 +1311,8 @@ describe('di', () => {
             }
             @Component({template: '<div dir otherDir #dir="dir" #otherDir="otherDir"></div>'})
             class MyComp {
-              @ViewChild(MyDir, {static: false}) directive !: MyDir;
-              @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+              @ViewChild(MyDir) directive !: MyDir;
+              @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
             }
 
             TestBed.configureTestingModule({declarations: [MyDir, MyOtherDir, MyComp]});
@@ -1408,9 +1408,9 @@ describe('di', () => {
          () => {
            @Component({selector: 'my-app', template: '<my-comp dir otherDir #dir="dir"></my-comp>'})
            class MyApp {
-             @ViewChild(MyComp, {static: false}) component !: MyComp;
-             @ViewChild(MyDir, {static: false}) directive !: MyDir;
-             @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+             @ViewChild(MyComp) component !: MyComp;
+             @ViewChild(MyDir) directive !: MyDir;
+             @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
            }
            TestBed.configureTestingModule({declarations: [MyApp, MyComp, MyDir, MyOtherDir]});
            const fixture = TestBed.createComponent(MyApp);
@@ -1431,8 +1431,8 @@ describe('di', () => {
            @Component({selector: 'my-comp', template: '<div dir otherDir #dir="dir"></div>'})
            class MyComp {
              constructor(public cdr: ChangeDetectorRef) {}
-             @ViewChild(MyDir, {static: false}) directive !: MyDir;
-             @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+             @ViewChild(MyDir) directive !: MyDir;
+             @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
            }
            TestBed.configureTestingModule({declarations: [MyComp, MyDir, MyOtherDir]});
            const fixture = TestBed.createComponent(MyComp);
@@ -1458,9 +1458,9 @@ describe('di', () => {
            })
            class MyApp {
              constructor(public cdr: ChangeDetectorRef) {}
-             @ViewChild(MyComp, {static: false}) component !: MyComp;
-             @ViewChild(MyDir, {static: false}) directive !: MyDir;
-             @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+             @ViewChild(MyComp) component !: MyComp;
+             @ViewChild(MyDir) directive !: MyDir;
+             @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
            }
            TestBed.configureTestingModule({declarations: [MyApp, MyComp, MyDir, MyOtherDir]});
            const fixture = TestBed.createComponent(MyApp);
@@ -1486,8 +1486,8 @@ describe('di', () => {
         class MyComp {
           showing = true;
           constructor(public cdr: ChangeDetectorRef) {}
-          @ViewChild(MyDir, {static: false}) directive !: MyDir;
-          @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+          @ViewChild(MyDir) directive !: MyDir;
+          @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
         }
 
         TestBed.configureTestingModule({declarations: [MyComp, MyDir, MyOtherDir]});
@@ -1509,8 +1509,8 @@ describe('di', () => {
         class MyComp {
           showing = true;
           constructor(public cdr: ChangeDetectorRef) {}
-          @ViewChild(MyDir, {static: false}) directive !: MyDir;
-          @ViewChild(MyOtherDir, {static: false}) otherDirective !: MyOtherDir;
+          @ViewChild(MyDir) directive !: MyDir;
+          @ViewChild(MyOtherDir) otherDirective !: MyOtherDir;
         }
 
         TestBed.configureTestingModule({declarations: [MyComp, MyDir, MyOtherDir]});
@@ -1559,7 +1559,7 @@ describe('di', () => {
 
       @Component({template: '<div injectorDir></div>'})
       class MyComp {
-        @ViewChild(InjectorDir, {static: false}) injectorDirInstance !: InjectorDir;
+        @ViewChild(InjectorDir) injectorDirInstance !: InjectorDir;
       }
 
       TestBed.configureTestingModule({declarations: [InjectorDir, MyComp]});
@@ -1652,7 +1652,7 @@ describe('di', () => {
       providers: [{provide: LOCALE_ID, useValue: 'en-GB'}]
     })
     class MyComp {
-      @ViewChild(MyDir, {static: false}) myDir !: MyDir;
+      @ViewChild(MyDir) myDir !: MyDir;
       constructor(@Inject(LOCALE_ID) public localeId: string) {}
     }
 
@@ -1674,7 +1674,7 @@ describe('di', () => {
 
       @Component({template: '<div dir exist="existValue" other="ignore"></div>'})
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1698,7 +1698,7 @@ describe('di', () => {
       @Component(
           {template: '<ng-template dir="initial" exist="existValue" other="ignore"></ng-template>'})
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1723,7 +1723,7 @@ describe('di', () => {
         template: '<ng-container dir="initial" exist="existValue" other="ignore"></ng-container>'
       })
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1750,7 +1750,7 @@ describe('di', () => {
             '<div dir style="margin: 1px; color: red;" class="hello there" other-attr="value"></div>'
       })
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1778,7 +1778,7 @@ describe('di', () => {
         template: '<div dir exist="existValue" svg:exist="testExistValue" other="otherValue"></div>'
       })
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
@@ -1809,7 +1809,7 @@ describe('di', () => {
             '<div dir exist="existValue" [binding]="bindingValue" (output)="outputValue" other="otherValue" ignore="ignoreValue"></div>'
       })
       class MyComp {
-        @ViewChild(MyDir, {static: false}) directiveInstance !: MyDir;
+        @ViewChild(MyDir) directiveInstance !: MyDir;
       }
 
       TestBed.configureTestingModule({declarations: [MyDir, MyComp]});

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -312,9 +312,9 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils deprecated', () =>
         `
       })
       class Comp {
-        @ViewChild(MyDir1, {static: false}) myDir1Instance !: MyDir1;
-        @ViewChild(MyDir2, {static: false}) myDir2Instance !: MyDir2;
-        @ViewChild(MyDir3, {static: false}) myDir3Instance !: MyDir3;
+        @ViewChild(MyDir1) myDir1Instance !: MyDir1;
+        @ViewChild(MyDir2) myDir2Instance !: MyDir2;
+        @ViewChild(MyDir3) myDir3Instance !: MyDir3;
       }
 
       TestBed.configureTestingModule({declarations: [Comp, MyDir1, MyDir2, MyDir3]});

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -121,7 +121,7 @@ describe('host bindings', () => {
       class ParentCmp {
         private _prop = '';
 
-        @ViewChild('template', {read: ViewContainerRef, static: false})
+        @ViewChild('template', {read: ViewContainerRef})
         vcr: ViewContainerRef = null !;
 
         private child: ComponentRef<ChildCmp> = null !;
@@ -314,7 +314,7 @@ describe('host bindings', () => {
 
     @Component({template: '<span dir></span>'})
     class App {
-      @ViewChild(Dir, {static: false}) directiveInstance !: Dir;
+      @ViewChild(Dir) directiveInstance !: Dir;
     }
 
     TestBed.configureTestingModule({declarations: [App, Dir]});
@@ -403,7 +403,7 @@ describe('host bindings', () => {
         `
     })
     class App {
-      @ViewChild(HostBindingDir, {static: false}) hostBindingDir !: HostBindingDir;
+      @ViewChild(HostBindingDir) hostBindingDir !: HostBindingDir;
     }
 
     TestBed.configureTestingModule({declarations: [App, SomeDir, HostTitleComp, HostBindingDir]});
@@ -471,7 +471,7 @@ describe('host bindings', () => {
 
        @Component({template: '<div someDir hostBindingDir></div>'})
        class App {
-         @ViewChild(HostBindingDir, {static: false}) hostBindingDir !: HostBindingDir;
+         @ViewChild(HostBindingDir) hostBindingDir !: HostBindingDir;
        }
 
        TestBed.configureTestingModule({declarations: [App, SomeDir, HostBindingDir]});
@@ -539,7 +539,7 @@ describe('host bindings', () => {
 
     @Component({template: '<input hostBindingDir [disabled]="isDisabled">'})
     class App {
-      @ViewChild(HostBindingInputDir, {static: false}) hostBindingInputDir !: HostBindingInputDir;
+      @ViewChild(HostBindingInputDir) hostBindingInputDir !: HostBindingInputDir;
       isDisabled = true;
     }
 
@@ -629,7 +629,7 @@ describe('host bindings', () => {
         `
     })
     class App {
-      @ViewChild(NameComp, {static: false}) nameComp !: NameComp;
+      @ViewChild(NameComp) nameComp !: NameComp;
       name = '';
     }
 
@@ -685,8 +685,8 @@ describe('host bindings', () => {
         `
     })
     class App {
-      @ViewChild(HostBindingComp, {static: false}) hostBindingComp !: HostBindingComp;
-      @ViewChild(NameComp, {static: false}) nameComp !: NameComp;
+      @ViewChild(HostBindingComp) hostBindingComp !: HostBindingComp;
+      @ViewChild(NameComp) nameComp !: NameComp;
       name = '';
       otherName = '';
     }
@@ -760,8 +760,8 @@ describe('host bindings', () => {
 
     @Component({template: '<host-binding-comp hostDir></host-binding-comp>'})
     class App {
-      @ViewChild(HostBindingComp, {static: false}) hostBindingComp !: HostBindingComp;
-      @ViewChild(HostBindingDir, {static: false}) hostBindingDir !: HostBindingDir;
+      @ViewChild(HostBindingComp) hostBindingComp !: HostBindingComp;
+      @ViewChild(HostBindingDir) hostBindingDir !: HostBindingDir;
     }
 
     TestBed.configureTestingModule({declarations: [App, HostBindingComp, HostBindingDir]});
@@ -799,7 +799,7 @@ describe('host bindings', () => {
 
     @Component({template: `<host-binding-comp></host-binding-comp>{{ name }}`})
     class App {
-      @ViewChild(HostBindingComp, {static: false}) hostBindingComp !: HostBindingComp;
+      @ViewChild(HostBindingComp) hostBindingComp !: HostBindingComp;
       name = '';
     }
 
@@ -849,8 +849,8 @@ describe('host bindings', () => {
       `
         })
         class App {
-          @ViewChild(SubDirective, {static: false}) subDir !: SubDirective;
-          @ViewChild(SuperDirective, {static: false}) superDir !: SuperDirective;
+          @ViewChild(SubDirective) subDir !: SubDirective;
+          @ViewChild(SuperDirective) superDir !: SuperDirective;
         }
 
         TestBed.configureTestingModule({declarations: [App, SuperDirective, SubDirective]});
@@ -958,7 +958,7 @@ describe('host bindings', () => {
 
       @Component({template: '<host-binding-to-styles></host-binding-to-styles>'})
       class App {
-        @ViewChild(HostBindingToStyles, {static: false}) hostBindingDir !: HostBindingToStyles;
+        @ViewChild(HostBindingToStyles) hostBindingDir !: HostBindingToStyles;
       }
 
       TestBed.configureTestingModule({declarations: [App, HostBindingToStyles]});
@@ -987,7 +987,7 @@ describe('host bindings', () => {
 
       @Component({template: '<div hostStyles containerDir></div>'})
       class App {
-        @ViewChild(HostBindingToStyles, {static: false}) hostBindingDir !: HostBindingToStyles;
+        @ViewChild(HostBindingToStyles) hostBindingDir !: HostBindingToStyles;
       }
 
       TestBed.configureTestingModule({declarations: [App, HostBindingToStyles, ContainerDir]});
@@ -1038,7 +1038,7 @@ describe('host bindings', () => {
 
         @Component({template: `<${tag} unsafeUrlHostBindingDir></${tag}>`})
         class App {
-          @ViewChild(UnsafeDir, {static: false}) unsafeDir !: UnsafeDir;
+          @ViewChild(UnsafeDir) unsafeDir !: UnsafeDir;
         }
 
         TestBed.configureTestingModule({declarations: [App, UnsafeDir]});

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -243,7 +243,7 @@ describe('acceptance integration tests', () => {
 
       @Component({template: '<div><ng-container dir></ng-container></div>'})
       class App {
-        @ViewChild(TestDirective, {static: false}) testDirective !: TestDirective;
+        @ViewChild(TestDirective) testDirective !: TestDirective;
       }
 
       TestBed.configureTestingModule({declarations: [App, TestDirective]});
@@ -273,7 +273,7 @@ describe('acceptance integration tests', () => {
             '<ng-container dir [contentTpl]="content"><ng-template #content>Content</ng-template></ng-container>'
       })
       class App {
-        @ViewChild(TestDirective, {static: false}) testDirective !: TestDirective;
+        @ViewChild(TestDirective) testDirective !: TestDirective;
       }
 
       TestBed.configureTestingModule({declarations: [App, TestDirective]});
@@ -303,7 +303,7 @@ describe('acceptance integration tests', () => {
 
       @Component({template: '<ng-container><ng-template dir>Content</ng-template></ng-container>'})
       class App {
-        @ViewChild(TestDirective, {static: false}) testDirective !: TestDirective;
+        @ViewChild(TestDirective) testDirective !: TestDirective;
       }
 
       TestBed.configureTestingModule({declarations: [App, TestDirective]});
@@ -608,7 +608,7 @@ describe('acceptance integration tests', () => {
 
       @Component({template: '<todo></todo>'})
       class App {
-        @ViewChild(TodoComponentHostBinding, {static: false})
+        @ViewChild(TodoComponentHostBinding)
         todoComponentHostBinding !: TodoComponentHostBinding;
       }
 
@@ -844,7 +844,7 @@ describe('acceptance integration tests', () => {
 
         @Component({template: '<div hostBindingDir></div>'})
         class App {
-          @ViewChild(HostBindingDir, {static: false}) hostBindingDir !: HostBindingDir;
+          @ViewChild(HostBindingDir) hostBindingDir !: HostBindingDir;
         }
 
         TestBed.configureTestingModule({declarations: [App, HostBindingDir]});
@@ -1012,7 +1012,7 @@ describe('acceptance integration tests', () => {
           `
         })
         class App {
-          @ViewChild(StructuralComp, {static: false}) structuralComp !: StructuralComp;
+          @ViewChild(StructuralComp) structuralComp !: StructuralComp;
           value: any;
         }
 
@@ -1053,7 +1053,7 @@ describe('acceptance integration tests', () => {
          () => {
            @Component({template: '<div class="apple orange banana" DirWithClass></div>'})
            class App {
-             @ViewChild(DirWithClassDirective, {static: false})
+             @ViewChild(DirWithClassDirective)
              mockClassDirective !: DirWithClassDirective;
            }
 
@@ -1071,7 +1071,7 @@ describe('acceptance integration tests', () => {
          () => {
            @Component({template: '<div style="width:100px;height:200px" DirWithStyle></div>'})
            class App {
-             @ViewChild(DirWithStyleDirective, {static: false})
+             @ViewChild(DirWithStyleDirective)
              mockStyleDirective !: DirWithStyleDirective;
            }
 
@@ -1090,7 +1090,7 @@ describe('acceptance integration tests', () => {
          () => {
            @Component({template: '<div DirWithClass [class]="value"></div>'})
            class App {
-             @ViewChild(DirWithClassDirective, {static: false})
+             @ViewChild(DirWithClassDirective)
              mockClassDirective !: DirWithClassDirective;
              value = '';
            }
@@ -1109,7 +1109,7 @@ describe('acceptance integration tests', () => {
               () => {
                 @Component({template: '<div DirWithStyle [style]="value"></div>'})
                 class App {
-                  @ViewChild(DirWithStyleDirective, {static: false})
+                  @ViewChild(DirWithStyleDirective)
                   mockStyleDirective !: DirWithStyleDirective;
                   value !: {[key: string]: string};
                 }
@@ -1186,7 +1186,7 @@ describe('acceptance integration tests', () => {
             `
                 })
                 class App {
-                  @ViewChild(DirWithSingleStylingBindings, {static: false})
+                  @ViewChild(DirWithSingleStylingBindings)
                   dirInstance !: DirWithSingleStylingBindings;
                 }
 
@@ -1242,8 +1242,8 @@ describe('acceptance integration tests', () => {
                 @Component(
                     {template: '<div Dir1WithStyle Dir2WithStyle [style.width]="width"></div>'})
                 class App {
-                  @ViewChild(Dir1WithStyle, {static: false}) dir1Instance !: Dir1WithStyle;
-                  @ViewChild(Dir2WithStyle, {static: false}) dir2Instance !: Dir2WithStyle;
+                  @ViewChild(Dir1WithStyle) dir1Instance !: Dir1WithStyle;
+                  @ViewChild(Dir2WithStyle) dir2Instance !: Dir2WithStyle;
                   width: string|null = null;
                 }
 
@@ -1307,8 +1307,8 @@ describe('acceptance integration tests', () => {
                       '<div Dir1WithStyling Dir2WithStyling [style]="stylesExp" [class]="classesExp"></div>'
                 })
                 class App {
-                  @ViewChild(Dir1WithStyling, {static: false}) dir1Instance !: Dir1WithStyling;
-                  @ViewChild(Dir2WithStyling, {static: false}) dir2Instance !: Dir2WithStyling;
+                  @ViewChild(Dir1WithStyling) dir1Instance !: Dir1WithStyling;
+                  @ViewChild(Dir2WithStyling) dir2Instance !: Dir2WithStyling;
                   stylesExp: any = {};
                   classesExp: any = {};
                 }

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -1293,7 +1293,7 @@ describe('onInit', () => {
       `,
     })
     class App {
-      @ViewChild('container', {read: ViewContainerRef, static: false})
+      @ViewChild('container', {read: ViewContainerRef})
       viewContainerRef !: ViewContainerRef;
 
       constructor(public compFactoryResolver: ComponentFactoryResolver) {}

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -220,7 +220,7 @@ describe('event listeners', () => {
         count = 0;
         someValue = -1;
 
-        @ViewChild(FooDirective, {static: false}) fooDirective: FooDirective|null = null;
+        @ViewChild(FooDirective) fooDirective: FooDirective|null = null;
 
         fooChange() { this.count++; }
 

--- a/packages/core/test/acceptance/outputs_spec.ts
+++ b/packages/core/test/acceptance/outputs_spec.ts
@@ -43,7 +43,7 @@ describe('outputs', () => {
 
     @Component({template: '<button-toggle (change)="onChange()"></button-toggle>'})
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
       onChange() { counter++; }
     }
     TestBed.configureTestingModule({declarations: [App, ButtonToggle]});
@@ -64,7 +64,7 @@ describe('outputs', () => {
     @Component(
         {template: '<button-toggle (change)="onChange()" (reset)="onReset()"></button-toggle>'})
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
       onChange() { counter++; }
       onReset() { resetCounter++; }
     }
@@ -82,7 +82,7 @@ describe('outputs', () => {
   it('should eval component output expression when event is emitted', () => {
     @Component({template: '<button-toggle (change)="counter = counter + 1"></button-toggle>'})
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
       counter = 0;
     }
     TestBed.configureTestingModule({declarations: [App, ButtonToggle]});
@@ -102,7 +102,7 @@ describe('outputs', () => {
     @Component(
         {template: '<button-toggle *ngIf="condition" (change)="onChange()"></button-toggle>'})
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
       condition = true;
 
       onChange() { counter++; }
@@ -133,7 +133,7 @@ describe('outputs', () => {
       `
     })
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
       condition = true;
       condition2 = true;
 
@@ -168,8 +168,8 @@ describe('outputs', () => {
       `
     })
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
-      @ViewChild(DestroyComp, {static: false}) destroyComp !: DestroyComp;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
+      @ViewChild(DestroyComp) destroyComp !: DestroyComp;
       condition = true;
 
       onClick() { clickCounter++; }
@@ -206,7 +206,7 @@ describe('outputs', () => {
 
     @Component({template: '<button myButton (click)="onClick()">Click me</button>'})
     class App {
-      @ViewChild(MyButton, {static: false}) buttonDir !: MyButton;
+      @ViewChild(MyButton) buttonDir !: MyButton;
       onClick() { counter++; }
     }
     TestBed.configureTestingModule({declarations: [App, MyButton]});
@@ -228,8 +228,8 @@ describe('outputs', () => {
 
     @Component({template: '<button-toggle (change)="onChange()" otherDir></button-toggle>'})
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
-      @ViewChild(OtherDir, {static: false}) otherDir !: OtherDir;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
+      @ViewChild(OtherDir) otherDir !: OtherDir;
       onChange() { counter++; }
     }
     TestBed.configureTestingModule({declarations: [App, ButtonToggle, OtherDir]});
@@ -257,8 +257,8 @@ describe('outputs', () => {
           '<button-toggle (change)="onChange()" otherChangeDir [change]="change"></button-toggle>'
     })
     class App {
-      @ViewChild(ButtonToggle, {static: false}) buttonToggle !: ButtonToggle;
-      @ViewChild(OtherChangeDir, {static: false}) otherDir !: OtherChangeDir;
+      @ViewChild(ButtonToggle) buttonToggle !: ButtonToggle;
+      @ViewChild(OtherChangeDir) otherDir !: OtherChangeDir;
       change = true;
 
       onChange() { counter++; }

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -70,7 +70,7 @@ describe('pipe', () => {
       template: `<div my-dir [dirProp]="'a'|double"></div>`,
     })
     class App {
-      @ViewChild(Dir, {static: false}) directive !: Dir;
+      @ViewChild(Dir) directive !: Dir;
     }
 
     TestBed.configureTestingModule({declarations: [App, DoublePipe, Dir]});
@@ -421,7 +421,7 @@ describe('pipe', () => {
          })
          class App {
            @Input() something: any;
-           @ViewChild(SomeComp, {static: false}) comp !: SomeComp;
+           @ViewChild(SomeComp) comp !: SomeComp;
            pipeValue = 10;
            displayValue = 0;
          }
@@ -473,7 +473,7 @@ describe('pipe', () => {
          })
          class App {
            @Input() something: any;
-           @ViewChild(SomeComp, {static: false}) comp !: SomeComp;
+           @ViewChild(SomeComp) comp !: SomeComp;
            pipeValue = 10;
            displayValue = 0;
          }

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -177,7 +177,7 @@ describe('query logic', () => {
 
     it('should support ViewChild query inherited from undecorated superclasses', () => {
       class MyComp {
-        @ViewChild('foo', {static: false}) foo: any;
+        @ViewChild('foo') foo: any;
       }
 
       @Component({selector: 'sub-comp', template: '<div #foo></div>'})
@@ -193,7 +193,7 @@ describe('query logic', () => {
 
     it('should support ViewChild query inherited from undecorated grand superclasses', () => {
       class MySuperComp {
-        @ViewChild('foo', {static: false}) foo: any;
+        @ViewChild('foo') foo: any;
       }
 
       class MyComp extends MySuperComp {}
@@ -287,7 +287,7 @@ describe('query logic', () => {
           `
       })
       class App {
-        @ViewChild(Required, {static: false}) requiredEl !: Required;
+        @ViewChild(Required) requiredEl !: Required;
         viewChildAvailableInAfterViewInit?: boolean;
 
         ngAfterViewInit() {
@@ -529,7 +529,7 @@ describe('query logic', () => {
 
     it('should support ContentChild query inherited from undecorated superclasses', () => {
       class MyComp {
-        @ContentChild('foo', {static: false}) foo: any;
+        @ContentChild('foo') foo: any;
       }
 
       @Component({selector: 'sub-comp', template: '<ng-content></ng-content>'})
@@ -538,7 +538,7 @@ describe('query logic', () => {
 
       @Component({template: '<sub-comp><div #foo></div></sub-comp>'})
       class App {
-        @ViewChild(SubComp, {static: false}) subComp !: SubComp;
+        @ViewChild(SubComp) subComp !: SubComp;
       }
 
       TestBed.configureTestingModule({declarations: [App, SubComp]});
@@ -550,7 +550,7 @@ describe('query logic', () => {
 
     it('should support ContentChild query inherited from undecorated grand superclasses', () => {
       class MySuperComp {
-        @ContentChild('foo', {static: false}) foo: any;
+        @ContentChild('foo') foo: any;
       }
 
       class MyComp extends MySuperComp {}
@@ -561,7 +561,7 @@ describe('query logic', () => {
 
       @Component({template: '<sub-comp><div #foo></div></sub-comp>'})
       class App {
-        @ViewChild(SubComp, {static: false}) subComp !: SubComp;
+        @ViewChild(SubComp) subComp !: SubComp;
       }
 
       TestBed.configureTestingModule({declarations: [App, SubComp]});
@@ -593,7 +593,7 @@ describe('query logic', () => {
       `
       })
       class App {
-        @ViewChild(SubComp, {static: false}) subComp !: SubComp;
+        @ViewChild(SubComp) subComp !: SubComp;
       }
 
       TestBed.configureTestingModule({declarations: [App, SubComp, SomeDir]});
@@ -628,7 +628,7 @@ describe('query logic', () => {
       `
       })
       class App {
-        @ViewChild(SubComp, {static: false}) subComp !: SubComp;
+        @ViewChild(SubComp) subComp !: SubComp;
       }
 
       TestBed.configureTestingModule({declarations: [App, SubComp, SomeDir]});
@@ -881,21 +881,21 @@ describe('query logic', () => {
                <ng-template #tpl1 let-idx="idx">
                  <div #foo [id]="'foo1_' + idx"></div>
                </ng-template>
-               
+
                <div #foo id="middle"></div>
-               
+
                <ng-template #tpl2 let-idx="idx">
                  <div #foo [id]="'foo2_' + idx"></div>
                </ng-template>
-               
+
                <ng-template vc></ng-template>
              `,
            })
            class TestComponent {
-             @ViewChild(ViewContainerManipulatorDirective, {static: false})
+             @ViewChild(ViewContainerManipulatorDirective)
              vc !: ViewContainerManipulatorDirective;
-             @ViewChild('tpl1', {static: false}) tpl1 !: TemplateRef<any>;
-             @ViewChild('tpl2', {static: false}) tpl2 !: TemplateRef<any>;
+             @ViewChild('tpl1') tpl1 !: TemplateRef<any>;
+             @ViewChild('tpl2') tpl2 !: TemplateRef<any>;
              @ViewChildren('foo') query !: QueryList<any>;
            }
 
@@ -960,13 +960,13 @@ describe('query logic', () => {
                </ng-template>
 
                <ng-template vc #vi0="vc"></ng-template>
-               <ng-template vc #vi1="vc"></ng-template> 
+               <ng-template vc #vi1="vc"></ng-template>
              `,
            })
            class TestComponent {
-             @ViewChild('tpl', {static: false}) tpl !: TemplateRef<any>;
-             @ViewChild('vi0', {static: false}) vi0 !: ViewContainerManipulatorDirective;
-             @ViewChild('vi1', {static: false}) vi1 !: ViewContainerManipulatorDirective;
+             @ViewChild('tpl') tpl !: TemplateRef<any>;
+             @ViewChild('vi0') vi0 !: ViewContainerManipulatorDirective;
+             @ViewChild('vi1') vi1 !: ViewContainerManipulatorDirective;
              @ViewChildren('foo') query !: QueryList<any>;
            }
 
@@ -1009,7 +1009,7 @@ describe('query logic', () => {
             <ng-template #tpl>
               <span #foo id="from_tpl"></span>
             </ng-template>
-            
+
             <ng-template [ngTemplateOutlet]="show ? tpl : null"></ng-template>
           `,
         })
@@ -1139,8 +1139,8 @@ function initWithTemplate(compType: Type<any>, template: string) {
 
 @Component({selector: 'local-ref-query-component', template: '<ng-content></ng-content>'})
 class QueryComp {
-  @ViewChild('viewQuery', {static: false}) viewChild !: any;
-  @ContentChild('contentQuery', {static: false}) contentChild !: any;
+  @ViewChild('viewQuery') viewChild !: any;
+  @ContentChild('contentQuery') contentChild !: any;
 
   @ViewChildren('viewQuery') viewChildren !: QueryList<any>;
   @ContentChildren('contentQuery') contentChildren !: QueryList<any>;
@@ -1183,7 +1183,7 @@ class StaticViewQueryComp {
     this._textDir = value;
   }
 
-  @ViewChild('foo', {static: false})
+  @ViewChild('foo')
   get foo(): ElementRef { return this._foo; }
 
   set foo(value: ElementRef) {
@@ -1208,7 +1208,7 @@ class SubclassStaticViewQueryComp extends StaticViewQueryComp {
   @ViewChild('bar', {static: true})
   bar !: ElementRef;
 
-  @ViewChild('baz', {static: false})
+  @ViewChild('baz')
   baz !: ElementRef;
 }
 
@@ -1227,7 +1227,7 @@ class StaticContentQueryComp {
     this._textDir = value;
   }
 
-  @ContentChild('foo', {static: false})
+  @ContentChild('foo')
   get foo(): ElementRef { return this._foo; }
 
   set foo(value: ElementRef) {
@@ -1250,7 +1250,7 @@ class StaticContentQueryDir {
     this._textDir = value;
   }
 
-  @ContentChild('foo', {static: false})
+  @ContentChild('foo')
   get foo(): ElementRef { return this._foo; }
 
   set foo(value: ElementRef) {
@@ -1264,7 +1264,7 @@ class SubclassStaticContentQueryComp extends StaticContentQueryComp {
   @ContentChild('bar', {static: true})
   bar !: ElementRef;
 
-  @ContentChild('baz', {static: false})
+  @ContentChild('baz')
   baz !: ElementRef;
 }
 

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -685,7 +685,7 @@ describe('styling', () => {
       template: '<span dir [classesInSchool]="classes" [styleOfClothing]="style"></span>',
     })
     class App {
-      @ViewChild(Dir, {static: false}) dir !: Dir;
+      @ViewChild(Dir) dir !: Dir;
 
       classes = 'math';
       style = '80s';
@@ -1898,7 +1898,7 @@ describe('styling', () => {
        class ParentCmp {
          private _prop = '';
 
-         @ViewChild('template', {read: ViewContainerRef, static: false})
+         @ViewChild('template', {read: ViewContainerRef})
          vcr: ViewContainerRef = null !;
 
          private child: ComponentRef<ChildCmp> = null !;
@@ -1983,7 +1983,7 @@ describe('styling', () => {
        class ParentCmp {
          updateChild = false;
 
-         @ViewChild('template', {read: ViewContainerRef, static: false})
+         @ViewChild('template', {read: ViewContainerRef})
          vcr: ViewContainerRef = null !;
 
          private child: ComponentRef<ChildCmp> = null !;

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -37,7 +37,7 @@ describe('TemplateRef', () => {
         `
       })
       class App {
-        @ViewChild(MenuContent, {static: false}) content !: MenuContent;
+        @ViewChild(MenuContent) content !: MenuContent;
 
         constructor(public viewContainerRef: ViewContainerRef) {}
       }

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -141,7 +141,7 @@ describe('ViewContainerRef', () => {
         `
       })
       class TestComp {
-        @ViewChild('container', {read: ViewContainerRef, static: false}) vcRef !: ViewContainerRef;
+        @ViewChild('container', {read: ViewContainerRef}) vcRef !: ViewContainerRef;
 
         constructor(public cfr: ComponentFactoryResolver) {}
 
@@ -2128,7 +2128,7 @@ class ViewContainerRefComp {
   `
 })
 class ViewContainerRefApp {
-  @ViewChild(ViewContainerRefComp, {static: false}) vcrComp !: ViewContainerRefComp;
+  @ViewChild(ViewContainerRefComp) vcrComp !: ViewContainerRefComp;
 }
 
 @Directive({selector: '[structDir]'})

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -89,10 +89,10 @@ describe('view insertion', () => {
             `
       })
       class App {
-        @ViewChild('container', {read: ViewContainerRef, static: false})
+        @ViewChild('container', {read: ViewContainerRef})
         container: ViewContainerRef = null !;
 
-        @ViewChild('empty', {read: TemplateRef, static: false})
+        @ViewChild('empty', {read: TemplateRef})
         empty: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;
@@ -139,10 +139,10 @@ describe('view insertion', () => {
                 `
       })
       class Comp {
-        @ViewChild('container', {read: ViewContainerRef, static: false})
+        @ViewChild('container', {read: ViewContainerRef})
         container: ViewContainerRef = null !;
 
-        @ViewChild('projection', {read: TemplateRef, static: false})
+        @ViewChild('projection', {read: TemplateRef})
         projection: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;
@@ -200,10 +200,10 @@ describe('view insertion', () => {
                 `
       })
       class App {
-        @ViewChild('container', {read: ViewContainerRef, static: false})
+        @ViewChild('container', {read: ViewContainerRef})
         container: ViewContainerRef = null !;
 
-        @ViewChild('subContainer', {read: TemplateRef, static: false})
+        @ViewChild('subContainer', {read: TemplateRef})
         subContainer: TemplateRef<any> = null !;
 
         view0: EmbeddedViewRef<any> = null !;

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -376,7 +376,7 @@ const DEFAULT_COMPONENT_ID = '1';
           ]
         })
         class Cmp {
-          @ViewChild('element', {static: false})
+          @ViewChild('element')
           element: any;
           exp: any = '';
         }
@@ -1463,7 +1463,7 @@ const DEFAULT_COMPONENT_ID = '1';
               ])]
         })
         class Cmp {
-          @ViewChild('green', {static: false}) public element: any;
+          @ViewChild('green') public element: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1799,7 +1799,7 @@ const DEFAULT_COMPONENT_ID = '1';
         class Cmp {
           public exp: any;
 
-          @ViewChild('parent', {static: false}) public parentElement: any;
+          @ViewChild('parent') public parentElement: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1853,9 +1853,9 @@ const DEFAULT_COMPONENT_ID = '1';
              public exp1: any;
              public exp2: any;
 
-             @ViewChild('parent', {static: false}) public parent: any;
+             @ViewChild('parent') public parent: any;
 
-             @ViewChild('child', {static: false}) public child: any;
+             @ViewChild('child') public child: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1910,11 +1910,11 @@ const DEFAULT_COMPONENT_ID = '1';
              public exp1: any;
              public exp2: any;
 
-             @ViewChild('parent', {static: false}) public parent: any;
+             @ViewChild('parent') public parent: any;
 
-             @ViewChild('child1', {static: false}) public child1Elm: any;
+             @ViewChild('child1') public child1Elm: any;
 
-             @ViewChild('child2', {static: false}) public child2Elm: any;
+             @ViewChild('child2') public child2Elm: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2269,7 +2269,7 @@ const DEFAULT_COMPONENT_ID = '1';
               [transition(':enter', [style({opacity: 0}), animate('1s', style({opacity: 1}))])])]
         })
         class OuterCmp {
-          @ViewChild('inner', {static: false}) public inner: any;
+          @ViewChild('inner') public inner: any;
           public exp: any = null;
 
           update() { this.exp = 'go'; }
@@ -3260,7 +3260,7 @@ const DEFAULT_COMPONENT_ID = '1';
             ]
           })
           class Cmp {
-            @ViewChild('parent', {static: false}) public parentElm: any;
+            @ViewChild('parent') public parentElm: any;
             disableExp = false;
             exp = false;
           }
@@ -3351,7 +3351,7 @@ const DEFAULT_COMPONENT_ID = '1';
                 `
              })
              class ParentCmp {
-               @ViewChild('child', {static: false}) public child: ChildCmp|null = null;
+               @ViewChild('child') public child: ChildCmp|null = null;
                disableExp = false;
              }
 
@@ -3467,7 +3467,7 @@ const DEFAULT_COMPONENT_ID = '1';
                 `
              })
              class Cmp {
-               @ViewChild('container', {static: false}) public container: any;
+               @ViewChild('container') public container: any;
 
                disableExp = false;
                exp = '';

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -888,7 +888,7 @@ import {HostListener} from '../../src/metadata/directives';
              ]
            })
            class Cmp {
-             @ViewChild('container', {static: false}) public container: any;
+             @ViewChild('container') public container: any;
              public items: any[] = [];
            }
 
@@ -1202,9 +1202,9 @@ import {HostListener} from '../../src/metadata/directives';
              public exp1: any = '';
              public exp2: any = true;
 
-             @ViewChild('ancestor', {static: false}) public ancestorElm: any;
+             @ViewChild('ancestor') public ancestorElm: any;
 
-             @ViewChild('parent', {static: false}) public parentElm: any;
+             @ViewChild('parent') public parentElm: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1281,9 +1281,9 @@ import {HostListener} from '../../src/metadata/directives';
              public exp2: any = '';
              public parentExp: any = true;
 
-             @ViewChild('ancestor', {static: false}) public ancestorElm: any;
+             @ViewChild('ancestor') public ancestorElm: any;
 
-             @ViewChild('parent', {static: false}) public parentElm: any;
+             @ViewChild('parent') public parentElm: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1637,7 +1637,7 @@ import {HostListener} from '../../src/metadata/directives';
            class ParentCmp {
              public exp: any;
 
-             @ViewChild('child', {static: false}) public child: any;
+             @ViewChild('child') public child: any;
            }
 
            @Component({
@@ -1849,9 +1849,9 @@ import {HostListener} from '../../src/metadata/directives';
           public exp1: any;
           public exp2: any;
 
-          @ViewChild('parent', {static: false}) public elm1: any;
+          @ViewChild('parent') public elm1: any;
 
-          @ViewChild('child', {static: false}) public elm2: any;
+          @ViewChild('child') public elm2: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1911,7 +1911,7 @@ import {HostListener} from '../../src/metadata/directives';
              public exp: any;
              public items: any[] = [0, 1, 2, 3, 4];
 
-             @ViewChild('parent', {static: false}) public elm: any;
+             @ViewChild('parent') public elm: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -1981,7 +1981,7 @@ import {HostListener} from '../../src/metadata/directives';
           public exp: any;
           public items: any[] = [0, 1, 2, 3, 4];
 
-          @ViewChild('parent', {static: false}) public elm: any;
+          @ViewChild('parent') public elm: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2034,7 +2034,7 @@ import {HostListener} from '../../src/metadata/directives';
              public exp1: any;
              public exp2: any;
 
-             @ViewChild('parent', {static: false}) public elm: any;
+             @ViewChild('parent') public elm: any;
            }
 
            TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2104,7 +2104,7 @@ import {HostListener} from '../../src/metadata/directives';
           public exp1: any;
           public exp2: any;
 
-          @ViewChild('parent', {static: false}) public elm: any;
+          @ViewChild('parent') public elm: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2157,7 +2157,7 @@ import {HostListener} from '../../src/metadata/directives';
           public exp1: any;
           public exp2: any;
 
-          @ViewChild('parent', {static: false}) public elm: any;
+          @ViewChild('parent') public elm: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2209,7 +2209,7 @@ import {HostListener} from '../../src/metadata/directives';
           public exp1: any;
           public exp2: any;
 
-          @ViewChild('parent', {static: false}) public elm: any;
+          @ViewChild('parent') public elm: any;
         }
 
         TestBed.configureTestingModule({declarations: [Cmp]});
@@ -2258,7 +2258,7 @@ import {HostListener} from '../../src/metadata/directives';
            })
            class ParentCmp {
              public exp: boolean = true;
-             @ViewChild('child', {static: false}) public childElm: any;
+             @ViewChild('child') public childElm: any;
 
              public childEvent: any;
 
@@ -2694,7 +2694,7 @@ import {HostListener} from '../../src/metadata/directives';
         class ParentCmp {
           public exp: any;
 
-          @ViewChild('child', {static: false}) public childCmp: any;
+          @ViewChild('child') public childCmp: any;
         }
 
         @Component({
@@ -2758,7 +2758,7 @@ import {HostListener} from '../../src/metadata/directives';
           `
            })
            class ParentCmp {
-             @ViewChild('child', {static: false}) public childCmp: any;
+             @ViewChild('child') public childCmp: any;
 
              public exp: any;
              public log: string[] = [];
@@ -2936,7 +2936,7 @@ import {HostListener} from '../../src/metadata/directives';
            class ParentCmp {
              public exp: any;
 
-             @ViewChild('child', {static: false}) public childCmp: any;
+             @ViewChild('child') public childCmp: any;
            }
 
            @Component({
@@ -3015,13 +3015,13 @@ import {HostListener} from '../../src/metadata/directives';
            class ParentCmp {
              public exp: any;
 
-             @ViewChild('child', {static: false}) public innerCmp: any;
+             @ViewChild('child') public innerCmp: any;
            }
 
            @Component(
                {selector: 'child-cmp', template: '<grandchild-cmp #grandchild></grandchild-cmp>'})
            class ChildCmp {
-             @ViewChild('grandchild', {static: false}) public innerCmp: any;
+             @ViewChild('grandchild') public innerCmp: any;
            }
 
            @Component({

--- a/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
@@ -165,7 +165,7 @@ import {TestBed} from '../../testing';
         ]
       })
       class Cmp {
-        @ViewChild('elm', {static: false}) public element: any;
+        @ViewChild('elm') public element: any;
 
         public myAnimationExp = '';
       }
@@ -216,7 +216,7 @@ import {TestBed} from '../../testing';
         ]
       })
       class Cmp {
-        @ViewChild('elm', {static: false}) public element: any;
+        @ViewChild('elm') public element: any;
 
         public myAnimationExp = '';
       }

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -417,7 +417,7 @@ class SomeComponent {
       @Component({template: '<ng-container #vc></ng-container>'})
       class ContainerComp {
         // TODO(issue/24571): remove '!'.
-        @ViewChild('vc', {read: ViewContainerRef, static: false})
+        @ViewChild('vc', {read: ViewContainerRef})
         vc !: ViewContainerRef;
       }
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -167,7 +167,7 @@ class BankAccount {
  `
 })
 class SimpleContentComp {
-  @ViewChild('content', {static: false}) content !: ElementRef;
+  @ViewChild('content') content !: ElementRef;
 }
 
 @Component({

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -752,7 +752,7 @@ describe('Query API', () => {
               class AutoProjecting {
                 // TODO(issue/24571):
                 // remove '!'.
-                @ContentChild(TemplateRef, {static: false})
+                @ContentChild(TemplateRef)
                 content !: TemplateRef<any>;
 
                 // TODO(issue/24571):
@@ -784,7 +784,7 @@ describe('Query API', () => {
            class AutoProjecting {
              // TODO(issue/24571):
              // remove '!'.
-             @ContentChild(TemplateRef, {static: false})
+             @ContentChild(TemplateRef)
              content !: TemplateRef<any>;
 
              // TODO(issue/24571):
@@ -839,7 +839,7 @@ class NeedsContentChild implements AfterContentInit, AfterContentChecked {
   // TODO(issue/24571): remove '!'.
   _child !: TextDirective;
 
-  @ContentChild(TextDirective, {static: false})
+  @ContentChild(TextDirective)
   set child(value) {
     this._child = value;
     this.logs.push(['setter', value ? value.text : null]);
@@ -856,7 +856,7 @@ class NeedsContentChild implements AfterContentInit, AfterContentChecked {
 @Directive({selector: '[directive-needs-content-child]'})
 class DirectiveNeedsContentChild {
   // TODO(issue/24571): remove '!'.
-  @ContentChild(TextDirective, {static: false}) child !: TextDirective;
+  @ContentChild(TextDirective) child !: TextDirective;
 }
 
 @Component({selector: 'needs-view-child', template: `<div *ngIf="shouldShow" text="foo"></div>`})
@@ -867,7 +867,7 @@ class NeedsViewChild implements AfterViewInit, AfterViewChecked {
   // TODO(issue/24571): remove '!'.
   _child !: TextDirective;
 
-  @ViewChild(TextDirective, {static: false})
+  @ViewChild(TextDirective)
   set child(value) {
     this._child = value;
     this.logs.push(['setter', value ? value.text : null]);
@@ -917,13 +917,13 @@ class NeedsQuery {
 @Component({selector: 'needs-four-queries', template: ''})
 class NeedsFourQueries {
   // TODO(issue/24571): remove '!'.
-  @ContentChild(TextDirective, {static: false}) query1 !: TextDirective;
+  @ContentChild(TextDirective) query1 !: TextDirective;
   // TODO(issue/24571): remove '!'.
-  @ContentChild(TextDirective, {static: false}) query2 !: TextDirective;
+  @ContentChild(TextDirective) query2 !: TextDirective;
   // TODO(issue/24571): remove '!'.
-  @ContentChild(TextDirective, {static: false}) query3 !: TextDirective;
+  @ContentChild(TextDirective) query3 !: TextDirective;
   // TODO(issue/24571): remove '!'.
-  @ContentChild(TextDirective, {static: false}) query4 !: TextDirective;
+  @ContentChild(TextDirective) query4 !: TextDirective;
 }
 
 @Component({
@@ -1042,9 +1042,9 @@ class NeedsContentChildrenWithRead {
 @Component({selector: 'needs-content-child-read', template: ''})
 class NeedsContentChildWithRead {
   // TODO(issue/24571): remove '!'.
-  @ContentChild('q', {read: TextDirective, static: false}) textDirChild !: TextDirective;
+  @ContentChild('q', {read: TextDirective}) textDirChild !: TextDirective;
   // TODO(issue/24571): remove '!'.
-  @ContentChild('nonExisting', {read: TextDirective, static: false})
+  @ContentChild('nonExisting', {read: TextDirective})
   nonExistingVar !: TextDirective;
 }
 
@@ -1089,17 +1089,17 @@ class NeedsViewChildrenWithRead {
 })
 class NeedsViewChildWithRead {
   // TODO(issue/24571): remove '!'.
-  @ViewChild('q', {read: TextDirective, static: false}) textDirChild !: TextDirective;
+  @ViewChild('q', {read: TextDirective}) textDirChild !: TextDirective;
   // TODO(issue/24571): remove '!'.
-  @ViewChild('nonExisting', {read: TextDirective, static: false}) nonExistingVar !: TextDirective;
+  @ViewChild('nonExisting', {read: TextDirective}) nonExistingVar !: TextDirective;
 }
 
 @Component({selector: 'needs-viewcontainer-read', template: '<div #q></div>'})
 class NeedsViewContainerWithRead {
   // TODO(issue/24571): remove '!'.
-  @ViewChild('q', {read: ViewContainerRef, static: false}) vc !: ViewContainerRef;
+  @ViewChild('q', {read: ViewContainerRef}) vc !: ViewContainerRef;
   // TODO(issue/24571): remove '!'.
-  @ViewChild('nonExisting', {read: ViewContainerRef, static: false})
+  @ViewChild('nonExisting', {read: ViewContainerRef})
   nonExistingVar !: ViewContainerRef;
   // TODO(issue/24571): remove '!'.
   @ContentChild(TemplateRef, {static: true}) template !: TemplateRef<Object>;
@@ -1128,7 +1128,7 @@ class ManualProjecting {
   @ContentChild(TemplateRef, {static: true}) template !: TemplateRef<any>;
 
   // TODO(issue/24571): remove '!'.
-  @ViewChild('vc', {read: ViewContainerRef, static: false})
+  @ViewChild('vc', {read: ViewContainerRef})
   vc !: ViewContainerRef;
 
   // TODO(issue/24571): remove '!'.

--- a/packages/core/test/metadata/di_spec.ts
+++ b/packages/core/test/metadata/di_spec.ts
@@ -83,13 +83,13 @@ class Simple {
 @Component({selector: 'view-child-type-selector', template: ''})
 class ViewChildTypeSelectorComponent {
   // TODO(issue/24571): remove '!'.
-  @ViewChild(Simple, {static: false}) child !: Simple;
+  @ViewChild(Simple) child !: Simple;
 }
 
 @Component({selector: 'view-child-string-selector', template: ''})
 class ViewChildStringSelectorComponent {
   // TODO(issue/24571): remove '!'.
-  @ViewChild('child', {static: false}) child !: ElementRef;
+  @ViewChild('child') child !: ElementRef;
 }
 
 @Component({selector: 'view-children-type-selector', template: ''})

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -297,7 +297,7 @@ ivyEnabled && describe('render3 jit', () => {
   it('should compile ContentChild query with string predicate on a directive', () => {
     @Directive({selector: '[test]'})
     class TestDirective {
-      @ContentChild('foo', {static: false}) foo: ElementRef|undefined;
+      @ContentChild('foo') foo: ElementRef|undefined;
     }
 
     expect((TestDirective as any).ngDirectiveDef.contentQueries).not.toBeNull();
@@ -319,7 +319,7 @@ ivyEnabled && describe('render3 jit', () => {
 
     @Directive({selector: '[test]'})
     class TestDirective {
-      @ContentChild(SomeDir, {static: false}) dir: SomeDir|undefined;
+      @ContentChild(SomeDir) dir: SomeDir|undefined;
     }
 
     expect((TestDirective as any).ngDirectiveDef.contentQueries).not.toBeNull();
@@ -328,7 +328,7 @@ ivyEnabled && describe('render3 jit', () => {
   it('should compile ViewChild query on a component', () => {
     @Component({selector: 'test', template: ''})
     class TestComponent {
-      @ViewChild('foo', {static: false}) foo: ElementRef|undefined;
+      @ViewChild('foo') foo: ElementRef|undefined;
     }
 
     expect((TestComponent as any).ngComponentDef.foo).not.toBeNull();

--- a/packages/examples/core/di/ts/contentChild/content_child_example.ts
+++ b/packages/examples/core/di/ts/contentChild/content_child_example.ts
@@ -21,7 +21,7 @@ export class Pane {
   `
 })
 export class Tab {
-  @ContentChild(Pane, {static: false}) pane !: Pane;
+  @ContentChild(Pane) pane !: Pane;
 }
 
 @Component({

--- a/packages/examples/core/di/ts/contentChild/content_child_howto.ts
+++ b/packages/examples/core/di/ts/contentChild/content_child_howto.ts
@@ -15,7 +15,7 @@ class ChildDirective {
 
 @Directive({selector: 'someDir'})
 class SomeDir implements AfterContentInit {
-  @ContentChild(ChildDirective, {static: false}) contentChild !: ChildDirective;
+  @ContentChild(ChildDirective) contentChild !: ChildDirective;
 
   ngAfterContentInit() {
     // contentChild is set

--- a/packages/examples/core/di/ts/viewChild/view_child_example.ts
+++ b/packages/examples/core/di/ts/viewChild/view_child_example.ts
@@ -26,7 +26,7 @@ export class Pane {
   `,
 })
 export class ViewChildComp {
-  @ViewChild(Pane, {static: false})
+  @ViewChild(Pane)
   set pane(v: Pane) {
     setTimeout(() => { this.selectedPane = v.id; }, 0);
   }

--- a/packages/examples/core/di/ts/viewChild/view_child_howto.ts
+++ b/packages/examples/core/di/ts/viewChild/view_child_howto.ts
@@ -15,7 +15,7 @@ class ChildDirective {
 
 @Component({selector: 'someCmp', templateUrl: 'someCmp.html'})
 class SomeCmp implements AfterViewInit {
-  @ViewChild(ChildDirective, {static: false}) child !: ChildDirective;
+  @ViewChild(ChildDirective) child !: ChildDirective;
 
   ngAfterViewInit() {
     // child is set

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -178,7 +178,7 @@ import {el} from '../../testing/src/browser_util';
            })
            class Cmp {
              exp: any;
-             @ViewChild('elm', {static: false}) public element: any;
+             @ViewChild('elm') public element: any;
            }
 
            TestBed.configureTestingModule({
@@ -223,11 +223,11 @@ import {el} from '../../testing/src/browser_util';
              exp2: any = true;
              exp3: any = true;
 
-             @ViewChild('elm1', {static: false}) public elm1: any;
+             @ViewChild('elm1') public elm1: any;
 
-             @ViewChild('elm2', {static: false}) public elm2: any;
+             @ViewChild('elm2') public elm2: any;
 
-             @ViewChild('elm3', {static: false}) public elm3: any;
+             @ViewChild('elm3') public elm3: any;
            }
 
            TestBed.configureTestingModule({

--- a/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
+++ b/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
@@ -51,7 +51,7 @@ import {el} from '../../testing/src/browser_util';
            template: '...',
          })
          class Cmp {
-           @ViewChild('target', {static: false}) public target: any;
+           @ViewChild('target') public target: any;
 
            constructor(public builder: AnimationBuilder) {}
 


### PR DESCRIPTION
Cleans up all the places where we explicitly set `static: false` on queries.
