### PR TITLE
refactor(compiler): replace instanceof Array with Array.isArray

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -575,7 +575,7 @@ export class StaticReflector implements CompileReflector {
         if (isPrimitive(expression)) {
           return expression;
         }
-        if (expression instanceof Array) {
+        if (Array.isArray(expression)) {
           const result: any[] = [];
           for (const item of (<any>expression)) {
             // Check for a spread expression

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -168,7 +168,7 @@ export function stringify(token: any): string {
     return token;
   }
 
-  if (token instanceof Array) {
+  if (Array.isArray(token)) {
     return '[' + token.map(stringify).join(', ') + ']';
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32950


## What is the new behavior?
Replaced `instance of Array` with `Array.isArray` in  `compiler`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
