### PR TITLE
fix(language-service): Should not crash if expr ends unexpectedly

### DIFF
--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -21,26 +21,23 @@ import {findPropertyValueOfType, findTightestNode, offsetSpan, spanOf} from './u
  * @param ast contains HTML and template AST
  */
 export function getTemplateDiagnostics(ast: AstResult): ng.Diagnostic[] {
-  const results: ng.Diagnostic[] = [];
   const {parseErrors, templateAst, htmlAst, template} = ast;
-  if (parseErrors) {
-    results.push(...parseErrors.map(e => {
+  if (parseErrors && parseErrors.length) {
+    return parseErrors.map(e => {
       return {
         kind: ng.DiagnosticKind.Error,
         span: offsetSpan(spanOf(e.span), template.span.start),
         message: e.msg,
       };
-    }));
+    });
   }
-  const expressionDiagnostics = getTemplateExpressionDiagnostics({
+  return getTemplateExpressionDiagnostics({
     templateAst: templateAst,
     htmlAst: htmlAst,
     offset: template.span.start,
     query: template.query,
     members: template.members,
   });
-  results.push(...expressionDiagnostics);
-  return results;
 }
 
 /**

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -56,6 +56,19 @@ describe('diagnostics', () => {
     }
   });
 
+  it('should report error for unexpected end of expression', () => {
+    const content = mockHost.override(TEST_TEMPLATE, `{{ 5 / }}`);
+    const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(diags.length).toBe(1);
+    const {messageText, start, length} = diags[0];
+    expect(messageText)
+        .toBe(
+            'Parser Error: Unexpected end of expression: {{ 5 / }} ' +
+            'at the end of the expression [{{ 5 / }}] in /app/test.ng@0:0');
+    expect(start).toBe(0);
+    expect(length).toBe(content.length);
+  });
+
   // https://github.com/angular/vscode-ng-language-service/issues/242
   it('should support $any() type cast function', () => {
     mockHost.override(TEST_TEMPLATE, `<div>{{$any(title).xyz}}</div>`);


### PR DESCRIPTION
If there is any parser errors when parsing template, we should stop
immediately and not proceed with template expression diagnostics.

This regression is caused by https://github.com/angular/angular/commit/6d111546527812ab48f48e156f09ef41cb9be1ca
and affected v9.0.0-next.4 onwards.

PR closes https://github.com/angular/vscode-ng-language-service/issues/436

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
