### PR TITLE
Remove find component view

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -10,17 +10,14 @@ import {Injector} from '../di';
 import {getViewComponent} from '../render3/global_utils_api';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from '../render3/interfaces/container';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/node';
-import {StylingMapArray, TStylingContext} from '../render3/interfaces/styling';
 import {isComponentHost, isLContainer} from '../render3/interfaces/type_checks';
-import {LView, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
-import {NodeStylingDebug} from '../render3/styling/styling_debug';
+import {DECLARATION_COMPONENT_VIEW, LView, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from '../render3/util/misc_utils';
-import {isStylingContext, stylingMapToStringMap} from '../render3/util/styling_utils';
-import {findComponentView} from '../render3/util/view_traversal_utils';
 import {getComponentLViewByIndex, getNativeByTNodeOrNull} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
+
 import {createProxy} from './proxy';
 
 
@@ -533,7 +530,7 @@ function _queryNodeChildrenR3(
   } else if (tNode.type === TNodeType.Projection) {
     // Case 3: the TNode is a projection insertion point (i.e. a <ng-content>).
     // The nodes projected at this location all need to be processed.
-    const componentView = findComponentView(lView !);
+    const componentView = lView ![DECLARATION_COMPONENT_VIEW];
     const componentHost = componentView[T_HOST] as TElementNode;
     const head: TNode|null =
         (componentHost.projection as(TNode | null)[])[tNode.projection as number];

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -21,14 +21,13 @@ import {DirectiveDef, FactoryFn} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
 import {AttributeMarker, TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TNode, TNodeProviderIndexes, TNodeType} from './interfaces/node';
 import {isComponentDef, isComponentHost} from './interfaces/type_checks';
-import {DECLARATION_VIEW, INJECTOR, LView, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, INJECTOR, LView, TData, TVIEW, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {enterDI, leaveDI} from './state';
 import {isNameOnlyAttributeMarker} from './util/attrs_utils';
 import {getParentInjectorIndex, getParentInjectorView, hasParentInjector} from './util/injector_utils';
 import {stringifyForError} from './util/misc_utils';
 import {getInitialStylingValue} from './util/styling_utils';
-import {findComponentView} from './util/view_traversal_utils';
 
 
 
@@ -358,7 +357,7 @@ export function getOrCreateInjectable<T>(
       let injectorIndex = getInjectorIndex(tNode, lView);
       let parentLocation: RelativeInjectorLocation = NO_PARENT_INJECTOR;
       let hostTElementNode: TNode|null =
-          flags & InjectFlags.Host ? findComponentView(lView)[T_HOST] : null;
+          flags & InjectFlags.Host ? lView[DECLARATION_COMPONENT_VIEW][T_HOST] : null;
 
       // If we should skip this injector, or if there is no injector on this node, start by
       // searching

--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -8,12 +8,10 @@
 import {newArray} from '../../util/array_utils';
 import {TAttributes, TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {ProjectionSlots} from '../interfaces/projection';
-import {TVIEW, T_HOST} from '../interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, TVIEW, T_HOST} from '../interfaces/view';
 import {applyProjection} from '../node_manipulation';
 import {getProjectAsAttrValue, isNodeMatchingSelectorList, isSelectorInSelectorList} from '../node_selector_matcher';
 import {getLView, setIsNotParent} from '../state';
-import {findComponentView} from '../util/view_traversal_utils';
-
 import {getOrCreateTNode} from './shared';
 
 
@@ -75,7 +73,7 @@ export function matchingProjectionSlotIndex(tNode: TNode, projectionSlots: Proje
  * @codeGenApi
  */
 export function ɵɵprojectionDef(projectionSlots?: ProjectionSlots): void {
-  const componentNode = findComponentView(getLView())[T_HOST] as TElementNode;
+  const componentNode = getLView()[DECLARATION_COMPONENT_VIEW][T_HOST] as TElementNode;
 
   if (!componentNode.projection) {
     // If no explicit projection slots are defined, fall back to a single

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -173,9 +173,11 @@ export function createLView<T>(
   lView[SANITIZER] = sanitizer || parentLView && parentLView[SANITIZER] || null !;
   lView[INJECTOR as any] = injector || parentLView && parentLView[INJECTOR] || null;
   lView[T_HOST] = tHostNode;
-  lView[DECLARATION_COMPONENT_VIEW] = tView.type == TViewType.Embedded ?
-      (parentLView === null ? null : parentLView ![DECLARATION_COMPONENT_VIEW]) :
-      lView;
+  ngDevMode && assertEqual(
+                   tView.type == TViewType.Embedded ? parentLView !== null : true, true,
+                   'Embedded views must have parentLView');
+  lView[DECLARATION_COMPONENT_VIEW] =
+      tView.type == TViewType.Embedded ? parentLView ![DECLARATION_COMPONENT_VIEW] : lView;
   ngDevMode && attachLViewDebug(lView);
   return lView;
 }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -265,7 +265,7 @@ export interface LView extends Array<any> {
    *   - `LView[DECLARATION_LCONTAINER]` similar problem for queries
    *   - `LContainer[MOVED_VIEWS]` similar problem for queries
    */
-  [DECLARATION_COMPONENT_VIEW]: LView|null;
+  [DECLARATION_COMPONENT_VIEW]: LView;
 
   /**
    * A declaration point of embedded views (ones instantiated based on the content of a

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -20,7 +20,7 @@ import {ProceduralRenderer3, RElement, RNode, RText, Renderer3, isProceduralRend
 import {isLContainer, isLView, isRootView} from './interfaces/type_checks';
 import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, FLAGS, HOST, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, T_HOST, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
-import {findComponentView, getLViewParent} from './util/view_traversal_utils';
+import {getLViewParent} from './util/view_traversal_utils';
 import {getNativeByTNode, unwrapRNode} from './util/view_utils';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
@@ -261,7 +261,7 @@ function trackMovedView(declarationContainer: LContainer, lView: LView) {
   const movedViews = declarationContainer[MOVED_VIEWS];
   const insertedLContainer = lView[PARENT] as LContainer;
   ngDevMode && assertLContainer(insertedLContainer);
-  const insertedComponentLView = insertedLContainer[PARENT] ![DECLARATION_COMPONENT_VIEW] !;
+  const insertedComponentLView = insertedLContainer[PARENT] ![DECLARATION_COMPONENT_VIEW];
   ngDevMode && assertDefined(insertedComponentLView, 'Missing insertedComponentLView');
   const insertedComponentIsOnPush =
       (insertedComponentLView[FLAGS] & LViewFlags.CheckAlways) !== LViewFlags.CheckAlways;
@@ -695,7 +695,7 @@ function getFirstNativeNode(lView: LView, tNode: TNode | null): RNode|null {
         return getNativeByTNode(tNode, lView);
       }
     } else {
-      const componentView = findComponentView(lView);
+      const componentView = lView[DECLARATION_COMPONENT_VIEW];
       const componentHost = componentView[T_HOST] as TElementNode;
       const parentView = getLViewParent(componentView);
       const firstProjectedTNode: TNode|null =
@@ -846,7 +846,7 @@ export function applyProjection(lView: LView, tProjectionNode: TProjectionNode) 
 function applyProjectionRecursive(
     renderer: Renderer3, action: WalkTNodeTreeAction, lView: LView,
     tProjectionNode: TProjectionNode, renderParent: RElement | null, beforeNode: RNode | null) {
-  const componentLView = findComponentView(lView);
+  const componentLView = lView[DECLARATION_COMPONENT_VIEW];
   const componentNode = componentLView[T_HOST] as TElementNode;
   ngDevMode &&
       assertEqual(typeof tProjectionNode.projection, 'number', 'expecting projection index');

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -8,12 +8,9 @@
 
 import {assertDefined} from '../../util/assert';
 import {assertLView} from '../assert';
-import {TNodeType} from '../interfaces/node';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {CONTEXT, DECLARATION_VIEW, FLAGS, LView, LViewFlags, PARENT, RootContext, T_HOST} from '../interfaces/view';
-
+import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, RootContext} from '../interfaces/view';
 import {readPatchedLView} from './view_utils';
-
 
 
 /**
@@ -38,29 +35,6 @@ export function getRootView(componentOrLView: LView | {}): LView {
   let lView = isLView(componentOrLView) ? componentOrLView : readPatchedLView(componentOrLView) !;
   while (lView && !(lView[FLAGS] & LViewFlags.IsRoot)) {
     lView = getLViewParent(lView) !;
-  }
-  ngDevMode && assertLView(lView);
-  return lView;
-}
-
-/**
- * Given an `LView`, find the closest declaration view which is not an embedded view.
- *
- * This method searches for the `LView` associated with the component which declared the `LView`.
- *
- * This function may return itself if the `LView` passed in is not an embedded `LView`. Otherwise
- * it walks the declaration parents until it finds a component view (non-embedded-view.)
- *
- * @param lView LView for which we want a host element node
- * @returns The host node
- */
-export function findComponentView(lView: LView): LView {
-  let rootTNode = lView[T_HOST];
-  let declaredView: LView|null;
-  while (rootTNode !== null && rootTNode.type === TNodeType.View &&
-         (declaredView = lView[DECLARATION_VIEW]) !== null) {
-    lView = declaredView;
-    rootTNode = lView[T_HOST];
   }
   ngDevMode && assertLView(lView);
   return lView;

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -25,13 +25,12 @@ import {ActiveIndexFlag, CONTAINER_HEADER_OFFSET, LContainer, VIEW_REFS} from '.
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RComment, RElement, isProceduralRenderer} from './interfaces/renderer';
 import {isComponentHost, isLContainer, isLView, isRootView} from './interfaces/type_checks';
-import {DECLARATION_LCONTAINER, LView, LViewFlags, QUERIES, RENDERER, TView, T_HOST} from './interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, LView, LViewFlags, QUERIES, RENDERER, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode, removeView} from './node_manipulation';
 import {getParentInjectorTNode} from './node_util';
 import {getLView, getPreviousOrParentTNode} from './state';
 import {getParentInjectorView, hasParentInjector} from './util/injector_utils';
-import {findComponentView} from './util/view_traversal_utils';
 import {getComponentLViewByIndex, getNativeByTNode, setLContainerActiveIndex, unwrapRNode, viewAttachedToContainer} from './util/view_utils';
 import {ViewRef} from './view_ref';
 
@@ -389,7 +388,7 @@ function createViewRef(tNode: TNode, lView: LView, isPipe: boolean): ViewEngine_
       tNode.type === TNodeType.ElementContainer) {
     // The LView represents the location where the injection is requested from.
     // We need to locate the containing LView (in case where the `lView` is an embedded view)
-    const hostComponentView = findComponentView(lView);  // look up
+    const hostComponentView = lView[DECLARATION_COMPONENT_VIEW];  // look up
     return new ViewRef(hostComponentView, lView);
   }
   return null !;

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -15,10 +15,10 @@ import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootVie
 import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {isLContainer} from './interfaces/type_checks';
-import {CONTEXT, FLAGS, HOST, LView, LViewFlags, TVIEW, T_HOST} from './interfaces/view';
+import {CONTEXT, DECLARATION_COMPONENT_VIEW, FLAGS, HOST, LView, LViewFlags, TVIEW, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {destroyLView, renderDetachView} from './node_manipulation';
-import {findComponentView, getLViewParent} from './util/view_traversal_utils';
+import {getLViewParent} from './util/view_traversal_utils';
 import {unwrapRNode} from './util/view_utils';
 
 
@@ -331,7 +331,7 @@ function collectNativeNodes(
     if (tNodeType === TNodeType.ElementContainer || tNodeType === TNodeType.IcuContainer) {
       collectNativeNodes(lView, tNode.child, result);
     } else if (tNodeType === TNodeType.Projection) {
-      const componentView = findComponentView(lView);
+      const componentView = lView[DECLARATION_COMPONENT_VIEW];
       const componentHost = componentView[T_HOST] as TElementNode;
       const parentView = getLViewParent(componentView);
       let firstProjectedNode: TNode|null =

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -273,9 +273,6 @@
     "name": "findAttrIndexInNode"
   },
   {
-    "name": "findComponentView"
-  },
-  {
     "name": "findDirectiveMatches"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -228,9 +228,6 @@
     "name": "extractPipeDef"
   },
   {
-    "name": "findComponentView"
-  },
-  {
     "name": "generateExpandoInstructionBlock"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -576,9 +576,6 @@
     "name": "findAttrIndexInNode"
   },
   {
-    "name": "findComponentView"
-  },
-  {
     "name": "findDirectiveMatches"
   },
   {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -223,7 +223,7 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
-          null, createTView(TViewType.Embedded, -1, null, 1, 0, null, null, null, null, null), {},
+          null, createTView(TViewType.Component, -1, null, 1, 0, null, null, null, null, null), {},
           LViewFlags.CheckAlways, null, null, {} as any, {} as any);
       enterView(contentView, null);
       try {


### PR DESCRIPTION
This PR is on top of https://github.com/angular/angular/pull/33702 review only last commit named:
```
refactor(ivy): Remove `findComponentView` since we now store it in `LView[DECLARATION_COMPONENT_VIEW]`
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
