### PR TITLE
Add API doc to secondary package entry points

### DIFF
--- a/packages/animations/browser/PACKAGE.md
+++ b/packages/animations/browser/PACKAGE.md
@@ -1,0 +1,1 @@
+Provides infrastructure for cross-platform rendering of animations in a browser.

--- a/packages/animations/browser/testing/PACKAGE.md
+++ b/packages/animations/browser/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Provides infrastructure for testing of the Animations browser subsystem.

--- a/packages/animations/test/PACKAGE.md
+++ b/packages/animations/test/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for the Angular Animations driver.

--- a/packages/animations/test/PACKAGE.md
+++ b/packages/animations/test/PACKAGE.md
@@ -1,1 +1,0 @@
-Supplies a testing module for the Angular Animations driver.

--- a/packages/common/PACKAGE.md
+++ b/packages/common/PACKAGE.md
@@ -1,3 +1,3 @@
-Implements basic Angular directives and pipes, such as NgIf, NgForOf, DecimalPipe, and so on. 
+Implements basic Angular directives and pipes, such as `NgIf`, `NgForOf`, `DecimalPipe`, and so on.
 
 The `CommonModule` exports are re-exported by `BrowserModule`, which is included automatically in the root `AppModule` when you create a new app with the CLI `new` command.

--- a/packages/common/PACKAGE.md
+++ b/packages/common/PACKAGE.md
@@ -1,3 +1,3 @@
-Implements basic Angular directives and pipes, such as `NgIf`, `NgForOf`, `DecimalPipe`, and so on.
+Implements fundamental Angular framework functionality, including directives and pipes, location services used in routing, HTTP services, localization support, and so on.
 
 The `CommonModule` exports are re-exported by `BrowserModule`, which is included automatically in the root `AppModule` when you create a new app with the CLI `new` command.

--- a/packages/common/http/testing/PACKAGE.md
+++ b/packages/common/http/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for the Angular HTTP subsystem.

--- a/packages/common/testing/PACKAGE.md
+++ b/packages/common/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for basic Angular directives.

--- a/packages/common/testing/PACKAGE.md
+++ b/packages/common/testing/PACKAGE.md
@@ -1,1 +1,1 @@
-Supplies a testing module for basic Angular directives.
+Supplies infrastructure for testing functionality supplied by `@angular/common`.

--- a/packages/common/upgrade/PACKAGE.md
+++ b/packages/common/upgrade/PACKAGE.md
@@ -1,0 +1,2 @@
+Provides tools for upgrading from the `$location` service provided in AngularJS
+to Angular's [unified location service](guide/upgrade#using-the-unified-angular-location-service).

--- a/packages/core/testing/PACKAGE.md
+++ b/packages/core/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Provides infrastructure for testing Angular core functionality.

--- a/packages/platform-browser-dynamic/PACKAGE.md
+++ b/packages/platform-browser-dynamic/PACKAGE.md
@@ -1,0 +1,1 @@
+Supports [JIT](guide/glossary#jit) compilation and execution of Angular apps on different supported browsers.

--- a/packages/platform-browser-dynamic/testing/PACKAGE.md
+++ b/packages/platform-browser-dynamic/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for the Angular JIT platform-browser subsystem.

--- a/packages/platform-browser/animations/PACKAGE.md
+++ b/packages/platform-browser/animations/PACKAGE.md
@@ -1,0 +1,1 @@
+Provides infrastructure for the rendering of animations in supported browsers.

--- a/packages/platform-browser/testing/PACKAGE.md
+++ b/packages/platform-browser/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for the Angular platform-browser subsystem.

--- a/packages/platform-server/testing/PACKAGE.md
+++ b/packages/platform-server/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies a testing module for the Angular platform server subsystem.

--- a/packages/platform-webworker/PACKAGE.md
+++ b/packages/platform-webworker/PACKAGE.md
@@ -1,0 +1,2 @@
+**Deprecated** This package is deprecated and will be removed in version 10.
+See [Angular deprecations policy](guide/deprecations).

--- a/packages/upgrade/PACKAGE.md
+++ b/packages/upgrade/PACKAGE.md
@@ -1,2 +1,3 @@
-Supports the upgrade path from AngularJS to Angular, allowing
-components from both systems to be used in the same application.
+**Deprecated** Provided support for upgrading applications from Angular JS to Angular.
+Use `upgrade/static` package instead.
+See [Angular deprecation policy](guide/deprecations).

--- a/packages/upgrade/PACKAGE.md
+++ b/packages/upgrade/PACKAGE.md
@@ -1,3 +1,5 @@
-**Deprecated** Provided support for upgrading applications from Angular JS to Angular.
-Use `upgrade/static` package instead.
+Provides support for upgrading applications from Angular JS to Angular.
+The primary entry point is deprecated. Use the secondary entry point,
+ `upgrade/static`.
+
 See [Angular deprecation policy](guide/deprecations).

--- a/packages/upgrade/static/PACKAGE.md
+++ b/packages/upgrade/static/PACKAGE.md
@@ -1,0 +1,2 @@
+Supports the upgrade path from AngularJS to Angular, allowing
+components from both systems to be used in the same application.

--- a/packages/upgrade/static/PACKAGE.md
+++ b/packages/upgrade/static/PACKAGE.md
@@ -1,2 +1,2 @@
 Supports the upgrade path from AngularJS to Angular, allowing
-components from both systems to be used in the same application.
+components and services from both systems to be used in the same application.

--- a/packages/upgrade/static/testing/PACKAGE.md
+++ b/packages/upgrade/static/testing/PACKAGE.md
@@ -1,0 +1,1 @@
+Supplies testing functions for the AngularJS-to-Angular upgrade path.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
 API doc for package pages missing from sub-packages

Issue Number: N/A


## What is the new behavior?
Doc added to all package pages 
https://angular.io/api?type=package

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
