### PR TITLE
test(ivy): i18n - add XMB e2e integration test

### DIFF
--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -177,7 +177,7 @@
             },
             "runtime-translations": {
               "devServerTarget": "cli-hello-world-ivy-i18n:serve:runtime-translations",
-              "protractorConfig": "e2e/fr/protractor.conf.js"
+              "protractorConfig": "e2e/runtime/protractor.conf.js"
             },
             "translated-legacy": {
               "devServerTarget": "",

--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -81,6 +81,18 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true
+            },
+            "translated-legacy-xmb": {
+              "tsConfig": "tsconfig.legacy-xmb.json",
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
             }
           }
         },
@@ -161,7 +173,7 @@
               "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci"
             },
             "ci-production": {
-              "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci-production",
+              "devServerTarget": "cli-hello-world-ivy-i18n:serve:ci-production"
             },
             "runtime-translations": {
               "devServerTarget": "cli-hello-world-ivy-i18n:serve:runtime-translations",

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -13,6 +13,7 @@
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production && yarn translated:test && yarn translated:legacy-xlf:test && yarn translated:legacy-xmb:test",
     "translate": "localize-translate -r \"dist/\" -s \"**/*\" -l \"en-US\" -t \"src/locales/messages.de.json\" \"src/locales/messages.fr.json\" -o \"../tmp/translations/{{LOCALE}}\"",
+    "runtime:test": "yarn e2e --configuration=runtime-translations",
     "translated:test": "yarn build && yarn translate && yarn translated:fr:e2e && yarn translated:de:e2e && yarn translated:en:e2e",
     "translated:fr:serve": "serve ../tmp/translations/fr --listen 4200",
     "translated:fr:e2e": "npm-run-all -p -r translated:fr:serve \"ng e2e --configuration=translated-fr\"",

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -11,7 +11,7 @@
     "update-webdriver": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG",
     "start": "ng serve",
     "pretest": "ng version",
-    "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production && yarn translated:test && yarn translated:legacy:test",
+    "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production && yarn translated:test && yarn translated:legacy-xlf:test && yarn translated:legacy-xmb:test",
     "translate": "localize-translate -r \"dist/\" -s \"**/*\" -l \"en-US\" -t \"src/locales/messages.de.json\" \"src/locales/messages.fr.json\" -o \"../tmp/translations/{{LOCALE}}\"",
     "translated:test": "yarn build && yarn translate && yarn translated:fr:e2e && yarn translated:de:e2e && yarn translated:en:e2e",
     "translated:fr:serve": "serve ../tmp/translations/fr --listen 4200",
@@ -20,11 +20,14 @@
     "translated:de:e2e": "npm-run-all -p -r translated:de:serve \"ng e2e --configuration=translated-de\"",
     "translated:en:serve": "serve ../tmp/translations/en-US --listen 4200",
     "translated:en:e2e": "npm-run-all -p -r translated:en:serve \"ng e2e --configuration=translated-en\"",
-    "translated:legacy:test": "yarn translated:legacy:extract-and-update && ng build --configuration=translated-legacy && yarn translated:legacy:translate && yarn translated:legacy:e2e",
-    "translated:legacy:extract-and-update": "ng xi18n && sed -i.bak -e 's/source>/target>'/ -e 's/Hello/Bonjour/' -e 's/source-language=\"en-US\"/source-language=\"en-US\" target-language=\"legacy\"/' ../tmp/legacy-locales/messages.legacy.xlf",
-    "translated:legacy:translate": "localize-translate -r \"dist/\" -s \"**/*\" -t \"../tmp/legacy-locales/messages.legacy.xlf\" -o \"../tmp/translations/{{LOCALE}}\"",
     "translated:legacy:serve": "serve ../tmp/translations/legacy --listen 4200",
-    "translated:legacy:e2e": "npm-run-all -p -r translated:legacy:serve \"ng e2e --configuration=translated-legacy\""
+    "translated:legacy:e2e": "npm-run-all -p -r translated:legacy:serve \"ng e2e --configuration=translated-legacy\"",
+    "translated:legacy:translate": "localize-translate -r \"dist/\" -s \"**/*\" -o \"../tmp/translations/{{LOCALE}}\"",
+
+    "translated:legacy-xlf:test": "yarn ng xi18n && yarn translated:legacy-xlf:update-translations && yarn ng build --configuration=translated-legacy && yarn translated:legacy:translate -t \"../tmp/legacy-locales/messages.legacy.xlf\" && yarn translated:legacy:e2e",
+    "translated:legacy-xlf:update-translations": "sed -i.bak -e 's/source>/target>'/ -e 's/Hello/Bonjour/' -e 's/source-language=\"en-US\"/source-language=\"en-US\" target-language=\"legacy\"/' ../tmp/legacy-locales/messages.legacy.xlf",
+    "translated:legacy-xmb:test": "yarn ng xi18n --format=xmb --outFile=messages.legacy.xmb && yarn translated:legacy-xmb:update-translations && yarn ng build --configuration=translated-legacy-xmb && yarn translated:legacy:translate -t \"../tmp/legacy-locales/messages.legacy.xtb\" && yarn translated:legacy:e2e",
+    "translated:legacy-xmb:update-translations": "sed -e 's/messagebundle/translationbundle/' -e 's/<translationbundle>/<translationbundle lang=\"legacy\">/' -e 's/msg/translation/' -e 's/Hello/Bonjour/' -e 's/<source>.*<\\/source>//' ../tmp/legacy-locales/messages.legacy.xmb > ../tmp/legacy-locales/messages.legacy.xtb"
   },
   "private": true,
   "dependencies": {

--- a/integration/cli-hello-world-ivy-i18n/tsconfig.legacy-xmb.json
+++ b/integration/cli-hello-world-ivy-i18n/tsconfig.legacy-xmb.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app.json",
+  "angularCompilerOptions": {
+    "enableIvy": true,
+    "i18nInFormat": "xmb"
+  }
+}


### PR DESCRIPTION
This integration test now does a full e2e test of:

* extraction -> build -> translation - serve

for both XLIFF 1.2 and XMB formats.

Resolves https://github.com/angular/angular/pull/33444#issuecomment-547146280
