### PR TITLE
fix(platform-browser): add unique input event plugin

### DIFF
--- a/packages/platform-browser/src/dom/events/unique_input_event.ts
+++ b/packages/platform-browser/src/dom/events/unique_input_event.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {Inject, Injectable, InjectionToken, Optional} from '@angular/core';
+
+import {EventManagerPlugin} from './event_manager';
+
+/**
+ * The injection token for enabling unique input event plugin.
+ *
+ * @publicApi
+ */
+export const UNIQUE_INPUT_EVENT_PLUGIN_CONFIG =
+    new InjectionToken<UniqueInputEventPluginConfig>('UniqueInputEventPluginConfig');
+
+/**
+ * @publicApi
+ */
+export interface UniqueInputEventPluginConfig {
+  /**
+   * Function that determines that plugin should be applied to element
+   * Default is HTMLInputElement or HTMLTextAreaElement
+   */
+  shouldApplyToElement?(element: Element): boolean;
+  /**
+   * Function that determines that event is not require check for uniqueness
+   * By default, all non user agent events is trusted
+   */
+  shouldTrustEvent?(event: Event): boolean;
+}
+
+
+const DEFAULT_UNIQUE_INPUT_EVENT_PLUGIN_CONFIG: UniqueInputEventPluginConfig = {
+  shouldApplyToElement: (element: HTMLElement) => {
+    return element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement;
+  },
+  /** Trust all non user agent events */
+  shouldTrustEvent: (event: Event) => !event.isTrusted,
+};
+
+
+/**
+ * @description
+ *
+ * This plugin checks if value of element is changed before firing input event
+ *
+ * Internet Explorer 10+ implements 'input' event but it erroneously fires under various situations,
+ * e.g. when placeholder changes, when non english placeholder is used or a control is focused.
+ * Fixed only from Edge 15.15002
+ * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220
+ * Will not be fixed in Internet Explorer
+ * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11405058/
+ *
+ * @usageNotes
+ * ### Example
+ *
+ * ```
+ * @NgModule({
+ *   providers: [{
+ *      provide: EVENT_MANAGER_PLUGINS, multi: true,
+ *      useClass: UniqueInputEventPlugin, deps: [DOCUMENT],
+ *   }]
+ * })
+ * class MyModule {}
+ * ```
+ *
+ * If there is a need to control when the plugin will be enabled (for example, IE 10+),
+ * use `FactoryProvider` instead of `ClassProvider`
+ *
+ * @publicApi
+ */
+@Injectable()
+export class UniqueInputEventPlugin extends EventManagerPlugin {
+  private _config?: UniqueInputEventPluginConfig;
+
+  constructor(
+      @Inject(DOCUMENT) private _document: any,
+      @Optional() @Inject(UNIQUE_INPUT_EVENT_PLUGIN_CONFIG) config?: UniqueInputEventPluginConfig) {
+    super(_document);
+
+    if (config) {
+      this._config = {...DEFAULT_UNIQUE_INPUT_EVENT_PLUGIN_CONFIG, ...config};
+    }
+  }
+
+  supports(eventName: string): boolean { return !!(this._config) && eventName === 'input'; }
+
+
+  addEventListener(
+      element: HTMLElement, eventName: string,
+      originalHandler: (event: Event) => void): () => void {
+    if (this._config && this._config.shouldApplyToElement &&
+        this._config.shouldApplyToElement(element)) {
+      const targetElement = element as HTMLElement & {value?: any};
+
+      let value = targetElement.value;
+
+      /**
+       * Keydown event type MUST be dispatched before the beforeinput, input,
+       * and keyup events associated with the same key.
+       * https://www.w3.org/TR/uievents/#keydown
+       */
+      const keydownHandler = () => { value = targetElement.value; };
+
+      const inputHandler = (event: Event) => {
+        /**
+         * Event is trusted
+         * OR element.value changed after listener added
+         * OR element.value changed after input
+         * OR element.value changed after keydown
+         */
+        if ((this._config && this._config.shouldTrustEvent &&
+             this._config.shouldTrustEvent(event)) ||
+            targetElement.value !== value) {
+          value = targetElement.value;
+          originalHandler(event);
+        }
+      };
+
+      element.addEventListener('keydown', keydownHandler, false);
+      element.addEventListener(eventName, inputHandler, false);
+      return () => {
+        element.removeEventListener(eventName, inputHandler, false);
+        element.removeEventListener('keydown', keydownHandler, false);
+      };
+    }
+
+    element.addEventListener(eventName, originalHandler, false);
+    return () => element.removeEventListener(eventName, originalHandler, false);
+  }
+}

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -14,6 +14,7 @@ export {BrowserTransferStateModule, StateKey, TransferState, makeStateKey} from 
 export {By} from './dom/debug/by';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HAMMER_PROVIDERS__POST_R3__ as ɵHAMMER_PROVIDERS__POST_R3__, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
+export {UNIQUE_INPUT_EVENT_PLUGIN_CONFIG, UniqueInputEventPlugin, UniqueInputEventPluginConfig} from './dom/events/unique_input_event';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
 
 export * from './private_export';

--- a/packages/platform-browser/test/dom/events/unique_input_event_spec.ts
+++ b/packages/platform-browser/test/dom/events/unique_input_event_spec.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵgetDOM as getDOM} from '@angular/common';
+import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
+import {UniqueInputEventPlugin} from '@angular/platform-browser/src/dom/events/unique_input_event';
+
+import {dispatchEvent, el} from '../../../testing/src/browser_util';
+
+
+describe('UniqueInputEventPlugin', () => {
+  if (isNode) return;
+
+  let doc: any;
+  let inputElement: HTMLInputElement;
+  beforeEach(() => {
+    doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
+    inputElement = el('<input type="text">') as HTMLInputElement;
+  });
+
+  it('should work only if config is provided', () => {
+    const pluginWithoutConfig = new UniqueInputEventPlugin(doc);
+    expect(pluginWithoutConfig.supports('input')).toBe(false);
+
+    const pluginWithConfig = new UniqueInputEventPlugin(doc, {});
+    expect(pluginWithConfig.supports('input')).toBe(true);
+  });
+
+  it('should work only on elements which are allowed by config', () => {
+    const plugin = new UniqueInputEventPlugin(doc, {
+      shouldApplyToElement: (element: Element) => element instanceof HTMLInputElement,
+      shouldTrustEvent: () => false,
+    });
+
+    const enabledHandler = jasmine.createSpy('enabledHandler');
+    plugin.addEventListener(inputElement, 'input', enabledHandler);
+    dispatchEvent(inputElement, 'input');
+    expect(enabledHandler).not.toHaveBeenCalled();
+
+    const disabledHandler = jasmine.createSpy('enabledHandler');
+    const textAreaElement = el('<textarea></textarea>');
+    plugin.addEventListener(textAreaElement, 'input', disabledHandler);
+    dispatchEvent(textAreaElement, 'input');
+    expect(disabledHandler).toHaveBeenCalled();
+  });
+
+  it('should trust events which are allowed by config', () => {
+    const trustAllPlugin = new UniqueInputEventPlugin(doc, {
+      shouldTrustEvent: () => true,
+    });
+    const enabledHandler = jasmine.createSpy('enabledHandler');
+    trustAllPlugin.addEventListener(inputElement, 'input', enabledHandler);
+    dispatchEvent(inputElement, 'input');
+    expect(enabledHandler).toHaveBeenCalled();
+
+    const trustNonePlugin = new UniqueInputEventPlugin(doc, {
+      shouldTrustEvent: () => false,
+    });
+    const disabledHandler = jasmine.createSpy('enabledHandler');
+    trustNonePlugin.addEventListener(inputElement, 'input', enabledHandler);
+    dispatchEvent(inputElement, 'input');
+    expect(disabledHandler).not.toHaveBeenCalled();
+  });
+
+
+  describe('input event', () => {
+    let plugin: UniqueInputEventPlugin;
+    let handler: (event: Event) => void;
+    beforeEach(() => {
+      plugin = new UniqueInputEventPlugin(doc, {
+        shouldTrustEvent: () => false,
+      });
+      handler = jasmine.createSpy('handler');
+    });
+
+    it('should not fire input event when value is not changed', () => {
+      plugin.addEventListener(inputElement, 'input', handler);
+      dispatchEvent(inputElement, 'input');
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should fire input event when value is changed after listener added', () => {
+      inputElement.value = '1';
+      plugin.addEventListener(inputElement, 'input', handler);
+      inputElement.value = '2';
+      dispatchEvent(inputElement, 'input');
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('should fire input event when value changed by keyboard event', () => {
+      inputElement.value = '1';
+      plugin.addEventListener(inputElement, 'input', handler);
+      inputElement.value = '2';
+      dispatchEvent(inputElement, 'keydown');
+      inputElement.value = '3';
+      dispatchEvent(inputElement, 'input');
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('should fire input event when value changed by input event', () => {
+      inputElement.value = '1';
+      plugin.addEventListener(inputElement, 'input', handler);
+      inputElement.value = '2';
+      dispatchEvent(inputElement, 'input');
+      inputElement.value = '3';
+      dispatchEvent(inputElement, 'input');
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+});

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -129,4 +129,17 @@ export declare class TransferState {
     toJson(): string;
 }
 
+export declare const UNIQUE_INPUT_EVENT_PLUGIN_CONFIG: InjectionToken<UniqueInputEventPluginConfig>;
+
+export declare class UniqueInputEventPlugin extends EventManagerPlugin {
+    constructor(_document: any, config?: UniqueInputEventPluginConfig);
+    addEventListener(element: HTMLElement, eventName: string, originalHandler: (event: Event) => void): () => void;
+    supports(eventName: string): boolean;
+}
+
+export interface UniqueInputEventPluginConfig {
+    shouldApplyToElement?(element: Element): boolean;
+    shouldTrustEvent?(event: Event): boolean;
+}
+
 export declare const VERSION: Version;


### PR DESCRIPTION
This plugin checks if value of element is changed before firing input event  

Internet Explorer 10+ implements 'input' event but it erroneously fires under various situations, e.g. when placeholder changes, when non english placeholder is used or a control is focused

Fixed only from Edge 15.15002
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/
This bug will not be fixed in Internet Explorer 
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11405058/

Closes #14440, #17951, #15299, #16151

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Internet Explorer 10+ implements 'input' event but it erroneously fires under various situations, e.g. when placeholder changes, when non english placeholder is used or a control is focused

Issue Number: #14440, #17951, #15299, #16151

## What is the new behavior?
If plugin config is provided – input event is fired when value of element is changed.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Here is the problem reproduction (to fix IE behavior- uncomment the provider): https://stackblitz.com/edit/angular-feu5wd?embed=1&file=src/app.module.ts

I had to recreate the [PR](https://github.com/angular/angular/pull/29895) due to the accidental deletion of the associated fork.