### PR TITLE
fix(compiler-cli): resource inlining should remove moduleId property

### DIFF
--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -290,7 +290,7 @@ export interface CompilerOptions extends ts.CompilerOptions {
   /**
    * Whether to replace the `templateUrl` and `styleUrls` property in all
    * @Component decorators with inlined contents in `template` and `styles`
-   * properties.
+   * properties. Also removes the `moduleId` property if defined.
    * When enabled, the .js output of ngc will have no lazy-loaded `templateUrl`
    * or `styleUrl`s. Note that this requires that resources be available to
    * load statically at compile-time.

--- a/packages/compiler-cli/src/transformers/inline_resources.ts
+++ b/packages/compiler-cli/src/transformers/inline_resources.ts
@@ -82,6 +82,10 @@ export class InlineResourcesMetadataTransformer implements MetadataTransformer {
       delete arg['styleUrls'];
     }
 
+    if (arg['moduleId']) {
+      delete arg['moduleId'];
+    }
+
     return arg;
   }
 }
@@ -255,8 +259,8 @@ function isComponentSymbol(identifier: ts.Node, typeChecker: ts.TypeChecker) {
 }
 
 /**
- * For each property in the object literal, if it's templateUrl or styleUrls, replace it
- * with content.
+ * For each property in the object literal, if it's templateUrl or styleUrls,
+ * replace it with content. Also removes the "moduleId" property.
  * @param node the arguments to @Component() or args property of decorators: [{type:Component}]
  * @param loader provides access to the loadResource method of the host
  * @returns updated arguments
@@ -313,6 +317,10 @@ function updateComponentProperties(
         const template = loader.get(prop.initializer.text);
         newProperties.push(ts.updatePropertyAssignment(
             prop, ts.createIdentifier('template'), ts.createLiteral(template)));
+        break;
+
+      case 'moduleId':
+        // do not add "moduleId" to the new properties.
         break;
 
       default:

--- a/packages/compiler-cli/test/transformers/inline_resources_spec.ts
+++ b/packages/compiler-cli/test/transformers/inline_resources_spec.ts
@@ -43,6 +43,7 @@ describe('inline resources transformer', () => {
         @Component({
           templateUrl: './thing.html',
 	        otherProp: 3,
+	        moduleId: module.id,
 	      }) export class Foo {}`);
       expect(actual).not.toContain('templateUrl:');
       expect(actual.replace(/\s+/g, ' '))
@@ -80,6 +81,14 @@ describe('inline resources transformer', () => {
       expect(actual).not.toContain('styleUrls:');
       expect(actual).not.toContain('styles:');
     });
+    it('should remove moduleId', () => {
+      const actual = convert(`import {Component} from '@angular/core';
+        @Component({
+          moduleId: module.id,
+        })
+        export class Foo {}`);
+      expect(actual).not.toContain('moduleId');
+    });
   });
   describe('annotation input', () => {
     it('should replace templateUrl', () => {
@@ -94,6 +103,7 @@ describe('inline resources transformer', () => {
           },{
             type: Component,
             args: [{
+              moduleId: module.id,
               templateUrl: './thing.html'
           }],
         }];
@@ -102,7 +112,7 @@ describe('inline resources transformer', () => {
       expect(actual).not.toContain('templateUrl:');
       expect(actual.replace(/\s+/g, ' '))
           .toMatch(
-              /Foo\.decorators = [{ .*type: core_1\.Component, args: [{ template: "Some template" }]/);
+              /Foo\.decorators = \[ { .*type: core_1\.Component, args: \[{ template: "Some template" }] } ]/);
     });
     it('should replace styleUrls', () => {
       const actual = convert(`import {Component} from '@angular/core';
@@ -112,6 +122,7 @@ describe('inline resources transformer', () => {
         static decorators: {type: Function, args?: any[]}[] = [{
           type: Component,
           args: [{
+            moduleId: module.id,
             styleUrls: ['./thing1.css', './thing2.css'],
           }],
         }];
@@ -120,7 +131,7 @@ describe('inline resources transformer', () => {
       expect(actual).not.toContain('styleUrls:');
       expect(actual.replace(/\s+/g, ' '))
           .toMatch(
-              /Foo\.decorators = [{ .*type: core_1\.Component, args: [{ style: "Some template" }]/);
+              /Foo\.decorators = \[{ .*type: core_1\.Component, args: \[{ styles: \[".some_style {}", ".some_other_style {}"] }] }]/);
     });
   });
 });
@@ -129,6 +140,7 @@ describe('metadata transformer', () => {
   it('should transform decorators', () => {
     const source = `import {Component} from '@angular/core';
       @Component({
+        moduleId: module.id,
         templateUrl: './thing.html',
         styleUrls: ['./thing1.css', './thing2.css'],
         styles: ['h1 { color: red }'],
@@ -148,6 +160,7 @@ describe('metadata transformer', () => {
       expect(classData && isClassMetadata(classData))
           .toBeDefined(`Expected metadata to contain data for Foo`);
       if (classData && isClassMetadata(classData)) {
+        expect(JSON.stringify(classData)).not.toContain('moduleId');
         expect(JSON.stringify(classData)).not.toContain('templateUrl');
         expect(JSON.stringify(classData)).toContain('"template":"Some template"');
         expect(JSON.stringify(classData)).not.toContain('styleUrls');


### PR DESCRIPTION
When resource inlining has been enabled through the `enableResourceInlining`
compiler option, properties for `moduleId` are left in the component
decorator. This is not ideal because the `moduleId` is no longer needed,
but the dependency on the `moduleId` expression remains. e.g.

```ts
        MatPseudoCheckbox.decorators = [
            { type: i0.Component, args: [{
                        moduleId: module.id,
			template: '...' ,
```

This means that the component will not work if `module.id` is not
present in the environment where the component is loaded. One could
argue that the component author should simply remove `moduleId` from
the component, but the component could be used in JIT in development
mode where the `moduleId` property is needed.

This issue came up in `@angular/bazel` because when building libraries
with Bazel, resources should be inlined and the `moduleId` removed. This
is not the case right now, so when used in combination with
`ng_package`, the UMD bundles do not work in the browser due to
`module.id` being undefined.

**Note**: also fixes that a few test assertions were always passing regardless of the
decorator output.