### PR TITLE
test(language-service): test project cleanup

### DIFF
--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -11,43 +11,45 @@ import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 import {AppComponent} from './app.component';
-import {ExpectNumericType, LowercasePipe, PrivateReference, WrongFieldReference, WrongSubFieldReference} from './expression-cases';
-import {UnknownEven, UnknownPeople, UnknownTrackBy} from './ng-for-cases';
-import {ShowIf} from './ng-if-cases';
-import {AttributeBinding, CaseIncompleteOpen, CaseMissingClosing, CaseUnknown, EmptyInterpolation, EventBinding, ForLetIEqual, ForOfEmpty, ForOfLetEmpty, ForUsingComponent, NoValueAttribute, NumberModel, Pipes, PropertyBinding, References, StringModel, TemplateReference, TestComponent, TwoWayBinding} from './parsing-cases';
+import * as ExpressionCases from './expression-cases';
+import * as NgForCases from './ng-for-cases';
+import * as NgIfCases from './ng-if-cases';
+import * as ParsingCases from './parsing-cases';
 
 @NgModule({
   imports: [CommonModule, FormsModule],
   declarations: [
     AppComponent,
-    CaseIncompleteOpen,
-    CaseMissingClosing,
-    CaseUnknown,
-    Pipes,
-    TemplateReference,
-    NoValueAttribute,
-    AttributeBinding,
-    StringModel,
-    NumberModel,
-    PropertyBinding,
-    EventBinding,
-    TwoWayBinding,
-    EmptyInterpolation,
-    ForOfEmpty,
-    ForOfLetEmpty,
-    ForLetIEqual,
-    ForUsingComponent,
-    References,
-    TestComponent,
-    WrongFieldReference,
-    WrongSubFieldReference,
-    PrivateReference,
-    ExpectNumericType,
-    UnknownPeople,
-    UnknownEven,
-    UnknownTrackBy,
-    ShowIf,
-    LowercasePipe,
+    ExpressionCases.ExpectNumericType,
+    ExpressionCases.LowercasePipe,
+    ExpressionCases.PrivateReference,
+    ExpressionCases.WrongFieldReference,
+    ExpressionCases.WrongSubFieldReference,
+    NgForCases.UnknownEven,
+    NgForCases.UnknownPeople,
+    NgForCases.UnknownTrackBy,
+    NgIfCases.ShowIf,
+    ParsingCases.AsyncForUsingComponent,
+    ParsingCases.AttributeBinding,
+    ParsingCases.CaseIncompleteOpen,
+    ParsingCases.CaseMissingClosing,
+    ParsingCases.CaseUnknown,
+    ParsingCases.EmptyInterpolation,
+    ParsingCases.EventBinding,
+    ParsingCases.FooComponent,
+    ParsingCases.ForLetIEqual,
+    ParsingCases.ForOfEmpty,
+    ParsingCases.ForOfLetEmpty,
+    ParsingCases.ForUsingComponent,
+    ParsingCases.NoValueAttribute,
+    ParsingCases.NumberModel,
+    ParsingCases.Pipes,
+    ParsingCases.PropertyBinding,
+    ParsingCases.References,
+    ParsingCases.StringModel,
+    ParsingCases.TemplateReference,
+    ParsingCases.TestComponent,
+    ParsingCases.TwoWayBinding,
   ]
 })
 export class AppModule {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -91,9 +91,22 @@ export class NumberModel {
   @Output('outputAlias') modelChanged: EventEmitter<number> = new EventEmitter();
 }
 
+@Component({
+  selector: 'foo-component',
+  template: `
+    <div string-model ~{string-marker}="text"></div>
+    <div number-model ~{number-marker}="value"></div>
+  `,
+})
+export class FooComponent {
+  text: string = 'some text';
+  value: number = 42;
+}
+
 interface Person {
   name: string;
   age: number;
+  street: string;
 }
 
 @Component({
@@ -123,6 +136,17 @@ export class ForLetIEqual {
 })
 export class ForUsingComponent {
   people: Person[] = [];
+}
+
+@Component({
+  template: `
+    <div *ngFor="let person of people | async">
+      {{person.~{async-person-name}name}}
+    </div>
+  `,
+})
+export class AsyncForUsingComponent {
+  people: Promise<Person[]> = Promise.resolve([]);
 }
 
 @Component({

--- a/packages/language-service/test/project/tsconfig.json
+++ b/packages/language-service/test/project/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "//00": "This file is used for IDE only, actual compilation options is in MockTypescriptHost in test_utils.ts",
   "compilerOptions": {
+    "lib": ["es2015"],
     "strict": true,
     "experimentalDecorators": true,
     "baseUrl": "../../../..",

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -95,7 +95,7 @@ describe('TypeScriptServiceHost', () => {
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
     const templates = ngLSHost.getTemplates('/app/parsing-cases.ts');
-    expect(templates.length).toBe(16);
+    expect(templates.length).toBe(18);
   });
 
   it('should be able to find external template', () => {


### PR DESCRIPTION
This PR adds es2015 lib to the `tsconfig.json` of the test project so
that `Promise` could be used. Note this only affects diagnostics in the
IDE. The tsconfig in Language Service Mock Host is the actual config
values used, and it already has es2015 lib.

- Other minor cleanup: Rename imports in `main.ts`.
- Add more cases to `parsing-cases.ts`, which are tested in later PRs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
