### PR TITLE
fix(ngcc): rename the executable from `ivy-ngcc` to `ngcc`

### DIFF
--- a/aio/tools/examples/example-boilerplate.js
+++ b/aio/tools/examples/example-boilerplate.js
@@ -82,7 +82,7 @@ class ExampleBoilerPlate {
     if (ivy) {
       // We only need the "es2015" bundles as the CLI webpack build does not need
       // any other formats for building and serving.
-      shelljs.exec(`yarn --cwd ${SHARED_PATH} ivy-ngcc --properties es2015`);
+      shelljs.exec(`yarn --cwd ${SHARED_PATH} ngcc --properties es2015`);
     }
 
     exampleFolders.forEach(exampleFolder => {

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -7,7 +7,7 @@
     "e2e": "ng e2e --webdriver-update=false",
     "lint": "ng lint",
     "ng": "ng",
-    "postinstall": "yarn update-webdriver && yarn ivy-ngcc --properties es2015 --create-ivy-entry-points",
+    "postinstall": "yarn update-webdriver && yarn ngcc --properties es2015 --create-ivy-entry-points",
     "update-webdriver": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG",
     "start": "ng serve",
     "pretest": "ng version",

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -7,7 +7,7 @@
     "e2e": "ng e2e --webdriver-update=false",
     "lint": "ng lint",
     "ng": "ng",
-    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG && yarn ivy-ngcc",
+    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG && yarn ngcc",
     "start": "ng serve",
     "pretest": "ng version",
     "test": "ng test --progress=false --watch=false && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production"

--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -23,89 +23,89 @@ function assertSucceeded {
 }
 
 
-ivy-ngcc --help
-assertSucceeded "Expected 'ivy-ngcc --help' to succeed."
+ngcc --help
+assertSucceeded "Expected 'ngcc --help' to succeed."
 
-# node --inspect-brk $(npm bin)/ivy-ngcc -f esm2015
+# node --inspect-brk $(npm bin)/ngcc -f esm2015
 # Run ngcc and check it logged compilation output as expected
-ivy-ngcc | grep 'Compiling'
-assertSucceeded "Expected 'ivy-ngcc' to log 'Compiling'."
+ngcc | grep 'Compiling'
+assertSucceeded "Expected 'ngcc' to log 'Compiling'."
 
 
 # Did it add the appropriate build markers?
 
   # - esm2015
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm2015": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'esm2015' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'esm2015' in '@angular/common'."
 
   # - fesm2015
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm2015": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'fesm2015' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'fesm2015' in '@angular/common'."
 
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"es2015": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'es2015' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'es2015' in '@angular/common'."
 
   # - esm5
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"esm5": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'esm5' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'esm5' in '@angular/common'."
 
   # - fesm5
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"module": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'module' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'module' in '@angular/common'."
 
   cat node_modules/@angular/common/package.json | awk 'ORS=" "' | grep '"__processed_by_ivy_ngcc__":[^}]*"fesm5": "'
-  assertSucceeded "Expected 'ivy-ngcc' to add build marker for 'fesm5' in '@angular/common'."
+  assertSucceeded "Expected 'ngcc' to add build marker for 'fesm5' in '@angular/common'."
 
 
 # Did it replace the PRE_R3 markers correctly?
   grep "= SWITCH_COMPILE_COMPONENT__POST_R3__" node_modules/@angular/core/fesm2015/core.js
-  assertSucceeded "Expected 'ivy-ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm2015)."
+  assertSucceeded "Expected 'ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm2015)."
 
   grep "= SWITCH_COMPILE_COMPONENT__POST_R3__" node_modules/@angular/core/fesm5/core.js
-  assertSucceeded "Expected 'ivy-ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm5)."
+  assertSucceeded "Expected 'ngcc' to replace 'SWITCH_COMPILE_COMPONENT__PRE_R3__' in '@angular/core' (fesm5)."
 
 
 # Did it compile @angular/core/ApplicationModule correctly?
   grep "ApplicationModule.ngModuleDef = ɵɵdefineNgModule" node_modules/@angular/core/fesm2015/core.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm2015)."
+  assertSucceeded "Expected 'ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm2015)."
 
   grep "ApplicationModule.ngModuleDef = ɵɵdefineNgModule" node_modules/@angular/core/fesm5/core.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm5)."
+  assertSucceeded "Expected 'ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (fesm5)."
 
   grep "ApplicationModule.ngModuleDef = ɵngcc0.ɵɵdefineNgModule" node_modules/@angular/core/esm2015/src/application_module.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm2015)."
+  assertSucceeded "Expected 'ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm2015)."
 
   grep "ApplicationModule.ngModuleDef = ɵngcc0.ɵɵdefineNgModule" node_modules/@angular/core/esm5/src/application_module.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm5)."
+  assertSucceeded "Expected 'ngcc' to correctly compile 'ApplicationModule' in '@angular/core' (esm5)."
 
 
 # Did it transform @angular/core typing files correctly?
   grep "import [*] as ɵngcc0 from './src/r3_symbols';" node_modules/@angular/core/core.d.ts
-  assertSucceeded "Expected 'ivy-ngcc' to add an import for 'src/r3_symbols' in '@angular/core' typings."
+  assertSucceeded "Expected 'ngcc' to add an import for 'src/r3_symbols' in '@angular/core' typings."
 
   grep "static ngInjectorDef: ɵngcc0.ɵɵInjectorDef<ApplicationModule>;" node_modules/@angular/core/core.d.ts
-  assertSucceeded "Expected 'ivy-ngcc' to add a definition for 'ApplicationModule.ngInjectorDef' in '@angular/core' typings."
+  assertSucceeded "Expected 'ngcc' to add a definition for 'ApplicationModule.ngInjectorDef' in '@angular/core' typings."
 
 
 # Did it generate a base factory call for synthesized constructors correctly?
   grep "const ɵMatTable_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(MatTable);" node_modules/@angular/material/esm2015/table.js
-  assertSucceeded "Expected 'ivy-ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm2015)."
+  assertSucceeded "Expected 'ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm2015)."
 
   grep "const ɵMatTable_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(MatTable);" node_modules/@angular/material/esm5/table.es5.js
-  assertSucceeded "Expected 'ivy-ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm5)."
+  assertSucceeded "Expected 'ngcc' to generate a base factory for 'MatTable' in '@angular/material' (esm5)."
 
 
 # Did it generate a base definition for undecorated classes with inputs and view queries?
   grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm2015/menu.js
-  assertSucceeded "Expected 'ivy-ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm2015)."
+  assertSucceeded "Expected 'ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm2015)."
 
   grep "_MatMenuBase.ngBaseDef = ɵngcc0.ɵɵdefineBase({ inputs: {" node_modules/@angular/material/esm5/menu.es5.js
-  assertSucceeded "Expected 'ivy-ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm5)."
+  assertSucceeded "Expected 'ngcc' to generate a base definition for 'MatMenuBase' in '@angular/material' (esm5)."
 
 
 # Did it handle namespace imported decorators in UMD using `__decorate` syntax?
   grep "type: i0.Injectable" node_modules/@angular/common/bundles/common.umd.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly handle '__decorate' syntax in '@angular/common' (umd)."
+  assertSucceeded "Expected 'ngcc' to correctly handle '__decorate' syntax in '@angular/common' (umd)."
 
   # (and ensure the @angular/common package is indeed using `__decorate` syntax)
   grep "JsonPipe = __decorate(" node_modules/@angular/common/bundles/common.umd.js.__ivy_ngcc_bak
@@ -114,7 +114,7 @@ assertSucceeded "Expected 'ivy-ngcc' to log 'Compiling'."
 
 # Did it handle namespace imported decorators in UMD using static properties?
   grep "type: core.Injectable," node_modules/@angular/cdk/bundles/cdk-a11y.umd.js
-  assertSucceeded "Expected 'ivy-ngcc' to correctly handle decorators via static properties in '@angular/cdk/a11y' (umd)."
+  assertSucceeded "Expected 'ngcc' to correctly handle decorators via static properties in '@angular/cdk/a11y' (umd)."
 
   # (and ensure the @angular/cdk/a11y package is indeed using static properties)
   grep "FocusMonitor.decorators =" node_modules/@angular/cdk/bundles/cdk-a11y.umd.js.__ivy_ngcc_bak
@@ -123,20 +123,20 @@ assertSucceeded "Expected 'ivy-ngcc' to log 'Compiling'."
 
 # Can it be safely run again (as a noop)?
 # And check that it logged skipping compilation as expected
-ivy-ngcc -l debug | grep 'Skipping'
-assertSucceeded "Expected 'ivy-ngcc -l debug' to successfully rerun (as a noop) and log 'Skipping'."
+ngcc -l debug | grep 'Skipping'
+assertSucceeded "Expected 'ngcc -l debug' to successfully rerun (as a noop) and log 'Skipping'."
 
 # Does it process the tasks in parallel?
-ivy-ngcc -l debug | grep 'Running ngcc on ClusterExecutor'
-assertSucceeded "Expected 'ivy-ngcc -l debug' to run in parallel mode (using 'ClusterExecutor')."
+ngcc -l debug | grep 'Running ngcc on ClusterExecutor'
+assertSucceeded "Expected 'ngcc -l debug' to run in parallel mode (using 'ClusterExecutor')."
 
 # Check that running it with logging level error outputs nothing
-ivy-ngcc -l error | grep '.'
-assertFailed "Expected 'ivy-ngcc -l error' to not output anything."
+ngcc -l error | grep '.'
+assertFailed "Expected 'ngcc -l error' to not output anything."
 
 # Does running it with --formats fail?
-ivy-ngcc --formats fesm2015
-assertFailed "Expected 'ivy-ngcc --formats fesm2015' to fail (since '--formats' is deprecated)."
+ngcc --formats fesm2015
+assertFailed "Expected 'ngcc --formats fesm2015' to fail (since '--formats' is deprecated)."
 
 # Now try compiling the app using the ngcc compiled libraries
 ngc -p tsconfig-app.json
@@ -148,3 +148,11 @@ assertSucceeded "Expected the app to successfully compile with the ngcc-processe
 
   grep "directives: \[.*\.MatButton.*\]" dist/src/main.js
   assertSucceeded "Expected the compiled app's 'main.ts' to list 'MatButton' in 'directives'."
+
+
+# 'ivy-ngcc' should fail with an appropriate error message.
+  ivy-ngcc
+  assertFailed "Expected 'ivy-ngcc' to fail (since it was renamed to 'ngcc')."
+
+  ivy-ngcc 2>&1 | grep "Error: The 'ivy-ngcc' command was renamed to just 'ngcc'. Please update your usage."
+  assertSucceeded "Expected 'ivy-ngcc' to show an appropriate error message."

--- a/packages/compiler-cli/ngcc/main-ivy-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ivy-ngcc.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+console.error(
+    new Error('The \'ivy-ngcc\' command was renamed to just \'ngcc\'. Please update your usage.'));
+process.exit(1);

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "bin": {
-    "ivy-ngcc": "./ngcc/main-ngcc.js",
+    "ivy-ngcc": "./ngcc/main-ivy-ngcc.js",
+    "ngcc": "./ngcc/main-ngcc.js",
     "ngc": "./src/main.js",
     "ng-xi18n": "./src/extract_i18n.js"
   },


### PR DESCRIPTION
Previously, the executable for the Angular Compatibility Compiler (`ngcc`) was called `ivy-ngcc`. This would be confusing for users not familiar with our internal terminology, especially given that we call it `ngcc` in all our docs and presentations.

This commit renames the executable to `ngcc` and replaces `ivy-ngcc` with a script that errors with an informative message (prompting the user to use `ngcc` instead).

Jira issue: [FW-1624](https://angular-team.atlassian.net/browse/FW-1624)

##
Related PR: angular/angular-cli#15840