### PR TITLE
fix(ivy): do not always accept `undefined` for directive inputs

### DIFF
--- a/aio/src/app/custom-elements/code/code-tabs.component.ts
+++ b/aio/src/app/custom-elements/code/code-tabs.component.ts
@@ -27,7 +27,7 @@ export interface TabInfo {
     <div #content style="display: none"><ng-content></ng-content></div>
 
     <mat-card>
-      <mat-tab-group class="code-tab-group" disableRipple>
+      <mat-tab-group class="code-tab-group" [disableRipple]="true">
         <mat-tab style="overflow-y: hidden;" *ngFor="let tab of tabs">
           <ng-template mat-tab-label>
             <span class="{{ tab.class }}">{{ tab.header }}</span>

--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -63,7 +63,7 @@ export class CodeComponent implements OnChanges {
   @Input() hideCopy: boolean;
 
   /** Language to render the code (e.g. javascript, dart, typescript). */
-  @Input() language: string;
+  @Input() language: string | undefined;
 
   /**
    * Whether to display line numbers:
@@ -71,7 +71,7 @@ export class CodeComponent implements OnChanges {
    *  - If true: show
    *  - If number: show but start at that number
    */
-  @Input() linenums: boolean | number | string;
+  @Input() linenums: boolean | number | string | undefined;
 
   /** Path to the source of the code. */
   @Input() path: string;
@@ -81,12 +81,12 @@ export class CodeComponent implements OnChanges {
 
   /** Optional header to be displayed above the code. */
   @Input()
-  set header(header: string) {
+  set header(header: string | undefined) {
     this._header = header;
     this.ariaLabel = this.header ? `Copy code snippet from ${this.header}` : '';
   }
-  get header(): string { return this._header; }
-  private _header: string;
+  get header(): string|undefined { return this._header; }
+  private _header: string | undefined;
 
   @Output() codeFormatted = new EventEmitter<void>();
 

--- a/aio/src/app/layout/nav-item/nav-item.component.ts
+++ b/aio/src/app/layout/nav-item/nav-item.component.ts
@@ -10,7 +10,7 @@ export class NavItemComponent implements OnChanges {
   @Input() level = 1;
   @Input() node: NavigationNode;
   @Input() isParentExpanded = true;
-  @Input() selectedNodes: NavigationNode[];
+  @Input() selectedNodes: NavigationNode[] | undefined;
 
   isExpanded = false;
   isSelected = false;

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -8,7 +8,7 @@ import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
   </aio-nav-item>`
 })
 export class NavMenuComponent {
-  @Input() currentNode: CurrentNode;
+  @Input() currentNode: CurrentNode | undefined;
   @Input() isWide = false;
   @Input() nodes: NavigationNode[];
   get filteredNodes() { return this.nodes ? this.nodes.filter(n => !n.hidden) : []; }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -401,6 +401,7 @@ export class NgtscProgram implements api.Program {
         checkQueries: false,
         checkTemplateBodies: true,
         checkTypeOfInputBindings: true,
+        strictNullInputBindings: true,
         // Even in full template type-checking mode, DOM binding checks are not quite ready yet.
         checkTypeOfDomBindings: false,
         checkTypeOfPipes: true,
@@ -412,6 +413,7 @@ export class NgtscProgram implements api.Program {
         checkQueries: false,
         checkTemplateBodies: false,
         checkTypeOfInputBindings: false,
+        strictNullInputBindings: false,
         checkTypeOfDomBindings: false,
         checkTypeOfPipes: false,
         strictSafeNavigationTypes: false,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -84,6 +84,18 @@ export interface TypeCheckingConfig {
   checkTypeOfInputBindings: boolean;
 
   /**
+   * Whether to use strict null types for input bindings for directives.
+   *
+   * If this is `true`, applications that are compiled with TypeScript's `strictNullChecks` enabled
+   * will produce type errors for bindings which can evaluate to `undefined` or `null` where the
+   * inputs's type does not include `undefined` or `null` in its type. If set to `false`, all
+   * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
+   * null checks. This may be particularly useful when the directive is from a library that is not
+   * compiled with `strictNullChecks` enabled.
+   */
+  strictNullInputBindings: boolean;
+
+  /**
    * Whether to check the left-hand side type of binding operations to DOM properties.
    *
    * As `checkTypeOfBindings`, but only applies to bindings to DOM properties.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -123,7 +123,7 @@ export class TypeCheckContext {
     const ops = this.opMap.get(sf) !;
 
     // Push a `TypeCtorOp` into the operation queue for the source file.
-    ops.push(new TypeCtorOp(ref, ctorMeta, this.config));
+    ops.push(new TypeCtorOp(ref, ctorMeta));
   }
 
   /**
@@ -287,7 +287,7 @@ class TcbOp implements Op {
 class TypeCtorOp implements Op {
   constructor(
       readonly ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
-      readonly meta: TypeCtorMetadata, private config: TypeCheckingConfig) {}
+      readonly meta: TypeCtorMetadata) {}
 
   /**
    * Type constructor operations are inserted immediately before the end of the directive class.
@@ -296,7 +296,7 @@ class TypeCtorOp implements Op {
 
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter, printer: ts.Printer):
       string {
-    const tcb = generateInlineTypeCtor(this.ref.node, this.meta, this.config);
+    const tcb = generateInlineTypeCtor(this.ref.node, this.meta);
     return printer.printNode(ts.EmitHint.Unspecified, tcb, sf);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {TypeCheckingConfig} from './api';
 import {AbsoluteSpan, addParseSpanInfo, wrapForDiagnostics} from './diagnostics';
 
-const NULL_AS_ANY =
+export const NULL_AS_ANY =
     ts.createAsExpression(ts.createNull(), ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
 const UNDEFINED = ts.createIdentifier('undefined');
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -33,7 +33,7 @@ runInEachFileSystem(() => {
           }]);
 
       expect(messages).toEqual(
-          [`synthetic.html(1, 10): Type 'string' is not assignable to type 'number | undefined'.`]);
+          [`synthetic.html(1, 10): Type 'string' is not assignable to type 'number'.`]);
     });
 
     it('infers type of template variables', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -119,6 +119,7 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
   checkQueries: false,
   checkTemplateBodies: true,
   checkTypeOfInputBindings: true,
+  strictNullInputBindings: true,
   // Feature is still in development.
   // TODO(alxhub): enable when DOM checking via lib.dom.d.ts is further along.
   checkTypeOfDomBindings: false,
@@ -160,6 +161,7 @@ export function tcb(
     applyTemplateContextGuards: true,
     checkQueries: false,
     checkTypeOfInputBindings: true,
+    strictNullInputBindings: true,
     checkTypeOfDomBindings: false,
     checkTypeOfPipes: true,
     checkTemplateBodies: true,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -222,6 +222,7 @@ describe('type check blocks', () => {
       checkQueries: false,
       checkTemplateBodies: true,
       checkTypeOfInputBindings: true,
+      strictNullInputBindings: true,
       checkTypeOfDomBindings: false,
       checkTypeOfPipes: true,
       strictSafeNavigationTypes: true,
@@ -257,20 +258,37 @@ describe('type check blocks', () => {
       });
     });
 
+    describe('config.strictNullInputBindings', () => {
+      const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="b"></div>`;
+
+      it('should include null and undefined when enabled', () => {
+        const block = tcb(TEMPLATE, DIRECTIVES);
+        expect(block).toContain('Dir.ngTypeCtor({ dirInput: ((ctx).a) })');
+        expect(block).toContain('(ctx).b;');
+      });
+      it('should use the non-null assertion operator when disabled', () => {
+        const DISABLED_CONFIG:
+            TypeCheckingConfig = {...BASE_CONFIG, strictNullInputBindings: false};
+        const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
+        expect(block).toContain('Dir.ngTypeCtor({ dirInput: ((ctx).a!) })');
+        expect(block).toContain('(ctx).b!;');
+      });
+    });
+
     describe('config.checkTypeOfBindings', () => {
-      const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="a"></div>`;
+      const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="b"></div>`;
 
       it('should check types of bindings when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain('Dir.ngTypeCtor({ dirInput: ((ctx).a) })');
-        expect(block).toContain('(ctx).a;');
+        expect(block).toContain('(ctx).b;');
       });
       it('should not check types of bindings when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfInputBindings: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
         expect(block).toContain('Dir.ngTypeCtor({ dirInput: (((ctx).a as any)) })');
-        expect(block).toContain('((ctx).a as any);');
+        expect(block).toContain('((ctx).b as any);');
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -35,6 +35,17 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('((ctx).a)[(ctx).b];');
   });
 
+  it('should handle attribute values for directive inputs', () => {
+    const TEMPLATE = `<div dir inputA="value"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'DirA',
+      selector: '[dir]',
+      inputs: {inputA: 'inputA'},
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('inputA: ("value")');
+  });
+
   it('should handle empty bindings', () => {
     const TEMPLATE = `<div dir-a [inputA]=""></div>`;
     const DIRECTIVES: TestDeclaration[] = [{

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -67,6 +67,21 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
   });
 
+  it('should handle missing property bindings', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        fieldA: 'inputA',
+        fieldB: 'inputB',
+      },
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain('var _t2 = Dir.ngTypeCtor({ fieldA: ((ctx).foo), fieldB: (null as any) });');
+  });
+
   it('should generate a forward element reference correctly', () => {
     const TEMPLATE = `
       {{ i.value }}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -336,12 +336,10 @@ export declare class CommonModule {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText)
-          .toBe(`Type 'number' is not assignable to type 'string | undefined'.`);
+      expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
       expect(diags[0].start).toEqual(386);
       expect(diags[0].length).toEqual(14);
-      expect(diags[1].messageText)
-          .toBe(`Type 'number' is not assignable to type 'boolean | undefined'.`);
+      expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
       expect(diags[1].start).toEqual(401);
       expect(diags[1].length).toEqual(15);
     });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -80,6 +80,32 @@ export declare class CommonModule {
       env.driveMain();
     });
 
+    it('should check regular attributes that are directive inputs', () => {
+      env.write('test.ts', `
+        import {Component, Directive, NgModule, Input} from '@angular/core';
+    
+        @Component({
+          selector: 'test',
+          template: '<div dir foo="2"></div>',
+        })
+        class TestCmp {}
+    
+        @Directive({selector: '[dir]'})
+        class TestDir {
+          @Input() foo: number;
+        }
+    
+        @NgModule({
+          declarations: [TestCmp, TestDir],
+        })
+        class Module {}
+      `);
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+    });
+
     it('should check basic usage of NgIf', () => {
       env.write('test.ts', `
     import {CommonModule} from '@angular/common';


### PR DESCRIPTION
**fix(ivy): do not always accept `undefined` for directive inputs**

Prior to this change, the template type checker would always allow a
value of type `undefined` to be passed into a directive's inputs, even
if the input's type did not allow for it. This was due to how the type
constructor for a directive was generated, where a `Partial` mapped
type was used to allow for inputs to be unset. This essentially
introduces the `undefined` type as acceptable type for all inputs.

This commit removes the `Partial` type from the type constructor, which
means that we can no longer omit any properties that were unset.
Instead, any properties that are not set will still be included in the
type constructor call, having their value assigned to `any`.

Before:

```typescript
class NgForOf<T> {
  static ngTypeCtor<T>(init: Partial<Pick<NgForOf<T>,
    'ngForOf'|'ngForTrackBy'|'ngForTemplate'>>): NgForOf<T>;
}

NgForOf.ngTypeCtor(init: {ngForOf: ['foo', 'bar']});
```

After:

```typescript
class NgForOf<T> {
  static ngTypeCtor<T>(init: Pick<NgForOf<T>,
    'ngForOf'|'ngForTrackBy'|'ngForTemplate'>): NgForOf<T>;
}

NgForOf.ngTypeCtor(init: {
  ngForOf: ['foo', 'bar'],
  ngForTrackBy: null as any,
  ngForTemplate: null as any,
});
```

This change only affects generated type check code, the generated
runtime code is not affected.

Fixes #32690
Resolves FW-1606

---

**feat(ivy): check regular attributes that correspond with directive inputs**

Prior to this change, a static attribute that corresponds with a
directive's input would not be type-checked against the type of the
input. This is unfortunate, as a static value always has type `string`,
whereas the directive's input type might be something different. This
typically occurs when a developer forgets to enclose the attribute name
in brackets to make it a property binding.

This commit lets static attributes be considered as bindings with string
values, so that they will be properly type-checked.

---

**feat(ivy): disable strict null checks for input bindings**

This commit introduces an internal config option of the template type
checker that allows to disable strict null checks of input bindings to
directives. This may be particularly useful when a directive is from a
library that is not compiled with `strictNullChecks` enabled.

Right now, strict null checks are enabled when  `fullTemplateTypeCheck`
is turned on, and disabled when it's off. In the near future, several of
the internal configuration options will be added as public Angular
compiler options so that users can have fine-grained control over which
areas of the template type checker to enable, allowing for a more
incremental migration strategy.