### PR TITLE
fix(language-service): Recompute analyzed modules only when source files change

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -192,7 +192,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   }
 
   /**
-   * Checks whether the program has changed, and invalidate caches if it has.
+   * Checks whether the program has changed, and invalidate static symbols in
+   * the source files that have changed.
    * Returns true if modules are up-to-date, false otherwise.
    * This should only be called by getAnalyzedModules().
    */
@@ -203,30 +204,46 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     }
     this.lastProgram = program;
 
-    // Invalidate file that have changed in the static symbol resolver
+    // Even though the program has changed, it could be the case that none of
+    // the source files have changed. If all source files remain the same, then
+    // program is still up-to-date, and we should not invalidate caches.
+    let filesAdded = 0;
+    const filesChangedOrRemoved: string[] = [];
+
+    // Check if any source files have been added / changed since last computation.
     const seen = new Set<string>();
-    for (const sourceFile of program.getSourceFiles()) {
-      const fileName = sourceFile.fileName;
+    for (const {fileName} of program.getSourceFiles()) {
       seen.add(fileName);
       const version = this.tsLsHost.getScriptVersion(fileName);
       const lastVersion = this.fileVersions.get(fileName);
-      this.fileVersions.set(fileName, version);
-      // Should not invalidate file on the first encounter or if file hasn't changed
-      if (lastVersion !== undefined && version !== lastVersion) {
-        const symbols = this.staticSymbolResolver.invalidateFile(fileName);
-        this.reflector.invalidateSymbols(symbols);
+      if (lastVersion === undefined) {
+        filesAdded++;
+        this.fileVersions.set(fileName, version);
+      } else if (version !== lastVersion) {
+        filesChangedOrRemoved.push(fileName);  // changed
+        this.fileVersions.set(fileName, version);
       }
     }
 
-    // Remove file versions that are no longer in the program and invalidate them.
-    const missing = Array.from(this.fileVersions.keys()).filter(f => !seen.has(f));
-    missing.forEach(f => {
-      this.fileVersions.delete(f);
-      const symbols = this.staticSymbolResolver.invalidateFile(f);
-      this.reflector.invalidateSymbols(symbols);
-    });
+    // Check if any source files have been removed since last computation.
+    for (const [fileName] of this.fileVersions) {
+      if (!seen.has(fileName)) {
+        filesChangedOrRemoved.push(fileName);  // removed
+        // Because Maps are iterated in insertion order, it is safe to delete
+        // entries from the same map while iterating.
+        // See https://stackoverflow.com/questions/35940216 and
+        // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-map.prototype.foreach
+        this.fileVersions.delete(fileName);
+      }
+    }
 
-    return false;
+    for (const fileName of filesChangedOrRemoved) {
+      const symbols = this.staticSymbolResolver.invalidateFile(fileName);
+      this.reflector.invalidateSymbols(symbols);
+    }
+
+    // Program is up-to-date iff no files are added, changed, or removed.
+    return filesAdded === 0 && filesChangedOrRemoved.length === 0;
   }
 
   /**

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -114,9 +114,7 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
 
   override(fileName: string, content: string) {
     this.scriptVersion.set(fileName, (this.scriptVersion.get(fileName) || 0) + 1);
-    if (fileName.endsWith('.ts')) {
-      this.projectVersion++;
-    }
+    this.projectVersion++;
     if (content) {
       this.overrides.set(fileName, content);
       this.overrideDirectory.add(path.dirname(fileName));

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -50,7 +50,7 @@ describe('TypeScriptServiceHost', () => {
     expect(analyzedModules.files.length).toBe(0);
     expect(analyzedModules.ngModules.length).toBe(0);
     expect(analyzedModules.ngModuleByPipeOrDirective.size).toBe(0);
-    expect(analyzedModules.symbolsMissingModule).toEqual([]);
+    expect(analyzedModules.symbolsMissingModule).toBeUndefined();
   });
 
   it('should clear the caches if new script is added', () => {
@@ -166,8 +166,14 @@ describe('TypeScriptServiceHost', () => {
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
     const oldModules = ngLSHost.getAnalyzedModules();
+    const oldProgram = ngLSHost.program;
     tsLSHost.override('/app/test.ng', '<div></div>');
     const newModules = ngLSHost.getAnalyzedModules();
+    const newProgram = ngLSHost.program;
+    // Assert that the program has changed because external template was updated
+    expect(newProgram).not.toBe(oldProgram);
+    // But, analyzed modules should remain the same because none of the source
+    // files have changed.
     expect(newModules).toBe(oldModules);
   });
 


### PR DESCRIPTION
This commit fixes a bug brought up by @andrius-pra whereby the language
service host would recompute the analyzed modules even when none of the
source files changes. This is due to a bug in our unit test that
precludes non-TS files from incrementing the project version.
Consequently, when the external template is updated, the program remains
the same.

With the bug fixed, the next step is to figure out if any source files
have been added / changed / removed since the last computation. The
previously analyzed could be safely retained only when none of these
operations happen.

Note: This restores the behavior @andrius-pra fixed in https://github.com/angular/angular/pull/32562 but regressed in https://github.com/angular/angular/pull/32543

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
