### PR TITLE
docs(platform-webworker): mark all public APIs as deprecated

### DIFF
--- a/packages/platform-webworker/src/web_workers/shared/client_message_broker.ts
+++ b/packages/platform-webworker/src/web_workers/shared/client_message_broker.ts
@@ -144,6 +144,7 @@ interface ResponseMessageData {
 
 /**
  * @publicApi
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
  */
 export class FnArg {
   constructor(
@@ -152,6 +153,7 @@ export class FnArg {
 
 /**
  * @publicApi
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
  */
 export class UiArguments {
   constructor(public method: string, public args?: FnArg[]) {}

--- a/packages/platform-webworker/src/web_workers/shared/message_bus.ts
+++ b/packages/platform-webworker/src/web_workers/shared/message_bus.ts
@@ -53,6 +53,7 @@ export abstract class MessageBus implements MessageBusSource, MessageBusSink {
 
 /**
  * @publicApi
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
  */
 export interface MessageBusSource {
   /**
@@ -79,6 +80,7 @@ export interface MessageBusSource {
 
 /**
  * @publicApi
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
  */
 export interface MessageBusSink {
   /**

--- a/packages/platform-webworker/src/worker_render.ts
+++ b/packages/platform-webworker/src/worker_render.ts
@@ -150,6 +150,7 @@ function initWebWorkerRenderPlatform(injector: Injector): () => void {
 
 /**
  * @publicApi
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
  */
 export const platformWorkerUi =
     createPlatformFactory(platformCore, 'workerUi', _WORKER_UI_PLATFORM_PROVIDERS);

--- a/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
+++ b/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
@@ -11,6 +11,7 @@ export declare class ClientMessageBrokerFactory {
     createMessageBroker(channel: string, runInZone?: boolean): ClientMessageBroker;
 }
 
+/** @deprecated */
 export declare class FnArg {
     type: Type<any> | SerializerTypes;
     value: any;
@@ -25,12 +26,14 @@ export declare abstract class MessageBus implements MessageBusSource, MessageBus
     abstract to(channel: string): EventEmitter<any>;
 }
 
+/** @deprecated */
 export interface MessageBusSink {
     attachToZone(zone: NgZone): void;
     initChannel(channel: string, runInZone: boolean): void;
     to(channel: string): EventEmitter<any>;
 }
 
+/** @deprecated */
 export interface MessageBusSource {
     attachToZone(zone: NgZone): void;
     from(channel: string): EventEmitter<any>;
@@ -40,6 +43,7 @@ export interface MessageBusSource {
 /** @deprecated */
 export declare const platformWorkerApp: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
 
+/** @deprecated */
 export declare const platformWorkerUi: (extraProviders?: StaticProvider[] | undefined) => import("@angular/core").PlatformRef;
 
 /** @deprecated */
@@ -67,6 +71,7 @@ export declare class ServiceMessageBrokerFactory {
     createMessageBroker(channel: string, runInZone?: boolean): ServiceMessageBroker;
 }
 
+/** @deprecated */
 export declare class UiArguments {
     args?: FnArg[] | undefined;
     method: string;


### PR DESCRIPTION
In ccc76f749, `@angular/platform-webworker` and `@angular/platform-webworker-dynamic` were deprecated (i.e. by deprecating all their public APIs). However, some public `@angular/platform-webworker` APIs were accidentally missed, additionally resulting in the package itself not showing up as deprecated on angular.io.

This commit fixes it by marking those remaining public APIs as deprecated.
