### PR TITLE
build: add ngJitMode to ng_rollup_bundle terser config

### DIFF
--- a/tools/ng_rollup_bundle/BUILD.bazel
+++ b/tools/ng_rollup_bundle/BUILD.bazel
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
-exports_files(["rollup.config.js"])
+exports_files([
+    "rollup.config.js",
+    "terser_config.json",
+])
 
 nodejs_binary(
     name = "rollup_with_build_optimizer",

--- a/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
+++ b/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
@@ -391,6 +391,7 @@ def ng_rollup_bundle(name, **kwargs):
         # maintain the comments off behavior. We pass the --comments flag with
         # a regex that always evaluates to false to do this.
         "args": ["--comments", "/bogus_string_to_suppress_all_comments^/"],
+        "config_file": "//tools/ng_rollup_bundle:terser_config.json",
         "sourcemap": False,
     }
 

--- a/tools/ng_rollup_bundle/terser_config.json
+++ b/tools/ng_rollup_bundle/terser_config.json
@@ -1,0 +1,12 @@
+{
+    "compress": {
+        "global_defs": {"ngDevMode": false, "ngI18nClosureMode": false, "ngJitMode": false},
+        "keep_fnames": "bazel_no_debug",
+        "passes": 3,
+        "pure_getters": true,
+        "reduce_funcs": "bazel_no_debug",
+        "reduce_vars": "bazel_no_debug",
+        "sequences": "bazel_no_debug"
+    },
+    "mangle": "bazel_no_debug"
+}


### PR DESCRIPTION
This adds a `tools/ng_rollup_bundle/terser_config.json` file adding `ngJitMode` and overriding the default terser_minified config provided by the rule.

Change requested by @alxhub in https://github.com/bazelbuild/rules_nodejs/pull/1338.

_After this change, the layer violation in rules_nodejs can be fixed by removing `"global_defs": {"ngDevMode": false, "ngI18nClosureMode": false},` from `terser_config.default.json` in rules_nodejs._

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
