### PR TITLE
docs: correct component names in NgComponentOutlet examples

### DIFF
--- a/packages/examples/common/ngComponentOutlet/ts/module.ts
+++ b/packages/examples/common/ngComponentOutlet/ts/module.ts
@@ -19,7 +19,7 @@ export class HelloWorld {
   selector: 'ng-component-outlet-simple-example',
   template: `<ng-container *ngComponentOutlet="HelloWorld"></ng-container>`
 })
-export class NgTemplateOutletSimpleExample {
+export class NgComponentOutletSimpleExample {
   // This field is necessary to expose HelloWorld to the template.
   HelloWorld = HelloWorld;
 }
@@ -46,7 +46,7 @@ export class CompleteComponent {
                                       injector: myInjector; 
                                       content: myContent"></ng-container>`
 })
-export class NgTemplateOutletCompleteExample {
+export class NgComponentOutletCompleteExample {
   // This field is necessary to expose CompleteComponent to the template.
   CompleteComponent = CompleteComponent;
   myInjector: Injector;
@@ -73,7 +73,7 @@ export class AppComponent {
 @NgModule({
   imports: [BrowserModule],
   declarations: [
-    AppComponent, NgTemplateOutletSimpleExample, NgTemplateOutletCompleteExample, HelloWorld,
+    AppComponent, NgComponentOutletSimpleExample, NgComponentOutletCompleteExample, HelloWorld,
     CompleteComponent
   ],
   entryComponents: [HelloWorld, CompleteComponent]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the code examples for NgComponentOutlets the class name is NgTemplateOutletSimpleExample  which doesn't match the selector of ng-component-outlet-simple-example. Template is used instead of Component. It is the same for NgTemplateOutletCompleteExample.

Issue Number: N/A


## What is the new behavior?
Correct the class names to match the selectors and the context of the examples for NgComponentOutlets. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
