### PR TITLE
fix(ivy): do not invoke change detection for destroyed views

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -37,7 +37,7 @@ import {isAnimationProp} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
 import {getInitialStylingValue} from '../util/styling_utils';
 import {getLViewParent} from '../util/view_traversal_utils';
-import {getComponentLViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isCreationMode, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
+import {getComponentLViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isCreationMode, isViewDestroyed, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from '../util/view_utils';
 
 import {selectIndexInternal} from './advance';
 import {LCleanup, LViewBlueprint, MatchesArray, TCleanup, TNodeConstructor, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor, attachLContainerDebug, attachLViewDebug, cloneToLView, cloneToTViewData} from './lview_debug';
@@ -1650,6 +1650,7 @@ export function tickRootContext(rootContext: RootContext) {
 }
 
 export function detectChangesInternal<T>(view: LView, context: T) {
+  if (isViewDestroyed(view)) return;
   const rendererFactory = view[RENDERER_FACTORY];
   if (rendererFactory.begin) rendererFactory.begin();
   try {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -9,6 +9,7 @@
 import {ViewEncapsulation} from '../metadata/view';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertDomNode, assertEqual} from '../util/assert';
+
 import {assertLContainer, assertLView, assertTNodeForLView} from './assert';
 import {attachPatchData} from './context_discovery';
 import {CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS, NATIVE, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
@@ -21,7 +22,7 @@ import {isLContainer, isLView, isRootView} from './interfaces/type_checks';
 import {CHILD_HEAD, CLEANUP, DECLARATION_LCONTAINER, FLAGS, HOST, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, T_HOST, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {findComponentView} from './util/view_traversal_utils';
-import {getNativeByTNode, getNativeByTNodeOrNull, unwrapRNode} from './util/view_utils';
+import {getNativeByTNode, getNativeByTNodeOrNull, isViewDestroyed, unwrapRNode} from './util/view_utils';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
 
@@ -336,7 +337,7 @@ export function removeView(lContainer: LContainer, removeIndex: number) {
  * @param lView The view to be destroyed.
  */
 export function destroyLView(lView: LView) {
-  if (!(lView[FLAGS] & LViewFlags.Destroyed)) {
+  if (!isViewDestroyed(lView)) {
     const renderer = lView[RENDERER];
     if (isProceduralRenderer(renderer) && renderer.destroyNode) {
       applyView(renderer, WalkTNodeTreeAction.Destroy, lView, null, null);
@@ -380,7 +381,7 @@ export function getParentState(lViewOrLContainer: LView | LContainer, rootView: 
  * @param view The LView to clean up
  */
 function cleanUpView(view: LView | LContainer): void {
-  if (isLView(view) && !(view[FLAGS] & LViewFlags.Destroyed)) {
+  if (isLView(view) && !isViewDestroyed(view)) {
     // Usually the Attached flag is removed when the view is detached from its parent, however
     // if it's a root view, the flag won't be unset hence why we're also removing on destroy.
     view[FLAGS] &= ~LViewFlags.Attached;

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -160,6 +160,11 @@ export function isCreationMode(view: LView): boolean {
   return (view[FLAGS] & LViewFlags.CreationMode) === LViewFlags.CreationMode;
 }
 
+/** Checks whether a given view is marked as destroyed */
+export function isViewDestroyed(view: LView): boolean {
+  return (view[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed;
+}
+
 /**
  * Returns a boolean for whether the view is attached to the change detection tree.
  *

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -19,7 +19,7 @@ import {CONTEXT, FLAGS, HOST, LView, LViewFlags, TVIEW, T_HOST} from './interfac
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {destroyLView, renderDetachView} from './node_manipulation';
 import {findComponentView, getLViewParent} from './util/view_traversal_utils';
-import {getNativeByTNode, unwrapRNode} from './util/view_utils';
+import {getNativeByTNode, isViewDestroyed, unwrapRNode} from './util/view_utils';
 
 
 
@@ -70,9 +70,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   get context(): T { return this._lView[CONTEXT] as T; }
 
-  get destroyed(): boolean {
-    return (this._lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed;
-  }
+  get destroyed(): boolean { return isViewDestroyed(this._lView); }
 
   destroy(): void {
     if (this._appRef) {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -975,6 +975,9 @@
     "name": "isStylingValueDefined"
   },
   {
+    "name": "isViewDestroyed"
+  },
+  {
     "name": "iterateListLike"
   },
   {


### PR DESCRIPTION
Prior to this commit, calling change detection for destroyed views resulted in errors being thrown in some cases. This commit adds a check to make sure change detection is invoked for non-destroyed views only.

This PR resolves FW-1636.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No