### PR TITLE
perf(ivy): improve styling performance

### DIFF
--- a/packages/core/src/render3/util/styling_utils.ts
+++ b/packages/core/src/render3/util/styling_utils.ts
@@ -414,10 +414,8 @@ export function normalizeIntoStylingMap(
   let map: {[key: string]: any}|undefined|null;
   let allValuesTrue = false;
   if (typeof newValues === 'string') {  // [class] bindings allow string values
-    if (newValues.length) {
-      props = newValues.split(/\s+/);
-      allValuesTrue = true;
-    }
+    props = splitOnWhitespace(newValues);
+    allValuesTrue = props !== null;
   } else {
     props = newValues ? Object.keys(newValues) : null;
     map = newValues;
@@ -433,6 +431,32 @@ export function normalizeIntoStylingMap(
   }
 
   return stylingMapArr;
+}
+
+function splitOnWhitespace(text: string): string[]|null {
+  let array: string[]|null = null;
+  let length = text.length;
+  let start = 0;
+  let foundChar = false;
+  for (let i = 0; i < length; i++) {
+    const char = text.charCodeAt(i);
+    if (char === 32 /*' '*/) {
+      if (foundChar) {
+        if (array === null) array = [];
+        array.push(text.substring(start, i));
+        foundChar = false;
+      }
+      start = i + 1;
+    } else {
+      foundChar = true
+    }
+  }
+  if (foundChar) {
+    if (array === null) array = [];
+    array.push(text.substring(start, length));
+    foundChar = false;
+  }
+  return array;
 }
 
 // TODO (matsko|AndrewKushnir): refactor this once we figure out how to generate separate

--- a/packages/core/src/render3/util/styling_utils.ts
+++ b/packages/core/src/render3/util/styling_utils.ts
@@ -433,14 +433,14 @@ export function normalizeIntoStylingMap(
   return stylingMapArr;
 }
 
-function splitOnWhitespace(text: string): string[]|null {
+export function splitOnWhitespace(text: string): string[]|null {
   let array: string[]|null = null;
   let length = text.length;
   let start = 0;
   let foundChar = false;
   for (let i = 0; i < length; i++) {
     const char = text.charCodeAt(i);
-    if (char === 32 /*' '*/) {
+    if (char <= 32 /*' '*/) {
       if (foundChar) {
         if (array === null) array = [];
         array.push(text.substring(start, i));
@@ -448,7 +448,7 @@ function splitOnWhitespace(text: string): string[]|null {
       }
       start = i + 1;
     } else {
-      foundChar = true
+      foundChar = true;
     }
   }
   if (foundChar) {

--- a/packages/core/test/render3/util/styling_utils_spec.ts
+++ b/packages/core/test/render3/util/styling_utils_spec.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {splitOnWhitespace} from '@angular/core/src/render3/util/styling_utils';
+
+describe('styling_utils', () => {
+  describe('splitOnWhitespace', () => {
+    it('should treat empty strings as null', () => {
+      expect(splitOnWhitespace('')).toEqual(null);
+      expect(splitOnWhitespace('  ')).toEqual(null);
+      expect(splitOnWhitespace(' \n\r\t ')).toEqual(null);
+    });
+
+    it('should split strings into parts', () => {
+      expect(splitOnWhitespace('a\nb\rc')).toEqual(['a', 'b', 'c']);
+      expect(splitOnWhitespace('\ta-long\nb-long\rc-long ')).toEqual([
+        'a-long', 'b-long', 'c-long'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
change the existing implementation from using

```
string.split(/\s+/);
```

to a char scan which performers the same thing.

The reason why `split(/\s+/)` is slow is that:
- `/\s+/` allocates new `RegExp` every time this code executes.
- `RegExp` scans are a lot more expensive because they are more powerful.

