### PR TITLE
build: remove --nowatchfs flag as --watchfs is a noop on windows now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,10 +18,6 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # See https://github.com/bazelbuild/bazel/issues/4603
 build --symlink_prefix=dist/
 
-# Disable watchfs as it causes tests to be flaky on Windows
-# https://github.com/angular/angular/issues/29541
-build --nowatchfs
-
 # Turn off legacy external runfiles
 run --nolegacy_external_runfiles
 test --nolegacy_external_runfiles


### PR DESCRIPTION
Removing `--nowatchfs` to allow for linux/os x to get back, albeit minimal, performance gains.

`--watchfs` is now a noop on bazel for windows as seen [here](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java#L90)