### PR TITLE
feat(compiler-cli): resolve type of exported *ngIf variable.

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
@@ -154,6 +154,19 @@ function refinedVariableType(
     }
   }
 
+  // Special case the ngIf directive ( *ngIf="data$ | async as variable" )
+  const ngIfDirective =
+      templateElement.directives.find(d => identifierName(d.directive.type) === 'NgIf');
+  if (ngIfDirective) {
+    const ngIfBinding = ngIfDirective.inputs.find(i => i.directiveName === 'ngIf');
+    if (ngIfBinding) {
+      const bindingType = new AstType(info.members, info.query, {}).getType(ngIfBinding.value);
+      if (bindingType) {
+        return bindingType;
+      }
+    }
+  }
+
   // We can't do better, return any
   return info.query.getBuiltinType(BuiltinType.Any);
 }

--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -127,6 +127,18 @@ describe('expression diagnostics', () => {
       </div>
     `,
                                                            'Identifier \'nume\' is not defined'));
+  it('should accept an async *ngIf', () => accept(`
+      <div *ngIf="promised_person | async as p">
+        {{p.name.first}} {{p.name.last}}
+      </div>
+    `));
+  it('should reject misspelled field in async *ngIf', () => reject(
+                                                          `
+      <div *ngIf="promised_person | async as p">
+        {{p.name.first}} {{p.nume.last}}
+      </div>
+    `,
+                                                          'Identifier \'nume\' is not defined'));
   it('should reject access to potentially undefined field',
      () => reject(`<div>{{maybe_person.name.first}}`, 'The expression might be null'));
   it('should accept a safe accss to an undefined field',

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -61,6 +61,20 @@ describe('completions', () => {
     expectContains(fileName, 'name', 'name', 'street');
   });
 
+  it('should be able to get completions for exported *ngIf variable', () => {
+    const fileName = mockHost.addCode(`
+      interface Person {
+        name: string,
+        street: string
+      }
+
+      @Component({template: '<div *ngIf="promised_person | async as person">{{person.~{name}name}}</div'})
+      export class MyComponent {
+        promised_person: Promise<Person>
+      }`);
+    expectContains(fileName, 'name', 'name', 'street');
+  });
+
   it('should be able to infer the type of a ngForOf with an async pipe', () => {
     const fileName = mockHost.addCode(`
       interface Person {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Angular compiler does not resolve the type of exported variable from *ngIf directive. It always returns `any` type. So language service can't provide completions for type members.

Issue Number: angular/vscode-ng-language-service#255


## What is the new behavior?
Compiler will try resolve type of exported variable and will use this type for type-checking.  Angular language service will use this type for completions, go to definition and quick info functionality. Also language service will provide more accurate diagnostic errors during development.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
