### PR TITLE
fix(language-service): Resolve template variable in nested scope

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -283,6 +283,20 @@ describe('completions', () => {
       const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
       expectContain(completions, CompletionKind.PROPERTY, ['name', 'age', 'street']);
     });
+
+    it('should be able to resolve variable in nested loop', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <div *ngFor="let leagueMembers of league">
+          <div *ngFor="let member of leagueMembers">
+            {{member.~{position}}}
+          </div>
+        </div>
+      `);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'position');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      // member variable of type Hero has properties 'id' and 'name'.
+      expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
+    });
   });
 
   describe('data binding', () => {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -173,6 +173,23 @@ describe('diagnostics', () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it('should report diagnostic for invalid property in nested ngFor', () => {
+    const content = mockHost.override(TEST_TEMPLATE, `
+      <div *ngFor="let leagueMembers of league">
+        <div *ngFor="let member of leagueMembers">
+          {{member.xyz}}
+        </div>
+      </div>
+    `);
+    const diagnostics = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(diagnostics.length).toBe(1);
+    const {messageText, start, length} = diagnostics[0];
+    expect(messageText)
+        .toBe(`Identifier 'xyz' is not defined. 'Hero' does not contain such a member`);
+    expect(start).toBe(content.indexOf('member.xyz'));
+    expect(length).toBe('member.xyz'.length);
+  });
+
   describe('with $event', () => {
     it('should accept an event', () => {
       const fileName = '/app/test.ng';

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -189,6 +189,7 @@ export class TemplateReference {
   title = 'Some title';
   hero: Hero = {id: 1, name: 'Windstorm'};
   heroes: Hero[] = [this.hero];
+  league: Hero[][] = [this.heroes];
   anyValue: any;
   myClick(event: any) {}
 }


### PR DESCRIPTION
This commit fixes a bug whereby template variables in nested scope are
not resolved properly and instead are simply typed as `any`.

PR closes https://github.com/angular/vscode-ng-language-service/issues/144

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
