### PR TITLE
test(language-service): Remove redundant marker methods in MockHost

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -196,11 +196,8 @@ describe('completions', () => {
   });
 
   function expectContains(fileName: string, locationMarker: string, ...names: string[]) {
-    let location = mockHost.getMarkerLocations(fileName) ![locationMarker];
-    if (location == null) {
-      throw new Error(`No marker ${locationMarker} found.`);
-    }
-    expectEntries(locationMarker, ngService.getCompletionsAt(fileName, location), ...names);
+    const marker = mockHost.getLocationMarkerFor(fileName, locationMarker);
+    expectEntries(locationMarker, ngService.getCompletionsAt(fileName, marker.start), ...names);
   }
 });
 

--- a/packages/language-service/test/language_service_spec.ts
+++ b/packages/language-service/test/language_service_spec.ts
@@ -20,7 +20,7 @@ describe('service without angular', () => {
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   const fileName = '/app/test.ng';
-  let position = mockHost.getMarkerLocations(fileName) !['h1-content'];
+  const position = mockHost.getLocationMarkerFor(fileName, 'h1-content').start;
 
   it('should not crash a get template references',
      () => expect(() => ngService.getTemplateReferences()));

--- a/packages/language-service/test/project/app/expression-cases.ts
+++ b/packages/language-service/test/project/app/expression-cases.ts
@@ -14,28 +14,28 @@ export interface Person {
 }
 
 @Component({
-  template: '{{~{foo}foo~{foo-end}}}',
+  template: '{{~{start-foo}foo~{end-foo}}}',
 })
 export class WrongFieldReference {
   bar = 'bar';
 }
 
 @Component({
-  template: '{{~{nam}person.nam~{nam-end}}}',
+  template: '{{~{start-nam}person.nam~{end-nam}}}',
 })
 export class WrongSubFieldReference {
   person: Person = {name: 'Bob', age: 23};
 }
 
 @Component({
-  template: '{{~{myField}myField~{myField-end}}}',
+  template: '{{~{start-myField}myField~{end-myField}}}',
 })
 export class PrivateReference {
   private myField = 'My Field';
 }
 
 @Component({
-  template: '{{~{mod}"a" ~{mod-end}% 2}}',
+  template: '{{~{start-mod}"a" ~{end-mod}% 2}}',
 })
 export class ExpectNumericType {
 }

--- a/packages/language-service/test/project/app/ng-for-cases.ts
+++ b/packages/language-service/test/project/app/ng-for-cases.ts
@@ -15,7 +15,7 @@ export interface Person {
 
 @Component({
   template: `
-    <div *ngFor="let person of ~{people_1}people_1~{people_1-end}">
+    <div *ngFor="let person of ~{start-people_1}people_1~{end-people_1}">
       <span>{{person.name}}</span>
     </div>`,
 })
@@ -24,7 +24,7 @@ export class UnknownPeople {
 
 @Component({
   template: `
-    <div ~{even_1}*ngFor="let person of people; let e = even_1"~{even_1-end}>
+    <div ~{start-even_1}*ngFor="let person of people; let e = even_1"~{end-even_1}>
       <span>{{person.name}}</span>
     </div>`,
 })
@@ -34,7 +34,7 @@ export class UnknownEven {
 
 @Component({
   template: `
-    <div *ngFor="let person of people; trackBy ~{trackBy_1}trackBy_1~{trackBy_1-end}">
+    <div *ngFor="let person of people; trackBy ~{start-trackBy_1}trackBy_1~{end-trackBy_1}">
       <span>{{person.name}}</span>
     </div>`,
 })

--- a/packages/language-service/test/project/app/ng-if-cases.ts
+++ b/packages/language-service/test/project/app/ng-if-cases.ts
@@ -10,7 +10,7 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    <div ~{implicit}*ngIf="show; let l=unknown"~{implicit-end}>
+    <div ~{start-implicit}*ngIf="show; let l=unknown"~{end-implicit}>
       Showing now!
     </div>`,
 })


### PR DESCRIPTION
Remove the following methods from MockHost:

1. `getMarkerLocations`: Replaced with `getLocationMarkerFor()`
2. `getReferenceMarkers`: Replaced with `getReferenceMarkerFor()`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
