### PR TITLE
fix(forms): Correct required validator to handle objects with a property `length: 0`

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -14,8 +14,13 @@ import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, Validator
 import {AbstractControl} from './model';
 
 function isEmptyInputValue(value: any): boolean {
-  // we don't check for string here so it also works with arrays
-  return value == null || value.length === 0;
+  /**
+   * Check if the object is a string or array before evaluating the length attribute.
+   * This avoids falsely rejecting objects that contain a custom length attribute.
+   * For example, the object {id: 1, length: 0, width: 0} should not be returned as empty.
+   */
+  return value == null ||
+      ((typeof value === 'string' || Array.isArray(value)) && value.length === 0);
 }
 
 function hasValidLength(value: any): boolean {

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -194,6 +194,10 @@ describe('Validators', () => {
 
     it('should not error on a non-empty array',
        () => expect(Validators.required(new FormControl([1, 2]))).toBeNull());
+
+    it('should not error on an object containing a length attribute that is zero', () => {
+      expect(Validators.required(new FormControl({id: 1, length: 0, width: 0}))).toBeNull();
+    });
   });
 
   describe('requiredTrue', () => {


### PR DESCRIPTION
Form required validator should not reject objects that contain a length attribute set to zero.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: #30718

{id: 1, length: 0, width: 0} is evaluated as empty value.

## What is the new behavior?
{id: 1, length: 0, width: 0} is evaluated as **non-empty** value.

## Does this PR introduce a breaking change?

- [X] Yes (Didn't back when it was submitted)
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
