### PR TITLE
build: fix ng_rollup_bundle es2015 bundling

### DIFF
--- a/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
+++ b/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
@@ -405,9 +405,9 @@ def ng_rollup_bundle(name, **kwargs):
         visibility = visibility,
         **kwargs
     )
-    terser_minified(name = name + ".min", src = name + "", visibility = visibility, **common_terser_args)
+    terser_minified(name = name + ".min", src = name, visibility = visibility, **common_terser_args)
     native.filegroup(name = name + ".min.js", srcs = [name + ".min"], visibility = visibility)
-    terser_minified(name = name + ".min_debug", src = name + "", debug = True, visibility = visibility, **common_terser_args)
+    terser_minified(name = name + ".min_debug", src = name, debug = True, visibility = visibility, **common_terser_args)
     native.filegroup(name = name + ".min_debug.js", srcs = [name + ".min_debug"], visibility = visibility)
     npm_package_bin(
         name = "_%s_brotli" % name,
@@ -428,9 +428,9 @@ def ng_rollup_bundle(name, **kwargs):
         visibility = visibility,
         **kwargs
     )
-    terser_minified(name = name + ".min.es2015", src = name + "", visibility = visibility, **common_terser_args)
+    terser_minified(name = name + ".min.es2015", src = name + ".es2015", visibility = visibility, **common_terser_args)
     native.filegroup(name = name + ".min.es2015.js", srcs = [name + ".min.es2015"], visibility = visibility)
-    terser_minified(name = name + ".min_debug.es2015", src = name + "", debug = True, visibility = visibility, **common_terser_args)
+    terser_minified(name = name + ".min_debug.es2015", src = name + ".es2015", debug = True, visibility = visibility, **common_terser_args)
     native.filegroup(name = name + ".min_debug.es2015.js", srcs = [name + ".min_debug.es2015"], visibility = visibility)
     npm_package_bin(
         name = "_%s_es2015_brotli" % name,


### PR DESCRIPTION
This fixes an issue bundling es2015 with ng_rollup_bundle that was covered up by a typo when refactoring ng_rollup_bundle to not use legacy rollup_bundle internals and to use the new terser_minified rule and npm_package_bin to call brotli.

Note: ng_rollup_bundle is only used in the angular repo and not externally so this issue does not affect users

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
