### PR TITLE
perf(core): create factory in providerToRecord only when needed

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -461,10 +461,10 @@ function getUndecoratedInjectableFactory(token: Function) {
 
 function providerToRecord(
     provider: SingleProvider, ngModuleType: InjectorType<any>, providers: any[]): Record<any> {
-  let factory: (() => any)|undefined = providerToFactory(provider, ngModuleType, providers);
   if (isValueProvider(provider)) {
     return makeRecord(undefined, provider.useValue);
   } else {
+    const factory: (() => any)|undefined = providerToFactory(provider, ngModuleType, providers);
     return makeRecord(factory, NOT_YET);
   }
 }


### PR DESCRIPTION
In providerToRecord move creating the factory into a condition which actually needs it to avoid unnecessary creating it

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes) 

## What is the current behavior?
Factory gets created unnecessary

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
