### PR TITLE
feat(ngcc): execute schematic-like migrations in ngcc

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -7,6 +7,7 @@
  */
 import {ConstantPool} from '@angular/compiler';
 import * as ts from 'typescript';
+
 import {BaseDefDecoratorHandler, ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ReferencesRegistry, ResourceLoader} from '../../../src/ngtsc/annotations';
 import {CycleAnalyzer, ImportGraph} from '../../../src/ngtsc/cycles';
 import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
@@ -18,9 +19,12 @@ import {ClassDeclaration} from '../../../src/ngtsc/reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../src/ngtsc/scope';
 import {CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
 import {NgccClassSymbol, NgccReflectionHost} from '../host/ngcc_host';
-import {Migration, MigrationHost} from '../migrations/migration';
+import {Migration} from '../migrations/migration';
+import {MissingInjectableMigration} from '../migrations/missing_injectable_migration';
+import {UndecoratedParentMigration} from '../migrations/undecorated_parent_migration';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {isDefined} from '../utils';
+
 import {DefaultMigrationHost} from './migration_host';
 import {AnalyzedClass, AnalyzedFile, CompiledClass, CompiledFile, DecorationAnalyses} from './types';
 import {analyzeDecorators, isWithinPackage} from './util';
@@ -100,7 +104,7 @@ export class DecorationAnalyzer {
         this.reflectionHost, this.evaluator, this.metaRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
         this.isCore),
   ];
-  migrations: Migration[] = [];
+  migrations: Migration[] = [new UndecoratedParentMigration(), new MissingInjectableMigration()];
 
   constructor(
       private fs: FileSystem, private bundle: EntryPointBundle,
@@ -118,10 +122,9 @@ export class DecorationAnalyzer {
                               .filter(sourceFile => isWithinPackage(this.packagePath, sourceFile))
                               .map(sourceFile => this.analyzeFile(sourceFile))
                               .filter(isDefined);
-    const migrationHost = new DefaultMigrationHost(
-        this.reflectionHost, this.fullMetaReader, this.evaluator, this.handlers,
-        this.bundle.entryPoint.path, analyzedFiles);
-    analyzedFiles.forEach(analyzedFile => this.migrateFile(migrationHost, analyzedFile));
+
+    this.applyMigrations(analyzedFiles);
+
     analyzedFiles.forEach(analyzedFile => this.resolveFile(analyzedFile));
     const compiledFiles = analyzedFiles.map(analyzedFile => this.compileFile(analyzedFile));
     compiledFiles.forEach(
@@ -147,21 +150,27 @@ export class DecorationAnalyzer {
     return analyzedClass;
   }
 
-  protected migrateFile(migrationHost: MigrationHost, analyzedFile: AnalyzedFile): void {
-    analyzedFile.analyzedClasses.forEach(({declaration}) => {
-      this.migrations.forEach(migration => {
-        try {
-          const result = migration.apply(declaration, migrationHost);
-          if (result !== null) {
-            this.diagnosticHandler(result);
+  protected applyMigrations(analyzedFiles: AnalyzedFile[]): void {
+    const migrationHost = new DefaultMigrationHost(
+        this.reflectionHost, this.fullMetaReader, this.evaluator, this.handlers,
+        this.bundle.entryPoint.path, analyzedFiles);
+
+    this.migrations.forEach(migration => {
+      analyzedFiles.forEach(analyzedFile => {
+        analyzedFile.analyzedClasses.forEach(({declaration}) => {
+          try {
+            const result = migration.apply(declaration, migrationHost);
+            if (result !== null) {
+              this.diagnosticHandler(result);
+            }
+          } catch (e) {
+            if (isFatalDiagnosticError(e)) {
+              this.diagnosticHandler(e.toDiagnostic());
+            } else {
+              throw e;
+            }
           }
-        } catch (e) {
-          if (isFatalDiagnosticError(e)) {
-            this.diagnosticHandler(e.toDiagnostic());
-          } else {
-            throw e;
-          }
-        }
+        });
       });
     });
   }

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -119,7 +119,8 @@ export class DecorationAnalyzer {
                               .map(sourceFile => this.analyzeFile(sourceFile))
                               .filter(isDefined);
     const migrationHost = new DefaultMigrationHost(
-        this.reflectionHost, this.fullMetaReader, this.evaluator, this.handlers, analyzedFiles);
+        this.reflectionHost, this.fullMetaReader, this.evaluator, this.handlers,
+        this.bundle.entryPoint.path, analyzedFiles);
     analyzedFiles.forEach(analyzedFile => this.migrateFile(migrationHost, analyzedFile));
     analyzedFiles.forEach(analyzedFile => this.resolveFile(analyzedFile));
     const compiledFiles = analyzedFiles.map(analyzedFile => this.compileFile(analyzedFile));

--- a/packages/compiler-cli/ngcc/src/analysis/migration_host.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/migration_host.ts
@@ -53,7 +53,7 @@ export class DefaultMigrationHost implements MigrationHost {
     }
 
     const analyzedClass = analyzedFile.analyzedClasses.find(c => c.declaration === clazz);
-    if (analyzedClass === undefined || analyzedClass.decorators === null) {
+    if (analyzedClass === undefined) {
       return null;
     }
 

--- a/packages/compiler-cli/ngcc/src/analysis/migration_host.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/migration_host.ts
@@ -6,15 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {ErrorCode, FatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
+import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {MetadataReader} from '../../../src/ngtsc/metadata';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
 import {DecoratorHandler} from '../../../src/ngtsc/transform';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {MigrationHost} from '../migrations/migration';
+
 import {AnalyzedClass, AnalyzedFile} from './types';
-import {analyzeDecorators} from './util';
+import {analyzeDecorators, isWithinPackage} from './util';
 
 /**
  * The standard implementation of `MigrationHost`, which is created by the
@@ -24,7 +27,7 @@ export class DefaultMigrationHost implements MigrationHost {
   constructor(
       readonly reflectionHost: NgccReflectionHost, readonly metadata: MetadataReader,
       readonly evaluator: PartialEvaluator, private handlers: DecoratorHandler<any, any>[],
-      private analyzedFiles: AnalyzedFile[]) {}
+      private entryPointPath: AbsoluteFsPath, private analyzedFiles: AnalyzedFile[]) {}
 
   injectSyntheticDecorator(clazz: ClassDeclaration, decorator: Decorator): void {
     const classSymbol = this.reflectionHost.getClassSymbol(clazz) !;
@@ -40,6 +43,25 @@ export class DefaultMigrationHost implements MigrationHost {
     } else {
       mergeAnalyzedClasses(oldAnalyzedClass, newAnalyzedClass);
     }
+  }
+
+  getAllDecorators(clazz: ClassDeclaration): Decorator[]|null {
+    const sourceFile = clazz.getSourceFile();
+    const analyzedFile = this.analyzedFiles.find(file => file.sourceFile === sourceFile);
+    if (analyzedFile === undefined) {
+      return null;
+    }
+
+    const analyzedClass = analyzedFile.analyzedClasses.find(c => c.declaration === clazz);
+    if (analyzedClass === undefined || analyzedClass.decorators === null) {
+      return null;
+    }
+
+    return analyzedClass.decorators;
+  }
+
+  isInScope(clazz: ClassDeclaration): boolean {
+    return isWithinPackage(this.entryPointPath, clazz.getSourceFile());
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -347,7 +347,12 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   /** Gets all decorators of the given class symbol. */
   getDecoratorsOfSymbol(symbol: NgccClassSymbol): Decorator[]|null {
     const {classDecorators} = this.acquireDecoratorInfo(symbol);
-    return classDecorators;
+    if (classDecorators === null) {
+      return null;
+    }
+
+    // Return a clone of the array to prevent consumers from mutating the cache.
+    return Array.from(classDecorators);
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -344,7 +344,10 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     return superDeclaration;
   }
 
-  /** Gets all decorators of the given class symbol. */
+  /**
+   * Gets all decorators of the given class symbol. Any decorator that have been synthetically
+   * injected by a migration will not be present in the returned collection.
+   */
   getDecoratorsOfSymbol(symbol: NgccClassSymbol): Decorator[]|null {
     const {classDecorators} = this.acquireDecoratorInfo(symbol);
     if (classDecorators === null) {

--- a/packages/compiler-cli/ngcc/src/migrations/migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/migration.ts
@@ -42,4 +42,20 @@ export interface MigrationHost {
    * @param decorator the decorator to inject.
    */
   injectSyntheticDecorator(clazz: ClassDeclaration, decorator: Decorator): void;
+
+  /**
+   * Retrieves all decorators that are associated with the class, including synthetic decorators
+   * that have been injected before.
+   * @param clazz the class for which all decorators are retrieved.
+   * @returns the list of the decorators, or null if the class was not decorated.
+   */
+  getAllDecorators(clazz: ClassDeclaration): Decorator[]|null;
+
+  /**
+   * Determines whether the provided class in within scope of the entry-point that is currently
+   * being compiled.
+   * @param clazz the class for which to be determine whether it is within the current entry-point.
+   * @returns true if the file is part of the compiled entry-point, false otherwise.
+   */
+  isInScope(clazz: ClassDeclaration): boolean;
 }

--- a/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import {forwardRefResolver} from '../../../src/ngtsc/annotations';
+import {Reference} from '../../../src/ngtsc/imports';
+import {ResolvedValue, ResolvedValueMap} from '../../../src/ngtsc/partial_evaluator';
+import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
+
+import {Migration, MigrationHost} from './migration';
+import {createInjectableDecorator, isClassDeclaration} from './utils';
+
+/**
+ * Ensures that classes that are provided as an Angular service in either `NgModule.providers` or
+ * `Directive.providers`/`Component.viewProviders` also have an `@Injectable()` decorator. This
+ * decorator is now mandatory, as otherwise the compiler would not compile an injectable definition
+ * for the service. This is unlike View Engine, where having just an unrelated decorator may have
+ * been sufficient for the service to become injectable.
+ *
+ * In essence, this migration operates on classes that are themselves an NgModule, Directive or
+ * Component. Their metadata is statically evaluated so that their "providers"/"viewProviders"
+ * properties can be analyzed. For any provider that refers to an undecorated class, the class will
+ * be migrated to have an `@Injectable()` decorator.
+ *
+ * This implementation mirrors the "missing-injectable" schematic.
+ */
+export class MissingInjectableMigration implements Migration {
+  apply(clazz: ClassDeclaration, host: MigrationHost): ts.Diagnostic|null {
+    const decorators = host.reflectionHost.getDecoratorsOfDeclaration(clazz);
+    if (decorators === null) {
+      return null;
+    }
+
+    for (const decorator of decorators) {
+      const name = getAngularCoreDecoratorName(decorator);
+      if (name === 'NgModule') {
+        migrateNgModuleProviders(decorator, host);
+      } else if (name === 'Directive') {
+        migrateDirectiveProviders(decorator, host, /* isComponent */ false);
+      } else if (name === 'Component') {
+        migrateDirectiveProviders(decorator, host, /* isComponent */ true);
+      }
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Iterates through all `NgModule.providers` and adds the `@Injectable()` decorator to any provider
+ * that is not otherwise decorated.
+ */
+function migrateNgModuleProviders(decorator: Decorator, host: MigrationHost): void {
+  if (decorator.args === null || decorator.args.length !== 1) {
+    return;
+  }
+
+  const metadata = host.evaluator.evaluate(decorator.args[0], forwardRefResolver);
+  if (!(metadata instanceof Map)) {
+    return;
+  }
+
+  migrateProviders(metadata, 'providers', host);
+}
+
+/**
+ * Iterates through all `Directive.providers` and if `isComponent` is set to true also
+ * `Component.viewProviders` and adds the `@Injectable()` decorator to any provider that is not
+ * otherwise decorated.
+ */
+function migrateDirectiveProviders(
+    decorator: Decorator, host: MigrationHost, isComponent: boolean): void {
+  if (decorator.args === null || decorator.args.length !== 1) {
+    return;
+  }
+
+  const metadata = host.evaluator.evaluate(decorator.args[0], forwardRefResolver);
+  if (!(metadata instanceof Map)) {
+    return;
+  }
+
+  migrateProviders(metadata, 'providers', host);
+  if (isComponent) {
+    migrateProviders(metadata, 'viewProviders', host);
+  }
+}
+
+/**
+ * Given an object with decorator metadata, iterates through the list of providers to add
+ * `@Injectable()` to any provider that is not otherwise decorated.
+ */
+function migrateProviders(metadata: ResolvedValueMap, field: string, host: MigrationHost): void {
+  if (!metadata.has(field)) {
+    return;
+  }
+  const providers = metadata.get(field) !;
+  if (!Array.isArray(providers)) {
+    return;
+  }
+
+  for (const provider of providers) {
+    migrateProvider(provider, host);
+  }
+}
+
+/**
+ * Analyzes a single provider entry and determines the class that is required to have an
+ * `@Injectable()` decorator.
+ */
+function migrateProvider(provider: ResolvedValue, host: MigrationHost): void {
+  if (provider instanceof Map) {
+    if (!provider.has('provide') || provider.has('useValue') || provider.has('useFactory') ||
+        provider.has('useExisting')) {
+      return;
+    }
+    if (provider.has('useClass')) {
+      migrateProviderClass(provider.get('useClass') !, host);
+    } else {
+      migrateProviderClass(provider.get('provide') !, host);
+    }
+  } else if (Array.isArray(provider)) {
+    for (const v of provider) {
+      migrateProvider(v, host);
+    }
+  } else {
+    migrateProviderClass(provider, host);
+  }
+}
+
+/**
+ * Given a provider class, adds the `@Injectable()` decorator if no other relevant Angular decorator
+ * is present on the class.
+ */
+function migrateProviderClass(provider: ResolvedValue, host: MigrationHost): void {
+  // Providers that do not refer to a class cannot be migrated.
+  if (!(provider instanceof Reference)) {
+    return;
+  }
+
+  const clazz = provider.node as ts.Declaration;
+  if (isClassDeclaration(clazz) && host.isInScope(clazz) && needsInjectableDecorator(clazz, host)) {
+    host.injectSyntheticDecorator(clazz, createInjectableDecorator(clazz));
+  }
+}
+
+const NO_MIGRATE_DECORATORS = new Set(['Injectable', 'Directive', 'Component', 'Pipe']);
+
+/**
+ * Determines if the given class needs to be decorated with `@Injectable()` based on whether it
+ * already has an Angular decorator applied.
+ */
+function needsInjectableDecorator(clazz: ClassDeclaration, host: MigrationHost): boolean {
+  const decorators = host.getAllDecorators(clazz);
+  if (decorators === null) {
+    return true;
+  }
+
+  for (const decorator of decorators) {
+    const name = getAngularCoreDecoratorName(decorator);
+    if (name !== null && NO_MIGRATE_DECORATORS.has(name)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Determines the original name of a decorator if it is from '@angular/core'. For other decorators,
+ * null is returned.
+ */
+export function getAngularCoreDecoratorName(decorator: Decorator): string|null {
+  if (decorator.import === null || decorator.import.from !== '@angular/core') {
+    return null;
+  }
+
+  return decorator.import.name;
+}

--- a/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
@@ -17,10 +17,13 @@ import {createInjectableDecorator, isClassDeclaration} from './utils';
 
 /**
  * Ensures that classes that are provided as an Angular service in either `NgModule.providers` or
- * `Directive.providers`/`Component.viewProviders` also have an `@Injectable()` decorator. This
- * decorator is now mandatory, as otherwise the compiler would not compile an injectable definition
- * for the service. This is unlike View Engine, where having just an unrelated decorator may have
- * been sufficient for the service to become injectable.
+ * `Directive.providers`/`Component.viewProviders` are decorated with one of the `@Injectable`,
+ * `@Directive`, `@Component` or `@Pipe` decorators, adding an `@Injectable()` decorator when none
+ * are present.
+ *
+ * At least one decorator is now mandatory, as otherwise the compiler would not compile an
+ * injectable definition for the service. This is unlike View Engine, where having just an unrelated
+ * decorator may have been sufficient for the service to become injectable.
  *
  * In essence, this migration operates on classes that are themselves an NgModule, Directive or
  * Component. Their metadata is statically evaluated so that their "providers"/"viewProviders"

--- a/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {ErrorCode, makeDiagnostic} from '../../../src/ngtsc/diagnostics';
+
+import {Reference} from '../../../src/ngtsc/imports';
 import {ClassDeclaration} from '../../../src/ngtsc/reflection';
-import {isRelativePath} from '../utils';
+
 import {Migration, MigrationHost} from './migration';
 import {createDirectiveDecorator, hasConstructor, hasDirectiveDecorator, isClassDeclaration} from './utils';
+
 
 /**
  * Ensure that the parents of directives and components that have no constructor are also decorated
@@ -59,36 +61,49 @@ export class UndecoratedParentMigration implements Migration {
     }
 
     // Only interested in `clazz` if it inherits from a base class.
-    const baseClassExpr = host.reflectionHost.getBaseClassExpression(clazz);
-    if (baseClassExpr === null) {
-      return null;
-    }
+    let baseClazzRef = determineBaseClass(clazz, host);
+    while (baseClazzRef !== null) {
+      const baseClazz = baseClazzRef.node;
 
-    if (!ts.isIdentifier(baseClassExpr)) {
-      return makeDiagnostic(
-          ErrorCode.NGCC_MIGRATION_EXTERNAL_BASE_CLASS, baseClassExpr,
-          `${clazz.name.text} class has a dynamic base class ${baseClassExpr.getText()}, so it is not possible to migrate.`);
-    }
+      // Do not proceed if the base class already has a decorator, or is not in scope of the
+      // entry-point that is currently being compiled.
+      if (hasDirectiveDecorator(host, baseClazz) || !host.isInScope(baseClazz)) {
+        break;
+      }
 
-    const baseClazz = host.reflectionHost.getDeclarationOfIdentifier(baseClassExpr) !.node;
-    if (baseClazz === null || !isClassDeclaration(baseClazz)) {
-      return null;
-    }
+      // Inject an `@Directive()` decorator for the base class.
+      host.injectSyntheticDecorator(baseClazz, createDirectiveDecorator(baseClazz));
 
-    // Only interested in this base class if it doesn't have a `Directive` or `Component` decorator.
-    if (hasDirectiveDecorator(host, baseClazz)) {
-      return null;
-    }
+      // If the base class has a constructor, there's no need to continue walking up the
+      // inheritance chain. The injected decorator ensures that a factory is generated that does
+      // not delegate to the base class.
+      if (hasConstructor(host, baseClazz)) {
+        break;
+      }
 
-    const importInfo = host.reflectionHost.getImportOfIdentifier(baseClassExpr);
-    if (importInfo !== null && !isRelativePath(importInfo.from)) {
-      return makeDiagnostic(
-          ErrorCode.NGCC_MIGRATION_EXTERNAL_BASE_CLASS, baseClassExpr,
-          'The base class was imported from an external entry-point so we cannot add a directive to it.');
+      // Continue with another level of class inheritance.
+      baseClazzRef = determineBaseClass(baseClazz, host);
     }
-
-    host.injectSyntheticDecorator(baseClazz, createDirectiveDecorator(baseClazz));
 
     return null;
   }
+}
+
+/**
+ * Computes a reference to the base class, or `null` if the class has no base class or if it could
+ * not be statically determined.
+ */
+function determineBaseClass(
+    clazz: ClassDeclaration, host: MigrationHost): Reference<ClassDeclaration>|null {
+  const baseClassExpr = host.reflectionHost.getBaseClassExpression(clazz);
+  if (baseClassExpr === null) {
+    return null;
+  }
+
+  const baseClass = host.evaluator.evaluate(baseClassExpr);
+  if (!(baseClass instanceof Reference) || !isClassDeclaration(baseClass.node as ts.Declaration)) {
+    return null;
+  }
+
+  return baseClass as Reference<ClassDeclaration>;
 }

--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -19,7 +19,8 @@ export function isClassDeclaration(clazz: ts.Declaration): clazz is ClassDeclara
  * Returns true if the `clazz` is decorated as a `Directive` or `Component`.
  */
 export function hasDirectiveDecorator(host: MigrationHost, clazz: ClassDeclaration): boolean {
-  return host.metadata.getDirectiveMetadata(new Reference(clazz)) !== null;
+  const ref = new Reference(clazz);
+  return host.metadata.getDirectiveMetadata(ref) !== null || host.metadata.isAbstractDirective(ref);
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -55,6 +55,27 @@ export function createDirectiveDecorator(clazz: ClassDeclaration): Decorator {
 }
 
 /**
+ * Create an empty `Injectable` decorator that will be associated with the `clazz`.
+ */
+export function createInjectableDecorator(clazz: ClassDeclaration): Decorator {
+  const decoratorType = ts.createIdentifier('Injectable');
+  const decoratorNode = ts.createObjectLiteral([
+    ts.createPropertyAssignment('type', decoratorType),
+    ts.createPropertyAssignment('args', ts.createArrayLiteral([])),
+  ]);
+
+  setParentPointers(clazz.getSourceFile(), decoratorNode);
+
+  return {
+    name: 'Injectable',
+    identifier: decoratorType,
+    import: {name: 'Injectable', from: '@angular/core'},
+    node: decoratorNode,
+    args: [],
+  };
+}
+
+/**
  * Ensure that a tree of AST nodes have their parents wired up.
  */
 export function setParentPointers(parent: ts.Node, child: ts.Node): void {

--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -33,24 +33,12 @@ export function hasConstructor(host: MigrationHost, clazz: ClassDeclaration): bo
  * Create an empty `Directive` decorator that will be associated with the `clazz`.
  */
 export function createDirectiveDecorator(clazz: ClassDeclaration): Decorator {
-  const selectorArg = ts.createObjectLiteral([
-    // TODO: At the moment ngtsc does not accept a directive with no selector
-    ts.createPropertyAssignment('selector', ts.createStringLiteral('NGCC_DUMMY')),
-  ]);
-  const decoratorType = ts.createIdentifier('Directive');
-  const decoratorNode = ts.createObjectLiteral([
-    ts.createPropertyAssignment('type', decoratorType),
-    ts.createPropertyAssignment('args', ts.createArrayLiteral([selectorArg])),
-  ]);
-
-  setParentPointers(clazz.getSourceFile(), decoratorNode);
-
   return {
     name: 'Directive',
-    identifier: decoratorType,
+    identifier: null,
     import: {name: 'Directive', from: '@angular/core'},
-    node: decoratorNode,
-    args: [selectorArg],
+    node: clazz.name,
+    args: [],
   };
 }
 
@@ -58,27 +46,11 @@ export function createDirectiveDecorator(clazz: ClassDeclaration): Decorator {
  * Create an empty `Injectable` decorator that will be associated with the `clazz`.
  */
 export function createInjectableDecorator(clazz: ClassDeclaration): Decorator {
-  const decoratorType = ts.createIdentifier('Injectable');
-  const decoratorNode = ts.createObjectLiteral([
-    ts.createPropertyAssignment('type', decoratorType),
-    ts.createPropertyAssignment('args', ts.createArrayLiteral([])),
-  ]);
-
-  setParentPointers(clazz.getSourceFile(), decoratorNode);
-
   return {
     name: 'Injectable',
-    identifier: decoratorType,
+    identifier: null,
     import: {name: 'Injectable', from: '@angular/core'},
-    node: decoratorNode,
+    node: clazz.name,
     args: [],
   };
-}
-
-/**
- * Ensure that a tree of AST nodes have their parents wired up.
- */
-export function setParentPointers(parent: ts.Node, child: ts.Node): void {
-  child.parent = parent;
-  ts.forEachChild(child, grandchild => setParentPointers(child, grandchild));
 }

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -199,10 +199,10 @@ runInEachFileSystem(() => {
         it('should call `apply()` on each migration for each class', () => {
           expect(migrationLogs).toEqual([
             'migration1:MyComponent',
-            'migration2:MyComponent',
             'migration1:MyDirective',
-            'migration2:MyDirective',
             'migration1:MyOtherComponent',
+            'migration2:MyComponent',
+            'migration2:MyDirective',
             'migration2:MyOtherComponent',
           ]);
         });

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -6,156 +6,256 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ErrorCode} from '../../../src/ngtsc/diagnostics';
+import {AbsoluteFsPath, absoluteFrom} from '../../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
 import {DefaultMigrationHost} from '../../src/analysis/migration_host';
 import {AnalyzedClass, AnalyzedFile} from '../../src/analysis/types';
 import {NgccClassSymbol} from '../../src/host/ngcc_host';
 
-describe('DefaultMigrationHost', () => {
-  describe('injectSyntheticDecorator()', () => {
-    const mockHost: any = {
-      getClassSymbol: (node: any): NgccClassSymbol | undefined => {
-        const symbol = { valueDeclaration: node, name: node.name.text } as any;
-        return {
-          name: node.name.text,
-          declaration: symbol,
-          implementation: symbol,
+runInEachFileSystem(() => {
+  describe('DefaultMigrationHost', () => {
+    let _: typeof absoluteFrom;
+    let entryPointPath: AbsoluteFsPath;
+    let mockHost: any;
+    let mockMetadata: any = {};
+    let mockEvaluator: any = {};
+    let mockClazz: any;
+    let mockDecorator: any = {name: 'MockDecorator'};
+    beforeEach(() => {
+      _ = absoluteFrom;
+      entryPointPath = _('/node_modules/some-package/entry-point');
+      mockHost = {
+        getClassSymbol: (node: any): NgccClassSymbol | undefined => {
+          const symbol = { valueDeclaration: node, name: node.name.text } as any;
+          return {
+            name: node.name.text,
+            declaration: symbol,
+            implementation: symbol,
+          };
+        },
+      };
+      const mockSourceFile: any = {
+        fileName: _('/node_modules/some-package/entry-point/test-file.js'),
+      };
+      mockClazz = {
+        name: {text: 'MockClazz'},
+        getSourceFile: () => mockSourceFile,
+      };
+    });
+
+    describe('injectSyntheticDecorator()', () => {
+      it('should call `detect()` on each of the provided handlers', () => {
+        const log: string[] = [];
+        const handler1 = new TestHandler('handler1', log);
+        const handler2 = new TestHandler('handler2', log);
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler1, handler2], entryPointPath, []);
+        host.injectSyntheticDecorator(mockClazz, mockDecorator);
+        expect(log).toEqual([
+          `handler1:detect:MockClazz:MockDecorator`,
+          `handler2:detect:MockClazz:MockDecorator`,
+        ]);
+      });
+
+      it('should call `analyze()` on each of the provided handlers whose `detect()` call returns a result',
+         () => {
+           const log: string[] = [];
+           const handler1 = new TestHandler('handler1', log);
+           const handler2 = new AlwaysDetectHandler('handler2', log);
+           const handler3 = new TestHandler('handler3', log);
+           const host = new DefaultMigrationHost(
+               mockHost, mockMetadata, mockEvaluator, [handler1, handler2, handler3],
+               entryPointPath, []);
+           host.injectSyntheticDecorator(mockClazz, mockDecorator);
+           expect(log).toEqual([
+             `handler1:detect:MockClazz:MockDecorator`,
+             `handler2:detect:MockClazz:MockDecorator`,
+             `handler3:detect:MockClazz:MockDecorator`,
+             'handler2:analyze:MockClazz',
+           ]);
+         });
+
+      it('should add a newly `AnalyzedFile` to the `analyzedFiles` object', () => {
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+        host.injectSyntheticDecorator(mockClazz, mockDecorator);
+        expect(analyzedFiles.length).toEqual(1);
+        expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
+        expect(analyzedFiles[0].analyzedClasses[0].name).toEqual('MockClazz');
+      });
+
+      it('should add a newly `AnalyzedClass` to an existing `AnalyzedFile` object', () => {
+        const DUMMY_CLASS_1: any = {};
+        const DUMMY_CLASS_2: any = {};
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [{
+          sourceFile: mockClazz.getSourceFile(),
+          analyzedClasses: [DUMMY_CLASS_1, DUMMY_CLASS_2],
+        }];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+        host.injectSyntheticDecorator(mockClazz, mockDecorator);
+        expect(analyzedFiles.length).toEqual(1);
+        expect(analyzedFiles[0].analyzedClasses.length).toEqual(3);
+        expect(analyzedFiles[0].analyzedClasses[2].name).toEqual('MockClazz');
+      });
+
+      it('should add a new decorator into an already existing `AnalyzedClass`', () => {
+        const analyzedClass: AnalyzedClass = {
+          name: 'MockClazz',
+          declaration: mockClazz,
+          matches: [],
+          decorators: null,
         };
-      },
-    };
-    const mockMetadata: any = {};
-    const mockEvaluator: any = {};
-    const mockClazz: any = {
-      name: {text: 'MockClazz'},
-      getSourceFile: () => { fileName: 'test-file.js'; },
-    };
-    const mockDecorator: any = {name: 'MockDecorator'};
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [{
+          sourceFile: mockClazz.getSourceFile(),
+          analyzedClasses: [analyzedClass],
+        }];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+        host.injectSyntheticDecorator(mockClazz, mockDecorator);
+        expect(analyzedFiles.length).toEqual(1);
+        expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
+        expect(analyzedFiles[0].analyzedClasses[0]).toBe(analyzedClass);
+        expect(analyzedClass.decorators !.length).toEqual(1);
+        expect(analyzedClass.decorators ![0].name).toEqual('MockDecorator');
+      });
 
-    it('should call `detect()` on each of the provided handlers', () => {
-      const log: string[] = [];
-      const handler1 = new TestHandler('handler1', log);
-      const handler2 = new TestHandler('handler2', log);
-      const host =
-          new DefaultMigrationHost(mockHost, mockMetadata, mockEvaluator, [handler1, handler2], []);
-      host.injectSyntheticDecorator(mockClazz, mockDecorator);
-      expect(log).toEqual([
-        `handler1:detect:MockClazz:MockDecorator`,
-        `handler2:detect:MockClazz:MockDecorator`,
-      ]);
+      it('should merge a new decorator into pre-existing decorators an already existing `AnalyzedClass`',
+         () => {
+           const analyzedClass: AnalyzedClass = {
+             name: 'MockClazz',
+             declaration: mockClazz,
+             matches: [],
+             decorators: [{name: 'OtherDecorator'} as Decorator],
+           };
+           const log: string[] = [];
+           const handler = new AlwaysDetectHandler('handler', log);
+           const analyzedFiles: AnalyzedFile[] = [{
+             sourceFile: mockClazz.getSourceFile(),
+             analyzedClasses: [analyzedClass],
+           }];
+           const host = new DefaultMigrationHost(
+               mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+           host.injectSyntheticDecorator(mockClazz, mockDecorator);
+           expect(analyzedFiles.length).toEqual(1);
+           expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
+           expect(analyzedFiles[0].analyzedClasses[0]).toBe(analyzedClass);
+           expect(analyzedClass.decorators !.length).toEqual(2);
+           expect(analyzedClass.decorators ![1].name).toEqual('MockDecorator');
+         });
+
+      it('should throw an error if the injected decorator already exists', () => {
+        const analyzedClass: AnalyzedClass = {
+          name: 'MockClazz',
+          declaration: mockClazz,
+          matches: [],
+          decorators: [{name: 'MockDecorator'} as Decorator],
+        };
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [{
+          sourceFile: mockClazz.getSourceFile(),
+          analyzedClasses: [analyzedClass],
+        }];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+        expect(() => host.injectSyntheticDecorator(mockClazz, mockDecorator))
+            .toThrow(jasmine.objectContaining(
+                {code: ErrorCode.NGCC_MIGRATION_DECORATOR_INJECTION_ERROR}));
+      });
     });
 
-    it('should call `analyze()` on each of the provided handlers whose `detect()` call returns a result',
-       () => {
-         const log: string[] = [];
-         const handler1 = new TestHandler('handler1', log);
-         const handler2 = new AlwaysDetectHandler('handler2', log);
-         const handler3 = new TestHandler('handler3', log);
-         const host = new DefaultMigrationHost(
-             mockHost, mockMetadata, mockEvaluator, [handler1, handler2, handler3], []);
-         host.injectSyntheticDecorator(mockClazz, mockDecorator);
-         expect(log).toEqual([
-           `handler1:detect:MockClazz:MockDecorator`,
-           `handler2:detect:MockClazz:MockDecorator`,
-           `handler3:detect:MockClazz:MockDecorator`,
-           'handler2:analyze:MockClazz',
-         ]);
-       });
+    describe('getAllDecorators', () => {
+      it('should be null for unknown source files', () => {
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
 
-    it('should add a newly `AnalyzedFile` to the `analyzedFiles` object', () => {
-      const log: string[] = [];
-      const handler = new AlwaysDetectHandler('handler', log);
-      const analyzedFiles: AnalyzedFile[] = [];
-      const host =
-          new DefaultMigrationHost(mockHost, mockMetadata, mockEvaluator, [handler], analyzedFiles);
-      host.injectSyntheticDecorator(mockClazz, mockDecorator);
-      expect(analyzedFiles.length).toEqual(1);
-      expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
-      expect(analyzedFiles[0].analyzedClasses[0].name).toEqual('MockClazz');
+        const decorators = host.getAllDecorators(mockClazz);
+        expect(decorators).toBeNull();
+      });
+
+      it('should be null for unknown classes', () => {
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const analyzedFiles: AnalyzedFile[] = [];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+
+        const sourceFile: any = {};
+        const unrelatedClass: any = {
+          getSourceFile: () => sourceFile,
+        };
+        analyzedFiles.push({sourceFile, analyzedClasses: [unrelatedClass]});
+
+        const decorators = host.getAllDecorators(mockClazz);
+        expect(decorators).toBeNull();
+      });
+
+      it('should include injected decorators', () => {
+        const log: string[] = [];
+        const handler = new AlwaysDetectHandler('handler', log);
+        const existingDecorator = { name: 'ExistingDecorator' } as Decorator;
+        const analyzedClass: AnalyzedClass = {
+          name: 'MockClazz',
+          declaration: mockClazz,
+          matches: [],
+          decorators: [existingDecorator],
+        };
+        const analyzedFiles: AnalyzedFile[] = [{
+          sourceFile: mockClazz.getSourceFile(),
+          analyzedClasses: [analyzedClass],
+        }];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [handler], entryPointPath, analyzedFiles);
+        host.injectSyntheticDecorator(mockClazz, mockDecorator);
+
+        const decorators = host.getAllDecorators(mockClazz) !;
+        expect(decorators.length).toBe(2);
+        expect(decorators[0]).toBe(existingDecorator);
+        expect(decorators[1]).toBe(mockDecorator);
+      });
     });
 
-    it('should add a newly `AnalyzedClass` to an existing `AnalyzedFile` object', () => {
-      const DUMMY_CLASS_1: any = {};
-      const DUMMY_CLASS_2: any = {};
-      const log: string[] = [];
-      const handler = new AlwaysDetectHandler('handler', log);
-      const analyzedFiles: AnalyzedFile[] = [{
-        sourceFile: mockClazz.getSourceFile(),
-        analyzedClasses: [DUMMY_CLASS_1, DUMMY_CLASS_2],
-      }];
-      const host =
-          new DefaultMigrationHost(mockHost, mockMetadata, mockEvaluator, [handler], analyzedFiles);
-      host.injectSyntheticDecorator(mockClazz, mockDecorator);
-      expect(analyzedFiles.length).toEqual(1);
-      expect(analyzedFiles[0].analyzedClasses.length).toEqual(3);
-      expect(analyzedFiles[0].analyzedClasses[2].name).toEqual('MockClazz');
-    });
+    describe('isInScope', () => {
+      it('should be true for nodes within the entry-point', () => {
+        const analyzedFiles: AnalyzedFile[] = [];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [], entryPointPath, analyzedFiles);
 
-    it('should add a new decorator into an already existing `AnalyzedClass`', () => {
-      const analyzedClass: AnalyzedClass = {
-        name: 'MockClazz',
-        declaration: mockClazz,
-        matches: [],
-        decorators: null,
-      };
-      const log: string[] = [];
-      const handler = new AlwaysDetectHandler('handler', log);
-      const analyzedFiles: AnalyzedFile[] = [{
-        sourceFile: mockClazz.getSourceFile(),
-        analyzedClasses: [analyzedClass],
-      }];
-      const host =
-          new DefaultMigrationHost(mockHost, mockMetadata, mockEvaluator, [handler], analyzedFiles);
-      host.injectSyntheticDecorator(mockClazz, mockDecorator);
-      expect(analyzedFiles.length).toEqual(1);
-      expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
-      expect(analyzedFiles[0].analyzedClasses[0]).toBe(analyzedClass);
-      expect(analyzedClass.decorators !.length).toEqual(1);
-      expect(analyzedClass.decorators ![0].name).toEqual('MockDecorator');
-    });
+        const sourceFile: any = {
+          fileName: _('/node_modules/some-package/entry-point/relative.js'),
+        };
+        const clazz: any = {
+          getSourceFile: () => sourceFile,
+        };
+        expect(host.isInScope(clazz)).toBe(true);
+      });
 
-    it('should merge a new decorator into pre-existing decorators an already existing `AnalyzedClass`',
-       () => {
-         const analyzedClass: AnalyzedClass = {
-           name: 'MockClazz',
-           declaration: mockClazz,
-           matches: [],
-           decorators: [{name: 'OtherDecorator'} as Decorator],
-         };
-         const log: string[] = [];
-         const handler = new AlwaysDetectHandler('handler', log);
-         const analyzedFiles: AnalyzedFile[] = [{
-           sourceFile: mockClazz.getSourceFile(),
-           analyzedClasses: [analyzedClass],
-         }];
-         const host = new DefaultMigrationHost(
-             mockHost, mockMetadata, mockEvaluator, [handler], analyzedFiles);
-         host.injectSyntheticDecorator(mockClazz, mockDecorator);
-         expect(analyzedFiles.length).toEqual(1);
-         expect(analyzedFiles[0].analyzedClasses.length).toEqual(1);
-         expect(analyzedFiles[0].analyzedClasses[0]).toBe(analyzedClass);
-         expect(analyzedClass.decorators !.length).toEqual(2);
-         expect(analyzedClass.decorators ![1].name).toEqual('MockDecorator');
-       });
+      it('should be false for nodes outside the entry-point', () => {
+        const analyzedFiles: AnalyzedFile[] = [];
+        const host = new DefaultMigrationHost(
+            mockHost, mockMetadata, mockEvaluator, [], entryPointPath, analyzedFiles);
 
-    it('should throw an error if the injected decorator already exists', () => {
-      const analyzedClass: AnalyzedClass = {
-        name: 'MockClazz',
-        declaration: mockClazz,
-        matches: [],
-        decorators: [{name: 'MockDecorator'} as Decorator],
-      };
-      const log: string[] = [];
-      const handler = new AlwaysDetectHandler('handler', log);
-      const analyzedFiles: AnalyzedFile[] = [{
-        sourceFile: mockClazz.getSourceFile(),
-        analyzedClasses: [analyzedClass],
-      }];
-      const host =
-          new DefaultMigrationHost(mockHost, mockMetadata, mockEvaluator, [handler], analyzedFiles);
-      expect(() => host.injectSyntheticDecorator(mockClazz, mockDecorator))
-          .toThrow(
-              jasmine.objectContaining({code: ErrorCode.NGCC_MIGRATION_DECORATOR_INJECTION_ERROR}));
+        const sourceFile: any = {
+          fileName: _('/node_modules/some-package/other-entry/index.js'),
+        };
+        const clazz: any = {
+          getSourceFile: () => sourceFile,
+        };
+        expect(host.isInScope(clazz)).toBe(false);
+      });
     });
   });
 });

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
@@ -86,7 +86,7 @@ exports.OtherDirective = OtherDirective;
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.identifier.getText()).toEqual('core.Directive');
+        expect(decorator.identifier !.getText()).toEqual('core.Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
         expect(decorator.args !.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -175,7 +175,7 @@ runInEachFileSystem(() => {
 
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
-            expect(decorator.identifier.getText()).toEqual('Directive');
+            expect(decorator.identifier !.getText()).toEqual('Directive');
             expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
             expect(decorator.args !.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
@@ -197,7 +197,7 @@ runInEachFileSystem(() => {
 
                const decorator = decorators[0];
                expect(decorator.name).toEqual('Directive');
-               expect(decorator.identifier.getText()).toEqual('Directive');
+               expect(decorator.identifier !.getText()).toEqual('Directive');
                expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
                expect(decorator.args !.map(arg => arg.getText())).toEqual([
                  '{ selector: \'[someDirective]\' }',
@@ -219,7 +219,7 @@ runInEachFileSystem(() => {
 
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
-            expect(decorator.identifier.getText()).toEqual('Directive');
+            expect(decorator.identifier !.getText()).toEqual('Directive');
             expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
             expect(decorator.args !.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -1931,6 +1931,20 @@ runInEachFileSystem(() => {
         expect(classDecoratorsSecondary.length).toEqual(1);
         expect(classDecoratorsSecondary[0] !.map(d => d.name)).toEqual(['Directive']);
       });
+
+      it('should return a cloned array on each invocation', () => {
+        loadTestFiles(DECORATED_FILES);
+        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const classDecl =
+            getDeclaration(program, DECORATED_FILES[0].name, 'A', ts.isClassDeclaration) !;
+        const classSymbol = host.getClassSymbol(classDecl) !;
+
+        const firstResult = host.getDecoratorsOfSymbol(classSymbol);
+        const secondResult = host.getDecoratorsOfSymbol(classSymbol);
+
+        expect(firstResult).not.toBe(secondResult);
+      });
     });
 
     describe('getDtsDeclarationsOfClass()', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -202,7 +202,7 @@ export { SomeDirective };
 
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
-            expect(decorator.identifier.getText()).toEqual('Directive');
+            expect(decorator.identifier !.getText()).toEqual('Directive');
             expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
             expect(decorator.args !.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
@@ -224,7 +224,7 @@ export { SomeDirective };
 
                const decorator = decorators[0];
                expect(decorator.name).toEqual('Directive');
-               expect(decorator.identifier.getText()).toEqual('Directive');
+               expect(decorator.identifier !.getText()).toEqual('Directive');
                expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
                expect(decorator.args !.map(arg => arg.getText())).toEqual([
                  '{ selector: \'[someDirective]\' }',
@@ -245,7 +245,7 @@ export { SomeDirective };
 
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
-            expect(decorator.identifier.getText()).toEqual('Directive');
+            expect(decorator.identifier !.getText()).toEqual('Directive');
             expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
             expect(decorator.args !.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',

--- a/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
@@ -79,7 +79,7 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.identifier.getText()).toEqual('core.Directive');
+        expect(decorator.identifier !.getText()).toEqual('core.Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
         expect(decorator.args !.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',

--- a/packages/compiler-cli/ngcc/test/migrations/missing_injectable_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/missing_injectable_migration_spec.ts
@@ -1,0 +1,592 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import {AbsoluteFsPath, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
+import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {DecorationAnalyzer} from '../../src/analysis/decoration_analyzer';
+import {NgccReferencesRegistry} from '../../src/analysis/ngcc_references_registry';
+import {DecorationAnalyses} from '../../src/analysis/types';
+import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
+import {MissingInjectableMigration, getAngularCoreDecoratorName} from '../../src/migrations/missing_injectable_migration';
+import {MockLogger} from '../helpers/mock_logger';
+import {getRootFiles, makeTestEntryPointBundle} from '../helpers/utils';
+
+runInEachFileSystem(() => {
+  describe('MissingInjectableMigration', () => {
+    let _: typeof absoluteFrom;
+    let INDEX_FILENAME: AbsoluteFsPath;
+    beforeEach(() => {
+      _ = absoluteFrom;
+      INDEX_FILENAME = _('/node_modules/test-package/index.js');
+    });
+
+    describe('NgModule', () => runTests('NgModule', 'providers'));
+    describe('Directive', () => runTests('Directive', 'providers'));
+
+    describe('Component', () => {
+      runTests('Component', 'providers');
+      runTests('Component', 'viewProviders');
+
+      it('should migrate all providers defined in "viewProviders" and "providers" in the same ' +
+             'component',
+         () => {
+           const {program, analysis} = setUpAndAnalyzeProgram([{
+             name: INDEX_FILENAME,
+             contents: `
+            import {Component} from '@angular/core';
+          
+            export class ServiceA {}
+            export class ServiceB {}
+            export class ServiceC {}
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: Component, args: [{
+                  template: "",
+                  providers: [ServiceA],
+                  viewProviders: [ServiceB],
+                }]
+              }
+            ];
+          `,
+           }]);
+
+           const index = program.getSourceFile(INDEX_FILENAME) !;
+           expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(true);
+           expect(hasInjectableDecorator(index, analysis, 'ServiceB')).toBe(true);
+           expect(hasInjectableDecorator(index, analysis, 'ServiceC')).toBe(false);
+         });
+    });
+
+    function runTests(
+        type: 'NgModule' | 'Directive' | 'Component', propName: 'providers' | 'viewProviders') {
+      const args = type === 'Component' ? 'template: "", ' : '';
+
+      it(`should migrate type provider in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+            export class OtherService {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'OtherService')).toBe(false);
+      });
+
+      it(`should migrate object literal provider in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+            export class OtherService {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [{provide: MyService}]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'OtherService')).toBe(false);
+      });
+
+      it(`should migrate object literal provider with forwardRef in ${type}`, async() => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}, forwardRef} from '@angular/core';
+            
+            export class MyService {}
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [{provide: forwardRef(() => MyService) }]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+      });
+
+      it(`should not migrate object literal provider with "useValue" in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [{provide: MyService, useValue: null }]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it(`should not migrate object literal provider with "useFactory" in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [{provide: MyService, useFactory: () => null }]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it(`should not migrate object literal provider with "useExisting" in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+            export class MyToken {}
+            export class MyTokenAlias {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [
+                MyService,
+                {provide: MyToken, useExisting: MyService},
+                {provide: MyTokenAlias, useExisting: MyToken},
+              ]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'MyToken')).toBe(false);
+        expect(hasInjectableDecorator(index, analysis, 'MyTokenAlias')).toBe(false);
+      });
+
+      it(`should migrate object literal provider with "useClass" in ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class MyService {}
+            export class MyToken {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [{provide: MyToken, useClass: MyService}]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'MyToken')).toBe(false);
+      });
+
+      it('should not migrate provider which is already decorated with @Injectable', () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {Injectable, ${type}} from '@angular/core';
+          
+            export class MyService {}
+            MyService.decorators = [
+              { type: Injectable }
+            ];
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(getInjectableDecorators(index, analysis, 'MyService').length).toBe(1);
+      });
+
+      it('should not migrate provider which is already decorated with @Directive', () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {Directive, ${type}} from '@angular/core';
+          
+            export class MyService {}
+            MyService.decorators = [
+              { type: Directive }
+            ];
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it('should not migrate provider which is already decorated with @Component', () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {Component, ${type}} from '@angular/core';
+          
+            export class MyService {}
+            MyService.decorators = [
+              { type: Component, args: [{template: ""}] }
+            ];
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it('should not migrate provider which is already decorated with @Pipe', () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {Pipe, ${type}} from '@angular/core';
+          
+            export class MyService {}
+            MyService.decorators = [
+              { type: Pipe, args: [{name: "pipe"}] }
+            ];
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it(`should migrate multiple providers in same ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class ServiceA {}
+            export class ServiceB {}
+                
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [ServiceA, ServiceB]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceB')).toBe(true);
+      });
+
+      it(`should migrate multiple mixed providers in same ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class ServiceA {}
+            export class ServiceB {}
+            export class ServiceC {}
+            export class ServiceD {}
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [
+                  ServiceA,
+                  {provide: ServiceB},
+                  {provide: SomeToken, useClass: ServiceC},
+                ]
+              }] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceB')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceC')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceD')).toBe(false);
+      });
+
+
+      it(`should migrate multiple nested providers in same ${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+          import {${type}} from '@angular/core';
+        
+          export class ServiceA {}
+          export class ServiceB {}
+          export class ServiceC {}
+          export class ServiceD {}
+          
+          export class TestClass {}
+          TestClass.decorators = [
+            { type: ${type}, args: [{${args}${propName}: [
+                ServiceA,
+                [
+                  {provide: ServiceB},
+                  ServiceC,
+                ],
+              ]}]
+            }
+          ];
+         `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceB')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceC')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceD')).toBe(false);
+      });
+
+      it('should migrate providers referenced indirectly', () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class ServiceA {}
+            export class ServiceB {}
+            export class ServiceC {}
+            
+            const PROVIDERS = [ServiceA, ServiceB];
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: PROVIDERS}] }
+            ];
+          `
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceB')).toBe(true);
+        expect(hasInjectableDecorator(index, analysis, 'ServiceC')).toBe(false);
+      });
+
+      it(`should migrate provider once if referenced in multiple ${type} definitions`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class ServiceA {}
+            export class ServiceB {}
+            
+            export class TestClassA {}
+            TestClassA.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [ServiceA]}] }
+            ];
+            
+            export class TestClassB {}
+            TestClassB.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [ServiceA, ServiceB]}] }
+            ];
+          `
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(getInjectableDecorators(index, analysis, 'ServiceA').length).toBe(1);
+        expect(getInjectableDecorators(index, analysis, 'ServiceB').length).toBe(1);
+      });
+
+      type !== 'Component' && it(`should support @${type} without metadata argument`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from '@angular/core';
+          
+            export class ServiceA {}
+                    
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'ServiceA')).toBe(false);
+      });
+
+      it(`should migrate services in a different file`, () => {
+        const SERVICE_FILENAME = _('/node_modules/test-package/service.js');
+        const {program, analysis} = setUpAndAnalyzeProgram([
+          {
+            name: INDEX_FILENAME,
+            contents: `
+            import {${type}} from '@angular/core';
+            import {MyService} from './service';
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+          },
+          {
+            name: SERVICE_FILENAME,
+            contents: `
+            export declare class MyService {}
+          `,
+          }
+        ]);
+
+        const index = program.getSourceFile(SERVICE_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+      });
+
+      it(`should not migrate services in a different package`, () => {
+        const SERVICE_FILENAME = _('/node_modules/external/index.d.ts');
+        const {program, analysis} = setUpAndAnalyzeProgram([
+          {
+            name: INDEX_FILENAME,
+            contents: `
+            import {${type}} from '@angular/core';
+            import {MyService} from 'external';
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+          },
+          {
+            name: SERVICE_FILENAME,
+            contents: `
+            export declare class MyService {}
+          `,
+          }
+        ]);
+
+        const index = program.getSourceFile(SERVICE_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+
+      it(`should deal with renamed imports for @${type}`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type} as Renamed} from '@angular/core';
+          
+            export class MyService {}
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: Renamed, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(true);
+      });
+
+      it(`should deal with decorators named @${type} not from '@angular/core'`, () => {
+        const {program, analysis} = setUpAndAnalyzeProgram([{
+          name: INDEX_FILENAME,
+          contents: `
+            import {${type}} from 'other';
+          
+            export class MyService {}
+            
+            export class TestClass {}
+            TestClass.decorators = [
+              { type: ${type}, args: [{${args}${propName}: [MyService]}] }
+            ];
+          `,
+        }]);
+
+        const index = program.getSourceFile(INDEX_FILENAME) !;
+        expect(hasInjectableDecorator(index, analysis, 'MyService')).toBe(false);
+      });
+    }
+
+    function setUpAndAnalyzeProgram(testFiles: TestFile[]) {
+      loadTestFiles(testFiles);
+      loadFakeCore(getFileSystem());
+      const errors: ts.Diagnostic[] = [];
+      const rootFiles = getRootFiles(testFiles);
+      const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
+      const program = bundle.src.program;
+
+      const reflectionHost =
+          new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+      const referencesRegistry = new NgccReferencesRegistry(reflectionHost);
+      const analyzer = new DecorationAnalyzer(
+          getFileSystem(), bundle, reflectionHost, referencesRegistry, error => errors.push(error));
+      analyzer.migrations = [new MissingInjectableMigration()];
+      return {program, analysis: analyzer.analyzeProgram(), errors};
+    }
+
+    function getInjectableDecorators(
+        sourceFile: ts.SourceFile, analysis: DecorationAnalyses, className: string) {
+      const file = analysis.get(sourceFile);
+      if (file === undefined) {
+        return [];
+      }
+
+      const clazz = file.compiledClasses.find(c => c.name === className);
+      if (clazz === undefined || clazz.decorators === null) {
+        return [];
+      }
+
+      return clazz.decorators.filter(
+          decorator => getAngularCoreDecoratorName(decorator) === 'Injectable');
+    }
+
+    function hasInjectableDecorator(
+        sourceFile: ts.SourceFile, analysis: DecorationAnalyses, className: string) {
+      return getInjectableDecorators(sourceFile, analysis, className).length > 0;
+    }
+  });
+});

--- a/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
@@ -148,13 +148,22 @@ runInEachFileSystem(() => {
          const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !) !;
          expect(file.compiledClasses.find(c => c.name === 'DerivedClass')).toBeDefined();
          expect(file.compiledClasses.find(c => c.name === 'RealBaseClass')).toBeUndefined();
+
+         const intermediateClass = file.compiledClasses.find(c => c.name === 'IntermediateClass') !;
+         expect(intermediateClass.decorators !.length).toEqual(1);
+         const intermediateDecorator = intermediateClass.decorators ![0];
+         expect(intermediateDecorator.name).toEqual('Directive');
+         expect(intermediateDecorator.identifier).toBeNull('The decorator must be synthesized');
+         expect(intermediateDecorator.import).toEqual({from: '@angular/core', name: 'Directive'});
+         expect(intermediateDecorator.args !.length).toEqual(0);
+
          const baseClass = file.compiledClasses.find(c => c.name === 'BaseClass') !;
          expect(baseClass.decorators !.length).toEqual(1);
-         const decorator = baseClass.decorators ![0];
-         expect(decorator.name).toEqual('Directive');
-         expect(decorator.identifier).toBeNull('The decorator must be synthesized');
-         expect(decorator.import).toEqual({from: '@angular/core', name: 'Directive'});
-         expect(decorator.args !.length).toEqual(0);
+         const baseDecorator = baseClass.decorators ![0];
+         expect(baseDecorator.name).toEqual('Directive');
+         expect(baseDecorator.identifier).toBeNull('The decorator must be synthesized');
+         expect(baseDecorator.import).toEqual({from: '@angular/core', name: 'Directive'});
+         expect(baseDecorator.args !.length).toEqual(0);
        });
 
     it('should handle the base class being in a different file (same package) as the derived class',

--- a/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
@@ -26,19 +26,20 @@ runInEachFileSystem(() => {
     });
 
     it('should ignore undecorated classes', () => {
-      const {program, analysis} = setUpAndAnalyzeProgram([{
+      const {program, analysis, errors} = setUpAndAnalyzeProgram([{
         name: INDEX_FILENAME,
         contents: `
         export class DerivedClass extends BaseClass {}
         export class BaseClass {}
       `
       }]);
+      expect(errors).toEqual([]);
       const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !);
       expect(file).toBeUndefined();
     });
 
     it('should ignore an undecorated base class if the derived class has a constructor', () => {
-      const {program, analysis} = setUpAndAnalyzeProgram([{
+      const {program, analysis, errors} = setUpAndAnalyzeProgram([{
         name: INDEX_FILENAME,
         contents: `
         import {Directive, ViewContainerRef} from '@angular/core';
@@ -54,6 +55,7 @@ runInEachFileSystem(() => {
         export class BaseClass {}
       `
       }]);
+      expect(errors).toEqual([]);
       const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !) !;
       expect(file.compiledClasses.find(c => c.name === 'DerivedClass')).toBeDefined();
       expect(file.compiledClasses.find(c => c.name === 'BaseClass')).toBeUndefined();
@@ -61,7 +63,7 @@ runInEachFileSystem(() => {
 
     it('should add a decorator to an undecorated base class if the derived class is a Directive with no constructor',
        () => {
-         const {program, analysis} = setUpAndAnalyzeProgram([{
+         const {program, analysis, errors} = setUpAndAnalyzeProgram([{
            name: INDEX_FILENAME,
            contents: `
         import {Directive, ViewContainerRef} from '@angular/core';
@@ -78,20 +80,87 @@ runInEachFileSystem(() => {
         ];
       `
          }]);
+         expect(errors).toEqual([]);
          const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !) !;
          expect(file.compiledClasses.find(c => c.name === 'DerivedClass')).toBeDefined();
          const baseClass = file.compiledClasses.find(c => c.name === 'BaseClass') !;
          expect(baseClass.decorators !.length).toEqual(1);
          const decorator = baseClass.decorators ![0];
          expect(decorator.name).toEqual('Directive');
+         expect(decorator.identifier).toBeNull('The decorator must be synthesized');
          expect(decorator.import).toEqual({from: '@angular/core', name: 'Directive'});
-         expect(decorator.args !.length).toEqual(1);
+         expect(decorator.args !.length).toEqual(0);
+       });
+
+    it('should not add a decorator to a base class that is already decorated', () => {
+      const {program, analysis, errors} = setUpAndAnalyzeProgram([{
+        name: INDEX_FILENAME,
+        contents: `
+        import {Directive, ViewContainerRef} from '@angular/core';
+        export class DerivedClass extends BaseClass {
+        }
+        DerivedClass.decorators = [
+          { type: Directive, args: [{ selector: '[dir]' }] }
+        ];
+        export class BaseClass {
+          constructor(private vcr: ViewContainerRef) {}
+        }
+        BaseClass.decorators = [
+          { type: Directive, args: [] }
+        ];
+        BaseClass.ctorParameters = () => [
+          { type: ViewContainerRef, }
+        ];
+      `
+      }]);
+      expect(errors).toEqual([]);
+      const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !) !;
+      expect(file.compiledClasses.find(c => c.name === 'DerivedClass')).toBeDefined();
+      const baseClass = file.compiledClasses.find(c => c.name === 'BaseClass') !;
+      expect(baseClass.decorators !.length).toEqual(1);
+      const decorator = baseClass.decorators ![0];
+      expect(decorator.name).toEqual('Directive');
+      expect(decorator.identifier).not.toBeNull('The decorator must not be synthesized');
+    });
+
+    it('should add decorators to all classes in an inheritance chain until a constructor is found',
+       () => {
+         const {program, analysis, errors} = setUpAndAnalyzeProgram([{
+           name: INDEX_FILENAME,
+           contents: `
+        import {Directive, ViewContainerRef} from '@angular/core';
+        export class DerivedClass extends IntermediateClass {
+        }
+        DerivedClass.decorators = [
+          { type: Directive, args: [{ selector: '[dir]' }] }
+        ];
+        export class IntermediateClass extends BaseClass {}
+        export class BaseClass extends RealBaseClass {
+          constructor(private vcr: ViewContainerRef) {}
+        }
+        BaseClass.ctorParameters = () => [
+          { type: ViewContainerRef, }
+        ];
+        export class RealBaseClass {}
+      `
+         }]);
+         expect(errors).toEqual([]);
+         const file = analysis.get(program.getSourceFile(INDEX_FILENAME) !) !;
+         expect(file.compiledClasses.find(c => c.name === 'DerivedClass')).toBeDefined();
+         expect(file.compiledClasses.find(c => c.name === 'RealBaseClass')).toBeUndefined();
+         const baseClass = file.compiledClasses.find(c => c.name === 'BaseClass') !;
+         expect(baseClass.decorators !.length).toEqual(1);
+         const decorator = baseClass.decorators ![0];
+         expect(decorator.name).toEqual('Directive');
+         expect(decorator.identifier).toBeNull('The decorator must be synthesized');
+         expect(decorator.import).toEqual({from: '@angular/core', name: 'Directive'});
+         expect(decorator.args !.length).toEqual(0);
        });
 
     it('should handle the base class being in a different file (same package) as the derived class',
        () => {
          const BASE_FILENAME = _('/node_modules/test-package/base.js');
-         const {program, analysis} = setUpAndAnalyzeProgram([
+         const {program, analysis, errors} = setUpAndAnalyzeProgram([
            {
              name: INDEX_FILENAME,
              contents: `
@@ -116,18 +185,20 @@ runInEachFileSystem(() => {
       `
            }
          ]);
+         expect(errors).toEqual([]);
          const file = analysis.get(program.getSourceFile(BASE_FILENAME) !) !;
          const baseClass = file.compiledClasses.find(c => c.name === 'BaseClass') !;
          expect(baseClass.decorators !.length).toEqual(1);
          const decorator = baseClass.decorators ![0];
          expect(decorator.name).toEqual('Directive');
+         expect(decorator.identifier).toBeNull('The decorator must be synthesized');
          expect(decorator.import).toEqual({from: '@angular/core', name: 'Directive'});
-         expect(decorator.args !.length).toEqual(1);
+         expect(decorator.args !.length).toEqual(0);
        });
 
-    it('should error if the base class being is a different package from the derived class', () => {
+    it('should skip the base class if it is in a different package from the derived class', () => {
       const BASE_FILENAME = _('/node_modules/other-package/index.js');
-      const {errors} = setUpAndAnalyzeProgram([
+      const {program, analysis, errors} = setUpAndAnalyzeProgram([
         {
           name: INDEX_FILENAME,
           contents: `
@@ -152,7 +223,9 @@ runInEachFileSystem(() => {
       `
         }
       ]);
-      expect(errors.length).toEqual(1);
+      expect(errors).toEqual([]);
+      const file = analysis.get(program.getSourceFile(BASE_FILENAME) !);
+      expect(file).toBeUndefined();
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/index.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/index.ts
@@ -16,3 +16,4 @@ export {InjectableDecoratorHandler} from './src/injectable';
 export {NgModuleDecoratorHandler} from './src/ng_module';
 export {PipeDecoratorHandler} from './src/pipe';
 export {NoopReferencesRegistry, ReferencesRegistry} from './src/references_registry';
+export {forwardRefResolver} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -122,6 +122,9 @@ function classMemberToMetadata(
  * Convert a reflected decorator to metadata.
  */
 function decoratorToMetadata(decorator: Decorator): ts.ObjectLiteralExpression {
+  if (decorator.identifier === null) {
+    throw new Error('Illegal state: synthesized decorator cannot be emitted in class metadata.');
+  }
   // Decorators have a type.
   const properties: ts.ObjectLiteralElementLike[] = [
     ts.createPropertyAssignment('type', ts.getMutableClone(decorator.identifier)),

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -76,17 +76,6 @@ export enum ErrorCode {
   NGCC_MIGRATION_DECORATOR_INJECTION_ERROR = 7001,
 
   /**
-   * Raised when ngcc tries to decorate a base class that was imported from outside the package.
-   */
-  NGCC_MIGRATION_EXTERNAL_BASE_CLASS = 7002,
-
-  /**
-   * Raised when ngcc tries to migrate a class that is extended from a dynamic base class
-   * expression.
-   */
-  NGCC_MIGRATION_DYNAMIC_BASE_CLASS = 7003,
-
-  /**
    * An element name failed validation against the DOM schema.
    */
   SCHEMA_INVALID_ELEMENT = 8001,

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -21,9 +21,10 @@ export interface Decorator {
   name: string;
 
   /**
-   * Identifier which refers to the decorator in the user's code.
+   * Identifier which refers to the decorator in the user's code, or `null` if the decorator is
+   * synthesized in ngcc.
    */
-  identifier: DecoratorIdentifier;
+  identifier: DecoratorIdentifier|null;
 
   /**
    * `Import` by which the decorator was brought into the module in which it was invoked, or `null`
@@ -32,7 +33,8 @@ export interface Decorator {
   import : Import | null;
 
   /**
-   * TypeScript reference to the decorator itself.
+   * TypeScript reference to the decorator itself, or the node for which the decorator was
+   * synthesized in ngcc.
    */
   node: ts.Node;
 


### PR DESCRIPTION
This PR contains several commits to introduce schematic-like migration in ngcc. More details can be found in each commit description.