### PR TITLE
perf(ivy): limit global state read, stricter null checks

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -327,7 +327,6 @@ function stylingMap(
   const native = getNativeByTNode(tNode, lView) as RElement;
   const oldValue = getValue(lView, bindingIndex);
   const hostBindingsMode = isHostStyling();
-  const sanitizer = getCurrentStyleSanitizer();
   const valueHasChanged = hasValueChanged(oldValue, value);
 
   // [style] and [class] bindings do not use `bind()` and will therefore
@@ -348,12 +347,12 @@ function stylingMap(
   // Direct Apply Case: bypass context resolution and apply the
   // style/class map values directly to the element
   if (allowDirectStyling(context, hostBindingsMode)) {
-    const sanitizerToUse = isClassBased ? null : sanitizer;
+    const sanitizerToUse = isClassBased ? null : getCurrentStyleSanitizer();
     const renderer = getRenderer(tNode, lView);
     applyStylingMapDirectly(
         renderer, context, native, lView, bindingIndex, value, isClassBased, sanitizerToUse,
         valueHasChanged, hasDirectiveInput);
-    if (sanitizerToUse) {
+    if (sanitizerToUse !== null) {
       // it's important we remove the current style sanitizer once the
       // element exits, otherwise it will be used by the next styling
       // instructions for the next element.
@@ -374,7 +373,7 @@ function stylingMap(
           valueHasChanged);
     } else {
       updateStyleViaContext(
-          context, lView, native, directiveIndex, null, bindingIndex, stylingMapArr, sanitizer,
+          context, lView, native, directiveIndex, null, bindingIndex, stylingMapArr, getCurrentStyleSanitizer(),
           valueHasChanged);
     }
 


### PR DESCRIPTION
Here is a series of minor changes that improve perf of the `stylingMap` function (notice spent in this function going from ~6.34% to ~4.74%). Individually those gains are not huge but collectively make real difference.

Before:

![Screenshot 2019-10-25 at 18 20 38](https://user-images.githubusercontent.com/973550/67587449-329d6480-f754-11e9-8f29-ca7834d6ec28.png)

After:

![Screenshot 2019-10-25 at 18 21 19](https://user-images.githubusercontent.com/973550/67587486-45b03480-f754-11e9-9a35-071abe3e7e63.png)