### PR TITLE
feat(language-service): add support for text replacement

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -175,10 +175,10 @@ export function getTemplateCompletions(
         null);
   }
 
+  const replacementSpan = getBoundedWordSpan(templateInfo, position);
   return result.map(entry => {
     return {
-      ...entry,
-      replacementSpan: getBoundedWordSpan(templateInfo, position),
+        ...entry, replacementSpan,
     };
   })
 }

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -67,9 +67,10 @@ function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextS
   //           ^---- cursor, at position `r` is at.
   // A cursor is not itself a character in the template; it has a left (lower) and right (upper)
   // index bound that hugs the cursor itself.
+  let templatePosition = position - template.span.start;
   // To perform word expansion, we want to determine the left and right indeces that hug the cursor.
   // There are three cases here.
-  let templatePosition = position - template.span.start;
+  //
   // 1. Case like
   //      wo|rd
   //    there is a clear left and right index.

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -55,6 +55,13 @@ function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextS
   const {template} = templateInfo;
   const templateSrc = template.source;
 
+  // TODO(ayazhafiz): A solution based on word expansion will always be expensive compared to one
+  // based on ASTs. Whatever penalty we incur is probably manageable for small-length (i.e. the
+  // majority of) identifiers, but the current solution involes a number of branchings and we can't
+  // control potentially very long identifiers. Consider moving to an AST-based solution once
+  // existing difficulties with AST spans are more clearly resolved (see #31898 for discussion of
+  // known problems, and #33091 for how they affect text replacement).
+  //
   // `templatePosition` represents the right-bound location of a cursor in the template.
   //    key.ent|ry
   //           ^---- cursor, at position `r` is at.

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -180,7 +180,7 @@ export function getTemplateCompletions(
     return {
         ...entry, replacementSpan,
     };
-  })
+  });
 }
 
 function attributeCompletions(info: AstResult, path: AstPath<HtmlAst>): ng.CompletionEntry[] {

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -10,7 +10,7 @@ import {AST, AstPath, Attribute, BoundDirectivePropertyAst, BoundElementProperty
 import {getExpressionScope} from '@angular/compiler-cli/src/language_services';
 
 import {AstResult} from './common';
-import {findAstAt, getExpressionCompletions} from './expressions';
+import {getExpressionCompletions} from './expressions';
 import {attributeNames, elementNames, eventNames, propertyNames} from './html_info';
 import {InlineTemplate} from './template';
 import * as ng from './types';

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -50,7 +50,8 @@ const ANGULAR_ELEMENTS: ReadonlyArray<ng.CompletionEntry> = [
  * `position`, nothing is returned.
  */
 function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextSpan|undefined {
-  const WORD_PART = /[0-9a-zA-Z_]/;
+  // Identifiers consist of alphanumeric characters, '_', or '$'.
+  const IDENTIFIER_PART = /[0-9a-zA-Z_$]/;
 
   const {template} = templateInfo;
   const templateSrc = template.source;
@@ -88,7 +89,7 @@ function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextS
     left = right = templateSrc.length - 1;
   }
 
-  if (!templateSrc[left].match(WORD_PART) && !templateSrc[right].match(WORD_PART)) {
+  if (!templateSrc[left].match(IDENTIFIER_PART) && !templateSrc[right].match(IDENTIFIER_PART)) {
     // Case like
     //         .|.
     // left ---^ ^--- right
@@ -98,9 +99,9 @@ function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextS
 
   // Expand on the left and right side until a word boundary is hit. Back up one expansion on both
   // side to stay inside the word.
-  while (left >= 0 && templateSrc[left].match(WORD_PART)) --left;
+  while (left >= 0 && templateSrc[left].match(IDENTIFIER_PART)) --left;
   ++left;
-  while (right < templateSrc.length && templateSrc[right].match(WORD_PART)) ++right;
+  while (right < templateSrc.length && templateSrc[right].match(IDENTIFIER_PART)) ++right;
   --right;
 
   const absoluteStartPosition = position - (templatePosition - left);

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -14,7 +14,7 @@ import {inSpan} from './utils';
 
 type AstPath = AstPathBase<AST>;
 
-function findAstAt(ast: AST, position: number, excludeEmpty: boolean = false): AstPath {
+export function findAstAt(ast: AST, position: number, excludeEmpty: boolean = false): AstPath {
   const path: AST[] = [];
   const visitor = new class extends NullAstVisitor {
     visit(ast: AST) {

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -14,7 +14,7 @@ import {inSpan} from './utils';
 
 type AstPath = AstPathBase<AST>;
 
-export function findAstAt(ast: AST, position: number, excludeEmpty: boolean = false): AstPath {
+function findAstAt(ast: AST, position: number, excludeEmpty: boolean = false): AstPath {
   const path: AST[] = [];
   const visitor = new class extends NullAstVisitor {
     visit(ast: AST) {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -373,11 +373,11 @@ describe('completions', () => {
 });
 
 describe('replace completions correctly', () => {
-  let mockHost: MockTypescriptHost;
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
   let ngLS: LanguageService;
 
   beforeEach(() => {
-    mockHost = new MockTypescriptHost(['/app/main.ts']);
+    mockHost.reset();
     const tsLS = ts.createLanguageService(mockHost);
     const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
     ngLS = createLanguageService(ngHost);
@@ -400,6 +400,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'key') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('property');
     expect(completion.replacementSpan).toBeUndefined();
   });
 
@@ -414,8 +415,9 @@ describe('replace completions correctly', () => {
     const location = mockHost.getLocationMarkerFor(fileName, 'start');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
     expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'a') !;
+    const completion = completions.entries.find(entry => entry.name === 'acronym') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('html element');
     expect(completion.replacementSpan).toEqual({start: location.start, length: 3});
   });
 
@@ -432,6 +434,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'acronym') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('html element');
     expect(completion.replacementSpan).toEqual({start: location.start - 4, length: 4});
   });
 
@@ -452,6 +455,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'key') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('property');
     expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 5});
   });
 
@@ -472,6 +476,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === '$title_1') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('property');
     expect(completion.replacementSpan).toEqual({start: location.start, length: 8});
   });
 
@@ -490,6 +495,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === '(click)') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('attribute');
     expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
   });
 
@@ -510,6 +516,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'handleClick') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('method');
     expect(completion.replacementSpan).toEqual({start: location.start - 3, length: 3});
   });
 
@@ -528,6 +535,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'div') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('html element');
     expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
   });
 
@@ -546,6 +554,7 @@ describe('replace completions correctly', () => {
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === '[(ngModel)]') !;
     expect(completion).toBeDefined();
+    expect(completion.kind).toBe('attribute');
     expect(completion.replacementSpan).toEqual({start: location.start - 5, length: 5});
   });
 });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -396,7 +396,6 @@ describe('replace completions correctly', () => {
           }
         `);
     const location = mockHost.getLocationMarkerFor(fileName, 'key');
-    debugger;
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'key') !;
@@ -410,9 +409,7 @@ describe('replace completions correctly', () => {
             selector: 'foo-component',
             template: \`~{start}abc\`,
           })
-          export class FooComponent {
-            handleClick() {}
-          }
+          export class FooComponent {}
         `);
     const location = mockHost.getLocationMarkerFor(fileName, 'start');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
@@ -428,9 +425,7 @@ describe('replace completions correctly', () => {
             selector: 'foo-component',
             template: \`acro~{end}\`,
           })
-          export class FooComponent {
-            handleClick() {}
-          }
+          export class FooComponent {}
         `);
     const location = mockHost.getLocationMarkerFor(fileName, 'end');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
@@ -440,7 +435,7 @@ describe('replace completions correctly', () => {
     expect(completion.replacementSpan).toEqual({start: location.start - 4, length: 4});
   });
 
-  it('should work for post-word replacements', () => {
+  it('should work for middle-word replacements', () => {
     const fileName = mockHost.addCode(`
           @Component({
             selector: 'foo-component',
@@ -451,9 +446,8 @@ describe('replace completions correctly', () => {
           export class FooComponent {
             obj: {key: 'value'};
           }
-        ~{a}`);
+        `);
     const location = mockHost.getLocationMarkerFor(fileName, 'key');
-    const loca = mockHost.getLocationMarkerFor(fileName, 'a');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
     expect(completions).toBeDefined();
     const completion = completions.entries.find(entry => entry.name === 'key') !;
@@ -461,24 +455,24 @@ describe('replace completions correctly', () => {
     expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 5});
   });
 
-  it('should work for interpolations', () => {
+  it('should work for all kinds of identifier characters', () => {
     const fileName = mockHost.addCode(`
           @Component({
             selector: 'foo-component',
             template: \`
-              <div>{{ti~{title}}}</div>
+              <div>{{~{field}$title_1}}</div>
             \`,
           })
           export class FooComponent {
-            title: string;
+            $title_1: string;
           }
         `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'title');
+    const location = mockHost.getLocationMarkerFor(fileName, 'field');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
     expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'title') !;
+    const completion = completions.entries.find(entry => entry.name === '$title_1') !;
     expect(completion).toBeDefined();
-    expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
+    expect(completion.replacementSpan).toEqual({start: location.start, length: 8});
   });
 
   it('should work for attributes', () => {
@@ -489,9 +483,7 @@ describe('replace completions correctly', () => {
               <div cl~{click}></div>
             \`,
           })
-          export class FooComponent {
-            title: string;
-          }
+          export class FooComponent {}
         `);
     const location = mockHost.getLocationMarkerFor(fileName, 'click');
     const completions = ngLS.getCompletionsAt(fileName, location.start) !;
@@ -519,6 +511,42 @@ describe('replace completions correctly', () => {
     const completion = completions.entries.find(entry => entry.name === 'handleClick') !;
     expect(completion).toBeDefined();
     expect(completion.replacementSpan).toEqual({start: location.start - 3, length: 3});
+  });
+
+  it('should work for element names', () => {
+    const fileName = mockHost.addCode(`
+          @Component({
+            selector: 'foo-component',
+            template: \`
+              <di~{div}></div>
+            \`,
+          })
+          export class FooComponent {}
+        `);
+    const location = mockHost.getLocationMarkerFor(fileName, 'div');
+    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+    expect(completions).toBeDefined();
+    const completion = completions.entries.find(entry => entry.name === 'div') !;
+    expect(completion).toBeDefined();
+    expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
+  });
+
+  it('should work for bindings', () => {
+    const fileName = mockHost.addCode(`
+          @Component({
+            selector: 'foo-component',
+            template: \`
+            <input ngMod~{model} />
+            \`,
+          })
+          export class FooComponent {}
+        `);
+    const location = mockHost.getLocationMarkerFor(fileName, 'model');
+    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+    expect(completions).toBeDefined();
+    const completion = completions.entries.find(entry => entry.name === '[(ngModel)]') !;
+    expect(completion).toBeDefined();
+    expect(completion.replacementSpan).toEqual({start: location.start - 5, length: 5});
   });
 });
 

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -120,6 +120,7 @@ describe('plugin', () => {
       expect(semanticDiags).toEqual([]);
     }
     const marker = mockHost.getLocationMarkerFor(MY_COMPONENT, 'tree');
+    debugger;
     const completions = plugin.getCompletionsAtPosition(MY_COMPONENT, marker.start, undefined);
     expect(completions).toBeDefined();
     expect(completions !.entries).toEqual([
@@ -127,7 +128,7 @@ describe('plugin', () => {
         name: 'children',
         kind: CompletionKind.PROPERTY as any,
         sortText: 'children',
-        replacementSpan: {start: 174, length: 8},
+        replacementSpan: {start: 182, length: 8},
       },
     ]);
   });

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -127,6 +127,7 @@ describe('plugin', () => {
         name: 'children',
         kind: CompletionKind.PROPERTY as any,
         sortText: 'children',
+        replacementSpan: {start: 174, length: 8},
       },
     ]);
   });

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -120,7 +120,6 @@ describe('plugin', () => {
       expect(semanticDiags).toEqual([]);
     }
     const marker = mockHost.getLocationMarkerFor(MY_COMPONENT, 'tree');
-    debugger;
     const completions = plugin.getCompletionsAtPosition(MY_COMPONENT, marker.start, undefined);
     expect(completions).toBeDefined();
     expect(completions !.entries).toEqual([


### PR DESCRIPTION
Adds a `replacementSpan` field on a completion that will allow typed
text to be replaced with the suggested completion value if a user
selects the completion. Previously, the completion value would simply be
appended to the text already typed. E.g. if we had

```
{{ti}}
```

typed in a template and `title` was recommended as a completion and
selected, the template would become

```
{{tititle}}
```

With `replacementSpan`, the original text `ti` will be replaced for
`title`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No