### PR TITLE
docs(common): fix condition in transformed *ngIf

### DIFF
--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -130,7 +130,7 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  * the content of this unlabeled `<ng-template>` tag.
  *
  * ```
- * <ng-template [ngIf]="hero-list" [ngIfElse]="loading">
+ * <ng-template [ngIf]="heroes" [ngIfElse]="loading">
  *  <div class="hero-list">
  *   ...
  *  </div>


### PR DESCRIPTION
`<div class="hero-list" *ngIf="heroes else loading">` defines `heroes` as condition, but (`class` attribute value) `hero-list` is used as condition in the transformed code.