### PR TITLE
Fixes needed for NativeScript support in ngcc

### DIFF
--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -50,7 +50,14 @@ if (require.main === module) {
                 'If specified then new `*_ivy_ngcc` entry-points will be added to package.json rather than modifying the ones in-place.\n' +
                 'For this to work you need to have custom resolution set up (e.g. in webpack) to look for these new entry-points.\n' +
                 'The Angular CLI does this already, so it is safe to use this option if the project is being built via the CLI.',
-            type: 'boolean'
+            type: 'boolean',
+          })
+          .option('async', {
+            describe:
+                'Whether to compile asynchronously. This is enabled by default as it allows compilations to be parallelized.\n' +
+                'Disabling asynchronous compilation may be useful for debugging.',
+            type: 'boolean',
+            default: true,
           })
           .option('l', {
             alias: 'loglevel',
@@ -86,7 +93,7 @@ if (require.main === module) {
         compileAllFormats,
         createNewEntryPointFormats,
         logger,
-        async: true,
+        async: options['async'],
       });
 
       if (logger) {

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -59,7 +59,7 @@ export class DecorationAnalyzer {
     // TODO(alxhub): there's no reason why ngcc needs the "logical file system" logic here, as ngcc
     // projects only ever have one rootDir. Instead, ngcc should just switch its emitted import
     // based on whether a bestGuessOwningModule is present in the Reference.
-    new LogicalProjectStrategy(this.typeChecker, new LogicalFileSystem(this.rootDirs)),
+    new LogicalProjectStrategy(this.reflectionHost, new LogicalFileSystem(this.rootDirs)),
   ]);
   dtsModuleScopeResolver =
       new MetadataDtsModuleScopeResolver(this.dtsMetaReader, /* aliasGenerator */ null);

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -148,7 +148,7 @@ export class DependencyResolver {
 
       const missingDependencies = Array.from(missing).filter(dep => !builtinNodeJsModules.has(dep));
 
-      if (missingDependencies.length > 0) {
+      if (missingDependencies.length > 0 && !entryPoint.ignoreMissingDependencies) {
         // This entry point has dependencies that are missing
         // so remove it from the graph.
         removeNodes(entryPoint, missingDependencies);

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -174,7 +174,8 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
       return null;
     }
 
-    return {node: importedFile, viaModule: importInfo.from};
+    const viaModule = !importInfo.from.startsWith('.') ? importInfo.from : null;
+    return {node: importedFile, viaModule};
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -43,6 +43,13 @@ export interface NgccEntryPointConfig {
    * entry-point's package.json file.
    */
   override?: PackageJsonFormatPropertiesMap;
+
+  /**
+   * Normally, ngcc will skip compilation of entrypoints that contain imports that can't be resolved
+   * or understood. If this option is specified, ngcc will proceed with compiling the entrypoint
+   * even in the face of such missing dependencies.
+   */
+  ignoreMissingDependencies?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -36,6 +36,8 @@ export interface EntryPoint extends JsonObject {
   typings: AbsoluteFsPath;
   /** Is this EntryPoint compiled with the Angular View Engine compiler? */
   compiledByAngular: boolean;
+  /** Should ngcc ignore missing dependencies and process this entrypoint anyway? */
+  ignoreMissingDependencies: boolean;
 }
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -120,6 +122,8 @@ export function getEntryPointInfo(
     package: packagePath,
     path: entryPointPath,
     typings: resolve(entryPointPath, typings), compiledByAngular,
+    ignoreMissingDependencies:
+        entryPointConfig !== undefined ? !!entryPointConfig.ignoreMissingDependencies : false,
   };
 
   return entryPointInfo;

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -99,9 +99,17 @@ export class EsmRenderingFormatter implements RenderingFormatter {
         } else {
           nodesToRemove.forEach(node => {
             // remove any trailing comma
-            const end = (output.slice(node.getEnd(), node.getEnd() + 1) === ',') ?
-                node.getEnd() + 1 :
-                node.getEnd();
+            const nextSibling = getNextSiblingInArray(node, items);
+            let end: number;
+
+            if (nextSibling !== null &&
+                output.slice(nextSibling.getFullStart() - 1, nextSibling.getFullStart()) === ',') {
+              end = nextSibling.getFullStart() - 1 + nextSibling.getLeadingTriviaWidth();
+            } else if (output.slice(node.getEnd(), node.getEnd() + 1) === ',') {
+              end = node.getEnd() + 1;
+            } else {
+              end = node.getEnd();
+            }
             output.remove(node.getFullStart(), end);
           });
         }
@@ -213,4 +221,9 @@ function generateImportString(
     importManager: ImportManager, importPath: string | null, importName: string) {
   const importAs = importPath ? importManager.generateNamedImport(importPath, importName) : null;
   return importAs ? `${importAs.moduleImport}.${importAs.symbol}` : `${importName}`;
+}
+
+function getNextSiblingInArray<T extends ts.Node>(node: T, array: ts.NodeArray<T>): T|null {
+  const index = array.indexOf(node);
+  return index !== -1 && array.length > index + 1 ? array[index + 1] : null;
 }

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -22,6 +22,7 @@ export function makeTestEntryPoint(
     path: absoluteFrom(`/node_modules/${entryPointName}`),
     typings: absoluteFrom(`/node_modules/${entryPointName}/index.d.ts`),
     compiledByAngular: true,
+    ignoreMissingDependencies: false,
   };
 }
 

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -143,6 +143,7 @@ runInEachFileSystem(() => {
            path: absoluteFrom('/node_modules/test'),
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          };
          const esm5bundle = makeEntryPointBundle(fs, entryPoint, './index.js', false, 'esm5', true);
 
@@ -189,6 +190,7 @@ runInEachFileSystem(() => {
            path: absoluteFrom('/node_modules/test'),
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,
@@ -210,6 +212,7 @@ runInEachFileSystem(() => {
            path: absoluteFrom('/node_modules/test'),
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          };
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, './index.js', false, 'esm5', /* transformDts */ true,

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -50,6 +50,7 @@ runInEachFileSystem(() => {
                _(`/project/node_modules/some_package/valid_entry_point/valid_entry_point.d.ts`),
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/valid_entry_point'),
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          });
        });
 
@@ -109,6 +110,7 @@ runInEachFileSystem(() => {
         typings: _('/project/node_modules/some_package/valid_entry_point/some_other.d.ts'),
         packageJson: overriddenPackageJson,
         compiledByAngular: true,
+        ignoreMissingDependencies: false,
       });
     });
 
@@ -155,6 +157,7 @@ runInEachFileSystem(() => {
                '/project/node_modules/some_package/missing_package_json/missing_package_json.d.ts'),
            packageJson: {name: 'some_package/missing_package_json', ...override},
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          });
        });
 
@@ -211,6 +214,7 @@ runInEachFileSystem(() => {
           typings: _(`/project/node_modules/some_package/missing_typings/${typingsPath}.d.ts`),
           packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_typings'),
           compiledByAngular: true,
+          ignoreMissingDependencies: false,
         });
       });
     }
@@ -234,6 +238,7 @@ runInEachFileSystem(() => {
            typings: _(`/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts`),
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
            compiledByAngular: false,
+           ignoreMissingDependencies: false,
          });
        });
 
@@ -260,6 +265,7 @@ runInEachFileSystem(() => {
            typings: _('/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts'),
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
            compiledByAngular: true,
+           ignoreMissingDependencies: false,
          });
        });
 
@@ -288,6 +294,7 @@ runInEachFileSystem(() => {
         packageJson:
             loadPackageJson(fs, '/project/node_modules/some_package/types_rather_than_typings'),
         compiledByAngular: true,
+        ignoreMissingDependencies: false,
       });
     });
 
@@ -319,6 +326,7 @@ runInEachFileSystem(() => {
         typings: _(`/project/node_modules/some_package/material_style/material_style.d.ts`),
         packageJson: loadPackageJson(fs, '/project/node_modules/some_package/material_style'),
         compiledByAngular: true,
+        ignoreMissingDependencies: false,
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -288,6 +288,28 @@ A.decorators = [
                  .toContain(`{ type: Directive, args: [{ selector: '[c]' }] }`);
            });
 
+        it('should handle a decorator with a trailing comment', () => {
+          const text = `
+import {Directive} from '@angular/core';
+export class A {}
+A.decorators = [
+  { type: Directive, args: [{ selector: '[a]' }] },
+  { type: OtherA }
+];
+          `;
+          const file = {name: _('/node_modules/test-package/index.js'), contents: text};
+          const {decorationAnalyses, sourceFile, renderer} = setup([file]);
+          const output = new MagicString(text);
+          const compiledClass =
+              decorationAnalyses.get(sourceFile) !.compiledClasses.find(c => c.name === 'A') !;
+          const decorator = compiledClass.decorators ![0];
+          const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
+          decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
+          renderer.removeDecorators(output, decoratorsToRemove);
+          // The decorator should have been removed correctly.
+          expect(output.toString()).toContain('A.decorators = [ { type: OtherA }');
+        });
+
 
         it('should delete the decorator (and its container if there are no other decorators left) that was matched in the analysis',
            () => {

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -196,7 +196,7 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
  * Instead, `LogicalProjectPath`s are used.
  */
 export class LogicalProjectStrategy implements ReferenceEmitStrategy {
-  constructor(private checker: ts.TypeChecker, private logicalFs: LogicalFileSystem) {}
+  constructor(private reflector: ReflectionHost, private logicalFs: LogicalFileSystem) {}
 
   emit(ref: Reference<ts.Node>, context: ts.SourceFile): Expression|null {
     const destSf = getSourceFile(ref.node);
@@ -220,7 +220,7 @@ export class LogicalProjectStrategy implements ReferenceEmitStrategy {
       return null;
     }
 
-    const name = findExportedNameOfNode(ref.node, destSf, this.checker);
+    const name = findExportedNameOfNode(ref.node, destSf, this.reflector);
     if (name === null) {
       // The target declaration isn't exported from the file it's declared in. This is an issue!
       return null;
@@ -237,11 +237,11 @@ export class LogicalProjectStrategy implements ReferenceEmitStrategy {
  * A `ReferenceEmitStrategy` which uses a `FileToModuleHost` to generate absolute import references.
  */
 export class FileToModuleStrategy implements ReferenceEmitStrategy {
-  constructor(private checker: ts.TypeChecker, private fileToModuleHost: FileToModuleHost) {}
+  constructor(private reflector: ReflectionHost, private fileToModuleHost: FileToModuleHost) {}
 
   emit(ref: Reference<ts.Node>, context: ts.SourceFile): Expression|null {
     const destSf = getSourceFile(ref.node);
-    const name = findExportedNameOfNode(ref.node, destSf, this.checker);
+    const name = findExportedNameOfNode(ref.node, destSf, this.reflector);
     if (name === null) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/imports/src/find_export.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/find_export.ts
@@ -7,26 +7,29 @@
  */
 
 import * as ts from 'typescript';
+import {ReflectionHost} from '../../reflection';
 
 /**
  * Find the name, if any, by which a node is exported from a given file.
  */
 export function findExportedNameOfNode(
-    target: ts.Node, file: ts.SourceFile, checker: ts.TypeChecker): string|null {
-  // First, get the exports of the file.
-  const symbol = checker.getSymbolAtLocation(file);
-  if (symbol === undefined) {
+    target: ts.Node, file: ts.SourceFile, reflector: ReflectionHost): string|null {
+  const exports = reflector.getExportsOfModule(file);
+  if (exports === null) {
     return null;
   }
-  const exports = checker.getExportsOfModule(symbol);
-
   // Look for the export which declares the node.
-  const found = exports.find(sym => symbolDeclaresNode(sym, target, checker));
-  if (found === undefined) {
+  const keys = Array.from(exports.keys());
+  const name = keys.find(key => {
+    const decl = exports.get(key);
+    return decl !== undefined && decl.node === target;
+  });
+
+  if (name === undefined) {
     throw new Error(
         `Failed to find exported name of node (${target.getText()}) in '${file.fileName}'.`);
   }
-  return found.name;
+  return name;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/imports/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/imports/test/BUILD.bazel
@@ -10,9 +10,11 @@ ts_library(
     ]),
     deps = [
         "//packages:types",
+        "//packages/compiler",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/testing",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ExternalExpr} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {LogicalFileSystem, absoluteFrom} from '../../file_system';
+import {runInEachFileSystem} from '../../file_system/testing';
+import {Declaration, TypeScriptReflectionHost} from '../../reflection';
+import {getDeclaration, makeProgram} from '../../testing';
+import {LogicalProjectStrategy} from '../src/emitter';
+import {Reference} from '../src/references';
+
+runInEachFileSystem(() => {
+  describe('LogicalProjectStrategy', () => {
+    let _: typeof absoluteFrom;
+    beforeEach(() => _ = absoluteFrom);
+
+    it('should enumerate exports with the ReflectionHost', () => {
+      // Use a modified ReflectionHost that prefixes all export names that it enumerates.
+      class TestHost extends TypeScriptReflectionHost {
+        getExportsOfModule(node: ts.Node): Map<string, Declaration>|null {
+          const realExports = super.getExportsOfModule(node);
+          if (realExports === null) {
+            return null;
+          }
+          const fakeExports = new Map<string, Declaration>();
+          realExports.forEach((decl, name) => { fakeExports.set(`test${name}`, decl); });
+          return fakeExports;
+        }
+      }
+
+      const {program} = makeProgram([
+        {
+          name: _('/index.ts'),
+          contents: `export class Foo {}`,
+        },
+        {
+          name: _('/context.ts'),
+          contents: 'export class Context {}',
+        }
+      ]);
+      const checker = program.getTypeChecker();
+      const logicalFs = new LogicalFileSystem([_('/')]);
+      const strategy = new LogicalProjectStrategy(new TestHost(checker), logicalFs);
+      const decl = getDeclaration(program, _('/index.ts'), 'Foo', ts.isClassDeclaration);
+      const context = program.getSourceFile(_('/context.ts')) !;
+      const ref = strategy.emit(new Reference(decl), context);
+      expect(ref).not.toBeNull();
+
+      // Expect the prefixed name from the TestHost.
+      expect((ref !as ExternalExpr).value.name).toEqual('testFoo');
+    });
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -460,7 +460,7 @@ export class NgtscProgram implements api.Program {
         // Finally, check if the reference is being written into a file within the project's logical
         // file system, and use a relative import if so. If this fails, ReferenceEmitter will throw
         // an error.
-        new LogicalProjectStrategy(checker, new LogicalFileSystem(this.rootDirs)),
+        new LogicalProjectStrategy(this.reflector, new LogicalFileSystem(this.rootDirs)),
       ]);
     } else {
       // The CompilerHost supports fileNameToModuleName, so use that to emit imports.
@@ -470,7 +470,7 @@ export class NgtscProgram implements api.Program {
         // Then use aliased references (this is a workaround to StrictDeps checks).
         new AliasStrategy(),
         // Then use fileNameToModuleName to emit imports.
-        new FileToModuleStrategy(checker, this.fileToModuleHost),
+        new FileToModuleStrategy(this.reflector, this.fileToModuleHost),
       ]);
       aliasGenerator = new AliasGenerator(this.fileToModuleHost);
     }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -280,6 +280,13 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         return null;
       }
       return this.getDeclarationOfSymbol(shorthandSymbol, originalId);
+    } else if (
+        symbol.valueDeclaration !== undefined && ts.isExportSpecifier(symbol.valueDeclaration)) {
+      const localTarget = this.checker.getExportSpecifierLocalTargetSymbol(symbol.valueDeclaration);
+      if (localTarget === undefined) {
+        return null;
+      }
+      return this.getDeclarationOfSymbol(localTarget, originalId);
     }
 
     const importInfo = originalId && this.getImportOfIdentifier(originalId);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -197,11 +197,12 @@ export function typecheck(
   const sf = program.getSourceFile(absoluteFrom('/main.ts')) !;
   const checker = program.getTypeChecker();
   const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
+  const reflectionHost = new TypeScriptReflectionHost(checker);
   const emitter = new ReferenceEmitter([
     new LocalIdentifierStrategy(),
     new AbsoluteModuleStrategy(
         program, checker, options, host, new TypeScriptReflectionHost(checker)),
-    new LogicalProjectStrategy(checker, logicalFs),
+    new LogicalProjectStrategy(reflectionHost, logicalFs),
   ]);
   const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, emitter, typeCheckFilePath);
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -62,12 +62,12 @@ TestClass.ngTypeCtor({value: 'test'});
         ];
         const {program, host, options} = makeProgram(files, undefined, undefined, false);
         const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
         const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
         const emitter = new ReferenceEmitter([
           new LocalIdentifierStrategy(),
-          new AbsoluteModuleStrategy(
-              program, checker, options, host, new TypeScriptReflectionHost(checker)),
-          new LogicalProjectStrategy(checker, logicalFs),
+          new AbsoluteModuleStrategy(program, checker, options, host, reflectionHost),
+          new LogicalProjectStrategy(reflectionHost, logicalFs),
         ]);
         const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, emitter, _('/_typecheck_.ts'));
         const TestClass =
@@ -94,12 +94,12 @@ TestClass.ngTypeCtor({value: 'test'});
         ];
         const {program, host, options} = makeProgram(files, undefined, undefined, false);
         const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
         const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
         const emitter = new ReferenceEmitter([
           new LocalIdentifierStrategy(),
-          new AbsoluteModuleStrategy(
-              program, checker, options, host, new TypeScriptReflectionHost(checker)),
-          new LogicalProjectStrategy(checker, logicalFs),
+          new AbsoluteModuleStrategy(program, checker, options, host, reflectionHost),
+          new LogicalProjectStrategy(reflectionHost, logicalFs),
         ]);
         const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, emitter, _('/_typecheck_.ts'));
         const TestClass =


### PR DESCRIPTION
This PR groups together a number of fixes required to support `nativescript-angular` and other such packages in ngcc.