### PR TITLE
feat(compiler): differentiate `SummaryKind`s of compile metadata

### DIFF
--- a/packages/compiler/src/compile_metadata.ts
+++ b/packages/compiler/src/compile_metadata.ts
@@ -261,6 +261,7 @@ export interface CompileEntryComponentMetadata {
 // as we need to be able to serialize this from/to JSON!
 export interface CompileDirectiveSummary extends CompileTypeSummary {
   type: CompileTypeMetadata;
+  summaryKind: CompileSummaryKind.Directive;
   isComponent: boolean;
   selector: string|null;
   exportAs: string|null;
@@ -485,6 +486,7 @@ export class CompileDirectiveMetadata {
 
 export interface CompilePipeSummary extends CompileTypeSummary {
   type: CompileTypeMetadata;
+  summaryKind: CompileSummaryKind.Pipe;
   name: string;
   pure: boolean;
 }
@@ -518,6 +520,7 @@ export class CompilePipeMetadata {
 // as we need to be able to serialize this from/to JSON!
 export interface CompileNgModuleSummary extends CompileTypeSummary {
   type: CompileTypeMetadata;
+  summaryKind: CompileSummaryKind.NgModule;
 
   // Note: This is transitive over the exported modules.
   exportedDirectives: CompileIdentifierMetadata[];


### PR DESCRIPTION
This commit differentiates the `SummaryKind`s of different
`CompileTypeSummary`s. This helps TypeScript make type inferences about
the superinterface of a `SummaryKind`, requiring less casting to the
expected superinterface when using `SummaryKind`s.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
