### PR TITLE
L frame expando

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 14678,
+        "main-es2015": 14861,
         "polyfills-es2015": 36808
       }
     }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -25,9 +25,9 @@ import {TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjecti
 import {RComment, RElement, RText} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {isLContainer} from './interfaces/type_checks';
-import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, TView, T_HOST} from './interfaces/view';
+import {HEADER_OFFSET, LView, RENDERER, TVIEW, TView, T_HOST} from './interfaces/view';
 import {appendChild, applyProjection, createTextNode, nativeRemoveNode} from './node_manipulation';
-import {getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from './state';
+import {getBindingIndex, getIsParent, getLView, getPreviousOrParentTNode, nextBindingIndex, setIsNotParent, setPreviousOrParentTNode} from './state';
 import {renderStringify} from './util/misc_utils';
 import {getNativeByIndex, getNativeByTNode, getTNode, load} from './util/view_utils';
 
@@ -669,7 +669,7 @@ export function ɵɵi18nEnd(): void {
  */
 function i18nEndFirstPass(lView: LView, tView: TView) {
   ngDevMode && assertEqual(
-                   lView[BINDING_INDEX], tView.bindingStartIndex,
+                   getBindingIndex(), tView.bindingStartIndex,
                    'i18nEnd should be called before any binding');
 
   const rootIndex = i18nIndexStack[i18nIndexStackPointer--];
@@ -1036,7 +1036,7 @@ let shiftsCounter = 0;
  */
 export function ɵɵi18nExp<T>(value: T): TsickleIssue1009 {
   const lView = getLView();
-  if (bindingUpdated(lView, lView[BINDING_INDEX]++, value)) {
+  if (bindingUpdated(lView, nextBindingIndex(), value)) {
     changeMask = changeMask | (1 << shiftsCounter);
   }
   shiftsCounter++;
@@ -1065,7 +1065,7 @@ export function ɵɵi18nApply(index: number) {
       updateOpCodes = (tI18n as TI18n).update;
       icus = (tI18n as TI18n).icus;
     }
-    const bindingsStartIndex = lView[BINDING_INDEX] - shiftsCounter - 1;
+    const bindingsStartIndex = getBindingIndex() - shiftsCounter - 1;
     readUpdateOpCodes(updateOpCodes, icus, bindingsStartIndex, changeMask, lView);
 
     // Reset changeMask & maskBit to default for the next update cycle

--- a/packages/core/src/render3/instructions/attribute.ts
+++ b/packages/core/src/render3/instructions/attribute.ts
@@ -7,8 +7,7 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
 
 import {TsickleIssue1009, elementAttributeInternal} from './shared';
 
@@ -31,7 +30,7 @@ export function ɵɵattribute(
     name: string, value: any, sanitizer?: SanitizerFn | null,
     namespace?: string): TsickleIssue1009 {
   const lView = getLView();
-  if (bindingUpdated(lView, lView[BINDING_INDEX]++, value)) {
+  if (bindingUpdated(lView, nextBindingIndex(), value)) {
     elementAttributeInternal(getSelectedIndex(), name, value, lView, sanitizer, namespace);
   }
   return ɵɵattribute;

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -11,12 +11,12 @@ import {attachPatchData} from '../context_discovery';
 import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags, registerPostOrderHooks} from '../hooks';
 import {ACTIVE_INDEX, CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {ComponentTemplate} from '../interfaces/definition';
-import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeFlags, TNodeType, TViewNode} from '../interfaces/node';
+import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType, TViewNode} from '../interfaces/node';
 import {isDirectiveHost} from '../interfaces/type_checks';
-import {BINDING_INDEX, FLAGS, HEADER_OFFSET, InitPhaseState, LView, LViewFlags, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
+import {FLAGS, HEADER_OFFSET, InitPhaseState, LView, LViewFlags, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild, removeView} from '../node_manipulation';
-import {getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
+import {getBindingIndex, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
 import {getNativeByTNode, load} from '../util/view_utils';
 
 import {addToViewTree, createDirectivesInstances, createLContainer, createTNode, createTView, getOrCreateTNode, resolveDirectives, saveResolvedLocalsInData} from './shared';
@@ -172,7 +172,7 @@ function containerInternal(
     lView: LView, nodeIndex: number, tagName: string | null,
     attrs: TAttributes | null): TContainerNode {
   ngDevMode && assertEqual(
-                   lView[BINDING_INDEX], lView[TVIEW].bindingStartIndex,
+                   getBindingIndex(), lView[TVIEW].bindingStartIndex,
                    'container nodes should be created before any bindings');
 
   const adjustedIndex = nodeIndex + HEADER_OFFSET;

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -14,10 +14,10 @@ import {TAttributes, TNodeFlags, TNodeType} from '../interfaces/node';
 import {RElement} from '../interfaces/renderer';
 import {StylingMapArray, TStylingContext} from '../interfaces/styling';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
-import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
+import {HEADER_OFFSET, LView, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
-import {decreaseElementDepthCount, getElementDepthCount, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, increaseElementDepthCount, setIsNotParent, setPreviousOrParentTNode} from '../state';
+import {decreaseElementDepthCount, getBindingIndex, getElementDepthCount, getIsParent, getLView, getNamespace, getPreviousOrParentTNode, getSelectedIndex, increaseElementDepthCount, setIsNotParent, setPreviousOrParentTNode} from '../state';
 import {setUpAttributes} from '../util/attrs_utils';
 import {getInitialStylingValue, hasClassInput, hasStyleInput, selectClassBasedInputName} from '../util/styling_utils';
 import {getNativeByTNode, getTNode} from '../util/view_utils';
@@ -48,7 +48,7 @@ export function ɵɵelementStart(
   const tViewConsts = tView.consts;
   const consts = tViewConsts === null || constsIndex == null ? null : tViewConsts[constsIndex];
   ngDevMode && assertEqual(
-                   lView[BINDING_INDEX], tView.bindingStartIndex,
+                   getBindingIndex(), tView.bindingStartIndex,
                    'elements should be created before any bindings');
 
   ngDevMode && ngDevMode.rendererCreateElement++;

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -11,10 +11,10 @@ import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
 import {TAttributes, TNodeType} from '../interfaces/node';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
-import {BINDING_INDEX, HEADER_OFFSET, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
+import {HEADER_OFFSET, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {assertNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
-import {getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
+import {getBindingIndex, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
 
 import {createDirectivesInstances, executeContentQueries, getOrCreateTNode, resolveDirectives, saveResolvedLocalsInData} from './shared';
 import {registerInitialStylingOnTNode} from './styling';
@@ -44,7 +44,7 @@ export function ɵɵelementContainerStart(
   const tViewConsts = tView.consts;
   const consts = tViewConsts === null || constsIndex == null ? null : tViewConsts[constsIndex];
   ngDevMode && assertEqual(
-                   lView[BINDING_INDEX], tView.bindingStartIndex,
+                   getBindingIndex(), tView.bindingStartIndex,
                    'element containers should be created before any bindings');
 
   ngDevMode && ngDevMode.rendererCreateComment++;

--- a/packages/core/src/render3/instructions/host_property.ts
+++ b/packages/core/src/render3/instructions/host_property.ts
@@ -7,8 +7,8 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX, TVIEW} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {TVIEW} from '../interfaces/view';
+import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {TsickleIssue1009, elementPropertyInternal, loadComponentRenderer, storePropertyBindingMetadata} from './shared';
@@ -30,7 +30,7 @@ import {TsickleIssue1009, elementPropertyInternal, loadComponentRenderer, storeP
 export function ɵɵhostProperty<T>(
     propName: string, value: T, sanitizer?: SanitizerFn | null): TsickleIssue1009 {
   const lView = getLView();
-  const bindingIndex = lView[BINDING_INDEX]++;
+  const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, value, sanitizer, true);
@@ -64,7 +64,7 @@ export function ɵɵhostProperty<T>(
 export function ɵɵupdateSyntheticHostBinding<T>(
     propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null): TsickleIssue1009 {
   const lView = getLView();
-  const bindingIndex = lView[BINDING_INDEX]++;
+  const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(

--- a/packages/core/src/render3/instructions/interpolation.ts
+++ b/packages/core/src/render3/instructions/interpolation.ts
@@ -8,7 +8,8 @@
 
 import {assertEqual, assertLessThan} from '../../util/assert';
 import {bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4} from '../bindings';
-import {BINDING_INDEX, LView} from '../interfaces/view';
+import {LView} from '../interfaces/view';
+import {getBindingIndex, incrementBindingIndex, nextBindingIndex, setBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {renderStringify} from '../util/misc_utils';
 
@@ -30,13 +31,13 @@ export function interpolationV(lView: LView, values: any[]): string|NO_CHANGE {
   ngDevMode && assertLessThan(2, values.length, 'should have at least 3 values');
   ngDevMode && assertEqual(values.length % 2, 1, 'should have an odd number of values');
   let isBindingUpdated = false;
-  let bindingIndex = lView[BINDING_INDEX];
+  let bindingIndex = getBindingIndex();
 
   for (let i = 1; i < values.length; i += 2) {
     // Check if bindings (odd indexes) have changed
     isBindingUpdated = bindingUpdated(lView, bindingIndex++, values[i]) || isBindingUpdated;
   }
-  lView[BINDING_INDEX] = bindingIndex;
+  setBindingIndex(bindingIndex);
 
   if (!isBindingUpdated) {
     return NO_CHANGE;
@@ -60,7 +61,7 @@ export function interpolationV(lView: LView, values: any[]): string|NO_CHANGE {
  */
 export function interpolation1(lView: LView, prefix: string, v0: any, suffix: string): string|
     NO_CHANGE {
-  const different = bindingUpdated(lView, lView[BINDING_INDEX]++, v0);
+  const different = bindingUpdated(lView, nextBindingIndex(), v0);
   return different ? prefix + renderStringify(v0) + suffix : NO_CHANGE;
 }
 
@@ -69,9 +70,9 @@ export function interpolation1(lView: LView, prefix: string, v0: any, suffix: st
  */
 export function interpolation2(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   const different = bindingUpdated2(lView, bindingIndex, v0, v1);
-  lView[BINDING_INDEX] += 2;
+  incrementBindingIndex(2);
 
   return different ? prefix + renderStringify(v0) + i0 + renderStringify(v1) + suffix : NO_CHANGE;
 }
@@ -82,9 +83,9 @@ export function interpolation2(
 export function interpolation3(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any,
     suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   const different = bindingUpdated3(lView, bindingIndex, v0, v1, v2);
-  lView[BINDING_INDEX] += 3;
+  incrementBindingIndex(3);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + suffix :
@@ -97,9 +98,9 @@ export function interpolation3(
 export function interpolation4(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   const different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
-  lView[BINDING_INDEX] += 4;
+  incrementBindingIndex(4);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -113,10 +114,10 @@ export function interpolation4(
 export function interpolation5(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated(lView, bindingIndex + 4, v4) || different;
-  lView[BINDING_INDEX] += 5;
+  incrementBindingIndex(5);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -130,10 +131,10 @@ export function interpolation5(
 export function interpolation6(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated2(lView, bindingIndex + 4, v4, v5) || different;
-  lView[BINDING_INDEX] += 6;
+  incrementBindingIndex(6);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -148,10 +149,10 @@ export function interpolation7(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, suffix: string): string|
     NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated3(lView, bindingIndex + 4, v4, v5, v6) || different;
-  lView[BINDING_INDEX] += 7;
+  incrementBindingIndex(7);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +
@@ -167,10 +168,10 @@ export function interpolation8(
     lView: LView, prefix: string, v0: any, i0: string, v1: any, i1: string, v2: any, i2: string,
     v3: any, i3: string, v4: any, i4: string, v5: any, i5: string, v6: any, i6: string, v7: any,
     suffix: string): string|NO_CHANGE {
-  const bindingIndex = lView[BINDING_INDEX];
+  const bindingIndex = getBindingIndex();
   let different = bindingUpdated4(lView, bindingIndex, v0, v1, v2, v3);
   different = bindingUpdated4(lView, bindingIndex + 4, v4, v5, v6, v7) || different;
-  lView[BINDING_INDEX] += 8;
+  incrementBindingIndex(8);
 
   return different ?
       prefix + renderStringify(v0) + i0 + renderStringify(v1) + i1 + renderStringify(v2) + i2 +

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -19,7 +19,7 @@ import {SelectorFlags} from '../interfaces/projection';
 import {TQueries} from '../interfaces/query';
 import {RComment, RElement, RNode} from '../interfaces/renderer';
 import {TStylingContext} from '../interfaces/styling';
-import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, HookData, INJECTOR, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, TData, TVIEW, TView as ITView, TView, T_HOST} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, HookData, INJECTOR, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, TData, TVIEW, TView as ITView, TView, T_HOST} from '../interfaces/view';
 import {DebugNodeStyling, NodeStylingDebug} from '../styling/styling_debug';
 import {attachDebugObject} from '../util/debug_utils';
 import {isStylingContext} from '../util/styling_utils';
@@ -325,7 +325,6 @@ export class LViewDebug {
   get declarationView() { return toDebug(this._raw_lView[DECLARATION_VIEW]); }
   get queries() { return this._raw_lView[QUERIES]; }
   get tHost() { return this._raw_lView[T_HOST]; }
-  get bindingIndex() { return this._raw_lView[BINDING_INDEX]; }
 
   /**
    * Normalized view of child views (and containers) attached at this location.

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -7,8 +7,8 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX, TVIEW} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {TVIEW} from '../interfaces/view';
+import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
 
 import {TsickleIssue1009, elementPropertyInternal, storePropertyBindingMetadata} from './shared';
 
@@ -34,7 +34,7 @@ import {TsickleIssue1009, elementPropertyInternal, storePropertyBindingMetadata}
 export function ɵɵproperty<T>(
     propName: string, value: T, sanitizer?: SanitizerFn | null): TsickleIssue1009 {
   const lView = getLView();
-  const bindingIndex = lView[BINDING_INDEX]++;
+  const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, value, sanitizer);

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {SanitizerFn} from '../interfaces/sanitization';
-import {BINDING_INDEX, TVIEW} from '../interfaces/view';
-import {getLView, getSelectedIndex} from '../state';
+import {TVIEW} from '../interfaces/view';
+import {getBindingIndex, getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
@@ -86,9 +86,9 @@ export function ɵɵpropertyInterpolate1(
   const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     elementPropertyInternal(lView, getSelectedIndex(), propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, getSelectedIndex(), propName, lView[BINDING_INDEX] - 1,
-                     prefix, suffix);
+    ngDevMode &&
+        storePropertyBindingMetadata(
+            lView[TVIEW].data, getSelectedIndex(), propName, getBindingIndex() - 1, prefix, suffix);
   }
   return ɵɵpropertyInterpolate1;
 }
@@ -133,7 +133,7 @@ export function ɵɵpropertyInterpolate2(
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode &&
         storePropertyBindingMetadata(
-            lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 2, prefix, i0, suffix);
+            lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 2, prefix, i0, suffix);
   }
   return ɵɵpropertyInterpolate2;
 }
@@ -179,9 +179,9 @@ export function ɵɵpropertyInterpolate3(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 3, prefix, i0,
-                     i1, suffix);
+    ngDevMode &&
+        storePropertyBindingMetadata(
+            lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 3, prefix, i0, i1, suffix);
   }
   return ɵɵpropertyInterpolate3;
 }
@@ -230,8 +230,8 @@ export function ɵɵpropertyInterpolate4(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 4, prefix, i0,
-                     i1, i2, suffix);
+                     lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 4, prefix, i0, i1,
+                     i2, suffix);
   }
   return ɵɵpropertyInterpolate4;
 }
@@ -283,8 +283,8 @@ export function ɵɵpropertyInterpolate5(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 5, prefix, i0,
-                     i1, i2, i3, suffix);
+                     lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 5, prefix, i0, i1,
+                     i2, i3, suffix);
   }
   return ɵɵpropertyInterpolate5;
 }
@@ -339,8 +339,8 @@ export function ɵɵpropertyInterpolate6(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 6, prefix, i0,
-                     i1, i2, i3, i4, suffix);
+                     lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 6, prefix, i0, i1,
+                     i2, i3, i4, suffix);
   }
   return ɵɵpropertyInterpolate6;
 }
@@ -397,8 +397,8 @@ export function ɵɵpropertyInterpolate7(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 7, prefix, i0,
-                     i1, i2, i3, i4, i5, suffix);
+                     lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 7, prefix, i0, i1,
+                     i2, i3, i4, i5, suffix);
   }
   return ɵɵpropertyInterpolate7;
 }
@@ -457,8 +457,8 @@ export function ɵɵpropertyInterpolate8(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode && storePropertyBindingMetadata(
-                     lView[TVIEW].data, nodeIndex, propName, lView[BINDING_INDEX] - 8, prefix, i0,
-                     i1, i2, i3, i4, i5, i6, suffix);
+                     lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 8, prefix, i0, i1,
+                     i2, i3, i4, i5, i6, suffix);
   }
   return ɵɵpropertyInterpolate8;
 }
@@ -507,7 +507,7 @@ export function ɵɵpropertyInterpolateV(
       }
       storePropertyBindingMetadata(
           lView[TVIEW].data, nodeIndex, propName,
-          lView[BINDING_INDEX] - interpolationInBetween.length + 1, ...interpolationInBetween);
+          getBindingIndex() - interpolationInBetween.length + 1, ...interpolationInBetween);
     }
   }
   return ɵɵpropertyInterpolateV;

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -7,9 +7,10 @@
  */
 import {assertDataInRange, assertEqual} from '../../util/assert';
 import {TNodeType} from '../interfaces/node';
-import {BINDING_INDEX, HEADER_OFFSET, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
+import {HEADER_OFFSET, RENDERER, TVIEW, T_HOST} from '../interfaces/view';
 import {appendChild, createTextNode} from '../node_manipulation';
-import {getLView, setIsNotParent} from '../state';
+import {getBindingIndex, getLView, setIsNotParent} from '../state';
+
 import {getOrCreateTNode} from './shared';
 
 
@@ -25,7 +26,7 @@ import {getOrCreateTNode} from './shared';
 export function ɵɵtext(index: number, value: string = ''): void {
   const lView = getLView();
   ngDevMode && assertEqual(
-                   lView[BINDING_INDEX], lView[TVIEW].bindingStartIndex,
+                   getBindingIndex(), lView[TVIEW].bindingStartIndex,
                    'text nodes should be created before any bindings');
   ngDevMode && assertDataInRange(lView, index + HEADER_OFFSET);
   const textNative = lView[index + HEADER_OFFSET] = createTextNode(value, lView[RENDERER]);

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -32,20 +32,19 @@ export const PARENT = 3;
 export const NEXT = 4;
 export const QUERIES = 5;
 export const T_HOST = 6;
-export const BINDING_INDEX = 7;
-export const CLEANUP = 8;
-export const CONTEXT = 9;
-export const INJECTOR = 10;
-export const RENDERER_FACTORY = 11;
-export const RENDERER = 12;
-export const SANITIZER = 13;
-export const CHILD_HEAD = 14;
-export const CHILD_TAIL = 15;
-export const DECLARATION_VIEW = 16;
-export const DECLARATION_LCONTAINER = 17;
-export const PREORDER_HOOK_FLAGS = 18;
+export const CLEANUP = 7;
+export const CONTEXT = 8;
+export const INJECTOR = 9;
+export const RENDERER_FACTORY = 10;
+export const RENDERER = 11;
+export const SANITIZER = 12;
+export const CHILD_HEAD = 13;
+export const CHILD_TAIL = 14;
+export const DECLARATION_VIEW = 15;
+export const DECLARATION_LCONTAINER = 16;
+export const PREORDER_HOOK_FLAGS = 17;
 /** Size of LView's header. Necessary to adjust for it when setting slots.  */
-export const HEADER_OFFSET = 19;
+export const HEADER_OFFSET = 18;
 
 
 // This interface replaces the real LView interface if it is an arg or a
@@ -119,15 +118,6 @@ export interface LView extends Array<any> {
    * If null, this is the root view of an application (root component is in this view).
    */
   [T_HOST]: TViewNode|TElementNode|null;
-
-  /**
-   * The binding index we should access next.
-   *
-   * This is stored so that bindings can continue where they left off
-   * if a view is left midway through processing bindings (e.g. if there is
-   * a setter that creates an embedded view, like in ngIf).
-   */
-  [BINDING_INDEX]: number;
 
   /**
    * When a view is destroyed, listeners need to be released and outputs need to be
@@ -381,6 +371,8 @@ export interface TView {
    * starts to store bindings only. Saving this value ensures that we
    * will begin reading bindings at the correct point in the array when
    * we are in update mode.
+   *
+   * -1 means that it has not been initialized.
    */
   bindingStartIndex: number;
 

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -12,9 +12,9 @@ import {PipeTransform} from '../change_detection/pipe_transform';
 import {getFactoryDef} from './definition';
 import {store} from './instructions/all';
 import {PipeDef, PipeDefList} from './interfaces/definition';
-import {BINDING_INDEX, HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
+import {HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
 import {ɵɵpureFunction1, ɵɵpureFunction2, ɵɵpureFunction3, ɵɵpureFunction4, ɵɵpureFunctionV} from './pure_function';
-import {getLView} from './state';
+import {getBindingIndex, getLView} from './state';
 import {NO_CHANGE} from './tokens';
 import {load} from './util/view_utils';
 
@@ -200,7 +200,7 @@ function unwrapValue(lView: LView, newValue: any): any {
     newValue = WrappedValue.unwrap(newValue);
     // The NO_CHANGE value needs to be written at the index where the impacted binding value is
     // stored
-    const bindingToInvalidateIdx = lView[BINDING_INDEX];
+    const bindingToInvalidateIdx = getBindingIndex();
     lView[bindingToInvalidateIdx] = NO_CHANGE;
   }
   return newValue;

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -48,6 +48,12 @@ export function assertLessThan<T>(actual: T, expected: T, msg: string) {
   }
 }
 
+export function assertLessThanOrEqual<T>(actual: T, expected: T, msg: string) {
+  if (actual > expected) {
+    throwError(msg);
+  }
+}
+
 export function assertGreaterThan<T>(actual: T, expected: T, msg: string) {
   if (actual <= expected) {
     throwError(msg);

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -3,9 +3,6 @@
     "name": "ACTIVE_INDEX"
   },
   {
-    "name": "BINDING_INDEX"
-  },
-  {
     "name": "BLOOM_MASK"
   },
   {
@@ -598,6 +595,9 @@
   },
   {
     "name": "setActiveHostElement"
+  },
+  {
+    "name": "setBindingIndex"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -3,9 +3,6 @@
     "name": "ACTIVE_INDEX"
   },
   {
-    "name": "BINDING_INDEX"
-  },
-  {
     "name": "BLOOM_MASK"
   },
   {
@@ -436,6 +433,9 @@
   },
   {
     "name": "setActiveHostElement"
+  },
+  {
+    "name": "setBindingIndex"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -3,9 +3,6 @@
     "name": "ACTIVE_INDEX"
   },
   {
-    "name": "BINDING_INDEX"
-  },
-  {
     "name": "BIT_MASK_START_VALUE"
   },
   {
@@ -1068,6 +1065,9 @@
     "name": "nativeRemoveNode"
   },
   {
+    "name": "nextBindingIndex"
+  },
+  {
     "name": "nextContextImpl"
   },
   {
@@ -1198,6 +1198,9 @@
   },
   {
     "name": "setActiveHostElement"
+  },
+  {
+    "name": "setBindingIndex"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -606,9 +606,6 @@
     "name": "getActiveDirectiveId"
   },
   {
-    "name": "getAndIncrementBindingIndex"
-  },
-  {
     "name": "getBeforeNodeForView"
   },
   {


### PR DESCRIPTION
For performance reasons we would like to keep the `LFrame` as small as possible.
However, there are many properties which are used only rarely by the instructions but still need
to be tracked. These are attached lazily to the `LFrame` through the `LFrameExpando`.

```
┌────────────────────────────────────┬─────────┬──────┬───────────┬───────────┬───────┐
│              (index)               │  time   │ unit │ base_time │ base_unit │   %   │
├────────────────────────────────────┼─────────┼──────┼───────────┼───────────┼───────┤
│           class_binding            │ 136.244 │ 'ns' │  145.997  │   'ns'    │ -6.68 │
│       directive_instantiate        │  1.726  │ 'us' │   1.782   │   'us'    │ -3.14 │
│        element_text_create         │ 925.171 │ 'ns' │  895.245  │   'ns'    │ 3.34  │
│           interpolation            │ 157.823 │ 'us' │  166.982  │   'us'    │ -5.49 │
│             listeners              │  1.621  │ 'us' │   1.611   │   'us'    │ 0.62  │
│ map_based_style_and_class_bindings │ 14.259  │ 'ms' │  14.393   │   'ms'    │ -0.93 │
│       noop_change_detection        │ 19.581  │ 'us' │  19.205   │   'us'    │ 1.96  │
│          property_binding          │ 176.239 │ 'us' │  190.614  │   'us'    │ -7.54 │
│      property_binding_update       │ 315.528 │ 'us' │  332.356  │   'us'    │ -5.06 │
│      style_and_class_bindings      │ 928.534 │ 'us' │  925.482  │   'us'    │ 0.33  │
│           style_binding            │ 413.135 │ 'us' │  380.729  │   'us'    │ 8.51  │
└────────────────────────────────────┴─────────┴──────┴───────────┴───────────┴───────┘
```