### PR TITLE
fix(ivy): incorrectly adding class when falsy value is set in the presence of sanitizer

### DIFF
--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -498,8 +498,8 @@ export const enum TStylingContextPropConfigFlags {
  * A function used to apply or remove styling from an element for a given property.
  */
 export interface ApplyStylingFn {
-  (renderer: Renderer3|ProceduralRenderer3|null, element: RElement, prop: string, value: any,
-   bindingIndex?: number|null): void;
+  (renderer: Renderer3|ProceduralRenderer3|null, element: RElement, prop: string,
+   sanitizedValue: any, rawValue: any, bindingIndex?: number|null): void;
 }
 
 /**

--- a/packages/core/src/render3/styling/map_based_bindings.ts
+++ b/packages/core/src/render3/styling/map_based_bindings.ts
@@ -227,7 +227,9 @@ function innerSyncStylingMap(
                   (value ? unwrapSafeValue(value) : null);
             }
 
-            applyStylingFn(renderer, element, prop, finalValue, bindingIndexToApply);
+            applyStylingFn(
+                renderer, element, prop, finalValue, useDefault ? defaultValue : value,
+                bindingIndexToApply);
           }
         }
 

--- a/packages/core/src/render3/styling/styling_debug.ts
+++ b/packages/core/src/render3/styling/styling_debug.ts
@@ -265,8 +265,9 @@ export class NodeStylingDebug implements DebugNodeStyling {
     }
 
     const mapFn: ApplyStylingFn =
-        (renderer: any, element: RElement, prop: string, value: string | null,
-         bindingIndex?: number | null) => fn(prop, value, bindingIndex || null);
+        (renderer: any, element: RElement, prop: string, sanitizedValue: string | null,
+         rawValue: string | null, bindingIndex?: number | null) =>
+            fn(prop, sanitizedValue, bindingIndex || null);
 
     const sanitizer = this._isClassBased ? null : (this._sanitizer || getCurrentStyleSanitizer());
 


### PR DESCRIPTION
Currently the styling instructions pass their sanitized value down to the function that decides whether to add or remove a style. The problem is that if a sanitizer is present, the value will be stringified which will throw off the falsy check inside the function. These changes fix the issue by passing in both the sanitized and unsanitized values, and using the raw value to do the check while assigning the sanitized one.
