### PR TITLE
fix(ivy): throw better error for missing generic type in ModuleWithProviders

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -59,6 +59,12 @@ export enum ErrorCode {
   NGMODULE_INVALID_REEXPORT = 6004,
 
   /**
+   * Raised when a `ModuleWithProviders` with a missing
+   * generic type argument is passed into an `NgModule`.
+   */
+  NGMODULE_MODULE_WITH_PROVIDERS_MISSING_GENERIC = 6005,
+
+  /**
    * Raised when ngcc tries to inject a synthetic decorator over one that already exists.
    */
   NGCC_MIGRATION_DECORATOR_INJECTION_ERROR = 7001,

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -44,7 +44,8 @@ export const Output = callablePropDecorator();
 export const ViewChild = callablePropDecorator();
 export const ViewChildren = callablePropDecorator();
 
-export type ModuleWithProviders<T> = any;
+// T defaults to `any` to reflect what is currently in core.
+export type ModuleWithProviders<T = any> = any;
 
 export class ChangeDetectorRef {}
 export class ElementRef {}

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1469,6 +1469,30 @@ runInEachFileSystem(os => {
                 'i0.ɵɵNgModuleDefWithMeta<TestModule, never, [typeof i1.RouterModule], never>');
       });
 
+      it('should throw if ModuleWithProviders is missing its generic type argument', () => {
+        env.write(`test.ts`, `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from 'router';
+
+          @NgModule({imports: [RouterModule.forRoot()]})
+          export class TestModule {}
+        `);
+
+        env.write('node_modules/router/index.d.ts', `
+          import {ModuleWithProviders, ɵɵNgModuleDefWithMeta} from '@angular/core';
+
+          declare class RouterModule {
+            static forRoot(): ModuleWithProviders;
+            static ɵmod: ɵɵNgModuleDefWithMeta<RouterModule, never, never, never>;
+          }
+        `);
+
+        const errors = env.driveDiagnostics();
+        expect(trim(errors[0].messageText as string))
+            .toContain(
+                `ModuleWithProviders annotation of RouterModule is missing its generic type argument in NgModule of TestModule`);
+      });
+
       it('should extract the generic type if it is provided as qualified type name', () => {
         env.write(`test.ts`, `
         import {NgModule} from '@angular/core';

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1486,11 +1486,12 @@ runInEachFileSystem(os => {
             static ɵmod: ɵɵNgModuleDefWithMeta<RouterModule, never, never, never>;
           }
         `);
-
         const errors = env.driveDiagnostics();
         expect(trim(errors[0].messageText as string))
             .toContain(
-                `ModuleWithProviders annotation of RouterModule is missing its generic type argument in NgModule of TestModule`);
+                `RouterModule.forRoot returns a ModuleWithProviders type without a generic type argument. ` +
+                `Please add a generic type argument to the ModuleWithProviders type. If this ` +
+                `occurrence is in library code you don't control, please contact the library authors.`);
       });
 
       it('should extract the generic type if it is provided as qualified type name', () => {


### PR DESCRIPTION
Currently if a `ModuleWithProviders` is missing its generic type, we throw a cryptic error like:

```
error TS-991010: Value at position 3 in the NgModule.imports of TodosModule is not a reference: [object Object]
```

These changes add a better error to make it easier to debug.
