### PR TITLE
docs: update to use latest 8.3.x CLI

### DIFF
--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -7,7 +7,7 @@ This guide contains everything you need to know about updating to the next Angul
 If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script:
 
 ```
-npm install --no-save @angular/cli@8.3.15
+npm install --no-save @angular/cli@^8.3.15
 ng update @angular/cli @angular/core --next
 ```
 


### PR DESCRIPTION
Change the "Updating to v9" docs to reflect that we want to use the latest 8.3.x CLI build for updating and not just 8.3.15.