### PR TITLE
fix(bazel): remove deprecated ng_setup_workspace() function

### DIFF
--- a/packages/bazel/index.bzl
+++ b/packages/bazel/index.bzl
@@ -14,10 +14,3 @@ ng_module = _ng_module
 ng_package = _ng_package
 # DO NOT ADD PUBLIC API without including in the documentation generation
 # Run `yarn bazel build //packages/bazel/docs` to verify
-
-def ng_setup_workspace():
-    print("""DEPRECATION WARNING:
-    ng_setup_workspace is no longer needed, and will be removed in a future release.
-    We assume you will fetch rules_nodejs in your WORKSPACE file, and no other dependencies remain here.
-    Simply remove any calls to this function and the corresponding load statement.
-    """)


### PR DESCRIPTION
This should be removed before for 9.0.0 rc

BREAKING CHANGE:
@angular/bazel ng_setup_workspace() is no longer needed and has been removed.
We assume you will fetch rules_nodejs in your WORKSPACE file, and no other dependencies remain here.
Simply remove any calls to this function and the corresponding load statement.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:

Removing deprecated function from @angular/bazel

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


@angular/bazel ng_setup_workspace() is no longer needed and has been removed.
We assume you will fetch rules_nodejs in your WORKSPACE file, and no other dependencies remain here.
Simply remove any calls to this function and the corresponding load statement.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
