### PR TITLE
perf(ivy): avoid unnecessary i18n pass while processing a template

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -33,6 +33,9 @@ function setI18nRefs(html: html.Node & {i18n?: i18n.AST}, i18n: i18n.Node) {
  * stored with other element's and attribute's information.
  */
 export class I18nMetaVisitor implements html.Visitor {
+  // whether visited nodes contain i18n information
+  public hasI18nMeta: boolean = false;
+
   // i18n message generation factory
   private _createI18nMessage = createI18nMessageFactory(this.interpolationConfig);
 
@@ -70,6 +73,7 @@ export class I18nMetaVisitor implements html.Visitor {
 
   visitElement(element: html.Element, context: any): any {
     if (hasI18nAttrs(element)) {
+      this.hasI18nMeta = true;
       const attrs: html.Attribute[] = [];
       const attrsMeta: {[key: string]: string} = {};
 
@@ -118,6 +122,7 @@ export class I18nMetaVisitor implements html.Visitor {
   visitExpansion(expansion: html.Expansion, context: any): any {
     let message;
     const meta = expansion.i18n;
+    this.hasI18nMeta = true;
     if (meta instanceof i18n.IcuPlaceholder) {
       // set ICU placeholder name (e.g. "ICU_1"),
       // generated while processing root element contents,


### PR DESCRIPTION
Prior to this commit, we always invoked second i18n pass (in case whitespace removal is on, which is a default), even if a given template doesn't contain i18n information. Now we store a flag (that indicates presence of i18n information in a template) during first i18n pass and use it to check whether second pass is needed.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No