### PR TITLE
[8.2.x] test(docs-infra): disable es5 size tracking in aio tests

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -2,11 +2,8 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 3042,
         "runtime-es2015": 3048,
-        "main-es5": 511052,
         "main-es2015": 450562,
-        "polyfills-es5": 129161,
         "polyfills-es2015": 53295
       }
     }
@@ -14,11 +11,8 @@
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 3042,
         "runtime-es2015": 3048,
-        "main-es5": 499085,
         "main-es2015": 438296,
-        "polyfills-es5": 129161,
         "polyfills-es2015": 53295
       }
     }
@@ -26,11 +20,8 @@
   "aio-local-ivy": {
     "master": {
       "uncompressed": {
-        "runtime-es5": 2932,
         "runtime-es2015": 2938,
-        "main-es5": 555102,
         "main-es2015": 572938,
-        "polyfills-es5": 129161,
         "polyfills-es2015": 53295
       }
     }


### PR DESCRIPTION
This is a backport of #33346 to 8.2.x.