### PR TITLE
fix(ngcc): handle new `__spreadArrays` tslib helper

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -627,10 +627,13 @@ function getTsHelperFn(node: ts.NamedDeclaration): TsHelperFn|null {
       stripDollarSuffix(node.name.text) :
       null;
 
-  if (name === '__spread') {
-    return TsHelperFn.Spread;
-  } else {
-    return null;
+  switch (name) {
+    case '__spread':
+      return TsHelperFn.Spread;
+    case '__spreadArrays':
+      return TsHelperFn.SpreadArrays;
+    default:
+      return null;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -15,10 +15,12 @@ import {ResolvedValue, ResolvedValueArray} from './result';
 
 export function evaluateTsHelperInline(
     helper: TsHelperFn, node: ts.Node, args: ResolvedValueArray): ResolvedValue {
-  if (helper === TsHelperFn.Spread) {
-    return evaluateTsSpreadHelper(node, args);
-  } else {
-    throw new Error(`Cannot evaluate unknown helper ${helper} inline`);
+  switch (helper) {
+    case TsHelperFn.Spread:
+    case TsHelperFn.SpreadArrays:
+      return evaluateTsSpreadHelper(node, args);
+    default:
+      throw new Error(`Cannot evaluate unknown helper ${helper} inline`);
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -336,6 +336,10 @@ export enum TsHelperFn {
    * Indicates the `__spread` function.
    */
   Spread,
+  /**
+   * Indicates the `__spreadArrays` function.
+   */
+  SpreadArrays,
 }
 
 /**


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33614


## What is the new behavior?
We already have special cases for the `__spread` helper function and with this change we handle the new tslib helper introduced in version 1.10 `__spreadArrays`.

For more context see: https://github.com/microsoft/tslib/releases/tag/1.10.0

Fixes: #33614

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
