### PR TITLE
test(docs-infra): disable es5 size tracking in aio tests

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -2,11 +2,8 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 2981,
         "runtime-es2015": 2987,
-        "main-es5": 545369,
         "main-es2015": 460590,
-        "polyfills-es5": 143165,
         "polyfills-es2015": 52503
       }
     }
@@ -14,11 +11,8 @@
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 2981,
         "runtime-es2015": 2987,
-        "main-es5": 545899,
         "main-es2015": 461159,
-        "polyfills-es5": 143165,
         "polyfills-es2015": 52503
       }
     }
@@ -26,11 +20,8 @@
   "aio-local-viewengine": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 3091,
         "runtime-es2015": 3097,
-        "main-es5": 521188,
         "main-es2015": 436779,
-        "polyfills-es5": 143165,
         "polyfills-es2015": 52503
       }
     }


### PR DESCRIPTION
Similar commit to disable es5 size tracking in integration tests: ff36a8daf