### PR TITLE
fix(compiler): i18n - ignore `alt-trans` tags in XLIFF 1.2

### DIFF
--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -25,6 +25,7 @@ const _MARKER_TAG = 'mrk';
 const _FILE_TAG = 'file';
 const _SOURCE_TAG = 'source';
 const _SEGMENT_SOURCE_TAG = 'seg-source';
+const _ALT_TRANS_TAG = 'alt-trans';
 const _TARGET_TAG = 'target';
 const _UNIT_TAG = 'trans-unit';
 const _CONTEXT_GROUP_TAG = 'context-group';
@@ -222,6 +223,7 @@ class XliffParser implements ml.Visitor {
       // ignore those tags
       case _SOURCE_TAG:
       case _SEGMENT_SOURCE_TAG:
+      case _ALT_TRANS_TAG:
         break;
 
       case _TARGET_TAG:

--- a/packages/compiler/test/i18n/serializers/xliff_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff_spec.ts
@@ -296,6 +296,30 @@ lignes`,
       it('should return the target locale',
          () => { expect(serializer.load(LOAD_XLIFF, 'url').locale).toEqual('fr'); });
 
+      it('should ignore alt-trans targets', () => {
+        const XLIFF = `
+          <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+            <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+              <body>
+                <trans-unit datatype="html" approved="no" id="registration.submit">
+                  <source>Continue</source>
+                  <target state="translated" xml:lang="de">Weiter</target>
+                  <context-group purpose="location">
+                    <context context-type="sourcefile">src/app/auth/registration-form/registration-form.component.html</context>
+                    <context context-type="linenumber">69</context>
+                  </context-group>
+                  <?sid 1110954287-0?>
+                  <alt-trans origin="autoFuzzy" tool="Swordfish" match-quality="71" ts="63">
+                    <source xml:lang="en">Content</source>
+                    <target state="translated" xml:lang="de">Content</target>
+                  </alt-trans>
+              </trans-unit>
+              </body>
+            </file>
+          </xliff>`;
+
+        expect(loadAsMap(XLIFF)).toEqual({'registration.submit': 'Weiter'});
+      });
 
       describe('structure errors', () => {
         it('should throw when a trans-unit has no translation', () => {


### PR DESCRIPTION
This is a patch version of https://github.com/angular/angular/pull/33450.