### PR TITLE
fix(language-service): Remove getTemplateReferences() from LanguageService API

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -28,11 +28,6 @@ export function createLanguageService(host: TypeScriptServiceHost): LanguageServ
 class LanguageServiceImpl implements LanguageService {
   constructor(private readonly host: TypeScriptServiceHost) {}
 
-  getTemplateReferences(): string[] {
-    this.host.getAnalyzedModules();  // same role as 'synchronizeHostData'
-    return this.host.getTemplateReferences();
-  }
-
   getDiagnostics(fileName: string): tss.Diagnostic[] {
     const analyzedModules = this.host.getAnalyzedModules();  // same role as 'synchronizeHostData'
     const results: Diagnostic[] = [];

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -44,7 +44,6 @@ export function getExternalFiles(project: tss.server.Project): string[] {
     // Without an Angular host there is no way to get template references.
     return [];
   }
-  ngLSHost.getAnalyzedModules();
   const templates = ngLSHost.getTemplateReferences();
   const logger = project.projectService.logger;
   if (logger.hasLevel(tss.server.LogLevel.verbose)) {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -394,11 +394,6 @@ export interface Hover {
  */
 export interface LanguageService {
   /**
-   * Returns a list of all the external templates referenced by the project.
-   */
-  getTemplateReferences(): string[];
-
-  /**
    * Returns a list of all error for all templates in the given file.
    */
   getDiagnostics(fileName: string): ts.Diagnostic[];

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -144,7 +144,10 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     return this.resolver.getReflector() as StaticReflector;
   }
 
-  getTemplateReferences(): string[] { return [...this.templateReferences]; }
+  getTemplateReferences(): string[] {
+    this.getAnalyzedModules();
+    return [...this.templateReferences];
+  }
 
   /**
    * Checks whether the program has changed and returns all analyzed modules.

--- a/packages/language-service/test/language_service_spec.ts
+++ b/packages/language-service/test/language_service_spec.ts
@@ -14,7 +14,7 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 import {MockTypescriptHost} from './test_utils';
 
 describe('service without angular', () => {
-  const mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts']);
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const service = ts.createLanguageService(mockHost);
   const ngHost = new TypeScriptServiceHost(mockHost, service);
   const ngService = createLanguageService(ngHost);
@@ -23,8 +23,6 @@ describe('service without angular', () => {
 
   beforeEach(() => { mockHost.reset(); });
 
-  it('should not crash a get template references',
-     () => { expect(() => ngService.getTemplateReferences()).not.toThrow(); });
   it('should not crash a get diagnostics',
      () => { expect(() => ngService.getDiagnostics(fileName)).not.toThrow(); });
 

--- a/packages/language-service/test/template_references_spec.ts
+++ b/packages/language-service/test/template_references_spec.ts
@@ -8,8 +8,6 @@
 
 import * as ts from 'typescript';
 
-import {createLanguageService} from '../src/language_service';
-import {LanguageService} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
@@ -18,15 +16,13 @@ describe('references', () => {
   const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const service = ts.createLanguageService(mockHost);
   const ngHost = new TypeScriptServiceHost(mockHost, service);
-  const ngService = createLanguageService(ngHost);
 
   beforeEach(() => { mockHost.reset(); });
 
-  it('should be able to get template references',
-     () => { expect(() => ngService.getTemplateReferences()).not.toThrow(); });
-
-  it('should be able to determine that test.ng is a template reference',
-     () => { expect(ngService.getTemplateReferences()).toContain('/app/test.ng'); });
+  it('should be able to determine that test.ng is a template reference', () => {
+    const templates = ngHost.getTemplateReferences();
+    expect(templates).toEqual(['/app/test.ng']);
+  });
 
   it('should be able to get template references for an invalid project', () => {
     const moduleCode = `
@@ -42,7 +38,8 @@ describe('references', () => {
     `;
     mockHost.addScript('/app/test.module.ts', moduleCode);
     mockHost.addScript('/app/test.component.ts', classCode);
-    expect(() => { ngService.getTemplateReferences(); }).not.toThrow();
+    const templates = ngHost.getTemplateReferences();
+    expect(templates).toEqual(['/app/test.ng']);
   });
 
 });


### PR DESCRIPTION
The method `getTemplateReferences()` appears in both the `LanguageService`
interface and `LanguageServiceHost` interface. It should belong in the
latter and not the former, since the former deals with the semantics of
the language and not the mechanics.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
