### PR TITLE
refactor(core): typo in undecorated-classes-with-di AOT failure message

### DIFF
--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -171,7 +171,7 @@ function gracefullyCreateProgram(
 
     return {program, compiler};
   } catch (e) {
-    logger.warn(`\n${MIGRATION_AOT_FAILURE}. The following project failed: ${tsconfigPath}\n`);
+    logger.warn(`\n${MIGRATION_AOT_FAILURE} The following project failed: ${tsconfigPath}\n`);
     logger.error(`${e.toString()}\n`);
     logger.info(MIGRATION_RERUN_MESSAGE);
     return null;

--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -1439,7 +1439,7 @@ describe('Undecorated classes with DI migration', () => {
       expect(warnOutput.length).toBe(1);
       expect(warnOutput[0])
           .toMatch(
-              /ensure there are no AOT compilation errors and rerun the migration.*project failed: tsconfig\.json/);
+              /ensure there are no AOT compilation errors and rerun the migration. The following project failed: tsconfig\.json/);
       expect(errorOutput.length).toBe(1);
       expect(errorOutput[0]).toMatch(/Cannot determine the module for class TestComp/);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is an extra period in the error message for `MIGRATION_AOT_FAILURE` as [the string](https://github.com/angular/angular/blob/01677b21b6ae057f8987b5d17c862286a3763615/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts#L29) and [the template](https://github.com/angular/angular/blob/01677b21b6ae057f8987b5d17c862286a3763615/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts#L174) it's used in both include a terminating period.
```
Please ensure there are no AOT compilation errors and rerun the migration.. The following project failed: tsconfig.app.json
```

Issue Number: N/A


## What is the new behavior?
```
Please ensure there are no AOT compilation errors and rerun the migration. The following project failed: tsconfig.app.json
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
