### PR TITLE
fix(compiler-cli): produce diagnostic messages in expression of PrefixNot node.

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_type.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_type.ts
@@ -304,6 +304,10 @@ export class AstType implements AstVisitor {
   }
 
   visitPrefixNot(ast: PrefixNot) {
+    // If we are producing diagnostics, visit the children
+    if (this.diagnostics) {
+      visitAstChildren(ast, this);
+    }
     // The type of a prefix ! is always boolean.
     return this.query.getBuiltinType(BuiltinType.Boolean);
   }

--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -98,6 +98,9 @@ describe('expression diagnostics', () => {
      () => reject(
          '<div *ngIf="persson">{{person.name.first}}</div>',
          'Identifier \'persson\' is not defined'));
+  it('should reject *ngIf of misspelled identifier in PrefixNot node',
+     () =>
+         reject('<div *ngIf="people && !persson"></div>', 'Identifier \'persson\' is not defined'));
   it('should accept an *ngFor', () => accept(`
       <div *ngFor="let p of people">
         {{p.name.first}} {{p.name.last}}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The function `getExpressionDiagnostics` doesn't report diagnostic messages when using `!` prefix before invalid expression.
![actual](https://user-images.githubusercontent.com/17968027/66604648-3e672380-ebb7-11e9-8ddc-e0af1e2692ba.gif)






Issue Number: angular/vscode-ng-language-service#381


## What is the new behavior?
The function `getExpressionDiagnostics`  always reports diagnostic messages for expression of PrefixNot node

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
