### PR TITLE
Template perf

### DIFF
--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -17,7 +17,7 @@ import {FLAGS, HEADER_OFFSET, InitPhaseState, LView, LViewFlags, RENDERER, TVIEW
 import {assertNodeType} from '../node_assert';
 import {appendChild, removeView} from '../node_manipulation';
 import {getBindingIndex, getCheckNoChangesMode, getIsParent, getLView, getPreviousOrParentTNode, setIsNotParent, setPreviousOrParentTNode} from '../state';
-import {getNativeByTNode, load} from '../util/view_utils';
+import {load} from '../util/view_utils';
 
 import {addToViewTree, createDirectivesInstances, createLContainer, createTNode, createTView, getOrCreateTNode, resolveDirectives, saveResolvedLocalsInData} from './shared';
 
@@ -185,7 +185,7 @@ function containerInternal(
   const lContainer = lView[adjustedIndex] = createLContainer(comment, lView, comment, tNode);
 
   appendChild(comment, tNode, lView);
-  attachPatchData(getNativeByTNode(tNode, lView), lView);
+  attachPatchData(comment, lView);
 
   // Containers are added to the current view tree instead of their embedded views
   // because views can be removed and re-inserted.

--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -100,6 +100,19 @@ ng_benchmark(
 )
 
 ng_rollup_bundle(
+    name = "ng_template_lib",
+    entry_point = ":ng_template/index.ts",
+    deps = [
+        ":perf_lib",
+    ],
+)
+
+ng_benchmark(
+    name = "ng_template",
+    bundle = ":ng_template_lib",
+)
+
+ng_rollup_bundle(
     name = "property_binding_lib",
     entry_point = ":property_binding/index.ts",
     deps = [

--- a/packages/core/test/render3/perf/ng_template/index.ts
+++ b/packages/core/test/render3/perf/ng_template/index.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ɵɵtemplate} from '../../../../src/render3/instructions/container';
+import {createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {RenderFlags} from '../../../../src/render3/interfaces/definition';
+import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
+import {createBenchmark} from '../micro_bench';
+import {createAndRenderLView} from '../setup';
+
+`<div>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+    <ng-template></ng-template>
+  </div>
+</ng-template>`;
+function testTemplate(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵtemplate(0, null, 0, 0);
+    ɵɵtemplate(1, null, 0, 0);
+    ɵɵtemplate(2, null, 0, 0);
+    ɵɵtemplate(3, null, 0, 0);
+    ɵɵtemplate(4, null, 0, 0);
+    ɵɵtemplate(5, null, 0, 0);
+    ɵɵtemplate(6, null, 0, 0);
+    ɵɵtemplate(7, null, 0, 0);
+    ɵɵtemplate(8, null, 0, 0);
+    ɵɵtemplate(9, null, 0, 0);
+  }
+}
+
+const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
+const embeddedTView = createTView(-1, testTemplate, 10, 0, null, null, null, null, null);
+
+// create view once so we don't profile first template pass
+createAndRenderLView(null, embeddedTView, viewTNode);
+
+// scenario to benchmark
+const elementTextCreate = createBenchmark('ng_template');
+const createTime = elementTextCreate('create');
+
+console.profile('ng_template_create');
+while (createTime()) {
+  createAndRenderLView(null, embeddedTView, viewTNode);
+}
+console.profileEnd();
+
+// report results
+elementTextCreate.report();


### PR DESCRIPTION
This PR includes a new benchmark focused on `<ng-template>` processing in the creation mode + a trivial improvement that speeds up this benchmark by ~15%by avoiding lookup-up in data structures when we've got data ready