### PR TITLE
docs(core): remove duplicate 'because'

### DIFF
--- a/aio/content/guide/migration-injectable.md
+++ b/aio/content/guide/migration-injectable.md
@@ -25,7 +25,7 @@ There are a few cases where the decorator won't be added. For example:
 
   - It already has another decorator such as `@Component()`, `@Directive()` or `@Pipe()`. These decorators already cause the compiler to generate the necessary information.
   - The provider definition has `useValue`, `useFactory`, or `useExisting`. In
-  these cases, the framework doesn't need the `@Injectable()` decorator to create the class because
+  these cases, the framework doesn't need the `@Injectable()` decorator to create the class
   because it can just use the value,
   factory function, or existing instance that was provided.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Fix duplicate 'because' in migration injectable docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
