### PR TITLE
fix(language-service): Add global symbol for $any()

### DIFF
--- a/packages/language-service/src/global_symbols.ts
+++ b/packages/language-service/src/global_symbols.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ng from '../src/types';
+
+export const EMPTY_SYMBOL_TABLE: Readonly<ng.SymbolTable> = {
+  size: 0,
+  get: () => undefined,
+  has: () => false,
+  values: () => [],
+};
+
+/**
+ * A factory function that returns a symbol table that contains all global symbols
+ * available in an interpolation scope in a template.
+ * This function creates the table the first time it is called, and return a cached
+ * value for all subsequent calls.
+ */
+export const createGlobalSymbolTable: (query: ng.SymbolQuery) => ng.SymbolTable = (function() {
+  let GLOBAL_SYMBOL_TABLE: ng.SymbolTable|undefined;
+  return function(query: ng.SymbolQuery) {
+    if (GLOBAL_SYMBOL_TABLE) {
+      return GLOBAL_SYMBOL_TABLE;
+    }
+    GLOBAL_SYMBOL_TABLE = query.createSymbolTable([
+      // The `$any()` method casts the type of an expression to `any`.
+      // https://angular.io/guide/template-syntax#the-any-type-cast-function
+      {
+        name: '$any',
+        kind: 'method',
+        type: {
+          name: '$any',
+          kind: 'method',
+          type: undefined,
+          language: 'typescript',
+          container: undefined,
+          public: true,
+          callable: true,
+          definition: undefined,
+          nullable: false,
+          members: () => EMPTY_SYMBOL_TABLE,
+          signatures: () => [],
+          selectSignature(args: ng.Symbol[]) {
+            if (args.length !== 1) {
+              return;
+            }
+            return {
+              arguments: EMPTY_SYMBOL_TABLE,  // not used
+              result: query.getBuiltinType(ng.BuiltinType.Any),
+            };
+          },
+          indexed: () => undefined,
+        },
+      },
+    ]);
+    return GLOBAL_SYMBOL_TABLE;
+  };
+})();

--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -10,6 +10,7 @@ import {getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@an
 import * as ts from 'typescript';
 
 import {isAstResult} from './common';
+import {createGlobalSymbolTable} from './global_symbols';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
 
@@ -48,8 +49,10 @@ abstract class BaseTemplate implements ng.TemplateSource {
     if (!this.membersTable) {
       const typeChecker = this.program.getTypeChecker();
       const sourceFile = this.classDeclNode.getSourceFile();
-      this.membersTable =
-          getClassMembersFromDeclaration(this.program, typeChecker, sourceFile, this.classDeclNode);
+      this.membersTable = this.query.mergeSymbolTable([
+        createGlobalSymbolTable(this.query),
+        getClassMembersFromDeclaration(this.program, typeChecker, sourceFile, this.classDeclNode),
+      ]);
     }
     return this.membersTable;
   }

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli",
         "//packages/compiler-cli/test:test_utils",
         "//packages/language-service",
         "@npm//typescript",
@@ -21,7 +22,6 @@ jasmine_node_test(
     name = "test",
     data = [
         "//packages/common:npm_package",
-        "//packages/compiler:npm_package",
         "//packages/core:npm_package",
         "//packages/forms:npm_package",
     ],

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -147,6 +147,12 @@ describe('completions', () => {
     expectContain(completions, CompletionKind.PROPERTY, ['title', 'subTitle']);
   });
 
+  it('should suggest $any() type cast function in an interpolation', () => {
+    const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'sub-start');
+    const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);
+    expectContain(completions, CompletionKind.METHOD, ['$any']);
+  });
+
   describe('in external template', () => {
     it('should be able to get entity completions in external template', () => {
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'entity-amp');

--- a/packages/language-service/test/global_symbols_spec.ts
+++ b/packages/language-service/test/global_symbols_spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSymbolQuery} from '@angular/compiler-cli';
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {EMPTY_SYMBOL_TABLE, createGlobalSymbolTable} from '../src/global_symbols';
+
+import {MockTypescriptHost} from './test_utils';
+
+describe('GlobalSymbolTable', () => {
+  const mockHost = new MockTypescriptHost([]);
+  const tsLS = ts.createLanguageService(mockHost);
+
+  it(`contains $any()`, () => {
+    const program = tsLS.getProgram() !;
+    const typeChecker = program.getTypeChecker();
+    const source = ts.createSourceFile('foo.ts', '', ts.ScriptTarget.ES2015);
+    const query = getSymbolQuery(program, typeChecker, source, () => EMPTY_SYMBOL_TABLE);
+    const table = createGlobalSymbolTable(query);
+    expect(table.has('$any')).toBe(true);
+  });
+});

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -13,6 +13,8 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
 
+const TEST_TEMPLATE = '/app/test.ng';
+
 describe('hover', () => {
   const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const tsLS = ts.createLanguageService(mockHost);
@@ -189,6 +191,19 @@ describe('hover', () => {
       length: 'StringModel'.length,
     });
     expect(toText(displayParts)).toBe('(directive) AppModule.StringModel: class');
+  });
+
+  it('should be able to provide quick info for $any() cast function', () => {
+    const content = mockHost.override(TEST_TEMPLATE, '<div>{{$any(title)}}</div>');
+    const position = content.indexOf('$any');
+    const quickInfo = ngLS.getHoverAt(TEST_TEMPLATE, position);
+    expect(quickInfo).toBeDefined();
+    const {textSpan, displayParts} = quickInfo !;
+    expect(textSpan).toEqual({
+      start: position,
+      length: '$any(title)'.length,
+    });
+    expect(toText(displayParts)).toBe('(method) $any');
   });
 });
 


### PR DESCRIPTION
This commit introduces a "global symbol table" in the language service for symbols that are available in the top level scope, and add `$any()` to it.

See https://angular.io/guide/template-syntax#the-any-type-cast-function
    
PR closes https://github.com/angular/vscode-ng-language-service/issues/242

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
