### PR TITLE
fix(upgrade): remove unused version export

### DIFF
--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -280,7 +280,6 @@ export function getAngularLib(): any {
  */
 export function setAngularJSGlobal(ng: any): void {
   angular = ng;
-  version = ng && ng.version;
 }
 
 /**
@@ -309,5 +308,3 @@ export const injector: typeof angular.injector =
 export const resumeBootstrap: typeof angular.resumeBootstrap = () => angular.resumeBootstrap();
 
 export const getTestability: typeof angular.getTestability = e => angular.getTestability(e);
-
-export let version = angular.version;

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -29,7 +29,8 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     describe('(basic use)', () => {
-      it('should have AngularJS loaded', () => expect(angular.version.major).toBe(1));
+      it('should have AngularJS loaded',
+         () => expect(angular.getAngularJSGlobal().version.major).toBe(1));
 
       it('should instantiate ng2 in ng1 template and project content', async(() => {
            const ng1Module = angular.module_('ng1', []);

--- a/packages/upgrade/static/test/integration/examples_spec.ts
+++ b/packages/upgrade/static/test/integration/examples_spec.ts
@@ -23,7 +23,8 @@ withEachNg1Version(() => {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
 
-    it('should have AngularJS loaded', () => expect(angular.version.major).toBe(1));
+    it('should have AngularJS loaded',
+       () => expect(angular.getAngularJSGlobal().version.major).toBe(1));
 
     it('should verify UpgradeAdapter example', async(() => {
 


### PR DESCRIPTION
In some module systems (Closure), it's illegal to mutate an export.
This mutated export isn't used anyway, so we can just remove it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

(appears unused, not public API)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
