### PR TITLE
feat(ivy): strictness flags for template type checking

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -426,6 +426,7 @@ export class NgtscProgram implements api.Program {
         checkTemplateBodies: true,
         checkTypeOfInputBindings: true,
         strictNullInputBindings: true,
+        checkTypeOfAttributes: true,
         // Even in full template type-checking mode, DOM binding checks are not quite ready yet.
         checkTypeOfDomBindings: false,
         checkTypeOfOutputEvents: true,
@@ -446,6 +447,7 @@ export class NgtscProgram implements api.Program {
         checkTemplateBodies: false,
         checkTypeOfInputBindings: false,
         strictNullInputBindings: false,
+        checkTypeOfAttributes: false,
         checkTypeOfDomBindings: false,
         checkTypeOfOutputEvents: false,
         checkTypeOfAnimationEvents: false,

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -424,19 +424,19 @@ export class NgtscProgram implements api.Program {
         applyTemplateContextGuards: true,
         checkQueries: false,
         checkTemplateBodies: true,
-        checkTypeOfInputBindings: true,
-        strictNullInputBindings: true,
-        checkTypeOfAttributes: true,
+        checkTypeOfInputBindings: false,
+        strictNullInputBindings: false,
+        checkTypeOfAttributes: false,
         // Even in full template type-checking mode, DOM binding checks are not quite ready yet.
         checkTypeOfDomBindings: false,
-        checkTypeOfOutputEvents: true,
-        checkTypeOfAnimationEvents: true,
+        checkTypeOfOutputEvents: false,
+        checkTypeOfAnimationEvents: false,
         // Checking of DOM events currently has an adverse effect on developer experience,
         // e.g. for `<input (blur)="update($event.target.value)">` enabling this check results in:
         // - error TS2531: Object is possibly 'null'.
         // - error TS2339: Property 'value' does not exist on type 'EventTarget'.
         checkTypeOfDomEvents: false,
-        checkTypeOfReferences: true,
+        checkTypeOfReferences: false,
         checkTypeOfPipes: true,
         strictSafeNavigationTypes: true,
       };
@@ -468,9 +468,7 @@ export class NgtscProgram implements api.Program {
     }
     if (this.options.strictOutputEventTypes !== undefined) {
       typeCheckingConfig.checkTypeOfOutputEvents = this.options.strictOutputEventTypes;
-    }
-    if (this.options.strictAnimationEventTypes !== undefined) {
-      typeCheckingConfig.checkTypeOfAnimationEvents = this.options.strictAnimationEventTypes;
+      typeCheckingConfig.checkTypeOfAnimationEvents = this.options.strictOutputEventTypes;
     }
     if (this.options.strictDomEventTypes !== undefined) {
       typeCheckingConfig.checkTypeOfDomEvents = this.options.strictDomEventTypes;

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -435,6 +435,7 @@ export class NgtscProgram implements api.Program {
         // - error TS2531: Object is possibly 'null'.
         // - error TS2339: Property 'value' does not exist on type 'EventTarget'.
         checkTypeOfDomEvents: false,
+        checkTypeOfReferences: true,
         checkTypeOfPipes: true,
         strictSafeNavigationTypes: true,
       };
@@ -449,6 +450,7 @@ export class NgtscProgram implements api.Program {
         checkTypeOfOutputEvents: false,
         checkTypeOfAnimationEvents: false,
         checkTypeOfDomEvents: false,
+        checkTypeOfReferences: false,
         checkTypeOfPipes: false,
         strictSafeNavigationTypes: false,
       };

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -458,6 +458,33 @@ export class NgtscProgram implements api.Program {
       };
     }
 
+    // Apply explicitly configured strictness flags on top of the default configuration
+    // based on "fullTemplateTypeCheck".
+    if (this.options.strictInputTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfInputBindings = this.options.strictInputTypes;
+    }
+    if (this.options.strictNullInputTypes !== undefined) {
+      typeCheckingConfig.strictNullInputBindings = this.options.strictNullInputTypes;
+    }
+    if (this.options.strictOutputEventTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfOutputEvents = this.options.strictOutputEventTypes;
+    }
+    if (this.options.strictAnimationEventTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfAnimationEvents = this.options.strictAnimationEventTypes;
+    }
+    if (this.options.strictDomEventTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfDomEvents = this.options.strictDomEventTypes;
+    }
+    if (this.options.strictSafeNavigationTypes !== undefined) {
+      typeCheckingConfig.strictSafeNavigationTypes = this.options.strictSafeNavigationTypes;
+    }
+    if (this.options.strictLocalRefTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfReferences = this.options.strictLocalRefTypes;
+    }
+    if (this.options.strictAttributeTypes !== undefined) {
+      typeCheckingConfig.checkTypeOfAttributes = this.options.strictAttributeTypes;
+    }
+
     // Execute the typeCheck phase of each decorator in the program.
     const prepSpan = this.perfRecorder.start('typeCheckPrep');
     const ctx = new TypeCheckContext(typeCheckingConfig, this.refEmitter !, this.typeCheckFilePath);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -134,6 +134,15 @@ export interface TypeCheckingConfig {
   checkTypeOfDomEvents: boolean;
 
   /**
+   * Whether to infer the type of local references.
+   *
+   * If this is `true`, the type of any `#ref` variable in the template will be determined by the
+   * referenced entity (either a directive or a DOM element). If set to `false`, the type of `ref`
+   * will be `any`.
+   */
+  checkTypeOfReferences: boolean;
+
+  /**
    * Whether to include type information from pipes in the type-checking operation.
    *
    * If this is `true`, then the pipe's type signature for `transform()` will be used to check the

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -101,10 +101,10 @@ export interface TypeCheckingConfig {
    * Whether to check text attributes that happen to be consumed by a directive or component.
    *
    * For example, in a template containing `<input matInput disabled>` the `disabled` attribute ends
-   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime the
-   * input will be set to the attribute's string value, which is the empty string for attributes
-   * without a value, so with this flag set to `true` an error would be reported. If set to `false`,
-   * text attributes will never report an error.
+   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime, the
+   * input will be set to the attribute's string value, which is an empty string for attributes
+   * without a value, so with this flag set to `true`, an error would be reported. If set to
+   * `false`, text attributes will never report an error.
    *
    * Note that if `checkTypeOfInputBindings` is set to `false`, this flag has no effect.
    */

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -92,8 +92,23 @@ export interface TypeCheckingConfig {
    * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
    * null checks. This may be particularly useful when the directive is from a library that is not
    * compiled with `strictNullChecks` enabled.
+   *
+   * If `checkTypeOfInputBindings` is set to `false`, this flag has no effect.
    */
   strictNullInputBindings: boolean;
+
+  /**
+   * Whether to check text attributes that happen to be consumed by a directive or component.
+   *
+   * For example, in a template containing `<input matInput disabled>` the `disabled` attribute ends
+   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime the
+   * input will be set to the attribute's string value, which is the empty string for attributes
+   * without a value, so with this flag set to `true` an error would be reported. If set to `false`,
+   * text attributes will never report an error.
+   *
+   * Note that if `checkTypeOfInputBindings` is set to `false`, this flag has no effect.
+   */
+  checkTypeOfAttributes: boolean;
 
   /**
    * Whether to check the left-hand side type of binding operations to DOM properties.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -954,6 +954,11 @@ class TcbExpressionTranslator {
           addParseSpanInfo(expr, toAbsoluteSpan(ast.span, this.sourceSpan));
           return expr;
         } else if (binding instanceof TmplAstReference) {
+          if (!this.tcb.env.config.checkTypeOfReferences) {
+            // References are pinned to 'any'.
+            return NULL_AS_ANY;
+          }
+
           const target = this.tcb.boundTarget.getReferenceTarget(binding);
           if (target === null) {
             throw new Error(`Unbound reference? ${binding.name}`);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1131,6 +1131,11 @@ function tcbGetDirectiveInputs(
       return;
     }
 
+    // Skip text attributes if configured to do so.
+    if (!tcb.env.config.checkTypeOfAttributes && attr instanceof TmplAstTextAttribute) {
+      return;
+    }
+
     // Skip the attribute if the directive does not have an input for it.
     if (!propMatch.has(attr.name)) {
       return;

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -154,6 +154,25 @@ runInEachFileSystem(() => {
       ]);
     });
 
+    it('checks text attributes that are consumed by bindings with literal string types', () => {
+      const messages = diagnose(
+          `<div dir mode="drak"></div><div dir mode="light"></div>`, `
+        class Dir {
+          mode: 'dark'|'light';
+        }
+        class TestComponent {}`,
+          [{
+            type: 'directive',
+            name: 'Dir',
+            selector: '[dir]',
+            inputs: {'mode': 'mode'},
+          }]);
+
+      expect(messages).toEqual([
+        `synthetic.html(1, 10): Type '"drak"' is not assignable to type '"dark" | "light"'.`,
+      ]);
+    });
+
     it('produces diagnostics for pipes', () => {
       const messages = diagnose(
           `<div>{{ person.name | pipe:person.age:1 }}</div>`, `

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -155,6 +155,7 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
   checkTypeOfOutputEvents: true,
   checkTypeOfAnimationEvents: true,
   checkTypeOfDomEvents: true,
+  checkTypeOfReferences: true,
   checkTypeOfPipes: true,
   strictSafeNavigationTypes: true,
 };
@@ -198,6 +199,7 @@ export function tcb(
     checkTypeOfOutputEvents: true,
     checkTypeOfAnimationEvents: true,
     checkTypeOfDomEvents: true,
+    checkTypeOfReferences: true,
     checkTypeOfPipes: true,
     checkTemplateBodies: true,
     strictSafeNavigationTypes: true,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -149,6 +149,7 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
   checkTemplateBodies: true,
   checkTypeOfInputBindings: true,
   strictNullInputBindings: true,
+  checkTypeOfAttributes: true,
   // Feature is still in development.
   // TODO(alxhub): enable when DOM checking via lib.dom.d.ts is further along.
   checkTypeOfDomBindings: false,
@@ -195,6 +196,7 @@ export function tcb(
     checkQueries: false,
     checkTypeOfInputBindings: true,
     strictNullInputBindings: true,
+    checkTypeOfAttributes: true,
     checkTypeOfDomBindings: false,
     checkTypeOfOutputEvents: true,
     checkTypeOfAnimationEvents: true,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -291,6 +291,7 @@ describe('type check blocks', () => {
       checkTypeOfOutputEvents: true,
       checkTypeOfAnimationEvents: true,
       checkTypeOfDomEvents: true,
+      checkTypeOfReferences: true,
       checkTypeOfPipes: true,
       strictSafeNavigationTypes: true,
     };
@@ -416,6 +417,20 @@ describe('type check blocks', () => {
       });
     });
 
+    describe('config.checkTypeOfReferences', () => {
+      const TEMPLATE = `<input #ref>{{ref.value}}`;
+
+      it('should trace references when enabled', () => {
+        const block = tcb(TEMPLATE);
+        expect(block).toContain('(_t1).value');
+      });
+
+      it('should use any for reference types when disabled', () => {
+        const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfReferences: false};
+        const block = tcb(TEMPLATE, [], DISABLED_CONFIG);
+        expect(block).toContain('(null as any).value');
+      });
+    });
 
     describe('config.checkTypeOfPipes', () => {
       const TEMPLATE = `{{a | test:b:c}}`;

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -287,6 +287,7 @@ describe('type check blocks', () => {
       checkTemplateBodies: true,
       checkTypeOfInputBindings: true,
       strictNullInputBindings: true,
+      checkTypeOfAttributes: true,
       checkTypeOfDomBindings: false,
       checkTypeOfOutputEvents: true,
       checkTypeOfAnimationEvents: true,
@@ -429,6 +430,31 @@ describe('type check blocks', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfReferences: false};
         const block = tcb(TEMPLATE, [], DISABLED_CONFIG);
         expect(block).toContain('(null as any).value');
+      });
+    });
+
+    describe('config.checkTypeOfAttributes', () => {
+      const TEMPLATE = `<textarea dir disabled cols="3" [rows]="2">{{ref.value}}</textarea>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {'disabled': 'disabled', 'cols': 'cols', 'rows': 'rows'},
+      }];
+
+      it('should assign string value to the input when enabled', () => {
+        const block = tcb(TEMPLATE, DIRECTIVES);
+        expect(block).toContain('disabled: ("")');
+        expect(block).toContain('cols: ("3")');
+        expect(block).toContain('rows: (2)');
+      });
+
+      it('should use any for attributes but still check bound attributes when disabled', () => {
+        const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfAttributes: false};
+        const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
+        expect(block).toContain('disabled: (null as any)');
+        expect(block).toContain('cols: (null as any)');
+        expect(block).toContain('rows: (2)');
       });
     });
 

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -121,7 +121,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * directive or component is receiving the binding. If set to `true`, both sides of the assignment
    * are checked.
    *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   *
+   * @deprecated
    */
   strictInputTypes?: boolean;
 
@@ -134,8 +136,10 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
    * null checks.
    *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise. Note that if
-   * `strictInputTypes` is set to `false`, this flag has no effect.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set. Note that if `strictInputTypes` is
+   * not set, or set to `false`, this flag has no effect.
+   *
+   * @deprecated
    */
   strictNullInputTypes?: boolean;
 
@@ -143,12 +147,15 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * Whether to check text attributes that happen to be consumed by a directive or component.
    *
    * For example, in a template containing `<input matInput disabled>` the `disabled` attribute ends
-   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime the
-   * input will be set to the attribute's string value, which is the empty string for attributes
-   * without a value, so with this flag set to `true` an error would be reported. If set to `false`,
-   * text attributes will never report an error.
+   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime, the
+   * input will be set to the attribute's string value, which is an empty string for attributes
+   * without a value, so with this flag set to `true`, an error would be reported. If set to
+   * `false`, text attributes will never report an error.
    *
-   * Note that if `strictInputTypes` is set to `false`, this flag has no effect.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set. Note that if `strictInputTypes` is
+   * not set, or set to `false`, this flag has no effect.
+   *
+   * @deprecated
    */
   strictAttributeTypes?: boolean;
 
@@ -159,7 +166,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * then the return type of `a?.b` for example will be the same as the type of the ternary
    * expression `a != null ? a.b : a`.
    *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   *
+   * @deprecated
    */
   strictSafeNavigationTypes?: boolean;
 
@@ -170,7 +179,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * referenced entity (either a directive or a DOM element). If set to `false`, the type of `ref`
    * will be `any`.
    *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   *
+   * @deprecated
    */
   strictLocalRefTypes?: boolean;
 
@@ -181,19 +192,11 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * `EventEmitter`/`Subject` of the output. If set to `false`, the `$event` variable will be of
    * type `any`.
    *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   *
+   * @deprecated
    */
   strictOutputEventTypes?: boolean;
-
-  /**
-   * Whether to infer the type of the `$event` variable in event bindings for animations.
-   *
-   * If this is `true`, the type of `$event` will be `AnimationEvent` from `@angular/animations`.
-   * If set to `false`, the `$event` variable will be of type `any`.
-   *
-   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
-   */
-  strictAnimationEventTypes?: boolean;
 
   /**
    * Whether to infer the type of the `$event` variable in event bindings to DOM events.
@@ -202,7 +205,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * `HTMLElementEventMap`, with a fallback to the native `Event` type. If set to `false`, the
    * `$event` variable will be of type `any`.
    *
-   * Defaults to `false`.
+   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   *
+   * @deprecated
    */
   strictDomEventTypes?: boolean;
 

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -112,6 +112,100 @@ export interface CompilerOptions extends ts.CompilerOptions {
   // This will be true be default in Angular 6.
   fullTemplateTypeCheck?: boolean;
 
+  /**
+   * Whether to check the type of a binding to a directive/component input against the type of the
+   * field on the directive/component.
+   *
+   * For example, if this is `false` then the expression `[input]="expr"` will have `expr` type-
+   * checked, but not the assignment of the resulting type to the `input` property of whichever
+   * directive or component is receiving the binding. If set to `true`, both sides of the assignment
+   * are checked.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   */
+  strictInputTypes?: boolean;
+
+  /**
+   * Whether to use strict null types for input bindings for directives.
+   *
+   * If this is `true`, applications that are compiled with TypeScript's `strictNullChecks` enabled
+   * will produce type errors for bindings which can evaluate to `undefined` or `null` where the
+   * inputs's type does not include `undefined` or `null` in its type. If set to `false`, all
+   * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
+   * null checks.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise. Note that if
+   * `strictInputTypes` is set to `false`, this flag has no effect.
+   */
+  strictNullInputTypes?: boolean;
+
+  /**
+   * Whether to check text attributes that happen to be consumed by a directive or component.
+   *
+   * For example, in a template containing `<input matInput disabled>` the `disabled` attribute ends
+   * up being consumed as an input with type `boolean` by the `matInput` directive. At runtime the
+   * input will be set to the attribute's string value, which is the empty string for attributes
+   * without a value, so with this flag set to `true` an error would be reported. If set to `false`,
+   * text attributes will never report an error.
+   *
+   * Note that if `strictInputTypes` is set to `false`, this flag has no effect.
+   */
+  strictAttributeTypes?: boolean;
+
+  /**
+   * Whether to use a strict type for null-safe navigation operations.
+   *
+   * If this is `false`, then the return type of `a?.b` or `a?()` will be `any`. If set to `true`,
+   * then the return type of `a?.b` for example will be the same as the type of the ternary
+   * expression `a != null ? a.b : a`.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   */
+  strictSafeNavigationTypes?: boolean;
+
+  /**
+   * Whether to infer the type of local references.
+   *
+   * If this is `true`, the type of `#ref` variables in the template will be determined by the
+   * referenced entity (either a directive or a DOM element). If set to `false`, the type of `ref`
+   * will be `any`.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   */
+  strictLocalRefTypes?: boolean;
+
+  /**
+   * Whether to infer the type of the `$event` variable in event bindings for directive outputs.
+   *
+   * If this is `true`, the type of `$event` will be inferred based on the generic type of
+   * `EventEmitter`/`Subject` of the output. If set to `false`, the `$event` variable will be of
+   * type `any`.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   */
+  strictOutputEventTypes?: boolean;
+
+  /**
+   * Whether to infer the type of the `$event` variable in event bindings for animations.
+   *
+   * If this is `true`, the type of `$event` will be `AnimationEvent` from `@angular/animations`.
+   * If set to `false`, the `$event` variable will be of type `any`.
+   *
+   * Defaults to `true` if "fullTemplateTypeCheck" is set, `false` otherwise.
+   */
+  strictAnimationEventTypes?: boolean;
+
+  /**
+   * Whether to infer the type of the `$event` variable in event bindings to DOM events.
+   *
+   * If this is `true`, the type of `$event` will be inferred based on TypeScript's
+   * `HTMLElementEventMap`, with a fallback to the native `Event` type. If set to `false`, the
+   * `$event` variable will be of type `any`.
+   *
+   * Defaults to `false`.
+   */
+  strictDomEventTypes?: boolean;
+
   // Whether to use the CompilerHost's fileNameToModuleName utility (if available) to generate
   // import module specifiers. This is false by default, and exists to support running ngtsc
   // within Google. This option is internal and is used by the ng_module.bzl rule to switch

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -59,6 +59,11 @@ export declare class CommonModule {
   static ɵmod: i0.ɵɵNgModuleDefWithMeta<CommonModule, [typeof NgIf, typeof NgForOf, typeof IndexPipe], never, [typeof NgIf, typeof NgForOf, typeof IndexPipe]>;
 }
 `);
+      env.write('node_modules/@angular/animations/index.d.ts', `
+export declare class AnimationEvent {
+  element: any;
+}
+`);
     });
 
     it('should check a simple component', () => {
@@ -140,6 +145,347 @@ export declare class CommonModule {
       //     .toEqual(
       //         `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`);
       expect(diags[2].messageText).toEqual(`Property 'focused' does not exist on type 'TestCmp'.`);
+    });
+
+    describe('strictInputTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, Directive, NgModule, Input} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div dir [foo]="invalid && 1"></div>',
+          })
+          class TestCmp {}
+      
+          @Directive({selector: '[dir]'})
+          class TestDir {
+            @Input() foo: string;
+          }
+      
+          @NgModule({
+            declarations: [TestCmp, TestDir],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should check expressions and their type when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+        expect(diags[1].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+
+      it('should check expressions but not their type when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+    });
+
+    describe('strictNullInputTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, Directive, NgModule, Input} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div dir [foo]="invalid && nullable"></div>',
+          })
+          class TestCmp {
+            nullable: string | null | undefined;
+          }
+      
+          @Directive({selector: '[dir]'})
+          class TestDir {
+            @Input() foo: string;
+          }
+      
+          @NgModule({
+            declarations: [TestCmp, TestDir],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should check expressions and their nullability when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictNullInputTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText)
+            .toEqual(`Type 'string | null | undefined' is not assignable to type 'string'.`);
+        expect(diags[1].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+
+      it('should check expressions but not their nullability when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictNullInputTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+    });
+
+    describe('strictSafeNavigationTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, Directive, NgModule, Input} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div dir [foo]="invalid && user?.name"></div>',
+          })
+          class TestCmp {
+            user?: {name: string};
+          }
+      
+          @Directive({selector: '[dir]'})
+          class TestDir {
+            @Input() foo: string;
+          }
+      
+          @NgModule({
+            declarations: [TestCmp, TestDir],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should infer result type for safe navigation expressions when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictSafeNavigationTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText)
+            .toEqual(`Type 'string | undefined' is not assignable to type 'string'.`);
+        expect(diags[1].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+
+      it('should not infer result type for safe navigation expressions when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictSafeNavigationTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+    });
+
+    describe('strictOutputEventTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, Directive, EventEmitter, NgModule, Output} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div dir (update)="invalid && update($event);"></div>',
+          })
+          class TestCmp {
+            update(data: string) {}
+          }
+      
+          @Directive({selector: '[dir]'})
+          class TestDir {
+            @Output() update = new EventEmitter<number>();
+          }
+      
+          @NgModule({
+            declarations: [TestCmp, TestDir],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should expressions and infer type of $event when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+        expect(diags[1].messageText)
+            .toEqual(`Argument of type 'number' is not assignable to parameter of type 'string'.`);
+      });
+
+      it('should check expressions but not infer type of $event when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+    });
+
+    describe('strictAnimationEventTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, NgModule} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div (@animation.done)="invalid; update($event);"></div>',
+          })
+          class TestCmp {
+            update(data: string) {}
+          }
+   
+          @NgModule({
+            declarations: [TestCmp],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should check expressions and let $event be of type AnimationEvent when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictAnimationEventTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+        expect(diags[1].messageText)
+            .toEqual(
+                `Argument of type 'AnimationEvent' is not assignable to parameter of type 'string'.`);
+      });
+
+      it('should check expressions and let $event be of type any when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictAnimationEventTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
+    });
+
+    describe('strictLocalRefTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, NgModule} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<input #ref>{{ref.does_not_exist}}',
+          })
+          class TestCmp {}
+   
+          @NgModule({
+            declarations: [TestCmp],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should infer the type of references when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictLocalRefTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'does_not_exist' does not exist on type 'HTMLInputElement'.`);
+      });
+
+      it('should let the type of reference be any when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictLocalRefTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+    });
+
+    describe('strictAttributeTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, Directive, NgModule, Input} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<textarea dir disabled cols="3"></textarea>',
+          })
+          class TestCmp {}
+      
+          @Directive({selector: '[dir]'})
+          class TestDir {
+            @Input() disabled: boolean;
+            @Input() cols: number;
+          }
+   
+          @NgModule({
+            declarations: [TestCmp, TestDir],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should produce an error for text attributes when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictAttributeTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+      });
+
+      it('should not produce an error for text attributes when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictAttributeTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+    });
+
+    describe('strictDomEventTypes', () => {
+      beforeEach(() => {
+        env.write('test.ts', `
+          import {Component, NgModule} from '@angular/core';
+      
+          @Component({
+            selector: 'test',
+            template: '<div (focus)="invalid; update($event)"></div>',
+          })
+          class TestCmp {
+            update(data: string) {}
+          }
+   
+          @NgModule({
+            declarations: [TestCmp],
+          })
+          class Module {}
+        `);
+      });
+
+      it('should check expressions and infer type of $event when enabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictDomEventTypes: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+        expect(diags[1].messageText)
+            .toEqual(
+                `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`);
+      });
+
+      it('should check expressions but not infer type of $event when disabled', () => {
+        env.tsconfig({fullTemplateTypeCheck: true, strictDomEventTypes: false});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
+      });
     });
 
     it('should check basic usage of NgIf', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -86,6 +86,8 @@ export declare class AnimationEvent {
     });
 
     it('should check regular attributes that are directive inputs', () => {
+      env.tsconfig(
+          {fullTemplateTypeCheck: true, strictInputTypes: true, strictAttributeTypes: true});
       env.write('test.ts', `
         import {Component, Directive, NgModule, Input} from '@angular/core';
     
@@ -112,6 +114,7 @@ export declare class AnimationEvent {
     });
 
     it('should check event bindings', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
       env.write('test.ts', `
         import {Component, Directive, EventEmitter, NgModule, Output} from '@angular/core';
     
@@ -216,7 +219,8 @@ export declare class AnimationEvent {
       });
 
       it('should check expressions and their nullability when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictNullInputTypes: true});
+        env.tsconfig(
+            {fullTemplateTypeCheck: true, strictInputTypes: true, strictNullInputTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -227,7 +231,8 @@ export declare class AnimationEvent {
       });
 
       it('should check expressions but not their nullability when disabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictNullInputTypes: false});
+        env.tsconfig(
+            {fullTemplateTypeCheck: true, strictInputTypes: true, strictNullInputTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -262,7 +267,12 @@ export declare class AnimationEvent {
       });
 
       it('should infer result type for safe navigation expressions when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictSafeNavigationTypes: true});
+        env.tsconfig({
+          fullTemplateTypeCheck: true,
+          strictInputTypes: true,
+          strictNullInputTypes: true,
+          strictSafeNavigationTypes: true
+        });
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -273,7 +283,11 @@ export declare class AnimationEvent {
       });
 
       it('should not infer result type for safe navigation expressions when disabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictSafeNavigationTypes: false});
+        env.tsconfig({
+          fullTemplateTypeCheck: true,
+          strictInputTypes: true,
+          strictSafeNavigationTypes: false
+        });
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -328,7 +342,7 @@ export declare class AnimationEvent {
       });
     });
 
-    describe('strictAnimationEventTypes', () => {
+    describe('strictOutputEventTypes and animation event bindings', () => {
       beforeEach(() => {
         env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
@@ -349,7 +363,7 @@ export declare class AnimationEvent {
       });
 
       it('should check expressions and let $event be of type AnimationEvent when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictAnimationEventTypes: true});
+        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -361,7 +375,7 @@ export declare class AnimationEvent {
       });
 
       it('should check expressions and let $event be of type any when disabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictAnimationEventTypes: false});
+        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -430,7 +444,8 @@ export declare class AnimationEvent {
       });
 
       it('should produce an error for text attributes when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictAttributeTypes: true});
+        env.tsconfig(
+            {fullTemplateTypeCheck: true, strictInputTypes: true, strictAttributeTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -439,7 +454,8 @@ export declare class AnimationEvent {
       });
 
       it('should not produce an error for text attributes when disabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictAttributeTypes: false});
+        env.tsconfig(
+            {fullTemplateTypeCheck: true, strictInputTypes: true, strictAttributeTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
@@ -558,6 +574,7 @@ export declare class AnimationEvent {
     });
 
     it('should report an error inside the NgFor template', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
       env.write('test.ts', `
     import {CommonModule} from '@angular/common';
     import {Component, NgModule} from '@angular/core';
@@ -661,6 +678,7 @@ export declare class AnimationEvent {
     });
 
     it('should constrain types using type parameter bounds', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
       env.write('test.ts', `
     import {CommonModule} from '@angular/common';
     import {Component, Input, NgModule} from '@angular/core';
@@ -713,6 +731,7 @@ export declare class AnimationEvent {
        });
 
     it('should properly type-check inherited directives', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
       env.write('test.ts', `
     import {Component, Directive, Input, NgModule} from '@angular/core';
 


### PR DESCRIPTION
**feat(ivy): strictness flags for template type checking**

The template type checking abilities of the Ivy compiler are far more
advanced than the level of template type checking that was previously
done for Angular templates. Up until now, a single compiler option
called "fullTemplateTypeCheck" was available to configure the level
of template type checking. However, now that more advanced type checking
is being done, new errors may surface that were previously not reported,
in which case it may not be feasible to fix all new errors at once.

Having only a single option to disable a large number of template type
checking capabilities does not allow for incrementally addressing newly
reported types of errors. As a solution, this commit introduces some new
compiler options to be able to enable/disable certain kinds of template
type checks on a fine-grained basis.

---

**feat(ivy): add flag to disable checking of empty attributes**

For elements that have a static attribute without a value, which is
typically the case for attributes like `disabled`, it may happen that
the element is matched by a directive that consumes the attribute as an
input. In that case, the template type checker will validate the
correctness of the attribute with respect to the directive's declared
type of the input, which would typically be `boolean` for the `disabled`
input. Since empty attributes are assigned the empty string at runtime,
the template type checker would report an error for this template.

This commit introduces a strictness flag to help alleviate this
particular situation, effectively ignoring empty attributes that happen
to be consumed by a directive.