### PR TITLE
ci: re-enable material unit tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ var_4_win: &cache_key_win_fallback v5-angular-win-node-12.0-
 
 # Cache key for the Material unit tests job. **Note** when updating the SHA in the cache keys,
 # also update the SHA for the "MATERIAL_REPO_COMMIT" environment variable.
-var_5: &material_unit_tests_cache_key v4-angular-material-818a8c7d6bb3f25d0637e5d6462cf9a84403b78f
-var_6: &material_unit_tests_cache_key_fallback v4-angular-material-
+var_5: &material_unit_tests_cache_key v5-angular-material-50514b2358f394f1f6d634fa181b563b7edd738b
+var_6: &material_unit_tests_cache_key_fallback v5-angular-material-
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages` and
 # `build-ivy-npm-packages`.
@@ -708,7 +708,11 @@ jobs:
       - run:
           # Run yarn install to fetch the Bazel binaries as used in the Material repo.
           name: Installing Material dependencies.
-          command: yarn --cwd ${MATERIAL_REPO_TMP_DIR} install --frozen-lockfile --non-interactive
+          # TODO: remove this once the repo has been updated to use NodeJS v12 and Yarn 1.19.1.
+          # We temporarily ignore the "engines" because the Angular components repository has
+          # minimum dependency on NodeJS v12 and Yarn 1.19.1, but the framework repository uses
+          # older versions.
+          command: yarn --ignore-engines --cwd ${MATERIAL_REPO_TMP_DIR} install --frozen-lockfile --non-interactive
       - save_cache:
           key: *material_unit_tests_cache_key
           paths:
@@ -869,10 +873,9 @@ workflows:
             - build-ivy-npm-packages
             - legacy-unit-tests-saucelabs
             - legacy-misc-tests
-      # FIXME: temporarily disabled until the components repo updates to typescript 3.6
-      #- material-unit-tests:
-      #    requires:
-      #      - build-ivy-npm-packages
+      - material-unit-tests:
+          requires:
+            - build-npm-packages
       - test_zonejs:
           requires:
             - setup

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -84,7 +84,7 @@ setPublicVar MATERIAL_REPO_TMP_DIR "/tmp/material2"
 setPublicVar MATERIAL_REPO_URL "https://github.com/angular/material2.git"
 setPublicVar MATERIAL_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI "config.yml".
-setPublicVar MATERIAL_REPO_COMMIT "818a8c7d6bb3f25d0637e5d6462cf9a84403b78f"
+setPublicVar MATERIAL_REPO_COMMIT "50514b2358f394f1f6d634fa181b563b7edd738b"
 
 # Source `$BASH_ENV` to make the variables available immediately.
 source $BASH_ENV;

--- a/scripts/ci/run_angular_material_unit_tests.sh
+++ b/scripts/ci/run_angular_material_unit_tests.sh
@@ -6,35 +6,16 @@ set -u -e -o pipefail
 # Save the dir for the root of the Angular repo.
 angular_dir=$(pwd)
 
-# Disable full template type check, as Material doesn't build cleanly with it enabled.
-# See https://github.com/angular/components/pull/16373 for details.
-# The "ivyTemplateTypeCheck" flag is set to True so that a minimum amount of type checking still
-# occurs, at a level compatible with that of VE's type checking. This ensures Ivy's type checker
-# is still tested against the Material repo, albeit in its non-strict mode.
-sed -i'.bak' "s/\(_ENABLE_NG_TYPE_CHECKING = \)True/\1False/g" ${MATERIAL_REPO_TMP_DIR}/tools/defaults.bzl
-sed -i'.bak' "s/\(\"ivyTemplateTypeCheck\": \)False/\1True/g" dist/packages-dist-ivy-aot/bazel/src/ng_module.bzl
-
-# The components repository updated to rules_nodejs#0.38.2 before Angular Bazel did. To do this,
-# the `@angular/bazel` v0.38.2 compatibility changes were patched on postinstall. This now
-# conflicts because we install a `@angular/bazel` version that already includes these compatibility
-# changes. This would result in the patch being a noop for which the `patch` command throws.
-# To work around this temporarily, we just ensure that the patch does not run on postinstall.
-# TODO: remove this once Angular components no longer needs the postinstall patch.
-sed -i -r "s/shelljs.cat.+angular_bazel_0\.38\.2\.patch.+;//g" ${MATERIAL_REPO_TMP_DIR}/tools/bazel/postinstall-patches.js
-
 # Switch into Material directory.
 cd ${MATERIAL_REPO_TMP_DIR}
 
-# Updates Material's package.json to refer to the packages-dist-ivy-aot directory.
+# Updates Material's package.json to refer to the packages-dist directory.
 # Note that it's not necessary to perform a yarn install, as Bazel performs its own yarn install.
-node ${angular_dir}/scripts/ci/update-deps-to-dist-packages.js ${MATERIAL_REPO_TMP_DIR}/package.json ${angular_dir}/dist/packages-dist-ivy-aot/
+node ${angular_dir}/scripts/ci/update-deps-to-dist-packages.js ${MATERIAL_REPO_TMP_DIR}/package.json ${angular_dir}/dist/packages-dist/
 
 # Copy the test blocklist into the "angular/components" repository. The components
 # repository automatically picks up the blocklist and disables the specified tests.
 cp ${angular_dir}/tools/material-ci/test-blocklist.ts ${MATERIAL_REPO_TMP_DIR}/test/
-
-# Ensure that the `@angular/localize` package is there. (It wasn't before v9.)
-yarn --cwd ${MATERIAL_REPO_TMP_DIR} add ${angular_dir}/dist/packages-dist-ivy-aot/localize
 
 # Create a symlink for the Bazel binary installed through NPM, as running through Yarn introduces OOM errors.
 ./scripts/circleci/setup_bazel_binary.sh


### PR DESCRIPTION
The Material units tests job has been disabled with the typescript upgrade
PR since the components repository was still on an old TypeScript version
(due to cyclic dependencies between the framework and components repository).

Since the components repository has been updated to `9.0.0-next.15` and now
uses the compatible TypeScript version, we can re-enable the job.

Related to this change, we need to ignore the `package.json` engines when installing
the dependencies of the components repo. This is because the components repo already
updated to NodeJS v12 and Yarn v1.19.1. This is not the case for the CI setup of
framework. For now, since we don't want to change the dev setup (as it slows down development
if everyone needs to update NodeJS and Yarn), we temporarily disable the engines.

Additionally, the material unit tests job now depends on the actual release packages
(not on the ngtsc compiled ones). This is because the components repo setup relies
on NGCC being run. This is also helpful for validating ngcc against the framework packages.