### PR TITLE
test(ivy): fined tune micro benchmark parameters

### DIFF
--- a/packages/core/test/render3/perf/micro_bench.ts
+++ b/packages/core/test/render3/perf/micro_bench.ts
@@ -8,10 +8,10 @@
 const performance = require('perf_hooks').performance;
 
 // Higher number here makes it more likely that we are more sure of the result.
-const MIN_SAMPLE_COUNT_NO_IMPROVEMENT = 100;
+const MIN_SAMPLE_COUNT_NO_IMPROVEMENT = 500;
 // A smaller number here means that we are coming too close on timer resultion, but it also means
 // that it is less likely that we will be bothered by GC or preemptive multi tasking.
-const MIN_SAMPLE_DURATION = 10;
+const MIN_SAMPLE_DURATION = 3;
 
 const UNITS = ['ms', 'us', 'ns', 'ps'];
 export interface Benchmark {


### PR DESCRIPTION
Decrease `MIN_SAMPLE_DURATION` to make it more likely that we cane fit into single time slice.
Increase `MIN_SAMPLE_COUNT_NO_IMPROVEMENT` to make it more likely to find the best
