### PR TITLE
docs: add migrating to version 9 guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -888,6 +888,7 @@ testing/**                                                      @angular/fw-test
 /aio/content/guide/migration-localize.md                        @angular/fw-docs-packaging @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/migration-module-with-providers.md           @angular/fw-docs-packaging @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/migration-ngcc.md                            @angular/fw-docs-packaging @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/updating-to-version-9.md                     @angular/fw-docs-packaging @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
 # ================================================

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -380,45 +380,6 @@ export class MyModule {
 }
 ```
 
-
-## Angular version 9 schematics
-
-{@a renderer-to-renderer2}
-### Migrating from `Renderer` to `Renderer2`
-
-See the [dedicated migration guide for Renderer](guide/migration-renderer).
-
-{@a undecorated-classes}
-### Migrating undecorated classes
-
-See the [dedicated migration guide for undecorated classes](guide/migration-undecorated-classes).
-
-{@a injectable}
-### Adding missing `@Injectable()` decorators
-
-See the [dedicated migration guide for adding missing `@Injectable` decorators](guide/migration-injectable).
-
-{@a flag-migration}
-### Migrating dynamic queries
-
- See the [dedicated migration guide for dynamic queries](guide/migration-dynamic-flag).
-
-{@a localize-migration}
-### Migrating to the new `$localize` i18n support
-
- See the [dedicated migration guide for `$localize`](guide/migration-localize).
-
-{@a module-with-providers}
-### Migrating `ModuleWithProviders`
-
- See the [dedicated migration guide for `ModuleWithProviders`](guide/migration-module-with-providers).
-{@a ngcc-migration}
-### Migrating to `ngcc` npm `postinstall` script
-
- See the [dedicated migration guide for `ngcc` npm `postinstall` script](guide/migration-ngcc).
-
-
-
 {@a removed}
 ## Removed APIs
 

--- a/aio/content/guide/migrating-to-version-9.md
+++ b/aio/content/guide/migrating-to-version-9.md
@@ -1,0 +1,43 @@
+# Migrating to Angular Version 9 
+
+This guide contains everything you need to know about migrating to the next Angular version.
+
+## Version 9 Schematics
+
+If your application uses the CLI, you can upgrade to version 9 automatically with the help of the `ng update` script. 
+The script will run a series of small migrations that will transform the code of your application to be compatible with version 9.
+ 
+If you're curious about the specific migrations being run (e.g. what code is changing and why), the guides below provide more context on each change and contain FAQs for common questions.
+
+- [Migrating from `Renderer` to `Renderer2`](guide/migration-renderer)
+- [Migrating undecorated classes](guide/migration-undecorated-classes)
+- [Migrating missing `@Injectable()` decorators](guide/migration-injectable)
+- [Migrating dynamic queries](guide/migration-dynamic-flag)
+- [Migrating to the new `$localize` i18n support](guide/migration-localize)
+- [Migrating `ModuleWithProviders`](guide/migration-module-with-providers)
+- [Migrating to `ngcc` npm `postinstall` script](guide/migration-ngcc)
+
+## Deprecations and Removals in Version 9
+
+### New Deprecations
+
+| API                                                                     | Replacement                          | Deprecation announced | Notes |
+| ------------------------------------------------------------------------| ------------------------------------ | --------------------- | ----- |
+| [`entryComponents`](api/core/NgModule#entryComponents)                  | none                                 | v9                    | See [`entryComponents`](guide/deprecations#entryComponents) |
+| [`ANALYZE_FOR_ENTRY_COMPONENTS`](api/core/ANALYZE_FOR_ENTRY_COMPONENTS) | none                                 | v9                    | See [`ANALYZE_FOR_ENTRY_COMPONENTS`](guide/deprecations#entryComponents) |
+| `ModuleWithProviders` without a generic                                 | `ModuleWithProviders` with a generic | v9                    | See [`ModuleWithProviders` section](guide/deprecations#moduleWithProviders) |
+
+### New Removals of Deprecated APIs
+
+| Package | API            | Replacement | Notes |
+| ------- | -------------- | ----------- | ----- |
+| `@angular/core`  | [`Renderer`](https://v8.angular.io/api/core/Renderer) | [`Renderer2`](https://angular.io/api/core/Renderer2) | [Migration guide.](guide/migration-renderer)
+| `@angular/core`  | [`RootRenderer`](https://v8.angular.io/api/core/RootRenderer) | [`RendererFactory2`](https://angular.io/api/core/RendererFactory2) | none
+| `@angular/core`  | [`RenderComponentType`](https://v8.angular.io/api/core/RenderComponentType) | [`RendererType2`](https://angular.io/api/core/RendererType2) | none
+| `@angular/common` | `DeprecatedI18NPipesModule` | [`CommonModule`](api/common/CommonModule#pipes) | none |
+| `@angular/common` | `DeprecatedCurrencyPipe` | [`CurrencyPipe`](api/common/CurrencyPipe) | none |
+| `@angular/common` | `DeprecatedDatePipe`     | [`DatePipe`](api/common/DatePipe) | none |
+| `@angular/common` | `DeprecatedDecimalPipe` | [`DecimalPipe`](api/common/DecimalPipe) | none |
+| `@angular/common` | `DeprecatedPercentPipe` | [`PercentPipe`](api/common/PercentPipe) | none |
+| `@angular/forms` | [`NgFormSelectorWarning`](https://v8.angular.io/api/forms/NgFormSelectorWarning) | none | none
+| `@angular/forms` | `ngForm` element selector | `ng-form` element selector | none

--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -1,10 +1,10 @@
-# Migrating to Angular Version 9 
+# Updating to Angular Version 9 
 
-This guide contains everything you need to know about migrating to the next Angular version.
+This guide contains everything you need to know about updating to the next Angular version.
 
 ## Version 9 Schematics
 
-If your application uses the CLI, you can upgrade to version 9 automatically with the help of the `ng update` script. 
+If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script. 
 The script will run a series of small migrations that will transform the code of your application to be compatible with version 9.
  
 If you're curious about the specific migrations being run (e.g. what code is changing and why), the guides below provide more context on each change and contain FAQs for common questions.

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -704,6 +704,11 @@
           "tooltip": "Angular versioning, release, support, and deprecation policies and practices."
         },
         {
+          "url": "guide/migrating-to-version-9",
+          "title": "Migrating to Version 9",
+          "tooltip": "Support for migrating your application from version 8 to 9."
+        },
+        {
           "url": "guide/deprecations",
           "title": "Deprecations",
           "tooltip": "Summary of Angular APIs and features that are deprecated."

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -704,9 +704,9 @@
           "tooltip": "Angular versioning, release, support, and deprecation policies and practices."
         },
         {
-          "url": "guide/migrating-to-version-9",
-          "title": "Migrating to Version 9",
-          "tooltip": "Support for migrating your application from version 8 to 9."
+          "url": "guide/updating-to-version-9",
+          "title": "Updating to Version 9",
+          "tooltip": "Support for updating your application from version 8 to 9."
         },
         {
           "url": "guide/deprecations",


### PR DESCRIPTION
This commit adds a guide to AIO navigation for
"Migrating to Version 9" and moves the schematics
section into the guide that previously lived in
the deprecations page. It also pastes a snippet
of the deprecations page in the new guide so users
don't have to filter out deprecations they've seen
before.

Note: Ivy compatibility section is coming up in a
follow-up PR. 