### PR TITLE
refactor(core): rename ngLocaleIdDef to ɵloc

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -324,7 +324,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
 
     if (this.localeId) {
       res.push({
-        name: 'ngLocaleIdDef',
+        name: 'ɵloc',
         initializer: new LiteralExpr(this.localeId),
         statements: [],
         type: STRING_TYPE

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -16,7 +16,7 @@ import {initNgDevMode} from '../util/ng_dev_mode';
 import {stringify} from '../util/stringify';
 
 import {EMPTY_ARRAY, EMPTY_OBJ} from './empty';
-import {NG_BASE_DEF, NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_LOCALE_ID_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
+import {NG_BASE_DEF, NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_LOC_ID_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
 import {ComponentDef, ComponentDefFeature, ComponentTemplate, ComponentType, ContentQueriesFunction, DirectiveDef, DirectiveDefFeature, DirectiveType, DirectiveTypesOrFactory, FactoryFn, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory, ViewQueriesFunction, ɵɵBaseDef} from './interfaces/definition';
 import {TAttributes} from './interfaces/node';
 // while SelectorFlags is unused here, it's required so that types don't get resolved lazily
@@ -776,5 +776,5 @@ export function getNgModuleDef<T>(type: any, throwNotFound?: boolean): NgModuleD
 }
 
 export function getNgLocaleIdDef(type: any): string|null {
-  return (type as any)[NG_LOCALE_ID_DEF] || null;
+  return (type as any)[NG_LOC_ID_DEF] || null;
 }

--- a/packages/core/src/render3/fields.ts
+++ b/packages/core/src/render3/fields.ts
@@ -12,7 +12,7 @@ export const NG_COMP_DEF = getClosureSafeProperty({ɵcmp: getClosureSafeProperty
 export const NG_DIR_DEF = getClosureSafeProperty({ɵdir: getClosureSafeProperty});
 export const NG_PIPE_DEF = getClosureSafeProperty({ɵpipe: getClosureSafeProperty});
 export const NG_MOD_DEF = getClosureSafeProperty({ɵmod: getClosureSafeProperty});
-export const NG_LOCALE_ID_DEF = getClosureSafeProperty({ngLocaleIdDef: getClosureSafeProperty});
+export const NG_LOC_ID_DEF = getClosureSafeProperty({ɵloc: getClosureSafeProperty});
 export const NG_BASE_DEF = getClosureSafeProperty({ngBaseDef: getClosureSafeProperty});
 export const NG_FACTORY_DEF = getClosureSafeProperty({ɵfac: getClosureSafeProperty});
 


### PR DESCRIPTION
LocaleID defs are not considered public API, so the property
that contains them should be prefixed with Angular's marker
for "private" ('ɵ') to discourage apps from relying on def
APIs directly.

This commit adds the prefix and shortens the name from
ngLocaleIdDef to loc. This is because property names
cannot be minified by Uglify without turning on property
mangling (which most apps have turned off) and are thus
size-sensitive.