### PR TITLE
fix(ngcc): do not fail when multiple workers try to create the same directory

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/cached_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/cached_file_system.ts
@@ -74,11 +74,6 @@ export class CachedFileSystem implements FileSystem {
     this.existsCache.set(to, true);
   }
 
-  mkdir(path: AbsoluteFsPath): void {
-    this.delegate.mkdir(path);
-    this.existsCache.set(path, true);
-  }
-
   ensureDir(path: AbsoluteFsPath): void {
     this.delegate.ensureDir(path);
     while (!this.isRoot(path)) {

--- a/packages/compiler-cli/src/ngtsc/file_system/src/invalid_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/invalid_file_system.ts
@@ -27,7 +27,6 @@ export class InvalidFileSystem implements FileSystem {
   extname(path: AbsoluteFsPath|PathSegment): string { throw makeError(); }
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { throw makeError(); }
   moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { throw makeError(); }
-  mkdir(path: AbsoluteFsPath): void { throw makeError(); }
   ensureDir(path: AbsoluteFsPath): void { throw makeError(); }
   isCaseSensitive(): boolean { throw makeError(); }
   resolve(...paths: string[]): AbsoluteFsPath { throw makeError(); }

--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -28,7 +28,6 @@ export class NodeJSFileSystem implements FileSystem {
   pwd(): AbsoluteFsPath { return this.normalize(process.cwd()) as AbsoluteFsPath; }
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { fs.copyFileSync(from, to); }
   moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { fs.renameSync(from, to); }
-  mkdir(path: AbsoluteFsPath): void { fs.mkdirSync(path); }
   ensureDir(path: AbsoluteFsPath): void {
     const parents: AbsoluteFsPath[] = [];
     while (!this.isRoot(path) && !this.exists(path)) {
@@ -73,7 +72,7 @@ export class NodeJSFileSystem implements FileSystem {
 
   private safeMkdir(path: AbsoluteFsPath): void {
     try {
-      this.mkdir(path);
+      fs.mkdirSync(path);
     } catch (err) {
       // Ignore the error, if the path already exists and points to a directory.
       // Re-throw otherwise.

--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -36,7 +36,7 @@ export class NodeJSFileSystem implements FileSystem {
       path = this.dirname(path);
     }
     while (parents.length) {
-      this.mkdir(parents.pop() !);
+      this.safeMkdir(parents.pop() !);
     }
   }
   isCaseSensitive(): boolean {
@@ -69,6 +69,18 @@ export class NodeJSFileSystem implements FileSystem {
   normalize<T extends string>(path: T): T {
     // Convert backslashes to forward slashes
     return path.replace(/\\/g, '/') as T;
+  }
+
+  private safeMkdir(path: AbsoluteFsPath): void {
+    try {
+      this.mkdir(path);
+    } catch (err) {
+      // Ignore the error, if the path already exists and points to a directory.
+      // Re-throw otherwise.
+      if (!this.exists(path) || !this.stat(path).isDirectory()) {
+        throw err;
+      }
+    }
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
@@ -46,7 +46,6 @@ export interface FileSystem {
   extname(path: AbsoluteFsPath|PathSegment): string;
   copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
   moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
-  mkdir(path: AbsoluteFsPath): void;
   ensureDir(path: AbsoluteFsPath): void;
   isCaseSensitive(): boolean;
   isRoot(path: AbsoluteFsPath): boolean;

--- a/packages/compiler-cli/src/ngtsc/file_system/test/cached_file_system_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/cached_file_system_spec.ts
@@ -234,22 +234,6 @@ describe('CachedFileSystem', () => {
     });
   });
 
-  describe('mkdir()', () => {
-    it('should call delegate', () => {
-      const spy = spyOn(delegate, 'mkdir');
-      fs.mkdir(xyzPath);
-      expect(spy).toHaveBeenCalledWith(xyzPath);
-    });
-
-    it('should update the "exists" cache', () => {
-      spyOn(delegate, 'mkdir');
-      const existsSpy = spyOn(delegate, 'exists');
-      fs.mkdir(xyzPath);
-      expect(fs.exists(xyzPath)).toEqual(true);
-      expect(existsSpy).not.toHaveBeenCalled();
-    });
-  });
-
   describe('ensureDir()', () => {
     it('should call delegate', () => {
       const ensureDirSpy = spyOn(delegate, 'ensureDir');

--- a/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
@@ -105,14 +105,6 @@ describe('NodeJSFileSystem', () => {
     });
   });
 
-  describe('mkdir()', () => {
-    it('should delegate to fs.mkdirSync()', () => {
-      const spy = spyOn(realFs, 'mkdirSync');
-      fs.mkdir(xyzPath);
-      expect(spy).toHaveBeenCalledWith(xyzPath);
-    });
-  });
-
   describe('ensureDir()', () => {
     it('should call exists() and fs.mkdir()', () => {
       const aPath = absoluteFrom('/a');

--- a/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as realFs from 'fs';
-import {absoluteFrom, relativeFrom, setFileSystem} from '../src/helpers';
+import {absoluteFrom, dirname, relativeFrom, setFileSystem} from '../src/helpers';
 import {NodeJSFileSystem} from '../src/node_js_file_system';
 import {AbsoluteFsPath} from '../src/types';
 
@@ -143,6 +143,70 @@ describe('NodeJSFileSystem', () => {
       fs.ensureDir(xyzPath);
       expect(existsCalls).toEqual([xyzPath, xyPath, xPath]);
       expect(mkdirCalls).toEqual([xPath, xyPath, xyzPath]);
+    });
+
+    it('should not fail if a directory (that did not exist before) does exist when trying to create it',
+       () => {
+         let abcPathExists = false;
+
+         spyOn(fs, 'exists').and.callFake((path: AbsoluteFsPath) => {
+           if (path === abcPath) {
+             // Pretend `abcPath` is created (e.g. by another process) right after we check if it
+             // exists for the first time.
+             const exists = abcPathExists;
+             abcPathExists = true;
+             return exists;
+           }
+           return false;
+         });
+         spyOn(fs, 'stat').and.returnValue({isDirectory: () => true});
+         const mkdirSyncSpy = spyOn(realFs, 'mkdirSync').and.callFake((path: string) => {
+           if (path === abcPath) {
+             throw new Error('It exists already. Supposedly.');
+           }
+         });
+
+         fs.ensureDir(abcPath);
+         expect(mkdirSyncSpy).toHaveBeenCalledTimes(3);
+         expect(mkdirSyncSpy).toHaveBeenCalledWith(abcPath);
+         expect(mkdirSyncSpy).toHaveBeenCalledWith(dirname(abcPath));
+       });
+
+    it('should fail if creating the directory throws and the directory does not exist', () => {
+      spyOn(fs, 'exists').and.returnValue(false);
+      spyOn(realFs, 'mkdirSync').and.callFake((path: string) => {
+        if (path === abcPath) {
+          throw new Error('Unable to create directory (for whatever reason).');
+        }
+      });
+
+      expect(() => fs.ensureDir(abcPath))
+          .toThrowError('Unable to create directory (for whatever reason).');
+    });
+
+    it('should fail if creating the directory throws and the path points to a file', () => {
+      const isDirectorySpy = jasmine.createSpy('isDirectory').and.returnValue(false);
+      let abcPathExists = false;
+
+      spyOn(fs, 'exists').and.callFake((path: AbsoluteFsPath) => {
+        if (path === abcPath) {
+          // Pretend `abcPath` is created (e.g. by another process) right after we check if it
+          // exists for the first time.
+          const exists = abcPathExists;
+          abcPathExists = true;
+          return exists;
+        }
+        return false;
+      });
+      spyOn(fs, 'stat').and.returnValue({isDirectory: isDirectorySpy});
+      spyOn(realFs, 'mkdirSync').and.callFake((path: string) => {
+        if (path === abcPath) {
+          throw new Error('It exists already. Supposedly.');
+        }
+      });
+
+      expect(() => fs.ensureDir(abcPath)).toThrowError('It exists already. Supposedly.');
+      expect(isDirectorySpy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
When `ngcc` is running in parallel mode (usually when run from the command line) and the `createNewEntryPointFormats` option is set to true (e.g. via the `--create-ivy-entry-points` command line option), it can happen that two workers end up trying to create the same directory at
the same time. This can lead to a race condition, where both check for the directory existence, see that the directory does not exist and both try to create it, with the second failing due the directory's having already been created by the first one. Note that this only affects directories and not files, because `ngcc` tasks operate on different sets of files.

This commit avoids this race condition by allowing `FileSystem`'s `ensureDir()` method to not fail if one of the directories it is trying to create already exists (and is indeed a directory). This is fine for
the `ensureDir()` method, since it's purpose is to ensure that the specified directory exists. So, even if the `mkdir()` call failed (because the directory exists), `ensureDir()` has still completed its mission.

Related discussion: https://github.com/angular/angular/pull/33049#issuecomment-540485703
[FW-1635](https://angular-team.atlassian.net/browse/FW-1635) #resolve
