### PR TITLE
refactor(language-service): find expression ASTs using absolute spans

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -370,7 +370,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
                                    new PropertyRead(
                                        span, span.toAbsolute(offset),
                                        new ImplicitReceiver(span, span.toAbsolute(offset)), ''),
-              valueRelativePosition);
+              this.position);
         } else {
           keyCompletions();
         }
@@ -379,10 +379,9 @@ class ExpressionVisitor extends NullTemplateVisitor {
   }
 
   visitBoundText(ast: BoundTextAst) {
-    const expressionPosition = this.position - ast.sourceSpan.start.offset;
-    if (inSpan(expressionPosition, ast.value.span)) {
+    if (inSpan(this.position, ast.value.sourceSpan)) {
       const completions = getExpressionCompletions(
-          this.getExpressionScope(), ast.value, expressionPosition, this.info.template.query);
+          this.getExpressionScope(), ast.value, this.position, this.info.template.query);
       if (completions) {
         this.result = this.symbolsToCompletions(completions);
       }
@@ -410,7 +409,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
 
   private get attributeValuePosition() {
     if (this.attr && this.attr.valueSpan) {
-      return this.position - this.attr.valueSpan.start.offset;
+      return this.position;
     }
     return 0;
   }

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -18,7 +18,8 @@ function findAstAt(ast: AST, position: number, excludeEmpty: boolean = false): A
   const path: AST[] = [];
   const visitor = new class extends NullAstVisitor {
     visit(ast: AST) {
-      if ((!excludeEmpty || ast.span.start < ast.span.end) && inSpan(position, ast.span)) {
+      if ((!excludeEmpty || ast.sourceSpan.start < ast.sourceSpan.end) &&
+          inSpan(position, ast.sourceSpan)) {
         path.push(ast);
         visitAstChildren(ast, this);
       }

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -39,11 +39,10 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
           const dinfo = diagnosticInfoFromTemplateInfo(info);
           const scope = getExpressionScope(dinfo, path, inEvent);
           if (attribute.valueSpan) {
-            const expressionOffset = attribute.valueSpan.start.offset;
-            const result = getExpressionSymbol(
-                scope, ast, templatePosition - expressionOffset, info.template.query);
+            const result = getExpressionSymbol(scope, ast, templatePosition, info.template.query);
             if (result) {
               symbol = result.symbol;
+              const expressionOffset = attribute.valueSpan.start.offset;
               span = offsetSpan(result.span, expressionOffset);
             }
           }
@@ -116,7 +115,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
               const dinfo = diagnosticInfoFromTemplateInfo(info);
               const scope = getExpressionScope(dinfo, path, /* includeEvent */ false);
               const result =
-                  getExpressionSymbol(scope, ast.value, expressionPosition, info.template.query);
+                  getExpressionSymbol(scope, ast.value, templatePosition, info.template.query);
               if (result) {
                 symbol = result.symbol;
                 span = offsetSpan(result.span, ast.sourceSpan.start.offset);


### PR DESCRIPTION
Moves to using the absolute span of an expression AST (relative to an
entire template) rather than a relative span (relative to the start
of the expression) to find an expression AST given a position in a
template.

This is part of the changes needed to support text replacement in
templates (#33091).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
