### PR TITLE
docs(compiler-cli): change in the fullTemplateTypeCheck default value

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -120,7 +120,7 @@ would be `"index.d.ts"`.
 
 When true (recommended), enables the [binding expression validation](guide/aot-compiler#binding-expression-validation) phase of the template compiler, which uses TypeScript to validate binding expressions.
 
-Default is currently false.
+Default is currently `true`.
 
 ### `generateCodeForLibraries`
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the Documentation about fullTemplateTypeCheckoption's stated the default value of `fullTemplateTypeCheckoption` is false. Which is not correct.

Issue Number: #33193


## What is the new behavior?
Documentation about `fullTemplateTypeCheckoption`, the default value mentioned in  the paragraph has been corrected to `true` as per the current compiler options.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
