### PR TITLE
fix(core): renderer-to-renderer2 migration not migrating methods

### DIFF
--- a/packages/core/schematics/test/renderer_to_renderer2_migration_spec.ts
+++ b/packages/core/schematics/test/renderer_to_renderer2_migration_spec.ts
@@ -35,7 +35,6 @@ describe('Renderer to Renderer2 migration', () => {
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
     writeFile('/node_modules/@angular/core/index.d.ts', `
-      export declare abstract class Renderer {}
       export declare function forwardRef(fn: () => any): any {}
     `);
 


### PR DESCRIPTION
The `renderer-to-renderer2` migration currently does not work
properly in v9 because the migration relies on the type checker
for detecting references to `Renderer` from `@angular/core`.

This is contradictory since the `Renderer` is no longer
exported in v9 `@angular/core`. In order to make sure that
the migration still works in v9, and that we can rely on the
type checker for the best possible detection, we take advantage
of module augmentation and in-memory add the `Renderer` export
to the `@angular/core` module.

---

Before coming up with the augmentation solution, I spent quite some time re-working the
detection to be not based on the `ts.TypeChecker`. Though, I went with this solution as it gives us
the best detection of the `Renderer` and doesn't involve reworking the whole detection.