### PR TITLE
docs: update update guide to use `ng update` instead of `npm i`

### DIFF
--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -7,12 +7,14 @@ This guide contains everything you need to know about updating to the next Angul
 If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script:
 
 ```
-npm install --no-save @angular/cli@^8.3.15
+ng update @angular/core@8 @angular/cli@8
+git add .
+git commit --all -m "build: update Angular packages to latest 8.x version"
 ng update @angular/cli @angular/core --next
 ```
 
 <div class="alert is-important">
-In order to improve the updating experience, we strongly suggest that you update your local `@angular/cli` to version 8.3.15 or later 8.x version before updating.
+In order to improve the updating experience, we strongly suggest that you update to the latest 8.x version of `@angular/core` and `@angular/cli`.
 
 Additionally, during the RC period, the `--next` command line flag is required. This flag will no longer be necessary once version 9 final is released.
 </div>


### PR DESCRIPTION
For more context see: https://github.com/angular/angular-cli/issues/16021

Closes: https://github.com/angular/angular-cli/issues/16021
