### PR TITLE
fix(zone.js): work around TS3.7 issue

### DIFF
--- a/packages/zone.js/lib/zone-spec/wtf.ts
+++ b/packages/zone.js/lib/zone-spec/wtf.ts
@@ -131,7 +131,8 @@
     const out: {[k: string]: any} = {};
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
-        let value = obj[key];
+        // explicit : any due to https://github.com/microsoft/TypeScript/issues/33191
+        let value: any = obj[key];
         switch (typeof value) {
           case 'object':
             const name = value && value.constructor && (<any>value.constructor).name;


### PR DESCRIPTION
In TypeScript 3.7, circularity detection misfires on the declaration of `value` here.
https://github.com/microsoft/TypeScript/issues/32950

Declaring an explicit type avoids the problem.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No