### PR TITLE
fix(ngcc): avoid warning when reflecting on index signature member

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -1212,9 +1212,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     let name: string|null = null;
     let nameNode: ts.Identifier|null = null;
 
-    if (!isClassMemberType(node) || ts.isIndexSignatureDeclaration(node)) {
-      // `node` is not a class member or is an index signature, for example on an abstract class:
-      // `abstract class Foo { [key: string]: any; }`
+    if (!isClassMemberType(node)) {
       return null;
     }
 
@@ -1780,7 +1778,10 @@ function isNamedDeclaration(node: ts.Declaration): node is ts.NamedDeclaration&
 
 function isClassMemberType(node: ts.Declaration): node is ts.ClassElement|
     ts.PropertyAccessExpression|ts.BinaryExpression {
-  return ts.isClassElement(node) || isPropertyAccess(node) || ts.isBinaryExpression(node);
+  return (ts.isClassElement(node) || isPropertyAccess(node) || ts.isBinaryExpression(node)) &&
+      // Additionally, ensure `node` is not an index signature, for example on an abstract class:
+      // `abstract class Foo { [key: string]: any; }`
+      !ts.isIndexSignatureDeclaration(node);
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -1212,7 +1212,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     let name: string|null = null;
     let nameNode: ts.Identifier|null = null;
 
-    if (!isClassMemberType(node)) {
+    if (!isClassMemberType(node) || ts.isIndexSignatureDeclaration(node)) {
+      // `node` is not a class member or is an index signature, for example on an abstract class:
+      // `abstract class Foo { [key: string]: any; }`
       return null;
     }
 


### PR DESCRIPTION
Previously, when `ngcc` was reflecting on class members it did not account for the fact that a member could be of the kind `IndexSignature`. This can happen, for example, on abstract classes (as is the case for [JsonCallbackContext][1]).

Trying to reflect on such members (and failing to recognize their kind), resulted in warnings, such as:
```
Warning: Unknown member type: "[key: string]: (data: any) => void;
```

While these warnings are harmless, they can be confusing and worrisome for users.

This commit avoids such warnings by detecting class members of the `IndexSignature` kind and ignoring them.

[1]: https://github.com/angular/angular/blob/4659cc26e/packages/common/http/src/jsonp.ts#L39
