### PR TITLE
fix(ivy): fix broken typechecking test on Windows

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -159,7 +159,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const TestClassWithCtor =
             getDeclaration(res.program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
         const typeCtor = TestClassWithCtor.members.find(isTypeCtor) !;
-        const ctorText = typeCtor.getText().replace(/[ \n]+/g, ' ');
+        const ctorText = typeCtor.getText().replace(/[ \r\n]+/g, ' ');
         expect(ctorText).toContain(
             'init: Pick<TestClass, "foo"> | { bar: typeof TestClass.ngAcceptInputType_bar; }');
       });


### PR DESCRIPTION
One of the template type-checking tests relies on the newline character,
which is different on Windows. This commit fixes the issue.
