### PR TITLE
build: set up all packages to publish via wombot proxy

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -23,5 +23,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -47,5 +47,8 @@
   "schematics": "./src/schematics/collection.json",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,5 +28,8 @@
   "sideEffects": [
     "**/global/*.js",
     "**/closure-locale.*"
-  ]
+  ],
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -45,5 +45,8 @@
   "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -22,5 +22,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": true
+  "sideEffects": true,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,8 @@
     "migrations": "./schematics/migrations.json",
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -26,5 +26,8 @@
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false,
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -26,5 +26,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -25,5 +25,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -13,5 +13,8 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -35,5 +35,8 @@
     "@babel/core": "^7.5.5",
     "glob": "7.1.2",
     "yargs": "13.1.0"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -26,5 +26,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -24,5 +24,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -35,5 +35,8 @@
   "sideEffects": false,
   "engines": {
     "node": ">=8.0"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -27,5 +27,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -25,5 +25,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -36,5 +36,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -27,5 +27,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -26,5 +26,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }


### PR DESCRIPTION
Set `publishConfig` attribute for all `package.json`s used for release.  Sets the registry to use Google's wombot proxy for publishing.