### PR TITLE
fix(ivy): reset style property value defined using [style.prop.px]

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -585,7 +585,7 @@ function resolveStylePropValue(
   if (value === NO_CHANGE) return value;
 
   let resolvedValue: string|null = null;
-  if (value !== null) {
+  if (isStylingValueDefined(value)) {
     if (suffix) {
       // when a suffix is applied then it will bypass
       // sanitization entirely (b/c a new string is created)

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2312,32 +2312,29 @@ describe('styling', () => {
 
   it('should allow to reset style property value defined using [style.prop.px] binding', () => {
     @Component({
-      template: `
-        <div [style.left.px]="left"></div>
-        <button (click)="setLeftTo(undefined)"></button>
-        <button (click)="setLeftTo(null)"></button>
-        <button (click)="setLeftTo('')"></button>
-        <button (click)="setLeftTo('20')"></button>
-      `,
+      template: '<div [style.left.px]="left"></div>',
     })
     class MyComp {
-      left = '10';  // initial value
-      setLeftTo(value: any) { this.left = value; }
+      left = '';
     }
 
     TestBed.configureTestingModule({declarations: [MyComp]});
     const fixture = TestBed.createComponent(MyComp);
     fixture.detectChanges();
 
+    const checks = [
+      ['15', '15px'],
+      [undefined, ''],
+      [null, ''],
+      ['', ''],
+      ['0', '0px'],
+    ];
     const div = fixture.nativeElement.querySelector('div');
-
-    const expected = ['', '', '', '20px'];
-    const buttons = fixture.nativeElement.querySelectorAll('button') !;
-    expect(div.style.left).toBe('10px');  // initial value
-    Array.from(buttons).forEach((button: any, index: number) => {
-      button.click();
+    checks.forEach((check: any[]) => {
+      const [fieldValue, expectedValue] = check;
+      fixture.componentInstance.left = fieldValue;
       fixture.detectChanges();
-      expect(div.style.left).toBe(expected[index]);
+      expect(div.style.left).toBe(expectedValue);
     });
   });
 

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2310,6 +2310,37 @@ describe('styling', () => {
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('three');
   });
 
+  it('should allow to reset style property value defined using [style.prop.px] binding', () => {
+    @Component({
+      template: `
+        <div [style.left.px]="left"></div>
+        <button (click)="setLeftTo(undefined)"></button>
+        <button (click)="setLeftTo(null)"></button>
+        <button (click)="setLeftTo('')"></button>
+        <button (click)="setLeftTo('20')"></button>
+      `,
+    })
+    class MyComp {
+      left = '10';  // initial value
+      setLeftTo(value: any) { this.left = value; }
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp]});
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    const div = fixture.nativeElement.querySelector('div');
+
+    const expected = ['', '', '', '20px'];
+    const buttons = fixture.nativeElement.querySelectorAll('button') !;
+    expect(div.style.left).toBe('10px');  // initial value
+    Array.from(buttons).forEach((button: any, index: number) => {
+      button.click();
+      fixture.detectChanges();
+      expect(div.style.left).toBe(expected[index]);
+    });
+  });
+
   onlyInIvy('only ivy treats [class] in concert with other class bindings')
       .it('should retain classes added externally', () => {
         @Component({template: `<div [class]="exp"></div>`})


### PR DESCRIPTION
Prior to this change, setting style prop value to undefined or empty string would not result in resetting prop value in case the style prop is defined using [style.prop.px] syntax. The problem is that the check for empty value (and thus reseting the value) considered successful only in case of `null` value. This commit updates the check to use `isStylingValueDefined` function that also checks for undefined and empty string.

This PR resolves FW-1676.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No