### PR TITLE
fix(language-service): Do not show HTML elements and attrs for ext template

### DIFF
--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -268,6 +268,7 @@ export enum CompletionKind {
   ELEMENT = 'element',
   ENTITY = 'entity',
   HTML_ATTRIBUTE = 'html attribute',
+  HTML_ELEMENT = 'html element',
   KEY = 'key',
   METHOD = 'method',
   PIPE = 'pipe',

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -36,7 +36,7 @@ describe('completions', () => {
     for (const location of locations) {
       const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, location);
       const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);
-      expectContain(completions, CompletionKind.ELEMENT, ['div', 'h1', 'h2', 'span']);
+      expectContain(completions, CompletionKind.HTML_ELEMENT, ['div', 'h1', 'h2', 'span']);
     }
   });
 
@@ -124,11 +124,11 @@ describe('completions', () => {
   it('should be able to return attributes of an incomplete element', () => {
     const m1 = mockHost.getLocationMarkerFor(PARSING_CASES, 'incomplete-open-lt');
     const c1 = ngLS.getCompletionsAt(PARSING_CASES, m1.start);
-    expectContain(c1, CompletionKind.ELEMENT, ['a', 'div', 'p', 'span']);
+    expectContain(c1, CompletionKind.HTML_ELEMENT, ['a', 'div', 'p', 'span']);
 
     const m2 = mockHost.getLocationMarkerFor(PARSING_CASES, 'incomplete-open-a');
     const c2 = ngLS.getCompletionsAt(PARSING_CASES, m2.start);
-    expectContain(c2, CompletionKind.ELEMENT, ['a', 'div', 'p', 'span']);
+    expectContain(c2, CompletionKind.HTML_ELEMENT, ['a', 'div', 'p', 'span']);
 
     const m3 = mockHost.getLocationMarkerFor(PARSING_CASES, 'incomplete-open-attr');
     const c3 = ngLS.getCompletionsAt(PARSING_CASES, m3.start);
@@ -138,7 +138,7 @@ describe('completions', () => {
   it('should be able to return completions with a missing closing tag', () => {
     const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'missing-closing');
     const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
-    expectContain(completions, CompletionKind.ELEMENT, ['a', 'div', 'p', 'span', 'h1', 'h2']);
+    expectContain(completions, CompletionKind.HTML_ELEMENT, ['a', 'div', 'p', 'span', 'h1', 'h2']);
   });
 
   it('should be able to return common attributes of an unknown tag', () => {
@@ -166,16 +166,21 @@ describe('completions', () => {
       expectContain(completions, CompletionKind.ENTITY, ['&amp;', '&gt;', '&lt;', '&iota;']);
     });
 
-    it('should be able to return html elements', () => {
+    it('should not return html elements', () => {
       const locations = ['empty', 'start-tag-h1', 'h1-content', 'start-tag', 'start-tag-after-h'];
       for (const location of locations) {
         const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, location);
         const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
-        expectContain(completions, CompletionKind.ELEMENT, ['div', 'h1', 'h2', 'span']);
+        expect(completions).toBeDefined();
+        const {entries} = completions !;
+        expect(entries).not.toContain(jasmine.objectContaining({name: 'div'}));
+        expect(entries).not.toContain(jasmine.objectContaining({name: 'h1'}));
+        expect(entries).not.toContain(jasmine.objectContaining({name: 'h2'}));
+        expect(entries).not.toContain(jasmine.objectContaining({name: 'span'}));
       }
     });
 
-    it('should be able to return element diretives', () => {
+    it('should be able to return element directives', () => {
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'empty');
       const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.COMPONENT, [
@@ -186,15 +191,15 @@ describe('completions', () => {
       ]);
     });
 
-    it('should be able to return h1 attributes', () => {
+    it('should not return html attributes', () => {
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'h1-after-space');
       const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
-      expectContain(completions, CompletionKind.HTML_ATTRIBUTE, [
-        'class',
-        'id',
-        'onclick',
-        'onmouseup',
-      ]);
+      expect(completions).toBeDefined();
+      const {entries} = completions !;
+      expect(entries).not.toContain(jasmine.objectContaining({name: 'class'}));
+      expect(entries).not.toContain(jasmine.objectContaining({name: 'id'}));
+      expect(entries).not.toContain(jasmine.objectContaining({name: 'onclick'}));
+      expect(entries).not.toContain(jasmine.objectContaining({name: 'onmouseup'}));
     });
 
     it('should be able to find common angular attributes', () => {


### PR DESCRIPTION
This commit removes HTML elements and HTML attributes from the
completions list for external template. This is because these
completions should be handled by the native HTML extension, and not
Angular.

Once we setup TextMate grammar for inline templates, we could remove the
HTML completions completely.

Also added `CompletionKind.HTML_ELEMENT`, since there's already `CompletionKind.HTML_ATTRIBUTE`.

PR closes https://github.com/angular/vscode-ng-language-service/issues/370

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
