### PR TITLE
fix(ivy): i18n - add XLIFF aliases for legacy message id support

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2067,9 +2067,39 @@ runInEachFileSystem(os => {
          expect(jsContents).toContain(':@@5dbba0a3da8dff890e20cf76eb075d58900fbcd3:Some text');
        });
 
+    it('should render legacy id when `enableI18nLegacyMessageIdFormat` is not false and `i18nInFormat` is set to "xliff"',
+       () => {
+         env.tsconfig({i18nInFormat: 'xliff'});
+         env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+        @Component({
+          selector: 'test',
+          template: '<div i18n>Some text</div>'
+        })
+        class FooCmp {}`);
+         env.driveMain();
+         const jsContents = env.getContents('test.js');
+         expect(jsContents).toContain(':@@5dbba0a3da8dff890e20cf76eb075d58900fbcd3:Some text');
+       });
+
     it('should render legacy id when `enableI18nLegacyMessageIdFormat` is not false and `i18nInFormat` is set to "xlf2"',
        () => {
          env.tsconfig({i18nInFormat: 'xlf2'});
+         env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+        @Component({
+          selector: 'test',
+          template: '<div i18n>Some text</div>'
+        })
+        class FooCmp {}`);
+         env.driveMain();
+         const jsContents = env.getContents('test.js');
+         expect(jsContents).toContain(':@@8321000940098097247:Some text');
+       });
+
+    it('should render legacy id when `enableI18nLegacyMessageIdFormat` is not false and `i18nInFormat` is set to "xliff2"',
+       () => {
+         env.tsconfig({i18nInFormat: 'xliff2'});
          env.write(`test.ts`, `
         import {Component} from '@angular/core';
         @Component({

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -52,10 +52,11 @@ export class I18nMetaVisitor implements html.Visitor {
       message.id = typeof meta !== 'string' && (meta as i18n.Message).id || decimalDigest(message);
     }
 
-    if (this.i18nLegacyMessageIdFormat === 'xlf') {
+    if (this.i18nLegacyMessageIdFormat === 'xlf' || this.i18nLegacyMessageIdFormat === 'xliff') {
       message.legacyId = computeDigest(message);
     } else if (
-        this.i18nLegacyMessageIdFormat === 'xlf2' || this.i18nLegacyMessageIdFormat === 'xmb') {
+        this.i18nLegacyMessageIdFormat === 'xlf2' || this.i18nLegacyMessageIdFormat === 'xliff2' ||
+        this.i18nLegacyMessageIdFormat === 'xmb') {
       message.legacyId = computeDecimalDigest(message);
     } else if (typeof meta !== 'string') {
       // This occurs if we are doing the 2nd pass after whitespace removal


### PR DESCRIPTION
The `legacyMessageIdFormat` is taken from the `i18nInFormat` property but we were only considering `xmb`, `xlf` and `xlf2` values.

The CLI also supports `xliff` and `xliff2` values for the
`i18nInFormat`.

This commit adds support for those aliases.
