### PR TITLE
feat(language-service): directive info when looking up attribute's symbol

### DIFF
--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -106,6 +106,20 @@ describe('hover', () => {
     expect(toText(displayParts)).toBe('(component) AppModule.TestComponent: class');
   });
 
+  it('should be able to find a reference to a directive', () => {
+    const fileName = mockHost.addCode(`
+      @Component({
+        template: '<test-comp «string-model»></test-comp>'
+      })
+      export class MyComponent { }`);
+    const marker = mockHost.getReferenceMarkerFor(fileName, 'string-model');
+    const quickInfo = ngLS.getHoverAt(fileName, marker.start);
+    expect(quickInfo).toBeTruthy();
+    const {textSpan, displayParts} = quickInfo !;
+    expect(textSpan).toEqual(marker);
+    expect(toText(displayParts)).toBe('(directive) StringModel');
+  });
+
   it('should be able to find an event provider', () => {
     const fileName = mockHost.addCode(`
       @Component({


### PR DESCRIPTION
Now, hovering over an attribute on an element will provide information
about the directive that attribute matches in the element, if any.
(More generally, we return information about directive symbols
matched on an element attribute.)

I believe this is similar to how the indexer provides this kind of
information, though more precise in the sense that this commit provides
directive information only if the directive selector exactly matches the
attribute selector. In another sense, this is a limitation.

In fact, there are the limitations of:

- Directives matched on the element, but with a selector of anything
  more than the attribute (e.g. `div[string-model]` or
  `[string-model][other-attr]`) will not be returned as symbols matching
  on the attribute.
- Only one symbol can be returned currently. If the attribute matches
  multiple directives, only one directive symbol will be returned.
  Furthermore, we cannot say that the directive symbol returned is
  determinstic.

Resolution of these limitations can be discussed in the future. At least
the second limitation should be very easy to fixup in a future commit.

This relies solely on the template compiler and is agnostic to any Ivy
changes, so this is strictly a feature enhancement that will not have to
be refactored when we migrate the language service to Ivy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
