### PR TITLE
refactor(ngcc): fix formatting of missing dependencies error

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -360,7 +360,7 @@ function getTargetedEntryPoints(
   if (invalidTarget !== undefined) {
     throw new Error(
         `The target entry-point "${invalidTarget.entryPoint.name}" has missing dependencies:\n` +
-        invalidTarget.missingDependencies.map(dep => ` - ${dep}\n`));
+        invalidTarget.missingDependencies.map(dep => ` - ${dep}\n`).join(''));
   }
   if (entryPointInfo.entryPoints.length === 0) {
     markNonAngularPackageAsProcessed(fs, pkgJsonUpdater, absoluteTargetEntryPointPath);


### PR DESCRIPTION
Previously, the list of missing dependencies was not explicitly joined, which resulted in the default `,` joiner being used during stringification.

This commit explicitly joins the missing dependency lines to avoid unnecessary commas.

Before:
```
The target entry-point "some-entry-point" has missing dependencies:
 - dependency 1
, - dependency 2
, - dependency 3
```

After:
```
The target entry-point "some-entry-point" has missing dependencies:
 - dependency 1
 - dependency 2
 - dependency 3
```
