### PR TITLE
perf(ivy): add benchmark for `[class]=exp` use case

### DIFF
--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -14,6 +14,14 @@ ts_library(
 )
 
 ng_rollup_bundle(
+    name = "class_binding",
+    entry_point = ":class_binding/index.ts",
+    deps = [
+        ":perf_lib",
+    ],
+)
+
+ng_rollup_bundle(
     name = "directive_instantiate",
     entry_point = ":directive_instantiate/index.ts",
     deps = [

--- a/packages/core/test/render3/perf/class_binding/index.ts
+++ b/packages/core/test/render3/perf/class_binding/index.ts
@@ -6,15 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵɵproperty} from '@angular/core/src/core';
-import {AttributeMarker, TAttributes, TNodeType, TViewNode} from '@angular/core/src/render3/interfaces/node';
-
-import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {createLView, createTNode, createTView, refreshView} from '../../../../src/render3/instructions/shared';
+import {AttributeMarker, TAttributes} from '@angular/core/src/render3/interfaces/node';
+import {ɵɵelement} from '../../../../src/render3/instructions/element';
 import {ɵɵclassMap, ɵɵclassProp} from '../../../../src/render3/instructions/styling';
 import {ComponentTemplate, RenderFlags} from '../../../../src/render3/interfaces/definition';
-import {HOST, LViewFlags, TVIEW} from '../../../../src/render3/interfaces/view';
 import {createBenchmark} from '../micro_bench';
-import {setupRootViewWithEmbeddedViews, setupTestHarness} from '../setup';
+import {setupTestHarness} from '../setup';
+
 
 const CLASSES_1_A = 'one';
 const CLASSES_1_B = CLASSES_1_A.toUpperCase();
@@ -58,8 +56,8 @@ function benchmark(name: string, template: ComponentTemplate<any>) {
   console.profileEnd();
 }
 
-
-benchmark(`[class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
+`<div [class]="toggleClasses ? CLASSES_1_A : CLASSES_1_B">`;
+benchmark(`[class]="CLASSES_1"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div');
   }
@@ -69,7 +67,8 @@ benchmark(`[class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
 });
 
 
-benchmark(`[class]=" '1 2' "`, function(rf: RenderFlags, ctx: any) {
+`<div [class]="toggleClasses ? CLASSES_2_A : CLASSES_2_B">`;
+benchmark(`[class]="CLASSES_2"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div');
   }
@@ -79,7 +78,8 @@ benchmark(`[class]=" '1 2' "`, function(rf: RenderFlags, ctx: any) {
 });
 
 
-benchmark(`[class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFlags, ctx: any) {
+`<div [class]="toggleClasses ? CLASSES_10_A : CLASSES_10_B">`;
+benchmark(`[class]="CLASSES_10"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div');
   }
@@ -89,6 +89,7 @@ benchmark(`[class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFlags, ctx: an
 });
 
 
+`<div class="A B">`;
 benchmark(`class="A B"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div', 0);
@@ -98,7 +99,9 @@ benchmark(`class="A B"`, function(rf: RenderFlags, ctx: any) {
 });
 
 
-benchmark(`class="A B" [class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
+`<div class="A B" 
+      [class]="toggleClasses ? CLASSES_1_A : CLASSES_1_B">`;
+benchmark(`class="A B" [class]="CLASSES_1"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div', 0);
   }
@@ -108,7 +111,9 @@ benchmark(`class="A B" [class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
 });
 
 
-benchmark(`class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFlags, ctx: any) {
+`<div class="A B" 
+      [class]="toggleClasses ? CLASSES_10_A : CLASSES_10_B">`;
+benchmark(`class="A B" [class]="CLASSES_10"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div', 0);
   }
@@ -117,8 +122,10 @@ benchmark(`class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFl
   }
 });
 
-
-benchmark(`class="A B" [class]=" '1' " [class.foo]="exp"`, function(rf: RenderFlags, ctx: any) {
+`<div class="A B" 
+      [class]="toggleClasses ? CLASSES_1_A : CLASSES_1_B"
+      [class.foo]="toggleClasses">`;
+benchmark(`class="A B" [class]="CLASSES_1" [class.foo]="exp"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div', 0);
   }
@@ -128,10 +135,11 @@ benchmark(`class="A B" [class]=" '1' " [class.foo]="exp"`, function(rf: RenderFl
   }
 });
 
-
+`<div class="A B" 
+      [class]="toggleClasses ? CLASSES_10_A : CLASSES_10_B"
+      [class.foo]="toggleClasses">`;
 benchmark(
-    `class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' " [class.foo]="exp"`,
-    function(rf: RenderFlags, ctx: any) {
+    `class="A B" [class]="CLASSES_10" [class.foo]="exp"`, function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
         ɵɵelement(0, 'div', 0);
       }
@@ -142,6 +150,7 @@ benchmark(
     });
 
 
+`<div [className]="toggleClasses ? CLASSES_10_A : CLASSES_10_B">`;
 benchmark(`[element.class]="exp"`, function(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelement(0, 'div');

--- a/packages/core/test/render3/perf/class_binding/index.ts
+++ b/packages/core/test/render3/perf/class_binding/index.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ɵɵproperty} from '@angular/core/src/core';
+import {AttributeMarker, TAttributes, TNodeType, TViewNode} from '@angular/core/src/render3/interfaces/node';
+
+import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
+import {createLView, createTNode, createTView, refreshView} from '../../../../src/render3/instructions/shared';
+import {ɵɵclassMap, ɵɵclassProp} from '../../../../src/render3/instructions/styling';
+import {ComponentTemplate, RenderFlags} from '../../../../src/render3/interfaces/definition';
+import {HOST, LViewFlags, TVIEW} from '../../../../src/render3/interfaces/view';
+import {createBenchmark} from '../micro_bench';
+import {setupRootViewWithEmbeddedViews, setupTestHarness} from '../setup';
+
+const CLASSES_1_A = 'one';
+const CLASSES_1_B = CLASSES_1_A.toUpperCase();
+const CLASSES_2_A = 'one two';
+const CLASSES_2_B = CLASSES_2_A.toUpperCase();
+const CLASSES_10_A = 'one two three four five six seven eight nine ten';
+const CLASSES_10_B = CLASSES_10_A.toUpperCase();
+let toggleClasses = true;
+
+const consts: TAttributes[] = [
+  [AttributeMarker.Classes, 'A', 'B']  // 0
+];
+const context: any = {};
+const createClassBindingBenchmark = createBenchmark('class binding: create:');
+const updateClassBindingBenchmark = createBenchmark('class binding: update:');
+const noopClassBindingBenchmark = createBenchmark('class binding: noop:');
+function benchmark(name: string, template: ComponentTemplate<any>) {
+  const harness = setupTestHarness(template, 1, 1, 1000, context, consts);
+
+  const createProfile = createClassBindingBenchmark(name);
+  console.profile('create: ' + name);
+  while (createProfile()) {
+    harness.createEmbeddedLView();
+  }
+  console.profileEnd();
+
+
+  const updateProfile = updateClassBindingBenchmark(name);
+  console.profile('update: ' + name);
+  while (updateProfile()) {
+    toggleClasses = !toggleClasses;
+    harness.detectChanges();
+  }
+  console.profileEnd();
+
+  const noopProfile = noopClassBindingBenchmark(name);
+  console.profile('nop: ' + name);
+  while (noopProfile()) {
+    harness.detectChanges();
+  }
+  console.profileEnd();
+}
+
+
+benchmark(`[class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div');
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_1_A : CLASSES_1_B);
+  }
+});
+
+
+benchmark(`[class]=" '1 2' "`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div');
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_2_A : CLASSES_2_B);
+  }
+});
+
+
+benchmark(`[class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div');
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_10_A : CLASSES_10_B);
+  }
+});
+
+
+benchmark(`class="A B"`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div', 0);
+  }
+  if (rf & 2) {
+  }
+});
+
+
+benchmark(`class="A B" [class]=" '1' "`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div', 0);
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_1_A : CLASSES_1_B);
+  }
+});
+
+
+benchmark(`class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' "`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div', 0);
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_10_A : CLASSES_10_B);
+  }
+});
+
+
+benchmark(`class="A B" [class]=" '1' " [class.foo]="exp"`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div', 0);
+  }
+  if (rf & 2) {
+    ɵɵclassMap(toggleClasses ? CLASSES_1_A : CLASSES_1_B);
+    ɵɵclassProp('foo', toggleClasses);
+  }
+});
+
+
+benchmark(
+    `class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' " [class.foo]="exp"`,
+    function(rf: RenderFlags, ctx: any) {
+      if (rf & 1) {
+        ɵɵelement(0, 'div', 0);
+      }
+      if (rf & 2) {
+        ɵɵclassMap(toggleClasses ? CLASSES_10_A : CLASSES_10_B);
+        ɵɵclassProp('foo', toggleClasses);
+      }
+    });
+
+
+benchmark(`[element.class]="exp"`, function(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div');
+  }
+  if (rf & 2) {
+    ɵɵproperty('className', toggleClasses ? CLASSES_10_A : CLASSES_10_B);
+  }
+});
+
+createClassBindingBenchmark.report();
+updateClassBindingBenchmark.report();
+noopClassBindingBenchmark.report();

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -9,7 +9,7 @@ import {addToViewTree, createLContainer, createLView, createTNode, createTView, 
 import {ComponentTemplate} from '../../../src/render3/interfaces/definition';
 import {TAttributes, TNodeType, TViewNode} from '../../../src/render3/interfaces/node';
 import {RComment} from '../../../src/render3/interfaces/renderer';
-import {LView, LViewFlags, TView} from '../../../src/render3/interfaces/view';
+import {LView, LViewFlags, RENDERER, RENDERER_FACTORY, TView} from '../../../src/render3/interfaces/view';
 import {insertView} from '../../../src/render3/node_manipulation';
 
 import {NoopRenderer, NoopRendererFactory, WebWorkerRenderNode} from './noop_renderer';
@@ -25,33 +25,59 @@ export function createAndRenderLView(
 export function setupRootViewWithEmbeddedViews(
     templateFn: ComponentTemplate<any>| null, decls: number, vars: number, noOfViews: number,
     embeddedViewContext: any = {}, consts: TAttributes[] | null = null): LView {
+  return setupTestHarness(templateFn, decls, vars, noOfViews, embeddedViewContext, consts)
+      .hostLView;
+}
+
+export interface TestHarness {
+  hostLView: LView, hostTView: TView, embeddedTView: TView, createEmbeddedLView(): LView,
+      detectChanges(): void;
+}
+
+export function setupTestHarness(
+    templateFn: ComponentTemplate<any>| null, decls: number, vars: number, noOfViews: number,
+    embeddedViewContext: any = {}, consts: TAttributes[] | null = null): TestHarness {
   // Create a root view with a container
-  const rootTView = createTView(-1, null, 1, 0, null, null, null, null, consts);
-  const tContainerNode = getOrCreateTNode(rootTView, null, 0, TNodeType.Container, null, null);
-  const rootLView = createLView(
-      null, rootTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
+  const hostTView = createTView(-1, null, 1, 0, null, null, null, null, consts);
+  const tContainerNode = getOrCreateTNode(hostTView, null, 0, TNodeType.Container, null, null);
+  const hostLView = createLView(
+      null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
       new NoopRendererFactory(), new NoopRenderer());
   const mockRNode = new WebWorkerRenderNode();
   const lContainer = createLContainer(
-      mockRNode as RComment, rootLView, mockRNode as RComment, tContainerNode, true);
-  addToViewTree(rootLView, lContainer);
+      mockRNode as RComment, hostLView, mockRNode as RComment, tContainerNode, true);
+  addToViewTree(hostLView, lContainer);
 
 
   // create test embedded views
-  const embeddedTView = createTView(-1, templateFn, decls, vars, null, null, null, null, null);
-  const viewTNode = createTNode(rootTView, null, TNodeType.View, -1, null, null) as TViewNode;
+  const embeddedTView = createTView(-1, templateFn, decls, vars, null, null, null, null, consts);
+  const viewTNode = createTNode(hostTView, null, TNodeType.View, -1, null, null) as TViewNode;
+  const rendererFactory = hostLView[RENDERER_FACTORY];
+  const renderer = hostLView[RENDERER];
+
+  function createEmbeddedLView(): LView {
+    const embeddedLView = createLView(
+        hostLView, embeddedTView, embeddedViewContext, LViewFlags.CheckAlways, null, viewTNode,
+        rendererFactory, renderer);
+    renderView(embeddedLView, embeddedTView, null);
+    return embeddedLView;
+  }
+
+  function detectChanges(): void { renderView(hostLView, hostTView, null); }
 
   // create embedded views and add them to the container
   for (let i = 0; i < noOfViews; i++) {
-    const embeddedLView = createLView(
-        rootLView, embeddedTView, embeddedViewContext, LViewFlags.CheckAlways, null, viewTNode,
-        new NoopRendererFactory(), new NoopRenderer());
-    renderView(embeddedLView, embeddedTView, null);
-    insertView(embeddedLView, lContainer, i);
+    insertView(createEmbeddedLView(), lContainer, i);
   }
 
   // run in the creation mode to set flags etc.
-  renderView(rootLView, rootTView, null);
+  detectChanges();
 
-  return rootLView;
+  return {
+    hostLView: hostLView,
+    hostTView: hostTView,
+    embeddedTView: embeddedTView,
+    createEmbeddedLView: createEmbeddedLView,
+    detectChanges: detectChanges,
+  };
 }

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -30,8 +30,11 @@ export function setupRootViewWithEmbeddedViews(
 }
 
 export interface TestHarness {
-  hostLView: LView, hostTView: TView, embeddedTView: TView, createEmbeddedLView(): LView,
-      detectChanges(): void;
+  hostLView: LView;
+  hostTView: TView;
+  embeddedTView: TView;
+  createEmbeddedLView(): LView;
+  detectChanges(): void;
 }
 
 export function setupTestHarness(


### PR DESCRIPTION
This PR demonstrates a use case where writing to the `[class]` is much slower that direct.

```
Benchmark: class binding: create:
  [class]=" '1' ": 162.153 ns(0%)
  [class]=" '1 2' ": 209.617 ns(-29%)
  [class]=" '1 2 3 4 5 6 7 8 9 0' ": 213.104 ns(-31%)
  class="A B" [class]=" '1' ": 269.382 ns(-66%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' ": 242.590 ns(-50%)
  class="A B" [class]=" '1' " [class.foo]="exp": 241.773 ns(-49%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' " [class.foo]="exp": 242.958 ns(-50%)
  [element.class]="exp": 194.625 ns(-20%)
Benchmark: class binding: update:
  [class]=" '1' ": 17.339 ns(0%)
  [class]=" '1 2' ": 30.814 ns(-78%)
  [class]=" '1 2 3 4 5 6 7 8 9 0' ": 30.544 ns(-76%)
  class="A B" [class]=" '1' ": 30.543 ns(-76%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' ": 30.569 ns(-76%)
  class="A B" [class]=" '1' " [class.foo]="exp": 30.543 ns(-76%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' " [class.foo]="exp": 30.543 ns(-76%)
  [element.class]="exp": 30.543 ns(-76%)
Benchmark: class binding: noop:
  [class]=" '1' ": 16.239 ns(0%)
  [class]=" '1 2' ": 28.265 ns(-74%)
  [class]=" '1 2 3 4 5 6 7 8 9 0' ": 28.019 ns(-73%)
  class="A B" [class]=" '1' ": 28.111 ns(-73%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' ": 28.111 ns(-73%)
  class="A B" [class]=" '1' " [class.foo]="exp": 28.111 ns(-73%)
  class="A B" [class]=" '1 2 3 4 5 6 7 8 9 0' " [class.foo]="exp": 28.111 ns(-73%)
  [element.class]="exp": 28.110 ns(-73%)
```

This is first step in understanding the issue.