### PR TITLE
docs(core): add migration guide links to schematics

### DIFF
--- a/packages/core/schematics/migrations/dynamic-queries/index.ts
+++ b/packages/core/schematics/migrations/dynamic-queries/index.ts
@@ -28,6 +28,10 @@ export default function(): Rule {
     const allPaths = [...buildPaths, ...testPaths];
 
     ctx.logger.info('------ Dynamic queries migration ------');
+    ctx.logger.info('As of Angular 9, the "static" flag defaults to false and is no ');
+    ctx.logger.info('longer required for your view and content queries. ');
+    ctx.logger.info('Read more about this in the dedicated guide: ');
+    ctx.logger.info('https://v9.angular.io/guide/migration-dynamic-flag');
 
     if (!allPaths.length) {
       throw new SchematicsException(

--- a/packages/core/schematics/migrations/missing-injectable/index.ts
+++ b/packages/core/schematics/migrations/missing-injectable/index.ts
@@ -24,6 +24,10 @@ export default function(): Rule {
     const failures: string[] = [];
 
     ctx.logger.info('------ Missing @Injectable migration ------');
+    ctx.logger.info('In Angular 9, enforcement of @Injectable decorators for DI is a bit ');
+    ctx.logger.info('stricter. Read more about this in the dedicated guide: ');
+    ctx.logger.info('https://v9.angular.io/guide/migration-injectable');
+
     if (!buildPaths.length && !testPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot add the "@Injectable" decorator to providers ' +

--- a/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
+++ b/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
@@ -32,8 +32,11 @@ export default function(): Rule {
     const logger = context.logger;
 
     logger.info('------ Renderer to Renderer2 Migration ------');
-    logger.info('As of Angular 9, the Renderer class is no longer available.');
-    logger.info('Renderer2 should be used instead.');
+    logger.info('As of Angular 9, the Renderer class is no longer available. ');
+    logger.info('Renderer2 should be used instead. Read more about this in ');
+    logger.info('the dedicated guide: ');
+    logger.info('https://v9.angular.io/guide/migration-renderer');
+
 
     if (!allPaths.length) {
       throw new SchematicsException(

--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
@@ -30,6 +30,9 @@ export default function(): Rule {
     logger.info(
         'As of Angular 9, it is no longer supported to have Angular field ' +
         'decorators on a class that does not have an Angular decorator.');
+    logger.info('Read more about this in the dedicated guide: ');
+    logger.info('https://v9.angular.io/guide/migration-undecorated-classes');
+
 
     if (!allPaths.length) {
       throw new SchematicsException(

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -38,6 +38,12 @@ export default function(): Rule {
     const failures: string[] = [];
 
     ctx.logger.info('------ Undecorated classes with DI migration ------');
+    ctx.logger.info(
+        'As of Angular 9, it is no longer supported to use Angular DI ' +
+        'on a class that does not have an Angular decorator. ');
+    ctx.logger.info('Read more about this in the dedicated guide: ');
+    ctx.logger.info('https://v9.angular.io/guide/migration-undecorated-classes');
+
 
     if (!buildPaths.length) {
       throw new SchematicsException(


### PR DESCRIPTION
Angular v9 schematics should print out a link to the migration
guide associated with each schematic. This way, users have an
easy way to find more information about the automatic code
transformations they will see with `ng update`.
