### PR TITLE
feat(ivy): give shim generation its own compiler options

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -305,6 +305,8 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "enableResourceInlining": ctx.attr.inline_resources,
         "generateCodeForLibraries": False,
         "allowEmptyCodegenFiles": True,
+        "generateNgFactoryShims": True,
+        "generateNgSummaryShims": True,
         # Summaries are only enabled if Angular outputs are to be produced.
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": _enable_ivy_value(ctx),

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -197,6 +197,23 @@ export interface CompilerOptions extends ts.CompilerOptions {
   enableResourceInlining?: boolean;
 
   /**
+   * Controls whether ngtsc will emit `.ngfactory.js` shims for each compiled `.ts` file.
+   *
+   * These shims support legacy imports from `ngfactory` files, by exporting a factory shim
+   * for each component or NgModule in the original `.ts` file.
+   */
+  generateNgFactoryShims?: boolean;
+
+  /**
+   * Controls whether ngtsc will emit `.ngsummary.js` shims for each compiled `.ts` file.
+   *
+   * These shims support legacy imports from `ngsummary` files, by exporting an empty object
+   * for each NgModule in the original `.ts` file. The only purpose of summaries is to feed them to
+   * `TestBed`, which is a no-op in Ivy.
+   */
+  generateNgSummaryShims?: boolean;
+
+  /**
    * Tells the compiler to generate definitions using the Render3 style code generation.
    * This option defaults to `true`.
    *


### PR DESCRIPTION
As a hack to get the Ivy compiler ngtsc off the ground, the existing
'allowEmptyCodegenFiles' option was used to control generation of ngfactory
and ngsummary shims during compilation. This option was selected since it's
enabled in google3 but never enabled in external projects.

As ngtsc is now mature and the role shims play in compilation is now better
understood across the ecosystem, this commit introduces two new compiler
options to control shim generation:

* generateNgFactoryShims controls the generation of .ngfactory shims.
* generateNgSummaryShims controls the generation of .ngsummary shims.

The 'allowEmptyCodegenFiles' option is still honored if either of the above
flags are not set explicitly.
