### PR TITLE
perf(ivy): chain styling instructions

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -708,8 +708,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const limit = stylingInstructions.length - 1;
     for (let i = 0; i <= limit; i++) {
       const instruction = stylingInstructions[i];
-      this._bindingSlots += instruction.allocateBindingSlots;
-      this.processStylingInstruction(elementIndex, instruction, false);
+      this._bindingSlots += this.processStylingUpdateInstruction(elementIndex, instruction);
     }
 
     // the reason why `undefined` is used is because the renderer understands this as a
@@ -1071,25 +1070,30 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     });
   }
 
-  private processStylingInstruction(
-      elementIndex: number, instruction: StylingInstruction|null, createMode: boolean) {
+  private processStylingUpdateInstruction(
+      elementIndex: number, instruction: StylingInstruction|null) {
+    let allocateBindingSlots = 0;
     if (instruction) {
-      if (createMode) {
-        this.creationInstruction(instruction.sourceSpan, instruction.reference, () => {
-          return instruction.params(value => this.convertPropertyBinding(value)) as o.Expression[];
-        });
-      } else {
-        this.updateInstructionWithAdvance(
-            elementIndex, instruction.sourceSpan, instruction.reference, () => {
-              return instruction
-                  .params(value => {
-                    return (instruction.supportsInterpolation && value instanceof Interpolation) ?
+      const calls: ChainableBindingInstruction[] = [];
+
+      instruction.calls.forEach(call => {
+        allocateBindingSlots += call.allocateBindingSlots;
+        calls.push({
+          sourceSpan: call.sourceSpan,
+          value: () => {
+            return call
+                .params(
+                    value => (call.supportsInterpolation && value instanceof Interpolation) ?
                         this.getUpdateInstructionArguments(value) :
-                        this.convertPropertyBinding(value);
-                  }) as o.Expression[];
-            });
-      }
+                        this.convertPropertyBinding(value)) as o.Expression[];
+          }
+        });
+      });
+
+      this.updateInstructionChainWithAdvance(elementIndex, instruction.reference, calls);
     }
+
+    return allocateBindingSlots;
   }
 
   private creationInstruction(
@@ -1127,8 +1131,13 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     this._updateCodeFns.push(() => {
       const calls = bindings.map(property => {
-        const fnParams = [property.value(), ...(property.params || [])];
+        const value = property.value();
+        const fnParams = Array.isArray(value) ? value : [value];
+        if (property.params) {
+          fnParams.push(...property.params);
+        }
         if (property.name) {
+          // We want the property name to always be the first function parameter.
           fnParams.unshift(o.literal(property.name));
         }
         return fnParams;
@@ -2045,7 +2054,7 @@ function hasTextChildrenOnly(children: t.Node[]): boolean {
 interface ChainableBindingInstruction {
   name?: string;
   sourceSpan: ParseSourceSpan|null;
-  value: () => o.Expression;
+  value: () => o.Expression | o.Expression[];
   params?: any[];
 }
 

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -8,7 +8,7 @@
 import {SafeValue} from '../../sanitization/bypass';
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {throwErrorIfNoChangesMode} from '../errors';
-import {setInputsForProperty} from '../instructions/shared';
+import {TsickleIssue1009, setInputsForProperty} from '../instructions/shared';
 import {AttributeMarker, TAttributes, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {RElement} from '../interfaces/renderer';
 import {StylingMapArray, StylingMapArrayIndex, TStylingContext} from '../interfaces/styling';
@@ -77,8 +77,10 @@ export function ɵɵstyleSanitizer(sanitizer: StyleSanitizeFn | null): void {
  * @codeGenApi
  */
 export function ɵɵstyleProp(
-    prop: string, value: string | number | SafeValue | null, suffix?: string | null): void {
+    prop: string, value: string | number | SafeValue | null,
+    suffix?: string | null): TsickleIssue1009 {
   stylePropInternal(getSelectedIndex(), prop, value, suffix);
+  return ɵɵstyleProp;
 }
 
 /**
@@ -133,7 +135,7 @@ export function stylePropInternal(
  *
  * @codeGenApi
  */
-export function ɵɵclassProp(className: string, value: boolean | null): void {
+export function ɵɵclassProp(className: string, value: boolean | null): TsickleIssue1009 {
   // if a value is interpolated then it may render a `NO_CHANGE` value.
   // in this case we do not need to do anything, but the binding index
   // still needs to be incremented because all styling binding values
@@ -159,6 +161,7 @@ export function ɵɵclassProp(className: string, value: boolean | null): void {
       ngDevMode.classPropCacheMiss++;
     }
   }
+  return ɵɵclassProp;
 }
 
 /**

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -724,7 +724,7 @@ export declare function ɵɵclassMapInterpolate8(prefix: string, v0: any, i0: st
 
 export declare function ɵɵclassMapInterpolateV(values: any[]): void;
 
-export declare function ɵɵclassProp(className: string, value: boolean | null): void;
+export declare function ɵɵclassProp(className: string, value: boolean | null): TsickleIssue1009;
 
 export declare type ɵɵComponentDefWithMeta<T, Selector extends String, ExportAs extends string[], InputMap extends {
     [key: string]: string;
@@ -1033,7 +1033,7 @@ export declare function ɵɵstyleMap(styles: {
     [styleName: string]: any;
 } | NO_CHANGE | null): void;
 
-export declare function ɵɵstyleProp(prop: string, value: string | number | SafeValue | null, suffix?: string | null): void;
+export declare function ɵɵstyleProp(prop: string, value: string | number | SafeValue | null, suffix?: string | null): TsickleIssue1009;
 
 export declare function ɵɵstylePropInterpolate1(prop: string, prefix: string, v0: any, suffix: string, valueSuffix?: string | null): TsickleIssue1009;
 


### PR DESCRIPTION
Adds support for chaining of `styleProp`, `classProp` and `stylePropInterpolateX` instructions whenever possible which should help generate less code. Note that one complication here is for `stylePropInterpolateX` instructions where we have to break into multiple chains if there are other styling instructions inbetween the interpolations which helps maintain the execution order.
