### PR TITLE
docs: correct vscode clang-format setup instructions

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -97,8 +97,7 @@ A better way is to set up your IDE to format the changed file on each file save.
 
 ### VS Code
 1. Install [Clang-Format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) extension for VS Code.
-
-It will automatically pick up the settings from Angular's [settings.json](../.vscode/settings.json).
+2. [Configure](../.vscode/README.md) settings.
 
 ### WebStorm / IntelliJ
 1. Install the [ClangFormatIJ](https://plugins.jetbrains.com/plugin/8396-clangformatij) plugin

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -97,7 +97,8 @@ A better way is to set up your IDE to format the changed file on each file save.
 
 ### VS Code
 1. Install [Clang-Format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) extension for VS Code.
-2. [Configure](../.vscode/README.md) settings.
+2. It will automatically pick up the settings from `.vscode/settings.json`.
+If you haven't already, create a `settings.json` file by following the instructions [here](../.vscode/README.md).
 
 ### WebStorm / IntelliJ
 1. Install the [ClangFormatIJ](https://plugins.jetbrains.com/plugin/8396-clangformatij) plugin


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The VSCode **clang-format** instructions incorrectly points out that workspace settings are automatically picked up by VSCode. This leads to new contributors possibly not being able to properly set up the VSCode clang-format extension.

Issue Number: N/A


## What is the new behavior?
The instructions are referring to the VSCode specific [readme](https://github.com/angular/angular/blob/master/.vscode/README.md) that describes how to configure the workspace settings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
