### PR TITLE
fix(language-service): Use index.d.ts for typings

### DIFF
--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -4,7 +4,7 @@
   "description": "Angular - language services",
   "main": "./bundles/language-service.umd.js",
   "module": "./fesm5/language-service.js",
-  "typings": "./language-service.d.ts",
+  "typings": "./index.d.ts",
   "author": "angular",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The current `typings` value in `package.json` causes the import of
`@angular/language-service` in TypeScript to be generated as

```
const language_service_1 = require("@angular/language-service/language-service");
```
in CJS output.

This breaks the import shim that overwrites the behavior of `require` at
runtime. Changing the typings to `index.d.ts` fixes the issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
