### PR TITLE
feat(docs-infra): simplify image styles and remove figure references

### DIFF
--- a/aio/content/guide/animations.md
+++ b/aio/content/guide/animations.md
@@ -69,11 +69,9 @@ Let's animate a simple transition that changes a single HTML element from one st
 
 In HTML, these attributes are set using ordinary CSS styles such as color and opacity. In Angular, use the `style()` function to specify a set of CSS styles for use with animations. You can collect a set of styles in an animation state, and give the state a name, such as `open` or `closed`.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/open-closed.png" alt="open and closed states">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/open-closed.png" alt="open and closed states">
+</div>
 
 ### Animation state and styles
 
@@ -168,11 +166,9 @@ The `trigger()` function describes the property name to watch for changes. When 
 
 In this example, we'll name the trigger `openClose`, and attach it to the `button` element. The trigger describes the open and closed states, and the timings for the two transitions.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/triggering-the-animation.png" alt="triggering the animation">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/triggering-the-animation.png" alt="triggering the animation">
+</div>
 
 <div class="alert is-helpful">
 

--- a/aio/content/guide/architecture-components.md
+++ b/aio/content/guide/architecture-components.md
@@ -51,11 +51,9 @@ You define a component's view with its companion template. A template is a form 
 
 Views are typically arranged hierarchically, allowing you to modify or show and hide entire UI sections or pages as a unit. The template immediately associated with a component defines that component's *host view*. The component can also define a *view hierarchy*, which contains *embedded views*, hosted by other components.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/component-tree.png" alt="Component tree" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/component-tree.png" alt="Component tree" class="left">
+</div>
 
 A view hierarchy can include views from components in the same NgModule, but it also can (and often does) include views from components that are defined in different NgModules.
 
@@ -83,11 +81,9 @@ Angular supports *two-way data binding*, a mechanism for coordinating the parts 
 
 The following diagram shows the four forms of data binding markup. Each form has a direction: to the DOM, from the DOM, or both.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/databinding.png" alt="Data Binding" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/databinding.png" alt="Data Binding" class="left">
+</div>
 
 This example from the `HeroListComponent` template uses three of these forms.
 
@@ -114,19 +110,15 @@ as with event binding.
 Angular processes *all* data bindings once for each JavaScript event cycle,
 from the root of the application component tree through all child components.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/component-databinding.png" alt="Data Binding" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/component-databinding.png" alt="Data Binding" class="left">
+</div>
 
 Data binding plays an important role in communication between a template and its component, and is also important for communication between parent and child components.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/parent-child-binding.png" alt="Parent/Child binding" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/parent-child-binding.png" alt="Parent/Child binding" class="left">
+</div>
 
 ### Pipes
 

--- a/aio/content/guide/architecture-modules.md
+++ b/aio/content/guide/architecture-modules.md
@@ -35,21 +35,17 @@ Here's a simple root NgModule definition.
 
 NgModules provide a *compilation context* for their components. A root NgModule always has a root component that is created during bootstrap, but any NgModule can include any number of additional components, which can be loaded through the router or created through the template. The components that belong to an NgModule share a compilation context.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/compilation-context.png" alt="Component compilation context" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/compilation-context.png" alt="Component compilation context" class="left">
+</div>
 
 <br class="clear">
 
 A component and its template together define a *view*. A component can contain a *view hierarchy*, which allows you to define arbitrarily complex areas of the screen that can be created, modified, and destroyed as a unit. A view hierarchy can mix views defined in components that belong to different NgModules. This is often the case, especially for UI libraries.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/view-hierarchy.png" alt="View hierarchy" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/view-hierarchy.png" alt="View hierarchy" class="left">
+</div>
 
 <br class="clear">
 

--- a/aio/content/guide/architecture-services.md
+++ b/aio/content/guide/architecture-services.md
@@ -70,11 +70,9 @@ When all requested services have been resolved and returned, Angular can call th
 
 The process of `HeroService` injection looks something like this.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/injector-injects.png" alt="Service" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/injector-injects.png" alt="Service" class="left">
+</div>
 
 ### Providing services
 

--- a/aio/content/guide/architecture.md
+++ b/aio/content/guide/architecture.md
@@ -113,11 +113,9 @@ To define navigation rules, you associate *navigation paths* with your component
 
 You've learned the basics about the main building blocks of an Angular application. The following diagram shows how these basic pieces are related.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/architecture/overview2.png" alt="overview">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/architecture/overview2.png" alt="overview">
+</div>
 
 * Together, a component and template define an Angular view.
   * A decorator on a component class adds the metadata, including a pointer to the associated template.

--- a/aio/content/guide/attribute-directives.md
+++ b/aio/content/guide/attribute-directives.md
@@ -175,11 +175,9 @@ Here's the updated directive in full:
 Run the app and confirm that the background color appears when
 the mouse hovers over the `p` and disappears as it moves out.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/attribute-directives/highlight-directive-anim.gif" alt="Second Highlight">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/attribute-directives/highlight-directive-anim.gif" alt="Second Highlight">
+</div>
 
 {@a bindings}
 
@@ -273,11 +271,9 @@ Revise the `AppComponent.color` so that it has no initial value.
 
 Here are the harness and directive in action.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/attribute-directives/highlight-directive-v2-anim.gif" alt="Highlight v.2">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/attribute-directives/highlight-directive-v2-anim.gif" alt="Highlight v.2">
+</div>
 
 {@a second-property}
 
@@ -311,11 +307,9 @@ because you made it _public_ with the `@Input` decorator.
 
 Here's how the harness should work when you're done coding.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/attribute-directives/highlight-directive-final-anim.gif" alt="Final Highlight">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/attribute-directives/highlight-directive-final-anim.gif" alt="Final Highlight">
+</div>
 
 ## Summary
 

--- a/aio/content/guide/component-interaction.md
+++ b/aio/content/guide/component-interaction.md
@@ -50,11 +50,9 @@ and each iteration's `hero` instance to the child's `hero` property.
 The running application displays three heroes:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/parent-to-child.png" alt="Parent-to-child">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/parent-to-child.png" alt="Parent-to-child">
+</div>
 
 
 
@@ -96,11 +94,9 @@ Here's the `NameParentComponent` demonstrating name variations including a name 
 
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/setter.png" alt="Parent-to-child-setter">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/setter.png" alt="Parent-to-child-setter">
+</div>
 
 
 
@@ -156,11 +152,9 @@ The `VersionParentComponent` supplies the `minor` and `major` values and binds b
 Here's the output of a button-pushing sequence:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/parent-to-child-on-changes.gif" alt="Parent-to-child-onchanges">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/parent-to-child-on-changes.gif" alt="Parent-to-child-onchanges">
+</div>
 
 
 
@@ -212,11 +206,9 @@ The framework passes the event argument&mdash;represented by `$event`&mdash;to t
 and the method processes it:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/child-to-parent.gif" alt="Child-to-parent">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/child-to-parent.gif" alt="Child-to-parent">
+</div>
 
 
 
@@ -276,11 +268,9 @@ uses interpolation to display the child's `seconds` property.
 Here we see the parent and child working together.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/countdown-timer-anim.gif" alt="countdown timer">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/countdown-timer-anim.gif" alt="countdown timer">
+</div>
 
 
 
@@ -431,11 +421,9 @@ the parent `MissionControlComponent` and the `AstronautComponent` children,
 facilitated by the service:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/component-interaction/bidirectional-service.gif" alt="bidirectional-service">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/component-interaction/bidirectional-service.gif" alt="bidirectional-service">
+</div>
 
 
 

--- a/aio/content/guide/dependency-injection-in-action.md
+++ b/aio/content/guide/dependency-injection-in-action.md
@@ -40,11 +40,9 @@ and the framework resolves the nested dependencies.
 
 When all dependencies are in place, `AppComponent` displays the user information.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/logged-in-user.png" alt="Logged In User">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/logged-in-user.png" alt="Logged In User">
+</div>
 
 {@a service-scope}
 
@@ -133,11 +131,9 @@ The template displays this data-bound property.
 Find this example in <live-example name="dependency-injection-in-action">live code</live-example>
 and confirm that the three `HeroBioComponent` instances have their own cached hero data.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/hero-bios.png" alt="Bios">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/hero-bios.png" alt="Bios">
+</div>
 
 {@a qualify-dependency-lookup}
 
@@ -195,11 +191,9 @@ placing it in the `<ng-content>` slot of the `HeroBioComponent` template.
 
 The result is shown below, with the hero's telephone number from `HeroContactComponent` projected above the hero description.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/hero-bio-and-content.png" alt="bio and contact">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/hero-bio-and-content.png" alt="bio and contact">
+</div>
 
 
 Here's `HeroContactComponent`, which demonstrates the qualifying decorators.
@@ -227,11 +221,9 @@ When the property is marked as optional, Angular sets `loggerService` to null an
 
 Here's `HeroBiosAndContactsComponent` in action.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/hero-bios-and-contacts.png" alt="Bios with contact into">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/hero-bios-and-contacts.png" alt="Bios with contact into">
+</div>
 
 
 
@@ -240,11 +232,9 @@ until it finds the logger at the `AppComponent` level.
 The logger logic kicks in and the hero display updates
 with the "!!!" marker to indicate that the logger was found.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/hero-bio-contact-no-host.png" alt="Without @Host">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/hero-bio-contact-no-host.png" alt="Without @Host">
+</div>
 
 
 If you restore the `@Host()` decorator and comment out `@Optional`,
@@ -304,11 +294,9 @@ first without a value (yielding the default color) and then with an assigned col
 
 The following image shows the effect of mousing over the `<hero-bios-and-contacts>` tag.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/highlight.png" alt="Highlighted bios">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/highlight.png" alt="Highlighted bios">
+</div>
 
 {@a providers}
 
@@ -359,11 +347,9 @@ You learned about some other methods in [Dependency Providers](guide/dependency-
 The following `HeroOfTheMonthComponent` example demonstrates many of the alternatives and why you need them.
 It's visually simple: a few properties and the logs produced by a logger.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/hero-of-month.png" alt="Hero of the month">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/hero-of-month.png" alt="Hero of the month">
+</div>
 
 The code behind it customizes how and where the DI framework provides dependencies.
 The use cases illustrate different ways to use the [*provide* object literal](guide/dependency-injection-providers#provide) to associate a definition object with a DI token.
@@ -474,11 +460,9 @@ The following example puts `MinimalLogger` to use in a simplified version of `He
 
 The `HeroOfTheMonthComponent` constructor's `logger` parameter is typed as `MinimalLogger`, so only the `logs` and `logInfo` members are visible in a TypeScript-aware editor.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/minimal-logger-intellisense.png" alt="MinimalLogger restricted API">
-    </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/minimal-logger-intellisense.png" alt="MinimalLogger restricted API">
+</div>
 
 
 Behind the scenes, Angular sets the `logger` parameter to the full service registered under the `LoggingService` token, which happens to be the `DateLoggerService` instance that was [provided above](guide/dependency-injection-in-action#useclass).
@@ -488,11 +472,9 @@ Behind the scenes, Angular sets the `logger` parameter to the full service regis
 
 This is illustrated in the following image, which displays the logging date.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/date-logger-entry.png" alt="DateLoggerService entry">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/date-logger-entry.png" alt="DateLoggerService entry">
+</div>
 
 </div>
 
@@ -645,11 +627,9 @@ and then pass them down to the base class through the constructor.
 In this contrived example, `SortedHeroesComponent` inherits from `HeroesBaseComponent`
 to display a *sorted* list of heroes.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/sorted-heroes.png" alt="Sorted Heroes">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/sorted-heroes.png" alt="Sorted Heroes">
+</div>
 
 The `HeroesBaseComponent` can stand on its own.
 It demands its own instance of `HeroService` to get heroes

--- a/aio/content/guide/dependency-injection-navtree.md
+++ b/aio/content/guide/dependency-injection-navtree.md
@@ -145,11 +145,9 @@ the same way you've done it before.
 
 Here's *Alex* and family in action.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/alex.png" alt="Alex in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/alex.png" alt="Alex in action">
+</div>
 
 
 
@@ -203,13 +201,9 @@ which *is* what parent means.
 Here's *Alice*, *Barry*, and family in action.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection-in-action/alice.png" alt="Alice in action">
-  </div>
-</figure>
-
-
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection-in-action/alice.png" alt="Alice in action">
+</div>
 
 {@a parent-token}
 

--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -434,11 +434,9 @@ showing exactly which classes are included in the bundle.
 
 Here's the output for the _main_ bundle of an example app called `cli-quickstart`.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/deployment/quickstart-sourcemap-explorer.png" alt="quickstart sourcemap explorer">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/deployment/quickstart-sourcemap-explorer.png" alt="quickstart sourcemap explorer">
+</div>
 
 {@a base-tag}
 

--- a/aio/content/guide/displaying-data.md
+++ b/aio/content/guide/displaying-data.md
@@ -8,12 +8,9 @@ conditionally show a message below the list.
 
 The final UI looks like this:
 
-
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/displaying-data/final.png" alt="Final UI">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/displaying-data/final.png" alt="Final UI">
+</div>
 
 <div class="alert is-helpful">
 
@@ -105,13 +102,9 @@ inside the `<app-root>` tag.
 
 Now run the app. It should display the title and hero name:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/displaying-data/title-and-hero.png" alt="Title and Hero">
-  </div>
-</figure>
-
-
+<div class="lightbox">
+  <img src="generated/images/guide/displaying-data/title-and-hero.png" alt="Title and Hero">
+</div>
 
 The next few sections review some of the coding choices in the app.
 
@@ -215,14 +208,9 @@ repeat items for any [iterable](https://developer.mozilla.org/en-US/docs/Web/Jav
 
 Now the heroes appear in an unordered list.
 
-
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/displaying-data/hero-names-list.png" alt="After ngfor">
-  </div>
-</figure>
-
-
+<div class="lightbox">
+  <img src="generated/images/guide/displaying-data/hero-names-list.png" alt="After ngfor">
+</div>
 
 
 ## Creating a class for the data

--- a/aio/content/guide/docs-style-guide.md
+++ b/aio/content/guide/docs-style-guide.md
@@ -1244,19 +1244,19 @@ Images should be specified in an `<img>` tag.
 
 For accessibility, always set the `alt` attribute with a meaningful description of the image.
 
-You should nest the `<img>` tag within a `<figure>` tag, which styles the image within a drop-shadow frame. You'll need the editor's permission to skip the `<figure>` tag.
+You should nest the `<img>` tag within a `<div class="lightbox">` tag, which styles the image within a drop-shadow frame. You'll need the editor's permission to skip the `lightbox` class on its `div` encapsulation.
 
 Here's a conforming example
 
-<figure>
+<div class="lightbox">
   <img src="generated/images/guide/docs-style-guide/flying-hero.png" alt="flying hero">
-</figure>
+</div>
 
 ```html
-<figure>
+<div class="lightbox">
   <img src="generated/images/guide/docs-style-guide/flying-hero.png"
        alt="flying hero">
-</figure>
+</div>
 ```
 
 _Note that the HTML image element does not have a closing tag._
@@ -1267,17 +1267,17 @@ The doc generator reads the image dimensions from the file and adds width and he
 
 Here's the "flying hero" at a more reasonable scale.
 
-<figure>
+<div class="lightbox">
  <img src="generated/images/guide/docs-style-guide/flying-hero.png" alt="flying Angular hero" width="200">
-</figure>
+</div>
 
 ```html
 
-<figure>
+<div class="lightbox">
  <img src="generated/images/guide/docs-style-guide/flying-hero.png"
    alt="flying Angular hero"
    width="200">
-</figure>
+</div>
 ```
 
 Wide images can be a problem. Most browsers try to rescale the image but wide images may overflow the document in certain viewports.
@@ -1285,9 +1285,9 @@ Wide images can be a problem. Most browsers try to rescale the image but wide im
 **Do not set a width greater than 700px**. If you wish to display a larger image, provide a link to the actual image that the user can click on to see the full size image separately as in this example of `source-map-explorer` output from the "Ahead-of-time Compilation" guide:
 
 <a href="generated/images/guide/docs-style-guide/toh-pt6-bundle.png" title="Click to view larger image">
-  <figure>
+  <div class="lightbox">
     <img src="generated/images/guide/docs-style-guide/toh-pt6-bundle-700w.png" alt="toh-pt6-bundle" width="300px">
-  </figure>
+  </div>
 </a>
 
 <h3 class="no-toc">Image compression</h3>

--- a/aio/content/guide/docs-style-guide.md
+++ b/aio/content/guide/docs-style-guide.md
@@ -1249,13 +1249,14 @@ You should nest the `<img>` tag within a `<div class="lightbox">` tag, which sty
 Here's a conforming example
 
 <div class="lightbox">
-  <img src="generated/images/guide/docs-style-guide/flying-hero.png" alt="flying hero">
+  <img src="generated/images/guide/docs-style-guide/flying-hero.png"
+    alt="flying hero">
 </div>
 
 ```html
 <div class="lightbox">
   <img src="generated/images/guide/docs-style-guide/flying-hero.png"
-       alt="flying hero">
+    alt="flying hero">
 </div>
 ```
 
@@ -1268,15 +1269,17 @@ The doc generator reads the image dimensions from the file and adds width and he
 Here's the "flying hero" at a more reasonable scale.
 
 <div class="lightbox">
- <img src="generated/images/guide/docs-style-guide/flying-hero.png" alt="flying Angular hero" width="200">
+  <img src="generated/images/guide/docs-style-guide/flying-hero.png"
+    alt="flying Angular hero"
+    width="200">
 </div>
 
 ```html
 
 <div class="lightbox">
- <img src="generated/images/guide/docs-style-guide/flying-hero.png"
-   alt="flying Angular hero"
-   width="200">
+  <img src="generated/images/guide/docs-style-guide/flying-hero.png"
+    alt="flying Angular hero"
+    width="200">
 </div>
 ```
 

--- a/aio/content/guide/dynamic-component-loader.md
+++ b/aio/content/guide/dynamic-component-loader.md
@@ -183,12 +183,8 @@ Here are two sample components and the `AdComponent` interface for reference:
 ## Final ad banner
  The final ad banner looks like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dynamic-component-loader/ads-example.gif" alt="Ads">
-  </div>
-</figure>
-
-
+<div class="lightbox">
+  <img src="generated/images/guide/dynamic-component-loader/ads-example.gif" alt="Ads">
+</div>
 
 See the <live-example name="dynamic-component-loader"></live-example>.

--- a/aio/content/guide/dynamic-form.md
+++ b/aio/content/guide/dynamic-form.md
@@ -197,12 +197,9 @@ Saving and retrieving the data is an exercise for another time.
 
 The final form looks like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dynamic-form/dynamic-form.png" alt="Dynamic-Form">
-  </div>
-</figure>
-
+<div class="lightbox">
+  <img src="generated/images/guide/dynamic-form/dynamic-form.png" alt="Dynamic-Form">
+</div>
 
 
 [Back to top](guide/dynamic-form#top)

--- a/aio/content/guide/elements.md
+++ b/aio/content/guide/elements.md
@@ -42,11 +42,9 @@ After you register your configured class with the browser's custom-element regis
 
 When your custom element is placed on a page, the browser creates an instance of the registered class and adds it to the DOM. The content is provided by the component's template, which uses Angular template syntax, and is rendered using the component and DOM data. Input properties in the component correspond to input attributes for the element.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/elements/customElement1.png" alt="Custom element in browser" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/elements/customElement1.png" alt="Custom element in browser" class="left">
+</div>
 
 <hr class="clear">
 
@@ -64,11 +62,9 @@ Use a JavaScript function, `customElements.define()`,  to register the configure
 and its associated custom-element tag with the browser's `CustomElementRegistry`.
 When the browser encounters the tag for the registered element, it uses the constructor to create a custom-element instance.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/elements/createElement.png" alt="Transform a component to a custom element" class="left">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/elements/createElement.png" alt="Transform a component to a custom element" class="left">
+</div>
 
 ### Mapping
 

--- a/aio/content/guide/feature-modules.md
+++ b/aio/content/guide/feature-modules.md
@@ -102,12 +102,9 @@ Next, in the `AppComponent`, `app.component.html`, add the tag `<app-customer-da
 
 Now, in addition to the title that renders by default, the `CustomerDashboardComponent` template renders too:
 
-
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/feature-modules/feature-module.png" alt="feature module component">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/feature-modules/feature-module.png" alt="feature module component">
+</div>
 
 <hr />
 

--- a/aio/content/guide/forms-overview.md
+++ b/aio/content/guide/forms-overview.md
@@ -67,11 +67,9 @@ Here's a component with an input field for a single control implemented using re
 
 The source of truth provides the value and status of the form element at a given point in time. In reactive forms, the form model is the source of truth. In the example above, the form model is the `FormControl` instance.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/key-diff-reactive-forms.png" alt="Reactive forms key differences">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/key-diff-reactive-forms.png" alt="Reactive forms key differences">
+</div>
 
 With reactive forms, the form model is explicitly defined in the component class. The reactive form directive (in this case, `FormControlDirective`) then links the existing `FormControl` instance to a specific form element in the view using a value accessor (`ControlValueAccessor` instance).
 
@@ -84,11 +82,9 @@ Here's the same component with an input field for a single control implemented u
 
 In template-driven forms, the source of truth is the template.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/key-diff-td-forms.png" alt="Template-driven forms key differences">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/key-diff-td-forms.png" alt="Template-driven forms key differences">
+</div>
 
 The abstraction of the form model promotes simplicity over structure. The template-driven form directive `NgModel` is responsible for creating and managing the `FormControl` instance for a given form element. It's less explicit, but you no longer have direct control over the form model.
 
@@ -102,11 +98,9 @@ When building forms in Angular, it's important to understand how the framework h
 
 As described above, in reactive forms each form element in the view is directly linked to a form model (`FormControl` instance). Updates from the view to the model and from the model to the view are synchronous and aren't dependent on the UI rendered. The diagrams below use the same favorite color example to demonstrate how data flows when an input field's value is changed from the view and then from the model.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/dataflow-reactive-forms-vtm.png" alt="Reactive forms data flow - view to model" width="100%">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/dataflow-reactive-forms-vtm.png" alt="Reactive forms data flow - view to model" width="100%">
+</div>
 
 The steps below outline the data flow from view to model.
 
@@ -116,11 +110,9 @@ The steps below outline the data flow from view to model.
 1. The `FormControl` instance emits the new value through the `valueChanges` observable.
 1. Any subscribers to the `valueChanges` observable receive the new value.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/dataflow-reactive-forms-mtv.png" alt="Reactive forms data flow - model to view" width="100%">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/dataflow-reactive-forms-mtv.png" alt="Reactive forms data flow - model to view" width="100%">
+</div>
 
 The steps below outline the data flow from model to view.
 
@@ -133,11 +125,9 @@ The steps below outline the data flow from model to view.
 
 In template-driven forms, each form element is linked to a directive that manages the form model internally. The diagrams below use the same favorite color example to demonstrate how data flows when an input field's value is changed from the view and then from the model.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/dataflow-td-forms-vtm.png" alt="Template-driven forms data flow - view to model" width="100%">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/dataflow-td-forms-vtm.png" alt="Template-driven forms data flow - view to model" width="100%">
+</div>
 
 The steps below outline the data flow from view to model when the input value changes from *Red* to *Blue*.
 
@@ -150,11 +140,9 @@ The steps below outline the data flow from view to model when the input value ch
 1. Because the component template uses two-way data binding for the `favoriteColor` property, the `favoriteColor` property in the component
 is updated to the value emitted by the `ngModelChange` event (*Blue*).
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms-overview/dataflow-td-forms-mtv.png" alt="Template-driven forms data flow - model to view" width="100%">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms-overview/dataflow-td-forms-mtv.png" alt="Template-driven forms data flow - model to view" width="100%">
+</div>
 
 The steps below outline the data flow from model to view when the `favoriteColor` changes from *Blue* to *Red*.
 

--- a/aio/content/guide/forms.md
+++ b/aio/content/guide/forms.md
@@ -45,11 +45,9 @@ otherwise wrestle with yourself.
 
 You'll learn to build a template-driven form that looks like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/hero-form-1.png" alt="Clean Form">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/hero-form-1.png" alt="Clean Form">
+</div>
 
 The *Hero Employment Agency* uses this form to maintain personal information about heroes.
 Every hero needs a job. It's the company mission to match the right hero with the right crisis.
@@ -58,11 +56,9 @@ Two of the three fields on this form are required. Required fields have a green 
 
 If you delete the hero name, the form displays a validation error in an attention-grabbing style:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/hero-form-2.png" alt="Invalid, Name Required">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/hero-form-2.png" alt="Invalid, Name Required">
+</div>
 
 Note that the *Submit* button is disabled, and the "required" bar to the left of the input control changes from green to red.
 
@@ -276,11 +272,9 @@ you display its name using the interpolation syntax.
 
 Running the app right now would be disappointing.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/hero-form-3.png" alt="Early form with no binding">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/hero-form-3.png" alt="Early form with no binding">
+</div>
 
 
 You don't see hero data because you're not binding to the `Hero` yet.
@@ -341,11 +335,9 @@ adding and deleting characters, you'd see them appear and disappear
 from the interpolated text.
 At some point it might look like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/ng-model-in-action.png" alt="ngModel in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/ng-model-in-action.png" alt="ngModel in action">
+</div>
 
 The diagnostic is evidence that values really are flowing from the input box to the model and
 back again.
@@ -391,11 +383,9 @@ After revision, the core of the form should look like this:
 
 If you run the app now and change every hero model property, the form might display like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/ng-model-in-action-2.png" alt="ngModel in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/ng-model-in-action-2.png" alt="ngModel in action">
+</div>
 
 The diagnostic near the top of the form
 confirms that all of your changes are reflected in the model.
@@ -493,19 +483,15 @@ Follow these steps *precisely*:
 
 The actions and effects are as follows:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/control-state-transitions-anim.gif" alt="Control State Transition">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/control-state-transitions-anim.gif" alt="Control State Transition">
+</div>
 
 You should see the following transitions and class names:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/ng-control-class-changes.png" alt="Control state transitions">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/ng-control-class-changes.png" alt="Control state transitions">
+</div>
 
 The `ng-valid`/`ng-invalid` pair is the most interesting, because you want to send a
 strong visual signal when the values are invalid. You also want to mark required fields.
@@ -518,11 +504,9 @@ To create such visual feedback, add definitions for the `ng-*` CSS classes.
 You can mark required fields and invalid data at the same time with a colored bar
 on the left of the input box:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/validity-required-indicator.png" alt="Invalid Form">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/validity-required-indicator.png" alt="Invalid Form">
+</div>
 
 You achieve this effect by adding these class definitions to a new `forms.css` file
 that you add to the project as a sibling to `index.html`:
@@ -541,11 +525,9 @@ Leverage the control's state to reveal a helpful message.
 
 When the user deletes the name, the form should look like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/forms/name-required-error.png" alt="Name required">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/forms/name-required-error.png" alt="Name required">
+</div>
 
 To achieve this effect, extend the `<input>` tag with the following:
 

--- a/aio/content/guide/frequent-ngmodules.md
+++ b/aio/content/guide/frequent-ngmodules.md
@@ -111,11 +111,9 @@ directives in `CommonModule`; they don’t need to re-install app-wide providers
 If you do import `BrowserModule` into a lazy loaded feature module,
 Angular returns an error telling you to use `CommonModule` instead.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/frequent-ngmodules/browser-module-error.gif" width=750 alt="BrowserModule error">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/frequent-ngmodules/browser-module-error.gif" width=750 alt="BrowserModule error">
+</div>
 
 <hr />
 

--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -108,11 +108,9 @@ The following diagram represents the relationship between the
 `root` `ModuleInjector` and its parent injectors as the
 previous paragraphs describe.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection/injectors.svg" alt="NullInjector, ModuleInjector, root injector">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection/injectors.svg" alt="NullInjector, ModuleInjector, root injector">
+</div>
 
 While the name `root` is a special alias, other `ModuleInjector`s
 don't have aliases. You have the option to create `ModuleInjector`s
@@ -1098,12 +1096,9 @@ Each tax return component has the following characteristics:
 * Can change a tax return without affecting a return in another component.
 * Has the ability to save the changes to its tax return or cancel them.
 
-
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection/hid-heroes-anim.gif" alt="Heroes in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection/hid-heroes-anim.gif" alt="Heroes in action">
+</div>
 
 Suppose that the `HeroTaxReturnComponent` had logic to manage and restore changes.
 That would be a pretty easy task for a simple hero tax return.
@@ -1172,11 +1167,9 @@ that have special capabilities suitable for whatever is going on in component (B
 Component (B) is the parent of another component (C) that defines its own, even _more specialized_ provider for `CarService`.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection/car-components.png" alt="car components">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection/car-components.png" alt="car components">
+</div>
 
 Behind the scenes, each component sets up its own injector with zero, one, or more providers defined for that component itself.
 
@@ -1185,11 +1178,9 @@ its injector produces an instance of `Car` resolved by injector (C) with an `Eng
 `Tires` resolved by the root injector (A).
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/dependency-injection/injector-tree.png" alt="car injector tree">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/dependency-injection/injector-tree.png" alt="car injector tree">
+</div>
 
 
 <hr />

--- a/aio/content/guide/language-service.md
+++ b/aio/content/guide/language-service.md
@@ -25,11 +25,9 @@ contextual possibilities and hints as you type.
 This example shows autocomplete in an interpolation. As you type it out,
 you can hit tab to complete.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/language-service/language-completion.gif" alt="autocompletion">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/language-service/language-completion.gif" alt="autocompletion">
+</div>
 
 There are also completions within elements. Any elements you have as a component selector will
 show up in the completion list.
@@ -39,22 +37,18 @@ show up in the completion list.
 The Angular Language Service can forewarn you of mistakes in your code.
 In this example, Angular doesn't know what `orders` is or where it comes from.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/language-service/language-error.gif" alt="error checking">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/language-service/language-error.gif" alt="error checking">
+</div>
 
 ### Quick info and navigation
 
 The quick-info feature allows you to hover to see where components, directives, modules, and so on come from.
 You can then click "Go to definition" or press F12 to go directly to the definition.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/language-service/language-navigation.gif" alt="navigation">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/language-service/language-navigation.gif" alt="navigation">
+</div>
 
 
 ## Angular Language Service in your editor

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -91,11 +91,9 @@ ng serve
 
 Then go to `localhost:4200` where you should see “customer-app” and three buttons.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/lazy-loading-ngmodules/three-buttons.png" width="300" alt="three buttons in the browser">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/lazy-loading-ngmodules/three-buttons.png" width="300" alt="three buttons in the browser">
+</div>
 
 These buttons work, because the CLI automatically added the routes to the feature modules to the `routes` array in `app.module.ts`.
 
@@ -137,30 +135,24 @@ The other feature module's routing module is configured similarly.
 
 You can check to see that a module is indeed being lazy loaded with the Chrome developer tools. In Chrome, open the dev tools by pressing `Cmd+Option+i` on a Mac or `Ctrl+Shift+j` on a PC and go to the Network Tab.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/lazy-loading-ngmodules/network-tab.png" width="600" alt="lazy loaded modules diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/lazy-loading-ngmodules/network-tab.png" width="600" alt="lazy loaded modules diagram">
+</div>
 
 
 Click on the Orders or Customers button. If you see a chunk appear, everything is wired up properly and the feature module is being lazy loaded. A chunk should appear for Orders and for Customers but will only appear once for each.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/lazy-loading-ngmodules/chunk-arrow.png" width="600" alt="lazy loaded modules diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/lazy-loading-ngmodules/chunk-arrow.png" width="600" alt="lazy loaded modules diagram">
+</div>
 
 
 To see it again, or to test after working in the project, clear everything out by clicking the circle with a line through it in the upper left of the Network Tab:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/lazy-loading-ngmodules/clear.gif" width="200" alt="lazy loaded modules diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/lazy-loading-ngmodules/clear.gif" width="200" alt="lazy loaded modules diagram">
+</div>
 
 
 Then reload with `Cmd+r` or `Ctrl+r`, depending on your platform.

--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -291,11 +291,9 @@ The peek-a-boo exists to show how Angular calls the hooks in the expected order.
 
 This snapshot reflects the state of the log after the user clicked the *Create...* button and then the *Destroy...* button.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/lifecycle-hooks/peek-a-boo.png" alt="Peek-a-boo">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/lifecycle-hooks/peek-a-boo.png" alt="Peek-a-boo">
+</div>
 
 The sequence of log messages follows the prescribed hook calling order:
 `OnChanges`, `OnInit`, `DoCheck`&nbsp;(3x), `AfterContentInit`, `AfterContentChecked`&nbsp;(3x),
@@ -351,11 +349,9 @@ Here it is attached to the repeated hero `<div>`:
 Each spy's birth and death marks the birth and death of the attached hero `<div>`
 with an entry in the *Hook Log* as seen here:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/lifecycle-hooks/spy-directive.gif' alt="Spy Directive">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/lifecycle-hooks/spy-directive.gif' alt="Spy Directive">
+</div>
 
 Adding a hero results in a new hero `<div>`. The spy's `ngOnInit()` logs that event.
 
@@ -444,11 +440,9 @@ The host `OnChangesParentComponent` binds to them like this:
 
 Here's the sample in action as the user makes changes.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/lifecycle-hooks/on-changes-anim.gif' alt="OnChanges">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/lifecycle-hooks/on-changes-anim.gif' alt="OnChanges">
+</div>
 
 The log entries appear as the string value of the *power* property changes.
 But the `ngOnChanges` does not catch changes to `hero.name`
@@ -479,11 +473,9 @@ This code inspects certain _values of interest_, capturing and comparing their c
 It writes a special message to the log when there are no substantive changes to the `hero` or the `power`
 so you can see how often `DoCheck` is called. The results are illuminating:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/lifecycle-hooks/do-check-anim.gif' alt="DoCheck">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/lifecycle-hooks/do-check-anim.gif' alt="DoCheck">
+</div>
 
 While the `ngDoCheck()` hook can detect when the hero's `name` has changed, it has a frightful cost.
 This hook is called with enormous frequency&mdash;after _every_
@@ -535,11 +527,9 @@ for one turn of the browser's JavaScript cycle and that's just long enough.
 
 Here's *AfterView* in action:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/lifecycle-hooks/after-view-anim.gif' alt="AfterView">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/lifecycle-hooks/after-view-anim.gif' alt="AfterView">
+</div>
 
 Notice that Angular frequently calls `AfterViewChecked()`, often when there are no changes of interest.
 Write lean hook methods to avoid performance problems.
@@ -582,11 +572,9 @@ The `<ng-content>` tag is a *placeholder* for the external content.
 It tells Angular where to insert that content.
 In this case, the projected content is the `<app-child>` from the parent.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/lifecycle-hooks/projected-child-view.png' alt="Projected Content">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/lifecycle-hooks/projected-child-view.png' alt="Projected Content">
+</div>
 
 <div class="alert is-helpful">
 

--- a/aio/content/guide/pipes.md
+++ b/aio/content/guide/pipes.md
@@ -106,13 +106,9 @@ As you click the button, the displayed date alternates between
 "**<samp>04/15/1988</samp>**" and
 "**<samp>Friday, April 15, 1988</samp>**".
 
-
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/pipes/date-format-toggle-anim.gif' alt="Date Format Toggle">
-  </div>
-</figure>
-
+<div class="lightbox">
+  <img src='generated/images/guide/pipes/date-format-toggle-anim.gif' alt="Date Format Toggle">
+</div>
 
 
 <div class="alert is-helpful">
@@ -188,11 +184,9 @@ Now you need a component to demonstrate the pipe.
 
 <code-example path="pipes/src/app/power-booster.component.ts" header="src/app/power-booster.component.ts"></code-example>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/pipes/power-booster.png' alt="Power Booster">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/pipes/power-booster.png' alt="Power Booster">
+</div>
 
 
 
@@ -234,11 +228,9 @@ your pipe and two-way data binding with `ngModel`.
 
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/pipes/power-boost-calculator-anim.gif' alt="Power Boost Calculator">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/pipes/power-boost-calculator-anim.gif' alt="Power Boost Calculator">
+</div>
 
 
 
@@ -313,11 +305,9 @@ The Flying Heroes application extends the
 code with checkbox switches and additional displays to help you experience these effects.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/pipes/flying-heroes-anim.gif' alt="Flying Heroes">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/pipes/flying-heroes-anim.gif' alt="Flying Heroes">
+</div>
 
 
 
@@ -494,11 +484,9 @@ both requesting the heroes from the `heroes.json` file.
 The component renders as the following:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/pipes/hero-list.png' alt="Hero List">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/pipes/hero-list.png' alt="Hero List">
+</div>
 
 
 

--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -64,11 +64,9 @@ The form control assigned to `name` is displayed when the component is added to 
 
 <code-example path="reactive-forms/src/app/app.component.1.html" region="app-name-editor" header="src/app/app.component.html (name editor)"></code-example>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/name-editor-1.png" alt="Name Editor">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/name-editor-1.png" alt="Name Editor">
+</div>
 
 ## Managing control values
 
@@ -110,11 +108,9 @@ Update the template with a button to simulate a name update. When you click the 
 
 The form model is the source of truth for the control, so when you click the button, the value of the input is changed within the component class, overriding its current value.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/name-editor-2.png" alt="Name Editor Update">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/name-editor-2.png" alt="Name Editor Update">
+</div>
 
 <div class="alert is-helpful">
 
@@ -192,11 +188,9 @@ To display the `ProfileEditor` component that contains the form, add it to a com
 
 `ProfileEditor` allows you to manage the form control instances for the `firstName` and `lastName` controls within the form group instance.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/profile-editor-1.png" alt="Profile Editor">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/profile-editor-1.png" alt="Profile Editor">
+</div>
 
 ## Creating nested form groups
 
@@ -220,11 +214,9 @@ Add the `address` form group containing the `street`, `city`, `state`, and `zip`
 
 The `ProfileEditor` form is displayed as one group, but the model is broken down further to represent the logical grouping areas.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/profile-editor-2.png" alt="Profile Editor Update">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/profile-editor-2.png" alt="Profile Editor Update">
+</div>
 
 <div class="alert is-helpful">
 
@@ -354,11 +346,9 @@ Display the current status of `profileForm` using interpolation.
 
 <code-example path="reactive-forms/src/app/profile-editor/profile-editor.component.html" region="display-status" header="src/app/profile-editor/profile-editor.component.html (display status)"></code-example>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/profile-editor-3.png" alt="Profile Editor Validation">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/profile-editor-3.png" alt="Profile Editor Validation">
+</div>
 
 The **Submit** button is disabled because `profileForm` is invalid due to the required `firstName` form control. After you fill out the `firstName` input, the form becomes valid and the **Submit** button is enabled.
 
@@ -422,11 +412,9 @@ Add the template HTML below after the `<div>` closing the `formGroupName` elemen
 
 The `*ngFor` directive iterates over each form control instance provided by the aliases form array instance. Because form array elements are unnamed, you assign the index to the `i` variable and pass it to each control to bind it to the `formControlName` input.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/reactive-forms/profile-editor-4.png" alt="Profile Editor Aliases">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/reactive-forms/profile-editor-4.png" alt="Profile Editor Aliases">
+</div>
 
 Each time a new alias instance is added, the new form array instance is provided its control based on the index. This allows you to track each individual control when calculating the status and value of the root control.
 

--- a/aio/content/guide/route-animations.md
+++ b/aio/content/guide/route-animations.md
@@ -25,11 +25,9 @@ Let's illustrate a router transition animation by navigating between two routes,
 
 </br>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/route-animation.gif" alt="Animations in action" width="440">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/route-animation.gif" alt="Animations in action" width="440">
+</div>
 
 ## Route configuration
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -765,21 +765,17 @@ Once the app warms up, you'll see a row of navigation buttons
 and the *Heroes* view with its list of heroes.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/hero-list.png' alt="Hero List">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/hero-list.png' alt="Hero List">
+</div>
 
 
 
 Select one hero and the app takes you to a hero editing screen.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/hero-detail.png' alt="Crisis Center Detail">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/hero-detail.png' alt="Crisis Center Detail">
+</div>
 
 
 
@@ -794,11 +790,9 @@ Angular app navigation updates the browser history as normal web navigation does
 Now click the *Crisis Center* link for a list of ongoing crises.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/crisis-center-list.png' alt="Crisis Center List">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/crisis-center-list.png' alt="Crisis Center List">
+</div>
 
 
 
@@ -809,11 +803,9 @@ Alter the name of a crisis.
 Notice that the corresponding name in the crisis list does _not_ change.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/crisis-center-detail.png' alt="Crisis Center Detail">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/crisis-center-detail.png' alt="Crisis Center Detail">
+</div>
 
 
 
@@ -827,11 +819,9 @@ Click the browser back button or the "Heroes" link instead.
 Up pops a dialog box.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/confirm-dialog.png' alt="Confirm Dialog">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/confirm-dialog.png' alt="Confirm Dialog">
+</div>
 
 
 
@@ -852,11 +842,9 @@ Proceed to the first application milestone.
 Begin with a simple version of the app that navigates between two empty views.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/router-1-anim.gif' alt="App in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/router-1-anim.gif' alt="App in action">
+</div>
 
 {@a import}
 
@@ -940,11 +928,9 @@ Registering the `RouterModule.forRoot()` in the `AppModule` imports makes the `R
 The root `AppComponent` is the application shell. It has a title, a navigation bar with two links, and a router outlet where the router swaps components on and off the page. Here's what you get:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/shell-and-outlet.png' alt="Shell">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/shell-and-outlet.png' alt="Shell">
+</div>
 
 The router outlet serves as a placeholder when the routed components will be rendered below it.
 
@@ -1377,11 +1363,9 @@ from the <live-example name="toh-pt4" title="Tour of Heroes: Services example co
 Here's how the user will experience this version of the app:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/router-2-anim.gif' alt="App in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/router-2-anim.gif' alt="App in action">
+</div>
 
 
 
@@ -1960,11 +1944,9 @@ For example, when returning to the hero-detail.component.ts list from the hero d
 it would be nice if the viewed hero was preselected in the list.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/selected-hero.png' alt="Selected hero">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/selected-hero.png' alt="Selected hero">
+</div>
 
 
 
@@ -2147,11 +2129,9 @@ Add some styles to apply when the list item is selected.
 
 When the user navigates from the heroes list to the "Magneta" hero and back, "Magneta" appears selected:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/selected-hero.png' alt="Selected List">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/selected-hero.png' alt="Selected List">
+</div>
 
 
 
@@ -2543,11 +2523,9 @@ to conform to the following recommended pattern for Angular applications:
 If your app had many feature areas, the app component trees might look like this:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/component-tree.png' alt="Component Tree">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/component-tree.png' alt="Component Tree">
+</div>
 
 
 
@@ -2811,11 +2789,9 @@ It displays a simple form with a header, an input box for the message,
 and two buttons, "Send" and "Cancel".
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/router/contact-popup.png' alt="Contact popup">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/router/contact-popup.png' alt="Contact popup">
+</div>
 
 
 

--- a/aio/content/guide/schematics-authoring.md
+++ b/aio/content/guide/schematics-authoring.md
@@ -359,11 +359,9 @@ When you add a new named schematic to this collection, it is automatically added
 In addition to the name and description, each schematic has a `factory` property that identifies the schematic’s entry point.
 In the example, you invoke the schematic's defined functionality by calling the `helloWorld()` function in the main file,  `hello-world/index.ts`.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/schematics/collection-files.gif" alt="overview">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/schematics/collection-files.gif" alt="overview">
+</div>
 
 Each named schematic in the collection has the following main parts.
 

--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -118,11 +118,9 @@ Angular recognizes the value as unsafe and automatically sanitizes it, which rem
 tag but keeps safe content such as the `<b>` element.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/security/binding-inner-html.png' alt='A screenshot showing interpolated and bound HTML values'>
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/security/binding-inner-html.png' alt='A screenshot showing interpolated and bound HTML values'>
+</div>
 
 
 ### Direct use of the DOM APIs and explicit sanitization calls
@@ -211,11 +209,9 @@ this, mark the URL value as a trusted URL using the `bypassSecurityTrustUrl` cal
 
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/security/bypass-security-component.png' alt='A screenshot showing an alert box created from a trusted URL'>
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/security/bypass-security-component.png' alt='A screenshot showing an alert box created from a trusted URL'>
+</div>
 
 
 

--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -74,11 +74,9 @@ To simulate a network issue, disable network interaction for your application. I
 2. Go to the **Network tab**.
 3. Check the **Offline box**.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/service-worker/offline-checkbox.png" alt="The offline checkbox in the Network tab is checked">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/service-worker/offline-checkbox.png" alt="The offline checkbox in the Network tab is checked">
+</div>
 
 Now the app has no access to network interaction.
 
@@ -88,11 +86,9 @@ With the addition of an Angular service worker, the application behavior changes
 
 If you look at the Network tab, you can verify that the service worker is active.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/service-worker/sw-active.png" alt="Requests are marked as from ServiceWorker">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/service-worker/sw-active.png" alt="Requests are marked as from ServiceWorker">
+</div>
 
 Notice that under the "Size" column, the requests state is `(from ServiceWorker)`. This means that the resources are not being loaded from the network. Instead, they are being loaded from the service worker's cache.
 
@@ -146,11 +142,9 @@ Now look at how the browser and service worker handle the updated application.
 
 1. Open http://localhost:8080 again in the same window. What happens?
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/service-worker/welcome-msg-en.png" alt="It still says Welcome to Service Workers!">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/service-worker/welcome-msg-en.png" alt="It still says Welcome to Service Workers!">
+</div>
 
 What went wrong? Nothing, actually. The Angular service worker is doing its job and serving the version of the application that it has **installed**, even though there is an update available. In the interest of speed, the service worker doesn't wait to check for updates before it serves the application that it has cached.
 
@@ -158,11 +152,9 @@ If you look at the `http-server` logs, you can see the service worker requesting
 
 2. Refresh the page.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/service-worker/welcome-msg-fr.png" alt="The text has changed to say Bienvenue à app!">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/service-worker/welcome-msg-fr.png" alt="The text has changed to say Bienvenue à app!">
+</div>
 
 The service worker installed the updated version of your app *in the background*, and the next time the page is loaded or reloaded, the service worker switches to the latest version.
 

--- a/aio/content/guide/set-document-title.md
+++ b/aio/content/guide/set-document-title.md
@@ -47,11 +47,9 @@ You can inject the `Title` service into the root `AppComponent` and expose a bin
 
 Bind that method to three anchor tags and voilà!
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/set-document-title/set-title-anim.gif" alt="Set title">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/set-document-title/set-title-anim.gif" alt="Set title">
+</div>
 
 Here's the complete solution:
 

--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -104,11 +104,9 @@ to `http://localhost:4200/`.
 Your app greets you with a message:
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/setup-local/app-works.png' alt="Welcome to my-app!">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/setup-local/app-works.png' alt="Welcome to my-app!">
+</div>
 
 
 ## Next steps

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -125,11 +125,9 @@ The `ngIf` directive doesn't hide elements with CSS. It adds and removes them ph
 Confirm that fact using browser developer tools to inspect the DOM.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/element-not-in-dom.png' alt="ngIf=false element not in DOM">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/element-not-in-dom.png' alt="ngIf=false element not in DOM">
+</div>
 
 
 
@@ -153,11 +151,9 @@ A directive could hide the unwanted paragraph instead by setting its `display` s
 While invisible, the element remains in the DOM.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/element-display-in-dom.png' alt="hidden element still in DOM">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/element-display-in-dom.png' alt="hidden element still in DOM">
+</div>
 
 
 
@@ -215,11 +211,9 @@ Internally, Angular translates the `*ngIf` _attribute_ into a `<ng-template>` _e
 The first form is not actually rendered, only the finished product ends up in the DOM.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/hero-div-in-dom.png' alt="hero div in DOM">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/hero-div-in-dom.png' alt="hero div in DOM">
+</div>
 
 
 
@@ -565,11 +559,9 @@ That's the fate of the middle "Hip!" in the phrase "Hip! Hip! Hooray!".
 Angular erases the middle "Hip!", leaving the cheer a bit less enthusiastic.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/template-rendering.png' alt="template tag rendering">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/template-rendering.png' alt="template tag rendering">
+</div>
 
 
 
@@ -625,11 +617,9 @@ You also have a CSS style rule that happens to apply to a `<span>` within a `<p>
 The constructed paragraph renders strangely.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/bad-paragraph.png' alt="spanned paragraph with bad style">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/bad-paragraph.png' alt="spanned paragraph with bad style">
+</div>
 
 
 
@@ -649,11 +639,9 @@ When you try this,
 the drop down is empty.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/bad-select.png' alt="spanned options don't work">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/bad-select.png' alt="spanned options don't work">
+</div>
 
 
 
@@ -674,11 +662,9 @@ Here's the conditional paragraph again, this time using `<ng-container>`.
 It renders properly.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/good-paragraph.png' alt="ngcontainer paragraph with proper style">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/good-paragraph.png' alt="ngcontainer paragraph with proper style">
+</div>
 
 
 
@@ -692,11 +678,9 @@ Now conditionally exclude a _select_ `<option>` with `<ng-container>`.
 The drop down works properly.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/select-ngcontainer-anim.gif' alt="ngcontainer options work properly">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/select-ngcontainer-anim.gif' alt="ngcontainer options work properly">
+</div>
 
 <div class="alert is-helpful">
 
@@ -844,11 +828,9 @@ When the `condition` is falsy, the top (A) paragraph appears and the bottom (B) 
 When the `condition` is truthy, the top (A) paragraph is removed and the bottom (B) paragraph appears.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/structural-directives/unless-anim.gif' alt="UnlessDirective in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/structural-directives/unless-anim.gif' alt="UnlessDirective in action">
+</div>
 
 
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -969,11 +969,9 @@ template statement on the right.
 The following event binding listens for the button's click events, calling
 the component's `onSave()` method whenever a click occurs:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/template-syntax/syntax-diagram.svg' alt="Syntax diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/template-syntax/syntax-diagram.svg' alt="Syntax diagram">
+</div>
 
 ### Target event
 
@@ -1308,11 +1306,9 @@ for example, the following changes the `<input>` value to uppercase:
 
 Here are all variations in action, including the uppercase version:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/built-in-directives/ng-model-anim.gif' alt="NgModel variations">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/built-in-directives/ng-model-anim.gif' alt="NgModel variations">
+</div>
 
 <hr/>
 
@@ -1516,11 +1512,9 @@ Here is an illustration of the `trackBy` effect.
 * With no `trackBy`, both buttons trigger complete DOM element replacement.
 * With `trackBy`, only changing the `id` triggers element replacement.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/built-in-directives/ngfor-trackby.gif" alt="Animation of trackBy">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/built-in-directives/ngfor-trackby.gif" alt="Animation of trackBy">
+</div>
 
 
 <div class="alert is-helpful">
@@ -1544,11 +1538,9 @@ Angular puts only the selected element into the DOM.
 
  <code-example path="built-in-directives/src/app/app.component.html" region="NgSwitch" header="src/app/app.component.html"></code-example>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/built-in-directives/ngswitch.gif" alt="Animation of NgSwitch">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/built-in-directives/ngswitch.gif" alt="Animation of NgSwitch">
+</div>
 
 `NgSwitch` is the controller directive. Bind it to an expression that returns
 the *switch value*, such as `feature`. Though the `feature` value in this
@@ -1703,11 +1695,9 @@ child component. So an `@Input()` allows data to be input _into_ the
 child component from the parent component.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/inputs-outputs/input.svg" alt="Input data flow diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/inputs-outputs/input.svg" alt="Input data flow diagram">
+</div>
 
 To illustrate the use of `@Input()`, edit these parts of your app:
 
@@ -1752,11 +1742,9 @@ With `@Input()`, Angular passes the value for `currentItem` to the child so that
 
 The following diagram shows this structure:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/inputs-outputs/input-diagram-target-source.svg" alt="Property binding diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/inputs-outputs/input-diagram-target-source.svg" alt="Property binding diagram">
+</div>
 
 The target in the square brackets, `[]`, is the property you decorate
 with `@Input()` in the child component. The binding source, the part
@@ -1788,11 +1776,9 @@ the child _out_ to the parent.
 An `@Output()` property should normally be initialized to an Angular [`EventEmitter`](api/core/EventEmitter) with values flowing out of the component as [events](#event-binding).
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/inputs-outputs/output.svg" alt="Output diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/inputs-outputs/output.svg" alt="Output diagram">
+</div>
 
 Just like with `@Input()`, you can use `@Output()`
 on a property of the child component but its type should be
@@ -1932,11 +1918,9 @@ The target, `item`, which is an `@Input()` property in the child component class
 The following diagram is of an `@Input()` and an `@Output()` on the same
 child component and shows the different parts of each:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/inputs-outputs/input-output-diagram.svg" alt="Input/Output diagram">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/inputs-outputs/input-output-diagram.svg" alt="Input/Output diagram">
+</div>
 
 As the diagram shows, use inputs and outputs together in the same manner as using them separately. Here, the child selector is `<app-input-output>` with `item` and `deleteRequest` being `@Input()` and `@Output()`
 properties in the child component class. The property `currentItem` and the method `crossOffItem()` are both in the parent component class.

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -41,11 +41,9 @@ It shows that Karma ran three tests that all passed.
 
 A chrome browser also opens and displays the test output in the "Jasmine HTML Reporter" like this.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/testing/initial-jasmine-html-reporter.png' alt="Jasmine HTML Reporter in the browser">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/testing/initial-jasmine-html-reporter.png' alt="Jasmine HTML Reporter in the browser">
+</div>
 
 Most people find this browser output easier to read than the console log.
 You can click on a test row to re-run just that test or click on a description to re-run the tests in the selected test group ("test suite").
@@ -2262,11 +2260,9 @@ tests with the `RouterTestingModule`.
 
 The `HeroDetailComponent` is a simple view with a title, two hero fields, and two buttons.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/testing/hero-detail.component.png' alt="HeroDetailComponent in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/testing/hero-detail.component.png' alt="HeroDetailComponent in action">
+</div>
 
 But there's plenty of template complexity even in this simple form.
 
@@ -2693,11 +2689,9 @@ A better solution is to create an artificial test component that demonstrates al
 
 <code-example path="testing/src/app/shared/highlight.directive.spec.ts" region="test-component" header="app/shared/highlight.directive.spec.ts (TestComponent)"></code-example>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/testing/highlight-directive-spec.png' alt="HighlightDirective spec in action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/testing/highlight-directive-spec.png' alt="HighlightDirective spec in action">
+</div>
 
 <div class="alert is-helpful">
 
@@ -2776,11 +2770,9 @@ Debug specs in the browser in the same way that you debug an application.
 1. Set a breakpoint in the test.
 1. Refresh the browser, and it stops at the breakpoint.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/testing/karma-1st-spec-debug.png' alt="Karma debugging">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/testing/karma-1st-spec-debug.png' alt="Karma debugging">
+</div>
 
 <hr>
 

--- a/aio/content/guide/transition-and-triggers.md
+++ b/aio/content/guide/transition-and-triggers.md
@@ -14,11 +14,9 @@ An asterisk `*` or *wildcard* matches any animation state. This is useful for de
 
 For example, a transition of `open => *` applies when the element's state changes from open to anything else.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/wildcard-state-500.png" alt="wildcard state expressions">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/wildcard-state-500.png" alt="wildcard state expressions">
+</div>
 
 Here's another code sample using the wildcard state together with our previous example using the `open` and `closed` states. Instead of defining each state-to-state transition pair, we're now saying that any transition to `closed` takes 1 second, and any transition to `open` takes 0.5 seconds.
 
@@ -34,11 +32,9 @@ Use a double arrow syntax to specify state-to-state transitions in both directio
 
 In our two-state button example, the wildcard isn't that useful because there are only two possible states, `open` and `closed`. Wildcard states are better when an element in one particular state has multiple potential states that it can change to. If our button can change from `open` to either `closed` or something like `inProgress`, using a wildcard state could reduce the amount of coding needed.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/wildcard-3-states.png" alt="wildcard state with 3 states">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/wildcard-3-states.png" alt="wildcard state with 3 states">
+</div>
 
 
 <code-example path="animations/src/app/open-close.component.ts" header="src/app/open-close.component.ts" region="trigger-transition" language="typescript"></code-example>
@@ -221,11 +217,9 @@ In the previous section, we saw a simple two-state transition. Now we'll create 
 
 Angular's `keyframe()` function is similar to keyframes in CSS. Keyframes allow several style changes within a single timing segment. For example, our button, instead of fading, could change color several times over a single 2-second timespan.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/keyframes-500.png" alt="keyframes">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/keyframes-500.png" alt="keyframes">
+</div>
 
 The code for this color change might look like this.
 
@@ -237,11 +231,9 @@ Keyframes include an *offset* that defines the point in the animation where each
 
 Defining offsets for keyframes is optional. If you omit them, evenly spaced offsets are automatically assigned. For example, three keyframes without predefined offsets receive offsets of 0, 0.5, and 1. Specifying an offset of 0.8 for the middle transition in the above example might look like this.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/keyframes-offset-500.png" alt="keyframes with offset">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/keyframes-offset-500.png" alt="keyframes with offset">
+</div>
 
 The code with offsets specified would be as follows.
 
@@ -260,11 +252,9 @@ Here's an example of using keyframes to create a pulse effect:
 
 * A keyframes sequence inserted in the middle that causes the button to appear to pulsate irregularly over the course of that same 1-second timeframe
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/animations/keyframes-pulsation.png" alt="keyframes with irregular pulsation">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/animations/keyframes-pulsation.png" alt="keyframes with irregular pulsation">
+</div>
 
 The code snippet for this animation might look like this.
 

--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -266,11 +266,9 @@ everything work seamlessly:
   When you register a downgraded service, you must explicitly specify a *string token* that you want to
   use in AngularJS.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/upgrade/injectors.png" alt="The two injectors in a hybrid application">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/upgrade/injectors.png" alt="The two injectors in a hybrid application">
+</div>
 
 #### Components and the DOM
 
@@ -304,11 +302,9 @@ ways:
     bridges the related concepts of AngularJS transclusion and Angular content
     projection together.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/upgrade/dom.png" alt="DOM element ownership in a hybrid application">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/upgrade/dom.png" alt="DOM element ownership in a hybrid application">
+</div>
 
 Whenever you use a component that belongs to the other framework, a
 switch between framework boundaries occurs. However, that switch only
@@ -351,11 +347,9 @@ AngularJS and Angular approaches. Here's what happens:
   every turn of the Angular zone. This also triggers AngularJS change
   detection after every event.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/upgrade/change_detection.png" alt="Change detection in a hybrid application">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/upgrade/change_detection.png" alt="Change detection in a hybrid application">
+</div>
 
 In practice, you do not need to call `$apply()`,
 regardless of whether it is in AngularJS or Angular. The

--- a/aio/content/guide/user-input.md
+++ b/aio/content/guide/user-input.md
@@ -82,11 +82,9 @@ Here's what the UI displays:
 
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/user-input/keyup1-anim.gif' alt="key up 1">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/user-input/keyup1-anim.gif' alt="key up 1">
+</div>
 
 
 
@@ -163,11 +161,9 @@ and the component does nothing.
 Type something in the input box, and watch the display update with each keystroke.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/user-input/keyup-loop-back-anim.gif' alt="loop back">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/user-input/keyup-loop-back-anim.gif' alt="loop back">
+</div>
 
 
 
@@ -215,11 +211,9 @@ Then Angular calls the event handler only when the user presses _Enter_.
 
 Here's how it works.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/user-input/keyup3-anim.gif' alt="key up 3">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/user-input/keyup3-anim.gif' alt="key up 3">
+</div>
 
 
 
@@ -249,11 +243,9 @@ The user can add a hero by typing the hero's name in the input box and
 clicking **Add**.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/user-input/little-tour-anim.gif' alt="Little Tour of Heroes">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/user-input/little-tour-anim.gif' alt="Little Tour of Heroes">
+</div>
 
 
 

--- a/aio/content/start/data.md
+++ b/aio/content/start/data.md
@@ -105,19 +105,15 @@ When the "Buy" button is clicked, you'll use the cart service to add the current
 
 1. To see the new "Buy" button, refresh the application and click on a product's name to display its details.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/product-details-buy.png' alt="Display details for selected product with a Buy button">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/product-details-buy.png' alt="Display details for selected product with a Buy button">
+    </div>
 
 1. Click the "Buy" button. The product is added to the stored list of items in the cart, and a message is displayed.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/buy-alert.png' alt="Display details for selected product with a Buy button">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/buy-alert.png' alt="Display details for selected product with a Buy button">
+    </div>
 
 
 ## Create the cart page
@@ -154,11 +150,9 @@ We'll create the cart page in two steps:
 
     (Note: The "Checkout" button that we provided in the top-bar component was already configured with a `routerLink` for `/cart`.)
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/cart-works.png' alt="Display cart page before customizing">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/cart-works.png' alt="Display cart page before customizing">
+    </div>
 
 
 ### Display the cart items
@@ -210,11 +204,9 @@ Services can be used to share data across components:
     1. Click "Checkout" to see the cart.
     1. To add another product, click "My Store" to return to the product list. Repeat the steps above.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/cart-page-full.png' alt="Cart page with products added">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/cart-page-full.png' alt="Cart page with products added">
+    </div>
 
 
 <div class="alert is-helpful">
@@ -371,19 +363,15 @@ Now that your app can retrieve shipping data, you'll create a shipping component
 
     Click on the "Checkout" button to see the updated cart. (Remember that changing the app causes the preview to refresh, which empties the cart.)
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/cart-empty-with-shipping-prices.png' alt="Cart with link to shipping prices">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/cart-empty-with-shipping-prices.png' alt="Cart with link to shipping prices">
+    </div>
 
     Click on the link to navigate to the shipping prices.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src='generated/images/guide/start/shipping-prices.png' alt="Display shipping prices">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src='generated/images/guide/start/shipping-prices.png' alt="Display shipping prices">
+    </div>
 
 
 ## Next steps

--- a/aio/content/start/forms.md
+++ b/aio/content/start/forms.md
@@ -73,11 +73,9 @@ Next, you'll add a checkout form at the bottom of the "Cart" page.
 
 After putting a few items in the cart, users can now review their items, enter name and address, and submit their purchase:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/start/cart-with-items-and-form.png' alt="Cart page with checkout form">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/start/cart-with-items-and-form.png' alt="Cart page with checkout form">
+</div>
 
 
 ## Next steps

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -21,11 +21,9 @@ To help you get started right away, this guide uses a simple ready-made applicat
 <live-example name="getting-started-v0" noDownload>Click here to create the ready-made sample project in StackBlitz.</live-example>
 </h4>
 
-<figure class="lightbox">
-  <div class="card">
-    <img src="generated/images/guide/start/new-app-all.gif" alt="Starter online store app">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src="generated/images/guide/start/new-app-all.gif" alt="Starter online store app">
+</div>
 
 * The preview pane on the right shows the starting state of the sample Angular app.
 It defines a frame with a top bar (containing the store name and checkout icon) and the title for a product list (which will be populated and dynamically updated with data from the application).
@@ -100,11 +98,9 @@ To help you get going, the following steps use predefined product data and metho
 
       The preview pane immediately updates to display the name of each product in the list.
 
-      <figure class="lightbox">
-        <div class="card">
-          <img src="generated/images/guide/start/template-syntax-product-names.png" alt="Product names added to list">
-        </div>
-      </figure>
+      <div class="lightbox">
+        <img src="generated/images/guide/start/template-syntax-product-names.png" alt="Product names added to list">
+      </div>
 
 1. To make each product name a link to product details, add the `<a>` element and set its title to be the product's name by using the property binding `[ ]` syntax, as follows:
 
@@ -118,11 +114,9 @@ To help you get going, the following steps use predefined product data and metho
     property value as text; property binding `[ ]` lets you
     use the property value in a template expression.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src="generated/images/guide/start/template-syntax-product-anchor.png" alt="Product name anchor text is product name property">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src="generated/images/guide/start/template-syntax-product-anchor.png" alt="Product name anchor text is product name property">
+    </div>
 
 
 4. Add the product descriptions. On the `<p>` element, use an `*ngIf` directive so that Angular only creates the `<p>` element if the current product has a description.
@@ -132,11 +126,9 @@ To help you get going, the following steps use predefined product data and metho
 
     The app now displays the name and description of each product in the list. Notice that the final product does not have a description paragraph. Because the product's description property is empty, Angular doesn't create the `<p>` element&mdash;including the word "Description".
 
-    <figure class="lightbox">
-      <div class="card">
+    <div class="lightbox">
       <img src="generated/images/guide/start/template-syntax-product-description.png" alt="Product descriptions added to list">
-      </div>
-    </figure>
+    </div>
 
 5. Add a button so users can share a product with friends. Bind the button's `click` event to the `share()` method (in `product-list.component.ts`). Event binding uses a set of parentheses, `( )`, around the event, as in the following `<button>` element:
 
@@ -145,19 +137,15 @@ To help you get going, the following steps use predefined product data and metho
 
     Each product now has a "Share" button:
 
-    <figure class="lightbox">
-      <div class="card">
+    <div class="lightbox">
       <img src="generated/images/guide/start/template-syntax-product-share-button.png" alt="Share button added for each product">
-      </div>
-    </figure>
+    </div>
 
     Test the "Share" button:
 
-    <figure class="lightbox">
-      <div class="card">
+    <div class="lightbox">
       <img src="generated/images/guide/start/template-syntax-product-share-alert.png" alt="Alert box indicating product has been shared">
-      </div>
-    </figure>
+    </div>
 
 The app now has a product list and sharing feature.
 In the process, you've learned to use five common features of Angular's template syntax:
@@ -212,11 +200,9 @@ An Angular application comprises a tree of components, in which each Angular com
 
 Currently, the example app has three components:
 
-<figure class="lightbox">
-  <div class="card">
+<div class="lightbox">
   <img src="generated/images/guide/start/app-components.png" alt="Online store with three components">
-  </div>
-</figure>
+</div>
 
 * `app-root` (orange box) is the application shell. This is the first component to load and the parent of all other components. You can think of it as the base page.
 * `app-top-bar` (blue background) is the store name and checkout button.
@@ -244,11 +230,9 @@ The next step is to create a new alert feature that takes a product as an input.
 
     1. Right click on the `app` folder and use the `Angular Generator` to generate a new component named `product-alerts`.
 
-        <figure class="lightbox">
-          <div class="card">
+        <div class="lightbox">
           <img src="generated/images/guide/start/generate-component.png" alt="StackBlitz command to generate component">
-          </div>
-        </figure>
+        </div>
 
         The generator creates starter files for all three parts of the component:
         * `product-alerts.component.ts`
@@ -295,11 +279,9 @@ The next step is to create a new alert feature that takes a product as an input.
 
 The new product alert component takes a product as input from the product list. With that input, it shows or hides the "Notify Me" button, based on the price of the product. The Phone XL price is over $700, so the "Notify Me" button appears on that product.
 
-<figure class="lightbox">
-  <div class="card">
+<div class="lightbox">
   <img src="generated/images/guide/start/product-alert-button.png" alt="Product alert button added to products over $700">
-  </div>
-</figure>
+</div>
 
 <div class="alert is-helpful">
 
@@ -342,11 +324,9 @@ To make the "Notify Me" button work, you need to configure two things:
 
 1. Try the "Notify Me" button:
 
-    <figure class="lightbox">
-      <div class="card">
+    <div class="lightbox">
       <img src="generated/images/guide/start/product-alert-notification.png" alt="Product alert notification confirmation dialog">
-      </div>
-    </figure>
+    </div>
 
 
 <div class="alert is-helpful">

--- a/aio/content/start/routing.md
+++ b/aio/content/start/routing.md
@@ -54,11 +54,9 @@ The app is already set up to use the Angular router and to use routing to naviga
 
     Notice that the URL in the preview window changes. The final segment is `products/1`.
 
-    <figure class="lightbox">
-      <div class="card">
-        <img src="generated/images/guide/start/product-details-works.png" alt="Product details page with updated URL">
-      </div>
-    </figure>
+    <div class="lightbox">
+      <img src="generated/images/guide/start/product-details-works.png" alt="Product details page with updated URL">
+    </div>
 
     
 
@@ -110,11 +108,9 @@ The product details component handles the display of each product. The Angular R
 
 Now, when the user clicks on a name in the product list, the router navigates you to the distinct URL for the product, swaps out the product list component for the product details component, and displays the product details. 
 
-  <figure class="lightbox">
-    <div class="card">
-      <img src="generated/images/guide/start/product-details-routed.png" alt="Product details page with updated URL and full details displayed">
-    </div>
-  </figure>
+<div class="lightbox">
+  <img src="generated/images/guide/start/product-details-routed.png" alt="Product details page with updated URL and full details displayed">
+</div>
 
 
 

--- a/aio/content/tutorial/index.md
+++ b/aio/content/tutorial/index.md
@@ -49,11 +49,9 @@ After completing all tutorial steps, the final app will look like this: <live-ex
 Here's a visual idea of where this tutorial leads, beginning with the "Dashboard"
 view and the most heroic heroes:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/heroes-dashboard-1.png' alt="Output of heroes dashboard">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/heroes-dashboard-1.png' alt="Output of heroes dashboard">
+</div>
 
 You can click the two links above the dashboard ("Dashboard" and "Heroes")
 to navigate between this Dashboard view and a Heroes view.
@@ -61,22 +59,18 @@ to navigate between this Dashboard view and a Heroes view.
 If you click the dashboard hero "Magneta," the router opens a "Hero Details" view
 where you can change the hero's name.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/hero-details-1.png' alt="Details of hero in app">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/hero-details-1.png' alt="Details of hero in app">
+</div>
 
 Clicking the "Back" button returns you to the Dashboard.
 Links at the top take you to either of the main views.
 If you click "Heroes," the app displays the "Heroes" master list view.
 
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/heroes-list-2.png' alt="Output of heroes list app">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/heroes-list-2.png' alt="Output of heroes list app">
+</div>
 
 When you click a different hero name, the read-only mini detail beneath the list reflects the new choice.
 
@@ -85,16 +79,12 @@ editable details of the selected hero.
 
 The following diagram captures all of the navigation options.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
+</div>
 
 Here's the app in action:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/toh-anim.gif' alt="Tour of Heroes in Action">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/toh-anim.gif' alt="Tour of Heroes in Action">
+</div>

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -196,11 +196,9 @@ It's difficult to identify the _selected hero_ in the list when all `<li>` eleme
 
 If the user clicks "Magneta", that hero should render with a distinctive but subtle background color like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/heroes-list-selected.png' alt="Selected hero">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/heroes-list-selected.png' alt="Selected hero">
+</div>
 
 That _selected hero_ coloring is the work of the `.selected` CSS class in the [styles you added earlier](#styles).
 You just have to apply the `.selected` class to the `<li>` when the user clicks it.

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -9,11 +9,9 @@ There are new requirements for the Tour of Heroes app:
 
 When you’re done, users will be able to navigate the app like this:
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
+</div>
 
 ## Add the `AppRoutingModule`
 

--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -513,11 +513,9 @@ That's the job of the [`AsyncPipe`](#asyncpipe) in the template.
 Run the app again. In the *Dashboard*, enter some text in the search box.
 If you enter characters that match any existing hero names, you'll see something like this.
 
-<figure class="lightbox">
-  <div class="card">
-    <img src='generated/images/guide/toh/toh-hero-search.png' alt="Hero Search Component">
-  </div>
-</figure>
+<div class="lightbox">
+  <img src='generated/images/guide/toh/toh-hero-search.png' alt="Hero Search Component">
+</div>
 
 ## Final code review
 

--- a/aio/src/styles/2-modules/_images.scss
+++ b/aio/src/styles/2-modules/_images.scss
@@ -32,7 +32,7 @@
     }
   }
 
-  figure {
+  .lightbox {
     margin: 0;
     margin-top: 14px;
     margin-bottom: 14px;
@@ -45,24 +45,19 @@
     justify-content: center;
     box-shadow: 2px 2px 5px 0 rgba(0, 0, 0, .2);
     margin: 16px 0;
+    background-color: $lightboxgray;
+    width: 100%;
+    display: flex;
+    justify-content: center;
 
-    &.lightbox {
-      background-color: $lightboxgray;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-    }
-
-    div.card {
+    img {
+      max-width: 100%;
+      height: auto;
+      padding: 8px;
+      margin: auto;
       box-shadow: 0 2px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);
       border-radius: 4px;
-      padding: 8px;
       background-color: $white;
-
-      img {
-        max-width: 100%;
-        height: auto;
-      }
     }
   }
 }


### PR DESCRIPTION
Reference #33259
Removes figures elements as AIO is not typically using captions or image groups where figures would be necessary or appropriate

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Removes `figure` elements not necessary

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No