### PR TITLE
fix(ivy): avoid using stale cache in TestBed if module overrides are defined

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -423,7 +423,7 @@ export function patchComponentDefWithScope<C>(
  *
  * By default this operation is memoized and the result is cached on the module's definition. You
  * can avoid memoization and previously stored results (if available) by providing the second
- * argument with the `false` value.
+ * argument with the `true` value (forcing transitive scopes recalculation).
  *
  * This function can be called on modules with components that have not fully compiled yet, but the
  * result should not be used until they have.

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Injector, Input, ModuleWithProviders, NgModule, Optional, Pipe, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
+import {Compiler, Component, Directive, ErrorHandler, Inject, Injectable, InjectionToken, Injector, Input, ModuleWithProviders, NgModule, Optional, Pipe, ViewChild, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineNgModule as defineNgModule, ɵɵtext as text} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -287,6 +287,59 @@ describe('TestBed', () => {
 
     // verify that original `ngOnDestroy` was not called
     expect(SimpleService.ngOnDestroyCalls).toBe(0);
+  });
+
+  describe('module overrides using TestBed.overrideModule', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: '...',
+    })
+    class TestComponent {
+      testField = 'default';
+    }
+
+    @NgModule({
+      declarations: [TestComponent],
+      exports: [TestComponent],
+    })
+    class TestModule {
+    }
+
+    @Component({
+      selector: 'app-root',
+      template: `<test-cmp #testCmpCtrl></test-cmp>`,
+    })
+    class AppComponent {
+      @ViewChild('testCmpCtrl', {static: true}) testCmpCtrl !: TestComponent;
+    }
+
+    @NgModule({
+      declarations: [AppComponent],
+      imports: [TestModule],
+    })
+    class AppModule {
+    }
+    @Component({
+      selector: 'test-cmp',
+      template: '...',
+    })
+    class MockTestComponent {
+      testField = 'overwritten';
+    }
+
+    it('should allow declarations override', () => {
+      TestBed.configureTestingModule({
+        imports: [AppModule],
+      });
+      // replace TestComponent with MockTestComponent
+      TestBed.overrideModule(TestModule, {
+        remove: {declarations: [TestComponent], exports: [TestComponent]},
+        add: {declarations: [MockTestComponent], exports: [MockTestComponent]}
+      });
+      const fixture = TestBed.createComponent(AppComponent);
+      const app = fixture.componentInstance;
+      expect(app.testCmpCtrl.testField).toBe('overwritten');
+    });
   });
 
   describe('multi providers', () => {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -341,13 +341,8 @@ export class R3TestBedCompiler {
             // are present, always re-calculate transitive scopes to have the most up-to-date
             // information available. The `moduleToScope` map avoids repeated re-calculation of
             // scopes for the same module.
-            const ignoreCache = !isTestingModule && this.hasModuleOverrides;
-            if (ignoreCache) {
-              // Calling `transitiveScopesFor` may change the `transitiveCompileScopes` field on
-              // NgModule def. Preserve current def, so we can restore it back to original value.
-              this.maybeStoreNgDef(NG_MOD_DEF, realType);
-            }
-            moduleToScope.set(moduleType, transitiveScopesFor(realType, ignoreCache));
+            const forceRecalc = !isTestingModule && this.hasModuleOverrides;
+            moduleToScope.set(moduleType, transitiveScopesFor(realType, forceRecalc));
           }
           return moduleToScope.get(moduleType) !;
         };


### PR DESCRIPTION
NgModule compilation in JIT mode (that is also used in TestBed) caches module scopes on NgModule defs (using `transitiveCompileScopes` field). Module overrides (defined via TestBed.overrideModule) may invalidate this data by adding/removing items in `declarations` list. This commit forces TestBed to recalculate transitive scopes in case module overrides are present, so TestBed always gets the most up-to-date information.

This PR resolves #33735.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No