### PR TITLE
docs(i18n): use neutral example host

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -797,7 +797,7 @@ error.
 When you use the CLI `build` or `serve` command to build your application for different locales, change the output path using the `--outputPath` command option (along with the i18n-specific command options), so that the translation files are saved to different locations.
 When you are serving a locale-specific version from a subdirectory, you can also change the base URL used by your app by specifying the `--baseHref` option.
 
-For example, if the French version of your application is served from https://myapp.com/fr/, configure the build for the French version as follows.
+For example, if the French version of your application is served from https://example.com/fr/, configure the build for the French version as follows.
 
 ```
 "configurations": {


### PR DESCRIPTION
Use https://example.com/fr/ instead of https://myapp.com/fr/ in the docs

## Does this PR introduce a breaking change?

- [x] No
