### PR TITLE
fix(ivy): auto register NgModules with ID

### DIFF
--- a/packages/core/src/linker/ng_module_factory_registration.ts
+++ b/packages/core/src/linker/ng_module_factory_registration.ts
@@ -56,7 +56,7 @@ export function registerNgModuleType(ngModuleType: NgModuleType) {
   }
 }
 
-export function clearModuleRegistry(): void {
+export function clearModulesForTest(): void {
   modules.clear();
 }
 

--- a/packages/core/src/linker/ng_module_factory_registration.ts
+++ b/packages/core/src/linker/ng_module_factory_registration.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+
 import {Type} from '../interface/type';
+import {autoRegisterModuleById} from '../render3/definition';
 import {NgModuleType} from '../render3/ng_module_ref';
 import {stringify} from '../util/stringify';
 
@@ -68,5 +70,5 @@ export function restoreRegisteredModulesState(moduleMap: ModuleRegistrationMap) 
 }
 
 export function getRegisteredNgModuleType(id: string) {
-  return modules.get(id);
+  return modules.get(id) || autoRegisterModuleById[id];
 }

--- a/packages/core/src/linker/ng_module_factory_registration.ts
+++ b/packages/core/src/linker/ng_module_factory_registration.ts
@@ -14,14 +14,13 @@ import {stringify} from '../util/stringify';
 
 import {NgModuleFactory} from './ng_module_factory';
 
-export type ModuleRegistrationMap = Map<string, NgModuleFactory<any>|NgModuleType>;
 
 /**
  * Map of module-id to the corresponding NgModule.
  * - In pre Ivy we track NgModuleFactory,
  * - In post Ivy we track the NgModuleType
  */
-let modules: ModuleRegistrationMap = new Map();
+const modules = new Map<string, NgModuleFactory<any>|NgModuleType>();
 
 /**
  * Registers a loaded module. Should only be called from generated NgModuleFactory code.
@@ -57,16 +56,8 @@ export function registerNgModuleType(ngModuleType: NgModuleType) {
   }
 }
 
-export function clearRegisteredModuleState(): void {
+export function clearModuleRegistry(): void {
   modules.clear();
-}
-
-export function getRegisteredModulesState(): ModuleRegistrationMap {
-  return new Map(modules);
-}
-
-export function restoreRegisteredModulesState(moduleMap: ModuleRegistrationMap) {
-  modules = new Map(moduleMap);
 }
 
 export function getRegisteredNgModuleType(id: string) {

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -22,6 +22,7 @@ import {TConstants} from './interfaces/node';
 // while SelectorFlags is unused here, it's required so that types don't get resolved lazily
 // see: https://github.com/Microsoft/web-build-tools/issues/1050
 import {CssSelectorList, SelectorFlags} from './interfaces/projection';
+import {NgModuleType} from './ng_module_ref';
 
 let _renderCompCount = 0;
 
@@ -338,6 +339,8 @@ export function extractPipeDef(type: Type<any>): PipeDef<any> {
   return def !;
 }
 
+export const autoRegisterModuleById: {[id: string]: NgModuleType} = {};
+
 /**
  * @codeGenApi
  */
@@ -376,6 +379,10 @@ export function ɵɵdefineNgModule<T>(def: {
     schemas: def.schemas || null,
     id: def.id || null,
   };
+  if (def.id != null) {
+    noSideEffects(
+        () => { autoRegisterModuleById[def.id !] = def.type as unknown as NgModuleType; });
+  }
   return res as never;
 }
 

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -17,7 +17,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {modifiedInIvy, obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
-import {clearRegisteredModuleState} from '../../src/linker/ng_module_factory_registration';
+import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
 import {stringify} from '../../src/util/stringify';
 
 class Engine {}
@@ -294,7 +294,11 @@ function declareTests(config?: {useJit: boolean}) {
     describe('id', () => {
       const token = 'myid';
 
-      afterEach(() => clearRegisteredModuleState());
+      // Ivy TestBed clears module registry in resetTestingModule so this afterEach is not needed
+      // for Ivy
+      if (!ivyEnabled) {
+        afterEach(() => clearModuleRegistry());
+      }
 
       it('should register loaded modules', () => {
         @NgModule({id: token})

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -17,7 +17,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {modifiedInIvy, obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
-import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
+import {clearModulesForTest} from '../../src/linker/ng_module_factory_registration';
 import {stringify} from '../../src/util/stringify';
 
 class Engine {}
@@ -294,11 +294,7 @@ function declareTests(config?: {useJit: boolean}) {
     describe('id', () => {
       const token = 'myid';
 
-      // Ivy TestBed clears module registry in resetTestingModule so this afterEach is not needed
-      // for Ivy
-      if (!ivyEnabled) {
-        afterEach(() => clearModuleRegistry());
-      }
+      afterEach(() => clearModulesForTest());
 
       it('should register loaded modules', () => {
         @NgModule({id: token})

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,13 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-<<<<<<< HEAD
-import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Injector, Input, ModuleWithProviders, NgModule, Optional, Pipe, getModuleFactory, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
-import {registerModuleFactory} from '@angular/core/src/linker/ng_module_factory_registration';
-import {NgModuleFactory} from '@angular/core/src/render3';
-=======
-import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Input, ModuleWithProviders, NgModule, Optional, Pipe, getModuleFactory, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
->>>>>>> parent of 63256b511a... fix(ivy): Only restore registered modules if user compiles modules with TestBed (#32944)
+import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Injector, Input, ModuleWithProviders, NgModule, Optional, Pipe, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -872,18 +866,5 @@ describe('TestBed', () => {
              expect((ComponentWithProvider as any).ɵcmp.providersResolver)
                  .toEqual(originalResolver);
            });
-      });
-
-  onlyInIvy('Ivy module registration happens when NgModuleFactory is created')
-      .it('cleans up registered modules', async() => {
-        @NgModule({id: 'my_module'})
-        class MyModule {
-        }
-
-        expect(() => getModuleFactory('my_module')).toThrowError();
-        await TestBed.inject(Compiler).compileModuleAsync(MyModule);
-        expect(() => getModuleFactory('my_module')).not.toThrowError();
-        TestBed.resetTestingModule();
-        expect(() => getModuleFactory('my_module')).toThrowError();
       });
 });

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+<<<<<<< HEAD
 import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Injector, Input, ModuleWithProviders, NgModule, Optional, Pipe, getModuleFactory, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
 import {registerModuleFactory} from '@angular/core/src/linker/ng_module_factory_registration';
 import {NgModuleFactory} from '@angular/core/src/render3';
+=======
+import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Input, ModuleWithProviders, NgModule, Optional, Pipe, getModuleFactory, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
+>>>>>>> parent of 63256b511a... fix(ivy): Only restore registered modules if user compiles modules with TestBed (#32944)
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -871,30 +875,15 @@ describe('TestBed', () => {
       });
 
   onlyInIvy('Ivy module registration happens when NgModuleFactory is created')
-      .describe('cleans up registered modules - ', () => {
-        it('removes modules registered with TestBed', async() => {
-          @NgModule({id: 'my_module'})
-          class MyModule {
-          }
+      .it('cleans up registered modules', async() => {
+        @NgModule({id: 'my_module'})
+        class MyModule {
+        }
 
-          expect(() => getModuleFactory('my_module')).toThrowError();
-          await TestBed.inject(Compiler).compileModuleAsync(MyModule);
-          expect(() => getModuleFactory('my_module')).not.toThrowError();
-          TestBed.resetTestingModule();
-          expect(() => getModuleFactory('my_module')).toThrowError();
-        });
-
-        it('does not remove modules registered outside TestBed (i.e., side effect registration in ngfactory files)',
-           () => {
-             @NgModule({id: 'auto_module'})
-             class AutoModule {
-             }
-
-             expect(() => getModuleFactory('auto_module')).toThrowError();
-             registerModuleFactory('auto_module', new NgModuleFactory(AutoModule));
-             expect(() => getModuleFactory('auto_module')).not.toThrowError();
-             TestBed.resetTestingModule();
-             expect(() => getModuleFactory('auto_module')).not.toThrowError();
-           });
+        expect(() => getModuleFactory('my_module')).toThrowError();
+        await TestBed.inject(Compiler).compileModuleAsync(MyModule);
+        expect(() => getModuleFactory('my_module')).not.toThrowError();
+        TestBed.resetTestingModule();
+        expect(() => getModuleFactory('my_module')).toThrowError();
       });
 });

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -35,7 +35,7 @@ import {MetadataOverride} from './metadata_override';
 import {TestBed} from './test_bed';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
 import {R3TestBedCompiler} from './r3_test_bed_compiler';
-import {clearRegisteredModuleState} from '../../src/linker/ng_module_factory_registration';
+import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
 
 let _nextRootElementId = 0;
 
@@ -229,6 +229,7 @@ export class TestBedRender3 implements TestBed {
   }
 
   resetTestingModule(): void {
+    clearModuleRegistry();
     this.checkGlobalCompilationFinished();
     resetCompiledComponents();
     if (this._compiler !== null) {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -35,7 +35,6 @@ import {MetadataOverride} from './metadata_override';
 import {TestBed} from './test_bed';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
 import {R3TestBedCompiler} from './r3_test_bed_compiler';
-import {clearModuleRegistry} from '../../src/linker/ng_module_factory_registration';
 
 let _nextRootElementId = 0;
 
@@ -229,7 +228,6 @@ export class TestBedRender3 implements TestBed {
   }
 
   resetTestingModule(): void {
-    clearModuleRegistry();
     this.checkGlobalCompilationFinished();
     resetCompiledComponents();
     if (this._compiler !== null) {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -9,7 +9,6 @@
 import {ResourceLoader} from '@angular/compiler';
 import {ApplicationInitStatus, COMPILER_OPTIONS, Compiler, Component, Directive, Injector, InjectorType, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, Type, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDirectiveDef as DirectiveDef, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵɵInjectableDef as InjectableDef} from '@angular/core';
 
-import {ModuleRegistrationMap, getRegisteredModulesState, restoreRegisteredModulesState} from '../../src/linker/ng_module_factory_registration';
 import {clearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution, resolveComponentResources, restoreComponentResolutionQueue} from '../../src/metadata/resource_loading';
 
 import {MetadataOverride} from './metadata_override';
@@ -42,7 +41,6 @@ interface CleanupOperation {
 
 export class R3TestBedCompiler {
   private originalComponentResolutionQueue: Map<Type<any>, Component>|null = null;
-  private originalRegisteredModules: null|ModuleRegistrationMap = null;
 
   // Testing module configuration
   private declarations: Type<any>[] = [];
@@ -277,9 +275,6 @@ export class R3TestBedCompiler {
    * @internal
    */
   async _compileNgModuleAsync(moduleType: Type<any>): Promise<void> {
-    if (this.originalRegisteredModules === null) {
-      this.originalRegisteredModules = getRegisteredModulesState();
-    }
     this.queueTypesFromModulesArray([moduleType]);
     await this.compileComponents();
     this.applyProviderOverrides();
@@ -567,10 +562,6 @@ export class R3TestBedCompiler {
     this.initialNgDefs.clear();
     this.moduleProvidersOverridden.clear();
     this.restoreComponentResolutionQueue();
-    if (this.originalRegisteredModules) {
-      restoreRegisteredModulesState(this.originalRegisteredModules);
-      this.originalRegisteredModules = null;
-    }
     // Restore the locale ID to the default value, this shouldn't be necessary but we never know
     setLocaleId(DEFAULT_LOCALE_ID);
   }


### PR DESCRIPTION
For projects that use lazy loaded modules, we've observed that tree shaking in tests sometimes results in the ngfactory file for the lazy loaded module being removed. This results in the `ng_module_factory_registration` map not registering the module's id so when code later attempts to retrieve the factory, it fails. This is because ngfactory files have a side effect of creating an `NgModuleFactory` (which calls `registerNgModuleType` in the constructor). This PR keeps track of modules at the point of creation, providing a backup for retrieving it if the ngfactory was somehow tree-shaken away.

This commit also reverts the changes to TestBed that dealt with restoring the registered modules in `ng_module_factory_registration.ts`. These reverts are necessary because this change would make it so that even if a module is not registered in the map there, it is still retrieved from the map from `defineNgModule`. The original fixes in `TestBed` were not necessary: test setup in google3 has since been modified to not need the state restore because it now recompiles the lazy loaded modules with `TestBed` before each test, ensuring new provider overrides take effect.

We should run global presubmit with this PR to ensure it doesn't break anything.