### PR TITLE
build(common): add global UMD export to locale files

### DIFF
--- a/packages/common/locales/BUILD.bazel
+++ b/packages/common/locales/BUILD.bazel
@@ -18,6 +18,7 @@ npm_package(
         # Workaround for `.d.ts`` containing `/// <amd-module .../>`
         # which are generated in TypeScript v2.9, but not before.
         "/// <amd-module name=.*/>": "",
+
         # Workaround for https://github.com/angular/angular/issues/23217
         # Webpack will detect that the UMD outputs from TypeScript pass the
         # `require` function into the module, and cannot accurately track
@@ -25,6 +26,12 @@ npm_package(
         # We don't actually import anything in the locale code so we can
         # null out the require reference passed into the module.
         "factory\(require, exports\)": "factory(null, exports)",
+
+        # Attach the locale to the global scope at `ng.common.locale...` if not UMD or CommonJS
+        "\(function \(factory\) {": "(function (root, factory) {",
+        "}\)\(function \(require, exports\) {": "})(typeof globalThis !== \"undefined\" && globalThis || typeof global !== \"undefined\" && global || typeof window !== \"undefined\" && window || this, function (require, exports) {",
+        #11111111111111111111111111111111111111111111111111111111222221111111111111111111111111111111111333333331111111111111111111111111111111111111111111114444411
+        "(if \(typeof define === \"function\" && define.amd\) {\n(\s*)define\(\"@angular/common/locales/([^\"]+)\", \[\"require\", \"exports\"], factory\);\n(\s*)})": "$1 else {\n$2if (typeof root.ng === \"undefined\") root.ng = {};if (typeof root.ng.common === \"undefined\") root.ng.common = {};if (typeof root.ng.common.locale === \"undefined\") root.ng.common.locale = {};var container = {};factory(null, container);root.ng.common.locale[\"$3\"] = container.default;\n$4}",
     },
     deps = [":locales"],
 )

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -15,7 +15,7 @@ import localeHu from '@angular/common/locales/hu';
 import localeSr from '@angular/common/locales/sr';
 import localeTh from '@angular/common/locales/th';
 import {isDate, toDate, formatDate} from '@angular/common/src/i18n/format_date';
-import {ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID} from '@angular/core';
+import {ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵLOCALE_DATA} from '@angular/core';
 
 describe('Format date', () => {
   describe('toDate', () => {
@@ -62,6 +62,13 @@ describe('Format date', () => {
       registerLocaleData(localeSr);
       registerLocaleData(localeTh);
       registerLocaleData(localeAr);
+    });
+
+    afterAll(() => {
+      // Clear out the loaded locales
+      for (const key in ɵLOCALE_DATA) {
+        delete ɵLOCALE_DATA[key];
+      }
     });
 
     beforeEach(() => { date = new Date(2015, 5, 15, 9, 3, 1, 550); });

--- a/packages/common/test/i18n/format_number_spec.ts
+++ b/packages/common/test/i18n/format_number_spec.ts
@@ -12,7 +12,7 @@ import localeFr from '@angular/common/locales/fr';
 import localeAr from '@angular/common/locales/ar';
 import {formatCurrency, formatNumber, formatPercent, registerLocaleData} from '@angular/common';
 import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
-import {ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID} from '@angular/core';
+import {ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵLOCALE_DATA} from '@angular/core';
 
 describe('Format number', () => {
   beforeAll(() => {
@@ -20,6 +20,13 @@ describe('Format number', () => {
     registerLocaleData(localeEsUS);
     registerLocaleData(localeFr);
     registerLocaleData(localeAr);
+  });
+
+  afterAll(() => {
+    // Clear out the loaded locales
+    for (const key in ɵLOCALE_DATA) {
+      delete ɵLOCALE_DATA[key];
+    }
   });
 
   describe('Number', () => {

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -10,7 +10,7 @@ import localeRo from '@angular/common/locales/ro';
 import localeSr from '@angular/common/locales/sr';
 import localeZgh from '@angular/common/locales/zgh';
 import localeFr from '@angular/common/locales/fr';
-import {LOCALE_ID} from '@angular/core';
+import {LOCALE_ID, ɵLOCALE_DATA} from '@angular/core';
 import {TestBed, inject} from '@angular/core/testing';
 import {NgLocaleLocalization, NgLocalization, getPluralCategory} from '@angular/common/src/i18n/localization';
 import {registerLocaleData} from '../../src/i18n/locale_data';
@@ -22,6 +22,13 @@ import {registerLocaleData} from '../../src/i18n/locale_data';
       registerLocaleData(localeSr);
       registerLocaleData(localeZgh);
       registerLocaleData(localeFr);
+    });
+
+    afterAll(() => {
+      // Clear out the loaded locales
+      for (const key in ɵLOCALE_DATA) {
+        delete ɵLOCALE_DATA[key];
+      }
     });
 
     describe('NgLocalization', () => {

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -11,6 +11,7 @@ import localeEn from '@angular/common/locales/en';
 import localeEnExtra from '@angular/common/locales/extra/en';
 import {PipeResolver} from '@angular/compiler/src/pipe_resolver';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
+import {ɵLOCALE_DATA} from '@angular/core';
 
 {
   let date: Date;
@@ -24,6 +25,13 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
     }
 
     beforeAll(() => { registerLocaleData(localeEn, localeEnExtra); });
+
+    afterAll(() => {
+      // Clear out the loaded locales
+      for (const key in ɵLOCALE_DATA) {
+        delete ɵLOCALE_DATA[key];
+      }
+    });
 
     beforeEach(() => {
       date = new Date(2015, 5, 15, 9, 3, 1, 550);

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -13,6 +13,7 @@ import localeAr from '@angular/common/locales/ar';
 import localeDeAt from '@angular/common/locales/de-AT';
 import {registerLocaleData, CurrencyPipe, DecimalPipe, PercentPipe, formatNumber} from '@angular/common';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
+import {ɵLOCALE_DATA} from '@angular/core';
 
 {
   describe('Number pipes', () => {
@@ -22,6 +23,13 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
       registerLocaleData(localeFr);
       registerLocaleData(localeAr);
       registerLocaleData(localeDeAt);
+    });
+
+    afterAll(() => {
+      // Clear out the loaded locales
+      for (const key in ɵLOCALE_DATA) {
+        delete ɵLOCALE_DATA[key];
+      }
     });
 
     describe('DecimalPipe', () => {


### PR DESCRIPTION
In order to support adding locales during compile-time
inlining of translations (i.e. after the TS build has completed),
we need to be able to attach the locale to the global scope.

This commit modifies the UMD wrapper of the final locale files
that appear in the `@angular/common` package to export the
locale onto the global object if not in AMD or CommonJS.

---

There is no capacity in the TS compiler to modify the UMD wrapper
that it exports. This commit continues the current approach of modifying
the files before they get added to the npm package.

This is slightly brittle to any change that TS might make to their UMD output.
We could mitigate this by making the regex more flexible (but more complex)
or we could move completely to a new tool (like rollup) for generating the UMD
wrapper for each file.

---

To support compile time localization, we need to be
able to provide the locales via a well known global property
ng.common.locale.

This commit changes findLocaleData() so that it will
attempt to read the local from the global if the locale
has not already been registered.

I had to touch a number of tests because they were registering locales
and leaving them in place, which affected subsequent tests.