### PR TITLE
fix(bazel): ng_module should not emit shim files under bazel and Ivy

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,4 +6,5 @@ aio/node_modules
 aio/tools/examples/shared/node_modules
 integration/bazel
 integration/bazel-schematics/demo
+integration/platform-server/node_modules
 packages/bazel/node_modules

--- a/integration/bazel/src/BUILD.bazel
+++ b/integration/bazel/src/BUILD.bazel
@@ -13,6 +13,7 @@ exports_files(["tsconfig.json"])
 ng_module(
     name = "src",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     deps = [
         "//src/hello-world",
         "@npm//@angular/common",

--- a/integration/bazel/src/hello-world/BUILD.bazel
+++ b/integration/bazel/src/hello-world/BUILD.bazel
@@ -17,6 +17,7 @@ ng_module(
         exclude = ["*.spec.ts"],
     ),
     assets = [":hello-world-styles"],
+    generate_ve_shims = True,
     deps = [
         "@npm//@angular/core",
         "@npm//@types",

--- a/modules/benchmarks/src/class_bindings/BUILD.bazel
+++ b/modules/benchmarks/src/class_bindings/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    generate_ve_shims = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    generate_ve_shims = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/modules/benchmarks/src/largeform/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/ng2/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 ng_module(
     name = "ng2",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     # FIXME-IVY(FW-998): ExpressionTranslatorVisitor#visitWriteKeyExpr is not implemented.
     tags = ["fixme-ivy-aot"],
     tsconfig = "//modules/benchmarks:tsconfig-build.json",

--- a/modules/benchmarks/src/largetable/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2/BUILD.bazel
@@ -10,6 +10,7 @@ package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 ng_module(
     name = "ng2",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,

--- a/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 ng_module(
     name = "ng2_switch",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,

--- a/modules/benchmarks/src/tree/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2/BUILD.bazel
@@ -10,6 +10,7 @@ package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 ng_module(
     name = "ng2",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,

--- a/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 ng_module(
     name = "ng2_switch",
     srcs = glob(["*.ts"]),
+    generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,

--- a/modules/benchmarks/src/views/BUILD.bazel
+++ b/modules/benchmarks/src/views/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    generate_ve_shims = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/bazel/src/builders/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/builders/files/src/BUILD.bazel.template
@@ -38,6 +38,7 @@ ng_module(
       "**/*.css",
       "**/*.html",
     ]) + ([":styles"] if len(glob(["**/*.scss"])) else []),
+    generate_ve_shims = True,
     deps = [
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -129,7 +129,7 @@ def _flat_module_out_file(ctx):
     Returns:
       a basename used for the flat module out (no extension)
     """
-    if hasattr(ctx.attr, "flat_module_out_file") and ctx.attr.flat_module_out_file:
+    if getattr(ctx.attr, "flat_module_out_file", False):
         return ctx.attr.flat_module_out_file
     return "%s_public_index" % ctx.label.name
 
@@ -149,7 +149,7 @@ def _should_produce_dts_bundle(ctx):
     # At the moment we cannot use this with ngtsc compiler since it emits
     # import * as ___ from local modules which is not supported
     # see: https://github.com/Microsoft/web-build-tools/issues/1029
-    return _is_view_engine_enabled(ctx) and hasattr(ctx.attr, "bundle_dts") and ctx.attr.bundle_dts
+    return _is_view_engine_enabled(ctx) and getattr(ctx.attr, "bundle_dts", False)
 
 def _should_produce_r3_symbols_bundle(ctx):
     """Should we produce r3_symbols bundle.

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    generate_ve_shims = True,
     module_name = "app_built",
     deps = [
         "//packages/compiler-cli/integrationtest/bazel/injectable_def/lib2",

--- a/packages/examples/common/BUILD.bazel
+++ b/packages/examples/common/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/core/BUILD.bazel
+++ b/packages/examples/core/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
             "**/*_howto.ts",
         ],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/forms/BUILD.bazel
+++ b/packages/examples/forms/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/router/activated-route/BUILD.bazel
+++ b/packages/examples/router/activated-route/BUILD.bazel
@@ -8,6 +8,7 @@ ng_module(
     srcs = glob(
         ["**/*.ts"],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/service-worker/push/BUILD.bazel
+++ b/packages/examples/service-worker/push/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/service-worker/registration-options/BUILD.bazel
+++ b/packages/examples/service-worker/registration-options/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
+    generate_ve_shims = True,
     # TODO: FW-1004 Type checking is currently not complete.
     type_check = False,
     deps = [

--- a/packages/examples/upgrade/upgrade_example.bzl
+++ b/packages/examples/upgrade/upgrade_example.bzl
@@ -12,6 +12,7 @@ def create_upgrade_example_targets(name, srcs, e2e_srcs, entry_module, assets = 
     ng_module(
         name = "%s_sources" % name,
         srcs = srcs,
+        generate_ve_shims = True,
         # TODO: FW-1004 Type checking is currently not complete.
         type_check = False,
         deps = [

--- a/packages/router/test/aot_ngsummary_test/BUILD.bazel
+++ b/packages/router/test/aot_ngsummary_test/BUILD.bazel
@@ -4,6 +4,7 @@ ng_module(
     name = "aot_routing_module",
     testonly = True,
     srcs = ["aot_router_module.ts"],
+    generate_ve_shims = True,
     deps = [
         "//packages/core",
         "//packages/router",


### PR DESCRIPTION
Under bazel and Ivy we don't need the shim files to be emmited by default.

We still need to the shims for blaze however because google3 code imports them.
