### PR TITLE
fix(compiler): absolute source span for template attribute expressions

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -118,7 +118,7 @@ export class BindingParser {
       tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan, absoluteOffset: number,
       targetMatchableAttrs: string[][], targetProps: ParsedProperty[],
       targetVars: ParsedVariable[]) {
-    const bindings = this._parseTemplateBindings(tplKey, tplValue, sourceSpan);
+    const bindings = this._parseTemplateBindings(tplKey, tplValue, sourceSpan, absoluteOffset);
 
     for (let i = 0; i < bindings.length; i++) {
       const binding = bindings[i];
@@ -137,13 +137,14 @@ export class BindingParser {
     }
   }
 
-  private _parseTemplateBindings(tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan):
-      TemplateBinding[] {
+  private _parseTemplateBindings(
+      tplKey: string, tplValue: string, sourceSpan: ParseSourceSpan,
+      absoluteOffset: number): TemplateBinding[] {
     const sourceInfo = sourceSpan.start.toString();
 
     try {
-      const bindingsResult = this._exprParser.parseTemplateBindings(
-          tplKey, tplValue, sourceInfo, sourceSpan.start.offset);
+      const bindingsResult =
+          this._exprParser.parseTemplateBindings(tplKey, tplValue, sourceInfo, absoluteOffset);
       this._reportExpressionParserErrors(bindingsResult.errors, sourceSpan);
       bindingsResult.templateBindings.forEach((binding) => {
         if (binding.expression) {

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -44,6 +44,13 @@ describe('expression AST absolute source spans', () => {
         .toContain(['condition ? true : false', new AbsoluteSourceSpan(22, 46)]);
   });
 
+  it('should provide absolute offsets of an expression in a template attribute', () => {
+    debugger;
+    expect(humanizeExpressionSource(parse('<div *ngIf="value | async"></div>').nodes)).toContain([
+      '(value | async)', new AbsoluteSourceSpan(12, 25)
+    ]);
+  });
+
   describe('binary expression', () => {
     it('should provide absolute offsets of a binary expression', () => {
       expect(humanizeExpressionSource(parse('<div>{{1 + 2}}<div>').nodes)).toContain([

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -45,7 +45,6 @@ describe('expression AST absolute source spans', () => {
   });
 
   it('should provide absolute offsets of an expression in a template attribute', () => {
-    debugger;
     expect(humanizeExpressionSource(parse('<div *ngIf="value | async"></div>').nodes)).toContain([
       '(value | async)', new AbsoluteSourceSpan(12, 25)
     ]);

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -102,7 +102,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     super.visitQuote(ast, null);
   }
 
-  visitTemplate(ast: t.Template) { t.visitAll(this, ast.children); }
+  visitTemplate(ast: t.Template) {
+    t.visitAll(this, ast.children);
+    t.visitAll(this, ast.templateAttrs);
+  }
   visitElement(ast: t.Element) {
     t.visitAll(this, ast.children);
     t.visitAll(this, ast.inputs);


### PR DESCRIPTION
Prior to this commit, the absolute spans (relative to template source
file rather than the start of an expression) of expressions in a
template attribute like `*ngIf` were generated incorrectly, equating to
the relative spans.
This fixes the bug by passing an `absoluteOffset` parameter when parsing
template bindings.

Through some levels of indirection, this is required for the Language
Service to support text replacement in https://github.com/angular/angular/pull/33091.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No