### PR TITLE
docs: fix selector in getting started guide

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -269,7 +269,7 @@ The next step is to create a new alert feature that takes a product as an input.
 
     1. Open `product-list.component.html`.
 
-    1. To include the new component, use its selector, `app-product-alert`, as you would an HTML element.
+    1. To include the new component, use its selector, `app-product-alerts`, as you would an HTML element.
 
     1. Pass the current product as input to the component using property binding.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The instructions refer to the component's selector as `app-product-alert` in one place, when all other references are written `app-product-alerts` (plural).


## What is the new behavior?
The selector name referenced in the instructions matches the code samples (`app-product-alerts`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
N/A