### PR TITLE
fix(ivy): extend assertion in `directiveInject` function to support IcuContainers

### DIFF
--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -47,7 +47,8 @@ export function ɵɵdirectiveInject<T>(
   if (lView == null) return ɵɵinject(token, flags);
   const tNode = getPreviousOrParentTNode();
   ngDevMode && assertNodeOfPossibleTypes(
-                   tNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
+                   tNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer,
+                   TNodeType.IcuContainer);
   return getOrCreateInjectable<T>(
       tNode as TDirectiveHostNode, lView, resolveForwardRef(token), flags);
 }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -1824,4 +1824,39 @@ describe('di', () => {
       expect(directive.other).toBe('otherValue');
     });
   });
+
+  it('should support dependencies in Pipes used inside ICUs', () => {
+    @Injectable()
+    class MyService {
+      transform(value: string): string { return `${value} (transformed)`; }
+    }
+
+    @Pipe({name: 'somePipe'})
+    class MyPipe {
+      constructor(private service: MyService) {}
+      transform(value: any): any { return this.service.transform(value); }
+    }
+
+    @Component({
+      template: `
+        <div i18n>{
+          count, select,
+          =1 {One}
+          other {Other value is: {{count | somePipe}}}
+        }</div>
+      `
+    })
+    class MyComp {
+      count = '2';
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [MyPipe, MyComp],
+      providers: [MyService],
+    });
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.innerHTML).toContain('Other value is: 2 (transformed)');
+  });
 });


### PR DESCRIPTION
Prior to this commit the assert that we have in `directiveInject` (assert introduced recently) didn't include IcuContainer TNode type and as a result, the error is thrown in case pipes with dependencies are used inside ICUs. This commit extends the assert to allow for IcuContainer TNode types.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No