### PR TITLE
build: update zone.js to use the new rollup_bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@bazel/jasmine": "0.40.0",
     "@bazel/karma": "0.40.0",
     "@bazel/protractor": "0.40.0",
+    "@bazel/rollup": "0.40.0",
     "@bazel/terser": "0.40.0",
     "@bazel/typescript": "0.40.0",
     "@microsoft/api-extractor": "^7.3.9",

--- a/packages/zone.js/BUILD.bazel
+++ b/packages/zone.js/BUILD.bazel
@@ -3,6 +3,8 @@ load("//packages/zone.js:bundles.bzl", "ES2015_BUNDLES", "ES5_BUNDLES", "ES5_GLO
 
 exports_files([
     "tsconfig.json",
+    "rollup-es5.config.js",
+    "rollup-es5_global-es2015.config.js",
 ])
 
 genrule(

--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -21,13 +21,12 @@ genrule(
 [
     rollup_bundle(
         name = b[0].replace("-", "_") + "_rollup",
+        config_file = "//packages/zone.js:rollup-es5.config.js",
         entry_point = b[1] + ".ts",
-        globals = {
-            "electron": "electron",
-        },
-        license_banner = "//packages:license-banner.txt",
         deps = [
             "//packages/zone.js/lib",
+            "@npm//rollup-plugin-commonjs",
+            "@npm//rollup-plugin-node-resolve",
         ],
     )
     for b in ES5_BUNDLES.items()
@@ -36,54 +35,15 @@ genrule(
 [
     rollup_bundle(
         name = b[0].replace("-", "_") + "_rollup",
+        config_file = "//packages/zone.js:rollup-es5_global-es2015.config.js",
         entry_point = b[1] + ".ts",
-        global_name = "Zone",
-        license_banner = "//packages:license-banner.txt",
         deps = [
             "//packages/zone.js/lib",
+            "@npm//rollup-plugin-commonjs",
+            "@npm//rollup-plugin-node-resolve",
         ],
     )
     for b in ES5_GLOBAL_BUNDLES.items() + ES2015_BUNDLES.items()
-]
-
-# the es5 filegroups
-[
-    filegroup(
-        name = b[0] + ".es5",
-        srcs = [":" + b[0].replace("-", "_") + "_rollup"],
-        output_group = "es5_umd",
-    )
-    for b in ES5_BUNDLES.items() + ES5_GLOBAL_BUNDLES.items()
-]
-
-# the es5.min filegroups
-[
-    filegroup(
-        name = b[0] + ".es5.min",
-        srcs = [":" + b[0].replace("-", "_") + "_rollup"],
-        output_group = "es5_umd_min",
-    )
-    for b in ES5_BUNDLES.items() + ES5_GLOBAL_BUNDLES.items()
-]
-
-# the es2015 filegroups
-[
-    filegroup(
-        name = b[0] + ".umd",
-        srcs = [":" + b[0].replace("-", "_") + "_rollup"],
-        output_group = "umd",
-    )
-    for b in ES2015_BUNDLES.items()
-]
-
-# the es2015.min filegroups
-[
-    filegroup(
-        name = b[0] + ".umd.min",
-        srcs = [":" + b[0].replace("-", "_") + "_rollup"],
-        output_group = "umd_min",
-    )
-    for b in ES2015_BUNDLES.items()
 ]
 
 # Extract and rename each es5 bundle to a .js and .min.js in the dist/ dir
@@ -91,8 +51,8 @@ genrule(
     genrule(
         name = b[0] + "-dist",
         srcs = [
-            b[0] + ".es5",
-            b[0] + ".es5.min",
+            b[0].replace("-", "_") + "_rollup.es5umd.js",
+            b[0].replace("-", "_") + "_rollup.min.es5umd.js",
         ],
         outs = [
             b[0] + ".js",
@@ -114,7 +74,7 @@ genrule(
     genrule(
         name = b[0] + "-dist-dev-test",
         srcs = [
-            b[0] + ".es5",
+            b[0].replace("-", "_") + "_rollup.es5umd.js",
         ],
         outs = [
             b[0] + ".dev.test.js",
@@ -131,7 +91,7 @@ genrule(
     genrule(
         name = b + "-dist-dev-test",
         srcs = [
-            b + ".umd",
+            b.replace("-", "_") + "_rollup.umd.js",
         ],
         outs = [
             b + ".dev.test.js",
@@ -149,7 +109,7 @@ genrule(
     genrule(
         name = b[0] + "-dist-test",
         srcs = [
-            b[0] + ".es5.min",
+            b[0].replace("-", "_") + "_rollup.min.es5umd.js",
         ],
         outs = [
             b[0] + ".test.min.js",
@@ -167,8 +127,8 @@ genrule(
     genrule(
         name = b + "-dist",
         srcs = [
-            b + ".umd",
-            b + ".umd.min",
+            b.replace("-", "_") + "_rollup.umd.js",
+            b.replace("-", "_") + "_rollup.min.umd.js",
         ],
         outs = [
             b + ".js",
@@ -190,7 +150,7 @@ genrule(
     genrule(
         name = b + "-dist-test",
         srcs = [
-            b + ".umd.min",
+            b.replace("-", "_") + "_rollup.min.umd.js",
         ],
         outs = [
             b + ".test.min.js",

--- a/packages/zone.js/rollup-es5.config.js
+++ b/packages/zone.js/rollup-es5.config.js
@@ -1,0 +1,19 @@
+const node = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+
+const banner = `/**
+* @license Angular v0.0.0-PLACEHOLDER
+* (c) 2010-2019 Google LLC. https://angular.io/
+* License: MIT
+*/`;
+
+module.exports = {
+  plugins: [
+    node({
+      mainFields: ['es2015', 'module', 'jsnext:main', 'main'],
+    }),
+    commonjs(),
+  ],
+  external: ['electron'],
+  output: {globals: {electron: 'electron'}, banner},
+}

--- a/packages/zone.js/rollup-es5.config.js
+++ b/packages/zone.js/rollup-es5.config.js
@@ -1,8 +1,21 @@
 const node = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 
+// Parse the stamp file produced by Bazel from the version control system
+let version = '<unknown>';
+if (bazel_stamp_file) {
+  const versionTag = require('fs')
+                         .readFileSync(bazel_stamp_file, {encoding: 'utf-8'})
+                         .split('\n')
+                         .find(s => s.startsWith('BUILD_SCM_VERSION'));
+  // Don't assume BUILD_SCM_VERSION exists
+  if (versionTag) {
+    version = versionTag.split(' ')[1].trim();
+  }
+}
+
 const banner = `/**
-* @license Angular v0.0.0-PLACEHOLDER
+* @license Angular v${version}
 * (c) 2010-2019 Google LLC. https://angular.io/
 * License: MIT
 */`;

--- a/packages/zone.js/rollup-es5_global-es2015.config.js
+++ b/packages/zone.js/rollup-es5_global-es2015.config.js
@@ -1,0 +1,18 @@
+const node = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+
+const banner = `/**
+* @license Angular v0.0.0-PLACEHOLDER
+* (c) 2010-2019 Google LLC. https://angular.io/
+* License: MIT
+*/`;
+
+module.exports = {
+  plugins: [
+    node({
+      mainFields: ['es2015', 'module', 'jsnext:main', 'main'],
+    }),
+    commonjs(),
+  ],
+  output: {name: 'Zone', banner},
+}

--- a/packages/zone.js/rollup-es5_global-es2015.config.js
+++ b/packages/zone.js/rollup-es5_global-es2015.config.js
@@ -1,8 +1,21 @@
 const node = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 
+// Parse the stamp file produced by Bazel from the version control system
+let version = '<unknown>';
+if (bazel_stamp_file) {
+  const versionTag = require('fs')
+                         .readFileSync(bazel_stamp_file, {encoding: 'utf-8'})
+                         .split('\n')
+                         .find(s => s.startsWith('BUILD_SCM_VERSION'));
+  // Don't assume BUILD_SCM_VERSION exists
+  if (versionTag) {
+    version = versionTag.split(' ')[1].trim();
+  }
+}
+
 const banner = `/**
-* @license Angular v0.0.0-PLACEHOLDER
+* @license Angular v${version}
 * (c) 2010-2019 Google LLC. https://angular.io/
 * License: MIT
 */`;

--- a/packages/zone.js/test/karma_test.bzl
+++ b/packages/zone.js/test/karma_test.bzl
@@ -14,19 +14,15 @@ def karma_test_prepare(name, env_srcs, env_deps, env_entry_point, test_srcs, tes
         entry_point = env_entry_point,
         deps = [
             ":" + name + "_env",
+            "@npm//rollup-plugin-commonjs",
+            "@npm//rollup-plugin-node-resolve",
         ],
-    )
-    native.filegroup(
-        name = name + "_env_rollup.es5",
-        testonly = True,
-        srcs = [":" + name + "_env_rollup"],
-        output_group = "umd",
     )
     native.genrule(
         name = name + "_env_trim_map",
         testonly = True,
         srcs = [
-            ":" + name + "_env_rollup.es5",
+            ":" + name + "_env_rollup.umd",
         ],
         outs = [
             name + "_env_rollup_trim_map.js",
@@ -45,24 +41,18 @@ def karma_test_prepare(name, env_srcs, env_deps, env_entry_point, test_srcs, tes
         name = name + "_rollup",
         testonly = True,
         entry_point = test_entry_point,
-        globals = {
-            "electron": "electron",
-        },
+        config_file = "//packages/zone.js:rollup-es5.config.js",
         deps = [
             ":" + name + "_test",
+            "@npm//rollup-plugin-commonjs",
+            "@npm//rollup-plugin-node-resolve",
         ],
-    )
-    native.filegroup(
-        name = name + "_rollup.es5",
-        testonly = True,
-        srcs = [":" + name + "_rollup"],
-        output_group = "umd",
     )
     native.genrule(
         name = name + "_trim_map",
         testonly = True,
         srcs = [
-            ":" + name + "_rollup.es5",
+            ":" + name + "_rollup.umd",
         ],
         outs = [
             name + "_rollup_trim_map.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,6 +315,11 @@
   dependencies:
     protractor "^5.4.2"
 
+"@bazel/rollup@0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@bazel/rollup/-/rollup-0.40.0.tgz#8ee08e1967c1ff7d549ce81b676872fa7e45afdb"
+  integrity sha512-7ZKzOIfHm0lEc3G/o2ykCZQlc7xcKSHiwIV4GIeaYJIbFUnO/L0cmaWzxOhdlr7NFfTdXcltTFnCrG7wlaad9A==
+
 "@bazel/terser@0.40.0":
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/@bazel/terser/-/terser-0.40.0.tgz#e31c76c32055a6bdffc711b05b530ae8df7ed1d5"


### PR DESCRIPTION
This switches the zone.js build to use the new nodejs `rollup_bundle` and `terser_minifed` rules and downlevel with the auto-generated `tsc` rule.