### PR TITLE
build: increase payload size limit

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 141461,
+        "main-es2015": 143181,
         "polyfills-es2015": 36808
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 147474,
+        "main-es2015": 149315,
         "polyfills-es2015": 36808
       }
     }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 225584,
+        "main-es2015": 227998,
         "polyfills-es2015": 36808,
         "5-es2015": 779
       }


### PR DESCRIPTION
integration_test is failing at master: example: https://circleci.com/gh/angular/angular/514805#tests/containers/1

cause appears to be: https://github.com/angular/angular/commit/44623a116158c8048ce61a873ed63a290c039202 