### PR TITLE
style: enforce disallowance of object constructor

### DIFF
--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -114,7 +114,7 @@ import {SpyChangeDetectorRef} from '../spies';
     });
 
     describe('Promise', () => {
-      const message = new Object();
+      const message = {};
       let pipe: AsyncPipe;
       let resolve: (result: any) => void;
       let reject: (error: any) => void;

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -33,7 +33,7 @@ export const INJECTOR = new InjectionToken<Injector>(
     -1 as any  // `-1` is used by Ivy DI system as special value to recognize it as `Injector`.
     );
 
-const _THROW_IF_NOT_FOUND = new Object();
+const _THROW_IF_NOT_FOUND = {};
 export const THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
 
 export const NG_TEMP_TOKEN_PATH = 'ngTempTokenPath';

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -16,7 +16,7 @@ import {ReflectiveDependency, ResolvedReflectiveFactory, ResolvedReflectiveProvi
 
 
 // Threshold for the dynamic version
-const UNDEFINED = new Object();
+const UNDEFINED = {};
 
 /**
  * A ReflectiveDependency injection container used for instantiating objects and resolving

--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -18,7 +18,7 @@ import {stringify} from '../util/stringify';
 import {DepDef, DepFlags, NgModuleData, NgModuleDefinition, NgModuleProviderDef, NodeFlags} from './types';
 import {splitDepsDsl, tokenKey} from './util';
 
-const UNDEFINED_VALUE = new Object();
+const UNDEFINED_VALUE = {};
 
 const InjectorRefTokenKey = tokenKey(Injector);
 const INJECTORRefTokenKey = tokenKey(INJECTOR);

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -26,7 +26,7 @@ import {DepFlags, ElementData, NgModuleData, NgModuleDefinition, NodeDef, NodeFl
 import {markParentViewsForCheck, resolveDefinition, rootRenderNodes, splitNamespace, tokenKey, viewParentEl} from './util';
 import {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView, renderDetachView} from './view_attach';
 
-const EMPTY_CONTEXT = new Object();
+const EMPTY_CONTEXT = {};
 
 // Attention: this function is called as top level function.
 // Putting any logic in here will destroy closure tree shaking!

--- a/packages/core/test/change_detection/change_detector_util_spec.ts
+++ b/packages/core/test/change_detection/change_detector_util_spec.ts
@@ -16,41 +16,41 @@ import {devModeEqual} from '@angular/core/src/change_detection/change_detection_
         expect(devModeEqual(['one'], ['one', 'two'])).toBe(false);
         expect(devModeEqual(['one', 'two'], ['one'])).toBe(false);
         expect(devModeEqual(['one'], 'one')).toBe(false);
-        expect(devModeEqual(['one'], new Object())).toBe(false);
+        expect(devModeEqual(['one'], {})).toBe(false);
         expect(devModeEqual('one', ['one'])).toBe(false);
-        expect(devModeEqual(new Object(), ['one'])).toBe(false);
+        expect(devModeEqual({}, ['one'])).toBe(false);
       });
 
       it('should compare primitive numbers', () => {
         expect(devModeEqual(1, 1)).toBe(true);
         expect(devModeEqual(1, 2)).toBe(false);
-        expect(devModeEqual(new Object(), 2)).toBe(false);
-        expect(devModeEqual(1, new Object())).toBe(false);
+        expect(devModeEqual({}, 2)).toBe(false);
+        expect(devModeEqual(1, {})).toBe(false);
       });
 
       it('should compare primitive strings', () => {
         expect(devModeEqual('one', 'one')).toBe(true);
         expect(devModeEqual('one', 'two')).toBe(false);
-        expect(devModeEqual(new Object(), 'one')).toBe(false);
-        expect(devModeEqual('one', new Object())).toBe(false);
+        expect(devModeEqual({}, 'one')).toBe(false);
+        expect(devModeEqual('one', {})).toBe(false);
       });
 
       it('should compare primitive booleans', () => {
         expect(devModeEqual(true, true)).toBe(true);
         expect(devModeEqual(true, false)).toBe(false);
-        expect(devModeEqual(new Object(), true)).toBe(false);
-        expect(devModeEqual(true, new Object())).toBe(false);
+        expect(devModeEqual({}, true)).toBe(false);
+        expect(devModeEqual(true, {})).toBe(false);
       });
 
       it('should compare null', () => {
         expect(devModeEqual(null, null)).toBe(true);
         expect(devModeEqual(null, 1)).toBe(false);
-        expect(devModeEqual(new Object(), null)).toBe(false);
-        expect(devModeEqual(null, new Object())).toBe(false);
+        expect(devModeEqual({}, null)).toBe(false);
+        expect(devModeEqual(null, {})).toBe(false);
       });
 
       it('should return true for other objects',
-         () => { expect(devModeEqual(new Object(), new Object())).toBe(true); });
+         () => { expect(devModeEqual({}, {})).toBe(true); });
     });
   });
 }

--- a/packages/core/test/view/anchor_spec.ts
+++ b/packages/core/test/view/anchor_spec.ts
@@ -40,7 +40,7 @@ import {compViewDef, createAndGetRootNodes} from './helper';
       });
 
       it('should add debug information to the renderer', () => {
-        const someContext = new Object();
+        const someContext = {};
         const {view, rootNodes} = createAndGetRootNodes(
             compViewDef([anchorDef(NodeFlags.None, null, null, 0)]), someContext);
         expect(getDebugNode(rootNodes[0]) !.nativeNode).toBe(asElementData(view, 0).renderElement);

--- a/packages/core/test/view/element_spec.ts
+++ b/packages/core/test/view/element_spec.ts
@@ -62,7 +62,7 @@ const removeEventListener = 'removeEventListener';
       });
 
       it('should add debug information to the renderer', () => {
-        const someContext = new Object();
+        const someContext = {};
         const {view, rootNodes} = createAndGetRootNodes(
             compViewDef([elementDef(0, NodeFlags.None, null, null, 0, 'div')]), someContext);
         expect(getDebugNode(rootNodes[0]) !.nativeNode).toBe(asElementData(view, 0).renderElement);

--- a/packages/core/test/view/embedded_view_spec.ts
+++ b/packages/core/test/view/embedded_view_spec.ts
@@ -16,8 +16,8 @@ import {compViewDef, compViewDefFactory, createAndGetRootNodes, createEmbeddedVi
   describe(`Embedded Views`, () => {
 
     it('should create embedded views with the right context', () => {
-      const parentContext = new Object();
-      const childContext = new Object();
+      const parentContext = {};
+      const childContext = {};
 
       const {view: parentView} = createAndGetRootNodes(
           compViewDef([

--- a/packages/core/test/view/text_spec.ts
+++ b/packages/core/test/view/text_spec.ts
@@ -41,7 +41,7 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, compViewDef, createAndGetRoot
       });
 
       it('should add debug information to the renderer', () => {
-        const someContext = new Object();
+        const someContext = {};
         const {view, rootNodes} =
             createAndGetRootNodes(compViewDef([textDef(0, null, ['a'])]), someContext);
         expect(getDebugNode(rootNodes[0]) !.nativeNode).toBe(asTextData(view, 0).renderText);

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -459,7 +459,7 @@ export declare abstract class Injector {
     abstract get<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>, notFoundValue?: T, flags?: InjectFlags): T;
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
-    static THROW_IF_NOT_FOUND: Object;
+    static THROW_IF_NOT_FOUND: {};
     static ɵprov: never;
     /** @deprecated */ static create(providers: StaticProvider[], parent?: Injector): Injector;
     static create(options: {

--- a/tslint.json
+++ b/tslint.json
@@ -19,6 +19,10 @@
     "no-duplicate-variable": true,
     "no-jasmine-focus": true,
     "no-var-keyword": true,
+    "prefer-literal": [
+      true,
+      "object"
+    ],
     "require-internal-with-underscore": true,
     "no-toplevel-property-access": [
       true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`Object` constructor is allowed to use, which violates [one](https://google.github.io/styleguide/jsguide.html#features-objects-ctor) of our style guide rules.

Issue Number: N/A


## What is the new behavior?
`Object` constructor is **not** allowed to use (enforced by the [prefer-literal](https://github.com/vrsource/vrsource-tslint-rules#prefer-literal) TSLint rule).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
