### PR TITLE
fix(language-service): make parsing-cases.ts diagnostics free

### DIFF
--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -29,7 +29,7 @@ const NG_IF_CASES = '/app/ng-if-cases.ts';
 const TEST_TEMPLATE = '/app/test.ng';
 
 describe('diagnostics', () => {
-  const mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const tsLS = ts.createLanguageService(mockHost);
   const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
   const ngLS = createLanguageService(ngHost);
@@ -45,6 +45,7 @@ describe('diagnostics', () => {
     const files = [
       '/app/app.component.ts',
       '/app/main.ts',
+      '/app/parsing-cases.ts',
     ];
     for (const file of files) {
       const syntaxDiags = tsLS.getSyntacticDiagnostics(file);

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -20,13 +20,13 @@ export class CaseIncompleteOpen {
 }
 
 @Component({
-  template: '<h1>Some <a> ~{missing-closing} text</h1>',
+  template: '<h1>Some <a> ~{missing-closing} text</a></h1>',
 })
 export class CaseMissingClosing {
 }
 
 @Component({
-  template: '<h1>Some <unknown ~{unknown-element}> text</h1>',
+  template: '<h1>Some <unknown ~{unknown-element}> text</unknown></h1>',
 })
 export class CaseUnknown {
 }
@@ -53,7 +53,7 @@ export class AttributeBinding {
 }
 
 @Component({
-  template: '<h1 [model]="~{property-binding-model}test"></h1>',
+  template: '<h1 [class]="~{property-binding-model}test"></h1>',
 })
 export class PropertyBinding {
   test: string = 'test';
@@ -70,8 +70,8 @@ export class EventBinding {
 
 @Component({
   template: `
-    <h1 [(model)]="~{two-way-binding-model}test"></h1>
-    <input ~{two-way-binding-input}></input>`,
+    <h1 [(id)]="~{two-way-binding-model}test"></h1>
+    <input ~{two-way-binding-input}/>`,
 })
 export class TwoWayBinding {
   test: string = 'test';
@@ -118,13 +118,13 @@ export class ForOfEmpty {
 }
 
 @Component({
-  template: '<div *ngFor="let ~{for-let-empty}"></div>',
+  template: '<div *ngFor="let ~{for-let-empty}i = index"></div>',
 })
 export class ForOfLetEmpty {
 }
 
 @Component({
-  template: '<div *ngFor="let i = ~{for-let-i-equal}"></div>',
+  template: '<div *ngFor="let i = ~{for-let-i-equal}index"></div>',
 })
 export class ForLetIEqual {
 }
@@ -163,14 +163,15 @@ export class AsyncForUsingComponent {
   template: `
     <div #div>
       <test-comp #test1>
-        {{~{test-comp-content}}}
+        {{~{test-comp-content}title}}
         {{test1.~{test-comp-after-test}name}}
-        {{div.~{test-comp-after-div}.innerText}}
+        {{div.~{test-comp-after-div}innerText}}
       </test-comp>
     </div>
     <test-comp #test2></test-comp>`,
 })
 export class References {
+  title = 'hello world';
 }
 
 /*BeginTestComponent*/ @Component({
@@ -193,7 +194,7 @@ export class TemplateReference {
 }
 
 @Component({
-  template: '{{~{empty-interpolation}}}',
+  template: '{{~{empty-interpolation}title}}',
 })
 export class EmptyInterpolation {
   title = 'Some title';


### PR DESCRIPTION
This commit cleans up `parsing-cases.ts` so we could add more regression
tests to the suite. Moving forward, tests that intentionally introduce
an error should override a template (i.e. creating a one-off), and not
in any of the static files.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
