### PR TITLE
perf(ivy): align (browser, benchpress, G3) the depth param for the tree benchmark

### DIFF
--- a/modules/benchmarks/src/tree/baseline/index.html
+++ b/modules/benchmarks/src/tree/baseline/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/incremental_dom/index.html
+++ b/modules/benchmarks/src/tree/incremental_dom/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/iv/index.html
+++ b/modules/benchmarks/src/tree/iv/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/ng1/index.html
+++ b/modules/benchmarks/src/tree/ng1/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/ng2/index.html
+++ b/modules/benchmarks/src/tree/ng2/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/ng2_next/index.html
+++ b/modules/benchmarks/src/tree/ng2_next/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/ng2_static/index.html
+++ b/modules/benchmarks/src/tree/ng2_static/index.html
@@ -8,7 +8,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/ng2_switch/index.html
+++ b/modules/benchmarks/src/tree/ng2_switch/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/render3/index.html
+++ b/modules/benchmarks/src/tree/render3/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/render3_function/index.html
+++ b/modules/benchmarks/src/tree/render3_function/index.html
@@ -9,7 +9,7 @@
   <h2>Params</h2>
   <form>
     Depth:
-    <input type="number" name="depth" placeholder="depth" value="9">
+    <input type="number" name="depth" placeholder="depth" value="10">
     <br>
     <button>Apply</button>
   </form>

--- a/modules/benchmarks/src/tree/tree_perf_test_utils.ts
+++ b/modules/benchmarks/src/tree/tree_perf_test_utils.ts
@@ -19,7 +19,7 @@ export function runTreeBenchmark({id, prepare, setup, work}: {
     id: id,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [{name: 'depth', value: 11}],
+    params: [],
     work: work,
     prepare: prepare,
     setup: setup


### PR DESCRIPTION
It turns out that we've used different `depth` values while running the "tree" benchmark in different environments (G3, benchpress, running in a browser). This PR standardises this value to `10` across the board.  