### PR TITLE
fix(router): compare elements of queryParams in case they are arrays

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -33,6 +33,15 @@ export function shallowEqual(a: {[x: string]: any}, b: {[x: string]: any}): bool
   let key: string;
   for (let i = 0; i < k1.length; i++) {
     key = k1[i];
+    if (Array.isArray(a[key]) && Array.isArray(b[key])) {
+      const v1: string[] = a[key];
+      const v2: string[] = b[key];
+      if (v1.length === v2.length && v1.every((v, i) => v === v2[i])) {
+        return true;
+      } else {
+        return false;
+      }
+    }
     if (a[key] !== b[key]) {
       return false;
     }


### PR DESCRIPTION
Close #33227

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33227


## What is the new behavior?

If the `queryParams`s are arrays, it would compare their values instead of comparing directly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
