### PR TITLE
ngtsc & ngcc support for module re-exports (monorepo imports)

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/types.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/types.ts
@@ -7,6 +7,7 @@
  */
 import {ConstantPool} from '@angular/compiler';
 import * as ts from 'typescript';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
 import {CompileResult, DecoratorHandler} from '../../../src/ngtsc/transform';
 
@@ -23,7 +24,14 @@ export interface AnalyzedClass {
   matches: {handler: DecoratorHandler<any, any>; analysis: any;}[];
 }
 
-export interface CompiledClass extends AnalyzedClass { compilation: CompileResult[]; }
+export interface CompiledClass extends AnalyzedClass {
+  compilation: CompileResult[];
+
+  /**
+   * Any re-exports which should be added next to this class, both in .js and (if possible) .d.ts.
+   */
+  reexports: Reexport[];
+}
 
 export interface CompiledFile {
   compiledClasses: CompiledClass[];

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -50,6 +50,13 @@ export interface NgccEntryPointConfig {
    * even in the face of such missing dependencies.
    */
   ignoreMissingDependencies?: boolean;
+
+  /**
+   * Enabling this option for an entrypoint tells ngcc that deep imports might be used for the files
+   * it contains, and that it should generate private re-exports alongside the NgModule of all the
+   * directives/pipes it makes available in support of those imports.
+   */
+  generateDeepReexports?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -38,6 +38,8 @@ export interface EntryPoint extends JsonObject {
   compiledByAngular: boolean;
   /** Should ngcc ignore missing dependencies and process this entrypoint anyway? */
   ignoreMissingDependencies: boolean;
+  /** Should ngcc generate deep re-exports for this entrypoint? */
+  generateDeepReexports: boolean;
 }
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -124,6 +126,8 @@ export function getEntryPointInfo(
     typings: resolve(entryPointPath, typings), compiledByAngular,
     ignoreMissingDependencies:
         entryPointConfig !== undefined ? !!entryPointConfig.ignoreMissingDependencies : false,
+    generateDeepReexports:
+        entryPointConfig !== undefined ? !!entryPointConfig.generateDeepReexports : false,
   };
 
   return entryPointInfo;

--- a/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
@@ -8,6 +8,7 @@
 import {dirname, relative} from 'canonical-path';
 import * as ts from 'typescript';
 import MagicString from 'magic-string';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {Import, ImportManager} from '../../../src/ngtsc/translator';
 import {ExportInfo} from '../analysis/private_declarations_analyzer';
 import {isRequireCall} from '../host/commonjs_host';
@@ -51,6 +52,17 @@ export class CommonJsRenderingFormatter extends Esm5RenderingFormatter {
       const exportStr = `\nexports.${e.identifier} = ${importNamespace}${namedImport.symbol};`;
       output.append(exportStr);
     });
+  }
+
+  addDirectExports(
+      output: MagicString, exports: Reexport[], importManager: ImportManager,
+      file: ts.SourceFile): void {
+    for (const e of exports) {
+      const namedImport = importManager.generateNamedImport(e.fromModule, e.symbolName);
+      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport}.` : '';
+      const exportStr = `\nexports.${e.asAlias} = ${importNamespace}${namedImport.symbol};`;
+      output.append(exportStr);
+    }
   }
 
   protected findEndOfImports(sf: ts.SourceFile): number {

--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -8,6 +8,7 @@
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 import {FileSystem} from '../../../src/ngtsc/file_system';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {CompileResult} from '../../../src/ngtsc/transform';
 import {translateType, ImportManager} from '../../../src/ngtsc/translator';
 import {DecorationAnalyses} from '../analysis/types';
@@ -33,6 +34,7 @@ class DtsRenderInfo {
   classInfo: DtsClassInfo[] = [];
   moduleWithProviders: ModuleWithProvidersInfo[] = [];
   privateExports: ExportInfo[] = [];
+  reexports: Reexport[] = [];
 }
 
 
@@ -94,6 +96,13 @@ export class DtsRenderer {
         const newStatement = `    static ${declaration.name}: ${typeStr};\n`;
         outputText.appendRight(endOfClass - 1, newStatement);
       });
+
+      if (renderInfo.reexports.length > 0) {
+        for (const e of renderInfo.reexports) {
+          const newStatement = `\nexport {${e.symbolName} as ${e.asAlias}} from '${e.fromModule}';`;
+          outputText.appendRight(endOfClass, newStatement);
+        }
+      }
     });
 
     this.dtsFormatter.addModuleWithProvidersParams(
@@ -102,8 +111,6 @@ export class DtsRenderer {
         outputText, dtsFile.fileName, renderInfo.privateExports, importManager, dtsFile);
     this.dtsFormatter.addImports(
         outputText, importManager.getAllImports(dtsFile.fileName), dtsFile);
-
-
 
     return renderSourceAndMap(dtsFile, input, outputText);
   }
@@ -123,6 +130,15 @@ export class DtsRenderer {
           const dtsFile = dtsDeclaration.getSourceFile();
           const renderInfo = dtsMap.has(dtsFile) ? dtsMap.get(dtsFile) ! : new DtsRenderInfo();
           renderInfo.classInfo.push({dtsDeclaration, compilation: compiledClass.compilation});
+          // Only add re-exports if the .d.ts tree is overlayed with the .js tree, as re-exports in
+          // ngcc are only used to support deep imports into e.g. commonjs code. For a deep import
+          // to work, the typing file and JS file must be in parallel trees. This logic will detect
+          // the simplest version of this case, which is sufficient to handle most commonjs
+          // libraries.
+          if (compiledClass.declaration.getSourceFile().fileName ===
+              dtsFile.fileName.replace(/\.d\.ts$/, '.js')) {
+            renderInfo.reexports.push(...compiledClass.reexports);
+          }
           dtsMap.set(dtsFile, renderInfo);
         }
       });

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -16,6 +16,7 @@ import {ModuleWithProvidersInfo} from '../analysis/module_with_providers_analyze
 import {ExportInfo} from '../analysis/private_declarations_analyzer';
 import {RenderingFormatter, RedundantDecoratorMap} from './rendering_formatter';
 import {stripExtension} from './utils';
+import {Reexport} from '../../../src/ngtsc/imports';
 
 /**
  * A RenderingFormatter that works with ECMAScript Module import and export statements.
@@ -55,6 +56,22 @@ export class EsmRenderingFormatter implements RenderingFormatter {
       const exportStr = `\nexport {${exportStatement}}${exportFrom};`;
       output.append(exportStr);
     });
+  }
+
+
+  /**
+   * Add plain exports to the end of the file.
+   *
+   * Unlike `addExports`, direct exports go directly in a .js and .d.ts file and don't get added to
+   * an entrypoint.
+   */
+  addDirectExports(
+      output: MagicString, exports: Reexport[], importManager: ImportManager,
+      file: ts.SourceFile): void {
+    for (const e of exports) {
+      const exportStatement = `\nexport {${e.symbolName} as ${e.asAlias}} from '${e.fromModule}';`;
+      output.append(exportStatement);
+    }
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -83,6 +83,11 @@ export class Renderer {
       compiledFile.compiledClasses.forEach(clazz => {
         const renderedDefinition = renderDefinitions(compiledFile.sourceFile, clazz, importManager);
         this.srcFormatter.addDefinitions(outputText, clazz, renderedDefinition);
+
+        if (!isEntryPoint && clazz.reexports.length > 0) {
+          this.srcFormatter.addDirectExports(
+              outputText, clazz.reexports, importManager, compiledFile.sourceFile);
+        }
       });
 
       this.srcFormatter.addConstants(

--- a/packages/compiler-cli/ngcc/src/rendering/rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/rendering_formatter.ts
@@ -7,6 +7,7 @@
  */
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {Import, ImportManager} from '../../../src/ngtsc/translator';
 import {ExportInfo} from '../analysis/private_declarations_analyzer';
 import {CompiledClass} from '../analysis/types';
@@ -31,6 +32,9 @@ export interface RenderingFormatter {
   addExports(
       output: MagicString, entryPointBasePath: string, exports: ExportInfo[],
       importManager: ImportManager, file: ts.SourceFile): void;
+  addDirectExports(
+      output: MagicString, exports: Reexport[], importManager: ImportManager,
+      file: ts.SourceFile): void;
   addDefinitions(output: MagicString, compiledClass: CompiledClass, definitions: string): void;
   removeDecorators(output: MagicString, decoratorsToRemove: RedundantDecoratorMap): void;
   rewriteSwitchableDeclarations(

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -80,6 +80,7 @@ runInEachFileSystem(() => {
         handler.resolve.and.callFake((decl: ts.Declaration, analysis: any) => {
           logs.push(`resolve: ${(decl as any).name.text}@${analysis.decoratorName}`);
           analysis.resolved = true;
+          return {};
         });
         // The "test" compilation result is just the name of the decorator being compiled
         // (suffixed with `(compiled)`)

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -6,15 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {AbsoluteFsPath, NgtscCompilerHost, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {TestFile} from '../../../src/ngtsc/file_system/testing';
 import {BundleProgram, makeBundleProgram} from '../../src/packages/bundle_program';
+import {NgccEntryPointConfig} from '../../src/packages/configuration';
 import {EntryPoint, EntryPointFormat} from '../../src/packages/entry_point';
 import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {NgccSourcesCompilerHost} from '../../src/packages/ngcc_compiler_host';
 
+export type TestConfig = Pick<NgccEntryPointConfig, 'generateDeepReexports'>;
+
 export function makeTestEntryPoint(
-    entryPointName: string, packageName: string = entryPointName): EntryPoint {
+    entryPointName: string, packageName: string = entryPointName, config?: TestConfig): EntryPoint {
   return {
     name: entryPointName,
     packageJson: {name: entryPointName},
@@ -23,6 +27,7 @@ export function makeTestEntryPoint(
     typings: absoluteFrom(`/node_modules/${entryPointName}/index.d.ts`),
     compiledByAngular: true,
     ignoreMissingDependencies: false,
+    generateDeepReexports: config !== undefined ? !!config.generateDeepReexports : false,
   };
 }
 
@@ -34,8 +39,8 @@ export function makeTestEntryPoint(
  */
 export function makeTestEntryPointBundle(
     packageName: string, format: EntryPointFormat, isCore: boolean, srcRootNames: AbsoluteFsPath[],
-    dtsRootNames?: AbsoluteFsPath[]): EntryPointBundle {
-  const entryPoint = makeTestEntryPoint(packageName);
+    dtsRootNames?: AbsoluteFsPath[], config?: TestConfig): EntryPointBundle {
+  const entryPoint = makeTestEntryPoint(packageName, packageName, config);
   const src = makeTestBundleProgram(srcRootNames[0], isCore);
   const dts =
       dtsRootNames ? makeTestDtsBundleProgram(dtsRootNames[0], entryPoint.package, isCore) : null;

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -144,6 +144,7 @@ runInEachFileSystem(() => {
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          };
          const esm5bundle = makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', true);
 
@@ -191,6 +192,7 @@ runInEachFileSystem(() => {
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,
@@ -213,6 +215,7 @@ runInEachFileSystem(() => {
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -51,6 +51,7 @@ runInEachFileSystem(() => {
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/valid_entry_point'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          });
        });
 
@@ -111,6 +112,7 @@ runInEachFileSystem(() => {
         packageJson: overriddenPackageJson,
         compiledByAngular: true,
         ignoreMissingDependencies: false,
+        generateDeepReexports: false,
       });
     });
 
@@ -158,6 +160,7 @@ runInEachFileSystem(() => {
            packageJson: {name: 'some_package/missing_package_json', ...override},
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          });
        });
 
@@ -215,6 +218,7 @@ runInEachFileSystem(() => {
           packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_typings'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
+          generateDeepReexports: false,
         });
       });
     }
@@ -239,6 +243,7 @@ runInEachFileSystem(() => {
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
            compiledByAngular: false,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          });
        });
 
@@ -266,6 +271,7 @@ runInEachFileSystem(() => {
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
+           generateDeepReexports: false,
          });
        });
 
@@ -295,6 +301,7 @@ runInEachFileSystem(() => {
             loadPackageJson(fs, '/project/node_modules/some_package/types_rather_than_typings'),
         compiledByAngular: true,
         ignoreMissingDependencies: false,
+        generateDeepReexports: false,
       });
     });
 
@@ -327,6 +334,7 @@ runInEachFileSystem(() => {
         packageJson: loadPackageJson(fs, '/project/node_modules/some_package/material_style'),
         compiledByAngular: true,
         ignoreMissingDependencies: false,
+        generateDeepReexports: false,
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -9,6 +9,7 @@ import MagicString from 'magic-string';
 import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {loadTestFiles} from '../../../test/helpers';
 import {Import, ImportManager} from '../../../src/ngtsc/translator';
 import {DecorationAnalyzer} from '../../src/analysis/decoration_analyzer';
@@ -28,6 +29,9 @@ class TestRenderingFormatter implements RenderingFormatter {
   }
   addExports(output: MagicString, baseEntryPointPath: string, exports: ExportInfo[]) {
     output.prepend('\n// ADD EXPORTS\n');
+  }
+  addDirectExports(output: MagicString, exports: Reexport[]) {
+    output.prepend('\n// ADD DIRECT EXPORTS\n');
   }
   addConstants(output: MagicString, constants: string, file: ts.SourceFile): void {
     output.prepend('\n// ADD CONSTANTS\n');

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -10,6 +10,7 @@ import * as ts from 'typescript';
 import {fromObject, generateMapFileComment, SourceMapConverter} from 'convert-source-map';
 import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {loadTestFiles} from '../../../test/helpers';
 import {Import, ImportManager} from '../../../src/ngtsc/translator';
 import {DecorationAnalyzer} from '../../src/analysis/decoration_analyzer';
@@ -30,6 +31,9 @@ class TestRenderingFormatter implements RenderingFormatter {
   }
   addExports(output: MagicString, baseEntryPointPath: string, exports: ExportInfo[]) {
     output.prepend('\n// ADD EXPORTS\n');
+  }
+  addDirectExports(output: MagicString, exports: Reexport[]): void {
+    output.prepend('\n// ADD DIRECT EXPORTS\n');
   }
   addConstants(output: MagicString, constants: string, file: ts.SourceFile): void {
     output.prepend('\n// ADD CONSTANTS\n');

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -65,6 +65,12 @@ export enum ErrorCode {
   NGMODULE_MODULE_WITH_PROVIDERS_MISSING_GENERIC = 6005,
 
   /**
+   * Raised when an NgModule exports multiple directives/pipes of the same name and the compiler
+   * attempts to generate private re-exports within the NgModule file.
+   */
+  NGMODULE_REEXPORT_NAME_COLLISION = 6006,
+
+  /**
    * Raised when ngcc tries to inject a synthetic decorator over one that already exists.
    */
   NGCC_MIGRATION_DECORATOR_INJECTION_ERROR = 7001,

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -23,16 +23,32 @@ export class FatalDiagnosticError {
   }
 }
 
-export function makeDiagnostic(
-    code: ErrorCode, node: ts.Node, messageText: string): ts.DiagnosticWithLocation {
+export function makeDiagnostic(code: ErrorCode, node: ts.Node, messageText: string, relatedInfo?: {
+  node: ts.Node,
+  messageText: string,
+}[]): ts.DiagnosticWithLocation {
   node = ts.getOriginalNode(node);
-  return {
+  const diag: ts.DiagnosticWithLocation = {
     category: ts.DiagnosticCategory.Error,
     code: Number('-99' + code.valueOf()),
     file: ts.getOriginalNode(node).getSourceFile(),
     start: node.getStart(undefined, false),
     length: node.getWidth(), messageText,
   };
+  if (relatedInfo !== undefined) {
+    diag.relatedInformation = relatedInfo.map(info => {
+      const infoNode = ts.getOriginalNode(info.node);
+      return {
+        category: ts.DiagnosticCategory.Message,
+        code: 0,
+        file: infoNode.getSourceFile(),
+        start: infoNode.getStart(),
+        length: infoNode.getWidth(),
+        messageText: info.messageText,
+      };
+    });
+  }
+  return diag;
 }
 
 export function isFatalDiagnosticError(err: any): err is FatalDiagnosticError {

--- a/packages/compiler-cli/src/ngtsc/imports/README.md
+++ b/packages/compiler-cli/src/ngtsc/imports/README.md
@@ -1,0 +1,209 @@
+# `imports`
+
+The `imports` module attempts to unify all import handling in ngtsc. It powers the compiler's reference system - how the compiler tracks classes like components, directives, NgModules, etc, and how it generates imports to them in user code. At its heart is the `Reference` abstraction, which combines a class `ts.Declaration` with any additional context needed to generate an import of that class in different situations.
+
+In Angular, users do not import the directives and pipes they use in templates directly. Instead, they import an NgModule, and the NgModule exports a set of directives/pipes which will be available in the template of any consumer. When generating code for the template, though, the directives/pipes used there need to be imported directly. This creates a challenge for the compiler: it must choose an ES module specifier from which they can be imported, since the user never provided it.
+
+Much of the logic around imports and references in the compiler is dedicated to answering this question. The compiler has two major modes of operation here:
+
+1. Module specifier (import path) tracking
+
+If a directive/pipe is within the user's program, then it can be imported directly. If not (e.g. the directive came from a library in `node_modules`), the compiler will look at the NgModule that caused the directive to be available in the template, look at its import, and attempt to use the same module specifier.
+
+This logic is based on the Angular Package Format, which dictates that libraries are organized into entrypoints, and both an NgModule and its directives/pipes must be exported from the same entrypoint (usually an `index.ts` file).
+
+Thus, if `CommonModule` is imported from the specifier '@angular/common', and its `NgIf` directive is used in a template, the compiler will always import `NgIf` from '@angular/common' as well.
+
+It's important to note that this logic is transitive. If the user instead imported `BrowserModule` from '@angular/platform-browser' (which re-exports `CommonModule` and thus `NgIf`), the compiler will note that `BrowserModule` itself imported `CommonModule` from '@angular/common', and so `NgIf` will be imported from '@angular/common' still.
+
+This logic of course breaks down for non-Angular Package Format libraries, such as "internal" libraries within a monorepo, which frequently don't use `index.ts` files or entrypoints. In this case, the user will likely import NgModules directly from their declaration (e.g. via a 'lib/module' specifier), and the compiler cannot simply assume that the user has exported all of the directives/pipes from the NgModule via this same specifier. In this case a compiler feature called "aliasing" kicks in (see below) and generates private exports from the NgModule file.
+
+2. Using a `FileToModuleHost`
+
+The `ts.CompilerHost` given to the compiler may optionally implement an interface called `FileToModuleHost`, which allows an absolute module specifier to be generated for any file. If a `FileToModuleHost` is present, the compiler will attempt to directly import all directives and pipes from the file which declares them, instead of going via the specifier of the NgModule as in the first mode described above. This logic is used internally in the Google monorepo.
+
+This approach comes with a significant caveat: the build system may prevent importing from files which are not directly declared dependencies of the current compilation (this is known as "strict dependency checking"). This is a problem when attempting to consume a re-exported directive. For example, if the user depends only on '@angular/platform-browser', imports `BrowserModule` from '@angular/platform-browser' and attempts to use the re-exported `NgIf`, the compiler cannot import `NgIf` directly from its declaration within '@angular/common', which is a transitive (but not direct) dependency.
+
+To support these re-exports, a compiler feature called "aliasing" will create a re-export of `NgIf` from within @angular/platform-browser when compiling that package. Then, the downstream application compiler can import `NgIf` via this "alias" re-export from a direct dependency, instead of needing to import it from a transitive dependency.
+
+## References
+
+At its heart, the compiler keeps track of the types (classes) it's operating on using the `ts.Declaration` of that class. This suffices to _identify_ a class; however, the compiler frequently needs to track not only the class itself, but how that class came to be known in a particular context. For example, the compiler might see that `CommonModule` is included in `AppModule`'s imports, but it also needs to keep track of from where `CommonModule` was imported to apply the logic of "module specifier tracking" described above.
+
+To do this, the compiler will wrap the `ts.Declaration` of `CommonModule` into a `Reference`. A `Reference` is a pointer to a `ts.Declaration` plus any additional information and context about _how_ that reference came to be.
+
+### Identifier tracking
+
+Where possible, the compiler tries to use existing user-provided imports to refer to classes, instead of generating new imports. This is possible because `Reference`s keep track of any `ts.Identifier`s encountered which refer to the referenced class. If Angular, in the course of processing a `ts.Expression` (such as the `declarations` array of an NgModule), determines that the `ts.Identifier` points to a `Reference`, it adds the `ts.Identifier` to that `Reference` for future use.
+
+The `Reference.getIdentityIn` method queries the `Reference` for a `ts.Identifier` that's valid in a given `ts.SourceFile`. This is used by the `LocalIdentifierStrategy` when emitting an `Expression` for the `Reference` (see the description of `ReferenceEmitter` below).
+
+#### Synthetic references
+
+In some cases, identifier tracking needs to be disabled for a `Reference`. For example, when the compiler synthesizes a `Reference` as part of "foreign function evaluation", the evaluated `ts.Identifier` may not be a direct reference to the `Reference`'s class at runtime, even if logically that interpretation makes sense in the context of the current expression.
+
+In these cases, the `Reference`s are marked as `synthetic`, which disables all `ts.Identifier` tracking.
+
+### Owning modules
+
+As described above, one piece of information the compiler tracks about a `Reference` is the module specifier from which it came. This is known as its "owning module".
+
+For a `Reference`, the compiler tracks both the module specifier itself as well as the context file which contained this module specifier (which is important for TypeScript module resolution operations).
+
+This information is tracked in `Reference.bestGuessOwningModule`. This field carries the "best guess" prefix because the compiler cannot verify that each `Reference` which was extracted from a given ES module is actually exported via that module specifier. This depends on the packaging convention the user chose to use. Since a `Reference` may not belong to any external module, `bestGuessOwningModule` may be `null`.
+
+For convenience, the module specifier as a string is also made available as `Reference.ownedByModuleGuess`.
+
+## ReferenceEmitter
+
+During evaluation of `ts.Expression`s, `Reference`s to specific directives/pipes/etc are created. During code generation, imports need to be generated for a particular component's template function, based on these `Reference`s. This job falls to the `ReferenceEmitter`.
+
+A `ReferenceEmitter` takes a `Reference` as well as a `ts.SourceFile` which will contain the import, and generates an `Expression` which can be used to refer to the referenced class within that file. This may or may not be an `ExternalExpression` (which would generate an import statement), depending on whether it's possible to rely on an existing import of the class within that file.
+
+`ReferenceEmitter` is a wrapper around one or more `ReferenceEmitStrategy` instances. Each strategy is tried in succession until an `Expression` can be determined. An error is produced if no valid mechanism of referring to the referenced class can be found.
+
+### `LocalIdentifierStrategy`
+
+This `ReferenceEmitStrategy` queries the `Reference` for a `ts.Identifier` that's valid in the requested file (see "identifier tracking" for `Reference`s above).
+
+### `LogicalProjectStrategy`
+
+This `ReferenceEmitStrategy` is used to import referenced classes that are declared in the current project, and not in any third-party or external libraries. It constructs an import path that's valid within the logical filesystem of the project, even if the project has multiple `rootDirs`.
+
+### `AbsoluteModuleStrategy`
+
+This `ReferenceEmitStrategy` uses the `bestGuessOwningModule` of a `Reference` to generate an import of the referenced class.
+
+Note that the `bestGuessOwningModule` only gives the module specifier for the import, not the symbol name. The user may have renamed the class as part of re-exporting it from an entrypoint, so the `AbsoluteModuleStrategy` searches the exports of the target module and finds the symbol name by which the class is re-exported, if it exists.
+
+### `FileToModuleStrategy`
+
+This `ReferenceEmitStrategy` uses a `FileToModuleHost` to implement the major import mode #2 described at the beginning of this document.
+
+Under this strategy, direct imports to referenced classes are constructed using globally valid absolute module specifiers determined by the `FileToModuleHost`.
+
+Like with `AbsoluteModuleStrategy`, the `FileToModuleHost` only gives the module specifier and not the symbol name, so an appropriate symbol name must be determined by searching the exports of the module.
+
+### `AliasStrategy`
+
+The `AliasStrategy` will choose the alias `Expression` of a `Reference`. This strategy is used before the `FileToModuleStrategy` to guarantee aliases are preferred to direct imports when available.
+
+See the description of aliasing in the case of `FileToModuleAliasingHost` below.
+
+## Aliasing and re-exports
+
+In certain cases, the exports written by the user are not sufficient to guarantee that a downstream compiler will be able to depend on directives/pipes correctly. In these circumstances the compiler's "aliasing" system creates new exports to bridge the gaps.
+
+An `AliasingHost` interface allows different aliasing strategies to be chosen based on the needs of the current compilation. It supports two operations:
+
+1. Determination of a re-export name, if needed, for a given directive/pipe.
+
+When compiling an NgModule, the compiler will consult the `AliasingHost` via its `maybeAliasSymbolAs` method to determine whether to add re-exports of any directives/pipes exported (directly or indirectly) by the NgModule.
+
+2. Determination of an alias `Expression` for a directive/pipe, based on a re-export that was expected to have been generated previously.
+
+When the user imports an NgModule from an external library (via a `.d.ts` file), the compiler will construct a "scope" of exported directives/pipes that this NgModule makes available to any templates. In the process of constructing this scope, the compiler creates `Reference`s for each directive/pipe.
+
+As part of this operation, the compiler will consult the `AliasingHost` via its `getAliasIn` method to determine whether an alias `Expression` should be used to refer to each class instead of going through other import generation logic. This alias is saved on the `Reference`.
+
+Because the first import of an NgModule from a user library to a `.d.ts` is always from a direct dependency, the result is that all `Reference`s to directives/pipes which can be used from this module will have an associated alias `Expression` specifying how to import them from that direct dependency, instead of from a transitive dependency.
+
+Aliasing is currently used in two cases:
+
+1. To address strict dependency checking issues when using a `FileToModuleHost`.
+2. To support dependening on non-Angular Package Format packages (e.g. private libraries in monorepos) which do not have an entrypoint file through which all directives/pipes/modules are exported.
+
+In environments with "strict dependency checking" as described above, an NgModule which exports another NgModule from one of its dependencies needs to export its directives/pipes as well, in order to make them available to the downstream compiler.
+
+### Aliasing under `FileToModuleHost`
+
+A `FileToModuleAliasingHost` implements `AliasingHost` and makes full use of the aliasing system in the case of a `FileToModuleHost`.
+
+When compiling an NgModule, re-exports are added under a stable name for each directive/pipe that's re-exported by the NgModule.
+
+When importing that NgModule, alias `Expression`s are added to all the `Reference`s for those directives/pipes that are guaranteed to be from a direct dependency.
+
+
+### Private re-exports for non-APF packages
+
+A `PrivateExportAliasingHost` is used to add re-exports of directives/pipes in the case where the compiler cannot determine that all directives/pipes are re-exported from a common entrypoint (like in the case of an Angular Package Format compilation).
+
+In this case, aliasing is used to proactively add re-exports of directives/pipes to the file of any NgModule which exports them, ensuring they can be imported from the same module specifier as the NgModule itself. This is only done if the user has not already added such exports directly.
+
+This `AliasingHost` does not tag any `Reference`s with aliases, and relies on the action of the `AbsoluteModuleStrategy` described above to find and select the alias re-export when attempting to write an import for a given `Reference`.
+
+## Default imports
+
+This aspect of the `imports` package is a little different than the rest of the code as it's not concerned with directive/pipe imports. Instead, it's concerned with a different problem: preventing the removal of default import statements which were converted from type-only to value imports through compilation.
+
+### Type-to-value compilation
+
+This occurs when a default import is used as a type parameter in a service constructor:
+
+```typescript
+import Foo from 'foo';
+
+@Injectable()
+export class Svc {
+  constructor(private foo: Foo) {}
+}
+```
+
+Here, `Foo` is used in the type position only, but the compiler will eventually generate an `inject(Foo)` call in the factory function for this service. The use of `Foo` like this in the output depends on the import statement surviving compilation.
+
+Due to quirks in TypeScript transformers (see below), TypeScript considers the import to be type-only and does not notice the additional usage as a value added during transformation, and so will attempt to remove the import. The default import managing system exists to prevent this.
+
+It consists of two mechanisms:
+
+1. A `DefaultImportTracker`, which records information about both default imports encountered in the program as well as usages of those imports added during compilation.
+
+A `DefaultImportRecorder` interface is used to allow for a noop implementation in cases (like ngcc) where this tracking isn't necessary.
+
+2. A TypeScript transformer which processes default import statements and can preserve those which are actually used.
+
+This is accessed via `DefaultImportTracker.importPreservingTransformer`.
+
+### Why default imports are problematic
+
+This section is the result of speculation, as we have not traced the TypeScript compiler thoroughly.
+
+Consider the class:
+
+```typescript
+import {Foo} from './foo';
+
+class X {
+  constructor(foo: Foo) {}
+}
+```
+
+Angular wants to generate a value expression (`inject(Foo)`), using the value side of the `Foo` type from the constructor.
+
+After transforms, this roughly looks like:
+
+```javascript
+let foo_1 = require('./foo');
+
+inject(foo_1.Foo);
+```
+
+The Angular compiler takes the `Foo` `ts.Identifier` from the import statement `import {Foo} from './foo'`, which has a "provenance" in TypeScript that indicates it's associated with the import statement. After transforms, TypeScript will scan the output code and notice this `ts.Identifier` is still present, and so it will choose to preserve the import statement.
+
+If, however, `Foo` was a default import:
+
+```typescript
+import Foo from './foo';
+```
+
+Then the generated code depends on a few factors (target/module/esModuleInterop settings), but roughly looks like:
+
+
+```javascript
+let foo_1 = require('./foo');
+
+inject(foo_1.default);
+```
+
+Note in this output, the `Foo` identifier from before has disappeared. TypeScript then does not find any `ts.Identifier`s which point back to the original import statement, and thus it concludes that the import is unused.
+
+It's likely that this case was overlooked in the design of the transformers API.

--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {AliasGenerator, AliasStrategy} from './src/alias';
+export {AliasStrategy, AliasingHost, FileToModuleAliasingHost, PrivateExportAliasingHost} from './src/alias';
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
 export {DefaultImportRecorder, DefaultImportTracker, NOOP_DEFAULT_IMPORT_RECORDER} from './src/default';
 export {AbsoluteModuleStrategy, FileToModuleHost, FileToModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitStrategy, ReferenceEmitter} from './src/emitter';

--- a/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
@@ -9,17 +9,126 @@
 import {Expression, ExternalExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {ClassDeclaration} from '../../reflection';
+import {ClassDeclaration, ReflectionHost, isNamedClassDeclaration} from '../../reflection';
 import {FileToModuleHost, ReferenceEmitStrategy} from './emitter';
 import {ImportMode, Reference} from './references';
 
 // Escape anything that isn't alphanumeric, '/' or '_'.
 const CHARS_TO_ESCAPE = /[^a-zA-Z0-9/_]/g;
 
-export class AliasGenerator {
+/**
+ * A host for the aliasing system, which allows for alternative exports/imports of directives/pipes.
+ *
+ * Given an import of an NgModule (e.g. `CommonModule`), the compiler must generate imports to the
+ * directives and pipes exported by this module (e.g. `NgIf`) when they're used in a particular
+ * template. In its default configuration, if the compiler is not directly able to import the
+ * component from another file within the same project, it will attempt to import the component
+ * from the same (absolute) path by which the module was imported. So in the above example if
+ * `CommonModule` was imported from '@angular/common', the compiler will attempt to import `NgIf`
+ * from '@angular/common' as well.
+ *
+ * The aliasing system interacts with the above logic in two distinct ways.
+ *
+ * 1) It can be used to create "alias" re-exports from different files, which can be used when the
+ *    user hasn't exported the directive(s) from the ES module containing the NgModule. These re-
+ *    exports can also be helpful when using a `FileToModuleHost`, which overrides the import logic
+ *    described above.
+ *
+ * 2) It can be used to get an alternative import expression for a directive or pipe, instead of
+ *    the import that the normal logic would apply. The alias used depends on the provenance of the
+ *    `Reference` which was obtained for the directive/pipe, which is usually a property of how it
+ *    came to be in a template's scope (e.g. by which NgModule).
+ *
+ * See the README.md for more information on how aliasing works within the compiler.
+ */
+export interface AliasingHost {
+  /**
+   * Controls whether any alias re-exports are rendered into .d.ts files.
+   *
+   * This is not always necessary for aliasing to function correctly, so this flag allows an
+   * `AliasingHost` to avoid cluttering the .d.ts files if exports are not strictly needed.
+   */
+  readonly aliasExportsInDts: boolean;
+
+  /**
+   * Determine a name by which `decl` should be re-exported from `context`, depending on the
+   * particular set of aliasing rules in place.
+   *
+   * `maybeAliasSymbolAs` can return `null`, in which case no alias export should be generated.
+   *
+   * @param ref a `Reference` to the directive/pipe to consider for aliasing.
+   * @param context the `ts.SourceFile` in which the alias re-export might need to be generated.
+   * @param ngModuleName the declared name of the `NgModule` within `context` for which the alias
+   * would be generated.
+   * @param isReExport whether the directive/pipe under consideration is re-exported from another
+   * NgModule (as opposed to being declared by it directly).
+   */
+  maybeAliasSymbolAs(
+      ref: Reference<ClassDeclaration>, context: ts.SourceFile, ngModuleName: string,
+      isReExport: boolean): string|null;
+
+  /**
+   * Determine an `Expression` by which `decl` should be imported from `via` using an alias export
+   * (which should have been previously created when compiling `via`).
+   *
+   * `getAliasIn` can return `null`, in which case no alias is needed to import `decl` from `via`
+   * (and the normal import rules should be used).
+   *
+   * @param decl the declaration of the directive/pipe which is being imported, and which might be
+   * aliased.
+   * @param via the `ts.SourceFile` which might contain an alias to the
+   */
+  getAliasIn(decl: ClassDeclaration, via: ts.SourceFile, isReExport: boolean): Expression|null;
+}
+
+/**
+ * An `AliasingHost` which generates and consumes alias re-exports when module names for each file
+ * are determined by a `FileToModuleHost`.
+ *
+ * When using a `FileToModuleHost`, aliasing prevents issues with transitive dependencies. See the
+ * README.md for more details.
+ */
+export class FileToModuleAliasingHost implements AliasingHost {
   constructor(private fileToModuleHost: FileToModuleHost) {}
 
-  aliasSymbolName(decl: ClassDeclaration, context: ts.SourceFile): string {
+  /**
+   * With a `FileToModuleHost`, aliases are chosen automatically without the need to look through
+   * the exports present in a .d.ts file, so we can avoid cluttering the .d.ts files.
+   */
+  readonly aliasExportsInDts = false;
+
+  maybeAliasSymbolAs(
+      ref: Reference<ClassDeclaration>, context: ts.SourceFile, ngModuleName: string,
+      isReExport: boolean): string|null {
+    if (!isReExport) {
+      // Aliasing is used with a FileToModuleHost to prevent transitive dependencies. Thus, aliases
+      // only need to be created for directives/pipes which are not direct declarations of an
+      // NgModule which exports them.
+      return null;
+    }
+    return this.aliasName(ref.node, context);
+  }
+
+  /**
+   * Generates an `Expression` to import `decl` from `via`, assuming an export was added when `via`
+   * was compiled per `maybeAliasSymbolAs` above.
+   */
+  getAliasIn(decl: ClassDeclaration, via: ts.SourceFile, isReExport: boolean): Expression|null {
+    if (!isReExport) {
+      // Directly exported directives/pipes don't require an alias, per the logic in
+      // `maybeAliasSymbolAs`.
+      return null;
+    }
+    // viaModule is the module it'll actually be imported from.
+    const moduleName = this.fileToModuleHost.fileNameToModuleName(via.fileName, via.fileName);
+    return new ExternalExpr({moduleName, name: this.aliasName(decl, via)});
+  }
+
+  /**
+   * Generates an alias name based on the full module name of the file which declares the aliased
+   * directive/pipe.
+   */
+  private aliasName(decl: ClassDeclaration, context: ts.SourceFile): string {
     // The declared module is used to get the name of the alias.
     const declModule =
         this.fileToModuleHost.fileNameToModuleName(decl.getSourceFile().fileName, context.fileName);
@@ -27,15 +136,75 @@ export class AliasGenerator {
     const replaced = declModule.replace(CHARS_TO_ESCAPE, '_').replace(/\//g, '$');
     return 'ɵng$' + replaced + '$$' + decl.name.text;
   }
-
-  aliasTo(decl: ClassDeclaration, via: ts.SourceFile): Expression {
-    const name = this.aliasSymbolName(decl, via);
-    // viaModule is the module it'll actually be imported from.
-    const moduleName = this.fileToModuleHost.fileNameToModuleName(via.fileName, via.fileName);
-    return new ExternalExpr({moduleName, name});
-  }
 }
 
+/**
+ * An `AliasingHost` which exports directives from any file containing an NgModule in which they're
+ * declared/exported, under a private symbol name.
+ *
+ * These exports support cases where an NgModule is imported deeply from an absolute module path
+ * (that is, it's not part of an Angular Package Format entrypoint), and the compiler needs to
+ * import any matched directives/pipes from the same path (to the NgModule file). See README.md for
+ * more details.
+ */
+export class PrivateExportAliasingHost implements AliasingHost {
+  constructor(private host: ReflectionHost) {}
+
+  /**
+   * Under private export aliasing, the `AbsoluteModuleStrategy` used for emitting references will
+   * will select aliased exports that it finds in the .d.ts file for an NgModule's file. Thus,
+   * emitting these exports in .d.ts is a requirement for the `PrivateExportAliasingHost` to
+   * function correctly.
+   */
+  readonly aliasExportsInDts = true;
+
+  maybeAliasSymbolAs(
+      ref: Reference<ClassDeclaration>, context: ts.SourceFile, ngModuleName: string): string|null {
+    if (ref.hasOwningModuleGuess) {
+      // Skip nodes that already have an associated absolute module specifier, since they can be
+      // safely imported from that specifier.
+      return null;
+    }
+    // Look for a user-provided export of `decl` in `context`. If one exists, then an alias export
+    // is not needed.
+    // TODO(alxhub): maybe add a host method to check for the existence of an export without going
+    // through the entire list of exports.
+    const exports = this.host.getExportsOfModule(context);
+    if (exports === null) {
+      // Something went wrong, and no exports were available at all. Bail rather than risk creating
+      // re-exports when they're not needed.
+      throw new Error(`Could not determine the exports of: ${context.fileName}`);
+    }
+    let found: boolean = false;
+    exports.forEach(value => {
+      if (value.node === ref.node) {
+        found = true;
+      }
+    });
+    if (found) {
+      // The module exports the declared class directly, no alias is necessary.
+      return null;
+    }
+    return `ɵngExportɵ${ngModuleName}ɵ${ref.node.name.text}`;
+  }
+
+  /**
+   * A `PrivateExportAliasingHost` only generates re-exports and does not direct the compiler to
+   * directly consume the aliases it creates.
+   *
+   * Instead, they're consumed indirectly: `AbsoluteModuleStrategy` `ReferenceEmitterStrategy` will
+   * select these alias exports automatically when looking for an export of the directive/pipe from
+   * the same path as the NgModule was imported.
+   *
+   * Thus, `getAliasIn` always returns `null`.
+   */
+  getAliasIn(): null { return null; }
+}
+
+/**
+ * A `ReferenceEmitStrategy` which will consume the alias attached to a particular `Reference` to a
+ * directive or pipe, if it exists.
+ */
 export class AliasStrategy implements ReferenceEmitStrategy {
   emit(ref: Reference<ts.Node>, context: ts.SourceFile, importMode: ImportMode): Expression|null {
     return ref.alias;

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -70,7 +70,7 @@ export const NOOP_DEFAULT_IMPORT_RECORDER: DefaultImportRecorder = {
  * a dangling reference, as TS will elide the import because it was only used in the type position
  * originally.
  *
- * To avoid this, the compiler must "touch" the imports with `ts.updateImportClause`, and should
+ * To avoid this, the compiler must "touch" the imports with `ts.getMutableClone`, and should
  * only do this for imports which are actually consumed. The `DefaultImportTracker` keeps track of
  * these imports as they're encountered and emitted, and implements a transform which can correctly
  * flag the imports as required.

--- a/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {AliasGenerator, Reference} from '../../imports';
+import {AliasingHost, Reference} from '../../imports';
 import {DirectiveMeta, MetadataReader, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
@@ -34,7 +34,7 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
   /**
    * @param dtsMetaReader a `MetadataReader` which can read metadata from `.d.ts` files.
    */
-  constructor(private dtsMetaReader: MetadataReader, private aliasGenerator: AliasGenerator|null) {}
+  constructor(private dtsMetaReader: MetadataReader, private aliasingHost: AliasingHost|null) {}
 
   /**
    * Resolve a `Reference`'d NgModule from a .d.ts file and produce a transitive `ExportScope`
@@ -76,22 +76,16 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
       // Attempt to process the export as a directive.
       const directive = this.dtsMetaReader.getDirectiveMetadata(exportRef);
       if (directive !== null) {
-        if (!declarations.has(exportRef.node)) {
-          directives.push(this.maybeAlias(directive, sourceFile));
-        } else {
-          directives.push(directive);
-        }
+        const isReExport = !declarations.has(exportRef.node);
+        directives.push(this.maybeAlias(directive, sourceFile, isReExport));
         continue;
       }
 
       // Attempt to process the export as a pipe.
       const pipe = this.dtsMetaReader.getPipeMetadata(exportRef);
       if (pipe !== null) {
-        if (!declarations.has(exportRef.node)) {
-          pipes.push(this.maybeAlias(pipe, sourceFile));
-        } else {
-          pipes.push(pipe);
-        }
+        const isReExport = !declarations.has(exportRef.node);
+        pipes.push(this.maybeAlias(pipe, sourceFile, isReExport));
         continue;
       }
 
@@ -101,7 +95,7 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
         // It is a module. Add exported directives and pipes to the current scope. This might
         // involve rewriting the `Reference`s to those types to have an alias expression if one is
         // required.
-        if (this.aliasGenerator === null) {
+        if (this.aliasingHost === null) {
           // Fast path when aliases aren't required.
           directives.push(...exportScope.exported.directives);
           pipes.push(...exportScope.exported.pipes);
@@ -115,10 +109,10 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
           // NgModule, and the re-exporting NgModule are all in the same file. In this case,
           // no import alias is needed as it would go to the same file anyway.
           for (const directive of exportScope.exported.directives) {
-            directives.push(this.maybeAlias(directive, sourceFile));
+            directives.push(this.maybeAlias(directive, sourceFile, /* isReExport */ true));
           }
           for (const pipe of exportScope.exported.pipes) {
-            pipes.push(this.maybeAlias(pipe, sourceFile));
+            pipes.push(this.maybeAlias(pipe, sourceFile, /* isReExport */ true));
           }
         }
       }
@@ -134,19 +128,21 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
     };
   }
 
-  private maybeAlias<T extends DirectiveMeta|PipeMeta>(dirOrPipe: T, maybeAliasFrom: ts.SourceFile):
-      T {
-    if (this.aliasGenerator === null) {
-      return dirOrPipe;
-    }
+  private maybeAlias<T extends DirectiveMeta|PipeMeta>(
+      dirOrPipe: T, maybeAliasFrom: ts.SourceFile, isReExport: boolean): T {
     const ref = dirOrPipe.ref;
-    if (ref.node.getSourceFile() !== maybeAliasFrom) {
-      return {
-        ...dirOrPipe,
-        ref: ref.cloneWithAlias(this.aliasGenerator.aliasTo(ref.node, maybeAliasFrom)),
-      };
-    } else {
+    if (this.aliasingHost === null || ref.node.getSourceFile() === maybeAliasFrom) {
       return dirOrPipe;
     }
+
+    const alias = this.aliasingHost.getAliasIn(ref.node, maybeAliasFrom, isReExport);
+    if (alias === null) {
+      return dirOrPipe;
+    }
+
+    return {
+      ...dirOrPipe,
+      ref: ref.cloneWithAlias(alias),
+    };
   }
 }

--- a/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
@@ -7,9 +7,10 @@
  */
 import {ExternalExpr, ExternalReference} from '@angular/compiler';
 import * as ts from 'typescript';
+
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {AliasGenerator, FileToModuleHost, Reference} from '../../imports';
+import {AliasingHost, FileToModuleAliasingHost, FileToModuleHost, Reference} from '../../imports';
 import {DtsMetadataReader} from '../../metadata';
 import {ClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {makeProgram} from '../../testing';
@@ -42,7 +43,7 @@ export declare type PipeMeta<A, B> = never;
  * destructured to retrieve references to specific declared classes.
  */
 function makeTestEnv(
-    modules: {[module: string]: string}, aliasGenerator: AliasGenerator | null = null): {
+    modules: {[module: string]: string}, aliasGenerator: AliasingHost | null = null): {
   refs: {[name: string]: Reference<ClassDeclaration>},
   resolver: MetadataDtsModuleScopeResolver,
 } {
@@ -182,7 +183,7 @@ runInEachFileSystem(() => {
             }
       `,
           },
-          new AliasGenerator(testHost));
+          new FileToModuleAliasingHost(testHost));
       const {ShallowModule} = refs;
       const scope = resolver.resolve(ShallowModule) !;
       const [DeepDir, MiddleDir, ShallowDir] = scopeToRefs(scope);
@@ -232,7 +233,7 @@ runInEachFileSystem(() => {
             }
     `,
           },
-          new AliasGenerator(testHost));
+          new FileToModuleAliasingHost(testHost));
       const {ShallowModule} = refs;
       const scope = resolver.resolve(ShallowModule) !;
       const [DeepDir, MiddleDir, ShallowDir] = scopeToRefs(scope);
@@ -265,7 +266,7 @@ runInEachFileSystem(() => {
                 }
               `,
              },
-             new AliasGenerator(testHost));
+             new FileToModuleAliasingHost(testHost));
          const {DeepExportModule} = refs;
          const scope = resolver.resolve(DeepExportModule) !;
          const [DeepDir] = scopeToRefs(scope);

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -260,6 +260,37 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * @internal
    */
   ivyTemplateTypeCheck?: boolean;
+
+  /**
+   * Enables the generation of alias re-exports of directives/pipes that are visible from an
+   * NgModule from that NgModule's file.
+   *
+   * This option should be disabled for application builds or for Angular Package Format libraries
+   * (where NgModules along with their directives/pipes are exported via a single entrypoint).
+   *
+   * For other library compilations which are intended to be path-mapped into an application build
+   * (or another library), enabling this option enables the resulting deep imports to work
+   * correctly.
+   *
+   * A consumer of such a path-mapped library will write an import like:
+   *
+   * ```typescript
+   * import {LibModule} from 'lib/deep/path/to/module';
+   * ```
+   *
+   * The compiler will attempt to generate imports of directives/pipes from that same module
+   * specifier (the compiler does not rewrite the user's given import path, unlike View Engine).
+   *
+   * ```typescript
+   * import {LibDir, LibCmp, LibPipe} from 'lib/deep/path/to/module';
+   * ```
+   *
+   * It would be burdensome for users to have to re-export all directives/pipes alongside each
+   * NgModule to support this import model. Enabling this option tells the compiler to generate
+   * private re-exports alongside the NgModule of all the directives/pipes it makes available, to
+   * support these future imports.
+   */
+  generateDeepReexports?: boolean;
 }
 
 export interface CompilerHost extends ts.CompilerHost {


### PR DESCRIPTION
This PR contains two commits: one for ngtsc and one for ngcc. These commits add support for a re-exporting scheme which allows deep imports to work for certain kinds of packages. Notably, this solves the "monorepo import problem".