### PR TITLE
ci: always run the publish_packages_as_artifacts jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -844,8 +844,6 @@ workflows:
           requires:
             - build-npm-packages
       - publish_packages_as_artifacts:
-          # Only run on PR builds. (For non-PR builds, the `publish_snapshot` job.)
-          <<: *only_on_pull_requests
           requires:
             - build-npm-packages
       - publish_snapshot:


### PR DESCRIPTION
We should always run the `publish_packages_as_artifacts` job since even on `master` there is value in being able to access the artifacts from committed code as well.