### PR TITLE
feat(ivy): better error messages for unknown components

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -150,7 +150,7 @@ runInEachFileSystem(() => {
 
       expect(messages).toEqual([
         `synthetic.html(1, 29): Property 'heihgt' does not exist on type 'TestComponent'. Did you mean 'height'?`,
-        `synthetic.html(1, 6): 'srcc' is not a valid property of <img>.`,
+        `synthetic.html(1, 6): Can't bind to 'srcc' since it isn't a known property of 'img'.`,
       ]);
     });
 


### PR DESCRIPTION
For elements in a template that look like custom elements, i.e.
containing a dash in their name, the template type checker will now
issue an error with instructions on how the resolve the issue.
Additionally, a property binding to a non-existent property will also
produce a more descriptive error message.

Resolves FW-1597

<img width="1043" alt="Screenshot 2019-10-09 at 20 46 49" src="https://user-images.githubusercontent.com/123679/66511737-d2fa5480-ead7-11e9-94c9-f05df8479097.png">
