### PR TITLE
fix(ivy): ensure saniziter is not used when direct class application occurs

### DIFF
--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -500,6 +500,10 @@ export function setCurrentStyleSanitizer(sanitizer: StyleSanitizeFn | null) {
   _currentSanitizer = sanitizer;
 }
 
+export function resetCurrentStyleSanitizer() {
+  setCurrentStyleSanitizer(null);
+}
+
 export function getCurrentStyleSanitizer() {
   return _currentSanitizer;
 }

--- a/packages/core/src/render3/styling/bindings.ts
+++ b/packages/core/src/render3/styling/bindings.ts
@@ -756,7 +756,7 @@ function applyStylingValue(
   let valueToApply: string|null = unwrapSafeValue(value);
   if (isStylingValueDefined(valueToApply)) {
     valueToApply =
-        sanitizer ? sanitizer(prop, value, StyleSanitizeMode.SanitizeOnly) : valueToApply;
+        sanitizer ? sanitizer(prop, value, StyleSanitizeMode.ValidateAndSanitize) : valueToApply;
     applyFn(renderer, element, prop, valueToApply, bindingIndex);
     return true;
   }
@@ -771,8 +771,9 @@ function findAndApplyMapValue(
     const p = getMapProp(map, i);
     if (p === prop) {
       let valueToApply = getMapValue(map, i);
-      valueToApply =
-          sanitizer ? sanitizer(prop, valueToApply, StyleSanitizeMode.SanitizeOnly) : valueToApply;
+      valueToApply = sanitizer ?
+          sanitizer(prop, valueToApply, StyleSanitizeMode.ValidateAndSanitize) :
+          valueToApply;
       applyFn(renderer, element, prop, valueToApply, bindingIndex);
       return true;
     }

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1155,6 +1155,9 @@
     "name": "resetComponentState"
   },
   {
+    "name": "resetCurrentStyleSanitizer"
+  },
+  {
     "name": "resetPreOrderHookFlags"
   },
   {


### PR DESCRIPTION
Prior to this patch, if a map-class binding is applied directly then
that value will be incorrectly provided a sanitizer even if there is no
sanitization present for an element.