### PR TITLE
refactor(core): rename ngInjectorDef to ɵinj and ngInjectable def to ɵprov

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -179,7 +179,7 @@ module.exports =
 
         .config(function(filterMembers) {
           filterMembers.notAllowedPatterns.push(
-            /^ng[A-Z].*Def$/
+            /^ng[A-Z].*Def$/, /^ɵ/
           );
         })
 

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -179,7 +179,7 @@ module.exports =
 
         .config(function(filterMembers) {
           filterMembers.notAllowedPatterns.push(
-            /^ng[A-Z].*Def$/, /^ɵ/
+            /^ɵ/
           );
         })
 

--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -83,8 +83,8 @@ assertSucceeded "Expected 'ngcc' to log 'Compiling'."
   grep "import [*] as ɵngcc0 from './src/r3_symbols';" node_modules/@angular/core/core.d.ts
   assertSucceeded "Expected 'ngcc' to add an import for 'src/r3_symbols' in '@angular/core' typings."
 
-  grep "static ngInjectorDef: ɵngcc0.ɵɵInjectorDef<ApplicationModule>;" node_modules/@angular/core/core.d.ts
-  assertSucceeded "Expected 'ngcc' to add a definition for 'ApplicationModule.ngInjectorDef' in '@angular/core' typings."
+  grep "static ɵinj: ɵngcc0.ɵɵInjectorDef<ApplicationModule>;" node_modules/@angular/core/core.d.ts
+  assertSucceeded "Expected 'ngcc' to add a definition for 'ApplicationModule.ɵinj' in '@angular/core' typings."
 
 
 # Did it generate a base factory call for synthesized constructors correctly?

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -126,9 +126,9 @@ describe('@angular/core ng_package', () => {
       });
 
       if (ivyEnabled) {
-        it('should have decorators downleveled to static props e.g. ngInjectableDef', () => {
+        it('should have decorators downleveled to static props e.g. ɵprov', () => {
           expect(shx.cat('fesm5/core.js')).not.toContain('__decorate');
-          expect(shx.cat('fesm5/core.js')).toContain('.ngInjectableDef = ');
+          expect(shx.cat('fesm5/core.js')).toContain('.ɵprov = ');
         });
       } else {
         it('should have decorators',

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -21,7 +21,7 @@ export abstract class ViewportScroller {
   // De-sugared tree-shakable injection
   // See #23917
   /** @nocollapse */
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: ViewportScroller,
     providedIn: 'root',
     factory: () => new BrowserViewportScroller(ɵɵinject(DOCUMENT), window, ɵɵinject(ErrorHandler))

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -125,14 +125,14 @@ describe('ngInjectableDef Bazel Integration', () => {
     expect(TestBed.inject(Service).value).toEqual('overridden');
   });
 
-  it('does not override existing ngInjectableDef', () => {
+  it('does not override existing ɵprov', () => {
     @Injectable({
       providedIn: 'root',
       useValue: new Service(false),
     })
     class Service {
       constructor(public value: boolean) {}
-      static ngInjectableDef = {
+      static ɵprov = {
         providedIn: 'root',
         factory: () => new Service(true),
         token: Service,
@@ -143,7 +143,7 @@ describe('ngInjectableDef Bazel Integration', () => {
     expect(TestBed.inject(Service).value).toEqual(true);
   });
 
-  it('does not override existing ngInjectableDef in case of inheritance', () => {
+  it('does not override existing ɵprov in case of inheritance', () => {
     @Injectable({
       providedIn: 'root',
       useValue: new ParentService(false),

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -270,14 +270,14 @@ A.ɵdir = ɵngcc0.ɵɵdefineDirective({ type: A, selectors: [["", "a", ""]] });
           const definitions: string = addDefinitionsSpy.calls.first().args[2];
           const ngModuleDef = definitions.indexOf('ɵmod');
           expect(ngModuleDef).not.toEqual(-1, 'ɵmod should exist');
-          const ngInjectorDef = definitions.indexOf('ngInjectorDef');
-          expect(ngInjectorDef).not.toEqual(-1, 'ngInjectorDef should exist');
+          const ngInjectorDef = definitions.indexOf('ɵinj');
+          expect(ngInjectorDef).not.toEqual(-1, 'ɵinj should exist');
           const setClassMetadata = definitions.indexOf('setClassMetadata');
           expect(setClassMetadata).not.toEqual(-1, 'setClassMetadata call should exist');
           expect(setClassMetadata)
               .toBeGreaterThan(ngModuleDef, 'setClassMetadata should follow ɵmod');
           expect(setClassMetadata)
-              .toBeGreaterThan(ngInjectorDef, 'setClassMetadata should follow ngInjectorDef');
+              .toBeGreaterThan(ngInjectorDef, 'setClassMetadata should follow ɵinj');
         });
 
         it('should render classes without decorators if handler matches', () => {

--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -423,7 +423,7 @@ export class MetadataBundler {
         result[key] = this.convertFunction(moduleName, value);
       } else if (isMetadataSymbolicCallExpression(value)) {
         // Class members can also contain static members that call a function with module
-        // references. e.g. "static ngInjectableDef = ɵɵdefineInjectable(..)". We also need to
+        // references. e.g. "static ɵprov = ɵɵdefineInjectable(..)". We also need to
         // convert these module references because otherwise these resolve to non-existent files.
         result[key] = this.convertValue(moduleName, value);
       } else {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -92,7 +92,7 @@ export class InjectableDecoratorHandler implements
     }
 
     results.push({
-      name: 'ngInjectableDef',
+      name: 'ɵprov',
       initializer: res.expression, statements,
       type: res.type,
     });
@@ -214,8 +214,7 @@ function extractInjectableCtorDeps(
     // Angular's DI.
     //
     // To deal with this, @Injectable() without an argument is more lenient, and if the
-    // constructor
-    // signature does not work for DI then an ngInjectableDef that throws.
+    // constructor signature does not work for DI then a provider def (ɵprov) that throws.
     if (strictCtorDeps) {
       ctorDeps = getValidConstructorDependencies(clazz, reflector, defaultImportRecorder, isCore);
     } else {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -24,8 +24,8 @@ import {ReferencesRegistry} from './references_registry';
 import {combineResolvers, findAngularDecorator, forwardRefResolver, getValidConstructorDependencies, isExpressionForwardReference, toR3Reference, unwrapExpression} from './util';
 
 export interface NgModuleAnalysis {
-  ɵmod: R3NgModuleMetadata;
-  ngInjectorDef: R3InjectorMetadata;
+  mod: R3NgModuleMetadata;
+  inj: R3InjectorMetadata;
   metadataStmt: Statement|null;
   declarations: Reference<ClassDeclaration>[];
   exports: Reference<ClassDeclaration>[];
@@ -236,7 +236,8 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     return {
       analysis: {
         id,
-        ɵmod: ngModuleDef, ngInjectorDef,
+        mod: ngModuleDef,
+        inj: ngInjectorDef,
         declarations: declarationRefs,
         exports: exportRefs,
         metadataStmt: generateSetClassMetadataCall(
@@ -256,7 +257,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
       const context = getSourceFile(node);
       for (const exportRef of analysis.exports) {
         if (isNgModule(exportRef.node, scope.compilation)) {
-          analysis.ngInjectorDef.imports.push(this.refEmitter.emit(exportRef, context));
+          analysis.inj.imports.push(this.refEmitter.emit(exportRef, context));
         }
       }
 
@@ -280,8 +281,8 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
   }
 
   compile(node: ClassDeclaration, analysis: NgModuleAnalysis): CompileResult[] {
-    const ngInjectorDef = compileInjector(analysis.ngInjectorDef);
-    const ngModuleDef = compileNgModule(analysis.ɵmod);
+    const ngInjectorDef = compileInjector(analysis.inj);
+    const ngModuleDef = compileNgModule(analysis.mod);
     const ngModuleStatements = ngModuleDef.additionalStatements;
     if (analysis.metadataStmt !== null) {
       ngModuleStatements.push(analysis.metadataStmt);
@@ -314,7 +315,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
         type: ngModuleDef.type,
       },
       {
-        name: 'ngInjectorDef',
+        name: 'ɵinj',
         initializer: ngInjectorDef.expression,
         statements: ngInjectorDef.statements,
         type: ngInjectorDef.type,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -77,7 +77,7 @@ runInEachFileSystem(() => {
       if (detected === undefined) {
         return fail('Failed to recognize @NgModule');
       }
-      const moduleDef = handler.analyze(TestModule, detected.metadata).analysis !.ɵmod;
+      const moduleDef = handler.analyze(TestModule, detected.metadata).analysis !.mod;
 
       expect(getReferenceIdentifierTexts(moduleDef.declarations)).toEqual(['TestComp']);
       expect(getReferenceIdentifierTexts(moduleDef.exports)).toEqual(['TestComp']);

--- a/packages/compiler-cli/src/transformers/nocollapse_hack.ts
+++ b/packages/compiler-cli/src/transformers/nocollapse_hack.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Closure compiler transforms the form `Service.ngInjectableDef = X` into
-// `Service$ngInjectableDef = X`. To prevent this transformation, such assignments need to be
+// Closure compiler transforms the form `Service.ɵprov = X` into
+// `Service$ɵprov = X`. To prevent this transformation, such assignments need to be
 // annotated with @nocollapse. Unfortunately, a bug in Typescript where comments aren't propagated
 // through the TS transformations precludes adding the comment via the AST. This workaround detects
-// the static assignments to R3 properties such as ngInjectableDef using a regex, as output files
+// the static assignments to R3 properties such as ɵprov using a regex, as output files
 // are written, and applies the annotation through regex replacement.
 //
 // TODO(alxhub): clean up once fix for TS transformers lands in upstream
@@ -22,7 +22,7 @@ const R3_DEF_NAME_PATTERN = [
   'ngBaseDef',
   'ɵcmp',
   'ɵdir',
-  'ngInjectableDef',
+  'ɵprov',
   'ɵinj',
   'ɵmod',
   'ɵpipe',

--- a/packages/compiler-cli/src/transformers/nocollapse_hack.ts
+++ b/packages/compiler-cli/src/transformers/nocollapse_hack.ts
@@ -23,7 +23,7 @@ const R3_DEF_NAME_PATTERN = [
   'ɵcmp',
   'ɵdir',
   'ngInjectableDef',
-  'ngInjectorDef',
+  'ɵinj',
   'ɵmod',
   'ɵpipe',
   'ɵfac',

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -88,7 +88,7 @@ describe('compiler compliance: dependency injection', () => {
       }`;
 
     const def = `
-      MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+      MyService.ɵprov = $r3$.ɵɵdefineInjectable({
         token: MyService,
         factory: function(t) {
           return MyService.ɵfac(t);
@@ -144,7 +144,7 @@ describe('compiler compliance: dependency injection', () => {
        };
 
        const def = `
-          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+          MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function() {
               return alternateFactory();
@@ -178,7 +178,7 @@ describe('compiler compliance: dependency injection', () => {
        };
 
        const def = `
-          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+          MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function MyService_Factory(t) {
               var r = null;
@@ -217,7 +217,7 @@ describe('compiler compliance: dependency injection', () => {
        };
 
        const factory = `
-          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+          MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function(t) {
               return MyAlternateService.ɵfac(t);
@@ -253,7 +253,7 @@ describe('compiler compliance: dependency injection', () => {
        };
 
        const factory = `
-          MyService.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+          MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function MyService_Factory(t) {
               var r = null;
@@ -290,7 +290,7 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      SomeProvider.ngInjectableDef = $r3$.ɵɵdefineInjectable({
+      SomeProvider.ɵprov = $r3$.ɵɵdefineInjectable({
         token: SomeProvider,
         factory: function(t) {
           return SomeProviderImpl.ɵfac(t);

--- a/packages/compiler-cli/test/metadata/bundler_spec.ts
+++ b/packages/compiler-cli/test/metadata/bundler_spec.ts
@@ -231,7 +231,7 @@ describe('metadata bundler', () => {
             import {sharedFn} from '../shared';
           
             export class MyClass {
-              static ngInjectableDef = sharedFn(); 
+              static ɵprov = sharedFn(); 
             }
           `,
         }
@@ -244,7 +244,7 @@ describe('metadata bundler', () => {
     // The unbundled metadata should reference symbols using the relative module path.
     expect(deepIndexMetadata.metadata['MyClass']).toEqual(jasmine.objectContaining<MetadataEntry>({
       statics: {
-        ngInjectableDef: {
+        ɵprov: {
           __symbolic: 'call',
           expression: {
             __symbolic: 'reference',
@@ -260,7 +260,7 @@ describe('metadata bundler', () => {
     // anywhere and it's not guaranteed that the relatively referenced files are present.
     expect(bundledMetadata.metadata['MyClass']).toEqual(jasmine.objectContaining<MetadataEntry>({
       statics: {
-        ngInjectableDef: {
+        ɵprov: {
           __symbolic: 'call',
           expression: {
             __symbolic: 'reference',

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -2082,7 +2082,7 @@ describe('ngc transformer command-line', () => {
         })
         export class ServiceModule {}
         `);
-        expect(source).not.toMatch(/ngInjectableDef/);
+        expect(source).not.toMatch(/ɵprov/);
       });
       it('on a service with a base class service', () => {
         const source = compileService(`
@@ -2102,7 +2102,7 @@ describe('ngc transformer command-line', () => {
         })
         export class ServiceModule {}
         `);
-        expect(source).not.toMatch(/ngInjectableDef/);
+        expect(source).not.toMatch(/ɵprov/);
       });
     });
 
@@ -2116,21 +2116,20 @@ describe('ngc transformer command-line', () => {
         })
         export class Service {}
       `);
-      expect(source).toMatch(/ngInjectableDef = .+\.ɵɵdefineInjectable\(/);
-      expect(source).toMatch(/ngInjectableDef.*token: Service/);
-      expect(source).toMatch(/ngInjectableDef.*providedIn: .+\.Module/);
+      expect(source).toMatch(/ɵprov = .+\.ɵɵdefineInjectable\(/);
+      expect(source).toMatch(/ɵprov.*token: Service/);
+      expect(source).toMatch(/ɵprov.*providedIn: .+\.Module/);
     });
 
-    it('ngInjectableDef in es5 mode is annotated @nocollapse when closure options are enabled',
-       () => {
-         writeConfig(`{
+    it('ɵprov in es5 mode is annotated @nocollapse when closure options are enabled', () => {
+      writeConfig(`{
         "extends": "./tsconfig-base.json",
         "angularCompilerOptions": {
           "annotateForClosureCompiler": true
         },
         "files": ["service.ts"]
       }`);
-         const source = compileService(`
+      const source = compileService(`
         import {Injectable} from '@angular/core';
         import {Module} from './module';
 
@@ -2139,8 +2138,8 @@ describe('ngc transformer command-line', () => {
         })
         export class Service {}
       `);
-         expect(source).toMatch(/\/\*\* @nocollapse \*\/ Service\.ngInjectableDef =/);
-       });
+      expect(source).toMatch(/\/\*\* @nocollapse \*\/ Service\.ɵprov =/);
+    });
 
     it('compiles a useValue InjectableDef', () => {
       const source = compileService(`
@@ -2155,7 +2154,7 @@ describe('ngc transformer command-line', () => {
         })
         export class Service {}
       `);
-      expect(source).toMatch(/ngInjectableDef.*return CONST_SERVICE/);
+      expect(source).toMatch(/ɵprov.*return CONST_SERVICE/);
     });
 
     it('compiles a useExisting InjectableDef', () => {
@@ -2172,7 +2171,7 @@ describe('ngc transformer command-line', () => {
         })
         export class Service {}
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\.ɵɵinject\(Existing\)/);
+      expect(source).toMatch(/ɵprov.*return ..\.ɵɵinject\(Existing\)/);
     });
 
     it('compiles a useFactory InjectableDef with optional dep', () => {
@@ -2192,7 +2191,7 @@ describe('ngc transformer command-line', () => {
           constructor(e: Existing|null) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.ɵɵinject\(Existing, 8\)/);
+      expect(source).toMatch(/ɵprov.*return ..\(..\.ɵɵinject\(Existing, 8\)/);
     });
 
     it('compiles a useFactory InjectableDef with skip-self dep', () => {
@@ -2212,7 +2211,7 @@ describe('ngc transformer command-line', () => {
           constructor(e: Existing) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.ɵɵinject\(Existing, 4\)/);
+      expect(source).toMatch(/ɵprov.*return ..\(..\.ɵɵinject\(Existing, 4\)/);
     });
 
     it('compiles a service that depends on a token', () => {
@@ -2229,9 +2228,9 @@ describe('ngc transformer command-line', () => {
           constructor(@Inject(TOKEN) value: boolean) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef = .+\.ɵɵdefineInjectable\(/);
-      expect(source).toMatch(/ngInjectableDef.*token: Service/);
-      expect(source).toMatch(/ngInjectableDef.*providedIn: .+\.Module/);
+      expect(source).toMatch(/ɵprov = .+\.ɵɵdefineInjectable\(/);
+      expect(source).toMatch(/ɵprov.*token: Service/);
+      expect(source).toMatch(/ɵprov.*providedIn: .+\.Module/);
     });
 
     it('generates exports.* references when outputting commonjs', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -61,12 +61,12 @@ runInEachFileSystem(os => {
 
 
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('Dep.ngInjectableDef =');
-      expect(jsContents).toContain('Service.ngInjectableDef =');
+      expect(jsContents).toContain('Dep.ɵprov =');
+      expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Dep>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
@@ -83,10 +83,10 @@ runInEachFileSystem(os => {
 
 
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('Store.ngInjectableDef =');
+      expect(jsContents).toContain('Store.ɵprov =');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Store<any>>;');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Store<any>>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Store<any>>;');
     });
 
     it('should compile Injectables with providedIn without errors', () => {
@@ -106,16 +106,16 @@ runInEachFileSystem(os => {
 
 
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('Dep.ngInjectableDef =');
-      expect(jsContents).toContain('Service.ngInjectableDef =');
+      expect(jsContents).toContain('Dep.ɵprov =');
+      expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents)
           .toContain(
               'Service.ɵfac = function Service_Factory(t) { return new (t || Service)(i0.ɵɵinject(Dep)); };');
       expect(jsContents).toContain('providedIn: \'root\' })');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Dep>;');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Dep>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
@@ -134,14 +134,14 @@ runInEachFileSystem(os => {
 
 
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('Service.ngInjectableDef =');
+      expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents)
           .toContain('factory: function () { return (function () { return new Service(); })(); }');
       expect(jsContents).toContain('Service_Factory(t) { return new (t || Service)(); }');
       expect(jsContents).toContain(', providedIn: \'root\' });');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
@@ -162,7 +162,7 @@ runInEachFileSystem(os => {
 
 
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('Service.ngInjectableDef =');
+      expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents).toContain('factory: function Service_Factory(t) { var r = null; if (t) {');
       expect(jsContents).toContain('return new (t || Service)(i0.ɵɵinject(Dep));');
       expect(jsContents)
@@ -170,7 +170,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('return r; }, providedIn: \'root\' });');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ngInjectableDef: i0.ɵɵInjectableDef<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
     });
 
@@ -375,7 +375,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('TestComponent.ɵcmp = i0.ɵɵdefineComponent');
       expect(jsContents).toContain('TestDirective.ɵdir = i0.ɵɵdefineDirective');
       expect(jsContents).toContain('TestPipe.ɵpipe = i0.ɵɵdefinePipe');
-      expect(jsContents).toContain('TestInjectable.ngInjectableDef = i0.ɵɵdefineInjectable');
+      expect(jsContents).toContain('TestInjectable.ɵprov = i0.ɵɵdefineInjectable');
       expect(jsContents).toContain('MyModule.ɵmod = i0.ɵɵdefineNgModule');
       expect(jsContents).toContain('MyModule.ɵinj = i0.ɵɵdefineInjector');
       expect(jsContents).toContain('inputs: { input: "input" }');
@@ -1183,10 +1183,10 @@ runInEachFileSystem(os => {
         expect(jsContents).toContain('TestNgModule.ɵmod =');
 
         // Validate that each class also has an injectable definition.
-        expect(jsContents).toContain('TestCmp.ngInjectableDef =');
-        expect(jsContents).toContain('TestDir.ngInjectableDef =');
-        expect(jsContents).toContain('TestPipe.ngInjectableDef =');
-        expect(jsContents).toContain('TestNgModule.ngInjectableDef =');
+        expect(jsContents).toContain('TestCmp.ɵprov =');
+        expect(jsContents).toContain('TestDir.ɵprov =');
+        expect(jsContents).toContain('TestPipe.ɵprov =');
+        expect(jsContents).toContain('TestNgModule.ɵprov =');
 
         // Validate that each class's .d.ts declaration has the primary definition.
         expect(dtsContents).toContain('ComponentDefWithMeta<TestCmp');

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -377,7 +377,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('TestPipe.ɵpipe = i0.ɵɵdefinePipe');
       expect(jsContents).toContain('TestInjectable.ngInjectableDef = i0.ɵɵdefineInjectable');
       expect(jsContents).toContain('MyModule.ɵmod = i0.ɵɵdefineNgModule');
-      expect(jsContents).toContain('MyModule.ngInjectorDef = i0.ɵɵdefineInjector');
+      expect(jsContents).toContain('MyModule.ɵinj = i0.ɵɵdefineInjector');
       expect(jsContents).toContain('inputs: { input: "input" }');
       expect(jsContents).toContain('outputs: { output: "output" }');
     });
@@ -650,7 +650,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('i0.ɵɵdefineNgModule({ type: TestModule });');
       expect(jsContents)
           .toContain(
-              `TestModule.ngInjectorDef = i0.ɵɵdefineInjector({ factory: ` +
+              `TestModule.ɵinj = i0.ɵɵdefineInjector({ factory: ` +
               `function TestModule_Factory(t) { return new (t || TestModule)(); }, providers: [{ provide: ` +
               `Token, useValue: 'test' }], imports: [[OtherModule]] });`);
 
@@ -658,7 +658,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵmod: i0.ɵɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], [typeof OtherModule], never>');
-      expect(dtsContents).toContain('static ngInjectorDef: i0.ɵɵInjectorDef');
+      expect(dtsContents).toContain('static ɵinj: i0.ɵɵInjectorDef');
     });
 
     it('should compile NgModules with factory providers without errors', () => {
@@ -690,7 +690,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('i0.ɵɵdefineNgModule({ type: TestModule });');
       expect(jsContents)
           .toContain(
-              `TestModule.ngInjectorDef = i0.ɵɵdefineInjector({ factory: ` +
+              `TestModule.ɵinj = i0.ɵɵdefineInjector({ factory: ` +
               `function TestModule_Factory(t) { return new (t || TestModule)(); }, providers: [{ provide: ` +
               `Token, useFactory: function () { return new Token(); } }], imports: [[OtherModule]] });`);
 
@@ -698,7 +698,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵmod: i0.ɵɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], [typeof OtherModule], never>');
-      expect(dtsContents).toContain('static ngInjectorDef: i0.ɵɵInjectorDef');
+      expect(dtsContents).toContain('static ɵinj: i0.ɵɵInjectorDef');
     });
 
     it('should compile NgModules with factory providers and deps without errors', () => {
@@ -734,7 +734,7 @@ runInEachFileSystem(os => {
       expect(jsContents).toContain('i0.ɵɵdefineNgModule({ type: TestModule });');
       expect(jsContents)
           .toContain(
-              `TestModule.ngInjectorDef = i0.ɵɵdefineInjector({ factory: ` +
+              `TestModule.ɵinj = i0.ɵɵdefineInjector({ factory: ` +
               `function TestModule_Factory(t) { return new (t || TestModule)(); }, providers: [{ provide: ` +
               `Token, useFactory: function (dep) { return new Token(dep); }, deps: [Dep] }], imports: [[OtherModule]] });`);
 
@@ -742,7 +742,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵmod: i0.ɵɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], [typeof OtherModule], never>');
-      expect(dtsContents).toContain('static ngInjectorDef: i0.ɵɵInjectorDef');
+      expect(dtsContents).toContain('static ɵinj: i0.ɵɵInjectorDef');
     });
 
     it('should compile NgModules with references to local components', () => {

--- a/packages/compiler-cli/test/transformers/nocollapse_hack_spec.ts
+++ b/packages/compiler-cli/test/transformers/nocollapse_hack_spec.ts
@@ -10,7 +10,7 @@ import {nocollapseHack} from '../../src/transformers/nocollapse_hack';
 
 describe('@nocollapse hack', () => {
   it('should add @nocollapse to a basic class', () => {
-    const decl = `Foo.ngInjectorDef = define(...);`;
+    const decl = `Foo.ɵinj = define(...);`;
     expect(nocollapseHack(decl)).toEqual('/** @nocollapse */ ' + decl);
   });
 
@@ -18,7 +18,7 @@ describe('@nocollapse hack', () => {
     const decl = `
       if (false) {
         /** @type {?} */
-        Foo.ngInjectorDef;
+        Foo.ɵinj;
       }
     `;
     expect(nocollapseHack(decl)).toContain('/** @nocollapse @type {?} */');

--- a/packages/compiler/design/architecture.md
+++ b/packages/compiler/design/architecture.md
@@ -9,7 +9,7 @@ This document details the new architecture of the Angular compiler in a post-Ivy
 
 ### The Ivy Compilation Model
 
-Broadly speaking, The Ivy model is that Angular decorators (`@Injectable`, etc) are compiled to static properties on the classes (`ngInjectableDef`). This operation must take place without global program knowledge, and in most cases only with knowledge of that single decorator.
+Broadly speaking, The Ivy model is that Angular decorators (`@Injectable`, etc) are compiled to static properties on the classes (`ɵprov`). This operation must take place without global program knowledge, and in most cases only with knowledge of that single decorator.
 
 The one exception is `@Component`, which requires knowledge of the metadata from the `@NgModule` which declares the component in order to properly generate the component def (`ɵcmp`). In particular, the selectors which are applicable during compilation of a component template are determined by the module that declares that component, and the transitive closure of the exports of that module's imports.
 

--- a/packages/compiler/design/separate_compilation.md
+++ b/packages/compiler/design/separate_compilation.md
@@ -87,7 +87,7 @@ class:
 
 Only one definition is generated per class. All components are directives so a
 `ɵcmp` contains all the `ɵdir` information. All directives
-are injectable so `ɵcmp` and `ɵdir` contain `ngInjectableDef`
+are injectable so `ɵcmp` and `ɵdir` contain `ɵprov`
 information.
 
 For `CompilePipeSummary` the table looks like:

--- a/packages/compiler/design/separate_compilation.md
+++ b/packages/compiler/design/separate_compilation.md
@@ -73,7 +73,7 @@ class:
 | `hostListeners`     | `ɵdir`                |
 | `hostProperties`    | `ɵdir`                |
 | `hostAttributes`    | `ɵdir`                |
-| `providers`         | `ngInjectorDef`       |
+| `providers`         | `ɵinj`                |
 | `viewProviders`     | `ɵcmp`                |
 | `queries`           | `ɵdir`                |
 | `guards`            | not used              |
@@ -282,7 +282,7 @@ export class MyPipe {
 The metadata for a module is transformed by:
 
 1. Remove the `@NgModule` directive.
-2. Add  `"ngInjectorDef": {}` static field.
+2. Add  `"ɵinj": {}` static field.
 3. Add `"ngModuleScope": <module-scope>` static field.
 
 The scope value is an array the following type:
@@ -329,7 +329,7 @@ export class MyModule {}
 *my.module.js*
 ```js
 export class MyModule {
-  static ngInjectorDef = ɵɵdefineInjector(...);
+  static ɵinj = ɵɵdefineInjector(...);
 }
 ```
 
@@ -342,7 +342,7 @@ export class MyModule {
     "MyModule": {
       "__symbolic": "class",
       "statics": {
-        "ngInjectorDef": {},
+        "ɵinj": {},
         "ngModuleScope": [
           {
             "type": {
@@ -389,7 +389,7 @@ manually written as:
 
 ```ts
 export class MyModule {
-  static ngInjectorDef = ɵɵdefineInjector({
+  static ɵinj = ɵɵdefineInjector({
     providers: [{
       provide: Service, useClass: ServiceImpl
     }],
@@ -440,7 +440,7 @@ properties by including a `// @__BUILD_OPTIMIZER_REMOVE_` comment:
 
 ```ts
 export class MyModule {
-  static ngInjectorDef = ɵɵdefineInjector({
+  static ɵinj = ɵɵdefineInjector({
     providers: [{
       provide: Service, useClass: ServiceImpl
     }],

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -204,7 +204,7 @@ export class ConstantPool {
       case DefinitionKind.Directive:
         return 'ɵdir';
       case DefinitionKind.Injector:
-        return 'ngInjectorDef';
+        return 'ɵinj';
       case DefinitionKind.Pipe:
         return 'ɵpipe';
     }

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -17,7 +17,7 @@ import {CssSelector} from './selector';
 export interface Inject { token: any; }
 export const createInject = makeMetadataFactory<Inject>('Inject', (token: any) => ({token}));
 export const createInjectionToken = makeMetadataFactory<object>(
-    'InjectionToken', (desc: string) => ({_desc: desc, ngInjectableDef: undefined}));
+    'InjectionToken', (desc: string) => ({_desc: desc, ɵprov: undefined}));
 
 export interface Attribute { attributeName?: string; }
 export const createAttribute =

--- a/packages/compiler/src/injectable_compiler.ts
+++ b/packages/compiler/src/injectable_compiler.ts
@@ -126,7 +126,7 @@ export class InjectableCompiler {
           className, null,
           [
             new o.ClassField(
-                'ngInjectableDef', o.INFERRED_TYPE, [o.StmtModifier.Static],
+                'ɵprov', o.INFERRED_TYPE, [o.StmtModifier.Static],
                 this.injectableDef(injectable, ctx)),
           ],
           [], new o.ClassMethod(null, [], []), []);

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -251,7 +251,7 @@ export function compileNgModuleFromRender2(
       /* name */ className,
       /* parent */ null,
       /* fields */[new o.ClassField(
-          /* name */ 'ngInjectorDef',
+          /* name */ 'ɵinj',
           /* type */ o.INFERRED_TYPE,
           /* modifiers */[o.StmtModifier.Static],
           /* initializer */ injectorDef, )],

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -143,7 +143,7 @@ export interface IterableDifferFactory {
  */
 export class IterableDiffers {
   /** @nocollapse */
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: IterableDiffers,
     providedIn: 'root',
     factory: () => new IterableDiffers([new DefaultIterableDifferFactory()])

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -118,7 +118,7 @@ export interface KeyValueDifferFactory {
  */
 export class KeyValueDiffers {
   /** @nocollapse */
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: KeyValueDiffers,
     providedIn: 'root',
     factory: () => new KeyValueDiffers([new DefaultKeyValueDifferFactory()])

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -229,7 +229,7 @@ export {
 } from './render3/fields';
 
 export {
-  NG_INJECTABLE_DEF as ɵNG_INJECTABLE_DEF,
+  NG_PROV_DEF as ɵNG_PROV_DEF,
   NG_INJ_DEF as ɵNG_INJ_DEF,
 } from './di/interface/defs';
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -230,7 +230,7 @@ export {
 
 export {
   NG_INJECTABLE_DEF as ɵNG_INJECTABLE_DEF,
-  NG_INJECTOR_DEF as ɵNG_INJECTOR_DEF,
+  NG_INJ_DEF as ɵNG_INJ_DEF,
 } from './di/interface/defs';
 
 export {

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -91,7 +91,7 @@ export const Injectable: InjectableDecorator = makeDecorator(
  *
  * @publicApi
  */
-export interface InjectableType<T> extends Type<T> { ngInjectableDef: ɵɵInjectableDef<T>; }
+export interface InjectableType<T> extends Type<T> { ɵprov: ɵɵInjectableDef<T>; }
 
 /**
  * Supports @Injectable() in JIT mode for Render2.
@@ -100,7 +100,7 @@ function render2CompileInjectable(injectableType: Type<any>, options?: {
   providedIn?: Type<any>| 'root' | 'platform' | 'any' | null
 } & InjectableProvider): void {
   if (options && options.providedIn !== undefined && !getInjectableDef(injectableType)) {
-    (injectableType as InjectableType<any>).ngInjectableDef = ɵɵdefineInjectable({
+    (injectableType as InjectableType<any>).ɵprov = ɵɵdefineInjectable({
       token: injectableType,
       providedIn: options.providedIn,
       factory: convertInjectableProviderToFactory(injectableType, options),

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -54,20 +54,20 @@ export class InjectionToken<T> {
   /** @internal */
   readonly ngMetadataName = 'InjectionToken';
 
-  readonly ngInjectableDef: never|undefined;
+  readonly ɵprov: never|undefined;
 
   constructor(protected _desc: string, options?: {
     providedIn?: Type<any>| 'root' | 'platform' | 'any' | null,
     factory: () => T
   }) {
-    this.ngInjectableDef = undefined;
+    this.ɵprov = undefined;
     if (typeof options == 'number') {
       // This is a special hack to assign __NG_ELEMENT_ID__ to this instance.
       // __NG_ELEMENT_ID__ is Used by Ivy to determine bloom filter id.
       // We are using it to assign `-1` which is used to identify `Injector`.
       (this as any).__NG_ELEMENT_ID__ = options;
     } else if (options !== undefined) {
-      this.ngInjectableDef = ɵɵdefineInjectable({
+      this.ɵprov = ɵɵdefineInjectable({
         token: this,
         providedIn: options.providedIn || 'root',
         factory: options.factory,

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -78,4 +78,4 @@ export class InjectionToken<T> {
   toString(): string { return `InjectionToken ${this._desc}`; }
 }
 
-export interface InjectableDefToken<T> extends InjectionToken<T> { ngInjectableDef: never; }
+export interface InjectableDefToken<T> extends InjectionToken<T> { ɵprov: never; }

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -90,7 +90,7 @@ export abstract class Injector {
   }
 
   /** @nocollapse */
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: Injector,
     providedIn: 'any' as any,
     factory: () => ɵɵinject(INJECTOR),

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -71,7 +71,7 @@ export interface ɵɵInjectorDef<T> {
   factory: () => T;
 
   // TODO(alxhub): Narrow down the type here once decorators properly change the return type of the
-  // class they are decorating (to add the ngInjectableDef property for example).
+  // class they are decorating (to add the ɵprov property for example).
   providers: (Type<any>|ValueProvider|ExistingProvider|FactoryProvider|ConstructorProvider|
               StaticClassProvider|ClassProvider|any[])[];
 
@@ -90,7 +90,7 @@ export interface InjectableType<T> extends Type<T> {
   /**
    * Opaque type whose structure is highly version dependent. Do not rely on any properties.
    */
-  ngInjectableDef: never;
+  ɵprov: never;
 }
 
 /**
@@ -126,7 +126,7 @@ export interface InjectorTypeWithProviders<T> {
  * Construct an `InjectableDef` which defines how a token will be constructed by the DI system, and
  * in which injectors (if any) it will be available.
  *
- * This should be assigned to a static `ngInjectableDef` field on a type, which will then be an
+ * This should be assigned to a static `ɵprov` field on a type, which will then be an
  * `InjectableType`.
  *
  * Options:
@@ -168,7 +168,7 @@ export const defineInjectable = ɵɵdefineInjectable;
  *   create the type must be provided. If that factory function needs to inject arguments, it can
  *   use the `inject` function.
  * * `providers`: an optional array of providers to add to the injector. Each provider must
- *   either have a factory or point to a type which has an `ngInjectableDef` static property (the
+ *   either have a factory or point to a type which has a `ɵprov` static property (the
  *   type must be an `InjectableType`).
  * * `imports`: an optional array of imports of other `InjectorType`s or `InjectorTypeWithModule`s
  *   whose providers will also be added to the injector. Locally provided types will override
@@ -184,39 +184,39 @@ export function ɵɵdefineInjector(options: {factory: () => any, providers?: any
 }
 
 /**
- * Read the `ngInjectableDef` for `type` in a way which is immune to accidentally reading inherited
- * value.
+ * Read the injectable def (`ɵprov`) for `type` in a way which is immune to accidentally reading
+ * inherited value.
  *
- * @param type A type which may have its own (non-inherited) `ngInjectableDef`.
+ * @param type A type which may have its own (non-inherited) `ɵprov`.
  */
 export function getInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
-  const def = type[NG_INJECTABLE_DEF] as ɵɵInjectableDef<T>;
+  const def = type[NG_PROV_DEF] as ɵɵInjectableDef<T>;
   // The definition read above may come from a base class. `hasOwnProperty` is not sufficient to
   // distinguish this case, as in older browsers (e.g. IE10) static property inheritance is
   // implemented by copying the properties.
   //
-  // Instead, the ngInjectableDef's token is compared to the type, and if they don't match then the
+  // Instead, the ɵprov's token is compared to the type, and if they don't match then the
   // property was not defined directly on the type itself, and was likely inherited. The definition
   // is only returned if the type matches the def.token.
   return def && def.token === type ? def : null;
 }
 
 /**
- * Read the `ngInjectableDef` for `type` or read the `ngInjectableDef` from one of its ancestors.
+ * Read the injectable def (`ɵprov`) for `type` or read the `ɵprov` from one of its ancestors.
  *
- * @param type A type which may have `ngInjectableDef`, via inheritance.
+ * @param type A type which may have `ɵprov`, via inheritance.
  *
  * @deprecated Will be removed in v10, where an error will occur in the scenario if we find the
- * `ngInjectableDef` on an ancestor only.
+ * `ɵprov` on an ancestor only.
  */
 export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
-  if (type && type[NG_INJECTABLE_DEF]) {
+  if (type && type[NG_PROV_DEF]) {
     // TODO(FW-1307): Re-add ngDevMode when closure can handle it
     // ngDevMode &&
     console.warn(
         `DEPRECATED: DI is instantiating a token "${type.name}" that inherits its @Injectable decorator but does not provide one itself.\n` +
         `This will become an error in v10. Please add @Injectable() to the "${type.name}" class.`);
-    return type[NG_INJECTABLE_DEF];
+    return type[NG_PROV_DEF];
   } else {
     return null;
   }
@@ -231,5 +231,5 @@ export function getInjectorDef<T>(type: any): ɵɵInjectorDef<T>|null {
   return type && type.hasOwnProperty(NG_INJ_DEF) ? (type as any)[NG_INJ_DEF] : null;
 }
 
-export const NG_INJECTABLE_DEF = getClosureSafeProperty({ngInjectableDef: getClosureSafeProperty});
+export const NG_PROV_DEF = getClosureSafeProperty({ɵprov: getClosureSafeProperty});
 export const NG_INJ_DEF = getClosureSafeProperty({ɵinj: getClosureSafeProperty});

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -104,7 +104,7 @@ export interface InjectorType<T> extends Type<T> {
   /**
    * Opaque type whose structure is highly version dependent. Do not rely on any properties.
    */
-  ngInjectorDef: never;
+  ɵinj: never;
 }
 
 /**
@@ -159,7 +159,7 @@ export const defineInjectable = ɵɵdefineInjectable;
 /**
  * Construct an `InjectorDef` which configures an injector.
  *
- * This should be assigned to a static `ngInjectorDef` field on a type, which will then be an
+ * This should be assigned to a static injector def (`ɵinj`) field on a type, which will then be an
  * `InjectorType`.
  *
  * Options:
@@ -223,13 +223,13 @@ export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|nu
 }
 
 /**
- * Read the `ngInjectorDef` type in a way which is immune to accidentally reading inherited value.
+ * Read the injector def type in a way which is immune to accidentally reading inherited value.
  *
- * @param type type which may have `ngInjectorDef`
+ * @param type type which may have an injector def (`ɵinj`)
  */
 export function getInjectorDef<T>(type: any): ɵɵInjectorDef<T>|null {
-  return type && type.hasOwnProperty(NG_INJECTOR_DEF) ? (type as any)[NG_INJECTOR_DEF] : null;
+  return type && type.hasOwnProperty(NG_INJ_DEF) ? (type as any)[NG_INJ_DEF] : null;
 }
 
 export const NG_INJECTABLE_DEF = getClosureSafeProperty({ngInjectableDef: getClosureSafeProperty});
-export const NG_INJECTOR_DEF = getClosureSafeProperty({ngInjectorDef: getClosureSafeProperty});
+export const NG_INJ_DEF = getClosureSafeProperty({ɵinj: getClosureSafeProperty});

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -190,7 +190,7 @@ export function ɵɵdefineInjector(options: {factory: () => any, providers?: any
  * @param type A type which may have its own (non-inherited) `ɵprov`.
  */
 export function getInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
-  const def = type[NG_PROV_DEF] as ɵɵInjectableDef<T>;
+  const def = (type[NG_PROV_DEF] || type[NG_INJECTABLE_DEF]) as ɵɵInjectableDef<T>;
   // The definition read above may come from a base class. `hasOwnProperty` is not sufficient to
   // distinguish this case, as in older browsers (e.g. IE10) static property inheritance is
   // implemented by copying the properties.
@@ -210,13 +210,14 @@ export function getInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
  * `ɵprov` on an ancestor only.
  */
 export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
-  if (type && type[NG_PROV_DEF]) {
+  const def = type && (type[NG_PROV_DEF] || type[NG_INJECTABLE_DEF]);
+  if (def) {
     // TODO(FW-1307): Re-add ngDevMode when closure can handle it
     // ngDevMode &&
     console.warn(
         `DEPRECATED: DI is instantiating a token "${type.name}" that inherits its @Injectable decorator but does not provide one itself.\n` +
         `This will become an error in v10. Please add @Injectable() to the "${type.name}" class.`);
-    return type[NG_PROV_DEF];
+    return def;
   } else {
     return null;
   }
@@ -228,8 +229,14 @@ export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|nu
  * @param type type which may have an injector def (`ɵinj`)
  */
 export function getInjectorDef<T>(type: any): ɵɵInjectorDef<T>|null {
-  return type && type.hasOwnProperty(NG_INJ_DEF) ? (type as any)[NG_INJ_DEF] : null;
+  return type && (type.hasOwnProperty(NG_INJ_DEF) || type.hasOwnProperty(NG_INJECTOR_DEF)) ?
+      (type as any)[NG_INJ_DEF] :
+      null;
 }
 
 export const NG_PROV_DEF = getClosureSafeProperty({ɵprov: getClosureSafeProperty});
 export const NG_INJ_DEF = getClosureSafeProperty({ɵinj: getClosureSafeProperty});
+
+// We need to keep these around so we can read off old defs if new defs are unavailable
+export const NG_INJECTABLE_DEF = getClosureSafeProperty({ngInjectableDef: getClosureSafeProperty});
+export const NG_INJECTOR_DEF = getClosureSafeProperty({ngInjectorDef: getClosureSafeProperty});

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -34,7 +34,7 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
       get: () => {
         if (ngInjectableDef === null) {
           ngInjectableDef = getCompilerFacade().compileInjectable(
-              angularCoreDiEnv, `ng:///${type.name}/ngInjectableDef.js`,
+              angularCoreDiEnv, `ng:///${type.name}/ɵprov.js`,
               getInjectableMetadata(type, srcMeta));
         }
         return ngInjectableDef;

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -12,7 +12,7 @@ import {NG_FACTORY_DEF} from '../../render3/fields';
 import {getClosureSafeProperty} from '../../util/property';
 import {resolveForwardRef} from '../forward_ref';
 import {Injectable} from '../injectable';
-import {NG_INJECTABLE_DEF} from '../interface/defs';
+import {NG_PROV_DEF} from '../interface/defs';
 import {ClassSansProvider, ExistingSansProvider, FactorySansProvider, ValueProvider, ValueSansProvider} from '../interface/provider';
 
 import {angularCoreDiEnv} from './environment';
@@ -22,15 +22,15 @@ import {convertDependencies, reflectDependencies} from './util';
 
 /**
  * Compile an Angular injectable according to its `Injectable` metadata, and patch the resulting
- * `ngInjectableDef` onto the injectable type.
+ * injectable def (`ɵprov`) onto the injectable type.
  */
 export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
   let ngInjectableDef: any = null;
   let ngFactoryDef: any = null;
 
-  // if NG_INJECTABLE_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_INJECTABLE_DEF)) {
-    Object.defineProperty(type, NG_INJECTABLE_DEF, {
+  // if NG_PROV_DEF is already defined on this class then don't overwrite it
+  if (!type.hasOwnProperty(NG_PROV_DEF)) {
+    Object.defineProperty(type, NG_PROV_DEF, {
       get: () => {
         if (ngInjectableDef === null) {
           ngInjectableDef = getCompilerFacade().compileInjectable(

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -176,11 +176,11 @@ export class R3Injector {
         // SkipSelf isn't set, check if the record belongs to this injector.
         let record: Record<T>|undefined|null = this.records.get(token);
         if (record === undefined) {
-          // No record, but maybe the token is scoped to this injector. Look for an ngInjectableDef
-          // with a scope matching this injector.
+          // No record, but maybe the token is scoped to this injector. Look for an injectable
+          // def with a scope matching this injector.
           const def = couldBeInjectableType(token) && getInjectableDef(token);
           if (def && this.injectableDefInScope(def)) {
-            // Found an ngInjectableDef and it's scoped to this injector. Pretend as if it was here
+            // Found an injectable def and it's scoped to this injector. Pretend as if it was here
             // all along.
             record = makeRecord(injectableDefOrInjectorDefFactory(token), NOT_YET);
           } else {
@@ -408,7 +408,7 @@ export class R3Injector {
 }
 
 function injectableDefOrInjectorDefFactory(token: Type<any>| InjectionToken<any>): () => any {
-  // Most tokens will have an ngInjectableDef directly on them, which specifies a factory directly.
+  // Most tokens will have an injectable def directly on them, which specifies a factory directly.
   const injectableDef = getInjectableDef(token);
   const factory = injectableDef !== null ? injectableDef.factory : getFactoryDef(token);
 
@@ -423,10 +423,10 @@ function injectableDefOrInjectorDefFactory(token: Type<any>| InjectionToken<any>
     return injectorDef.factory;
   }
 
-  // InjectionTokens should have an ngInjectableDef and thus should be handled above.
+  // InjectionTokens should have an injectable def (ɵprov) and thus should be handled above.
   // If it's missing that, it's an error.
   if (token instanceof InjectionToken) {
-    throw new Error(`Token ${stringify(token)} is missing an ngInjectableDef definition.`);
+    throw new Error(`Token ${stringify(token)} is missing a ɵprov definition.`);
   }
 
   // Undecorated types can sometimes be created if they have no constructor arguments.
@@ -447,8 +447,8 @@ function getUndecoratedInjectableFactory(token: Function) {
   }
 
   // The constructor function appears to have no parameters.
-  // This might be because it inherits from a super-class. In which case, use an ngInjectableDef
-  // from an ancestor if there is one.
+  // This might be because it inherits from a super-class. In which case, use an injectable
+  // def from an ancestor if there is one.
   // Otherwise this really is a simple class with no dependencies, so return a factory that
   // just instantiates the zero-arg constructor.
   const inheritedInjectableDef = getInheritedInjectableDef(token);

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -251,11 +251,11 @@ export class R3Injector {
     defOrWrappedDef = resolveForwardRef(defOrWrappedDef);
     if (!defOrWrappedDef) return false;
 
-    // Either the defOrWrappedDef is an InjectorType (with ngInjectorDef) or an
+    // Either the defOrWrappedDef is an InjectorType (with injector def) or an
     // InjectorDefTypeWithProviders (aka ModuleWithProviders). Detecting either is a megamorphic
     // read, so care is taken to only do the read once.
 
-    // First attempt to read the ngInjectorDef.
+    // First attempt to read the injector def (`ɵinj`).
     let def = getInjectorDef(defOrWrappedDef);
 
     // If that's not present, then attempt to read ngModule from the InjectorDefTypeWithProviders.
@@ -416,7 +416,8 @@ function injectableDefOrInjectorDefFactory(token: Type<any>| InjectionToken<any>
     return factory;
   }
 
-  // If the token is an NgModule, it's also injectable but the factory is on its ngInjectorDef.
+  // If the token is an NgModule, it's also injectable but the factory is on its injector def
+  // (`ɵinj`)
   const injectorDef = getInjectorDef(token);
   if (injectorDef !== null) {
     return injectorDef.factory;

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -350,7 +350,7 @@ function preR3NgModuleCompile(moduleType: Type<any>, metadata?: NgModule): void 
     imports = [...imports, metadata.exports];
   }
 
-  (moduleType as InjectorType<any>).ngInjectorDef = ɵɵdefineInjector({
+  (moduleType as InjectorType<any>).ɵinj = ɵɵdefineInjector({
     factory: convertInjectableProviderToFactory(moduleType, {useClass: moduleType}),
     providers: metadata && metadata.providers,
     imports: imports,

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -331,9 +331,9 @@ The above will create the following layout:
 | `EXPANDO`
 | 11..18| cumulativeBloom                              | templateBloom
 |       | *sub-section: `component` and `directives`*
-| 19    | `factory(Child.ɵcmp.factory)`*     | `Child`
+| 19    | `factory(Child.ɵcmp.factory)`*               | `Child`
 |       | *sub-section: `providers`*
-| 20    | `factory(ServiceA.ngInjectableDef.factory)`* | `ServiceA`
+| 20    | `factory(ServiceA.ɵprov.factory)`*           | `ServiceA`
 | 22    | `'someServiceBValue'`*                       | `ServiceB`
 |       | *sub-section: `viewProviders`*
 | 22    | `factory(()=> new Service())`*               | `ServiceC`
@@ -420,7 +420,7 @@ A pseudo-implementation of `inject` function.
 ```typescript
 function inject(token: any): any {
   let injectableDef;
-  if (typeof token === 'function' && injectableDef = token.ngInjectableDef) {
+  if (typeof token === 'function' && injectableDef = token.ɵprov) {
     const provideIn = injectableDef.provideIn;
    if (provideIn === '__node_injector__') {
       // if we are injecting `Injector` than create a wrapper object around the inject but which

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -8,7 +8,7 @@
 
 import {R3InjectorMetadataFacade, getCompilerFacade} from '../../compiler/compiler_facade';
 import {resolveForwardRef} from '../../di/forward_ref';
-import {NG_INJECTOR_DEF} from '../../di/interface/defs';
+import {NG_INJ_DEF} from '../../di/interface/defs';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {Component} from '../../metadata';
@@ -93,7 +93,7 @@ export function compileNgModule(moduleType: Type<any>, ngModule: NgModule = {}):
 }
 
 /**
- * Compiles and adds the `ɵmod` and `ngInjectorDef` properties to the module class.
+ * Compiles and adds the `ɵmod` and `ɵinj` properties to the module class.
  *
  * It's possible to compile a module via this API which will allow duplicate declarations in its
  * root.
@@ -135,7 +135,7 @@ export function compileNgModuleDefs(
   });
 
   let ngInjectorDef: any = null;
-  Object.defineProperty(moduleType, NG_INJECTOR_DEF, {
+  Object.defineProperty(moduleType, NG_INJ_DEF, {
     get: () => {
       if (ngInjectorDef === null) {
         ngDevMode && verifySemanticsOfNgModuleDef(
@@ -151,7 +151,7 @@ export function compileNgModuleDefs(
           ],
         };
         ngInjectorDef = getCompilerFacade().compileInjector(
-            angularCoreEnv, `ng:///${moduleType.name}/ngInjectorDef.js`, meta);
+            angularCoreEnv, `ng:///${moduleType.name}/ɵinj.js`, meta);
       }
       return ngInjectorDef;
     },

--- a/packages/core/src/sanitization/sanitizer.ts
+++ b/packages/core/src/sanitization/sanitizer.ts
@@ -17,7 +17,7 @@ import {SecurityContext} from './security';
 export abstract class Sanitizer {
   abstract sanitize(context: SecurityContext, value: {}|string|null): string|null;
   /** @nocollapse */
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: Sanitizer,
     providedIn: 'root',
     factory: () => null,

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -30,7 +30,7 @@
     "name": "NG_INJECTABLE_DEF"
   },
   {
-    "name": "NG_INJECTOR_DEF"
+    "name": "NG_INJ_DEF"
   },
   {
     "name": "NG_TEMP_TOKEN_PATH"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -27,10 +27,10 @@
     "name": "NG_FACTORY_DEF"
   },
   {
-    "name": "NG_INJECTABLE_DEF"
+    "name": "NG_INJ_DEF"
   },
   {
-    "name": "NG_INJ_DEF"
+    "name": "NG_PROV_DEF"
   },
   {
     "name": "NG_TEMP_TOKEN_PATH"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -27,6 +27,12 @@
     "name": "NG_FACTORY_DEF"
   },
   {
+    "name": "NG_INJECTABLE_DEF"
+  },
+  {
+    "name": "NG_INJECTOR_DEF"
+  },
+  {
     "name": "NG_INJ_DEF"
   },
   {

--- a/packages/core/test/bundling/injection/usage.ts
+++ b/packages/core/test/bundling/injection/usage.ts
@@ -9,7 +9,7 @@
 import {Injector, ɵcreateInjector as createInjector, ɵɵdefineInjectable, ɵɵdefineInjector} from '@angular/core';
 
 export class RootService {
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: RootService,
     providedIn: 'root',
     factory: () => new RootService(),
@@ -17,7 +17,7 @@ export class RootService {
 }
 
 export class ScopedService {
-  static ngInjectableDef = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: ScopedService,
     providedIn: null,
     factory: () => new ScopedService(),

--- a/packages/core/test/bundling/injection/usage.ts
+++ b/packages/core/test/bundling/injection/usage.ts
@@ -30,7 +30,7 @@ export class ScopedService {
 }
 
 export class DefinedInjector {
-  static ngInjectorDef = ɵɵdefineInjector({
+  static ɵinj = ɵɵdefineInjector({
     factory: () => new DefinedInjector(),
     providers: [ScopedService],
   });

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -135,10 +135,10 @@
     "name": "NG_FACTORY_DEF"
   },
   {
-    "name": "NG_INJECTABLE_DEF"
+    "name": "NG_PIPE_DEF"
   },
   {
-    "name": "NG_PIPE_DEF"
+    "name": "NG_PROV_DEF"
   },
   {
     "name": "NG_TEMPLATE_SELECTOR"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -135,6 +135,9 @@
     "name": "NG_FACTORY_DEF"
   },
   {
+    "name": "NG_INJECTABLE_DEF"
+  },
+  {
     "name": "NG_PIPE_DEF"
   },
   {

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -12,7 +12,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('InjectorDef-based createInjector()', () => {
   class CircularA {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: CircularA,
       providedIn: null,
       factory: () => ɵɵinject(CircularB),
@@ -20,7 +20,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class CircularB {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: CircularB,
       providedIn: null,
       factory: () => ɵɵinject(CircularA),
@@ -28,7 +28,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class Service {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: Service,
       providedIn: null,
       factory: () => new Service(),
@@ -36,7 +36,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class OptionalService {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: OptionalService,
       providedIn: null,
       factory: () => new OptionalService(),
@@ -59,7 +59,7 @@ describe('InjectorDef-based createInjector()', () => {
   class ServiceWithDep {
     constructor(readonly service: Service) {}
 
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ServiceWithDep,
       providedIn: null,
       // ChildService is derived from ServiceWithDep, so the factory function here must do the right
@@ -71,7 +71,7 @@ describe('InjectorDef-based createInjector()', () => {
   class ServiceWithOptionalDep {
     constructor(@Optional() readonly service: OptionalService|null) {}
 
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ServiceWithOptionalDep,
       providedIn: null,
       factory: () => new ServiceWithOptionalDep(ɵɵinject(OptionalService, InjectFlags.Optional)),
@@ -81,7 +81,7 @@ describe('InjectorDef-based createInjector()', () => {
   class ServiceWithMissingDep {
     constructor(readonly service: Service) {}
 
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ServiceWithMissingDep,
       providedIn: null,
       factory: () => new ServiceWithMissingDep(ɵɵinject(Service)),
@@ -91,7 +91,7 @@ describe('InjectorDef-based createInjector()', () => {
   class ServiceWithMultiDep {
     constructor(readonly locale: string[]) {}
 
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ServiceWithMultiDep,
       providedIn: null,
       factory: () => new ServiceWithMultiDep(ɵɵinject(LOCALE)),
@@ -99,7 +99,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class ServiceTwo {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ServiceTwo,
       providedIn: null,
       factory: () => new ServiceTwo(),
@@ -108,7 +108,7 @@ describe('InjectorDef-based createInjector()', () => {
 
   let deepServiceDestroyed = false;
   class DeepService {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: DeepService,
       providedIn: null,
       factory: () => new DeepService(),
@@ -119,7 +119,7 @@ describe('InjectorDef-based createInjector()', () => {
 
   let eagerServiceCreated: boolean = false;
   class EagerService {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: EagerService,
       providedIn: undefined,
       factory: () => new EagerService(),
@@ -218,7 +218,7 @@ describe('InjectorDef-based createInjector()', () => {
 
   let scopedServiceDestroyed = false;
   class ScopedService {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: ScopedService,
       providedIn: Module,
       factory: () => new ScopedService(),
@@ -228,7 +228,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class WrongScopeService {
-    static ngInjectableDef = ɵɵdefineInjectable({
+    static ɵprov = ɵɵdefineInjectable({
       token: WrongScopeService,
       providedIn: OtherModule,
       factory: () => new WrongScopeService(),

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -132,7 +132,7 @@ describe('InjectorDef-based createInjector()', () => {
   class DeepModule {
     constructor(eagerService: EagerService) { deepModuleCreated = true; }
 
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new DeepModule(ɵɵinject(EagerService)),
       imports: undefined,
       providers: [
@@ -150,7 +150,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class IntermediateModule {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new IntermediateModule(),
       imports: [DeepModule.safe()],
       providers: [],
@@ -160,7 +160,7 @@ describe('InjectorDef-based createInjector()', () => {
   class InjectorWithDep {
     constructor(readonly service: Service) {}
 
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new InjectorWithDep(ɵɵinject(Service)),
     });
   }
@@ -168,7 +168,7 @@ describe('InjectorDef-based createInjector()', () => {
   class ChildService extends ServiceWithDep {}
 
   class Module {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new Module(),
       imports: [IntermediateModule],
       providers: [
@@ -191,7 +191,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class OtherModule {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new OtherModule(),
       imports: undefined,
       providers: [],
@@ -199,7 +199,7 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class ModuleWithMissingDep {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new ModuleWithMissingDep(),
       imports: undefined,
       providers: [ServiceWithMissingDep],
@@ -209,7 +209,7 @@ describe('InjectorDef-based createInjector()', () => {
   class NotAModule {}
 
   class ImportsNotAModule {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new ImportsNotAModule(),
       imports: [NotAModule],
       providers: [],
@@ -236,21 +236,21 @@ describe('InjectorDef-based createInjector()', () => {
   }
 
   class MultiProviderA {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new MultiProviderA(),
       providers: [{provide: LOCALE, multi: true, useValue: 'A'}],
     });
   }
 
   class MultiProviderB {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new MultiProviderB(),
       providers: [{provide: LOCALE, multi: true, useValue: 'B'}],
     });
   }
 
   class WithProvidersTest {
-    static ngInjectorDef = ɵɵdefineInjector({
+    static ɵinj = ɵɵdefineInjector({
       factory: () => new WithProvidersTest(),
       imports: [
         {ngModule: MultiProviderA, providers: [{provide: LOCALE, multi: true, useValue: 'C'}]},
@@ -402,7 +402,7 @@ describe('InjectorDef-based createInjector()', () => {
         .toThrowError('Injector has already been destroyed.');
   });
 
-  it('should not crash when importing something that has no ngInjectorDef', () => {
+  it('should not crash when importing something that has no ɵinj', () => {
     injector = createInjector(ImportsNotAModule);
     expect(injector.get(ImportsNotAModule)).toBeDefined();
   });
@@ -419,7 +419,7 @@ describe('InjectorDef-based createInjector()', () => {
         constructor(missingType: any) {}
       }
       class ErrorModule {
-        static ngInjectorDef =
+        static ɵinj =
             ɵɵdefineInjector({factory: () => new ErrorModule(), providers: [MissingArgumentType]});
       }
       expect(() => createInjector(ErrorModule).get(MissingArgumentType))

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -1387,7 +1387,7 @@ function declareTests(config?: {useJit: boolean}) {
               }
 
               class Bar {
-                static ngInjectableDef: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+                static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
                   token: Bar,
                   factory: () => new Bar(),
                   providedIn: SomeModule,
@@ -1420,7 +1420,7 @@ function declareTests(config?: {useJit: boolean}) {
               }
 
               class Bar {
-                static ngInjectableDef: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+                static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
                   token: Bar,
                   factory: () => new Bar(),
                   providedIn: SomeModule,

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -90,7 +90,7 @@ describe('component', () => {
     }
 
     class MyModule {
-      static ngInjectorDef = ɵɵdefineInjector({
+      static ɵinj = ɵɵdefineInjector({
         factory: () => new MyModule(),
         providers: [{provide: MyService, useValue: new MyService('injector')}]
       });

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -63,7 +63,7 @@ describe('component', () => {
 
     class MyService {
       constructor(public value: string) {}
-      static ngInjectableDef = ɵɵdefineInjectable({
+      static ɵprov = ɵɵdefineInjectable({
         token: MyService,
         providedIn: 'root',
         factory: () => new MyService('no-injector'),

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -43,8 +43,8 @@ ivyEnabled && describe('render3 jit', () => {
     }
     const ServiceAny = Service as any;
 
-    expect(ServiceAny.ngInjectableDef).toBeDefined();
-    expect(ServiceAny.ngInjectableDef.providedIn).toBe('root');
+    expect(ServiceAny.ɵprov).toBeDefined();
+    expect(ServiceAny.ɵprov.providedIn).toBe('root');
     expect(ɵɵinject(Service) instanceof Service).toBe(true);
   });
 
@@ -167,7 +167,7 @@ ivyEnabled && describe('render3 jit', () => {
 
   it('compiles a module to an ɵinj with the providers', () => {
     class Token {
-      static ngInjectableDef = ɵɵdefineInjectable({
+      static ɵprov = ɵɵdefineInjectable({
         token: Token,
         providedIn: 'root',
         factory: () => 'default',

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -165,7 +165,7 @@ ivyEnabled && describe('render3 jit', () => {
     expect(moduleDef.declarations[0]).toBe(Cmp);
   });
 
-  it('compiles a module to an ngInjectorDef with the providers', () => {
+  it('compiles a module to an ɵinj with the providers', () => {
     class Token {
       static ngInjectableDef = ɵɵdefineInjectable({
         token: Token,
@@ -181,7 +181,7 @@ ivyEnabled && describe('render3 jit', () => {
       constructor(public token: Token) {}
     }
 
-    const injectorDef: ɵɵInjectorDef<Module> = (Module as any).ngInjectorDef;
+    const injectorDef: ɵɵInjectorDef<Module> = (Module as any).ɵinj;
     const instance = injectorDef.factory();
 
     // Since the instance was created outside of an injector using the module, the

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -326,7 +326,7 @@ describe('providers', () => {
 
   describe('single', () => {
     class MyModule {
-      static ngInjectorDef = ɵɵdefineInjector(
+      static ɵinj = ɵɵdefineInjector(
           {factory: () => new MyModule(), providers: [{provide: String, useValue: 'From module'}]});
     }
 
@@ -536,7 +536,7 @@ describe('providers', () => {
 
   describe('multi', () => {
     class MyModule {
-      static ngInjectorDef = ɵɵdefineInjector({
+      static ɵinj = ɵɵdefineInjector({
         factory: () => new MyModule(),
         providers: [{provide: String, useValue: 'From module', multi: true}]
       });
@@ -833,7 +833,7 @@ describe('providers', () => {
 
     it('should work with a module', () => {
       class MyModule {
-        static ngInjectorDef = ɵɵdefineInjector({
+        static ɵinj = ɵɵdefineInjector({
           factory: () => new MyModule(),
           providers: [{provide: String, useValue: 'From module'}]
         });
@@ -1126,7 +1126,7 @@ describe('providers', () => {
          expect(fixture.html).toEqual('<host-cmp>foo</host-cmp>');
 
          class MyAppModule {
-           static ngInjectorDef = ɵɵdefineInjector({
+           static ɵinj = ɵɵdefineInjector({
              factory: () => new MyAppModule(),
              imports: [],
              providers: [
@@ -1210,7 +1210,7 @@ describe('providers', () => {
 
   describe('injection flags', () => {
     class MyModule {
-      static ngInjectorDef = ɵɵdefineInjector(
+      static ɵinj = ɵɵdefineInjector(
           {factory: () => new MyModule(), providers: [{provide: String, useValue: 'Module'}]});
     }
     it('should not fall through to ModuleInjector if flags limit the scope', () => {

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -58,7 +58,7 @@ describe('providers', () => {
       public greet: string;
       constructor(private provider: GreeterProvider) { this.greet = this.provider.provide(); }
 
-      static ngInjectableDef = ɵɵdefineInjectable({
+      static ɵprov = ɵɵdefineInjectable({
         token: GreeterInj,
         factory: () => new GreeterInj(ɵɵinject(GreeterProvider as any)),
       });
@@ -816,7 +816,7 @@ describe('providers', () => {
     it('should work with root', () => {
       @Injectable({providedIn: 'root'})
       class FooForRoot {
-        static ngInjectableDef = ɵɵdefineInjectable({
+        static ɵprov = ɵɵdefineInjectable({
           token: FooForRoot,
           factory: () => new FooForRoot(),
           providedIn: 'root',
@@ -841,7 +841,7 @@ describe('providers', () => {
 
       @Injectable({providedIn: MyModule})
       class FooForModule {
-        static ngInjectableDef = ɵɵdefineInjectable({
+        static ɵprov = ɵɵdefineInjectable({
           token: FooForModule,
           factory: () => new FooForModule(),
           providedIn: MyModule,
@@ -1168,7 +1168,7 @@ describe('providers', () => {
          class MyService {
            constructor(public value: String) {}
 
-           static ngInjectableDef = ɵɵdefineInjectable({
+           static ɵprov = ɵɵdefineInjectable({
              token: MyService,
              factory: () => new MyService(ɵɵinject(String)),
            });
@@ -1188,7 +1188,7 @@ describe('providers', () => {
 
     it('should make sure that parent service does not see overrides in child directives', () => {
       class Greeter {
-        static ngInjectableDef = ɵɵdefineInjectable({
+        static ɵprov = ɵɵdefineInjectable({
           token: Greeter,
           factory: () => new Greeter(ɵɵinject(String)),
         });
@@ -1233,7 +1233,7 @@ describe('providers', () => {
     class SomeInj implements Some {
       constructor(public location: String) {}
 
-      static ngInjectableDef = ɵɵdefineInjectable({
+      static ɵprov = ɵɵdefineInjectable({
         token: SomeInj,
         factory: () => new SomeInj(ɵɵinject(String)),
       });

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -699,7 +699,7 @@ describe('TestBed', () => {
 
              // The providers for the module should have been restored to the original array, with
              // no trace of the overridden providers.
-             expect((Module as any).ngInjectorDef.providers).toEqual([Token]);
+             expect((Module as any).ɵinj.providers).toEqual([Token]);
            });
 
         it('should clean up overridden providers on components whose modules are compiled more than once',

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -25,7 +25,7 @@ class MyChildModule {}
 class NotMyModule {}
 
 class Bar {
-  static ngInjectableDef: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
     token: Bar,
     factory: () => new Bar(),
     providedIn: MyModule,
@@ -33,7 +33,7 @@ class Bar {
 }
 
 class Baz {
-  static ngInjectableDef: ɵɵInjectableDef<Baz> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<Baz> = ɵɵdefineInjectable({
     token: Baz,
     factory: () => new Baz(),
     providedIn: NotMyModule,
@@ -43,7 +43,7 @@ class Baz {
 class HasNormalDep {
   constructor(public foo: Foo) {}
 
-  static ngInjectableDef: ɵɵInjectableDef<HasNormalDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<HasNormalDep> = ɵɵdefineInjectable({
     token: HasNormalDep,
     factory: () => new HasNormalDep(inject(Foo)),
     providedIn: MyModule,
@@ -53,7 +53,7 @@ class HasNormalDep {
 class HasDefinedDep {
   constructor(public bar: Bar) {}
 
-  static ngInjectableDef: ɵɵInjectableDef<HasDefinedDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<HasDefinedDep> = ɵɵdefineInjectable({
     token: HasDefinedDep,
     factory: () => new HasDefinedDep(inject(Bar)),
     providedIn: MyModule,
@@ -63,7 +63,7 @@ class HasDefinedDep {
 class HasOptionalDep {
   constructor(public baz: Baz|null) {}
 
-  static ngInjectableDef: ɵɵInjectableDef<HasOptionalDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<HasOptionalDep> = ɵɵdefineInjectable({
     token: HasOptionalDep,
     factory: () => new HasOptionalDep(inject(Baz, InjectFlags.Optional)),
     providedIn: MyModule,
@@ -71,7 +71,7 @@ class HasOptionalDep {
 }
 
 class ChildDep {
-  static ngInjectableDef: ɵɵInjectableDef<ChildDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<ChildDep> = ɵɵdefineInjectable({
     token: ChildDep,
     factory: () => new ChildDep(),
     providedIn: MyChildModule,
@@ -80,7 +80,7 @@ class ChildDep {
 
 class FromChildWithOptionalDep {
   constructor(public baz: Baz|null) {}
-  static ngInjectableDef: ɵɵInjectableDef<FromChildWithOptionalDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<FromChildWithOptionalDep> = ɵɵdefineInjectable({
     token: FromChildWithOptionalDep,
     factory: () => new FromChildWithOptionalDep(inject(Baz, InjectFlags.Default)),
     providedIn: MyChildModule,
@@ -91,7 +91,7 @@ class FromChildWithSkipSelfDep {
   constructor(
       public skipSelfChildDep: ChildDep|null, public selfChildDep: ChildDep|null,
       public optionalSelfBar: Bar|null) {}
-  static ngInjectableDef: ɵɵInjectableDef<FromChildWithSkipSelfDep> = ɵɵdefineInjectable({
+  static ɵprov: ɵɵInjectableDef<FromChildWithSkipSelfDep> = ɵɵdefineInjectable({
     token: FromChildWithSkipSelfDep,
     factory: () => new FromChildWithSkipSelfDep(
                  inject(ChildDep, InjectFlags.SkipSelf|InjectFlags.Optional),
@@ -215,7 +215,7 @@ describe('NgModuleRef_ injector', () => {
 
       ngOnDestroy(): void { Service.destroyed++; }
 
-      static ngInjectableDef: ɵɵInjectableDef<Service> = ɵɵdefineInjectable({
+      static ɵprov: ɵɵInjectableDef<Service> = ɵɵdefineInjectable({
         token: Service,
         factory: () => new Service(),
         providedIn: 'root',

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {ApplicationInitStatus, COMPILER_OPTIONS, Compiler, Component, Directive, Injector, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, Type, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDirectiveDef as DirectiveDef, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJECTOR_DEF as NG_INJECTOR_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵɵInjectableDef as InjectableDef} from '@angular/core';
+import {ApplicationInitStatus, COMPILER_OPTIONS, Compiler, Component, Directive, Injector, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, Type, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDirectiveDef as DirectiveDef, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵɵInjectableDef as InjectableDef} from '@angular/core';
 import {ModuleRegistrationMap, getRegisteredModulesState, restoreRegisteredModulesState} from '../../src/linker/ng_module_factory_registration';
 
 import {clearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution, resolveComponentResources, restoreComponentResolutionQueue} from '../../src/metadata/resource_loading';
@@ -362,7 +362,7 @@ export class R3TestBedCompiler {
     }
     this.moduleProvidersOverridden.add(moduleType);
 
-    const injectorDef: any = (moduleType as any)[NG_INJECTOR_DEF];
+    const injectorDef: any = (moduleType as any)[NG_INJ_DEF];
     if (this.providerOverridesByToken.size > 0) {
       // Extract the list of providers from ModuleWithProviders, so we can define the final list of
       // providers that might have overrides.
@@ -373,9 +373,9 @@ export class R3TestBedCompiler {
                                    isModuleWithProviders(imported) ? imported.providers : []));
       const providers = [...providersFromModules, ...injectorDef.providers];
       if (this.hasProviderOverrides(providers)) {
-        this.maybeStoreNgDef(NG_INJECTOR_DEF, moduleType);
+        this.maybeStoreNgDef(NG_INJ_DEF, moduleType);
 
-        this.storeFieldOfDefOnType(moduleType, NG_INJECTOR_DEF, 'providers');
+        this.storeFieldOfDefOnType(moduleType, NG_INJ_DEF, 'providers');
         injectorDef.providers = this.getOverriddenProviders(providers);
       }
 
@@ -410,7 +410,7 @@ export class R3TestBedCompiler {
     }
     // Cache the initial ngModuleDef as it will be overwritten.
     this.maybeStoreNgDef(NG_MOD_DEF, ngModule);
-    this.maybeStoreNgDef(NG_INJECTOR_DEF, ngModule);
+    this.maybeStoreNgDef(NG_INJ_DEF, ngModule);
 
     compileNgModuleDefs(ngModule as NgModuleType<any>, metadata);
   }

--- a/packages/examples/core/di/ts/injector_spec.ts
+++ b/packages/examples/core/di/ts/injector_spec.ts
@@ -14,10 +14,10 @@ class MockRootScopeInjector implements Injector {
   get<T>(
       token: Type<T>|InjectionToken<T>, defaultValue?: any,
       flags: InjectFlags = InjectFlags.Default): T {
-    if ((token as any).ngInjectableDef && (token as any).ngInjectableDef.providedIn === 'root') {
+    if ((token as any).ɵprov && (token as any).ɵprov.providedIn === 'root') {
       const old = setCurrentInjector(this);
       try {
-        return (token as any).ngInjectableDef.factory();
+        return (token as any).ɵprov.factory();
       } finally {
         setCurrentInjector(old);
       }

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -446,7 +446,7 @@ export declare abstract class ViewportScroller {
     abstract scrollToPosition(position: [number, number]): void;
     abstract setHistoryScrollRestoration(scrollRestoration: 'auto' | 'manual'): void;
     abstract setOffset(offset: [number, number] | (() => [number, number])): void;
-    static ngInjectableDef: never;
+    static ɵprov: never;
 }
 
 export declare enum WeekDay {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -428,7 +428,7 @@ export interface InjectableDecorator {
 export declare type InjectableProvider = ValueSansProvider | ExistingSansProvider | StaticClassSansProvider | ConstructorSansProvider | FactorySansProvider | ClassSansProvider;
 
 export interface InjectableType<T> extends Type<T> {
-    ngInjectableDef: never;
+    ɵprov: never;
 }
 
 export interface InjectDecorator {
@@ -446,7 +446,7 @@ export declare enum InjectFlags {
 
 export declare class InjectionToken<T> {
     protected _desc: string;
-    readonly ngInjectableDef: never | undefined;
+    readonly ɵprov: never | undefined;
     constructor(_desc: string, options?: {
         providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
         factory: () => T;
@@ -459,7 +459,7 @@ export declare abstract class Injector {
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: Object;
-    static ngInjectableDef: never;
+    static ɵprov: never;
     /** @deprecated */ static create(providers: StaticProvider[], parent?: Injector): Injector;
     static create(options: {
         providers: StaticProvider[];
@@ -517,7 +517,7 @@ export declare class IterableDiffers {
     /** @deprecated */ factories: IterableDifferFactory[];
     constructor(factories: IterableDifferFactory[]);
     find(iterable: any): IterableDifferFactory;
-    static ngInjectableDef: never;
+    static ɵprov: never;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
     static extend(factories: IterableDifferFactory[]): StaticProvider;
 }
@@ -552,7 +552,7 @@ export declare class KeyValueDiffers {
     /** @deprecated */ factories: KeyValueDifferFactory[];
     constructor(factories: KeyValueDifferFactory[]);
     find(kv: any): KeyValueDifferFactory;
-    static ngInjectableDef: never;
+    static ɵprov: never;
     static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
     static extend<S>(factories: KeyValueDifferFactory[]): StaticProvider;
 }
@@ -1266,7 +1266,7 @@ export declare function resolveForwardRef<T>(type: T): T;
 
 export declare abstract class Sanitizer {
     abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
-    static ngInjectableDef: never;
+    static ɵprov: never;
 }
 
 export interface SchemaMetadata {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -471,7 +471,7 @@ export declare abstract class Injector {
 export declare const INJECTOR: InjectionToken<Injector>;
 
 export interface InjectorType<T> extends Type<T> {
-    ngInjectorDef: never;
+    ɵinj: never;
 }
 
 export interface Input {


### PR DESCRIPTION
Injector defs are not considered public API, so the property
that contains them should be prefixed with Angular's marker
for "private" ('ɵ') to discourage apps from relying on def
APIs directly.

This commit adds the prefix and shortens the name from
ngInjectorDef to inj. This is because property names
cannot be minified by Uglify without turning on property
mangling (which most apps have turned off) and are thus
size-sensitive.

---


Injectable defs are not considered public API, so the property
that contains them should be prefixed with Angular's marker
for "private" ('ɵ') to discourage apps from relying on def
APIs directly.

This commit adds the prefix and shortens the name from
ngInjectableDef to "prov" (for "provider", since injector defs
are known as "inj"). This is because property names cannot
be minified by Uglify without turning on property mangling
(which most apps have turned off) and are thus size-sensitive.