### PR TITLE
fix(ivy): `ViewRef.rootNodes` returns rootNodes from child views as well

### DIFF
--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -11,10 +11,12 @@ import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detec
 import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef} from '../linker/view_ref';
 import {assertDefined} from '../util/assert';
+
 import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupFn} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {CONTEXT, FLAGS, HOST, LView, LViewFlags, TView, T_HOST} from './interfaces/view';
+import {assertNodeOfPossibleTypes} from './node_assert';
 import {destroyLView, renderDetachView} from './node_manipulation';
 import {findComponentView, getLViewParent} from './util/view_traversal_utils';
 import {getNativeByTNode, getNativeByTNodeOrNull} from './util/view_utils';
@@ -302,8 +304,12 @@ export class RootViewRef<T> extends ViewRef<T> {
 
 function collectNativeNodes(lView: LView, tNode: TNode | null, result: any[]): any[] {
   while (tNode) {
+    ngDevMode && assertNodeOfPossibleTypes(
+                     tNode, TNodeType.Element, TNodeType.Container, TNodeType.Projection,
+                     TNodeType.ElementContainer);
     const nativeNode = getNativeByTNodeOrNull(tNode, lView);
     nativeNode && result.push(nativeNode);
+
     if (tNode.type === TNodeType.ElementContainer) {
       collectNativeNodes(lView, tNode.child, result);
     } else if (tNode.type === TNodeType.Container) {

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -10,11 +10,13 @@ import {ApplicationRef} from '../application_ref';
 import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef} from '../linker/view_ref';
+import {assertDefined} from '../util/assert';
 
 import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupFn} from './instructions/shared';
+import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
-import {CONTEXT, FLAGS, HOST, LView, LViewFlags, T_HOST} from './interfaces/view';
-import {destroyLView, renderDetachView} from './node_manipulation';
+import {CONTEXT, FLAGS, HOST, LView, LViewFlags, TView, T_HOST} from './interfaces/view';
+import {destroyLView, getLContainer, renderDetachView} from './node_manipulation';
 import {findComponentView, getLViewParent} from './util/view_traversal_utils';
 import {getNativeByTNode, getNativeByTNodeOrNull} from './util/view_utils';
 
@@ -38,7 +40,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
   get rootNodes(): any[] {
     if (this._lView[HOST] == null) {
       const tView = this._lView[T_HOST] as TViewNode;
-      return collectNativeNodes(this._lView, tView, []);
+      return collectNativeNodes(this._lView, tView.child, []);
     }
     return [];
   }
@@ -299,27 +301,35 @@ export class RootViewRef<T> extends ViewRef<T> {
   get context(): T { return null !; }
 }
 
-function collectNativeNodes(lView: LView, parentTNode: TNode, result: any[]): any[] {
-  let tNodeChild = parentTNode.child;
-
-  while (tNodeChild) {
-    const nativeNode = getNativeByTNodeOrNull(tNodeChild, lView);
+function collectNativeNodes(lView: LView, tNode: TNode | null, result: any[]): any[] {
+  while (tNode) {
+    const nativeNode = getNativeByTNodeOrNull(tNode, lView);
     nativeNode && result.push(nativeNode);
-    if (tNodeChild.type === TNodeType.ElementContainer) {
-      collectNativeNodes(lView, tNodeChild, result);
-    } else if (tNodeChild.type === TNodeType.Projection) {
+    if (tNode.type === TNodeType.ElementContainer) {
+      collectNativeNodes(lView, tNode.child, result);
+    } else if (tNode.type === TNodeType.Container) {
+      const lContainer = lView[tNode.index];
+      const containerTView = tNode.tViews !as TView;
+      ngDevMode && assertDefined(containerTView, 'TView expected');
+      const containerFirstChildTNode = containerTView.firstChild !;
+      if (containerFirstChildTNode) {
+        for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
+          collectNativeNodes(lContainer[i], containerFirstChildTNode, result);
+        }
+      }
+    } else if (tNode.type === TNodeType.Projection) {
       const componentView = findComponentView(lView);
       const componentHost = componentView[T_HOST] as TElementNode;
       const parentView = getLViewParent(componentView);
       let currentProjectedNode: TNode|null =
-          (componentHost.projection as(TNode | null)[])[tNodeChild.projection as number];
+          (componentHost.projection as(TNode | null)[])[tNode.projection as number];
 
       while (currentProjectedNode && parentView) {
         result.push(getNativeByTNode(currentProjectedNode, parentView));
         currentProjectedNode = currentProjectedNode.next;
       }
     }
-    tNodeChild = tNodeChild.next;
+    tNode = tNode.next;
   }
 
   return result;

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -11,12 +11,11 @@ import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detec
 import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef} from '../linker/view_ref';
 import {assertDefined} from '../util/assert';
-
 import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupFn} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {CONTEXT, FLAGS, HOST, LView, LViewFlags, TView, T_HOST} from './interfaces/view';
-import {destroyLView, getLContainer, renderDetachView} from './node_manipulation';
+import {destroyLView, renderDetachView} from './node_manipulation';
 import {findComponentView, getLViewParent} from './util/view_traversal_utils';
 import {getNativeByTNode, getNativeByTNodeOrNull} from './util/view_utils';
 
@@ -312,7 +311,7 @@ function collectNativeNodes(lView: LView, tNode: TNode | null, result: any[]): a
       const containerTView = tNode.tViews !as TView;
       ngDevMode && assertDefined(containerTView, 'TView expected');
       const containerFirstChildTNode = containerTView.firstChild !;
-      if (containerFirstChildTNode) {
+      if (containerFirstChildTNode !== null) {
         for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
           collectNativeNodes(lContainer[i], containerFirstChildTNode, result);
         }

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -918,7 +918,7 @@ describe('ViewContainerRef', () => {
       //   - VE ONLY: Extra comment node It is unclear why the VE adds the last one.
       const rootNodes = dirRef.viewRef !.rootNodes;
       expect(rootNodes.length).toBe(ivyEnabled ? 2 : 3);
-      expect(rootNodes[0].outerHTML).toBe('<!--bindings={\n  "ng-reflect-ng-if": "true"\n}-->');
+      expect(rootNodes[0].textContent).toBe('bindings={\n  "ng-reflect-ng-if": "true"\n}');
       expect(rootNodes[1].outerHTML).toBe('<div>Text</div>');
       if (!ivyEnabled) {
         expect(rootNodes[2].outerHTML)

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -895,6 +895,9 @@ describe('ViewContainerRef', () => {
         template: `
           <ng-template [dir]="true">
             <div *ngIf="true">Text</div>
+            <ng-container>container-content</ng-container>
+            <div i18n>assert TNodeType.IcuContainer is never a root node</div>
+            <ng-container i18n>assert TNodeType.IcuContainer is never a root node</ng-container>
           </ng-template>
         `,
       })
@@ -917,13 +920,15 @@ describe('ViewContainerRef', () => {
       //   - One <div>Text</div> node for the ngIf content.
       //   - VE ONLY: Extra comment node It is unclear why the VE adds the last one.
       const rootNodes = dirRef.viewRef !.rootNodes;
-      expect(rootNodes.length).toBe(ivyEnabled ? 2 : 3);
+      expect(rootNodes.length).toBe(7);
       expect(rootNodes[0].textContent).toBe('bindings={\n  "ng-reflect-ng-if": "true"\n}');
       expect(rootNodes[1].outerHTML).toBe('<div>Text</div>');
-      if (!ivyEnabled) {
-        expect(rootNodes[2].outerHTML)
-            .toBe('<!---->');  // It is unclear why the VE adds the last one.
-      }
+      expect(rootNodes[2].textContent).toBe(ivyEnabled ? 'ng-container' : '');
+      expect(rootNodes[3].outerHTML).toBe('container-content');
+      expect(rootNodes[4].outerHTML)
+          .toBe('<div>assert TNodeType.IcuContainer is never a root node</div>');
+      expect(rootNodes[5].textContent).toBe(ivyEnabled ? 'ng-container' : '');
+      expect(rootNodes[6].textContent).toBe('assert TNodeType.IcuContainer is never a root node');
     });
 
   });

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -924,7 +924,7 @@ describe('ViewContainerRef', () => {
       expect(rootNodes[0].textContent).toBe('bindings={\n  "ng-reflect-ng-if": "true"\n}');
       expect(rootNodes[1].outerHTML).toBe('<div>Text</div>');
       expect(rootNodes[2].textContent).toBe(ivyEnabled ? 'ng-container' : '');
-      expect(rootNodes[3].outerHTML).toBe('container-content');
+      expect(rootNodes[3].textContent).toBe('container-content');
       expect(rootNodes[4].outerHTML)
           .toBe('<div>assert TNodeType.IcuContainer is never a root node</div>');
       expect(rootNodes[5].textContent).toBe(ivyEnabled ? 'ng-container' : '');


### PR DESCRIPTION

The idea behind `rootNodes` is to return all of the nodes which need
to be added to the DOM in order for the `ViewRef` to be rendered.
The new implementation correctly takes into account the case where
one of the rootNodes is a container containing other `ViewRef`s.

