### PR TITLE
fix(ngcc): add reexports only once

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -96,14 +96,14 @@ export class DtsRenderer {
         const newStatement = `    static ${declaration.name}: ${typeStr};\n`;
         outputText.appendRight(endOfClass - 1, newStatement);
       });
-
-      if (renderInfo.reexports.length > 0) {
-        for (const e of renderInfo.reexports) {
-          const newStatement = `\nexport {${e.symbolName} as ${e.asAlias}} from '${e.fromModule}';`;
-          outputText.appendRight(endOfClass, newStatement);
-        }
-      }
     });
+
+    if (renderInfo.reexports.length > 0) {
+      for (const e of renderInfo.reexports) {
+        const newStatement = `\nexport {${e.symbolName} as ${e.asAlias}} from '${e.fromModule}';`;
+        outputText.append(newStatement);
+      }
+    }
 
     this.dtsFormatter.addModuleWithProvidersParams(
         outputText, renderInfo.moduleWithProviders, importManager);

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -918,23 +918,35 @@ runInEachFileSystem(() => {
               var __decorate = null;
               var core_1 = require("@angular/core");
               var directive_1 = require("./directive");
+              var LocalDir = /** @class */ (function () {
+                  function LocalDir() {
+                  }
+                  LocalDir = __decorate([
+                      core_1.Directive({
+                          selector: '[local]',
+                      })
+                  ], LocalDir);
+                  return LocalDir;
+              }());
               var FooModule = /** @class */ (function () {
                   function FooModule() {
                   }
                   FooModule = __decorate([
                       core_1.NgModule({
-                          declarations: [directive_1.Foo],
-                          exports: [directive_1.Foo],
+                          declarations: [directive_1.Foo, LocalDir],
+                          exports: [directive_1.Foo, LocalDir],
                       })
                   ], FooModule);
                   return FooModule;
               }());
+              exports.LocalDir = LocalDir;
               exports.FooModule = FooModule;
             `,
           },
           {
             name: _('/node_modules/test-package/module.d.ts'),
             contents: `
+              export declare class LocalDir {}
               export declare class FooModule {}
             `,
           },
@@ -1005,6 +1017,8 @@ runInEachFileSystem(() => {
         expect(jsContents).toContain('exports.ɵngExportɵFooModuleɵFoo = ɵngcc1.Foo;');
         expect(dtsContents)
             .toContain(`export {Foo as ɵngExportɵFooModuleɵFoo} from './directive';`);
+        expect(dtsContents.match(/ɵngExportɵFooModuleɵFoo/g) !.length).toBe(1);
+        expect(dtsContents).not.toContain(`ɵngExportɵFooModuleɵLocalDir`);
       });
     });
 


### PR DESCRIPTION
When ngcc is configured to generate reexports for a package using the
`generateDeepReexports` configuration option, it could incorrectly
render the reexports as often as the number of compiled classes in the
declaration file. This would cause compilation errors due to duplicated
declarations.