### PR TITLE
fix(language-service): reset MockHost after every spec instead of creating new LS

### DIFF
--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -13,7 +13,6 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler-cli/test:test_utils",
         "//packages/language-service",
-        "@npm//reflect-metadata",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -9,24 +9,17 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {LanguageService} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
 
 describe('definitions', () => {
-  let mockHost: MockTypescriptHost;
-  let service: ts.LanguageService;
-  let ngHost: TypeScriptServiceHost;
-  let ngService: LanguageService;
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
+  const service = ts.createLanguageService(mockHost);
+  const ngHost = new TypeScriptServiceHost(mockHost, service);
+  const ngService = createLanguageService(ngHost);
 
-  beforeEach(() => {
-    // Create a new mockHost every time to reset any files that are overridden.
-    mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
-    service = ts.createLanguageService(mockHost);
-    ngHost = new TypeScriptServiceHost(mockHost, service);
-    ngService = createLanguageService(ngHost);
-  });
+  beforeEach(() => { mockHost.reset(); });
 
   it('should be able to find field in an interpolation', () => {
     const fileName = mockHost.addCode(`
@@ -201,7 +194,6 @@ describe('definitions', () => {
   });
 
   it('should be able to find an input provider', () => {
-    // '/app/parsing-cases.ts', 'tcName',
     const fileName = mockHost.addCode(`
       @Component({
         template: '<test-comp ~{start-my}[«tcName»]="name"~{end-my}></div>'

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -8,7 +8,6 @@
 
 import * as ts from 'typescript';
 import {createLanguageService} from '../src/language_service';
-import * as ng from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 import {MockTypescriptHost} from './test_utils';
 
@@ -29,17 +28,12 @@ const NG_FOR_CASES = '/app/ng-for-cases.ts';
 const NG_IF_CASES = '/app/ng-if-cases.ts';
 
 describe('diagnostics', () => {
-  let mockHost: MockTypescriptHost;
-  let ngHost: TypeScriptServiceHost;
-  let tsLS: ts.LanguageService;
-  let ngLS: ng.LanguageService;
+  const mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
+  const tsLS = ts.createLanguageService(mockHost);
+  const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
+  const ngLS = createLanguageService(ngHost);
 
-  beforeEach(() => {
-    mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
-    tsLS = ts.createLanguageService(mockHost);
-    ngHost = new TypeScriptServiceHost(mockHost, tsLS);
-    ngLS = createLanguageService(ngHost);
-  });
+  beforeEach(() => { mockHost.reset(); });
 
   it('should produce no diagnostics for test.ng', () => {
     // there should not be any errors on existing external template

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -14,17 +14,22 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
 
-describe('hover', () => {
-  let mockHost: MockTypescriptHost;
-  let tsLS: ts.LanguageService;
-  let ngLSHost: TypeScriptServiceHost;
-  let ngLS: LanguageService;
+fdescribe('hover', () => {
+  // const mockHost: MockTypescriptHost;
+  // const tsLS: ts.LanguageService;
+  // const ngLSHost: TypeScriptServiceHost;
+  // const ngLS: LanguageService;
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
+  const tsLS = ts.createLanguageService(mockHost);
+  const ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
+  const ngLS = createLanguageService(ngLSHost);
 
   beforeEach(() => {
-    mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
-    tsLS = ts.createLanguageService(mockHost);
-    ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
-    ngLS = createLanguageService(ngLSHost);
+    // mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
+    // tsLS = ts.createLanguageService(mockHost);
+    // ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
+    // ngLS = createLanguageService(ngLSHost);
+    mockHost.reset();
   });
 
   it('should be able to find field in an interpolation', () => {
@@ -183,20 +188,20 @@ describe('hover', () => {
   });
 
   it('should be able to find the NgModule of a directive', () => {
-    const fileName = '/app/parsing-cases.ts';
+    const fileName = '/app/app.component.ts';
     mockHost.override(fileName, `
       import {Directive} from '@angular/core';
 
       @Directive({
         selector: '[string-model]',
       })
-      export class «StringModel» {}`);
-    const marker = mockHost.getReferenceMarkerFor(fileName, 'StringModel');
+      export class «AppComponent» {}`);
+    const marker = mockHost.getReferenceMarkerFor(fileName, 'AppComponent');
     const quickInfo = ngLS.getHoverAt(fileName, marker.start);
     expect(quickInfo).toBeTruthy();
     const {textSpan, displayParts} = quickInfo !;
     expect(textSpan).toEqual(marker);
-    expect(toText(displayParts)).toBe('(directive) AppModule.StringModel: class');
+    expect(toText(displayParts)).toBe('(directive) AppModule.AppComponent: class');
   });
 });
 

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -9,28 +9,17 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {LanguageService} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
 
-fdescribe('hover', () => {
-  // const mockHost: MockTypescriptHost;
-  // const tsLS: ts.LanguageService;
-  // const ngLSHost: TypeScriptServiceHost;
-  // const ngLS: LanguageService;
+describe('hover', () => {
   const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const tsLS = ts.createLanguageService(mockHost);
   const ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
   const ngLS = createLanguageService(ngLSHost);
 
-  beforeEach(() => {
-    // mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
-    // tsLS = ts.createLanguageService(mockHost);
-    // ngLSHost = new TypeScriptServiceHost(mockHost, tsLS);
-    // ngLS = createLanguageService(ngLSHost);
-    mockHost.reset();
-  });
+  beforeEach(() => { mockHost.reset(); });
 
   it('should be able to find field in an interpolation', () => {
     const fileName = mockHost.addCode(`
@@ -188,20 +177,18 @@ fdescribe('hover', () => {
   });
 
   it('should be able to find the NgModule of a directive', () => {
-    const fileName = '/app/app.component.ts';
-    mockHost.override(fileName, `
-      import {Directive} from '@angular/core';
-
-      @Directive({
-        selector: '[string-model]',
-      })
-      export class «AppComponent» {}`);
-    const marker = mockHost.getReferenceMarkerFor(fileName, 'AppComponent');
-    const quickInfo = ngLS.getHoverAt(fileName, marker.start);
+    const fileName = '/app/parsing-cases.ts';
+    const content = mockHost.readFile(fileName) !;
+    const position = content.indexOf('StringModel');
+    expect(position).toBeGreaterThan(0);
+    const quickInfo = ngLS.getHoverAt(fileName, position);
     expect(quickInfo).toBeTruthy();
     const {textSpan, displayParts} = quickInfo !;
-    expect(textSpan).toEqual(marker);
-    expect(toText(displayParts)).toBe('(directive) AppModule.AppComponent: class');
+    expect(textSpan).toEqual({
+      start: position,
+      length: 'StringModel'.length,
+    });
+    expect(toText(displayParts)).toBe('(directive) AppModule.StringModel: class');
   });
 });
 

--- a/packages/language-service/test/template_references_spec.ts
+++ b/packages/language-service/test/template_references_spec.ts
@@ -15,18 +15,12 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 import {MockTypescriptHost} from './test_utils';
 
 describe('references', () => {
-  let documentRegistry = ts.createDocumentRegistry();
-  let mockHost: MockTypescriptHost;
-  let service: ts.LanguageService;
-  let ngHost: TypeScriptServiceHost;
-  let ngService: LanguageService = createLanguageService(undefined !);
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
+  const service = ts.createLanguageService(mockHost);
+  const ngHost = new TypeScriptServiceHost(mockHost, service);
+  const ngService = createLanguageService(ngHost);
 
-  beforeEach(() => {
-    mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
-    service = ts.createLanguageService(mockHost, documentRegistry);
-    ngHost = new TypeScriptServiceHost(mockHost, service);
-    ngService = createLanguageService(ngHost);
-  });
+  beforeEach(() => { mockHost.reset(); });
 
   it('should be able to get template references',
      () => { expect(() => ngService.getTemplateReferences()).not.toThrow(); });

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import 'reflect-metadata';
 import * as ts from 'typescript';
 
 import {TypeScriptServiceHost} from '../src/typescript_host';


### PR DESCRIPTION
    This commit speeds up the tests by calling `MockHost.reset()` in
    `beforeEach()` instead of destroying the entire language service and
    creating a new one. The creation of a new language service instance is
    expensive due to the need to initialize many core Symbols when creating
    a new program.
    
    This speeds ups the test (on my local machine) from 35 secs to 15 secs.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
