### PR TITLE
refactor(core): shorten `ngFactoryDef` name

### DIFF
--- a/modules/benchmarks/src/tree/render3_function/index.ts
+++ b/modules/benchmarks/src/tree/render3_function/index.ts
@@ -18,7 +18,7 @@ export class TreeFunction {
   data: TreeNode = emptyTree;
 
   /** @nocollapse */
-  static ngFactoryDef = () => new TreeFunction;
+  static ɵfac = () => new TreeFunction;
 
   /** @nocollapse */
   static ɵcmp = ɵɵdefineComponent({

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -64,7 +64,7 @@ export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
  */
 export class NgClassBase {
   static ɵdir: any = ngClassDirectiveDef;
-  static ngFactoryDef: any = ngClassFactoryDef;
+  static ɵfac: any = ngClassFactoryDef;
 
   constructor(protected _delegate: NgClassImpl) {}
 

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -64,7 +64,7 @@ export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
  */
 export class NgStyleBase {
   static ɵdir: any = ngStyleDirectiveDef;
-  static ngFactory: any = ngStyleFactoryDef;
+  static ɵfac: any = ngStyleFactoryDef;
 
   constructor(protected _delegate: NgStyleImpl) {}
 

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -119,7 +119,7 @@ runInEachFileSystem(() => {
       const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
       expect(typingsFile.contents)
           .toContain(
-              'foo(x: number): number;\n    static ngFactoryDef: ɵngcc0.ɵɵFactoryDef<A>;\n    static ɵdir: ɵngcc0.ɵɵDirectiveDefWithMeta');
+              'foo(x: number): number;\n    static ɵfac: ɵngcc0.ɵɵFactoryDef<A>;\n    static ɵdir: ɵngcc0.ɵɵDirectiveDefWithMeta');
     });
 
     it('should render imports into typings files', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -188,7 +188,7 @@ runInEachFileSystem(() => {
             decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
         const addDefinitionsSpy = testFormatter.addDefinitions as jasmine.Spy;
         expect(addDefinitionsSpy.calls.first().args[2])
-            .toEqual(`A.ngFactoryDef = function A_Factory(t) { return new (t || A)(); };
+            .toEqual(`A.ɵfac = function A_Factory(t) { return new (t || A)(); };
 A.ɵcmp = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], decls: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵtext(0);
     } if (rf & 2) {
@@ -229,7 +229,7 @@ A.ɵcmp = ɵngcc0.ɵɵdefineComponent({ type: A, selectors: [["a"]], decls: 1, v
              }));
 
              expect(addDefinitionsSpy.calls.first().args[2])
-                 .toEqual(`A.ngFactoryDef = function A_Factory(t) { return new (t || A)(); };
+                 .toEqual(`A.ɵfac = function A_Factory(t) { return new (t || A)(); };
 A.ɵdir = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
 /*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
         type: Directive,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
@@ -12,10 +12,5 @@ import {CompileResult} from '../../transform';
 
 export function compileNgFactoryDefField(metadata: R3FactoryDefMetadata): CompileResult {
   const res = compileFactoryFromMetadata(metadata);
-  return {
-    name: 'ngFactoryDef',
-    initializer: res.factory,
-    statements: res.statements,
-    type: res.type
-  };
+  return {name: 'ɵfac', initializer: res.factory, statements: res.statements, type: res.type};
 }

--- a/packages/compiler-cli/src/transformers/nocollapse_hack.ts
+++ b/packages/compiler-cli/src/transformers/nocollapse_hack.ts
@@ -26,7 +26,7 @@ const R3_DEF_NAME_PATTERN = [
   'ngInjectorDef',
   'ngModuleDef',
   'ngPipeDef',
-  'ngFactoryDef',
+  'ɵfac',
 ].join('|');
 
 // Pattern matching `Identifier.property` where property is a Render3 property.

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -44,7 +44,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -93,7 +93,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -141,7 +141,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -189,7 +189,7 @@ describe('compiler compliance', () => {
 
       // The factory should look like this:
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -305,7 +305,7 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "id"]],
@@ -360,7 +360,7 @@ describe('compiler compliance', () => {
       ///////////////
 
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -475,7 +475,7 @@ describe('compiler compliance', () => {
       };
 
       const factory =
-          'MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         MyComponent.ɵcmp = i0.ɵɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
             decls: 1,
@@ -579,7 +579,7 @@ describe('compiler compliance', () => {
         });`;
 
       const ChildComponentFactory =
-          `ChildComponent.ngFactoryDef = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
+          `ChildComponent.ɵfac = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
 
       // SomeDirective definition should be:
       const SomeDirectiveDefinition = `
@@ -590,7 +590,7 @@ describe('compiler compliance', () => {
       `;
 
       const SomeDirectiveFactory =
-          `SomeDirective.ngFactoryDef = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+          `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // MyComponent definition should be:
       const MyComponentDefinition = `
@@ -613,17 +613,17 @@ describe('compiler compliance', () => {
       `;
 
       const MyComponentFactory =
-          `MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+          `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, ChildComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
+      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ɵfac');
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryDef');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponentDefinition.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ngFactoryDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ɵfac');
     });
 
     it('should support complex selectors', () => {
@@ -653,7 +653,7 @@ describe('compiler compliance', () => {
       `;
 
       const SomeDirectiveFactory =
-          `SomeDirective.ngFactoryDef = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+          `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
       // OtherDirective definition should be:
       const OtherDirectiveDefinition = `
@@ -664,15 +664,15 @@ describe('compiler compliance', () => {
       `;
 
       const OtherDirectiveFactory =
-          `OtherDirective.ngFactoryDef = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
+          `OtherDirective.ɵfac = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ngFactoryDef');
+      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
       expectEmit(source, OtherDirectiveDefinition, 'Incorrect OtherDirective.ɵdir');
-      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ngFactoryDef');
+      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ɵfac');
     });
 
     it('should support components without selector', () => {
@@ -708,14 +708,13 @@ describe('compiler compliance', () => {
       `;
 
       const EmptyOutletComponentFactory =
-          `EmptyOutletComponent.ngFactoryDef = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
+          `EmptyOutletComponent.ɵfac = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, EmptyOutletComponentDefinition, 'Incorrect EmptyOutletComponent.ɵcmp');
-      expectEmit(
-          source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ngFactoryDef');
+      expectEmit(source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ɵfac');
     });
 
     it('should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting',
@@ -750,7 +749,7 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-         const MyComponentFactory = `MyComponent.ngFactoryDef = function MyComponent_Factory(t) {
+         const MyComponentFactory = `MyComponent.ɵfac = function MyComponent_Factory(t) {
             return new (t || MyComponent)(
               $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
               $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
@@ -760,7 +759,7 @@ describe('compiler compliance', () => {
          const source = result.source;
 
          expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
+         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
        });
 
     it('should support structural directives', () => {
@@ -794,7 +793,7 @@ describe('compiler compliance', () => {
           selectors: [["", "if", ""]]
         });`;
       const IfDirectiveFactory =
-          `IfDirective.ngFactoryDef = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
+          `IfDirective.ɵfac = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
 
       const MyComponentDefinition = `
         const $c1$ = ["foo", ""];
@@ -830,15 +829,15 @@ describe('compiler compliance', () => {
         });`;
 
       const MyComponentFactory =
-          `MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+          `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, IfDirectiveDefinition, 'Incorrect IfDirective.ɵdir');
-      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ngFactoryDef');
+      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ɵfac');
       expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
     });
 
     describe('value composition', () => {
@@ -2024,8 +2023,8 @@ describe('compiler compliance', () => {
             });
         `;
 
-        const MyPipengFactoryDef = `
-          MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
+        const MyPipeFactoryDef = `
+          MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
         `;
 
         const MyPurePipeDefinition = `
@@ -2035,8 +2034,8 @@ describe('compiler compliance', () => {
               pure: true
             });`;
 
-        const MyPurePipengFactoryDef = `
-          MyPurePipe.ngFactoryDef = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
+        const MyPurePipeFactoryDef = `
+          MyPurePipe.ɵfac = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
         `;
 
         const MyAppDefinition = `
@@ -2074,9 +2073,9 @@ describe('compiler compliance', () => {
         const source = result.source;
 
         expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
-        expectEmit(source, MyPipengFactoryDef, 'Invalid pipe factory function');
+        expectEmit(source, MyPipeFactoryDef, 'Invalid pipe factory function');
         expectEmit(source, MyPurePipeDefinition, 'Invalid pure pipe definition');
-        expectEmit(source, MyPurePipengFactoryDef, 'Invalid pure pipe factory function');
+        expectEmit(source, MyPurePipeFactoryDef, 'Invalid pure pipe factory function');
         expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
       });
 
@@ -2191,7 +2190,7 @@ describe('compiler compliance', () => {
             `;
 
            const MyPipeFactory = `
-              MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
+              MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
             `;
 
            const MyOtherPipeDefinition = `
@@ -2202,7 +2201,7 @@ describe('compiler compliance', () => {
               });`;
 
            const MyOtherPipeFactory = `
-              MyOtherPipe.ngFactoryDef = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
+              MyOtherPipe.ɵfac = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
             `;
 
            const result = compile(files, angularFiles);
@@ -2603,8 +2602,7 @@ describe('compiler compliance', () => {
               });
             `;
 
-        const ForDirectiveFactory =
-            `ForOfDirective.ngFactoryDef = function ForOfDirective_Factory(t) {
+        const ForDirectiveFactory = `ForOfDirective.ɵfac = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };`;
 
@@ -2685,7 +2683,7 @@ describe('compiler compliance', () => {
         `;
 
         const ForDirectiveFactory = `
-          ForOfDirective.ngFactoryDef = function ForOfDirective_Factory(t) {
+          ForOfDirective.ɵfac = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };
         `;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -48,7 +48,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      MyComponent.ngFactoryDef = function MyComponent_Factory(t) {
+      MyComponent.ɵfac = function MyComponent_Factory(t) {
         return new (t || MyComponent)(
           $r3$.ɵɵinjectAttribute('name'),
           $r3$.ɵɵdirectiveInject(MyService),
@@ -83,7 +83,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      MyService.ngFactoryDef = function MyService_Factory(t) {
+      MyService.ɵfac = function MyService_Factory(t) {
         return new (t || MyService)($r3$.ɵɵinject(MyDependency));
       }`;
 
@@ -91,7 +91,7 @@ describe('compiler compliance: dependency injection', () => {
       MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
         token: MyService,
         factory: function(t) {
-          return MyService.ngFactoryDef(t);
+          return MyService.ɵfac(t);
         },
         providedIn: null
       });
@@ -102,7 +102,7 @@ describe('compiler compliance: dependency injection', () => {
     expectEmit(result.source, def, 'Incorrect injectable definition');
   });
 
-  it('should create a single ngFactoryDef if the class has more than one decorator', () => {
+  it('should create a single factory def if the class has more than one decorator', () => {
     const files = {
       app: {
         'spec.ts': `
@@ -117,7 +117,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const result = compile(files, angularFiles).source;
-    const matches = result.match(/MyPipe\.ngFactoryDef = function MyPipe_Factory/g);
+    const matches = result.match(/MyPipe\.ɵfac = function MyPipe_Factory/g);
     expect(matches ? matches.length : 0).toBe(1);
   });
 
@@ -220,7 +220,7 @@ describe('compiler compliance: dependency injection', () => {
           MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function(t) {
-              return MyAlternateService.ngFactoryDef(t);
+              return MyAlternateService.ɵfac(t);
             },
             providedIn: null
           });
@@ -293,7 +293,7 @@ describe('compiler compliance: dependency injection', () => {
       SomeProvider.ngInjectableDef = $r3$.ɵɵdefineInjectable({
         token: SomeProvider,
         factory: function(t) {
-          return SomeProviderImpl.ngFactoryDef(t);
+          return SomeProviderImpl.ɵfac(t);
         },
         providedIn: 'root'
       });
@@ -343,17 +343,17 @@ describe('compiler compliance: dependency injection', () => {
        const source = result.source;
 
        const MyPipeFactory = `
-        MyPipe.ngFactoryDef = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵdirectiveInject(Service)); };
+        MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵdirectiveInject(Service)); };
       `;
 
        const MyOtherPipeFactory = `
-        MyOtherPipe.ngFactoryDef = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵdirectiveInject(Service)); };
+        MyOtherPipe.ɵfac = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵdirectiveInject(Service)); };
       `;
 
        expectEmit(source, MyPipeFactory, 'Invalid pipe factory function');
        expectEmit(source, MyOtherPipeFactory, 'Invalid pipe factory function');
-       expect(source.match(/MyPipe\.ngFactoryDef =/g) !.length).toBe(1);
-       expect(source.match(/MyOtherPipe\.ngFactoryDef =/g) !.length).toBe(1);
+       expect(source.match(/MyPipe\.ɵfac =/g) !.length).toBe(1);
+       expect(source.match(/MyOtherPipe\.ɵfac =/g) !.length).toBe(1);
      });
 
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -53,14 +53,14 @@ describe('compiler compliance: directives', () => {
         `;
 
       const MyComponentFactory = `
-        MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+        MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
     });
 
     it('should not match directives on i18n-prefixed attributes', () => {
@@ -103,14 +103,14 @@ describe('compiler compliance: directives', () => {
         `;
 
       const MyComponentFactory = `
-        MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+        MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
       const result = compile(files, angularFiles);
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ngFactoryDef');
+      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
     });
 
     it('should match directives on element bindings', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -220,14 +220,14 @@ describe('compiler compliance: listen()', () => {
       `;
 
     const MyComponentFactory = `
-      MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+      MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     `;
 
     const result = compile(files, angularFiles);
     const source = result.source;
 
     expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-    expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ngFactoryDef');
+    expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
   });
 
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -144,7 +144,7 @@ describe('compiler compliance: providers', () => {
         result.source, `
     export class MyComponent {
     }
-    MyComponent.ngFactoryDef = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+    MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     MyComponent.ɵcmp = i0.ɵɵdefineComponent({
       type: MyComponent,
       selectors: [["my-component"]],

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -67,8 +67,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Dep>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with a generic service', () => {
@@ -85,7 +85,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('Store.ngInjectableDef =');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Store<any>>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Store<any>>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Store<any>>;');
     });
 
@@ -110,14 +110,14 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('Service.ngInjectableDef =');
       expect(jsContents)
           .toContain(
-              'Service.ngFactoryDef = function Service_Factory(t) { return new (t || Service)(i0.ɵɵinject(Dep)); };');
+              'Service.ɵfac = function Service_Factory(t) { return new (t || Service)(i0.ɵɵinject(Dep)); };');
       expect(jsContents).toContain('providedIn: \'root\' })');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Dep>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with providedIn and factory without errors', () => {
@@ -142,7 +142,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile Injectables with providedIn and factory with deps without errors', () => {
@@ -171,7 +171,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
     it('should compile @Injectable with an @Optional dependency', () => {
@@ -206,14 +206,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ɵcmp = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
+      expect(jsContents).toContain('TestCmp.ɵfac = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (dynamic inline template) without errors', () => {
@@ -231,7 +231,7 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ɵcmp = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
+      expect(jsContents).toContain('TestCmp.ɵfac = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
@@ -239,7 +239,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (function call inline template) without errors', () => {
@@ -260,14 +260,14 @@ runInEachFileSystem(os => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('TestCmp.ɵcmp = i0.ɵɵdefineComponent');
-      expect(jsContents).toContain('TestCmp.ngFactoryDef = function');
+      expect(jsContents).toContain('TestCmp.ɵfac = function');
       expect(jsContents).not.toContain('__decorate');
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
               'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestCmp>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
     });
 
     it('should compile Components (external template) without errors', () => {
@@ -899,10 +899,10 @@ runInEachFileSystem(os => {
               'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: false })');
       expect(jsContents)
           .toContain(
-              'TestPipe.ngFactoryDef = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
+              'TestPipe.ɵfac = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe>;');
     });
 
     it('should compile pure Pipes without errors', () => {
@@ -925,10 +925,10 @@ runInEachFileSystem(os => {
               'TestPipe.ngPipeDef = i0.ɵɵdefinePipe({ name: "test-pipe", type: TestPipe, pure: true })');
       expect(jsContents)
           .toContain(
-              'TestPipe.ngFactoryDef = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
+              'TestPipe.ɵfac = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe>;');
     });
 
     it('should compile Pipes with dependencies', () => {
@@ -969,7 +969,7 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain('static ngPipeDef: i0.ɵɵPipeDefWithMeta<TestPipe<any>, "test-pipe">;');
-      expect(dtsContents).toContain('static ngFactoryDef: i0.ɵɵFactoryDef<TestPipe<any>>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe<any>>;');
     });
 
     it('should include @Pipes in @NgModule scopes', () => {
@@ -1309,8 +1309,7 @@ runInEachFileSystem(os => {
 
           env.driveMain();
           const jsContents = env.getContents('test.js');
-          expect(jsContents)
-              .toContain('Test.ngFactoryDef = function Test_Factory(t) { throw new Error(');
+          expect(jsContents).toContain('Test.ɵfac = function Test_Factory(t) { throw new Error(');
         });
 
         it('should compile an @Injectable provided in the root on a class with a non-injectable constructor',
@@ -1327,7 +1326,7 @@ runInEachFileSystem(os => {
              env.driveMain();
              const jsContents = env.getContents('test.js');
              expect(jsContents)
-                 .toContain('Test.ngFactoryDef = function Test_Factory(t) { throw new Error(');
+                 .toContain('Test.ɵfac = function Test_Factory(t) { throw new Error(');
            });
 
       });
@@ -1640,7 +1639,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents)
           .toContain(
-              `FooCmp.ngFactoryDef = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
+              `FooCmp.ɵfac = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
     });
 
     it('should generate queries for components', () => {

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -117,8 +117,8 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
 function delegateToFactory(type: o.Expression) {
   return {
     statements: [],
-    // () => meta.type.ngFactoryDef(t)
+    // () => meta.type.ɵfac(t)
     factory: o.fn([new o.FnParam('t', o.DYNAMIC_TYPE)], [new o.ReturnStatement(type.callMethod(
-                                                            'ngFactoryDef', [o.variable('t')]))])
+                                                            'ɵfac', [o.variable('t')]))])
   };
 }

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -259,7 +259,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata, isPipe = false):
 }
 
 /**
- * Constructs the `ngFactoryDef` from directive/component/pipe metadata.
+ * Constructs the factory def (`ɵfac`) from directive/component/pipe metadata.
  */
 export function compileFactoryFromMetadata(meta: R3FactoryDefMetadata): R3FactoryFn {
   return compileFactoryFunction(

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -97,7 +97,7 @@ export function compilePipeFromRender2(
       /* parent */ null,
       /* fields */
       [new o.ClassField(
-          /* name */ 'ngFactoryDef',
+          /* name */ 'ɵfac',
           /* type */ o.INFERRED_TYPE,
           /* modifiers */[o.StmtModifier.Static],
           /* initializer */ factoryRes.factory)],

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -334,9 +334,8 @@ export function compileDirectiveFromRender2(
   const factoryRes = compileFactoryFromMetadata({...meta, injectFn: R3.directiveInject});
   const ngFactoryDefStatement = new o.ClassStmt(
       name, null,
-      [new o.ClassField(
-          'ngFactoryDef', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
-      [], new o.ClassMethod(null, [], []), []);
+      [new o.ClassField('ɵfac', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)], [],
+      new o.ClassMethod(null, [], []), []);
   const directiveDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(definitionField, o.INFERRED_TYPE, [o.StmtModifier.Static], res.expression)],
@@ -387,9 +386,8 @@ export function compileComponentFromRender2(
   const factoryRes = compileFactoryFromMetadata({...meta, injectFn: R3.directiveInject});
   const ngFactoryDefStatement = new o.ClassStmt(
       name, null,
-      [new o.ClassField(
-          'ngFactoryDef', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)],
-      [], new o.ClassMethod(null, [], []), []);
+      [new o.ClassField('ɵfac', o.INFERRED_TYPE, [o.StmtModifier.Static], factoryRes.factory)], [],
+      new o.ClassMethod(null, [], []), []);
   const componentDefStatement = new o.ClassStmt(
       name, null,
       [new o.ClassField(definitionField, o.INFERRED_TYPE, [o.StmtModifier.Static], res.expression)],

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -48,8 +48,8 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
       get: () => {
         if (ngFactoryDef === null) {
           const metadata = getInjectableMetadata(type, srcMeta);
-          ngFactoryDef = getCompilerFacade().compileFactory(
-              angularCoreDiEnv, `ng:///${type.name}/ngFactoryDef.js`, {
+          ngFactoryDef =
+              getCompilerFacade().compileFactory(angularCoreDiEnv, `ng:///${type.name}/ɵfac.js`, {
                 name: metadata.name,
                 type: metadata.type,
                 typeArgumentCount: metadata.typeArgumentCount,

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -760,7 +760,7 @@ export function getFactoryDef<T>(type: any): FactoryFn<T>|null;
 export function getFactoryDef<T>(type: any, throwNotFound?: boolean): FactoryFn<T>|null {
   const hasFactoryDef = type.hasOwnProperty(NG_FACTORY_DEF);
   if (!hasFactoryDef && throwNotFound === true && ngDevMode) {
-    throw new Error(`Type ${stringify(type)} does not have 'ngFactoryDef' property.`);
+    throw new Error(`Type ${stringify(type)} does not have 'ɵfac' property.`);
   }
   return hasFactoryDef ? type[NG_FACTORY_DEF] : null;
 }

--- a/packages/core/src/render3/fields.ts
+++ b/packages/core/src/render3/fields.ts
@@ -14,7 +14,7 @@ export const NG_PIPE_DEF = getClosureSafeProperty({ngPipeDef: getClosureSafeProp
 export const NG_MODULE_DEF = getClosureSafeProperty({ngModuleDef: getClosureSafeProperty});
 export const NG_LOCALE_ID_DEF = getClosureSafeProperty({ngLocaleIdDef: getClosureSafeProperty});
 export const NG_BASE_DEF = getClosureSafeProperty({ngBaseDef: getClosureSafeProperty});
-export const NG_FACTORY_DEF = getClosureSafeProperty({ngFactoryDef: getClosureSafeProperty});
+export const NG_FACTORY_DEF = getClosureSafeProperty({ɵfac: getClosureSafeProperty});
 
 /**
  * If a directive is diPublic, bloomAdd sets a property on the type with this constant as

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -80,7 +80,7 @@ export interface ComponentType<T> extends Type<T> { ɵcmp: never; }
  */
 export interface DirectiveType<T> extends Type<T> {
   ɵdir: never;
-  ngFactoryDef: () => T;
+  ɵfac: () => T;
 }
 
 export enum DirectiveDefFlags {

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -166,7 +166,7 @@ function addDirectiveFactoryDef(type: Type<any>, metadata: Directive | Component
       if (ngFactoryDef === null) {
         const meta = getDirectiveMetadata(type, metadata);
         ngFactoryDef = getCompilerFacade().compileFactory(
-            angularCoreEnv, `ng:///${type.name}/ngFactoryDef.js`,
+            angularCoreEnv, `ng:///${type.name}/ɵfac.js`,
             {...meta.metadata, injectFn: 'directiveInject', isPipe: false});
       }
       return ngFactoryDef;

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -23,7 +23,7 @@ export function compilePipe(type: Type<any>, meta: Pipe): void {
       if (ngFactoryDef === null) {
         const metadata = getPipeMetadata(type, meta);
         ngFactoryDef = getCompilerFacade().compileFactory(
-            angularCoreEnv, `ng:///${metadata.name}/ngFactoryDef.js`,
+            angularCoreEnv, `ng:///${metadata.name}/ɵfac.js`,
             {...metadata, injectFn: 'directiveInject', isPipe: true});
       }
       return ngFactoryDef;

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -33,7 +33,7 @@ describe('iv perf test', () => {
 
       it(`${iteration}. create ${count} divs in Render3`, () => {
         class Component {
-          static ngFactoryDef = () => new Component;
+          static ɵfac = () => new Component;
           static ɵcmp = ɵɵdefineComponent({
             type: Component,
             selectors: [['div']],

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -25,7 +25,7 @@ describe('change detection', () => {
       doCheckCount = 0;
       ngDoCheck(): void { this.doCheckCount++; }
 
-      static ngFactoryDef = () => new MyComponent();
+      static ɵfac = () => new MyComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -101,7 +101,7 @@ describe('change detection', () => {
 
       onClick() {}
 
-      static ngFactoryDef = () => comp = new MyComponent();
+      static ɵfac = () => comp = new MyComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],
@@ -139,7 +139,7 @@ describe('change detection', () => {
 
         onClick() {}
 
-        static ngFactoryDef = () => comp = new ManualComponent();
+        static ɵfac = () => comp = new ManualComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: ManualComponent,
           selectors: [['manual-comp']],
@@ -175,7 +175,7 @@ describe('change detection', () => {
       class ManualApp {
         name: string = 'Nancy';
 
-        static ngFactoryDef = () => new ManualApp();
+        static ɵfac = () => new ManualApp();
         static ɵcmp = ɵɵdefineComponent({
           type: ManualApp,
           selectors: [['manual-app']],
@@ -230,7 +230,7 @@ describe('change detection', () => {
              doCheckCount = 0;
              ngDoCheck(): void { this.doCheckCount++; }
 
-             static ngFactoryDef = () => parent = new ButtonParent();
+             static ɵfac = () => parent = new ButtonParent();
              static ɵcmp = ɵɵdefineComponent({
                type: ButtonParent,
                selectors: [['button-parent']],
@@ -307,7 +307,7 @@ describe('change detection', () => {
         return 'works';
       }
 
-      static ngFactoryDef = () => new MyComponent();
+      static ɵfac = () => new MyComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-comp']],

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -25,7 +25,7 @@ NgForOf.ɵdir = ɵɵdefineDirective({
   }
 });
 
-NgForOf.ngFactoryDef = () => new NgForOfDef(
+NgForOf.ɵfac = () => new NgForOfDef(
     ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any),
     ɵɵdirectiveInject(IterableDiffers));
 
@@ -35,7 +35,7 @@ NgIf.ɵdir = ɵɵdefineDirective({
   inputs: {ngIf: 'ngIf', ngIfThen: 'ngIfThen', ngIfElse: 'ngIfElse'}
 });
 
-NgIf.ngFactoryDef = () =>
+NgIf.ɵfac = () =>
     new NgIfDef(ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any));
 
 NgTemplateOutlet.ɵdir = ɵɵdefineDirective({
@@ -46,5 +46,4 @@ NgTemplateOutlet.ɵdir = ɵɵdefineDirective({
       {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}
 });
 
-NgTemplateOutlet.ngFactoryDef = () =>
-    new NgTemplateOutletDef(ɵɵdirectiveInject(ViewContainerRef as any));
+NgTemplateOutlet.ɵfac = () => new NgTemplateOutletDef(ɵɵdirectiveInject(ViewContainerRef as any));

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -20,7 +20,7 @@ describe('ComponentFactory', () => {
   describe('constructor()', () => {
     it('should correctly populate default properties', () => {
       class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
+        static ɵfac = () => new TestComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: TestComponent,
           selectors: [['test', 'foo'], ['bar']],
@@ -41,7 +41,7 @@ describe('ComponentFactory', () => {
 
     it('should correctly populate defined properties', () => {
       class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
+        static ɵfac = () => new TestComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,
@@ -89,7 +89,7 @@ describe('ComponentFactory', () => {
       createRenderer3Spy = spyOn(domRendererFactory3, 'createRenderer').and.callThrough();
 
       class TestComponent {
-        static ngFactoryDef = () => new TestComponent();
+        static ɵfac = () => new TestComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -21,7 +21,7 @@ describe('component', () => {
 
     increment() { this.count++; }
 
-    static ngFactoryDef = () => new CounterComponent;
+    static ɵfac = () => new CounterComponent;
     static ɵcmp = ɵɵdefineComponent({
       type: CounterComponent,
       encapsulation: ViewEncapsulation.None,
@@ -71,7 +71,7 @@ describe('component', () => {
     }
     class MyComponent {
       constructor(public myService: MyService) {}
-      static ngFactoryDef = () => new MyComponent(ɵɵdirectiveInject(MyService));
+      static ɵfac = () => new MyComponent(ɵɵdirectiveInject(MyService));
       static ɵcmp = ɵɵdefineComponent({
         type: MyComponent,
         encapsulation: ViewEncapsulation.None,
@@ -115,7 +115,7 @@ describe('component', () => {
       // @Input
       name = '';
 
-      static ngFactoryDef = () => new Comp();
+      static ɵfac = () => new Comp();
       static ɵcmp = ɵɵdefineComponent({
         type: Comp,
         selectors: [['comp']],
@@ -169,7 +169,7 @@ it('should not invoke renderer destroy method for embedded views', () => {
   class Comp {
     visible = true;
 
-    static ngFactoryDef =
+    static ɵfac =
         () => {
           comp = new Comp();
           return comp;
@@ -247,7 +247,7 @@ describe('component with a container', () => {
   class WrapperComponent {
     // TODO(issue/24571): remove '!'.
     items !: string[];
-    static ngFactoryDef = () => new WrapperComponent;
+    static ɵfac = () => new WrapperComponent;
     static ɵcmp = ɵɵdefineComponent({
       type: WrapperComponent,
       encapsulation: ViewEncapsulation.None,
@@ -324,7 +324,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
-    static ngFactoryDef = () => new TreeComponent();
+    static ɵfac = () => new TreeComponent();
     static ɵcmp = ɵɵdefineComponent({
       type: TreeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -389,7 +389,7 @@ describe('recursive components', () => {
 
     ngOnDestroy() { events.push('destroy' + this.data.value); }
 
-    static ngFactoryDef = () => new NgIfTree();
+    static ɵfac = () => new NgIfTree();
     static ɵcmp = ɵɵdefineComponent({
       type: NgIfTree,
       encapsulation: ViewEncapsulation.None,
@@ -530,7 +530,7 @@ describe('recursive components', () => {
     class TestInputsComponent {
       // TODO(issue/24571): remove '!'.
       minifiedName !: string;
-      static ngFactoryDef = () => new TestInputsComponent();
+      static ɵfac = () => new TestInputsComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: TestInputsComponent,
         encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -693,7 +693,7 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates in test below so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
-      static ngFactoryDef =
+      static ɵfac =
           () => {
             log.push('comp!');
             return new Comp();
@@ -712,7 +712,7 @@ describe('JS control flow', () => {
       condition = true;
       condition2 = true;
 
-      static ngFactoryDef = () => new App();
+      static ɵfac = () => new App();
       static ɵcmp = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],
@@ -763,7 +763,7 @@ describe('JS control flow', () => {
     // Intentionally duplicating the templates from above so we are
     // testing the behavior on firstTemplatePass for each of these tests
     class Comp {
-      static ngFactoryDef =
+      static ɵfac =
           () => {
             log.push('comp!');
             return new Comp();
@@ -782,7 +782,7 @@ describe('JS control flow', () => {
       condition = false;
       condition2 = true;
 
-      static ngFactoryDef = () => new App();
+      static ɵfac = () => new App();
       static ɵcmp = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -28,7 +28,7 @@ describe('di', () => {
     class DirB {
       value = 'DirB';
 
-      static ngFactoryDef = () => new DirB();
+      static ɵfac = () => new DirB();
       static ɵdir =
           ɵɵdefineDirective({selectors: [['', 'dirB', '']], type: DirB, inputs: {value: 'value'}});
     }
@@ -39,7 +39,7 @@ describe('di', () => {
         // TODO(issue/24571): remove '!'.
         value !: string;
 
-        static ngFactoryDef = () => new DirB();
+        static ɵfac = () => new DirB();
         static ɵdir =
             ɵɵdefineDirective({type: DirB, selectors: [['', 'dirB', '']], inputs: {value: 'dirB'}});
       }
@@ -50,7 +50,7 @@ describe('di', () => {
         class DirA {
           constructor(@Optional() public dirB: DirB|null) {}
 
-          static ngFactoryDef =
+          static ɵfac =
               () => {
                 dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Optional));
                 return dirA;
@@ -81,7 +81,7 @@ describe('di', () => {
         class DirA {
           constructor(@Self() public dirB: DirB) {}
 
-          static ngFactoryDef = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
+          static ɵfac = () => dirA = new DirA(ɵɵdirectiveInject(DirB, InjectFlags.Self));
           static ɵdir = ɵɵdefineDirective({type: DirA, selectors: [['', 'dirA', '']]});
         }
 
@@ -117,7 +117,7 @@ describe('di', () => {
     class MyComp {
       constructor(public renderer: Renderer2) {}
 
-      static ngFactoryDef = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
+      static ɵfac = () => new MyComp(ɵɵdirectiveInject(Renderer2 as any));
       static ɵcmp = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['my-comp']],

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -240,7 +240,7 @@ describe('instructions', () => {
       class NestedLoops {
         rows = [['a', 'b'], ['A', 'B'], ['a', 'b'], ['A', 'B']];
 
-        static ngFactoryDef = function ToDoAppComponent_Factory() { return new NestedLoops(); };
+        static ɵfac = function ToDoAppComponent_Factory() { return new NestedLoops(); };
         static ɵcmp = ɵɵdefineComponent({
           type: NestedLoops,
           selectors: [['nested-loops']],

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -117,7 +117,7 @@ describe('render3 integration test', () => {
       // TODO(issue/24571): remove '!'.
       afterTree !: Tree;
 
-      static ngFactoryDef = () => new ChildComponent;
+      static ɵfac = () => new ChildComponent;
       static ɵcmp = ɵɵdefineComponent({
         selectors: [['child']],
         type: ChildComponent,
@@ -199,7 +199,7 @@ describe('render3 integration test', () => {
 describe('component styles', () => {
   it('should pass in the component styles directly into the underlying renderer', () => {
     class StyledComp {
-      static ngFactoryDef = () => new StyledComp();
+      static ɵfac = () => new StyledComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StyledComp,
         styles: ['div { color: red; }'],
@@ -227,7 +227,7 @@ describe('component animations', () => {
     const animB = {name: 'b'};
 
     class AnimComp {
-      static ngFactoryDef = () => new AnimComp();
+      static ɵfac = () => new AnimComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AnimComp,
         decls: 0,
@@ -254,7 +254,7 @@ describe('component animations', () => {
 
   it('should include animations in the renderType data array even if the array is empty', () => {
     class AnimComp {
-      static ngFactoryDef = () => new AnimComp();
+      static ɵfac = () => new AnimComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AnimComp,
         decls: 0,
@@ -274,7 +274,7 @@ describe('component animations', () => {
 
   it('should allow [@trigger] bindings to be picked up by the underlying renderer', () => {
     class AnimComp {
-      static ngFactoryDef = () => new AnimComp();
+      static ɵfac = () => new AnimComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AnimComp,
         decls: 1,
@@ -311,7 +311,7 @@ describe('component animations', () => {
   it('should allow creation-level [@trigger] properties to be picked up by the underlying renderer',
      () => {
        class AnimComp {
-         static ngFactoryDef = () => new AnimComp();
+         static ɵfac = () => new AnimComp();
          static ɵcmp = ɵɵdefineComponent({
            type: AnimComp,
            decls: 1,
@@ -345,7 +345,7 @@ describe('component animations', () => {
 
   //   it('should allow host binding animations to be picked up and rendered', () => {
   //     class ChildCompWithAnim {
-  //       static ngFactoryDef = () => new ChildCompWithAnim();
+  //       static ɵfac = () => new ChildCompWithAnim();
   //       static ɵdir = ɵɵdefineDirective({
   //         type: ChildCompWithAnim,
   //         selectors: [['child-comp-with-anim']],
@@ -360,7 +360,7 @@ describe('component animations', () => {
   //     }
 
   //     class ParentComp {
-  //       static ngFactoryDef = () => new ParentComp();
+  //       static ɵfac = () => new ParentComp();
   //       static ɵcmp = ɵɵdefineComponent({
   //         type: ParentComp,
   //         decls: 1,
@@ -390,7 +390,7 @@ describe('component animations', () => {
 describe('element discovery', () => {
   it('should only monkey-patch immediate child nodes in a component', () => {
     class StructuredComp {
-      static ngFactoryDef = () => new StructuredComp();
+      static ɵfac = () => new StructuredComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -422,7 +422,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in a sub component', () => {
     class ChildComp {
-      static ngFactoryDef = () => new ChildComp();
+      static ɵfac = () => new ChildComp();
       static ɵcmp = ɵɵdefineComponent({
         type: ChildComp,
         selectors: [['child-comp']],
@@ -439,7 +439,7 @@ describe('element discovery', () => {
     }
 
     class ParentComp {
-      static ngFactoryDef = () => new ParentComp();
+      static ɵfac = () => new ParentComp();
       static ɵcmp = ɵɵdefineComponent({
         type: ParentComp,
         selectors: [['parent-comp']],
@@ -472,7 +472,7 @@ describe('element discovery', () => {
 
   it('should only monkey-patch immediate child nodes in an embedded template container', () => {
     class StructuredComp {
-      static ngFactoryDef = () => new StructuredComp();
+      static ɵfac = () => new StructuredComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -522,7 +522,7 @@ describe('element discovery', () => {
 
   it('should return a context object from a given dom node', () => {
     class StructuredComp {
-      static ngFactoryDef = () => new StructuredComp();
+      static ɵfac = () => new StructuredComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -560,7 +560,7 @@ describe('element discovery', () => {
 
   it('should cache the element context on a element was pre-emptively monkey-patched', () => {
     class StructuredComp {
-      static ngFactoryDef = () => new StructuredComp();
+      static ɵfac = () => new StructuredComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -592,7 +592,7 @@ describe('element discovery', () => {
   it('should cache the element context on an intermediate element that isn\'t pre-emptively monkey-patched',
      () => {
        class StructuredComp {
-         static ngFactoryDef = () => new StructuredComp();
+         static ɵfac = () => new StructuredComp();
          static ɵcmp = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -625,7 +625,7 @@ describe('element discovery', () => {
   it('should be able to pull in element context data even if the element is decorated using styling',
      () => {
        class StructuredComp {
-         static ngFactoryDef = () => new StructuredComp();
+         static ɵfac = () => new StructuredComp();
          static ɵcmp = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -673,7 +673,7 @@ describe('element discovery', () => {
          </section>
        */
        class ProjectorComp {
-         static ngFactoryDef = () => new ProjectorComp();
+         static ɵfac = () => new ProjectorComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ProjectorComp,
            selectors: [['projector-comp']],
@@ -696,7 +696,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryDef = () => new ParentComp();
+         static ɵfac = () => new ParentComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -770,7 +770,7 @@ describe('element discovery', () => {
   it('should return `null` when an element context is retrieved that is a DOM node that was not created by Angular',
      () => {
        class StructuredComp {
-         static ngFactoryDef = () => new StructuredComp();
+         static ɵfac = () => new StructuredComp();
          static ɵcmp = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -797,7 +797,7 @@ describe('element discovery', () => {
 
   it('should by default monkey-patch the bootstrap component with context details', () => {
     class StructuredComp {
-      static ngFactoryDef = () => new StructuredComp();
+      static ɵfac = () => new StructuredComp();
       static ɵcmp = ɵɵdefineComponent({
         type: StructuredComp,
         selectors: [['structured-comp']],
@@ -836,22 +836,22 @@ describe('element discovery', () => {
        let myDir3Instance: MyDir2|null = null;
 
        class MyDir1 {
-         static ngFactoryDef = () => myDir1Instance = new MyDir1();
+         static ɵfac = () => myDir1Instance = new MyDir1();
          static ɵdir = ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
        }
 
        class MyDir2 {
-         static ngFactoryDef = () => myDir2Instance = new MyDir2();
+         static ɵfac = () => myDir2Instance = new MyDir2();
          static ɵdir = ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
        }
 
        class MyDir3 {
-         static ngFactoryDef = () => myDir3Instance = new MyDir2();
+         static ɵfac = () => myDir3Instance = new MyDir2();
          static ɵdir = ɵɵdefineDirective({type: MyDir3, selectors: [['', 'my-dir-3', '']]});
        }
 
        class StructuredComp {
-         static ngFactoryDef = () => new StructuredComp();
+         static ɵfac = () => new StructuredComp();
          static ɵcmp = ɵɵdefineComponent({
            type: StructuredComp,
            selectors: [['structured-comp']],
@@ -917,17 +917,17 @@ describe('element discovery', () => {
        let childComponentInstance: ChildComp|null = null;
 
        class MyDir1 {
-         static ngFactoryDef = () => myDir1Instance = new MyDir1();
+         static ɵfac = () => myDir1Instance = new MyDir1();
          static ɵdir = ɵɵdefineDirective({type: MyDir1, selectors: [['', 'my-dir-1', '']]});
        }
 
        class MyDir2 {
-         static ngFactoryDef = () => myDir2Instance = new MyDir2();
+         static ɵfac = () => myDir2Instance = new MyDir2();
          static ɵdir = ɵɵdefineDirective({type: MyDir2, selectors: [['', 'my-dir-2', '']]});
        }
 
        class ChildComp {
-         static ngFactoryDef = () => childComponentInstance = new ChildComp();
+         static ɵfac = () => childComponentInstance = new ChildComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -942,7 +942,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryDef = () => new ParentComp();
+         static ɵfac = () => new ParentComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -1005,7 +1005,7 @@ describe('element discovery', () => {
   it('should monkey-patch sub components with the view data and then replace them with the context result once a lookup occurs',
      () => {
        class ChildComp {
-         static ngFactoryDef = () => new ChildComp();
+         static ɵfac = () => new ChildComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ChildComp,
            selectors: [['child-comp']],
@@ -1022,7 +1022,7 @@ describe('element discovery', () => {
        }
 
        class ParentComp {
-         static ngFactoryDef = () => new ParentComp();
+         static ɵfac = () => new ParentComp();
          static ɵcmp = ɵɵdefineComponent({
            type: ParentComp,
            selectors: [['parent-comp']],
@@ -1066,7 +1066,7 @@ describe('element discovery', () => {
 describe('sanitization', () => {
   it('should sanitize data using the provided sanitization interface', () => {
     class SanitizationComp {
-      static ngFactoryDef = () => new SanitizationComp();
+      static ɵfac = () => new SanitizationComp();
       static ɵcmp = ɵɵdefineComponent({
         type: SanitizationComp,
         selectors: [['sanitize-this']],
@@ -1108,7 +1108,7 @@ describe('sanitization', () => {
       // @HostBinding()
       cite: any = 'http://cite-dir-value';
 
-      static ngFactoryDef = () => hostBindingDir = new UnsafeUrlHostBindingDir();
+      static ɵfac = () => hostBindingDir = new UnsafeUrlHostBindingDir();
       static ɵdir = ɵɵdefineDirective({
         type: UnsafeUrlHostBindingDir,
         selectors: [['', 'unsafeUrlHostBindingDir', '']],
@@ -1124,7 +1124,7 @@ describe('sanitization', () => {
     }
 
     class SimpleComp {
-      static ngFactoryDef = () => new SimpleComp();
+      static ɵfac = () => new SimpleComp();
       static ɵcmp = ɵɵdefineComponent({
         type: SimpleComp,
         selectors: [['sanitize-this']],

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -34,7 +34,7 @@ ivyEnabled && describe('render3 jit', () => {
     const SomeCmpAny = SomeCmp as any;
 
     expect(SomeCmpAny.ɵcmp).toBeDefined();
-    expect(SomeCmpAny.ngFactoryDef() instanceof SomeCmp).toBe(true);
+    expect(SomeCmpAny.ɵfac() instanceof SomeCmp).toBe(true);
   });
 
   it('compiles an injectable with a type provider', () => {
@@ -242,7 +242,7 @@ ivyEnabled && describe('render3 jit', () => {
     }
 
     const pipeDef = (P as any).ngPipeDef as PipeDef<P>;
-    const pipeFactory = (P as any).ngFactoryDef as FactoryFn<P>;
+    const pipeFactory = (P as any).ɵfac as FactoryFn<P>;
     expect(pipeDef.name).toBe('test-pipe');
     expect(pipeDef.pure).toBe(false, 'pipe should not be pure');
     expect(pipeFactory() instanceof P)

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -55,7 +55,7 @@ describe('lifecycles', () => {
           events.push(`${name}${this.val}`);
         }
 
-        static ngFactoryDef = () => new Component();
+        static ɵfac = () => new Component();
         static ɵcmp = ɵɵdefineComponent({
           type: Component,
           selectors: [[name]],
@@ -70,7 +70,7 @@ describe('lifecycles', () => {
     class Directive {
       ngOnInit() { events.push('dir'); }
 
-      static ngFactoryDef = () => new Directive();
+      static ɵfac = () => new Directive();
       static ɵdir = ɵɵdefineDirective({type: Directive, selectors: [['', 'dir', '']]});
     }
 

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -27,7 +27,7 @@ describe('event listeners', () => {
 
     onClick() { this.counter++; }
 
-    static ngFactoryDef =
+    static ɵfac =
         () => {
           let comp = new MyComp();
           comps.push(comp);
@@ -60,7 +60,7 @@ describe('event listeners', () => {
     /* @HostListener('body:click') */
     onBodyClick() { events.push('component - body:click'); }
 
-    static ngFactoryDef =
+    static ɵfac =
         () => {
           let comp = new MyCompWithGlobalListeners();
           comps.push(comp);
@@ -98,9 +98,7 @@ describe('event listeners', () => {
     /* @HostListener('body:click') */
     onBodyClick() { events.push('directive - body:click'); }
 
-    static ngFactoryDef = function HostListenerDir_Factory() {
-      return new GlobalHostListenerDir();
-    };
+    static ɵfac = function HostListenerDir_Factory() { return new GlobalHostListenerDir(); };
     static ɵdir = ɵɵdefineDirective({
       type: GlobalHostListenerDir,
       selectors: [['', 'hostListenerDir', '']],
@@ -134,7 +132,7 @@ describe('event listeners', () => {
       return this.handlerReturnValue;
     }
 
-    static ngFactoryDef = () => new PreventDefaultComp();
+    static ɵfac = () => new PreventDefaultComp();
     static ɵcmp = ɵɵdefineComponent({
       type: PreventDefaultComp,
       selectors: [['prevent-default-comp']],
@@ -325,7 +323,7 @@ describe('event listeners', () => {
 
       onClick() { this.counter++; }
 
-      static ngFactoryDef = () => new AppComp();
+      static ɵfac = () => new AppComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -386,7 +384,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
-      static ngFactoryDef = () => new AppComp();
+      static ɵfac = () => new AppComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -450,7 +448,7 @@ describe('event listeners', () => {
 
       onClick(index: number) { this.counters[index]++; }
 
-      static ngFactoryDef = () => new AppComp();
+      static ɵfac = () => new AppComp();
       static ɵcmp = ɵɵdefineComponent({
         type: AppComp,
         selectors: [['app-comp']],
@@ -529,7 +527,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
-      static ngFactoryDef = () => { return new MyComp(); };
+      static ɵfac = () => { return new MyComp(); };
       static ɵcmp = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -580,7 +578,7 @@ describe('event listeners', () => {
       /* @HostListener('click') */
       onClick() { events.push('click!'); }
 
-      static ngFactoryDef = function HostListenerDir_Factory() { return new HostListenerDir(); };
+      static ɵfac = function HostListenerDir_Factory() { return new HostListenerDir(); };
       static ɵdir = ɵɵdefineDirective({
         type: HostListenerDir,
         selectors: [['', 'hostListenerDir', '']],
@@ -632,7 +630,7 @@ describe('event listeners', () => {
 
       onClick(a: any, b: any) { this.counter += a + b; }
 
-      static ngFactoryDef = () => new MyComp();
+      static ɵfac = () => new MyComp();
       static ɵcmp = ɵɵdefineComponent({
         type: MyComp,
         selectors: [['comp']],
@@ -913,7 +911,7 @@ describe('event listeners', () => {
 
       onClick(comp: any) { this.comp = comp; }
 
-      static ngFactoryDef = () => new App();
+      static ɵfac = () => new App();
       static ɵcmp = ɵɵdefineComponent({
         type: App,
         selectors: [['app']],

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -21,7 +21,7 @@ describe('outputs', () => {
     change = new EventEmitter();
     resetStream = new EventEmitter();
 
-    static ngFactoryDef = () => buttonToggle = new ButtonToggle();
+    static ɵfac = () => buttonToggle = new ButtonToggle();
     static ɵcmp = ɵɵdefineComponent({
       type: ButtonToggle,
       selectors: [['button-toggle']],
@@ -37,7 +37,7 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
-    static ngFactoryDef = () => otherDir = new OtherDir;
+    static ɵfac = () => otherDir = new OtherDir;
     static ɵdir = ɵɵdefineDirective(
         {type: OtherDir, selectors: [['', 'otherDir', '']], outputs: {changeStream: 'change'}});
   }

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -29,7 +29,7 @@ describe('pipe', () => {
     class WrappingPipe implements PipeTransform {
       transform(value: any) { return new WrappedValue('Bar'); }
 
-      static ngFactoryDef = function WrappingPipe_Factory() { return new WrappingPipe(); };
+      static ɵfac = function WrappingPipe_Factory() { return new WrappingPipe(); };
       static ngPipeDef = ɵɵdefinePipe({name: 'wrappingPipe', type: WrappingPipe, pure: false});
     }
 

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -867,7 +867,7 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
-        static ngFactoryDef =
+        static ɵfac =
             () => { return new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)); }
 
         static ɵcmp = ɵɵdefineComponent({
@@ -900,7 +900,7 @@ describe('providers', () => {
             [{provide: String, useValue: 'foo'}, {provide: Number, useValue: 2, multi: true}],
       })
       class ComponentWithProviders {
-        static ngFactoryDef = () => new ComponentWithProviders();
+        static ɵfac = () => new ComponentWithProviders();
         static ɵcmp = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -953,7 +953,7 @@ describe('providers', () => {
       class Repeated {
         constructor(private s: String, private n: Number) {}
 
-        static ngFactoryDef =
+        static ɵfac =
             () => { return new Repeated(ɵɵdirectiveInject(String), ɵɵdirectiveInject(Number)); }
 
         static ɵcmp = ɵɵdefineComponent({
@@ -989,7 +989,7 @@ describe('providers', () => {
         viewProviders: [{provide: toString, useValue: 'foo'}],
       })
       class ComponentWithProviders {
-        static ngFactoryDef = () => new ComponentWithProviders();
+        static ɵfac = () => new ComponentWithProviders();
         static ɵcmp = ɵɵdefineComponent({
           type: ComponentWithProviders,
           selectors: [['component-with-providers']],
@@ -1038,7 +1038,7 @@ describe('providers', () => {
     class EmbeddedComponent {
       constructor(private s: String) {}
 
-      static ngFactoryDef = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
+      static ɵfac = () => new EmbeddedComponent(ɵɵdirectiveInject(String));
       static ɵcmp = ɵɵdefineComponent({
         type: EmbeddedComponent,
         selectors: [['embedded-cmp']],
@@ -1059,7 +1059,7 @@ describe('providers', () => {
     class HostComponent {
       constructor(public vcref: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-      static ngFactoryDef = () => hostComponent = new HostComponent(
+      static ɵfac = () => hostComponent = new HostComponent(
           ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
           static ɵcmp = ɵɵdefineComponent({
@@ -1085,7 +1085,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
-      static ngFactoryDef = () => new AppComponent();
+      static ɵfac = () => new AppComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1247,7 +1247,7 @@ describe('providers', () => {
     class MyComponent {
       constructor() {}
 
-      static ngFactoryDef = () => new MyComponent();
+      static ɵfac = () => new MyComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: MyComponent,
         selectors: [['my-cmp']],
@@ -1274,7 +1274,7 @@ describe('providers', () => {
     class AppComponent {
       constructor() {}
 
-      static ngFactoryDef = () => new AppComponent();
+      static ɵfac = () => new AppComponent();
       static ɵcmp = ɵɵdefineComponent({
         type: AppComponent,
         selectors: [['app-cmp']],
@@ -1337,7 +1337,7 @@ describe('providers', () => {
       class MyComponent {
         constructor(foo: InjectableWithLifeCycleHooks) {}
 
-        static ngFactoryDef =
+        static ɵfac =
             () => { return new MyComponent(ɵɵdirectiveInject(InjectableWithLifeCycleHooks)); }
 
         static ɵcmp = ɵɵdefineComponent({
@@ -1366,7 +1366,7 @@ describe('providers', () => {
       class App {
         public condition = true;
 
-        static ngFactoryDef = () => new App();
+        static ɵfac = () => new App();
         static ɵcmp = ɵɵdefineComponent({
           type: App,
           selectors: [['app-cmp']],
@@ -1441,7 +1441,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildComponent {
-    static ngFactoryDef = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
+    static ɵfac = () => testComponentInjection(defs.viewChild, new ViewChildComponent());
     static ɵcmp = ɵɵdefineComponent({
       type: ViewChildComponent,
       selectors: [['view-child']],
@@ -1458,7 +1458,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildDirective {
-    static ngFactoryDef = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
+    static ɵfac = () => testDirectiveInjection(defs.viewChild, new ViewChildDirective());
     static ɵdir = ɵɵdefineDirective({
       type: ViewChildDirective,
       selectors: [['view-child']],
@@ -1467,7 +1467,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ContentChildComponent {
-    static ngFactoryDef =
+    static ɵfac =
         () => { return testComponentInjection(defs.contentChild, new ContentChildComponent()); }
 
     static ɵcmp = ɵɵdefineComponent({
@@ -1487,7 +1487,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ContentChildDirective {
-    static ngFactoryDef =
+    static ɵfac =
         () => { return testDirectiveInjection(defs.contentChild, new ContentChildDirective()); }
 
     static ɵdir = ɵɵdefineDirective({
@@ -1500,7 +1500,7 @@ function expectProvidersScenario(defs: {
 
 
   class ParentComponent {
-    static ngFactoryDef = () => testComponentInjection(defs.parent, new ParentComponent());
+    static ɵfac = () => testComponentInjection(defs.parent, new ParentComponent());
     static ɵcmp = ɵɵdefineComponent({
       type: ParentComponent,
       selectors: [['parent']],
@@ -1518,7 +1518,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective {
-    static ngFactoryDef = () => testDirectiveInjection(defs.parent, new ParentDirective());
+    static ɵfac = () => testDirectiveInjection(defs.parent, new ParentDirective());
     static ɵdir = ɵɵdefineDirective({
       type: ParentDirective,
       selectors: [['parent']],
@@ -1527,7 +1527,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective2 {
-    static ngFactoryDef = () => testDirectiveInjection(defs.parent, new ParentDirective2());
+    static ɵfac = () => testDirectiveInjection(defs.parent, new ParentDirective2());
     static ɵdir = ɵɵdefineDirective({
       type: ParentDirective2,
       selectors: [['parent']],
@@ -1537,7 +1537,7 @@ function expectProvidersScenario(defs: {
 
 
   class App {
-    static ngFactoryDef = () => testComponentInjection(defs.app, new App());
+    static ɵfac = () => testComponentInjection(defs.app, new App());
     static ɵcmp = ɵɵdefineComponent({
       type: App,
       selectors: [['app']],

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -19,7 +19,7 @@ describe('object literals', () => {
     // TODO(issue/24571): remove '!'.
     config !: {[key: string]: any};
 
-    static ngFactoryDef = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
+    static ɵfac = function ObjectComp_Factory() { return objectComp = new ObjectComp(); };
     static ɵcmp = ɵɵdefineComponent({
       type: ObjectComp,
       selectors: [['object-comp']],

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -220,7 +220,7 @@ describe('query', () => {
       class MyDirective {
         constructor(public service: Service) {}
 
-        static ngFactoryDef = function MyDirective_Factory() {
+        static ɵfac = function MyDirective_Factory() {
           return directive = new MyDirective(ɵɵdirectiveInject(Service));
         };
         static ɵdir = ɵɵdefineDirective({
@@ -248,7 +248,7 @@ describe('query', () => {
           service?: Service;
           alias?: Alias;
 
-          static ngFactoryDef = function App_Factory() { return new App(); };
+          static ɵfac = function App_Factory() { return new App(); };
           static ɵcmp = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -294,7 +294,7 @@ describe('query', () => {
         class App {
           service?: Service;
 
-          static ngFactoryDef = function App_Factory() { return new App(); };
+          static ɵfac = function App_Factory() { return new App(); };
           static ɵcmp = ɵɵdefineComponent({
             type: App,
             selectors: [['app']],
@@ -838,7 +838,7 @@ describe('query', () => {
         let childInstance: Child;
 
         class Child {
-          static ngFactoryDef = () => childInstance = new Child();
+          static ɵfac = () => childInstance = new Child();
           static ɵcmp = ɵɵdefineComponent({
             type: Child,
             selectors: [['child']],
@@ -1420,7 +1420,7 @@ describe('query', () => {
         this.vcr.createEmbeddedView(this.temp);
       }
 
-      static ngFactoryDef = () => new SomeDir(
+      static ɵfac = () => new SomeDir(
           ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
 
           static ɵdir = ɵɵdefineDirective({
@@ -1481,7 +1481,7 @@ describe('query', () => {
         this.contentCheckedQuerySnapshot = this.foos ? this.foos.length : 0;
       }
 
-      static ngFactoryDef = () => withContentInstance = new WithContentDirective();
+      static ɵfac = () => withContentInstance = new WithContentDirective();
       static ɵdir = ɵɵdefineDirective({
         type: WithContentDirective,
         selectors: [['', 'with-content', '']],
@@ -1679,7 +1679,7 @@ describe('query', () => {
     it('should report results to appropriate queries where deep content queries are nested', () => {
       class QueryDirective {
         fooBars: any;
-        static ngFactoryDef = () => new QueryDirective();
+        static ɵfac = () => new QueryDirective();
         static ɵdir = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1745,7 +1745,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
-        static ngFactoryDef = () => new QueryDirective();
+        static ɵfac = () => new QueryDirective();
         static ɵdir = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1802,7 +1802,7 @@ describe('query', () => {
 
       class QueryDirective {
         fooBars: any;
-        static ngFactoryDef = () => new QueryDirective();
+        static ɵfac = () => new QueryDirective();
         static ɵdir = ɵɵdefineDirective({
           type: QueryDirective,
           selectors: [['', 'query', '']],
@@ -1863,7 +1863,7 @@ describe('query', () => {
        () => {
          class ShallowQueryDirective {
            foos: any;
-           static ngFactoryDef = () => new ShallowQueryDirective();
+           static ɵfac = () => new ShallowQueryDirective();
            static ɵdir = ɵɵdefineDirective({
              type: ShallowQueryDirective,
              selectors: [['', 'shallow-query', '']],
@@ -1884,7 +1884,7 @@ describe('query', () => {
 
          class DeepQueryDirective {
            foos: any;
-           static ngFactoryDef = () => new DeepQueryDirective();
+           static ɵfac = () => new DeepQueryDirective();
            static ɵdir = ɵɵdefineDirective({
              type: DeepQueryDirective,
              selectors: [['', 'deep-query', '']],
@@ -1946,7 +1946,7 @@ describe('query', () => {
     class TextDirective {
       value !: string;
 
-      static ngFactoryDef = () => new TextDirective();
+      static ɵfac = () => new TextDirective();
       static ɵdir = ɵɵdefineDirective(
           {type: TextDirective, selectors: [['', 'text', '']], inputs: {value: 'text'}});
     }
@@ -1958,7 +1958,7 @@ describe('query', () => {
         // @ContentChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
-        static ngFactoryDef = () => contentQueryDirective = new ContentQueryDirective();
+        static ɵfac = () => contentQueryDirective = new ContentQueryDirective();
         static ɵcmp = ɵɵdefineDirective({
           type: ContentQueryDirective,
           selectors: [['', 'content-query', '']],
@@ -2029,7 +2029,7 @@ describe('query', () => {
         // @ViewChildren(TextDirective)
         texts !: QueryList<TextDirective>;
 
-        static ngFactoryDef = () => new ViewQueryComponent();
+        static ɵfac = () => new ViewQueryComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: ViewQueryComponent,
           selectors: [['view-query']],

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -374,7 +374,7 @@ export function createComponent(
     consts: TAttributes[] = []): ComponentType<any> {
   return class Component {
     value: any;
-    static ngFactoryDef = () => new Component;
+    static ɵfac = () => new Component;
     static ɵcmp = ɵɵdefineComponent({
       type: Component,
       selectors: [[name]],
@@ -394,7 +394,7 @@ export function createComponent(
 export function createDirective(
     name: string, {exportAs}: {exportAs?: string[]} = {}): DirectiveType<any> {
   return class Directive {
-    static ngFactoryDef = () => new Directive();
+    static ɵfac = () => new Directive();
     static ɵdir = ɵɵdefineDirective({
       type: Directive,
       selectors: [['', name, '']],

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -26,7 +26,7 @@ describe('renderer factory lifecycle', () => {
   rendererFactory.end = () => logs.push('end');
 
   class SomeComponent {
-    static ngFactoryDef = () => new SomeComponent;
+    static ɵfac = () => new SomeComponent;
     static ɵcmp = ɵɵdefineComponent({
       type: SomeComponent,
       encapsulation: ViewEncapsulation.None,
@@ -46,7 +46,7 @@ describe('renderer factory lifecycle', () => {
   }
 
   class SomeComponentWhichThrows {
-    static ngFactoryDef = () => new SomeComponentWhichThrows;
+    static ɵfac = () => new SomeComponentWhichThrows;
     static ɵcmp = ɵɵdefineComponent({
       type: SomeComponentWhichThrows,
       encapsulation: ViewEncapsulation.None,
@@ -150,7 +150,7 @@ describe('Renderer2 destruction hooks', () => {
 
   it('should call renderer.destroy for each component destroyed', () => {
     class SimpleComponent {
-      static ngFactoryDef = () => new SimpleComponent;
+      static ɵfac = () => new SimpleComponent;
       static ɵcmp = ɵɵdefineComponent({
         type: SimpleComponent,
         encapsulation: ViewEncapsulation.None,

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -29,7 +29,7 @@ describe('ViewContainerRef', () => {
   beforeEach(() => directiveInstance = null);
 
   class DirectiveWithVCRef {
-    static ngFactoryDef = () => directiveInstance = new DirectiveWithVCRef(
+    static ɵfac = () => directiveInstance = new DirectiveWithVCRef(
         ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
         static ɵdir = ɵɵdefineDirective({
@@ -57,7 +57,7 @@ describe('ViewContainerRef', () => {
            let directiveInstances: TestDirective[] = [];
 
            class TestDirective {
-             static ngFactoryDef =
+             static ɵfac =
                  () => {
                    const instance = new TestDirective(
                        ɵɵdirectiveInject(ViewContainerRef as any),
@@ -101,7 +101,7 @@ describe('ViewContainerRef', () => {
            class TestComponent {
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
-             static ngFactoryDef = () => new TestComponent();
+             static ɵfac = () => new TestComponent();
              static ɵcmp = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -137,7 +137,7 @@ describe('ViewContainerRef', () => {
            let directiveInstance: TestDirective;
 
            class TestDirective {
-             static ngFactoryDef = () => directiveInstance = new TestDirective(
+             static ɵfac = () => directiveInstance = new TestDirective(
                  ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any))
 
                  static ɵdir =
@@ -173,7 +173,7 @@ describe('ViewContainerRef', () => {
              condition = false;
              // TODO(issue/24571): remove '!'.
              testDir !: TestDirective;
-             static ngFactoryDef = () => new TestComponent();
+             static ɵfac = () => new TestComponent();
              static ɵcmp = ɵɵdefineComponent({
                type: TestComponent,
                encapsulation: ViewEncapsulation.None,
@@ -241,7 +241,7 @@ describe('ViewContainerRef', () => {
         class AppComp {
           constructor(public vcr: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
 
-          static ngFactoryDef =
+          static ɵfac =
               () => {
                 return new AppComp(
                     ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver());
@@ -261,7 +261,7 @@ describe('ViewContainerRef', () => {
 
           ngDoCheck() { this.doCheckCount++; }
 
-          static ngFactoryDef = () => dynamicComp = new DynamicComp();
+          static ɵfac = () => dynamicComp = new DynamicComp();
 
           static ɵcmp = ɵɵdefineComponent({
             type: DynamicComp,
@@ -365,7 +365,7 @@ describe('ViewContainerRef', () => {
 
     @Component({selector: 'app', template: ''})
     class AppCmpt {
-      static ngFactoryDef = () =>
+      static ɵfac = () =>
           new AppCmpt(ɵɵdirectiveInject(ViewContainerRef as any), injectComponentFactoryResolver())
 
               static ɵcmp = ɵɵdefineComponent({
@@ -435,7 +435,7 @@ describe('ViewContainerRef', () => {
         // @ViewChildren('foo')
         foo !: QueryList<any>;
 
-        static ngFactoryDef = () => dynamicComp = new DynamicCompWithViewQueries();
+        static ɵfac = () => dynamicComp = new DynamicCompWithViewQueries();
         static ɵcmp = ɵɵdefineComponent({
           type: DynamicCompWithViewQueries,
           selectors: [['dynamic-cmpt-with-view-queries']],
@@ -482,7 +482,7 @@ describe('ViewContainerRef', () => {
 
       // We want the ViewRef, so we rely on the knowledge that `ViewRef` is actually given
       // when injecting `ChangeDetectorRef`.
-      static ngFactoryDef = () =>
+      static ɵfac = () =>
           new CompWithListenerThatDestroysItself(ɵɵdirectiveInject(ChangeDetectorRef as any))
 
               static ɵcmp = ɵɵdefineComponent({

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -505,7 +505,7 @@ describe('TestBed', () => {
          */
         const getAOTCompiledComponent = () => {
           class ComponentClass {
-            static ngFactoryDef = () => new ComponentClass();
+            static ɵfac = () => new ComponentClass();
             static ɵcmp = defineComponent({
               type: ComponentClass,
               selectors: [['comp']],

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -224,8 +224,8 @@ export declare class NgClassBase {
     getValue(): {
         [key: string]: any;
     } | null;
-    static ngFactoryDef: any;
     static ɵdir: any;
+    static ɵfac: any;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -309,8 +309,8 @@ export declare class NgStyleBase {
     getValue(): {
         [key: string]: any;
     } | null;
-    static ngFactory: any;
     static ɵdir: any;
+    static ɵfac: any;
 }
 
 export declare class NgSwitch {


### PR DESCRIPTION


Factory defs are not considered public API, so the property
that contains them should be prefixed with Angular's marker
for "private" ('ɵ') to discourage apps from relying on def
APIs directly.

This commit adds the prefix and shortens the name from
ngFactoryDef to fac. This is because property names
cannot be minified by Uglify without turning on property
mangling (which most apps have turned off) and are thus
size-sensitive.

Note that the other "defs" (ngPipeDef, etc) will be
prefixed and shortened in follow-up PRs, in an attempt to
limit how large and conflict-y this change is.

Size note: AIO minified size down ~700 bytes in main bundle, 
job board app down ~2 KB in main bundle. AIO diff is not 
large enough yet to trigger the size test.