### PR TITLE
feat(ivy): graceful evaluation of unknown or invalid expressions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/dynamic.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/dynamic.ts
@@ -38,9 +38,10 @@ export const enum DynamicValueReason {
   EXTERNAL_REFERENCE,
 
   /**
-   * A type of `ts.Expression` that `StaticInterpreter` doesn't know how to evaluate.
+   * Syntax that `StaticInterpreter` doesn't know how to evaluate, for example a type of
+   * `ts.Expression` that is not supported.
    */
-  UNKNOWN_EXPRESSION_TYPE,
+  UNSUPPORTED_SYNTAX,
 
   /**
    * A declaration of a `ts.Identifier` could not be found.
@@ -80,8 +81,8 @@ export class DynamicValue<R = unknown> {
     return new DynamicValue(node, ref, DynamicValueReason.EXTERNAL_REFERENCE);
   }
 
-  static fromUnknownExpressionType(node: ts.Node): DynamicValue {
-    return new DynamicValue(node, undefined, DynamicValueReason.UNKNOWN_EXPRESSION_TYPE);
+  static fromUnsupportedSyntax(node: ts.Node): DynamicValue {
+    return new DynamicValue(node, undefined, DynamicValueReason.UNSUPPORTED_SYNTAX);
   }
 
   static fromUnknownIdentifier(node: ts.Identifier): DynamicValue {
@@ -108,8 +109,8 @@ export class DynamicValue<R = unknown> {
     return this.code === DynamicValueReason.EXTERNAL_REFERENCE;
   }
 
-  isFromUnknownExpressionType(this: DynamicValue<R>): this is DynamicValue {
-    return this.code === DynamicValueReason.UNKNOWN_EXPRESSION_TYPE;
+  isFromUnsupportedSyntax(this: DynamicValue<R>): this is DynamicValue {
+    return this.code === DynamicValueReason.UNSUPPORTED_SYNTAX;
   }
 
   isFromUnknownIdentifier(this: DynamicValue<R>): this is DynamicValue {


### PR DESCRIPTION
During static evaluation of expressions within ngtsc, it may occur that
certain expressions or just parts thereof cannot be statically
interpreted for some reason. The static interpreter keeps track of the
failure reason and the code path that was evaluated by means of
`DynamicValue`, which will allow descriptive errors. In some situations
however, the static interpreter would throw an exception instead,
resulting in a crash of the compilation. Not only does this cause
non-descriptive errors, more importantly does it prevent the evaluated
result from being partial, i.e. parts of the result can be dynamic if
their value does not have to be statically available to the compiler.

This commit refactors the static interpreter to never throw errors for
certain expressions that it cannot evaluate.

Resolves FW-1582