### PR TITLE
fix(compiler-cli): attach the correct `viaModule` to namespace imports

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -1558,7 +1558,7 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe(null);
+        expect(actualDeclaration !.viaModule).toBe('@angular/core');
       });
 
       it('should return the original declaration of an aliased class', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1788,7 +1788,7 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe(null);
+        expect(actualDeclaration !.viaModule).toBe('@angular/core');
       });
 
       it('should return the correct declaration for an inner function identifier inside an ES5 IIFE',

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -191,14 +191,13 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       return null;
     }
 
-    // Ignore decorators that are defined locally (not imported).
     const decl: ts.Declaration = symbol.declarations[0];
-    if (!ts.isImportSpecifier(decl)) {
+    const importDecl = getContainingImportDeclaration(decl);
+
+    // Ignore declarations that are defined locally (not imported).
+    if (importDecl === null) {
       return null;
     }
-
-    // Walk back from the specifier to find the declaration, which carries the module specifier.
-    const importDecl = decl.parent !.parent !.parent !;
 
     // The module specifier is guaranteed to be a string literal, so this should always pass.
     if (!ts.isStringLiteral(importDecl.moduleSpecifier)) {
@@ -206,13 +205,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       return null;
     }
 
-    // Read the module specifier.
-    const from = importDecl.moduleSpecifier.text;
-
-    // Compute the name by which the decorator was exported, not imported.
-    const name = (decl.propertyName !== undefined ? decl.propertyName : decl.name).text;
-
-    return {from, name};
+    return {from: importDecl.moduleSpecifier.text, name: getExportedName(decl, id)};
   }
 
   /**
@@ -548,4 +541,24 @@ function getFarLeftIdentifier(propertyAccess: ts.PropertyAccessExpression): ts.I
     propertyAccess = propertyAccess.expression;
   }
   return ts.isIdentifier(propertyAccess.expression) ? propertyAccess.expression : null;
+}
+
+/**
+ * Return the ImportDeclaration for the given `node` if it is either an `ImportSpecifier` or a
+ * `NamespaceImport`. If not return `null`.
+ */
+function getContainingImportDeclaration(node: ts.Node): ts.ImportDeclaration|null {
+  return ts.isImportSpecifier(node) ? node.parent !.parent !.parent ! :
+                                      ts.isNamespaceImport(node) ? node.parent.parent : null;
+}
+
+/**
+ * Compute the name by which the `decl` was exported, not imported.
+ * If no such declaration can be found (e.g. it is a namespace import)
+ * then fallback to the `originalId`.
+ */
+function getExportedName(decl: ts.Declaration, originalId: ts.Identifier): string {
+  return ts.isImportSpecifier(decl) ?
+      (decl.propertyName !== undefined ? decl.propertyName : decl.name).text :
+      originalId.text;
 }


### PR DESCRIPTION
Previously declarations that were imported via a namespace import
were given the same `bestGuessOwningModule` as the context
where they were imported to. This causes problems with resolving
`ModuleWithProviders` that have a type that has been imported in
this way, causing errors like:

```
ERROR in Symbol UIRouterModule declared in
.../@uirouter/angular/uiRouterNgModule.d.ts
is not exported from
.../@uirouter/angular/uirouter-angular.d.ts
(import into .../src/app/child.module.ts)
```

This commit modifies the `TypescriptReflectionHost.getDirectImportOfIdentifier()`
method so that it also understands how to attach the correct `viaModule` to
the identifier of the namespace import.

Resolves #32166
