### PR TITLE
fix(core): undecorated-classes-with-di migration should report config errors

### DIFF
--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -1495,5 +1495,32 @@ describe('Undecorated classes with DI migration', () => {
       expect(warnOutput.length).toBe(0);
       expect(errorOutput.length).toBe(0);
     });
+
+    it('should not throw if tsconfig references non-existent source file', async() => {
+      writeFile('/tsconfig.json', JSON.stringify({
+        compilerOptions: {
+          lib: ['es2015'],
+        },
+        files: [
+          './non-existent.ts',
+        ]
+      }));
+
+      let failed = false;
+      try {
+        await runMigration();
+      } catch (e) {
+        failed = true;
+      }
+
+      expect(failed).toBe(false, 'Expected the migration not to fail.');
+      expect(warnOutput.length).toBe(1);
+      expect(errorOutput.length).toBe(1);
+      expect(warnOutput[0])
+          .toContain(
+              'TypeScript project "tsconfig.json" has configuration errors. This could cause an ' +
+              'incomplete migration. Please fix the following failures and rerun the migration:');
+      expect(errorOutput[0]).toMatch(/non-existent\.ts' not found/);
+    });
   });
 });


### PR DESCRIPTION
Currently TypeScript projects with an invalid tsconfig configuration,
cause the undecorated-classes-with-di migration to throw. Instead we
should gracefully exit the migration (like we do for syntactical
diagnostics), but report that there are configuration issues.

This issue surfaced when testing this migration in combination
with the Angular CLI migrations. One of the CLI migrations currently
causes invalid tsconfig files which then cause this issue in the
undecorated-classes-with-di migration. https://github.com/angular/angular-cli/issues/16035