### PR TITLE
test(language-service): Completions test should reuse existing host and services

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {CompletionKind, LanguageService} from '../src/types';
+import {CompletionKind} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
@@ -24,6 +24,8 @@ describe('completions', () => {
   const tsLS = ts.createLanguageService(mockHost);
   const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
   const ngLS = createLanguageService(ngHost);
+
+  beforeEach(() => { mockHost.reset(); });
 
   it('should be able to get entity completions', () => {
     const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'entity-amp');
@@ -370,192 +372,182 @@ describe('completions', () => {
     //   expectContain(completions, CompletionKind.PROPERTY, ['innerText']);
     // });
   });
-});
 
-describe('replace completions correctly', () => {
-  const mockHost = new MockTypescriptHost(['/app/main.ts']);
-  let ngLS: LanguageService;
+  describe('replacement span', () => {
+    it('should not generate replacement entries for zero-length replacements', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <div>{{obj.~{key}}}</div>
+          \`,
+        })
+        export class FooComponent {
+          obj: {key: 'value'};
+        }
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'key');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'key') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('property');
+      expect(completion.replacementSpan).toBeUndefined();
+    });
 
-  beforeEach(() => {
-    mockHost.reset();
-    const tsLS = ts.createLanguageService(mockHost);
-    const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
-    ngLS = createLanguageService(ngHost);
-  });
+    it('should work for start of template', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`~{start}abc\`,
+        })
+        export class FooComponent {}
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'start');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'acronym') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('html element');
+      expect(completion.replacementSpan).toEqual({start: location.start, length: 3});
+    });
 
-  it('should not generate replacement entries for zero-length replacements', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <div>{{obj.~{key}}}</div>
-            \`,
-          })
-          export class FooComponent {
-            obj: {key: 'value'};
-          }
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'key');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'key') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('property');
-    expect(completion.replacementSpan).toBeUndefined();
-  });
+    it('should work for end of template', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`acro~{end}\`,
+        })
+        export class FooComponent {}
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'end');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'acronym') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('html element');
+      expect(completion.replacementSpan).toEqual({start: location.start - 4, length: 4});
+    });
 
-  it('should work for start of template', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`~{start}abc\`,
-          })
-          export class FooComponent {}
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'start');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'acronym') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('html element');
-    expect(completion.replacementSpan).toEqual({start: location.start, length: 3});
-  });
+    it('should work for middle-word replacements', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <div>{{obj.ke~{key}key}}</div>
+          \`,
+        })
+        export class FooComponent {
+          obj: {key: 'value'};
+        }
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'key');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'key') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('property');
+      expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 5});
+    });
 
-  it('should work for end of template', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`acro~{end}\`,
-          })
-          export class FooComponent {}
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'end');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'acronym') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('html element');
-    expect(completion.replacementSpan).toEqual({start: location.start - 4, length: 4});
-  });
+    it('should work for all kinds of identifier characters', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <div>{{~{field}$title_1}}</div>
+          \`,
+        })
+        export class FooComponent {
+          $title_1: string;
+        }
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'field');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === '$title_1') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('property');
+      expect(completion.replacementSpan).toEqual({start: location.start, length: 8});
+    });
 
-  it('should work for middle-word replacements', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <div>{{obj.ke~{key}key}}</div>
-            \`,
-          })
-          export class FooComponent {
-            obj: {key: 'value'};
-          }
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'key');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'key') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('property');
-    expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 5});
-  });
+    it('should work for attributes', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <div cl~{click}></div>
+          \`,
+        })
+        export class FooComponent {}
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'click');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === '(click)') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('attribute');
+      expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
+    });
 
-  it('should work for all kinds of identifier characters', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <div>{{~{field}$title_1}}</div>
-            \`,
-          })
-          export class FooComponent {
-            $title_1: string;
-          }
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'field');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === '$title_1') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('property');
-    expect(completion.replacementSpan).toEqual({start: location.start, length: 8});
-  });
+    it('should work for events', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <div (click)="han~{handleClick}"></div>
+          \`,
+        })
+        export class FooComponent {
+          handleClick() {}
+        }
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'handleClick');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'handleClick') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('method');
+      expect(completion.replacementSpan).toEqual({start: location.start - 3, length: 3});
+    });
 
-  it('should work for attributes', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <div cl~{click}></div>
-            \`,
-          })
-          export class FooComponent {}
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'click');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === '(click)') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('attribute');
-    expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
-  });
+    it('should work for element names', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
+            <di~{div}></div>
+          \`,
+        })
+        export class FooComponent {}
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'div');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === 'div') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('html element');
+      expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
+    });
 
-  it('should work for events', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <div (click)="han~{handleClick}"></div>
-            \`,
-          })
-          export class FooComponent {
-            handleClick() {}
-          }
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'handleClick');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'handleClick') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('method');
-    expect(completion.replacementSpan).toEqual({start: location.start - 3, length: 3});
-  });
-
-  it('should work for element names', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
-              <di~{div}></div>
-            \`,
-          })
-          export class FooComponent {}
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'div');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === 'div') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('html element');
-    expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
-  });
-
-  it('should work for bindings', () => {
-    const fileName = mockHost.addCode(`
-          @Component({
-            selector: 'foo-component',
-            template: \`
+    it('should work for bindings', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          selector: 'foo-component',
+          template: \`
             <input ngMod~{model} />
-            \`,
-          })
-          export class FooComponent {}
-        `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'model');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expect(completions).toBeDefined();
-    const completion = completions.entries.find(entry => entry.name === '[(ngModel)]') !;
-    expect(completion).toBeDefined();
-    expect(completion.kind).toBe('attribute');
-    expect(completion.replacementSpan).toEqual({start: location.start - 5, length: 5});
+          \`,
+        })
+        export class FooComponent {}
+      `);
+      const location = mockHost.getLocationMarkerFor(fileName, 'model');
+      const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+      expect(completions).toBeDefined();
+      const completion = completions.entries.find(entry => entry.name === '[(ngModel)]') !;
+      expect(completion).toBeDefined();
+      expect(completion.kind).toBe('attribute');
+      expect(completion.replacementSpan).toEqual({start: location.start - 5, length: 5});
+    });
   });
 });
 


### PR DESCRIPTION
Sorry I missed this in the PR yesterday. 
Reusing the single instance of MockHost and language services makes the tests run much faster.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
