### PR TITLE
ngcc - use inner/outer class names as appropriate

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -86,6 +86,23 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
     return iife.parent.arguments[0];
   }
 
+  getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier {
+    const innerClass = this.getInnerFunctionDeclarationFromClassDeclaration(clazz);
+    if (innerClass === undefined) {
+      throw new Error(
+          `getInternalNameOfClass() called on a non-ES5 class: expected ${clazz.name.text} to have an inner class declaration`);
+    }
+    if (innerClass.name === undefined) {
+      throw new Error(
+          `getInternalNameOfClass() called on a class with an anonymous inner declaration: expected a name on:\n${innerClass.getText()}`);
+    }
+    return innerClass.name;
+  }
+
+  getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier {
+    return this.getInternalNameOfClass(clazz);
+  }
+
   /**
    * In ES5, the implementation of a class is a function expression that is hidden inside an IIFE,
    * whose value is assigned to a variable (which represents the class to the rest of the program).

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -83,7 +83,7 @@ export class Transformer {
     // Transform the source files and source maps.
     const srcFormatter = this.getRenderingFormatter(reflectionHost, bundle);
 
-    const renderer = new Renderer(srcFormatter, this.fs, this.logger, bundle);
+    const renderer = new Renderer(reflectionHost, srcFormatter, this.fs, this.logger, bundle);
     let renderedFiles = renderer.renderProgram(
         decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
 

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -96,7 +96,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
     if (!classSymbol) {
       throw new Error(`Compiled class does not have a valid symbol: ${compiledClass.name}`);
     }
-    const insertionPoint = classSymbol.declaration.valueDeclaration !.getEnd();
+    const insertionPoint = classSymbol.declaration.valueDeclaration.getEnd();
     output.appendLeft(insertionPoint, '\n' + definitions);
   }
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -147,6 +147,24 @@ var NoDecoratorConstructorClass = (function() {
   }
   return NoDecoratorConstructorClass;
 }());
+var OuterClass1 = (function() {
+  function InnerClass1() {
+  }
+  return InnerClass1;
+}());
+var OuterClass2 = (function() {
+  function InnerClass2() {
+  }
+  InnerClass2_1 = InnerClass12
+  var InnerClass2_1;
+  return InnerClass2;
+}());
+var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
+var ChildClass = /** @class */ (function (_super) {
+  __extends(ChildClass, _super);
+  function InnerChildClass() {}
+  return InnerChildClass;
+}(SuperClass);
 exports.EmptyClass = EmptyClass;
 exports.NoDecoratorConstructorClass = NoDecoratorConstructorClass;
 `,
@@ -2210,6 +2228,54 @@ exports.ExternalModule = ExternalModule;
              expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
                  .toEqual(_('/typings/class2.d.ts'));
            });
+      });
+
+      describe('getInternalNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+
+          const emptyClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
+      });
+
+      describe('getAdjacentNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+
+          const emptyClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
       });
 
       describe('getModuleWithProvidersFunctions', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -2088,6 +2088,28 @@ runInEachFileSystem(() => {
          });
     });
 
+    describe('getInternalNameOfClass()', () => {
+      it('should return the name of the class (there is no separate inner class in ES2015)', () => {
+        loadTestFiles([SIMPLE_CLASS_FILE]);
+        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const node =
+            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        expect(host.getInternalNameOfClass(node).text).toEqual('EmptyClass');
+      });
+    });
+
+    describe('getAdjacentNameOfClass()', () => {
+      it('should return the name of the class (there is no separate inner class in ES2015)', () => {
+        loadTestFiles([SIMPLE_CLASS_FILE]);
+        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const node =
+            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        expect(host.getAdjacentNameOfClass(node).text).toEqual('EmptyClass');
+      });
+    });
+
     describe('getModuleWithProvidersFunctions()', () => {
       it('should find every exported function that returns an object that looks like a ModuleWithProviders object',
          () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -192,6 +192,24 @@ runInEachFileSystem(() => {
       }
       return NoDecoratorConstructorClass;
     }());
+    var OuterClass1 = (function() {
+      function InnerClass1() {
+      }
+      return InnerClass1;
+    }());
+    var OuterClass2 = (function() {
+      function InnerClass2() {
+      }
+      InnerClass2_1 = InnerClass12
+      var InnerClass2_1;
+      return InnerClass2;
+    }());
+    var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
+    var ChildClass = /** @class */ (function (_super) {
+      __extends(ChildClass, _super);
+      function InnerChildClass() {}
+      return InnerChildClass;
+    }(SuperClass);
   `,
       };
 
@@ -2329,6 +2347,54 @@ runInEachFileSystem(() => {
            expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
                .toEqual(_('/typings/class2.d.ts'));
          });
+    });
+
+    describe('getInternalNameOfClass()', () => {
+      it('should return the name of the inner class declaration', () => {
+        loadTestFiles([SIMPLE_CLASS_FILE]);
+        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+
+        const emptyClass = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+        expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+        const class1 = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+        expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
+
+        const class2 = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+        expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
+
+        const childClass = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+        expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
+      });
+    });
+
+    describe('getAdjacentNameOfClass()', () => {
+      it('should return the name of the inner class declaration', () => {
+        loadTestFiles([SIMPLE_CLASS_FILE]);
+        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+
+        const emptyClass = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+        expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+        const class1 = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+        expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
+
+        const class2 = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+        expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
+
+        const childClass = getDeclaration(
+            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+        expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
+      });
     });
 
     describe('getModuleWithProvidersFunctions', () => {

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -163,6 +163,24 @@ runInEachFileSystem(() => {
     }
     return NoDecoratorConstructorClass;
   }());
+  var OuterClass1 = (function() {
+    function InnerClass1() {
+    }
+    return InnerClass1;
+  }());
+  var OuterClass2 = (function() {
+    function InnerClass2() {
+    }
+    InnerClass2_1 = InnerClass12
+    var InnerClass2_1;
+    return InnerClass2;
+  }());
+  var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
+  var ChildClass = /** @class */ (function (_super) {
+    __extends(ChildClass, _super);
+    function InnerChildClass() {}
+    return InnerChildClass;
+  }(SuperClass);
   exports.EmptyClass = EmptyClass;
   exports.NoDecoratorConstructorClass = NoDecoratorConstructorClass;
 })));`,
@@ -2219,6 +2237,54 @@ runInEachFileSystem(() => {
              expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
                  .toEqual(_('/typings/class2.d.ts'));
            });
+      });
+
+      describe('getInternalNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+
+          const emptyClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+          expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
+      });
+
+      describe('getAdjacentNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+
+          const emptyClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+          expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
       });
 
       describe('getModuleWithProvidersFunctions', () => {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -274,6 +274,7 @@ export function extractDirectiveMetadata(
     outputs: {...outputsFromMeta, ...outputsFromFields}, queries, viewQueries, selector,
     fullInheritance: !!(flags & HandlerFlags.FULL_INHERITANCE),
     type: new WrappedNodeExpr(clazz.name),
+    internalType: new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz)),
     typeArgumentCount: reflector.getGenericArityOfClass(clazz) || 0,
     typeSourceSpan: EMPTY_SOURCE_SPAN, usesInheritance, exportAs, providers
   };

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -81,6 +81,7 @@ export class InjectableDecoratorHandler implements
       const factoryRes = compileNgFactoryDefField({
         name: meta.name,
         type: meta.type,
+        internalType: meta.internalType,
         typeArgumentCount: meta.typeArgumentCount,
         deps: analysis.ctorDeps,
         injectFn: Identifiers.inject,
@@ -114,6 +115,7 @@ function extractInjectableMetadata(
     reflector: ReflectionHost): R3InjectableMetadata {
   const name = clazz.name.text;
   const type = new WrappedNodeExpr(clazz.name);
+  const internalType = new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz));
   const typeArgumentCount = reflector.getGenericArityOfClass(clazz) || 0;
   if (decorator.args === null) {
     throw new FatalDiagnosticError(
@@ -125,6 +127,7 @@ function extractInjectableMetadata(
       name,
       type,
       typeArgumentCount,
+      internalType,
       providedIn: new LiteralExpr(null),
     };
   } else if (decorator.args.length === 1) {
@@ -159,6 +162,7 @@ function extractInjectableMetadata(
         name,
         type,
         typeArgumentCount,
+        internalType,
         providedIn,
         useValue: new WrappedNodeExpr(unwrapForwardRef(meta.get('useValue') !, reflector)),
       };
@@ -167,6 +171,7 @@ function extractInjectableMetadata(
         name,
         type,
         typeArgumentCount,
+        internalType,
         providedIn,
         useExisting: new WrappedNodeExpr(unwrapForwardRef(meta.get('useExisting') !, reflector)),
       };
@@ -175,6 +180,7 @@ function extractInjectableMetadata(
         name,
         type,
         typeArgumentCount,
+        internalType,
         providedIn,
         useClass: new WrappedNodeExpr(unwrapForwardRef(meta.get('useClass') !, reflector)),
         userDeps,
@@ -186,11 +192,12 @@ function extractInjectableMetadata(
         name,
         type,
         typeArgumentCount,
+        internalType,
         providedIn,
         useFactory: factory, userDeps,
       };
     } else {
-      return {name, type, typeArgumentCount, providedIn};
+      return {name, type, typeArgumentCount, internalType, providedIn};
     }
   } else {
     throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -28,7 +28,7 @@ export function generateSetClassMetadataCall(
   if (!reflection.isClass(clazz)) {
     return null;
   }
-  const id = ts.updateIdentifier(clazz.name);
+  const id = ts.updateIdentifier(reflection.getAdjacentNameOfClass(clazz));
 
   // Reflect over the class decorators. If none are present, or those that are aren't from
   // Angular, then return null. Otherwise, turn them into metadata.

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -198,6 +198,8 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
 
     const ngModuleDef: R3NgModuleMetadata = {
       type: new WrappedNodeExpr(node.name),
+      internalType: new WrappedNodeExpr(this.reflector.getInternalNameOfClass(node)),
+      adjacentType: new WrappedNodeExpr(this.reflector.getAdjacentNameOfClass(node)),
       bootstrap,
       declarations,
       exports,
@@ -227,6 +229,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     const ngInjectorDef: R3InjectorMetadata = {
       name,
       type: new WrappedNodeExpr(node.name),
+      internalType: new WrappedNodeExpr(this.reflector.getInternalNameOfClass(node)),
       deps: getValidConstructorDependencies(
           node, this.reflector, this.defaultImportRecorder, this.isCore),
       providers,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -51,6 +51,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
   analyze(clazz: ClassDeclaration, decorator: Decorator): AnalysisOutput<PipeHandlerData> {
     const name = clazz.name.text;
     const type = new WrappedNodeExpr(clazz.name);
+    const internalType = new WrappedNodeExpr(this.reflector.getInternalNameOfClass(clazz));
     if (decorator.args === null) {
       throw new FatalDiagnosticError(
           ErrorCode.DECORATOR_NOT_CALLED, Decorator.nodeForError(decorator),
@@ -97,6 +98,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
         meta: {
           name,
           type,
+          internalType,
           typeArgumentCount: this.reflector.getGenericArityOfClass(clazz) || 0, pipeName,
           deps: getValidConstructorDependencies(
               clazz, this.reflector, this.defaultImportRecorder, this.isCore),

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -622,4 +622,24 @@ export interface ReflectionHost {
    * `ts.Program` as the input declaration.
    */
   getDtsDeclaration(declaration: ts.Declaration): ts.Declaration|null;
+
+  /**
+   * Get a `ts.Identifier` for a given `ClassDeclaration` which can be used to refer to the class
+   * within its definition (such as in static fields).
+   *
+   * This can differ from `clazz.name` when ngcc runs over ES5 code, since the class may have a
+   * different name within its IIFE wrapper than it does externally.
+   */
+  getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier;
+
+  /**
+   * Get a `ts.Identifier` for a given `ClassDeclaration` which can be used to refer to the class
+   * from statements that are "adjacent", and conceptually tightly bound, to the class but not
+   * actually inside it.
+   *
+   * Similar to `getInternalNameOfClass()`, this name can differ from `clazz.name` when ngcc runs
+   * over ES5 code, since these "adjacent" statements need to exist in the IIFE where the class may
+   * have a different name than it does externally.
+   */
+  getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier;
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -182,6 +182,9 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
   getDtsDeclaration(_: ts.Declaration): ts.Declaration|null { return null; }
 
+  getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier { return clazz.name; }
+
+  getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier { return clazz.name; }
 
   protected getDirectImportOfIdentifier(id: ts.Identifier): Import|null {
     const symbol = this.checker.getSymbolAtLocation(id);

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -19,7 +19,7 @@ import {ParseError, ParseSourceSpan, r3JitTypeSourceSpan} from './parse_util';
 import {R3DependencyMetadata, R3FactoryTarget, R3ResolvedDependencyType, compileFactoryFunction} from './render3/r3_factory';
 import {R3JitReflector} from './render3/r3_jit';
 import {R3InjectorMetadata, R3NgModuleMetadata, compileInjector, compileNgModule} from './render3/r3_module_compiler';
-import {compilePipeFromMetadata} from './render3/r3_pipe_compiler';
+import {R3PipeMetadata, compilePipeFromMetadata} from './render3/r3_pipe_compiler';
 import {R3Reference} from './render3/util';
 import {R3DirectiveMetadata, R3QueryMetadata} from './render3/view/api';
 import {ParsedHostBindings, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
@@ -37,9 +37,10 @@ export class CompilerFacadeImpl implements CompilerFacade {
 
   compilePipe(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, facade: R3PipeMetadataFacade):
       any {
-    const metadata = {
+    const metadata: R3PipeMetadata = {
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
+      internalType: new WrappedNodeExpr(facade.type),
       typeArgumentCount: facade.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(facade.deps),
       pipeName: facade.pipeName,
@@ -55,6 +56,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const {expression, statements} = compileInjectable({
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
+      internalType: new WrappedNodeExpr(facade.type),
       typeArgumentCount: facade.typeArgumentCount,
       providedIn: computeProvidedIn(facade.providedIn),
       useClass: wrapExpression(facade, USE_CLASS),
@@ -73,6 +75,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const meta: R3InjectorMetadata = {
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
+      internalType: new WrappedNodeExpr(facade.type),
       deps: convertR3DependencyMetadataArray(facade.deps),
       providers: new WrappedNodeExpr(facade.providers),
       imports: facade.imports.map(i => new WrappedNodeExpr(i)),
@@ -86,6 +89,8 @@ export class CompilerFacadeImpl implements CompilerFacade {
       facade: R3NgModuleMetadataFacade): any {
     const meta: R3NgModuleMetadata = {
       type: new WrappedNodeExpr(facade.type),
+      internalType: new WrappedNodeExpr(facade.type),
+      adjacentType: new WrappedNodeExpr(facade.type),
       bootstrap: facade.bootstrap.map(wrapReference),
       declarations: facade.declarations.map(wrapReference),
       imports: facade.imports.map(wrapReference),
@@ -159,6 +164,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const factoryRes = compileFactoryFunction({
       name: meta.name,
       type: new WrappedNodeExpr(meta.type),
+      internalType: new WrappedNodeExpr(meta.type),
       typeArgumentCount: meta.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(meta.deps),
       injectFn: meta.injectFn === 'directiveInject' ? Identifiers.directiveInject :
@@ -247,6 +253,7 @@ function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3
     ...facade as R3DirectiveMetadataFacadeNoPropAndWhitespace,
     typeSourceSpan: facade.typeSourceSpan,
     type: new WrappedNodeExpr(facade.type),
+    internalType: new WrappedNodeExpr(facade.type),
     deps: convertR3DependencyMetadataArray(facade.deps),
     host: extractHostBindings(facade.propMetadata, facade.typeSourceSpan, facade.host),
     inputs: {...inputsFromMetadata, ...inputsFromType},

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -28,6 +28,15 @@ export interface R3PipeMetadata {
   type: o.Expression;
 
   /**
+   * An expression representing the pipe being compiled, intended for use within a class definition
+   * itself.
+   *
+   * This can differ from the outer `type` if the class is being compiled by ngcc and is inside an
+   * IIFE structure that uses a different name internally.
+   */
+  internalType: o.Expression;
+
+  /**
    * Number of generic type parameters of the type itself.
    */
   typeArgumentCount: number;
@@ -80,10 +89,12 @@ export function compilePipeFromRender2(
     return error(`Cannot resolve the name of ${pipe.type}`);
   }
 
+  const type = outputCtx.importExpr(pipe.type.reference);
   const metadata: R3PipeMetadata = {
     name,
+    type,
+    internalType: type,
     pipeName: pipe.name,
-    type: outputCtx.importExpr(pipe.type.reference),
     typeArgumentCount: 0,
     deps: dependenciesFromGlobalMetadata(pipe.type, outputCtx, reflector),
     pure: pipe.pure,

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -29,6 +29,15 @@ export interface R3DirectiveMetadata {
   type: o.Expression;
 
   /**
+   * An expression representing a reference to the directive being compiled, intended for use within
+   * a class definition itself.
+   *
+   * This can differ from the outer `type` if the class is being compiled by ngcc and is inside
+   * an IIFE structure that uses a different name internally.
+   */
+  internalType: o.Expression;
+
+  /**
    * Number of generic type parameters of the type itself.
    */
   typeArgumentCount: number;

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -45,7 +45,7 @@ function baseDirectiveFields(
   const selectors = core.parseSelectorToR3Selector(meta.selector);
 
   // e.g. `type: MyDirective`
-  definitionMap.set('type', meta.type);
+  definitionMap.set('type', meta.internalType);
 
   // e.g. `selectors: [['', 'someDir', '']]`
   if (selectors.length > 0) {


### PR DESCRIPTION
// FW-1651

In the `@ngx-formly/material` library, there are directives that inherit from other classes. In ES5 format this results in class declarations that have the following form:

```
var Child = /** @class */ (function (_super) {
    __extends(Child_Inner, _super);
    function Child_Inner() {...}
    return Child_Inner;
}(Parent));
```

But then ngcc is adding definitions into the class as follows:

```
var Child = /** @class */ (function (_super) {
    __extends(Child_Inner, _super);
    function Child_Inner() {...}
    Child.ɵfac = ...;
    Child.ɵdir = ...;
    return Child_Inner;
}(Parent));
```

Note that the new definitions are referring to `Child` which is the outer class identifier.

Unfortunately this `Child` identifier has not been initialised at the time the definitions are attached, so we get a `Reference` error.

One approach was to move the definitions outside of the IIFE as follows:

```
var Child = /** @class */ (function (_super) {
    __extends(Child_Inner, _super);
    function Child_Inner() {...}
    return Child_Inner;
}(Parent));
Child.ɵfac = ...;
Child.ɵdir = ...;
```
This works for this case, but fails if the decorator definition contains references to identifiers that are only defined inside the IIFE. For example:

```
var BrowserModule = /** @class */ (function () {
    function BrowserModule(parentModule) {...}
    BrowserModule_1 = BrowserModule;
    var BrowserModule_1;
    BrowserModule = BrowserModule_1 = __decorate([
      __param(0, Optional()),
      __param(0, SkipSelf()),
      __param(0, Inject(BrowserModule_1)),
      __metadata("design:paramtypes", [Object])
    ], BrowserModule);
    return BrowserModule;
}());
BrowserModule.ɵmod = ɵngcc0.ɵɵdefineNgModule({ type: BrowserModule });
BrowserModule.ɵinj = ɵngcc0.ɵɵdefineInjector({
  factory: function BrowserModule_Factory(t) {
    return new (t || BrowserModule)(ɵngcc0.ɵɵinject(BrowserModule_1, 12));
  },
  providers: BROWSER_MODULE_PROVIDERS,
  imports: [CommonModule, ApplicationModule]
});
```

Here you can see that the `ɵɵdefineInjector()` call references `BrowserModule_1` which is only defined within the IIFE.

Also this is not correct because it stops the class from being tree shaken, since the IIFE is the unit of tree shaking.

So the proper solution is to teach ngcc/ngtsc which identifiers to use when generating ES5 definitions.
