### PR TITLE
feat(core): missing-injectable migration should migrate empty object literal providers

### DIFF
--- a/integration/ng_update_migrations/src/app/migration-tests/providers-test-module.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/providers-test-module.ts
@@ -34,9 +34,9 @@ class BaseProviderCase {
   constructor(zone: NgZone) {}
 }
 
-export class ProvideCase extends BaseProviderCase {}
+export class EmptyProviderLiteralCase {}
 
-export class ProviderClass {}
+export class ProviderClass extends BaseProviderCase {}
 
 export class DontNeedCase {}
 
@@ -46,7 +46,7 @@ export class DirectiveCase {}
 @NgModule({
   providers: [
     TypeCase,
-    {provide: ProvideCase},
+    {provide: EmptyProviderLiteralCase},
     {provide: DontNeedCase, useValue: 0},
     {provide: DontNeedCase, useFactory: () => null},
     {provide: DontNeedCase, useExisting: TypeCase},
@@ -56,4 +56,3 @@ export class DirectiveCase {}
   declarations: [ProvidersTestDirective, ProvidersTestComponent],
 })
 export class ProvidersTestModule {}
-

--- a/integration/ng_update_migrations/src/app/migration-tests/providers-test-module_expected.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/providers-test-module_expected.ts
@@ -41,11 +41,10 @@ class BaseProviderCase {
   constructor(zone: NgZone) {}
 }
 
-@Injectable()
-export class ProvideCase extends BaseProviderCase {}
+export class EmptyProviderLiteralCase {}
 
 @Injectable()
-export class ProviderClass {}
+export class ProviderClass extends BaseProviderCase {}
 
 export class DontNeedCase {}
 
@@ -55,7 +54,7 @@ export class DirectiveCase {}
 @NgModule({
   providers: [
     TypeCase,
-    {provide: ProvideCase},
+    { provide: EmptyProviderLiteralCase, useValue: undefined },
     {provide: DontNeedCase, useValue: 0},
     {provide: DontNeedCase, useFactory: () => null},
     {provide: DontNeedCase, useExisting: TypeCase},
@@ -65,4 +64,3 @@ export class DirectiveCase {}
   declarations: [ProvidersTestDirective, ProvidersTestComponent],
 })
 export class ProvidersTestModule {}
-

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -160,7 +160,7 @@ export class StaticInterpreter {
     return array;
   }
 
-  private visitObjectLiteralExpression(node: ts.ObjectLiteralExpression, context: Context):
+  protected visitObjectLiteralExpression(node: ts.ObjectLiteralExpression, context: Context):
       ResolvedValue {
     const map: ResolvedValueMap = new Map<string, ResolvedValue>();
     for (let i = 0; i < node.properties.length; i++) {

--- a/packages/core/schematics/migrations/missing-injectable/google3/tslint_update_recorder.ts
+++ b/packages/core/schematics/migrations/missing-injectable/google3/tslint_update_recorder.ts
@@ -54,5 +54,13 @@ export class TslintUpdateRecorder implements UpdateRecorder {
         this.ruleName, fix));
   }
 
+
+  updateObjectLiteral(node: ts.ObjectLiteralExpression, newText: string): void {
+    this.failures.push(new RuleFailure(
+        this.sourceFile, node.getStart(), node.getEnd(),
+        `Object literal needs to be updated to: ${newText}`, this.ruleName,
+        Replacement.replaceFromTo(node.getStart(), node.getEnd(), newText)));
+  }
+
   commitUpdate() {}
 }

--- a/packages/core/schematics/migrations/missing-injectable/index.ts
+++ b/packages/core/schematics/migrations/missing-injectable/index.ts
@@ -107,6 +107,10 @@ function runMissingInjectableMigration(
         treeRecorder.remove(namedBindings.getStart(), namedBindings.getWidth());
         treeRecorder.insertRight(namedBindings.getStart(), newNamedBindings);
       },
+      updateObjectLiteral(node: ts.ObjectLiteralExpression, newText: string) {
+        treeRecorder.remove(node.getStart(), node.getWidth());
+        treeRecorder.insertRight(node.getStart(), newText);
+      },
       commitUpdate() { tree.commitUpdate(treeRecorder); }
     };
     updateRecorders.set(sourceFile, recorder);

--- a/packages/core/schematics/migrations/missing-injectable/providers_evaluator.ts
+++ b/packages/core/schematics/migrations/missing-injectable/providers_evaluator.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {forwardRefResolver} from '@angular/compiler-cli/src/ngtsc/annotations';
+import {ResolvedValue} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
+import {StaticInterpreter} from '@angular/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter';
+import * as ts from 'typescript';
+
+export interface ProviderLiteral {
+  node: ts.ObjectLiteralExpression;
+  resolvedValue: ResolvedValue;
+}
+
+/**
+ * Providers evaluator that extends the ngtsc static interpreter. This is necessary because
+ * the static interpreter by default only exposes the resolved value, but we are also interested
+ * in the TypeScript nodes that declare providers. It would be possible to manually traverse the
+ * AST to collect these nodes, but that would mean that we need to re-implement the static
+ * interpreter in order to handle all possible scenarios. (e.g. spread operator, function calls,
+ * callee scope). This can be avoided by simply extending the static interpreter and intercepting
+ * the "visitObjectLiteralExpression" method.
+ */
+export class ProvidersEvaluator extends StaticInterpreter {
+  private _providerLiterals: ProviderLiteral[] = [];
+
+  visitObjectLiteralExpression(node: ts.ObjectLiteralExpression, context: any) {
+    const resolvedValue =
+        super.visitObjectLiteralExpression(node, {...context, insideProviderDef: true});
+    // do not collect nested object literals. e.g. a provider could use a
+    // spread assignment (which resolves to another object literal). In that
+    // case the referenced object literal is not a provider object literal.
+    if (!context.insideProviderDef) {
+      this._providerLiterals.push({node, resolvedValue});
+    }
+    return resolvedValue;
+  }
+
+  /**
+   * Evaluates the given expression and returns its statically resolved value
+   * and a list of object literals which define Angular providers.
+   */
+  evaluate(expr: ts.Expression) {
+    this._providerLiterals = [];
+    const resolvedValue = this.visit(expr, {
+      originatingFile: expr.getSourceFile(),
+      absoluteModuleName: null,
+      resolutionContext: expr.getSourceFile().fileName,
+      scope: new Map(),
+      foreignFunctionResolver: forwardRefResolver
+    });
+    return {resolvedValue, literals: this._providerLiterals};
+  }
+}

--- a/packages/core/schematics/migrations/missing-injectable/update_recorder.ts
+++ b/packages/core/schematics/migrations/missing-injectable/update_recorder.ts
@@ -18,5 +18,6 @@ export interface UpdateRecorder {
   updateExistingImport(namedBindings: ts.NamedImports, newNamedBindings: string): void;
   addClassDecorator(node: ts.ClassDeclaration, text: string, className: string): void;
   replaceDecorator(node: ts.Decorator, newText: string, className: string): void;
+  updateObjectLiteral(node: ts.ObjectLiteralExpression, newText: string): void;
   commitUpdate(): void;
 }

--- a/packages/core/schematics/test/google3/missing_injectable_rule_spec.ts
+++ b/packages/core/schematics/test/google3/missing_injectable_rule_spec.ts
@@ -121,6 +121,7 @@ describe('Google3 missing injectable tslint rule', () => {
         export class MyServiceE {}
         export class MyServiceF {}
         export class MyServiceG {}
+        export class MyServiceH {}
             
         @${type}({${propName}: [
           WithPipe,
@@ -135,6 +136,7 @@ describe('Google3 missing injectable tslint rule', () => {
           {provide: null, useExisting: MyServiceE},
           {provide: MyServiceF, useFactory: () => null},
           {provide: MyServiceG, useValue: null},
+          {provide: MyServiceH, deps: []},
         ]})
         export class TestClass {}
       `);
@@ -149,11 +151,13 @@ describe('Google3 missing injectable tslint rule', () => {
           .toMatch(/WithDirective {}\s+@Component\(\)\s+export class WithComponent/);
       expect(getFile('/index.ts')).toMatch(/@Injectable\(\)\s+export class MyServiceA/);
       expect(getFile('/index.ts')).toMatch(/@Injectable\(\)\s+export class MyServiceB/);
-      expect(getFile('/index.ts')).toMatch(/@Injectable\(\)\s+export class MyServiceC/);
+      expect(getFile('/index.ts')).toMatch(/MyServiceB {}\s+export class MyServiceC/);
       expect(getFile('/index.ts')).toMatch(/@Injectable\(\)\s+export class MyServiceD/);
       expect(getFile('/index.ts')).toMatch(/MyServiceD {}\s+export class MyServiceE/);
       expect(getFile('/index.ts')).toMatch(/MyServiceE {}\s+export class MyServiceF/);
       expect(getFile('/index.ts')).toMatch(/MyServiceF {}\s+export class MyServiceG/);
+      expect(getFile('/index.ts')).toMatch(/MyServiceG {}\s+export class MyServiceH/);
+      expect(getFile('/index.ts')).toContain(`{ provide: MyServiceC, useValue: undefined },`);
     });
 
     it(`should migrate provider once if referenced in multiple ${type} definitions`, () => {


### PR DESCRIPTION
In View Engine, providers which neither used `useValue`, `useClass`,
`useFactory` or `useExisting`, were interpreted differently.

e.g.

```ts
{provide: X} -> {provide: X, useValue: undefined}, // this is how it works in View Engine
{provide: X} -> {provide: X, useClass: X}, // this is how it works in Ivy
```

The missing-injectable migration should migrate such providers to the
explicit `useValue` provider. This ensures that there is no unexpected
behavioral change when updating to v9.

See: https://next.angular.io/guide/ivy-compatibility#less-common-changes
