### PR TITLE
build: restore functionality of the micro benchmarks `profile_all.js` script

### DIFF
--- a/packages/core/test/render3/perf/profile_all.js
+++ b/packages/core/test/render3/perf/profile_all.js
@@ -30,7 +30,7 @@ const profileTests =
 // build tests
 shell.exec(
     `yarn bazel build --define=compile=aot ` +
-    profileTests.map((name) => `//packages/core/test/render3/perf:${name}.min_debug.es2015.js`)
+    profileTests.map((name) => `//packages/core/test/render3/perf:${name}_lib.min_debug.es2015.js`)
         .join(' '));
 
 // profile tests
@@ -61,7 +61,7 @@ profileTests.forEach((name) => {
   // tslint:disable-next-line:no-console
   console.log('----------------', name, '----------------');
   const log =
-      shell.exec(`node dist/bin/packages/core/test/render3/perf/${name}.min_debug.es2015.js`);
+      shell.exec(`node dist/bin/packages/core/test/render3/perf/${name}_lib.min_debug.es2015.js`);
   if (log.code != 0) throw new Error(log);
   const matches = log.stdout.match(/: ([\d\.]+) (.s)/);
   const runTime = times[name] || (times[name] = {name: name});


### PR DESCRIPTION
The 4b81bb5c979382d5f698e0cd729763dd675c226c patch seemingly broke the
`profile_all.js` file due to the file renaming. This patch restores the
functionality of said script.