### PR TITLE
docs: clarify instructions on where to create the proxy.conf.json file

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -328,7 +328,7 @@ For more information, see [Autoprefixer documentation](https://autoprefixer.gith
 You can use the [proxying support](https://webpack.js.org/configuration/dev-server/#devserver-proxy) in the `webpack` dev server to divert certain URLs to a backend server, by passing a file to the `--proxy-config` build option.
 For example, to divert all calls for `http://localhost:4200/api` to a server running on `http://localhost:3000/api`, take the following steps.
 
-1. Create a file `proxy.conf.json` in the projects `src/` folder, in the same directory as `package.json`.
+1. Create a file `proxy.conf.json` in your project's `src/` folder.
 
 1. Add the following content to the new proxy file:
     ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The guide on where to create the `proxy.conf.json` file was a little bit confusing. Readers may think that the `src` folder contains the `package.json` which is not the case.


## What is the new behavior?
The guide is clearer about the location of the `proxy.conf.json` file. It is now also applicable to Angular workspaces generated with `--create-application=false`. In those cases, the `src` folder is not in the same level as the `package.json` file. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
