### PR TITLE
ci: publish tarballs for the zone.js package as CI build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,15 +570,25 @@ jobs:
     environment:
       NG_PACKAGES_DIR: &ng_packages_dir 'dist/packages-dist'
       NG_PACKAGES_ARCHIVES_DIR: &ng_packages_archives_dir 'dist/packages-dist-archives'
+      ZONEJS_PACKAGES_DIR: &zonejs_packages_dir 'dist/zone.js-dist'
+      ZONEJS_PACKAGES_ARCHIVES_DIR: &zonejs_packages_archives_dir 'dist/zone.js-dist-archives'
     steps:
       - custom_attach_workspace
       - init_environment
+      # Publish `@angular/*` packages.
       - run:
-          name: Create artifacts
+          name: Create artifacts for @angular/* packages
           command: ./scripts/ci/create-package-archives.sh $CI_PULL_REQUEST $CI_COMMIT $NG_PACKAGES_DIR $NG_PACKAGES_ARCHIVES_DIR
       - store_artifacts:
           path: *ng_packages_archives_dir
           destination: angular
+      # Publish `zone.js` package.
+      - run:
+          name: Create artifacts for zone.js package
+          command: ./scripts/ci/create-package-archives.sh $CI_PULL_REQUEST $CI_COMMIT $ZONEJS_PACKAGES_DIR $ZONEJS_PACKAGES_ARCHIVES_DIR
+      - store_artifacts:
+          path: *zonejs_packages_archives_dir
+          destination: zone.js
 
   # This job updates the content of repos like github.com/angular/core-builds
   # for every green build on angular/angular.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,6 +509,7 @@ jobs:
           root: *workspace_location
           paths:
             - ng/dist/packages-dist
+            - ng/dist/zone.js-dist
 
       # Save dependencies and bazel repository cache to use on subsequent runs.
       - save_cache:

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world-ivy-compat/yarn.lock
+++ b/integration/cli-hello-world-ivy-compat/yarn.lock
@@ -8435,5 +8435,5 @@ yn@^2.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -31,7 +31,7 @@
     "rxjs": "file:../../node_modules/rxjs",
     "serve": "^11.2.0",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world-ivy-i18n/yarn.lock
+++ b/integration/cli-hello-world-ivy-i18n/yarn.lock
@@ -8427,5 +8427,5 @@ yn@^3.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world-ivy-minimal/yarn.lock
+++ b/integration/cli-hello-world-ivy-minimal/yarn.lock
@@ -8435,5 +8435,5 @@ yn@^2.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/cli-hello-world-lazy-rollup/package.json
+++ b/integration/cli-hello-world-lazy-rollup/package.json
@@ -20,7 +20,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "^1.10.0",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world-lazy-rollup/yarn.lock
+++ b/integration/cli-hello-world-lazy-rollup/yarn.lock
@@ -7910,5 +7910,5 @@ yn@^3.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/cli-hello-world-lazy/package.json
+++ b/integration/cli-hello-world-lazy/package.json
@@ -20,7 +20,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "^1.10.0",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world-lazy/yarn.lock
+++ b/integration/cli-hello-world-lazy/yarn.lock
@@ -7910,5 +7910,5 @@ yn@^3.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/cli-hello-world/yarn.lock
+++ b/integration/cli-hello-world/yarn.lock
@@ -10348,5 +10348,5 @@ yn@^2.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/dynamic-compiler/package.json
+++ b/integration/dynamic-compiler/package.json
@@ -41,6 +41,6 @@
     "core-js": "file:../../node_modules/core-js",
     "rxjs": "file:../../node_modules/rxjs",
     "systemjs": "file:../../node_modules/systemjs",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   }
 }

--- a/integration/dynamic-compiler/yarn.lock
+++ b/integration/dynamic-compiler/yarn.lock
@@ -3648,5 +3648,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/hello_world__closure/package.json
+++ b/integration/hello_world__closure/package.json
@@ -13,7 +13,7 @@
     "google-closure-compiler": "20180716.0.0",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/hello_world__closure/yarn.lock
+++ b/integration/hello_world__closure/yarn.lock
@@ -4183,5 +4183,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/hello_world__systemjs_umd/package.json
+++ b/integration/hello_world__systemjs_umd/package.json
@@ -21,7 +21,7 @@
     "rxjs": "file:../../node_modules/rxjs",
     "systemjs": "0.20.2",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/hello_world__systemjs_umd/yarn.lock
+++ b/integration/hello_world__systemjs_umd/yarn.lock
@@ -2404,5 +2404,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/i18n/package.json
+++ b/integration/i18n/package.json
@@ -14,7 +14,7 @@
     "google-closure-compiler": "git+https://github.com/alexeagle/closure-compiler.git#packagejson.dist",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/i18n/yarn.lock
+++ b/integration/i18n/yarn.lock
@@ -3595,5 +3595,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/injectable-def/package.json
+++ b/integration/injectable-def/package.json
@@ -14,7 +14,7 @@
     "@types/node": "file:../../node_modules/@types/node",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/injectable-def/yarn.lock
+++ b/integration/injectable-def/yarn.lock
@@ -3506,5 +3506,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/ivy-i18n/package.json
+++ b/integration/ivy-i18n/package.json
@@ -45,7 +45,7 @@
     "rxjs": "file:../../node_modules/rxjs",
     "serve": "^11.2.0",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/ivy-i18n/yarn.lock
+++ b/integration/ivy-i18n/yarn.lock
@@ -8427,5 +8427,5 @@ yn@^3.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/ng_elements/package.json
+++ b/integration/ng_elements/package.json
@@ -14,7 +14,7 @@
     "google-closure-compiler": "20180319.0.0",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/ng_elements/yarn.lock
+++ b/integration/ng_elements/yarn.lock
@@ -3595,5 +3595,5 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/ng_update/package.json
+++ b/integration/ng_update/package.json
@@ -24,6 +24,6 @@
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   }
 }

--- a/integration/ng_update/yarn.lock
+++ b/integration/ng_update/yarn.lock
@@ -1578,5 +1578,5 @@ yargs@13.1.0:
     y18n "^4.0.0"
     yargs-parser "^13.0.0"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/ng_update_migrations/package.json
+++ b/integration/ng_update_migrations/package.json
@@ -21,7 +21,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.900.0-rc.0",

--- a/integration/ng_update_migrations/yarn.lock
+++ b/integration/ng_update_migrations/yarn.lock
@@ -7700,5 +7700,5 @@ yeast@0.1.2:
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/ngcc/package.json
+++ b/integration/ngcc/package.json
@@ -17,7 +17,7 @@
     "@types/node": "file:../../node_modules/@types/node",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/ngcc/yarn.lock
+++ b/integration/ngcc/yarn.lock
@@ -3594,5 +3594,5 @@ yeast@0.1.2:
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/platform-server/package.json
+++ b/integration/platform-server/package.json
@@ -19,7 +19,7 @@
     "express": "^4.14.1",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "file:../../node_modules/typescript",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",

--- a/integration/platform-server/yarn.lock
+++ b/integration/platform-server/yarn.lock
@@ -4384,5 +4384,5 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-"zone.js@file:../../node_modules/zone.js":
+"zone.js@file:../../dist/zone.js-dist/zone.js":
   version "0.10.2"

--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -36,9 +36,6 @@ else
   TEST_DIRS=$(ls | grep -v node_modules)
 fi
 
-# We need to build zone.js npm package because it is not built in build-packages-dist.sh
-${bazel_bin} build //packages/zone.js:npm_package
-
 # Workaround https://github.com/yarnpkg/yarn/issues/2165
 # Yarn will cache file://dist URIs and not update Angular code
 readonly cache=.yarn_local_cache

--- a/integration/service-worker-schema/package.json
+++ b/integration/service-worker-schema/package.json
@@ -11,6 +11,6 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
     "rxjs": "file:../../node_modules/rxjs",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   }
 }

--- a/integration/terser/package.json
+++ b/integration/terser/package.json
@@ -11,6 +11,6 @@
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
     "rxjs": "file:../../node_modules/rxjs",
     "terser": "3.17.0",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   }
 }

--- a/integration/typings_test_ts36/package.json
+++ b/integration/typings_test_ts36/package.json
@@ -22,7 +22,7 @@
     "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "3.6.4",
-    "zone.js": "file:../../dist/bin/packages/zone.js/npm_package"
+    "zone.js": "file:../../dist/zone.js-dist/zone.js"
   },
   "scripts": {
     "test": "tsc"

--- a/scripts/build-packages-dist.sh
+++ b/scripts/build-packages-dist.sh
@@ -4,3 +4,23 @@ source $(dirname $0)/package-builder.sh
 
 # Build the legacy (view engine) npm packages into dist/packages-dist
 buildTargetPackages "dist/packages-dist" "legacy" "Production"
+
+# Build the `zone.js` npm package (into `dist/bin/packages/zone.js/npm_package/`), because it might be needed
+# by other scripts/tests.
+#
+# NOTE: The `zone.js` package is not built as part of `buildTargetPackages()` above, nor is it
+#       copied into the `dist/packages-dist/` directory (despite its source's being in `packages/`),
+#       because it is not published to npm under the `@angular` scope (as happens for the rest of
+#       the packages).
+echo "# Building zone.js npm package..."
+yarn --silent bazel build //packages/zone.js:npm_package
+
+# Copy artifacts to `dist/zone.js-dist/`, so they can be easier persisted on CI.
+readonly buildOutputDir="$base_dir/dist/bin/packages/zone.js/npm_package"
+readonly distTargetDir="$base_dir/dist/zone.js-dist/zone.js"
+
+echo "# Copying artifacts to '$distTargetDir'..."
+mkdir -p $distTargetDir
+rm -rf $distTargetDir
+cp -R $buildOutputDir $distTargetDir
+chmod -R u+w $distTargetDir

--- a/scripts/ci/create-package-archives.sh
+++ b/scripts/ci/create-package-archives.sh
@@ -15,11 +15,14 @@ echo "  Preparing output directory: $outputDir"
 rm -rf "$outputDir"
 mkdir -p "$outputDir"
 
-# Create a compressed archive containing all packages.
-# (This is useful for copying all packages into `node_modules/` (without changing `package.json`).)
-outputFileName=all$fileSuffix
-echo "  Creating archive with all packages --> '$outputFileName'..."
-tar --create --gzip --directory "$inputDir" --file "$outputDir/$outputFileName" --transform s/^\./packages/ .
+# If there are more than one packages in `$inputDir`...
+if [[ $(ls -1 "$inputDir" | wc -l) -gt 1 ]]; then
+  # Create a compressed archive containing all packages.
+  # (This is useful for copying all packages into `node_modules/` (without changing `package.json`).)
+  outputFileName=all$fileSuffix
+  echo "  Creating archive with all packages --> '$outputFileName'..."
+  tar --create --gzip --directory "$inputDir" --file "$outputDir/$outputFileName" --transform s/^\./packages/ .
+fi
 
 # Create a compressed archive for each package.
 # (This is useful for referencing the path/URL to the resulting archive in `package.json`.)


### PR DESCRIPTION
Since #33321, Angular packages have been persisted on each build as CircleCI build artifacts (`.tgz` files), which can be used to install dependencies on a project (for the purpose of testing or trying out a change before a PR being merged and without having to build the packages from source locally).

Previously, only packages published to npm under the `@angular` scope were persisted as build artifacts.

This commit adds the `zone.js` package to the list of persisted packages.

Fixes #33686.

##
This PR also updates the `integration/ngcc/debug-test.sh` script build `zone.js`
from sources as needed. (See commit message for more details.)