### PR TITLE
fix(docs-infra): do not break when cookies are disabled in the browser

### DIFF
--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -94,6 +94,22 @@ describe('ScrollService', () => {
     }
   });
 
+  it('should not break when cookies are disabled in the browser', () => {
+    // Simulate `window.sessionStorage` being inaccessible, when cookies are disabled.
+    spyOnProperty(window, 'sessionStorage', 'get').and.throwError('The operation is insecure');
+
+    expect(() => {
+      const platformLoc = platformLocation as PlatformLocation;
+      const service = new ScrollService(document, platformLoc, viewportScrollerStub, location);
+
+      service.updateScrollLocationHref();
+      expect(service.getStoredScrollLocationHref()).toBeNull();
+
+      service.removeStoredScrollInfo();
+      expect(service.getStoredScrollPosition()).toBeNull();
+    }).not.toThrow();
+  });
+
   describe('#topOffset', () => {
     it('should query for the top-bar by CSS selector', () => {
       expect(document.querySelector).not.toHaveBeenCalled();


### PR DESCRIPTION
fix(docs-infra): changed window.sessionStorage to default params when cookies disabled

Whenever cookies are disabled windows.sessionStorage is not available for the app so If it throws an error I give it a default value

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the current scenario whenever the browser is configured not to accept cookies, the angular.io homepage shows a blank page without any content because windows.sessionStorage is not defined

Issue Number: #33795


## What is the new behavior?
In the new behavior whenever window.sessionStorage is not defined I give it a default value

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
