### PR TITLE
feat(ivy): allow the locale to be set via a global property

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -30,8 +30,8 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 128258,
-        "polyfills-es2015": 42102
+        "main-es2015": 138032,
+        "polyfills-es2015": 37494
       }
     }
   },

--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -4,13 +4,6 @@
   "newProjectRoot": "projects",
   "projects": {
     "cli-hello-world-ivy-i18n": {
-      "i18n": {
-        "locales": {
-          "fr": "src/locales/messages.fr.json",
-          "de": "src/locales/messages.de.json"
-        },
-        "sourceLocale": "en"
-      },
       "projectType": "application",
       "schematics": {},
       "root": "",
@@ -69,6 +62,14 @@
                 }
               ]
             },
+            "runtime-translations": {
+              "fileReplacements": [
+                {
+                  "replace": "src/polyfills.ts",
+                  "with": "src/polyfills-runtime.ts"
+                }
+              ]
+            },
             "translated-legacy": {
               "tsConfig": "tsconfig.legacy.json",
               "optimization": true,
@@ -97,6 +98,10 @@
             },
             "ci-production": {
               "browserTarget": "cli-hello-world-ivy-i18n:build:production",
+              "progress": false
+            },
+            "runtime-translations": {
+              "browserTarget": "cli-hello-world-ivy-i18n:build:runtime-translations",
               "progress": false
             }
           }
@@ -144,7 +149,7 @@
         "e2e": {
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
-            "protractorConfig": "e2e/runtime/protractor.conf.js",
+            "protractorConfig": "e2e/en/protractor.conf.js",
             "devServerTarget": "cli-hello-world-ivy-i18n:serve",
             "webdriverUpdate": false
           },
@@ -156,7 +161,11 @@
               "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci"
             },
             "ci-production": {
-              "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci-production"
+              "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci-production",
+            },
+            "runtime-translations": {
+              "devServerTarget": "cli-hello-world-ivy-i18n:serve:runtime-translations",
+              "protractorConfig": "e2e/fr/protractor.conf.js"
             },
             "translated-legacy": {
               "devServerTarget": "",

--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -4,6 +4,13 @@
   "newProjectRoot": "projects",
   "projects": {
     "cli-hello-world-ivy-i18n": {
+      "i18n": {
+        "locales": {
+          "fr": "src/locales/messages.fr.json",
+          "de": "src/locales/messages.de.json"
+        },
+        "sourceLocale": "en"
+      },
       "projectType": "application",
       "schematics": {},
       "root": "",
@@ -33,6 +40,7 @@
               "tsConfig": "tsconfig.view-engine.json"
             },
             "production": {
+              "localize": false, // TODO: enable when CLI supports inlining the locale
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/integration/cli-hello-world-ivy-i18n/e2e/README.md
+++ b/integration/cli-hello-world-ivy-i18n/e2e/README.md
@@ -5,7 +5,10 @@ translation scenarios, but they are all built with IVY enabled.
 
 ### runtime
 
-Translations are provided at runtime by calling `loadTranslations()` in the polyfill.ts
+A new `polyfills.ts` file is provided (`polyfills-runtime.ts`) which is swapped in by a file
+replacement in the `angular.json` configuration. In this new file:
+ * Runtime translations are provided (`loadTranslations()`).
+ * The current locale is set (`$localize.locale = 'fr'`) and loaded (`registerLocaleData(localeFr);`)
 
 ### de and fr
 

--- a/integration/cli-hello-world-ivy-i18n/e2e/de/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/de/app.e2e-spec.ts
@@ -14,4 +14,13 @@ describe('cli-hello-world-ivy App', () => {
   it('should display welcome message', () => {
     expect(page.getParagraph('message')).toEqual('Willkommen in der i18n App. (inline)');
   });
+
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('de'); });
+
+  // TODO : Re-enable when CLI translation inlining supports locale inlining (and so we can use it
+  // to load the correct locale data)
+  xit('the date pipe should show the localized month', () => {
+    page.navigateTo();
+    expect(page.getParagraph('date')).toEqual('Januar');
+  });
 });

--- a/integration/cli-hello-world-ivy-i18n/e2e/en/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/en/app.e2e-spec.ts
@@ -12,4 +12,11 @@ describe('cli-hello-world-ivy App', () => {
 
   it('should display welcome message',
      () => { expect(page.getParagraph('message')).toEqual('Welcome to the i18n app.'); });
+
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('en-US'); });
+
+  it('the date pipe should show the localized month', () => {
+    page.navigateTo();
+    expect(page.getParagraph('date')).toEqual('January');
+  });
 });

--- a/integration/cli-hello-world-ivy-i18n/e2e/fr/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/fr/app.e2e-spec.ts
@@ -13,4 +13,11 @@ describe('cli-hello-world-ivy App', () => {
   it('should display welcome message', () => {
     expect(page.getParagraph('message')).toEqual('Bienvenue sur l\'application i18n. (inline)');
   });
+
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('fr'); });
+
+  it('the date pipe should show the localized month', () => {
+    page.navigateTo();
+    expect(page.getParagraph('date')).toEqual('janvier');
+  });
 });

--- a/integration/cli-hello-world-ivy-i18n/e2e/legacy/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/legacy/app.e2e-spec.ts
@@ -15,4 +15,6 @@ describe('cli-hello-world-ivy App', () => {
     // See "translated:legacy:extract-and-update" in package.json.
     expect(page.getParagraph('message')).toEqual('Welcome to the i18n app.');
   });
+
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('fr'); });
 });

--- a/integration/cli-hello-world-ivy-i18n/e2e/legacy/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/legacy/app.e2e-spec.ts
@@ -16,5 +16,5 @@ describe('cli-hello-world-ivy App', () => {
     expect(page.getParagraph('message')).toEqual('Welcome to the i18n app.');
   });
 
-  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('fr'); });
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('legacy'); });
 });

--- a/integration/cli-hello-world-ivy-i18n/e2e/runtime/app.e2e-spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/e2e/runtime/app.e2e-spec.ts
@@ -19,4 +19,11 @@ describe('cli-hello-world-ivy App', () => {
     page.navigateTo();
     expect(page.getParagraph('pipe')).toEqual('100 % awesome');
   });
+
+  it('should display the locale', () => { expect(page.getParagraph('locale')).toEqual('fr'); });
+
+  it('the date pipe should show the localized month', () => {
+    page.navigateTo();
+    expect(page.getParagraph('date')).toEqual('janvier');
+  });
 });

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -13,18 +13,13 @@
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production && yarn translated:test && yarn translated:legacy:test",
     "translate": "localize-translate -r \"dist/\" -s \"**/*\" -l \"en-US\" -t \"src/locales/messages.*\" -o \"../tmp/translations/{{LOCALE}}\"",
-
     "translated:test": "yarn build && yarn translate && yarn translated:fr:e2e && yarn translated:de:e2e && yarn translated:en:e2e",
-
     "translated:fr:serve": "serve ../tmp/translations/fr --listen 4200",
     "translated:fr:e2e": "npm-run-all -p -r translated:fr:serve \"ng e2e --configuration=translated-fr\"",
-
     "translated:de:serve": "serve ../tmp/translations/de --listen 4200",
     "translated:de:e2e": "npm-run-all -p -r translated:de:serve \"ng e2e --configuration=translated-de\"",
-
     "translated:en:serve": "serve ../tmp/translations/en-US --listen 4200",
     "translated:en:e2e": "npm-run-all -p -r translated:en:serve \"ng e2e --configuration=translated-en\"",
-
     "translated:legacy:test": "yarn translated:legacy:extract-and-update && ng build --configuration=translated-legacy && yarn translated:legacy:translate && yarn translated:legacy:e2e",
     "translated:legacy:extract-and-update": "ng xi18n && sed -i.bak -e 's/source>/target>'/ -e 's/Hello/Bonjour/' -e 's/source-language=\"en-US\"/source-language=\"en-US\" target-language=\"legacy\"/' ../tmp/legacy-locales/messages.legacy.xlf",
     "translated:legacy:translate": "localize-translate -r \"dist/\" -s \"**/*\" -t \"../tmp/legacy-locales/messages.legacy.xlf\" -o \"../tmp/translations/{{LOCALE}}\"",
@@ -50,8 +45,8 @@
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.900.0-next.12",
-    "@angular/cli": "file:../../node_modules/@angular/cli",
+    "@angular-devkit/build-angular": "^0.900.0-next.14",
+    "@angular/cli": "^9.0.0-next.14",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "@angular/language-service": "file:../../dist/packages-dist/language-service",
     "@types/jasmine": "~3.4.0",

--- a/integration/cli-hello-world-ivy-i18n/src/app/app.component.html
+++ b/integration/cli-hello-world-ivy-i18n/src/app/app.component.html
@@ -7,7 +7,9 @@
   <p id="message">{{ message }}</p>
   <img width="300" alt="Angular Logo" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg==">
 </div>
+<p id="locale">{{ locale }}</p>
 <p id="pipe">{{ 1 | percent }} awesome</p>
+<p id="date">{{ jan | date : 'LLLL' }}</p>
 <h2>Here are some links to help you start: </h2>
 <ul>
   <li>

--- a/integration/cli-hello-world-ivy-i18n/src/app/app.component.spec.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/app/app.component.spec.ts
@@ -27,6 +27,6 @@ describe('AppComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('h1').textContent)
-        .toContain('Bonjour cli-hello-world-ivy-compat!');
+        .toContain('Hello cli-hello-world-ivy-compat!');
   });
 });

--- a/integration/cli-hello-world-ivy-i18n/src/app/app.component.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/app/app.component.ts
@@ -1,8 +1,10 @@
-import {Component} from '@angular/core';
+import {Component, Inject, LOCALE_ID} from '@angular/core';
 
 @Component(
     {selector: 'app-root', templateUrl: './app.component.html', styleUrls: ['./app.component.css']})
 export class AppComponent {
+  constructor(@Inject(LOCALE_ID) public locale: string) {}
   title = `cli-hello-world-ivy-compat`;
   message = $localize `Welcome to the i18n app.`;
+  jan = new Date(2000, 0, 1);
 }

--- a/integration/cli-hello-world-ivy-i18n/src/app/app.module.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/app/app.module.ts
@@ -1,17 +1,13 @@
 import {registerLocaleData} from '@angular/common';
-import {LOCALE_ID, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import localeFr from '@angular/common/locales/fr';
 import {AppComponent} from './app.component';
 
 // adding this code to detect issues like https://github.com/angular/angular-cli/issues/10322
+// it should not affect the CLI importing additional locale data for compile time inlined bundles.
 registerLocaleData(localeFr);
 
-@NgModule({
-  declarations: [AppComponent],
-  imports: [BrowserModule],
-  providers: [{provide: LOCALE_ID, useValue: 'fr'}],
-  bootstrap: [AppComponent]
-})
+@NgModule({declarations: [AppComponent], imports: [BrowserModule], bootstrap: [AppComponent]})
 export class AppModule {
 }

--- a/integration/cli-hello-world-ivy-i18n/src/polyfills-runtime.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/polyfills-runtime.ts
@@ -41,9 +41,11 @@
  *
  * The following flags will work for all browsers.
  *
- * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+ * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch
+ * requestAnimationFrame
  * (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- * (window as any).__zone_symbol__UNPATCHED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+ * (window as any).__zone_symbol__UNPATCHED_EVENTS = ['scroll', 'mousemove']; // disable patch
+ * specified eventNames
  *
  *  in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
  *  with the following flag, it will bypass `zone.js` patch for IE/Edge
@@ -62,6 +64,22 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
  */
 import '@angular/localize/init';
 
+// Note that `computeMsgId` is a private API at this stage. It will probably be exported directly
+// from `@angular/localize` at some point.
+import {computeMsgId} from '@angular/compiler';
+import {loadTranslations} from '@angular/localize';
+
+// Load some runtime translations!
+loadTranslations({
+  [computeMsgId(' Hello {$INTERPOLATION}! ')]: 'Bonjour {$INTERPOLATION}!',
+  [computeMsgId('Welcome to the i18n app.')]: 'Bienvenue sur l\'application i18n.',
+});
+
+// Set up the locale for the runtime inlining (EXPERIMENTAL)
+$localize.locale = 'fr';
+import {registerLocaleData} from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
+registerLocaleData(localeFr);
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
@@ -73,6 +73,9 @@ loadTranslations({
   [computeMsgId('Welcome to the i18n app.')]: 'Bienvenue sur l\'application i18n.',
 });
 
+// Set the locale for the runtime inlining (EXPERIMENTAL)
+$localize.locale = 'fr';
+
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */

--- a/integration/cli-hello-world-ivy-i18n/yarn.lock
+++ b/integration/cli-hello-world-ivy-i18n/yarn.lock
@@ -2,38 +2,39 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/architect@0.900.0-next.11":
-  version "0.900.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.900.0-next.11.tgz#c1b1f6b428903eedf70422b34471d80a1243a682"
-  integrity sha512-SHgxd0tou/xlBG5XTPa//l0h1czxV0CUzMQ/QoMNin0n11JXFCIBooUzg5kguR8g4LvwzTAhHIx3ZVpypTOMtQ==
+"@angular-devkit/architect@0.900.0-next.14":
+  version "0.900.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.900.0-next.14.tgz#446bc66537edb057fe8a29c0d5f952d6da72d4ed"
+  integrity sha512-cWr5kurKlfpQRVplZFNG4LF/StSnWWB3n2OKp3BZcd3tlsR8GmH7GRN+YLH9LRbfJHgmBikPBz75JDKn3zyEkw==
   dependencies:
-    "@angular-devkit/core" "9.0.0-next.11"
+    "@angular-devkit/core" "9.0.0-next.14"
     rxjs "6.5.3"
 
-"@angular-devkit/build-angular@^0.900.0-next.11":
-  version "0.900.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-0.900.0-next.11.tgz#6ce47d1dc31437785c2e758900f67517b8debad6"
-  integrity sha512-f0UbBAfseXVd4ldQPNgn3y/QYQwu/Pj+A6wsJAtA5LQaCHVCd4tn+0076Lqj/m6ooWlOM7n0kXL6OrD1lLsn3A==
+"@angular-devkit/build-angular@^0.900.0-next.14":
+  version "0.900.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-0.900.0-next.14.tgz#d18e76c1d09dff18b70cf5051c35530a7693d54d"
+  integrity sha512-cU3soynun2u06v8qMfHHVa5M215hrByWqKsl0qmJUK3ErjEoL0bZwKAuk5rJIUyR3n3dY29qCw8qxC29gBbO2w==
   dependencies:
-    "@angular-devkit/architect" "0.900.0-next.11"
-    "@angular-devkit/build-optimizer" "0.900.0-next.11"
-    "@angular-devkit/build-webpack" "0.900.0-next.11"
-    "@angular-devkit/core" "9.0.0-next.11"
+    "@angular-devkit/architect" "0.900.0-next.14"
+    "@angular-devkit/build-optimizer" "0.900.0-next.14"
+    "@angular-devkit/build-webpack" "0.900.0-next.14"
+    "@angular-devkit/core" "9.0.0-next.14"
     "@babel/core" "7.6.4"
+    "@babel/generator" "7.6.4"
     "@babel/preset-env" "7.6.3"
-    "@ngtools/webpack" "9.0.0-next.11"
+    "@ngtools/webpack" "9.0.0-next.14"
     ajv "6.10.2"
     autoprefixer "9.6.5"
-    browserslist "4.7.0"
+    browserslist "4.7.1"
     cacache "13.0.1"
-    caniuse-lite "1.0.30000999"
+    caniuse-lite "1.0.30001002"
     circular-dependency-plugin "5.2.0"
     clean-css "4.2.1"
     copy-webpack-plugin "5.0.4"
-    core-js "3.3.2"
+    core-js "3.3.3"
     file-loader "4.2.0"
     find-cache-dir "3.0.0"
-    glob "7.1.4"
+    glob "7.1.5"
     istanbul-instrumenter-loader "3.0.1"
     jest-worker "24.9.0"
     karma-source-map-support "1.4.0"
@@ -41,16 +42,17 @@
     less-loader "5.0.0"
     license-webpack-plugin "2.1.3"
     loader-utils "1.2.3"
+    magic-string "0.25.4"
     mini-css-extract-plugin "0.8.0"
     minimatch "3.0.4"
-    open "6.4.0"
+    open "7.0.0"
     parse5 "4.0.0"
     postcss "7.0.18"
     postcss-import "12.0.1"
     postcss-loader "3.0.0"
     raw-loader "3.1.0"
     regenerator-runtime "0.13.3"
-    rollup "1.24.0"
+    rollup "1.25.1"
     rxjs "6.5.3"
     sass "1.23.0"
     sass-loader "8.0.0"
@@ -62,10 +64,10 @@
     style-loader "1.0.0"
     stylus "0.54.7"
     stylus-loader "3.0.2"
-    terser "4.3.8"
+    terser "4.3.9"
     terser-webpack-plugin "2.1.3"
     tree-kill "1.2.1"
-    webpack "4.41.1"
+    webpack "4.41.2"
     webpack-dev-middleware "3.7.2"
     webpack-dev-server "3.8.2"
     webpack-merge "4.2.2"
@@ -73,10 +75,10 @@
     webpack-subresource-integrity "1.3.4"
     worker-plugin "3.2.0"
 
-"@angular-devkit/build-optimizer@0.900.0-next.11":
-  version "0.900.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.900.0-next.11.tgz#dc29609ae65d2c463ebc927cc43bc21d06f47475"
-  integrity sha512-YpPqtOymhnq7I3hMnqgnaUpWvc9oxKPLm1TnRcULmL4SSlHjhCNvEaoWBX+/EBa+4Zba+kG2cNN2jHV1IA/Pjw==
+"@angular-devkit/build-optimizer@0.900.0-next.14":
+  version "0.900.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.900.0-next.14.tgz#e00b9eeb84dc773a0ef040871fa0bbbe78a381d8"
+  integrity sha512-XWUjgEDcskCYbmNJTTlVn8SQAiVwSHl3tJqwA4MCvUXChd2QNjmjl7MhLG/3AYbgzF3UDPUvSuiheUSzFlo7rQ==
   dependencies:
     loader-utils "1.2.3"
     source-map "0.7.3"
@@ -84,19 +86,19 @@
     typescript "3.6.4"
     webpack-sources "1.4.3"
 
-"@angular-devkit/build-webpack@0.900.0-next.11":
-  version "0.900.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.900.0-next.11.tgz#21553341a338e07a77bcbaa958f609df648c70d9"
-  integrity sha512-D2ZNQ7h4bL8jBie4PqJc/7IYYbYmNdY8aEPugBnra0IlqjoE+sdjdAxHdCnyi0qTvigDbQZPaZQoYlr1nhygzQ==
+"@angular-devkit/build-webpack@0.900.0-next.14":
+  version "0.900.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.900.0-next.14.tgz#af21b0c40944562993aae8357b2f0b77bcb7a344"
+  integrity sha512-j9wXafszZMdN98ldfc6GlZbUXA6aAxYkGiQG/FX5KhK++lBpQMwrx7y7Xurirzu8Lp0fqAWh9fpWtLTuM9m/Xg==
   dependencies:
-    "@angular-devkit/architect" "0.900.0-next.11"
-    "@angular-devkit/core" "9.0.0-next.11"
+    "@angular-devkit/architect" "0.900.0-next.14"
+    "@angular-devkit/core" "9.0.0-next.14"
     rxjs "6.5.3"
 
-"@angular-devkit/core@9.0.0-next.11":
-  version "9.0.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-9.0.0-next.11.tgz#b8988c1fbfc3c42600dd5f9127cdfff4d14985b9"
-  integrity sha512-e95eStdGjt4waesu/E3D/J2T3AHucmovUXov/iURZCvzlzG6jCXvwWVsRh7Zk7OWqUBvyCZ5T1cn7lAPc5UW6A==
+"@angular-devkit/core@9.0.0-next.14":
+  version "9.0.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-9.0.0-next.14.tgz#42a51699ae3158c4578822e9f6f32ed3e250a80d"
+  integrity sha512-OEuU7lHshuDd3lO2rK3p0uxWulWpMWGDQipXInrGDBM77NXuSgtmVsU+ZQlU46XObSjkrr/8YAo97UFlbZby1g==
   dependencies:
     ajv "6.10.2"
     fast-json-stable-stringify "2.0.0"
@@ -104,25 +106,27 @@
     rxjs "6.5.3"
     source-map "0.7.3"
 
-"@angular-devkit/schematics@9.0.0-next.11":
-  version "9.0.0-next.11"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-9.0.0-next.11.tgz#bb3659f1ee677db969ced806da7a8857a08633c8"
-  integrity sha512-853PB1+6dQLgNI6DSFmsFFR6H3ivWcEjyCQWyC74OvwtCGl8ZvrJuJLUy7TQB2f7ygkRqyaJMV7PhNpk3dw+vg==
+"@angular-devkit/schematics@9.0.0-next.14":
+  version "9.0.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-9.0.0-next.14.tgz#a35744348dc5dc46028512f499ce6634d268d749"
+  integrity sha512-TCG8ZQ7eEaqP2u5pPLC7yJB3GMqLO5NmojMyXc40Khop/srWbahQRlGL9UEPUvbWDhfLlx6VpaIwBVzIcDX38A==
   dependencies:
-    "@angular-devkit/core" "9.0.0-next.11"
+    "@angular-devkit/core" "9.0.0-next.14"
     rxjs "6.5.3"
 
 "@angular/animations@file:../../dist/packages-dist/animations":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
-"@angular/cli@file:../../node_modules/@angular/cli":
-  version "9.0.0-next.11"
+"@angular/cli@^9.0.0-next.14":
+  version "9.0.0-next.14"
+  resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-9.0.0-next.14.tgz#483d11a9a384bfc62d152a3f1d1a7c03ca4179e1"
+  integrity sha512-sE2ypfAjYLNGJr1isFmkUEG3PMFNe9Qs5kq4bkuV85yhfonhKk78QutF7lCvOK9fb3d5BkjDezHWF+bEvIcTNw==
   dependencies:
-    "@angular-devkit/architect" "0.900.0-next.11"
-    "@angular-devkit/core" "9.0.0-next.11"
-    "@angular-devkit/schematics" "9.0.0-next.11"
-    "@schematics/angular" "9.0.0-next.11"
-    "@schematics/update" "0.900.0-next.11"
+    "@angular-devkit/architect" "0.900.0-next.14"
+    "@angular-devkit/core" "9.0.0-next.14"
+    "@angular-devkit/schematics" "9.0.0-next.14"
+    "@schematics/angular" "9.0.0-next.14"
+    "@schematics/update" "0.900.0-next.14"
     "@yarnpkg/lockfile" "1.1.0"
     ansi-colors "4.1.1"
     debug "^4.1.1"
@@ -130,19 +134,20 @@
     inquirer "7.0.0"
     npm-package-arg "6.1.1"
     npm-pick-manifest "3.0.2"
-    open "6.4.0"
+    open "7.0.0"
     pacote "9.5.8"
     read-package-tree "5.3.1"
+    rimraf "3.0.0"
     semver "6.3.0"
     symbol-observable "1.2.0"
     universal-analytics "^0.4.20"
     uuid "^3.3.2"
 
 "@angular/common@file:../../dist/packages-dist/common":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/compiler-cli@file:../../dist/packages-dist/compiler-cli":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
   dependencies:
     canonical-path "1.0.0"
     chokidar "^2.1.1"
@@ -156,32 +161,32 @@
     yargs "13.1.0"
 
 "@angular/compiler@file:../../dist/packages-dist/compiler":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/core@file:../../dist/packages-dist/core":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/language-service@file:../../dist/packages-dist/language-service":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/localize@file:../../dist/packages-dist/localize":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
   dependencies:
     "@babel/core" "^7.5.5"
     glob "7.1.2"
     yargs "13.1.0"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@angular/router@file:../../dist/packages-dist/router":
-  version "9.0.0-next.11"
+  version "9.0.0-next.12"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
@@ -230,22 +235,22 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/generator@7.6.4", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
+  dependencies:
+    "@babel/types" "^7.6.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.6.2":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.2.tgz#dac8a3c2df118334c2a29ff3446da1636a8f8c03"
   integrity sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==
   dependencies:
     "@babel/types" "^7.6.0"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
-  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
-  dependencies:
-    "@babel/types" "^7.6.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -877,32 +882,31 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@ngtools/webpack@9.0.0-next.11":
-  version "9.0.0-next.11"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-9.0.0-next.11.tgz#fcff75b83509161e257e29bdbe4578097f8a370d"
-  integrity sha512-Z94ZJCW7pdR1k26T8puFD3zoL525HORFO9o6mURSLnFLapGLp7Y6H6CetRZuCLiFHjMaV6wWixXeE6Uph2JUZA==
+"@ngtools/webpack@9.0.0-next.14":
+  version "9.0.0-next.14"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-9.0.0-next.14.tgz#da927f08a2f51717ce8466575ae605cdafb72de9"
+  integrity sha512-7kj4WCDi31cFPc+x4VjE8vjcoMBWZtToyBHvLgHRetyo9afG92mbrAzzEg4mQb9a9pYNCiYZXVKdoWG7psVTuQ==
   dependencies:
-    "@angular-devkit/core" "9.0.0-next.11"
+    "@angular-devkit/core" "9.0.0-next.14"
     enhanced-resolve "4.1.1"
     rxjs "6.5.3"
-    tree-kill "1.2.1"
     webpack-sources "1.4.3"
 
-"@schematics/angular@9.0.0-next.11":
-  version "9.0.0-next.11"
-  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-9.0.0-next.11.tgz#166e7d8ef0d1992831dd88820c7a519ca5ab6c80"
-  integrity sha512-fAA2jnT4NzO286FtoqYjxugRe1wq69o1SpuKtFXbIvFGvPPQdv1/UlNGjDkuURT7SiNRuLLALOqyFXh2LC9vXg==
+"@schematics/angular@9.0.0-next.14":
+  version "9.0.0-next.14"
+  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-9.0.0-next.14.tgz#ef5267d284eb7eeb40d4f87617999dfea68cd7f7"
+  integrity sha512-epx3HbhsYSsfmzD6ch2N31O9uyn3IBbP0lp5PbV3IaJEymFTNE9Kd62Plmd/gLTMEeMbdtTC1oc1O554Y6c0vQ==
   dependencies:
-    "@angular-devkit/core" "9.0.0-next.11"
-    "@angular-devkit/schematics" "9.0.0-next.11"
+    "@angular-devkit/core" "9.0.0-next.14"
+    "@angular-devkit/schematics" "9.0.0-next.14"
 
-"@schematics/update@0.900.0-next.11":
-  version "0.900.0-next.11"
-  resolved "https://registry.yarnpkg.com/@schematics/update/-/update-0.900.0-next.11.tgz#235c895e8ebbbf92d1e33fa2e1be5ece407c12cf"
-  integrity sha512-qZ/Ry3ckREcM0rCr0JUy+I076P9lSRZ8e3dgKb5lsehdP1YqNkDO+mRtbbsKD37+YlPFIOigA7OYkcol78862Q==
+"@schematics/update@0.900.0-next.14":
+  version "0.900.0-next.14"
+  resolved "https://registry.yarnpkg.com/@schematics/update/-/update-0.900.0-next.14.tgz#70fff750dddfdacb0abf92261adec02a88d7ea28"
+  integrity sha512-Thwomg2kLYOw2SclRzMveopNZ9sTH9VK5izlooB+0az1sGBcmOeOWXcyib5NTcmYqMWfJdZkEyL5//soJweNrA==
   dependencies:
-    "@angular-devkit/core" "9.0.0-next.11"
-    "@angular-devkit/schematics" "9.0.0-next.11"
+    "@angular-devkit/core" "9.0.0-next.14"
+    "@angular-devkit/schematics" "9.0.0-next.14"
     "@yarnpkg/lockfile" "1.1.0"
     ini "1.3.5"
     pacote "9.5.8"
@@ -934,10 +938,10 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.4.2.tgz#49f672de24043b3c1fb919901fd3cd36f027bc93"
   integrity sha512-SaSSGOzwUnBEn64c+HTyVTJhRf8F1CXZLnxYx2ww3UrgGBmEEw38RSux2l3fYiT9brVLP67DU5omWA6V9OHI5Q==
 
-"@types/jasmine@~2.8.8":
-  version "2.8.16"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.16.tgz#a6cb24b1149d65293bd616923500014838e14e7d"
-  integrity sha512-056oRlBBp7MDzr+HoU5su099s/s7wjZ3KcHxLfv+Byqb9MwdLUvsfLgw1VS97hsh3ddxSPyQu+olHMnoVTUY6g==
+"@types/jasmine@~3.4.0":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.4.4.tgz#be3fbd73e72725edb44e6f7f509cd52912d1550c"
+  integrity sha512-+/sHcTPyDS1JQacDRRRWb+vNrjBwnD+cKvTaWlxlJ/uOOFvzCkjOwNaqVjYMLfsjzNi0WtDH9RyReDXPG1Cdug==
 
 "@types/jasminewd2@~2.0.3":
   version "2.0.8"
@@ -1331,7 +1335,7 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-app-root-path@^2.1.0:
+app-root-path@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.2.1.tgz#d0df4a682ee408273583d43f6f79e9892624bc9a"
   integrity sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==
@@ -1366,12 +1370,25 @@ arg@2.0.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-2.0.0.tgz#c06e7ff69ab05b3a4a03ebe0407fac4cba657545"
   integrity sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==
 
+arg@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
+  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -1398,11 +1415,6 @@ array-flatten@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
-array-slice@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
-  integrity sha1-3Tz7gO15c6dRF82sabC5nshhhvU=
-
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -1414,11 +1426,6 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
-
-array-unique@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
-  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1474,6 +1481,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
@@ -1528,6 +1540,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axobject-query@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
+  integrity sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1758,13 +1777,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^0.1.2:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-0.1.5.tgz#c085711085291d8b75fdd74eab0f8597280711e6"
-  integrity sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=
-  dependencies:
-    expand-range "^0.1.0"
-
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -1781,7 +1793,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1852,7 +1864,16 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@4.7.0, browserslist@^4.6.0, browserslist@^4.6.6, browserslist@^4.7.0:
+browserslist@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.1.tgz#bd400d1aea56538580e8c4d5f1c54ac11b5ab468"
+  integrity sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==
+  dependencies:
+    caniuse-lite "^1.0.30000999"
+    electron-to-chromium "^1.3.284"
+    node-releases "^1.1.36"
+
+browserslist@^4.6.0, browserslist@^4.6.6, browserslist@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
   integrity sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==
@@ -1886,7 +1907,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@^1.0.0, buffer-from@^1.1.0:
+buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -2049,7 +2070,12 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@1.0.30000999, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30000999:
+caniuse-lite@1.0.30001002:
+  version "1.0.30001002"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz#ba999a737b1abd5bf0fd47efe43a09b9cadbe9b0"
+  integrity sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==
+
+caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30000999:
   version "1.0.30000999"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz#427253a69ad7bea4aa8d8345687b8eec51ca0e43"
   integrity sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==
@@ -2113,7 +2139,7 @@ chardet@^0.7.0:
   optionalDependencies:
     fsevents "~2.1.0"
 
-chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.1.1, chokidar@^2.1.8:
+chokidar@^2.0.2, chokidar@^2.1.1, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -2131,6 +2157,21 @@ chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.1.1, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.0.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.2.2.tgz#a433973350021e09f2b853a2287781022c0dc935"
+  integrity sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.2.0"
+  optionalDependencies:
+    fsevents "~2.1.1"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
@@ -2156,11 +2197,6 @@ circular-dependency-plugin@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz#e09dbc2dd3e2928442403e2d45b41cea06bc0a93"
   integrity sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw==
-
-circular-json@^0.5.5:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
-  integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2242,17 +2278,20 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codelyzer@~4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-4.5.0.tgz#a65ddeeeca2894653253a89bfa229118ff9f59b1"
-  integrity sha512-oO6vCkjqsVrEsmh58oNlnJkRXuA30hF8cdNAQV9DytEalDwyOFRvHMnlKFzmOStNerOmPGZU9GAHnBo4tGvtiQ==
+codelyzer@^5.1.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-5.2.0.tgz#b0ee573a12779c996090e596c5c1755479d83758"
+  integrity sha512-izfUfhEOOgAizszPlEDxo71DK/C4wprZw0vkY6UWcOSTQvN1JyfXf9DXwaV7WX+/JC+hH0ShXfdtGLA9Rca7LA==
   dependencies:
-    app-root-path "^2.1.0"
-    css-selector-tokenizer "^0.7.0"
+    app-root-path "^2.2.1"
+    aria-query "^3.0.0"
+    axobject-query "^2.0.2"
+    css-selector-tokenizer "^0.7.1"
     cssauron "^1.4.0"
+    damerau-levenshtein "^1.0.4"
     semver-dsl "^1.0.1"
     source-map "^0.5.7"
-    sprintf-js "^1.1.1"
+    sprintf-js "^1.1.2"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2284,13 +2323,6 @@ colors@^1.1.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combine-lists@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/combine-lists/-/combine-lists-1.0.1.tgz#458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6"
-  integrity sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=
-  dependencies:
-    lodash "^4.5.0"
-
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -2302,6 +2334,11 @@ commander@2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^2.11.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.1"
@@ -2500,12 +2537,12 @@ core-js-compat@^3.1.1:
     browserslist "^4.6.6"
     semver "^6.3.0"
 
-core-js@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.2.tgz#cd42da1d7b0bb33ef11326be3a721934277ceb42"
-  integrity sha512-S1FfZpeBchkhyoY76YAdFzKS4zz9aOK7EeFaNA2aJlyXyA+sgqz6xdxmLPGXEAf0nF44MVN1kSjrA9Kt3ATDQg==
+core-js@3.3.3, core-js@^3.1.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.3.tgz#b7048d3c6c1a52b5fe55a729c1d4ccdffe0891bb"
+  integrity sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow==
 
-core-js@^2.2.0, core-js@^2.4.0:
+core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -2603,7 +2640,7 @@ css-parse@~2.0.0:
   dependencies:
     css "^2.0.0"
 
-css-selector-tokenizer@^0.7.0:
+css-selector-tokenizer@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz#a177271a8bca5019172f4f891fc6eed9cbf68d5d"
   integrity sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==
@@ -2644,6 +2681,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+damerau-levenshtein@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz#780cf7144eb2e8dbd1c3bb83ae31100ccc31a414"
+  integrity sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2651,10 +2693,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-format@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-1.2.0.tgz#615e828e233dd1ab9bb9ae0950e0ceccfa6ecad8"
-  integrity sha1-YV6CjiM90aubua4JUODOzPpuytg=
+date-format@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
+  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -2854,10 +2896,15 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -2937,6 +2984,11 @@ electron-to-chromium@^1.3.247:
   version "1.3.277"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz#38b7b297f9b3f67ea900a965c1b11a555de526ec"
   integrity sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==
+
+electron-to-chromium@^1.3.284:
+  version "1.3.294"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.294.tgz#bf732e1c531395b81f508bfc2a0098c75e860142"
+  integrity sha512-PR6e84kZbW2iQW+jJI0cg500LHzhoi+LPsmOnvHlu41OLE0CTAx2vphJUzkRmX8bwZ85QlVvn0tb/D6QmqdZxQ==
 
 elliptic@^6.0.0:
   version "6.5.1"
@@ -3209,15 +3261,6 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expand-braces@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"
-  integrity sha1-SIsdHSRRyz06axks/AMPRMWFX+o=
-  dependencies:
-    array-slice "^0.2.3"
-    array-unique "^0.2.1"
-    braces "^0.1.2"
-
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -3230,14 +3273,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-expand-range@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-0.1.1.tgz#4cb8eda0993ca56fa4f41fc42f3cbb4ccadff044"
-  integrity sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=
-  dependencies:
-    is-number "^0.1.1"
-    repeat-string "^0.2.2"
 
 express@^4.17.1:
   version "4.17.1"
@@ -3524,12 +3559,14 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-access@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
-  integrity sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
-    null-check "^1.0.0"
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -3572,6 +3609,11 @@ fsevents@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.0.tgz#ce1a5f9ac71c6d75278b0c5bd236d7dfece4cbaa"
   integrity sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==
+
+fsevents@~2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.1.tgz#74c64e21df71721845d0c44fe54b7f56b82995a9"
+  integrity sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -3658,7 +3700,19 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.4, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
+  integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -3715,7 +3769,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
@@ -4295,11 +4349,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-number@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-0.1.1.tgz#69a7af116963d47206ec9bd9b48a14216f1e3806"
-  integrity sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -4400,6 +4449,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -4539,15 +4593,15 @@ istanbul-reports@^2.2.4:
   dependencies:
     handlebars "^4.1.2"
 
+jasmine-core@^3.3, jasmine-core@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
+  integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
+
 jasmine-core@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
   integrity sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=
-
-jasmine-core@~2.99.1:
-  version "2.99.1"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
-  integrity sha1-5kAN8ea1bhMLYcS80JPap/boyhU=
 
 jasmine-spec-reporter@~4.2.1:
   version "4.2.1"
@@ -4665,6 +4719,13 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -4690,33 +4751,32 @@ jszip@^3.1.3:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-karma-chrome-launcher@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
-  integrity sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==
+karma-chrome-launcher@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
+  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
   dependencies:
-    fs-access "^1.0.0"
     which "^1.2.1"
 
-karma-coverage-istanbul-reporter@~2.0.1:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-2.0.6.tgz#7b6e9c88781447bb87aa6ac24bf74b93e558adc3"
-  integrity sha512-WFh77RI8bMIKdOvI/1/IBmgnM+Q7NOLhnwG91QJrM8lW+CIXCjTzhhUsT/svLvAkLmR10uWY4RyYbHMLkTglvg==
+karma-coverage-istanbul-reporter@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-2.1.0.tgz#5f1bcc13c5e14ee1d91821ee8946861674f54c75"
+  integrity sha512-UH0mXPJFJyK5uiK7EkwGtQ8f30lCBAfqRResnZ4pzLJ04SOp4SPlYkmwbbZ6iVJ6sQFVzlDUXlntBEsLRdgZpg==
   dependencies:
     istanbul-api "^2.1.6"
     minimatch "^3.0.4"
 
-karma-jasmine-html-reporter@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.2.2.tgz#48a8e5ef18807617ee2b5e33c1194c35b439524c"
-  integrity sha1-SKjl7xiAdhfuK14zwRlMNbQ5Ukw=
-  dependencies:
-    karma-jasmine "^1.0.2"
+karma-jasmine-html-reporter@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.4.2.tgz#16d100fd701271192d27fd28ddc90b710ad36fff"
+  integrity sha512-7g0gPj8+9JepCNJR9WjDyQ2RkZ375jpdurYQyAYv8PorUCadepl8vrD6LmMqOGcM17cnrynBawQYZHaumgDjBw==
 
-karma-jasmine@^1.0.2, karma-jasmine@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-1.1.2.tgz#394f2b25ffb4a644b9ada6f22d443e2fd08886c3"
-  integrity sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=
+karma-jasmine@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-2.0.1.tgz#26e3e31f2faf272dd80ebb0e1898914cc3a19763"
+  integrity sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==
+  dependencies:
+    jasmine-core "^3.3"
 
 karma-source-map-support@1.4.0:
   version "1.4.0"
@@ -4725,28 +4785,27 @@ karma-source-map-support@1.4.0:
   dependencies:
     source-map-support "^0.5.5"
 
-karma@~3.1.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.4.tgz#3890ca9722b10d1d14b726e1335931455788499e"
-  integrity sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==
+karma@~4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-4.3.0.tgz#e14471ea090a952265a42ebb442b1a3c09832559"
+  integrity sha512-NSPViHOt+RW38oJklvYxQC4BSQsv737oQlr/r06pCM+slDOr4myuI1ivkRmp+3dVpJDfZt2DmaPJ2wkx+ZZuMQ==
   dependencies:
     bluebird "^3.3.0"
     body-parser "^1.16.1"
-    chokidar "^2.0.3"
+    braces "^3.0.2"
+    chokidar "^3.0.0"
     colors "^1.1.0"
-    combine-lists "^1.0.0"
     connect "^3.6.0"
-    core-js "^2.2.0"
+    core-js "^3.1.3"
     di "^0.0.1"
     dom-serialize "^2.2.0"
-    expand-braces "^0.1.1"
     flatted "^2.0.0"
     glob "^7.1.1"
     graceful-fs "^4.1.2"
     http-proxy "^1.13.0"
     isbinaryfile "^3.0.0"
-    lodash "^4.17.5"
-    log4js "^3.0.0"
+    lodash "^4.17.14"
+    log4js "^4.0.0"
     mime "^2.3.1"
     minimatch "^3.0.2"
     optimist "^0.6.1"
@@ -4879,21 +4938,21 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.5.0:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log4js@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-3.0.6.tgz#e6caced94967eeeb9ce399f9f8682a4b2b28c8ff"
-  integrity sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==
+log4js@^4.0.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-4.5.1.tgz#e543625e97d9e6f3e6e7c9fc196dd6ab2cae30b5"
+  integrity sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==
   dependencies:
-    circular-json "^0.5.5"
-    date-format "^1.2.0"
-    debug "^3.1.0"
-    rfdc "^1.1.2"
-    streamroller "0.7.0"
+    date-format "^2.0.0"
+    debug "^4.1.1"
+    flatted "^2.0.0"
+    rfdc "^1.1.4"
+    streamroller "^1.0.6"
 
 loglevel@^1.6.4:
   version "1.6.4"
@@ -5393,6 +5452,13 @@ node-releases@^1.1.29:
   dependencies:
     semver "^6.3.0"
 
+node-releases@^1.1.36:
+  version "1.1.38"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.38.tgz#d81b365df2936654ba37f509ba2fbe91eff2578b"
+  integrity sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==
+  dependencies:
+    semver "^6.3.0"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -5515,11 +5581,6 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-null-check@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
-  integrity sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=
-
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -5632,12 +5693,12 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
-  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+open@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.0.tgz#7e52999b14eb73f90f0f0807fe93897c4ae73ec9"
+  integrity sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==
   dependencies:
-    is-wsl "^1.1.0"
+    is-wsl "^2.1.0"
 
 opn@^5.5.0:
   version "5.5.0"
@@ -6315,7 +6376,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -6360,6 +6421,13 @@ readdirp@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.3.tgz#d6e011ed5b9240a92f08651eeb40f7942ceb6cc1"
   integrity sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==
+  dependencies:
+    picomatch "^2.0.4"
+
+readdirp@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
+  integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
   dependencies:
     picomatch "^2.0.4"
 
@@ -6482,11 +6550,6 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-0.2.2.tgz#c7a8d3236068362059a7e4651fc6884e8b1fb4ae"
-  integrity sha1-x6jTI2BoNiBZp+RlH8aITosftK4=
-
 repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
@@ -6592,10 +6655,17 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-rfdc@^1.1.2:
+rfdc@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
   integrity sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==
+
+rimraf@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
@@ -6612,10 +6682,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup@1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.24.0.tgz#0ace969508babb7a5fcb228e831e9c9a2873c2b0"
-  integrity sha512-PiFETY/rPwodQ8TTC52Nz2DSCYUATznGh/ChnxActCr8rV5FIk3afBUb3uxNritQW/Jpbdn3kq1Rwh1HHYMwdQ==
+rollup@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.25.1.tgz#905707d686dc8d7218af63dcfb9e37d1f3dc3c34"
+  integrity sha512-K8ytdEzMa6anHSnfTIs2BLB+NXlQ4qmWwdNHBpYQNWCbZAzj+DRVk7+ssbLSgddwpFW1nThr2GElR+jASF2NPA==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"
@@ -7171,7 +7241,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-sprintf-js@^1.1.1:
+sprintf-js@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
   integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
@@ -7256,15 +7326,16 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-streamroller@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-0.7.0.tgz#a1d1b7cf83d39afb0d63049a5acbf93493bdf64b"
-  integrity sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==
+streamroller@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-1.0.6.tgz#8167d8496ed9f19f05ee4b158d9611321b8cacd9"
+  integrity sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==
   dependencies:
-    date-format "^1.2.0"
-    debug "^3.1.0"
-    mkdirp "^0.5.1"
-    readable-stream "^2.3.0"
+    async "^2.6.2"
+    date-format "^2.0.0"
+    debug "^3.2.6"
+    fs-extra "^7.0.1"
+    lodash "^4.17.14"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -7490,19 +7561,19 @@ terser-webpack-plugin@^1.4.1:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@4.3.8, terser@^4.1.2:
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.8.tgz#707f05f3f4c1c70c840e626addfdb1c158a17136"
-  integrity sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==
+terser@4.3.9, terser@^4.3.8:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.9.tgz#e4be37f80553d02645668727777687dad26bbca8"
+  integrity sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^4.3.8:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.9.tgz#e4be37f80553d02645668727777687dad26bbca8"
-  integrity sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==
+terser@^4.1.2:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.8.tgz#707f05f3f4c1c70c840e626addfdb1c158a17136"
+  integrity sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -7622,19 +7693,16 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-node@~7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+ts-node@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
+  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
   dependencies:
-    arrify "^1.0.0"
-    buffer-from "^1.1.0"
-    diff "^3.1.0"
+    arg "^4.1.0"
+    diff "^4.0.1"
     make-error "^1.1.1"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
     source-map-support "^0.5.6"
-    yn "^2.0.0"
+    yn "^3.0.0"
 
 tslib@1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
@@ -7781,6 +7849,11 @@ universal-analytics@^0.4.20:
     debug "^3.0.0"
     request "^2.88.0"
     uuid "^3.0.0"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -8053,10 +8126,10 @@ webpack-subresource-integrity@1.3.4:
   dependencies:
     webpack-sources "^1.3.0"
 
-webpack@4.41.1:
-  version "4.41.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.1.tgz#5388dd3047d680d5d382a84249fd4750e87372fd"
-  integrity sha512-ak7u4tUu/U63sCVxA571IuPZO/Q0pZ9cEXKg+R/woxkDzVovq57uB6L2Hlg/pC8LCU+TWpvtcYwsstivQwMJmw==
+webpack@4.41.2:
+  version "4.41.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.2.tgz#c34ec76daa3a8468c9b61a50336d8e3303dce74e"
+  integrity sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"
@@ -8275,10 +8348,10 @@ yeast@0.1.2:
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
-yn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
-  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 "zone.js@file:../../node_modules/zone.js":
   version "0.10.2"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js",
     "test-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot --test_tag_filters=-no-ivy-aot,-fixme-ivy-aot",
+    "test-non-ivy": "bazel test --build_tag_filters=-ivy-only --test_tag_filters=-ivy-only",
     "test-fixme-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy-aot --test_tag_filters=-no-ivy-aot",
     "list-fixme-ivy-targets": "bazel query --output=label 'attr(\"tags\", \"\\[.*fixme-ivy.*\\]\", //...) except kind(\"sh_binary\", //...) except kind(\"devmode_js_sources\", //...)' | sort",
     "bazel": "bazel",

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -46,19 +46,27 @@ export function _localeFactory(locale?: string): string {
  * Work out the locale from the potential global properties.
  *
  * * Closure Compiler: use `goog.LOCALE`.
- *   Note: default `goog.LOCALE` value is `en`, while Angular used `en-US`.
- *   In order to preserve backwards compatibility, we use Angular default value over Closure
- *   Compiler's one.
  * * Ivy enabled: use `$localize.locale`
- *   Note: During compile time inlining of translations `$localize.locale` will be replaced with a
- *   string literal that is the current locale.
- *   In runtime translation evaluation, the developer is required to set `$localize.locale` if
- *   required, or just to provide their own `LOCALE_ID` provider.
  */
 export function getGlobalLocale(): string {
-  return (ngI18nClosureMode && typeof goog !== 'undefined' && goog.LOCALE !== 'en') ?
-      goog.LOCALE :
-      ((ivyEnabled && typeof $localize !== 'undefined' && $localize.locale) || DEFAULT_LOCALE_ID);
+  if (ngI18nClosureMode && typeof goog !== 'undefined' && goog.LOCALE !== 'en') {
+    // * The default `goog.LOCALE` value is `en`, while Angular used `en-US`.
+    // * In order to preserve backwards compatibility, we use Angular default value over
+    //   Closure Compiler's one.
+    return goog.LOCALE;
+  } else {
+    // KEEP `typeof $localize !== 'undefined' && $localize.locale` IN SYNC WITH THE LOCALIZE
+    // COMPILE-TIME INLINER.
+    //
+    // * During compile time inlining of translations the expression will be replaced
+    //   with a string literal that is the current locale. Other forms of this expression are not
+    //   guaranteed to be replaced.
+    //
+    // * During runtime translation evaluation, the developer is required to set `$localize.locale`
+    //   if required, or just to provide their own `LOCALE_ID` provider.
+    return (ivyEnabled && typeof $localize !== 'undefined' && $localize.locale) ||
+        DEFAULT_LOCALE_ID;
+  }
 }
 
 /**

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -24,6 +24,8 @@ import {SCHEDULER} from './render3/component_ref';
 import {setLocaleId} from './render3/i18n';
 import {NgZone} from './zone';
 
+declare const $localize: {locale?: string};
+
 export function _iterableDiffersFactory() {
   return defaultIterableDiffers;
 }
@@ -33,22 +35,30 @@ export function _keyValueDiffersFactory() {
 }
 
 export function _localeFactory(locale?: string): string {
-  if (locale) {
-    if (ivyEnabled) {
-      setLocaleId(locale);
-    }
-    return locale;
+  locale = locale || getGlobalLocale();
+  if (ivyEnabled) {
+    setLocaleId(locale);
   }
-  // Use `goog.LOCALE` as default value for `LOCALE_ID` token for Closure Compiler.
-  // Note: default `goog.LOCALE` value is `en`, when Angular used `en-US`. In order to preserve
-  // backwards compatibility, we use Angular default value over Closure Compiler's one.
-  if (ngI18nClosureMode && typeof goog !== 'undefined' && goog.LOCALE !== 'en') {
-    if (ivyEnabled) {
-      setLocaleId(goog.LOCALE);
-    }
-    return goog.LOCALE;
-  }
-  return DEFAULT_LOCALE_ID;
+  return locale;
+}
+
+/**
+ * Work out the locale from the potential global properties.
+ *
+ * * Closure Compiler: use `goog.LOCALE`.
+ *   Note: default `goog.LOCALE` value is `en`, while Angular used `en-US`.
+ *   In order to preserve backwards compatibility, we use Angular default value over Closure
+ *   Compiler's one.
+ * * Ivy enabled: use `$localize.locale`
+ *   Note: During compile time inlining of translations `$localize.locale` will be replaced with a
+ *   string literal that is the current locale.
+ *   In runtime translation evaluation, the developer is required to set `$localize.locale` if
+ *   required, or just to provide their own `LOCALE_ID` provider.
+ */
+export function getGlobalLocale(): string {
+  return (ngI18nClosureMode && typeof goog !== 'undefined' && goog.LOCALE !== 'en') ?
+      goog.LOCALE :
+      ((ivyEnabled && typeof $localize !== 'undefined' && $localize.locale) || DEFAULT_LOCALE_ID);
 }
 
 /**

--- a/packages/localize/src/localize/src/localize.ts
+++ b/packages/localize/src/localize/src/localize.ts
@@ -22,15 +22,15 @@ export interface LocalizeFn {
   translate?: TranslateFn;
   /**
    * The current locale of the translated messages.
-   * 
+   *
    * The compile-time translation inliner is able to replace the following code:
-   * 
+   *
    * ```
-   * $localize && $localize.locale
+   * typeof $localize !== "undefined" && $localize.locale
    * ```
-   * 
+   *
    * with a string literal of the current locale. E.g.
-   * 
+   *
    * ```
    * "fr"
    * ```

--- a/packages/localize/src/localize/src/localize.ts
+++ b/packages/localize/src/localize/src/localize.ts
@@ -20,6 +20,22 @@ export interface LocalizeFn {
    * different translations.
    */
   translate?: TranslateFn;
+  /**
+   * The current locale of the translated messages.
+   * 
+   * The compile-time translation inliner is able to replace the following code:
+   * 
+   * ```
+   * $localize && $localize.locale
+   * ```
+   * 
+   * with a string literal of the current locale. E.g.
+   * 
+   * ```
+   * "fr"
+   * ```
+   */
+  locale?: string;
 }
 
 export interface TranslateFn {

--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -9,7 +9,7 @@ import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
 import {Diagnostics} from '../../diagnostics';
-import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isGlobalIdentifier, isNamedIdentifier, translate, unwrapMessagePartsFromTemplateLiteral} from './source_file_utils';
+import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromTemplateLiteral} from './source_file_utils';
 
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
@@ -20,7 +20,7 @@ export function makeEs2015TranslatePlugin(
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>) {
         try {
           const tag = path.get('tag');
-          if (isNamedIdentifier(tag, localizeName) && isGlobalIdentifier(tag)) {
+          if (isLocalize(tag, localizeName)) {
             const messageParts = unwrapMessagePartsFromTemplateLiteral(path.node.quasi.quasis);
             const translated = translate(
                 diagnostics, translations, messageParts, path.node.quasi.expressions,

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -9,7 +9,7 @@ import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
 import {Diagnostics} from '../../diagnostics';
-import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isGlobalIdentifier, isNamedIdentifier, translate, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from './source_file_utils';
+import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from './source_file_utils';
 
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
@@ -20,7 +20,7 @@ export function makeEs5TranslatePlugin(
       CallExpression(callPath: NodePath<CallExpression>) {
         try {
           const calleePath = callPath.get('callee');
-          if (isNamedIdentifier(calleePath, localizeName) && isGlobalIdentifier(calleePath)) {
+          if (isLocalize(calleePath, localizeName)) {
             const messageParts = unwrapMessagePartsFromLocalizeCall(callPath);
             const expressions = unwrapSubstitutionsFromLocalizeCall(callPath.node);
             const translated =

--- a/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {NodePath, PluginObj} from '@babel/core';
+import {LogicalExpression, MemberExpression, stringLiteral} from '@babel/types';
+
+import {TranslatePluginOptions, isLocalize} from './source_file_utils';
+
+/**
+ * This Babel plugin will replace the following code forms with a string literal containing the
+ * given `locale`.
+ *
+ * * `$localize.locale`                                            -> `"locale"`
+ * * `typeof $localize !== "undefined" && $localize.locale`        -> `"locale"`
+ * * `xxx && typeof $localize !== "undefined" && $localize.locale` -> `"xxx && locale"`
+ * * `$localize.locale || default`                                 -> `"locale" || default`
+ *
+ * @param locale The name of the locale to inline into the code.
+ * @param options Additional options including the name of the `$localize` function.
+ */
+export function makeLocalePlugin(
+    locale: string, {localizeName = '$localize'}: TranslatePluginOptions = {}): PluginObj {
+  return {
+    visitor: {
+      MemberExpression(expression: NodePath<MemberExpression>) {
+        const obj = expression.get('object');
+        if (!isLocalize(obj, localizeName)) {
+          return;
+        }
+        const property = expression.get('property') as NodePath;
+        if (!property.isIdentifier({name: 'locale'})) {
+          return;
+        }
+        // Check for the `$localize.locale` being guarded by a check on the existence of
+        // `$localize`.
+        const parent = expression.parentPath;
+        if (parent.isLogicalExpression({operator: '&&'}) && parent.get('right') === expression) {
+          const left = parent.get('left');
+          if (isLocalizeGuard(left, localizeName)) {
+            // Replace `typeof $localize !== "undefined" && $localize.locale` with
+            // `$localize.locale`
+            parent.replaceWith(expression);
+          } else if (
+              left.isLogicalExpression({operator: '&&'}) &&
+              isLocalizeGuard(left.get('right'), localizeName)) {
+            // The `$localize` is part of a preceding logical AND.
+            // Replace XXX && typeof $localize !== "undefined" && $localize.locale` with `XXX &&
+            // $localize.locale`
+            left.replaceWith(left.get('left'));
+          }
+        }
+
+        // Replace the `$localize.locale` with the string literal
+        expression.replaceWith(stringLiteral(locale));
+      }
+    }
+  };
+}
+
+/**
+ * Returns true if the expression one of:
+ * * `typeof $localize !== "undefined"`
+ * * `"undefined" !== typeof $localize`
+ * * `typeof $localize != "undefined"`
+ * * `"undefined" != typeof $localize`
+ *
+ * @param expression the expression to check
+ * @param localizeName the name of the `$localize` symbol
+ */
+function isLocalizeGuard(expression: NodePath, localizeName: string): boolean {
+  if (!expression.isBinaryExpression() ||
+      !(expression.node.operator === '!==' || expression.node.operator === '!=')) {
+    return false;
+  }
+  const left = expression.get('left');
+  const right = expression.get('right');
+
+  return (left.isUnaryExpression({operator: 'typeof'}) &&
+          isLocalize(left.get('argument'), localizeName) &&
+          right.isStringLiteral({value: 'undefined'})) ||
+      (right.isUnaryExpression({operator: 'typeof'}) &&
+       isLocalize(right.get('argument'), localizeName) &&
+       left.isStringLiteral({value: 'undefined'}));
+}

--- a/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {NodePath, PluginObj} from '@babel/core';
-import {LogicalExpression, MemberExpression, stringLiteral} from '@babel/types';
+import {MemberExpression, stringLiteral} from '@babel/types';
 
 import {TranslatePluginOptions, isLocalize} from './source_file_utils';
 
@@ -35,6 +35,10 @@ export function makeLocalePlugin(
         if (!property.isIdentifier({name: 'locale'})) {
           return;
         }
+        if (expression.parentPath.isAssignmentExpression() &&
+            expression.parentPath.get('left') === expression) {
+          return;
+        }
         // Check for the `$localize.locale` being guarded by a check on the existence of
         // `$localize`.
         const parent = expression.parentPath;
@@ -53,7 +57,6 @@ export function makeLocalePlugin(
             left.replaceWith(left.get('left'));
           }
         }
-
         // Replace the `$localize.locale` with the string literal
         expression.replaceWith(stringLiteral(locale));
       }

--- a/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
@@ -17,7 +17,9 @@ import {TranslationBundle, TranslationHandler} from '../translator';
 
 import {makeEs2015TranslatePlugin} from './es2015_translate_plugin';
 import {makeEs5TranslatePlugin} from './es5_translate_plugin';
+import {makeLocalePlugin} from './locale_plugin';
 import {TranslatePluginOptions} from './source_file_utils';
+
 
 
 /**
@@ -76,6 +78,7 @@ export class SourceFileTranslationHandler implements TranslationHandler {
       compact: true,
       generatorOpts: {minified: true},
       plugins: [
+        makeLocalePlugin(translationBundle.locale),
         makeEs2015TranslatePlugin(diagnostics, translationBundle.translations, options),
         makeEs5TranslatePlugin(diagnostics, translationBundle.translations, options),
       ],

--- a/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
@@ -11,8 +11,21 @@ import * as t from '@babel/types';
 import {Diagnostics} from '../../diagnostics';
 
 /**
- * Is the given `expression` an identifier with the correct name
+ * Is the given `expression` the global `$localize` identifier?
+ *
  * @param expression The expression to check.
+ * @param localizeName The configured name of `$localize`.
+ */
+export function isLocalize(
+    expression: NodePath, localizeName: string): expression is NodePath<t.Identifier> {
+  return isNamedIdentifier(expression, localizeName) && isGlobalIdentifier(expression);
+}
+
+/**
+ * Is the given `expression` an identifier with the correct `name`?
+ *
+ * @param expression The expression to check.
+ * @param name The name of the identifier we are looking for.
  */
 export function isNamedIdentifier(
     expression: NodePath, name: string): expression is NodePath<t.Identifier> {

--- a/packages/localize/src/tools/test/translate/source_files/locale_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/locale_plugin_spec.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {transformSync} from '@babel/core';
+import {makeLocalePlugin} from '../../../src/translate/source_files/locale_plugin';
+
+describe('makeLocalePlugin', () => {
+  it('should replace $localize.locale with the locale string', () => {
+    const input = '$localize.locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('"fr";');
+  });
+
+  it('should replace $localize.locale with the locale string in the context of a variable assignment',
+     () => {
+       const input = 'const a = $localize.locale;';
+       const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output.code).toEqual('const a = "fr";');
+     });
+
+  it('should replace $localize.locale with the locale string in the context of a binary expression',
+     () => {
+       const input = '$localize.locale || "default";';
+       const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output.code).toEqual('"fr" || "default";');
+     });
+
+  it('should remove reference to `$localize` if used to guard the locale', () => {
+    const input = 'typeof $localize !== "undefined" && $localize.locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('"fr";');
+  });
+
+  it('should remove reference to `$localize` if used in a longer logical expression to guard the locale',
+     () => {
+       const input1 = 'x || y && typeof $localize !== "undefined" && $localize.locale;';
+       const output1 = transformSync(input1, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output1.code).toEqual('x || y && "fr";');
+
+       const input2 = 'x || y && "undefined" !== typeof $localize && $localize.locale;';
+       const output2 = transformSync(input2, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output2.code).toEqual('x || y && "fr";');
+
+       const input3 = 'x || y && typeof $localize != "undefined" && $localize.locale;';
+       const output3 = transformSync(input3, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output3.code).toEqual('x || y && "fr";');
+
+       const input4 = 'x || y && "undefined" != typeof $localize && $localize.locale;';
+       const output4 = transformSync(input4, {plugins: [makeLocalePlugin('fr')]}) !;
+       expect(output4.code).toEqual('x || y && "fr";');
+     });
+
+  it('should ignore properties on $localize other than `locale`', () => {
+    const input = '$localize.notLocale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('$localize.notLocale;');
+  });
+
+  it('should ignore indexed property on $localize', () => {
+    const input = '$localize["locale"];';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('$localize["locale"];');
+  });
+
+  it('should ignore `locale` on objects other than $localize', () => {
+    const input = '$notLocalize.locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('$notLocalize.locale;');
+  });
+
+  it('should ignore `$localize.locale` if `$localize` is not global', () => {
+    const input = 'const $localize = {};\n$localize.locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('const $localize = {};\n$localize.locale;');
+  });
+
+  it('should ignore `locale` if it is not directly accessed from `$localize`', () => {
+    const input = 'const {locale} = $localize;\nconst a = locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('const {\n  locale\n} = $localize;\nconst a = locale;');
+  });
+});

--- a/packages/localize/src/tools/test/translate/source_files/locale_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/locale_plugin_spec.ts
@@ -83,4 +83,16 @@ describe('makeLocalePlugin', () => {
     const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
     expect(output.code).toEqual('const {\n  locale\n} = $localize;\nconst a = locale;');
   });
+
+  it('should ignore `$localize.locale` on LHS of an assignment', () => {
+    const input = 'let a;\na = $localize.locale = "de";';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('let a;\na = $localize.locale = "de";');
+  });
+
+  it('should handle `$localize.locale on RHS of an assignment', () => {
+    const input = 'let a;\na = $localize.locale;';
+    const output = transformSync(input, {plugins: [makeLocalePlugin('fr')]}) !;
+    expect(output.code).toEqual('let a;\na = "fr";');
+  });
 });


### PR DESCRIPTION
The ivy compile time inlining tools work on the code after it has
been compiled and bundled (potentially minified and mangled).
It is only at this point in the processing that the current locale
can be specified.

// FW-1639

See https://github.com/angular/angular-cli/issues/15896
