### PR TITLE
Add elements project type for boilerplate example projects

### DIFF
--- a/aio/content/examples/elements/example-config.json
+++ b/aio/content/examples/elements/example-config.json
@@ -1,0 +1,3 @@
+{
+  "projectType": "elements"
+}

--- a/aio/tools/examples/example-boilerplate.js
+++ b/aio/tools/examples/example-boilerplate.js
@@ -30,6 +30,8 @@ const BOILERPLATE_PATHS = {
 // This maps the CLI files that exists in a parent folder
 const cliRelativePath = BOILERPLATE_PATHS.cli.map(file => `../cli/${file}`);
 
+BOILERPLATE_PATHS.elements = [...cliRelativePath, 'package.json'];
+
 BOILERPLATE_PATHS.i18n = [...cliRelativePath, 'angular.json', 'package.json'];
 
 BOILERPLATE_PATHS['service-worker'] = [...cliRelativePath, 'angular.json', 'package.json'];

--- a/aio/tools/examples/shared/boilerplate/elements/package.json
+++ b/aio/tools/examples/shared/boilerplate/elements/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "angular.io-example",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^8.0.0",
+    "@angular/common": "^8.0.0",
+    "@angular/compiler": "^8.0.0",
+    "@angular/core": "^8.0.0",
+    "@angular/elements": "^8.0.0",
+    "@angular/forms": "^8.0.0",
+    "@angular/platform-browser": "^8.0.0",
+    "@angular/platform-browser-dynamic": "^8.0.0",
+    "@angular/router": "^8.0.0",
+    "angular-in-memory-web-api": "^0.8.0",
+    "core-js": "^2.5.4",
+    "rxjs": "^6.5.1",
+    "tslib": "^1.10.0",
+    "web-animations-js": "^2.3.1",
+    "zone.js": "~0.10.2"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^0.800.0",
+    "@angular/cli": "^8.0.0",
+    "@angular/compiler-cli": "^8.0.0",
+    "@angular/language-service": "^8.0.0",
+    "@types/jasmine": "~3.3.8",
+    "@types/jasminewd2": "~2.0.3",
+    "@types/node": "~8.9.4",
+    "codelyzer": "~5.0.0",
+    "jasmine-core": "~2.99.1",
+    "jasmine-marbles": "^0.6.0",
+    "jasmine-spec-reporter": "~4.2.1",
+    "karma": "~4.1.0",
+    "karma-chrome-launcher": "~2.2.0",
+    "karma-coverage-istanbul-reporter": "~2.0.1",
+    "karma-jasmine": "~2.0.1",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "~5.4.0",
+    "ts-node": "~7.0.0",
+    "tslint": "~5.15.0",
+    "typescript": "~3.4.4"
+  }
+}


### PR DESCRIPTION
Added elements project type to the boilerplate sample projects to fix the issue with the angular elements example project in the Angular docs needing to be updated due to the angular elements package not being present in the `package.json` file when the zip file is downloaded.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When downloading the zip from the [https://angular.io/generated/zips/elements/elements.zip](https://angular.io/generated/zips/elements/elements.zip) the `@angular/elements` package is not included in the `package.json`

Issue Number: #31332 


## What is the new behavior? 
the `@angular/elements` package should now be included when downloading the following zip mentioned above.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
