### PR TITLE
fix(ivy): wrap functions from "providers" in parentheses in Closure mode

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -89,17 +89,18 @@ export class DecorationAnalyzer {
         this.scopeRegistry, this.scopeRegistry, this.isCore, this.resourceManager, this.rootDirs,
         /* defaultPreserveWhitespaces */ false,
         /* i18nUseExternalIds */ true, /* i18nLegacyMessageIdFormat */ '', this.moduleResolver,
-        this.cycleAnalyzer, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER),
+        this.cycleAnalyzer, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER,
+        /* annotateForClosureCompiler */ false),
     new DirectiveDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
-        this.isCore),
+        this.isCore, /* annotateForClosureCompiler */ false),
     new InjectableDecoratorHandler(
         this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
         /* strictCtorDeps */ false),
     new NgModuleDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullMetaReader, this.fullRegistry,
         this.scopeRegistry, this.referencesRegistry, this.isCore, /* routeAnalyzer */ null,
-        this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER),
+        this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER, /* annotateForClosureCompiler */ false),
     new PipeDecoratorHandler(
         this.reflectionHost, this.evaluator, this.metaRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
         this.isCore),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -354,7 +354,7 @@ export function readBaseClass(
 
 const parensWrapperTransformerFactory: ts.TransformerFactory<ts.Expression> =
     (context: ts.TransformationContext) => {
-      const visitor = (node: ts.Node): ts.Node => {
+      const visitor: ts.Visitor = (node: ts.Node): ts.Node => {
         const visited = ts.visitEachChild(node, visitor, context);
         if (ts.isArrowFunction(visited) || ts.isFunctionExpression(visited)) {
           return ts.createParen(visited);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -60,9 +60,11 @@ runInEachFileSystem(() => {
       const refEmitter = new ReferenceEmitter([]);
 
       const handler = new ComponentDecoratorHandler(
-          reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry, false,
-          new NoopResourceLoader(), [''], false, true, '', moduleResolver, cycleAnalyzer,
-          refEmitter, NOOP_DEFAULT_IMPORT_RECORDER);
+          reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry,
+          /* isCore */ false, new NoopResourceLoader(), /* rootDirs */[''],
+          /* defaultPreserveWhitespaces */ false, /* i18nUseExternalIds */ true,
+          /* i18nLegacyMessageIdFormat */ '', moduleResolver, cycleAnalyzer, refEmitter,
+          NOOP_DEFAULT_IMPORT_RECORDER, /* annotateForClosureCompiler */ false);
       const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
       const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
       if (detected === undefined) {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -49,7 +49,8 @@ runInEachFileSystem(() => {
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
       const handler = new DirectiveDecoratorHandler(
-          reflectionHost, evaluator, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER, false);
+          reflectionHost, evaluator, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+          /* isCore */ false, /* annotateForClosureCompiler */ false);
 
       const analyzeDirective = (dirName: string) => {
         const DirNode = getDeclaration(program, _('/entry.ts'), dirName, isNamedClassDeclaration);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -69,7 +69,8 @@ runInEachFileSystem(() => {
 
       const handler = new NgModuleDecoratorHandler(
           reflectionHost, evaluator, metaReader, metaRegistry, scopeRegistry, referencesRegistry,
-          false, null, refEmitter, NOOP_DEFAULT_IMPORT_RECORDER);
+          false, null, refEmitter, NOOP_DEFAULT_IMPORT_RECORDER,
+          /* annotateForClosureCompiler */ false);
       const TestModule =
           getDeclaration(program, _('/entry.ts'), 'TestModule', isNamedClassDeclaration);
       const detected =

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -591,16 +591,18 @@ export class NgtscProgram implements api.Program {
           this.isCore, this.resourceManager, this.rootDirs,
           this.options.preserveWhitespaces || false, this.options.i18nUseExternalIds !== false,
           this.getI18nLegacyMessageFormat(), this.moduleResolver, this.cycleAnalyzer,
-          this.refEmitter, this.defaultImportTracker, this.incrementalState),
+          this.refEmitter, this.defaultImportTracker, this.closureCompilerEnabled,
+          this.incrementalState),
       new DirectiveDecoratorHandler(
-          this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore),
+          this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore,
+          this.closureCompilerEnabled),
       new InjectableDecoratorHandler(
           this.reflector, this.defaultImportTracker, this.isCore,
           this.options.strictInjectionParameters || false),
       new NgModuleDecoratorHandler(
           this.reflector, evaluator, this.metaReader, metaRegistry, scopeRegistry,
           referencesRegistry, this.isCore, this.routeAnalyzer, this.refEmitter,
-          this.defaultImportTracker, this.options.i18nInLocale),
+          this.defaultImportTracker, this.closureCompilerEnabled, this.options.i18nInLocale),
       new PipeDecoratorHandler(
           this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore),
     ];

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -357,6 +357,147 @@ runInEachFileSystem(os => {
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain('/** @nocollapse */ TestCmp.ɵcmp');
       });
+
+      /**
+       * The following set of tests verify that after Tsickle run we do not have cases which trigger
+       * automatic semicolon insertion, which breaks the code. In order to avoid the problem, we
+       * wrap all function expressions in certain fields ("providers" and "viewProviders") in
+       * parentheses. More info on Tsickle processing related to this case can be found here:
+       * https://github.com/angular/tsickle/blob/d7974262571c8a17d684e5ba07680e1b1993afdd/src/jsdoc_transformer.ts#L1021
+       */
+      describe(
+          'wrap functions in certain fields in parentheses when closure annotations are requested',
+          () => {
+            const providers = `
+              [{
+                provide: 'token-a',
+                useFactory: (service: Service) => {
+                  return () => service.id;
+                }
+              }, {
+                provide: 'token-b',
+                useFactory: function(service: Service) {
+                  return function() {
+                    return service.id;
+                  }
+                }
+              }]
+            `;
+
+            const service = `
+              export class Service {
+                id: string = 'service-id';
+              }
+            `;
+
+            const verifyOutput = (jsContents: string) => {
+              // verify that there is no pattern that triggers automatic semicolon insertion
+              expect(trim(jsContents)).not.toContain(trim(`
+                return /**
+                * @return {?}
+                */
+              `));
+              expect(trim(jsContents)).toContain(trim(`
+                [{
+                    provide: 'token-a',
+                    useFactory: (function (service) {
+                        return (/**
+                        * @return {?}
+                        */
+                        function () { return service.id; });
+                    })
+                }, {
+                    provide: 'token-b',
+                    useFactory: (function (service) {
+                        return (/**
+                        * @return {?}
+                        */
+                        function () {
+                            return service.id;
+                        });
+                    })
+                }]
+              `));
+            };
+
+            it('should wrap functions in "providers" list in NgModule', () => {
+              env.tsconfig({
+                'annotateForClosureCompiler': true,
+              });
+              env.write('service.ts', service);
+              env.write('test.ts', `
+                import {NgModule} from '@angular/core';
+                import {Service} from './service';
+
+                @NgModule({
+                  providers: ${providers}
+                })
+                export class SomeModule {}
+              `);
+
+              env.driveMain();
+              verifyOutput(env.getContents('test.js'));
+            });
+
+            it('should wrap functions in "providers" list in Component', () => {
+              env.tsconfig({
+                'annotateForClosureCompiler': true,
+              });
+              env.write('service.ts', service);
+              env.write('test.ts', `
+                import {Component} from '@angular/core';
+                import {Service} from './service';
+
+                @Component({
+                  template: '...',
+                  providers: ${providers}
+                })
+                export class SomeComponent {}
+              `);
+
+              env.driveMain();
+              verifyOutput(env.getContents('test.js'));
+            });
+
+            it('should wrap functions in "viewProviders" list in Component', () => {
+              env.tsconfig({
+                'annotateForClosureCompiler': true,
+              });
+              env.write('service.ts', service);
+              env.write('test.ts', `
+                import {Component} from '@angular/core';
+                import {Service} from './service';
+
+                @Component({
+                  template: '...',
+                  viewProviders: ${providers}
+                })
+                export class SomeComponent {}
+              `);
+
+              env.driveMain();
+              verifyOutput(env.getContents('test.js'));
+            });
+
+            it('should wrap functions in "providers" list in Directive', () => {
+              env.tsconfig({
+                'annotateForClosureCompiler': true,
+              });
+              env.write('service.ts', service);
+              env.write('test.ts', `
+                import {Directive} from '@angular/core';
+                import {Service} from './service';
+
+                @Directive({
+                  providers: ${providers}
+                })
+                export class SomeDirective {}
+              `);
+
+              env.driveMain();
+              verifyOutput(env.getContents('test.js'));
+            });
+          });
     }
 
     it('should recognize aliased decorators', () => {


### PR DESCRIPTION
Due to the fact that Tsickle runs between analyze and transform phases in Angular, Tsickle may transform nodes (add comments with type annotations for Closure) that we captured during the analyze phase. As a result, some patterns where a function is returned from another function may trigger automatic semicolon insertion, which breaks the code (makes functions return `undefined` instead of a function). In order to avoid the problem, this commit updates the code to wrap all functions in some expression ("privders" and "viewProviders") in parentheses. More info can be found in Tsickle source code here: https://github.com/angular/tsickle/blob/d7974262571c8a17d684e5ba07680e1b1993afdd/src/jsdoc_transformer.ts#L1021

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No