### PR TITLE
fix(ivy): Find event listeners register using angular fast path.

### DIFF
--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -9,6 +9,7 @@
 
 import {CommonModule, NgIfContext, ɵgetDOM as getDOM} from '@angular/common';
 import {Component, DebugElement, DebugNode, Directive, ElementRef, EmbeddedViewRef, EventEmitter, HostBinding, Injectable, Input, NO_ERRORS_SCHEMA, OnInit, Output, Renderer2, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {NgZone} from '@angular/core/src/zone';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {hasClass} from '@angular/platform-browser/testing/src/browser_util';
@@ -795,13 +796,21 @@ class TestCmptWithPropInterpolation {
       @Component({template: ''})
       class TestComponent implements OnInit {
         count = 0;
-        eventObj: any;
-        constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
+        eventObj1: any;
+        eventObj2: any;
+        constructor(
+            private renderer: Renderer2, private elementRef: ElementRef, private ngZone: NgZone) {}
 
         ngOnInit() {
           this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
             this.count++;
-            this.eventObj = event;
+            this.eventObj1 = event;
+          });
+          this.ngZone.runOutsideAngular(() => {
+            this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
+              this.count++;
+              this.eventObj2 = event;
+            });
           });
         }
       }
@@ -816,8 +825,8 @@ class TestCmptWithPropInterpolation {
         const event = {value: true};
         fixture.detectChanges();
         fixture.debugElement.triggerEventHandler('click', event);
-        expect(fixture.componentInstance.count).toBe(1);
-        expect(fixture.componentInstance.eventObj).toBe(event);
+        expect(fixture.componentInstance.count).toBe(2);
+        expect(fixture.componentInstance.eventObj2).toBe(event);
       }
     });
 


### PR DESCRIPTION
Angular sometimes registers events using [fast path](https://github.com/angular/angular/blob/1d429b216556911edc4b0675ece4cb9081967155/packages/platform-browser/src/dom/events/dom_events.ts#L142-L195)
which than need to be located correctly by the `DebugNode` so that
`triggerEventHandler` works correctly.

Fixes #33687

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/33687


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
