### PR TITLE
Clarify createUrlTree usage of NavigationExtras

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -867,7 +867,8 @@ export class Router {
    * Otherwise, applies the given command starting from the root.
    *
    * @param commands An array of commands to apply.
-   * @param navigationExtras Options that control the navigation strategy.
+   * @param navigationExtras Options that control the navigation strategy. This function
+   * only utilizes properties in `NavigationExtras` that would change the provided URL.
    * @returns The new URL tree.
    *
    * @usageNotes


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some folks have assumed that passing some `NavigationExtras` like `replaceUrl` to`createUrlTree` will cause a subsequent navigation with that `UrlTree` will replace the existing URL in browser history.

Issue Number: N/A


## What is the new behavior?
This documentation change clarifies that only a subset of `NavigationExtras` are used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
