### PR TITLE
fix(ivy): ensure overrides for 'multi: true' only appear once in final providers

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -316,7 +316,7 @@ describe('TestBed', () => {
       }
     }
 
-    beforeEach(() => MyMod.multi = false);
+    beforeEach(() => MyMod.multi = true);
 
     it('when provider is a "regular" provider', () => {
       MyMod.multi = false;
@@ -329,13 +329,25 @@ describe('TestBed', () => {
     });
 
     it('when provider is multi', () => {
-      MyMod.multi = true;
       @NgModule({imports: [MyMod.forRoot()]})
       class MyMod2 {
       }
       TestBed.configureTestingModule({imports: [MyMod2]});
       TestBed.overrideProvider(TOKEN, {useValue: ['override']});
       expect(TestBed.inject(TOKEN)).toEqual(['override']);
+    });
+
+    it('restores the original value', () => {
+      @NgModule({imports: [MyMod.forRoot()]})
+      class MyMod2 {
+      }
+      TestBed.configureTestingModule({imports: [MyMod2]});
+      TestBed.overrideProvider(TOKEN, {useValue: ['override']});
+      expect(TestBed.inject(TOKEN)).toEqual(['override']);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({imports: [MyMod2]});
+      expect(TestBed.inject(TOKEN)).toEqual(['forRootValue']);
     });
   });
 

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -231,6 +231,25 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World !');
   });
 
+  it('allow to override multi provider', () => {
+    const token = new InjectionToken<string[]>('token');
+    @NgModule({providers: [{provide: token, useValue: 'valueFromModule', multi: true}]})
+    class MyModule {
+    }
+
+    @NgModule({providers: [{provide: token, useValue: 'valueFromModule2', multi: true}]})
+    class MyModule2 {
+    }
+
+    TestBed.configureTestingModule({imports: [MyModule, MyModule2]});
+    const overrideValue = ['override'];
+    TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+
+    const value = TestBed.inject(token);
+    expect(value.length).toEqual(overrideValue.length);
+    expect(value).toEqual(overrideValue);
+  });
+
   it('should allow overriding a provider defined via ModuleWithProviders (using TestBed.overrideProvider)',
      () => {
        const serviceOverride = {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -252,34 +252,47 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World a second time!');
   });
 
-  describe('allow override of multi provider', () => {
-    const token = new InjectionToken<string[]>('token');
-    @NgModule({providers: [{provide: token, useValue: 'valueFromModule', multi: true}]})
+  describe('multi providers', () => {
+    const multiToken = new InjectionToken<string[]>('multiToken');
+    const singleToken = new InjectionToken<string>('singleToken');
+    @NgModule({providers: [{provide: multiToken, useValue: 'valueFromModule', multi: true}]})
     class MyModule {
     }
 
-    @NgModule({providers: [{provide: token, useValue: 'valueFromModule2', multi: true}]})
+    @NgModule({
+      providers: [
+        {provide: singleToken, useValue: 't1'},
+        {provide: multiToken, useValue: 'valueFromModule2', multi: true},
+        {provide: multiToken, useValue: 'secondValueFromModule2', multi: true}
+      ]
+    })
     class MyModule2 {
     }
 
     beforeEach(() => { TestBed.configureTestingModule({imports: [MyModule, MyModule2]}); });
 
-    it('with an array', () => {
-      const overrideValue = ['override'];
-      TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+    it('is preserved when other provider is overridden', () => {
+      TestBed.overrideProvider(singleToken, {useValue: ''});
+      const value = TestBed.inject(multiToken);
+      expect(value.length).toEqual(3);
+    });
 
-      const value = TestBed.inject(token);
+    it('overridden with an array', () => {
+      const overrideValue = ['override'];
+      TestBed.overrideProvider(multiToken, { useValue: overrideValue, multi: true } as any);
+
+      const value = TestBed.inject(multiToken);
       expect(value.length).toEqual(overrideValue.length);
       expect(value).toEqual(overrideValue);
     });
 
-    it('with a non-array', () => {
+    it('overridden with a non-array', () => {
       // This is actually invalid because multi providers return arrays. We have this here so we can
       // ensure Ivy behaves the same as VE does currently.
       const overrideValue = 'override';
-      TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+      TestBed.overrideProvider(multiToken, { useValue: overrideValue, multi: true } as any);
 
-      const value = TestBed.inject(token);
+      const value = TestBed.inject(multiToken);
       expect(value.length).toEqual(overrideValue.length);
       expect(value).toEqual(overrideValue as {} as string[]);
     });

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -231,7 +231,7 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World !');
   });
 
-  it('allow to override multi provider', () => {
+  describe('allow override of multi provider', () => {
     const token = new InjectionToken<string[]>('token');
     @NgModule({providers: [{provide: token, useValue: 'valueFromModule', multi: true}]})
     class MyModule {
@@ -241,13 +241,27 @@ describe('TestBed', () => {
     class MyModule2 {
     }
 
-    TestBed.configureTestingModule({imports: [MyModule, MyModule2]});
-    const overrideValue = ['override'];
-    TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+    beforeEach(() => { TestBed.configureTestingModule({imports: [MyModule, MyModule2]}); });
 
-    const value = TestBed.inject(token);
-    expect(value.length).toEqual(overrideValue.length);
-    expect(value).toEqual(overrideValue);
+    it('with an array', () => {
+      const overrideValue = ['override'];
+      TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+
+      const value = TestBed.inject(token);
+      expect(value.length).toEqual(overrideValue.length);
+      expect(value).toEqual(overrideValue);
+    });
+
+    it('with a non-array', () => {
+      // This is actually invalid because multi providers return arrays. We have this here so we can
+      // ensure Ivy behaves the same as VE does currently.
+      const overrideValue = 'override';
+      TestBed.overrideProvider(token, { useValue: overrideValue, multi: true } as any);
+
+      const value = TestBed.inject(token);
+      expect(value.length).toEqual(overrideValue.length);
+      expect(value).toEqual(overrideValue as {} as string[]);
+    });
   });
 
   it('should allow overriding a provider defined via ModuleWithProviders (using TestBed.overrideProvider)',

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -225,10 +225,31 @@ describe('TestBed', () => {
   });
 
   it('allow to override a provider', () => {
-    TestBed.overrideProvider(NAME, {useValue: 'injected World !'});
+    TestBed.overrideProvider(NAME, {useValue: 'injected World!'});
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
-    expect(hello.nativeElement).toHaveText('Hello injected World !');
+    expect(hello.nativeElement).toHaveText('Hello injected World!');
+  });
+
+  it('uses the most recent provider override', () => {
+    TestBed.overrideProvider(NAME, {useValue: 'injected World!'});
+    TestBed.overrideProvider(NAME, {useValue: 'injected World a second time!'});
+    const hello = TestBed.createComponent(HelloWorld);
+    hello.detectChanges();
+    expect(hello.nativeElement).toHaveText('Hello injected World a second time!');
+  });
+
+  it('overrides a providers in an array', () => {
+    TestBed.configureTestingModule({
+      imports: [HelloWorldModule],
+      providers: [
+        [{provide: NAME, useValue: 'injected World!'}],
+      ]
+    });
+    TestBed.overrideProvider(NAME, {useValue: 'injected World a second time!'});
+    const hello = TestBed.createComponent(HelloWorld);
+    hello.detectChanges();
+    expect(hello.nativeElement).toHaveText('Hello injected World a second time!');
   });
 
   describe('allow override of multi provider', () => {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -381,8 +381,15 @@ export class R3TestBedCompiler {
 
       // Apply provider overrides to imported modules recursively
       const moduleDef: any = (moduleType as any)[NG_MOD_DEF];
-      for (const importType of moduleDef.imports) {
-        this.applyProviderOverridesToModule(importType);
+      for (const importedModule of moduleDef.imports) {
+        this.applyProviderOverridesToModule(importedModule);
+      }
+      // Also override the providers on any ModuleWithProviders imports since those don't appear in
+      // the moduleDef.
+      for (const importedModule of flatten(injectorDef.imports)) {
+        if (isModuleWithProviders(importedModule)) {
+          importedModule.providers = this.getOverriddenProviders(importedModule.providers);
+        }
       }
     }
   }

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -620,8 +620,9 @@ export class R3TestBedCompiler {
   private getOverriddenProviders(providers?: Provider[]): Provider[] {
     if (!providers || !providers.length || this.providerOverridesByToken.size === 0) return [];
 
-    const overrides = this.getProviderOverrides(providers);
-    const overriddenProviders = [...providers, ...overrides];
+    const flattenedProviders = flatten<Provider[]>(providers);
+    const overrides = this.getProviderOverrides(flattenedProviders);
+    const overriddenProviders = [...flattenedProviders, ...overrides];
     const tokenToProviderMap: Map<any, Provider> = new Map();
 
     // Iterate through providers from the end so only the most recent provider is used for a given

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -154,12 +154,15 @@ export class R3TestBedCompiler {
   overrideProvider(
       token: any,
       provider: {useFactory?: Function, useValue?: any, deps?: any[], multi?: boolean}): void {
-    const providerDef = provider.useFactory ? {
-      provide: token,
-      useFactory: provider.useFactory,
-      deps: provider.deps || [],
-    } :
-                                              {provide: token, useValue: provider.useValue};
+    // Note, we explicitly avoid setting `multi: true` here. If multi is true and we set it, TestBed
+    // will override
+    // all instances of the token and when the test module is finalized, the injector will add each
+    // occurrence of the
+    // override to the records. We only ever want one when it's overridden, so we treat it as
+    // non-multi.
+    const providerDef = provider.useFactory ?
+        {provide: token, useFactory: provider.useFactory, deps: provider.deps || []} :
+        {provide: token, useValue: provider.useValue};
 
     let injectableDef: InjectableDef<any>|null;
     const isRoot =


### PR DESCRIPTION
At the moment, if you override a provider with `mutli: true`, the TestBed goes through and overrides each place where the token is provided. Then the injector processes all of them and adds each occurrence to the provider records. As a result, if you override a `multi: true` provider, you get too many instances in the final output. You should only get the one that was provided in the override (see the test in this PR).