### PR TITLE
fix(compiler-cli): Pass SourceFile to getLeadingTriviaWidth

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -59,8 +59,12 @@ export class FactoryGenerator implements ShimGenerator {
     let comment: string = '';
     if (original.statements.length > 0) {
       const firstStatement = original.statements[0];
-      if (firstStatement.getLeadingTriviaWidth() > 0) {
-        comment = firstStatement.getFullText().substr(0, firstStatement.getLeadingTriviaWidth());
+      // Must pass SourceFile to getLeadingTriviaWidth(), otherwise it'll try to
+      // get SourceFile by recursively looking up the parent of the Node and fail,
+      // because parent is undefined.
+      const leadingTriviaWidth = firstStatement.getLeadingTriviaWidth(original);
+      if (leadingTriviaWidth > 0) {
+        comment = firstStatement.getFullText().substr(0, leadingTriviaWidth);
       }
     }
 


### PR DESCRIPTION
This commit fixes a crash in the Angular Kythe indexer caused by failure
to retrieve `SourceFile` in a `Statement`.

Crash logs:
```
  TypeError: Cannot read property 'text' of undefined
    at Object.getTokenPosOfNode (typescript/stable/lib/typescript.js:8957:72)
    at NodeObject.getStart (typescript/stable/lib/typescript.js:121419:23)
    at NodeObject.getLeadingTriviaWidth (typescript/stable/lib/typescript.js:121439:25)
    at FactoryGenerator.generate (angular2/rc/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts:64:49)
    at GeneratedShimsHostWrapper.getSourceFile (angular2/rc/packages/compiler-cli/src/ngtsc/shims/src/host.ts:88:26)
    at findSourceFile (typescript/stable/lib/typescript.js:90654:29)
    at typescript/stable/lib/typescript.js:90553:85
    at getSourceFileFromReferenceWorker (typescript/stable/lib/typescript.js:90520:34)
    at processSourceFile (typescript/stable/lib/typescript.js:90553:13)
    at processRootFile (typescript/stable/lib/typescript.js:90383:13)
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
