### PR TITLE
docs: add html template for sizer component in template syntax guide

### DIFF
--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1105,6 +1105,8 @@ It has a `size` value property and a companion `sizeChange` event:
 
 <code-example path="two-way-binding/src/app/sizer/sizer.component.ts" header="src/app/sizer.component.ts"></code-example>
 
+<code-example path="two-way-binding/src/app/sizer/sizer.component.html" header="src/app/sizer.component.html"></code-example>
+
 The initial `size` is an input value from a property binding.
 Clicking the buttons increases or decreases the `size`, within
 min/max value constraints,


### PR DESCRIPTION
fixes #33771

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33771

The code example for the sizer component (`src/app/sizer.component.ts`) is missing the html template in the "Template Syntax" guide.

## What is the new behavior?

A code example has been added to display the html template (`src/app/sizer.component.html`) of the sizer component in the "Template Syntax" guide.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is my first contribution. Let me know if I missed something.

I followed the instructions mentioned in the [aio/README.md](https://github.com/angular/angular/blob/master/aio/README.md) and in the [Angular Documentation Style Guide](https://angular.io/guide/docs-style-guide).
I ran `yarn setup` and `yarn serve-and-sync` to make sure that the changes work as expected.