### PR TITLE
style: enforce disallowance of String, Number and Boolean constructors

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
       true,
       "log"
     ],
+    "no-construct": true,
     "no-duplicate-imports": true,
     "no-duplicate-variable": true,
     "no-jasmine-focus": true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`Boolean`, `Number`, `String` and `Symbol` constructors are allowed to use, which violates [one](https://google.github.io/styleguide/jsguide.html#disallowed-features-wrapper-objects) of our style guide rules.

Issue Number: N/A


## What is the new behavior?
`Boolean`, `Number` and `String` constructors are **not** allowed to use (enforced by the [no-construct](https://palantir.github.io/tslint/rules/no-construct/) TSLint rule).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
