### PR TITLE
docs(ivy): improve the missing `$localize` error message

### DIFF
--- a/integration/side-effects/snapshots/core/esm2015.js
+++ b/integration/side-effects/snapshots/core/esm2015.js
@@ -13,5 +13,5 @@ const __global = "undefined" !== typeof global && global;
 const _global = __globalThis || __global || __window || __self;
 
 if (ngDevMode) _global.$localize = _global.$localize || function() {
-    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please run `ng add @angular/localize` from the Angular CLI.\n" + "(For non-CLI projects, add `import '@angular/localize/init';` to your polyfills.ts file)");
+    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please run `ng add @angular/localize` from the Angular CLI.\n" + "(For non-CLI projects, add `import '@angular/localize/init';` to your `polyfills.ts` file.\n" + "For server-side rendering applications add the import to your `main.server.ts` file.)");
 };

--- a/integration/side-effects/snapshots/core/esm5.js
+++ b/integration/side-effects/snapshots/core/esm5.js
@@ -15,5 +15,5 @@ var __global = "undefined" !== typeof global && global;
 var _global = __globalThis || __global || __window || __self;
 
 if (ngDevMode) _global.$localize = _global.$localize || function() {
-    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please run `ng add @angular/localize` from the Angular CLI.\n" + "(For non-CLI projects, add `import '@angular/localize/init';` to your polyfills.ts file)");
+    throw new Error("It looks like your application or one of its dependencies is using i18n.\n" + "Angular 9 introduced a global `$localize()` function that needs to be loaded.\n" + "Please run `ng add @angular/localize` from the Angular CLI.\n" + "(For non-CLI projects, add `import '@angular/localize/init';` to your `polyfills.ts` file.\n" + "For server-side rendering applications add the import to your `main.server.ts` file.)");
 };

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -48,6 +48,7 @@ if (ngDevMode) {
         'It looks like your application or one of its dependencies is using i18n.\n' +
         'Angular 9 introduced a global `$localize()` function that needs to be loaded.\n' +
         'Please run `ng add @angular/localize` from the Angular CLI.\n' +
-        '(For non-CLI projects, add `import \'@angular/localize/init\';` to your polyfills.ts file)');
+        '(For non-CLI projects, add `import \'@angular/localize/init\';` to your `polyfills.ts` file.\n' +
+        'For server-side rendering applications add the import to your `main.server.ts` file.)');
   };
 }


### PR DESCRIPTION
If the application is not running directly in the browser, e.g.
universal or app-shell, then the `$localize` import must be
adding to a different file than for normal browser applications.

This commit adds more information about this to avoid any
confusion.

// FW-1557