### PR TITLE
fix(language-service): Function alias should be callable

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -91,29 +91,6 @@ function getDefinitionOf(info: DiagnosticTemplateInfo, ast: TemplateAst): Defini
 }
 
 /**
- * Resolve the specified `variable` from the `directives` list and return the
- * corresponding symbol. If resolution fails, return the `any` type.
- * @param variable template variable to resolve
- * @param directives template context
- * @param query
- */
-function findSymbolForVariableInDirectives(
-    variable: VariableAst, directives: DirectiveAst[], query: SymbolQuery): Symbol {
-  for (const d of directives) {
-    // Get the symbol table for the directive's StaticSymbol
-    const table = query.getTemplateContext(d.directive.type.reference);
-    if (!table) {
-      continue;
-    }
-    const symbol = table.get(variable.value);
-    if (symbol) {
-      return symbol;
-    }
-  }
-  return query.getBuiltinType(BuiltinType.Any);
-}
-
-/**
  * Resolve all variable declarations in a template by traversing the specified
  * `path`.
  * @param info
@@ -126,9 +103,8 @@ function getVarDeclarations(
     if (!(current instanceof EmbeddedTemplateAst)) {
       continue;
     }
-    const {directives, variables} = current;
-    for (const variable of variables) {
-      let symbol = findSymbolForVariableInDirectives(variable, directives, info.query);
+    for (const variable of current.variables) {
+      let symbol = info.members.get(variable.value) || info.query.getBuiltinType(BuiltinType.Any);
       const kind = info.query.getTypeKind(symbol);
       if (kind === BuiltinType.Any || kind === BuiltinType.Unbound) {
         // For special cases such as ngFor and ngIf, the any type is not very useful.

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -109,6 +109,16 @@ describe('diagnostics', () => {
         .toBe(`Identifier 'age' is not defined. 'Hero' does not contain such a member`);
   });
 
+  it('should not report error for variable initialized as class method', () => {
+    mockHost.override(TEST_TEMPLATE, `
+      <ng-template let-greet="myClick">
+        <span (click)="greet()"></span>
+      </ng-template>
+    `);
+    const diagnostics = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(diagnostics).toEqual([]);
+  });
+
   describe('in expression-cases.ts', () => {
     it('should report access to an unknown field', () => {
       const diags = ngLS.getDiagnostics(EXPRESSION_CASES).map(d => d.messageText);


### PR DESCRIPTION
This commit fixes a long standing bug whereby a template variable that
gets initialized to a class method gets resolved to the Any type, thus
when it is called the language service produces error "Member X is not
callable".

PR closes #16643
PR closes angular/vscode-ng-language-service#234

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
