### PR TITLE
feat(language-service): completions support for indexed types

### DIFF
--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -280,7 +280,20 @@ class TypeWrapper implements Symbol {
     return selectSignature(this.tsType, this.context, types);
   }
 
-  indexed(argument: Symbol): Symbol|undefined { return undefined; }
+  indexed(argument: Symbol): Symbol|undefined {
+    const type = argument instanceof TypeWrapper ? argument : argument.type;
+    if (!(type instanceof TypeWrapper)) return;
+
+    const typeKind = typeKindOf(type.tsType);
+    switch (typeKind) {
+      case BuiltinType.Number:
+        const nType = this.tsType.getNumberIndexType();
+        return nType && new TypeWrapper(nType, this.context);
+      case BuiltinType.String:
+        const sType = this.tsType.getStringIndexType();
+        return sType && new TypeWrapper(sType, this.context);
+    }
+  }
 }
 
 class SymbolWrapper implements Symbol {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -117,6 +117,52 @@ describe('completions', () => {
     expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
   });
 
+  it('should be able to get property completions for members in an array', () => {
+    const fileName = mockHost.addCode(`
+        interface Book {
+          numberOfPages: number;
+        }
+
+        @Component({
+          selector: 'library',
+          template: \`
+            <div>{{books[0].~{props}}}</div>
+          \`,
+        })
+        export class Library {
+          books: Book[];
+        }
+      `);
+    const location = mockHost.getLocationMarkerFor(fileName, 'props');
+    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+    expectContain(completions, CompletionKind.PROPERTY, ['numberOfPages']);
+  });
+
+  it('should be able to get property completions for members in an indexed type', () => {
+    const fileName = mockHost.addCode(`
+        interface Book {
+          numberOfPages: number;
+        }
+
+        interface BookCatalog {
+          [title: string]: Book;
+        }
+
+        @Component({
+          selector: 'library',
+          template: \`
+            <div>{{books['Angular Design'].~{props}}}</div>
+          \`,
+        })
+        export class Library {
+          books: BookCatalog;
+        }
+      `);
+    const location = mockHost.getLocationMarkerFor(fileName, 'props');
+    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
+    expectContain(completions, CompletionKind.PROPERTY, ['numberOfPages']);
+  });
+
   it('should be able to return attribute names with an incompete attribute', () => {
     const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'no-value-attribute');
     const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -118,12 +118,14 @@ describe('completions', () => {
   });
 
   it('should be able to get property completions for members in an array', () => {
+    mockHost.override(TEST_TEMPLATE, `{{ heroes[0].~{heroes-number-index}}}`);
     const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-number-index');
     const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
     expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
   });
 
   it('should be able to get property completions for members in an indexed type', () => {
+    mockHost.override(TEST_TEMPLATE, `{{ heroesByName['Jacky'].~{heroes-string-index}}}`);
     const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
     const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
     expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -118,49 +118,15 @@ describe('completions', () => {
   });
 
   it('should be able to get property completions for members in an array', () => {
-    const fileName = mockHost.addCode(`
-        interface Book {
-          numberOfPages: number;
-        }
-
-        @Component({
-          selector: 'library',
-          template: \`
-            <div>{{books[0].~{props}}}</div>
-          \`,
-        })
-        export class Library {
-          books: Book[];
-        }
-      `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'props');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expectContain(completions, CompletionKind.PROPERTY, ['numberOfPages']);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-number-index');
+    const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+    expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
   });
 
   it('should be able to get property completions for members in an indexed type', () => {
-    const fileName = mockHost.addCode(`
-        interface Book {
-          numberOfPages: number;
-        }
-
-        interface BookCatalog {
-          [title: string]: Book;
-        }
-
-        @Component({
-          selector: 'library',
-          template: \`
-            <div>{{books['Angular Design'].~{props}}}</div>
-          \`,
-        })
-        export class Library {
-          books: BookCatalog;
-        }
-      `);
-    const location = mockHost.getLocationMarkerFor(fileName, 'props');
-    const completions = ngLS.getCompletionsAt(fileName, location.start) !;
-    expectContain(completions, CompletionKind.PROPERTY, ['numberOfPages']);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
+    const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+    expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
   });
 
   it('should be able to return attribute names with an incompete attribute', () => {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -119,6 +119,15 @@ describe('diagnostics', () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it('should produce diagnostics for invalid index type property access', () => {
+    mockHost.override(TEST_TEMPLATE, `
+        {{heroes[0].badProperty}}`);
+    const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(diags.length).toBe(1);
+    expect(diags[0].messageText)
+        .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
+  });
+
   describe('in expression-cases.ts', () => {
     it('should report access to an unknown field', () => {
       const diags = ngLS.getDiagnostics(EXPRESSION_CASES).map(d => d.messageText);

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -190,6 +190,7 @@ export class TemplateReference {
   hero: Hero = {id: 1, name: 'Windstorm'};
   heroes: Hero[] = [this.hero];
   league: Hero[][] = [this.heroes];
+  heroesByName: {[name: string]: Hero} = {};
   anyValue: any;
   myClick(event: any) {}
 }

--- a/packages/language-service/test/project/app/test.ng
+++ b/packages/language-service/test/project/app/test.ng
@@ -8,3 +8,6 @@
   <label>name: </label>
 </div>
 &~{entity-amp}amp;
+
+{{ heroes[0].~{heroes-number-index}name }}
+{{ heroesByName['Jacky'].~{heroes-string-index}name }}

--- a/packages/language-service/test/project/app/test.ng
+++ b/packages/language-service/test/project/app/test.ng
@@ -8,6 +8,3 @@
   <label>name: </label>
 </div>
 &~{entity-amp}amp;
-
-{{ heroes[0].~{heroes-number-index}name }}
-{{ heroesByName['Jacky'].~{heroes-string-index}name }}


### PR DESCRIPTION
Previously, indexing a container type would not return completions for
the indexed type because for every TypeScript type, the recorded index
type was always marked as `undefined`, regardless of the index
signature.

This PR now returns the index type of TypeScript containers with numeric
or string index signatures. This allows use to generate completions for
arrays and defined index types:

```typescript
interface Container<T> {
  [key: string]: T;
}
const ctr: Container<T>;
ctr['stringKey']. // gives `T.` completions

const arr: T[];
arr[0]. // gives `T.` completions
```

Note that this does _not_ provide completions for properties indexed by
string literals, e.g.

```typescript
interface Container<T> {
  foo: T;
}
const ctr: Container<T>;
ctr['foo']. // does not give `T.` completions
```

Tests to `compiler-cli/src/diagnostics` have not been added, as that module appears to exclusively serve the Language Service, so in some sense Language Service tests "are enough".

Closes angular/vscode-ng-language-service#110
Closes angular/vscode-ng-language-service#277
Closes #29811 via replacement

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No