### PR TITLE
fix(router): add function to compare a single query parameter which have multiple values

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -12,7 +12,7 @@ import {map} from 'rxjs/operators';
 
 import {Data, ResolveData, Route} from './config';
 import {PRIMARY_OUTLET, ParamMap, Params, convertToParamMap} from './shared';
-import {UrlSegment, UrlSegmentGroup, UrlTree, equalSegments} from './url_tree';
+import {UrlSegment, UrlSegmentGroup, UrlTree, equalQueryParams, equalSegments} from './url_tree';
 import {shallowEqual, shallowEqualArrays} from './utils/collection';
 import {Tree, TreeNode} from './utils/tree';
 
@@ -386,7 +386,7 @@ export function advanceActivatedRoute(route: ActivatedRoute): void {
     const currentSnapshot = route.snapshot;
     const nextSnapshot = route._futureSnapshot;
     route.snapshot = nextSnapshot;
-    if (!shallowEqual(currentSnapshot.queryParams, nextSnapshot.queryParams)) {
+    if (!equalQueryParams(currentSnapshot.queryParams, nextSnapshot.queryParams)) {
       (<any>route.queryParams).next(nextSnapshot.queryParams);
     }
     if (currentSnapshot.fragment !== nextSnapshot.fragment) {

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -109,3 +109,16 @@ export function wrapIntoObservable<T>(value: T | Promise<T>| Observable<T>): Obs
 
   return of (value);
 }
+
+export function areArraysEqual(arr1: any[], arr2: any[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  return arr1.every((val, index) => {
+    if (Array.isArray(val) && Array.isArray(arr2[index])) {
+      return areArraysEqual(val, arr2[index]);
+    }
+    return val === arr2[index];
+  });
+}

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -11,8 +11,8 @@ import {Injector} from '@angular/core';
 import {LoadedRouterConfig, RunGuardsAndResolvers} from '../config';
 import {ChildrenOutletContexts, OutletContext} from '../router_outlet_context';
 import {ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments} from '../router_state';
-import {equalPath} from '../url_tree';
-import {forEach, shallowEqual} from '../utils/collection';
+import {equalPath, equalQueryParams} from '../url_tree';
+import {forEach} from '../utils/collection';
 import {TreeNode, nodeChildrenAsMap} from '../utils/tree';
 
 export class CanActivate {
@@ -156,14 +156,14 @@ function shouldRunGuardsAndResolvers(
 
     case 'pathParamsOrQueryParamsChange':
       return !equalPath(curr.url, future.url) ||
-          !shallowEqual(curr.queryParams, future.queryParams);
+          !equalQueryParams(curr.queryParams, future.queryParams);
 
     case 'always':
       return true;
 
     case 'paramsOrQueryParamsChange':
       return !equalParamsAndUrlSegments(curr, future) ||
-          !shallowEqual(curr.queryParams, future.queryParams);
+          !equalQueryParams(curr.queryParams, future.queryParams);
 
     case 'paramsChange':
     default:

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DefaultUrlSerializer, containsTree} from '../src/url_tree';
+import {DefaultUrlSerializer, containsTree, equalQueryParams} from '../src/url_tree';
 
 describe('UrlTree', () => {
   const serializer = new DefaultUrlSerializer();
@@ -41,9 +41,21 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, true)).toBe(true);
       });
 
+      it('should return true when queryParams are the same array values', () => {
+        const t1 = serializer.parse('/one/two?test=1&test=2&page=5');
+        const t2 = serializer.parse('/one/two?test=1&test=2&page=5');
+        expect(containsTree(t1, t2, true)).toBe(true);
+      });
+
       it('should return false when queryParams are not the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when queryParams are not the same array values', () => {
+        const t1 = serializer.parse('/one/two?test=1&test=2&page=5');
+        const t2 = serializer.parse('/one/two?test=1&test=3&page=5');
         expect(containsTree(t1, t2, true)).toBe(false);
       });
 
@@ -115,6 +127,12 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, false)).toBe(true);
       });
 
+      it('should return true when queryParams are the same array values', () => {
+        const t1 = serializer.parse('/one/two?test=1&test=2&page=5');
+        const t2 = serializer.parse('/one/two?test=1&test=2&page=5');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
       it('should return true when container contains containees queryParams', () => {
         const t1 = serializer.parse('/one/two?test=1&u=5');
         const t2 = serializer.parse('/one/two?u=5');
@@ -139,11 +157,29 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, false)).toBe(false);
       });
 
+      it('should return false when containee has different array values of queryParams', () => {
+        const t1 = serializer.parse('/one/two?test=1&test=2&page=5');
+        const t2 = serializer.parse('/one/two?test=1&test=3&page=5');
+        expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
       it('should return false when containee has more queryParams than container', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
         expect(containsTree(t1, t2, false)).toBe(false);
       });
+    });
+  });
+
+  describe('equalQueryParams', () => {
+    it('should return true for the same params', () => {
+      expect(equalQueryParams({'a': '1', 'b': '2'}, {'a': '1', 'b': '2'})).toBe(true);
+      expect(equalQueryParams({'a': ['1', '2', '3']}, {'a': ['1', '2', '3']})).toBe(true);
+    });
+
+    it('should return false for different arrays', () => {
+      expect(equalQueryParams({'a': '1', 'b': '2'}, {'a': '1', 'b': '3'})).toBe(false);
+      expect(equalQueryParams({'a': ['1', '2', '3']}, {'a': ['1', '2', '4']})).toBe(false);
     });
   });
 });

--- a/packages/router/test/utils/collection.spec.ts
+++ b/packages/router/test/utils/collection.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {areArraysEqual} from '../../src/utils/collection';
+
+describe('collection', () => {
+  it('#areArraysEqual should return true for equal arrays', () => {
+    expect(areArraysEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(areArraysEqual([[1, 2], [3, 4]], [[1, 2], [3, 4]])).toBe(true);
+  });
+
+  it('#areArraysEqual should return false for different arrays', () => {
+    expect(areArraysEqual([1, 2, 3], [1, 2])).toBe(false);
+    expect(areArraysEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+    expect(areArraysEqual([[1, 2], [3, 4]], [[1, 2]])).toBe(false);
+    expect(areArraysEqual([[1, 2], [3, 4]], [[1, 2], [4, 5]])).toBe(false);
+  });
+});


### PR DESCRIPTION
`route.queryParamMap` observable shouldn't be triggered if query parameters are not changed.
It should work in the same way as it is now for query parameters which do not have
multiple values.

This commit adds an additional checking for query parameter with multiple values.
Previously during comparing values of query parameters from previous route and
current one @angular/router makes decision that query parameters were changed and
and triggers `route.queryParamMap` observable even if parameters have the same values.
It happened because arrays are compared by reference, not by values.
fix #33227

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #33227


## What is the new behavior?
`route.queryParamMap` observable will not be triggered if query parameter with multiple values are not changed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No