### PR TITLE
refactor(core): update migrations descriptions

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -2,52 +2,52 @@
   "schematics": {
     "migration-v8-move-document": {
       "version": "8.0.0-beta",
-      "description": "Migrates DOCUMENT Injection token from platform-browser imports to common import",
+      "description": "@DOCUMENT migration. Migrates DOCUMENT Injection token from platform-browser imports to common import.",
       "factory": "./migrations/move-document/index"
     },
     "migration-v8-static-queries": {
       "version": "8.0.0-beta",
-      "description": "Migrates ViewChild and ContentChild to explicit query timing",
+      "description": "ViewChild and ContentChild to explicit query timing migration. In Angular version 8, developers need to explicitly specify the timing of ViewChild and ContentChild queries. Read more about this here: https://v8.angular.io/guide/static-query-migration",
       "factory": "./migrations/static-queries/index"
     },
     "migration-v8-template-local-variables": {
       "version": "8.0.0-beta",
-      "description": "Warns developers if values are assigned to template variables",
+      "description": "Template Variable Assignment migration. Warns developers if values are assigned to template variables.",
       "factory": "./migrations/template-var-assignment/index"
     },
     "migration-v9-renderer-to-renderer2": {
       "version": "9.0.0-beta",
-      "description": "The Renderer class has been marked as deprecated since Angular version 4. This migration converts usage of Renderer to Renderer2. For additional information please see: https://v9.angular.io/guide/migration-renderer",
+      "description": "Renderer to Renderer2 migration. As of Angular 9, the Renderer class is no longer available. Renderer2 should be used instead. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-renderer",
       "factory": "./migrations/renderer-to-renderer2/index"
     },
     "migration-v9-missing-injectable": {
       "version": "9.0.0-beta",
-      "description": "Decorates all declared undecorated provider classes with @Injectable.",
+      "description": "Missing @Injectable migration. In Angular 9, enforcement of @Injectable decorators for DI is a bit stricter. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-injectable",
       "factory": "./migrations/missing-injectable/index"
     },
     "migration-v9-undecorated-classes-with-di": {
       "version": "9.0.0-beta",
-      "description": "Adds an Angular decorator to undecorated base classes of directives/components that use dependency injection. Copies metadata from base classes to derived directives/components/pipes that are not decorated. For additional information please see: https://v9.angular.io/guide/migration-undecorated-classes",
+      "description": "Undecorated classes with DI migration. As of Angular 9, it is no longer supported to use Angular DI on a class that does not have an Angular decorator. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-di/index"
     },
     "migration-v9-undecorated-classes-with-decorated-fields": {
       "version": "9.0.0-beta",
-      "description": "Adds an Angular decorator to undecorated classes that have decorated fields.",
+      "description": "Undecorated classes with decorated fields migration. As of Angular 9, it is no longer supported to have Angular field decorators on a class that does not have an Angular decorator. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
     },
     "migration-v9-dynamic-queries": {
       "version": "9-beta",
-      "description": "Removes the `static` flag from dynamic queries.",
+      "description": "Removes the `static` flag from dynamic queries. As of Angular 9, the \"static\" flag defaults to false and is no longer required for your view and content queries. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-dynamic-flag",
       "factory": "./migrations/dynamic-queries/index"
     },
     "migration-v9-postinstall-ngcc": {
       "version": "9-beta",
-      "description": "Adds an ngcc call as a postinstall hook in package.json",
+      "description": "NGCC postinstall migration. Adds an ngcc invocation to npm/yarn's postinstall script. See more info here: https://v9.angular.io/guide/migration-ngcc",
       "factory": "./migrations/postinstall-ngcc/index"
     },
     "migration-v9-module-with-providers": {
       "version": "9.0.0-beta",
-      "description": "Adds explicit typing to `ModuleWithProviders`",
+      "description": "ModuleWithProviders migration. In Angular 9, the ModuleWithProviders type without a generic has been deprecated. This migration adds the generic where it is missing. See more info here: https://v9.angular.io/guide/migration-module-with-providers",
       "factory": "./migrations/module-with-providers/index"
     }
   }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -37,7 +37,7 @@
     },
     "migration-v9-dynamic-queries": {
       "version": "9-beta",
-      "description": "Removes the `static` flag from dynamic queries. As of Angular 9, the \"static\" flag defaults to false and is no longer required for your view and content queries. Read more about this here: https://v9.angular.io/guide/migration-dynamic-flag",
+      "description": "Static flag migration. Removes the `static` flag from dynamic queries. As of Angular 9, the \"static\" flag defaults to false and is no longer required for your view and content queries. Read more about this here: https://v9.angular.io/guide/migration-dynamic-flag",
       "factory": "./migrations/dynamic-queries/index"
     },
     "migration-v9-postinstall-ngcc": {

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -17,37 +17,37 @@
     },
     "migration-v9-renderer-to-renderer2": {
       "version": "9.0.0-beta",
-      "description": "Renderer to Renderer2 migration. As of Angular 9, the Renderer class is no longer available. Renderer2 should be used instead. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-renderer",
+      "description": "Renderer to Renderer2 migration. As of Angular 9, the Renderer class is no longer available. Renderer2 should be used instead. Read more about this here: https://v9.angular.io/guide/migration-renderer",
       "factory": "./migrations/renderer-to-renderer2/index"
     },
     "migration-v9-missing-injectable": {
       "version": "9.0.0-beta",
-      "description": "Missing @Injectable migration. In Angular 9, enforcement of @Injectable decorators for DI is a bit stricter. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-injectable",
+      "description": "Missing @Injectable migration. In Angular 9, enforcement of @Injectable decorators for DI is a bit stricter. Read more about this here: https://v9.angular.io/guide/migration-injectable",
       "factory": "./migrations/missing-injectable/index"
     },
     "migration-v9-undecorated-classes-with-di": {
       "version": "9.0.0-beta",
-      "description": "Undecorated classes with DI migration. As of Angular 9, it is no longer supported to use Angular DI on a class that does not have an Angular decorator. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-undecorated-classes",
+      "description": "Undecorated classes with DI migration. As of Angular 9, it is no longer supported to use Angular DI on a class that does not have an Angular decorator. Read more about this here: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-di/index"
     },
     "migration-v9-undecorated-classes-with-decorated-fields": {
       "version": "9.0.0-beta",
-      "description": "Undecorated classes with decorated fields migration. As of Angular 9, it is no longer supported to have Angular field decorators on a class that does not have an Angular decorator. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-undecorated-classes",
+      "description": "Undecorated classes with decorated fields migration. As of Angular 9, it is no longer supported to have Angular field decorators on a class that does not have an Angular decorator. Read more about this here: https://v9.angular.io/guide/migration-undecorated-classes",
       "factory": "./migrations/undecorated-classes-with-decorated-fields/index"
     },
     "migration-v9-dynamic-queries": {
       "version": "9-beta",
-      "description": "Removes the `static` flag from dynamic queries. As of Angular 9, the \"static\" flag defaults to false and is no longer required for your view and content queries. Read more about this in the dedicated guide: https://v9.angular.io/guide/migration-dynamic-flag",
+      "description": "Removes the `static` flag from dynamic queries. As of Angular 9, the \"static\" flag defaults to false and is no longer required for your view and content queries. Read more about this here: https://v9.angular.io/guide/migration-dynamic-flag",
       "factory": "./migrations/dynamic-queries/index"
     },
     "migration-v9-postinstall-ngcc": {
       "version": "9-beta",
-      "description": "NGCC postinstall migration. Adds an ngcc invocation to npm/yarn's postinstall script. See more info here: https://v9.angular.io/guide/migration-ngcc",
+      "description": "NGCC postinstall migration. Adds an ngcc invocation to npm/yarn's postinstall script. Read more about this here: https://v9.angular.io/guide/migration-ngcc",
       "factory": "./migrations/postinstall-ngcc/index"
     },
     "migration-v9-module-with-providers": {
       "version": "9.0.0-beta",
-      "description": "ModuleWithProviders migration. In Angular 9, the ModuleWithProviders type without a generic has been deprecated. This migration adds the generic where it is missing. See more info here: https://v9.angular.io/guide/migration-module-with-providers",
+      "description": "ModuleWithProviders migration. In Angular 9, the ModuleWithProviders type without a generic has been deprecated. This migration adds the generic where it is missing. Read more about this here: https://v9.angular.io/guide/migration-module-with-providers",
       "factory": "./migrations/module-with-providers/index"
     }
   }

--- a/packages/core/schematics/migrations/dynamic-queries/index.ts
+++ b/packages/core/schematics/migrations/dynamic-queries/index.ts
@@ -27,12 +27,6 @@ export default function(): Rule {
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 
-    ctx.logger.info('------ Dynamic queries migration ------');
-    ctx.logger.info('As of Angular 9, the "static" flag defaults to false and is no ');
-    ctx.logger.info('longer required for your view and content queries. ');
-    ctx.logger.info('Read more about this in the dedicated guide: ');
-    ctx.logger.info('https://v9.angular.io/guide/migration-dynamic-flag');
-
     if (!allPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot migrate dynamic queries.');

--- a/packages/core/schematics/migrations/missing-injectable/index.ts
+++ b/packages/core/schematics/migrations/missing-injectable/index.ts
@@ -23,11 +23,6 @@ export default function(): Rule {
     const basePath = process.cwd();
     const failures: string[] = [];
 
-    ctx.logger.info('------ Missing @Injectable migration ------');
-    ctx.logger.info('In Angular 9, enforcement of @Injectable decorators for DI is a bit ');
-    ctx.logger.info('stricter. Read more about this in the dedicated guide: ');
-    ctx.logger.info('https://v9.angular.io/guide/migration-injectable');
-
     if (!buildPaths.length && !testPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot add the "@Injectable" decorator to providers ' +
@@ -42,10 +37,7 @@ export default function(): Rule {
       ctx.logger.info('Could not migrate all providers automatically. Please');
       ctx.logger.info('manually migrate the following instances:');
       failures.forEach(message => ctx.logger.warn(`⮑   ${message}`));
-    } else {
-      ctx.logger.info('Successfully migrated all undecorated providers.');
     }
-    ctx.logger.info('-------------------------------------------');
   };
 }
 

--- a/packages/core/schematics/migrations/module-with-providers/index.ts
+++ b/packages/core/schematics/migrations/module-with-providers/index.ts
@@ -29,12 +29,6 @@ export default function(): Rule {
     const allPaths = [...buildPaths, ...testPaths];
     const failures: string[] = [];
 
-    ctx.logger.info('------ ModuleWithProviders migration ------');
-    ctx.logger.info('In Angular 9, the ModuleWithProviders type without a ');
-    ctx.logger.info('generic has been deprecated. This migration adds the ');
-    ctx.logger.info('generic where it is missing. See more info here:');
-    ctx.logger.info('https://v9.angular.io/guide/migration-module-with-providers');
-
     if (!allPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot migrate ModuleWithProviders.');
@@ -48,11 +42,7 @@ export default function(): Rule {
       ctx.logger.info('Could not migrate all instances of ModuleWithProviders');
       ctx.logger.info('Please manually fix the following failures:');
       failures.forEach(message => ctx.logger.warn(`⮑   ${message}`));
-    } else {
-      ctx.logger.info('Successfully migrated all found ModuleWithProviders.');
     }
-
-    ctx.logger.info('----------------------------------------------');
   };
 }
 

--- a/packages/core/schematics/migrations/postinstall-ngcc/index.ts
+++ b/packages/core/schematics/migrations/postinstall-ngcc/index.ts
@@ -17,11 +17,6 @@ import {appendPropertyInAstObject, findPropertyInAstObject, insertPropertyInAstO
  */
 export default function(): Rule {
   return (tree: Tree, context: SchematicContext) => {
-    context.logger.info('------ ngcc postinstall migration ------');
-    context.logger.info('This migration adds an ngcc invocation to npm/yarn\'s ');
-    context.logger.info('postinstall script. See more info here: ');
-    context.logger.info('https://v9.angular.io/guide/migration-ngcc');
-
     addPackageJsonScript(
         tree, 'postinstall',
         'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points');

--- a/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
+++ b/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
@@ -31,13 +31,6 @@ export default function(): Rule {
     const allPaths = [...buildPaths, ...testPaths];
     const logger = context.logger;
 
-    logger.info('------ Renderer to Renderer2 Migration ------');
-    logger.info('As of Angular 9, the Renderer class is no longer available. ');
-    logger.info('Renderer2 should be used instead. Read more about this in ');
-    logger.info('the dedicated guide: ');
-    logger.info('https://v9.angular.io/guide/migration-renderer');
-
-
     if (!allPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot migrate Renderer usages to Renderer2.');

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -55,12 +55,6 @@ async function runMigration(tree: Tree, context: SchematicContext) {
   const basePath = process.cwd();
   const logger = context.logger;
 
-  logger.info('------ Static Query Migration ------');
-  logger.info('With Angular version 8, developers need to');
-  logger.info('explicitly specify the timing of ViewChild and');
-  logger.info('ContentChild queries. Read more about this here:');
-  logger.info('https://v8.angular.io/guide/static-query-migration');
-
   if (!buildPaths.length && !testPaths.length) {
     throw new SchematicsException(
         'Could not find any tsconfig file. Cannot migrate queries ' +
@@ -105,8 +99,6 @@ async function runMigration(tree: Tree, context: SchematicContext) {
     logger.info('https://v8.angular.io/guide/static-query-migration');
     failures.forEach(failure => logger.warn(`⮑   ${failure}`));
   }
-
-  logger.info('------------------------------------------------');
 }
 
 /**

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -87,6 +87,5 @@ function runTemplateVariableAssignmentCheck(
     logger.info('');
     logger.info('The following template assignments were found:');
     collectedFailures.forEach(failure => logger.warn(`⮑   ${failure}`));
-    logger.info('------------------------------------------------');
   }
 }

--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
@@ -24,15 +24,6 @@ export default function(): Rule {
     const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
-    const logger = context.logger;
-
-    logger.info('------ Undecorated classes with decorated fields migration ------');
-    logger.info(
-        'As of Angular 9, it is no longer supported to have Angular field ' +
-        'decorators on a class that does not have an Angular decorator.');
-    logger.info('Read more about this in the dedicated guide: ');
-    logger.info('https://v9.angular.io/guide/migration-undecorated-classes');
-
 
     if (!allPaths.length) {
       throw new SchematicsException(

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -9,7 +9,6 @@
 import {logging} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {AotCompiler} from '@angular/compiler';
-import {createCompilerHost} from '@angular/compiler-cli';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {relative} from 'path';
@@ -37,14 +36,6 @@ export default function(): Rule {
     const basePath = process.cwd();
     const failures: string[] = [];
 
-    ctx.logger.info('------ Undecorated classes with DI migration ------');
-    ctx.logger.info(
-        'As of Angular 9, it is no longer supported to use Angular DI ' +
-        'on a class that does not have an Angular decorator. ');
-    ctx.logger.info('Read more about this in the dedicated guide: ');
-    ctx.logger.info('https://v9.angular.io/guide/migration-undecorated-classes');
-
-
     if (!buildPaths.length) {
       throw new SchematicsException(
           'Could not find any tsconfig file. Cannot migrate undecorated derived classes and ' +
@@ -59,12 +50,7 @@ export default function(): Rule {
       ctx.logger.info('Could not migrate all undecorated classes that use dependency');
       ctx.logger.info('injection. Please manually fix the following failures:');
       failures.forEach(message => ctx.logger.warn(`⮑   ${message}`));
-    } else {
-      ctx.logger.info('Successfully migrated all found undecorated classes');
-      ctx.logger.info('that use dependency injection.');
     }
-
-    ctx.logger.info('----------------------------------------------');
   };
 }
 


### PR DESCRIPTION
With the next version of the CLI we don't need to add logging for the description of the schematic as part of the schematic itself.

This is because now, the CLI will print the description defined in the `migrations.json` file.

See: https://github.com/angular/angular-cli/pull/15951
