### PR TITLE
fix: should not tick nested timer in fakeAsync test

### DIFF
--- a/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
@@ -25,21 +25,21 @@ describe('Angular async helper', () => {
        async(() => { setTimeout(() => { actuallyDone = true; }, 0); }));
 
     it('should run async test with task', async(() => {
-      const id = setInterval(() => {
-        actuallyDone = true;
-        clearInterval(id);
-      }, 100);
-    }));
+         const id = setInterval(() => {
+           actuallyDone = true;
+           clearInterval(id);
+         }, 100);
+       }));
 
     it('should run async test with successful promise', async(() => {
-      const p = new Promise(resolve => { setTimeout(resolve, 10); });
-      p.then(() => { actuallyDone = true; });
-    }));
+         const p = new Promise(resolve => { setTimeout(resolve, 10); });
+         p.then(() => { actuallyDone = true; });
+       }));
 
     it('should run async test with failed promise', async(() => {
-      const p = new Promise((resolve, reject) => { setTimeout(reject, 10); });
-      p.catch(() => { actuallyDone = true; });
-    }));
+         const p = new Promise((resolve, reject) => { setTimeout(reject, 10); });
+         p.catch(() => { actuallyDone = true; });
+       }));
 
     // Use done. Can also use async or fakeAsync.
     it('should run async test with successful delayed Observable', (done: DoneFn) => {
@@ -48,56 +48,84 @@ describe('Angular async helper', () => {
     });
 
     it('should run async test with successful delayed Observable', async(() => {
-      const source = of (true).pipe(delay(10));
-      source.subscribe(val => actuallyDone = true, err => fail(err));
-    }));
+         const source = of (true).pipe(delay(10));
+         source.subscribe(val => actuallyDone = true, err => fail(err));
+       }));
 
     it('should run async test with successful delayed Observable', fakeAsync(() => {
-      const source = of (true).pipe(delay(10));
-      source.subscribe(val => actuallyDone = true, err => fail(err));
+         const source = of (true).pipe(delay(10));
+         source.subscribe(val => actuallyDone = true, err => fail(err));
 
-      tick(10);
-    }));
+         tick(10);
+       }));
   });
 
   describe('fakeAsync', () => {
     // #docregion fake-async-test-tick
     it('should run timeout callback with delay after call tick with millis', fakeAsync(() => {
-        let called = false;
-        setTimeout(() => { called = true; }, 100);
-        tick(100);
-        expect(called).toBe(true);
-      }));
+         let called = false;
+         setTimeout(() => { called = true; }, 100);
+         tick(100);
+         expect(called).toBe(true);
+       }));
     // #enddocregion fake-async-test-tick
+
+    // #docregion fake-async-test-tick-new-macro-task-sync
+    it('should run new macro task callback with delay after call tick with millis',
+       fakeAsync(() => {
+         function nestedTimer(cb: () => any): void { setTimeout(() => setTimeout(() => cb())); }
+         const callback = jasmine.createSpy('callback');
+         nestedTimer(callback);
+         expect(callback).not.toHaveBeenCalled();
+         tick(0);
+         // the nested timeout will also be triggered
+         expect(callback).toHaveBeenCalled();
+       }));
+    // #enddocregion fake-async-test-tick-new-macro-task-sync
+
+    // #docregion fake-async-test-tick-new-macro-task-async
+    it('should not run new macro task callback with delay after call tick with millis',
+       fakeAsync(() => {
+         function nestedTimer(cb: () => any): void { setTimeout(() => setTimeout(() => cb())); }
+         const callback = jasmine.createSpy('callback');
+         nestedTimer(callback);
+         expect(callback).not.toHaveBeenCalled();
+         tick(0, {processNewMacroTasksSynchronously: false});
+         // the nested timeout will not be triggered
+         expect(callback).not.toHaveBeenCalled();
+         tick(0);
+         expect(callback).toHaveBeenCalled();
+       }));
+    // #enddocregion fake-async-test-tick-new-macro-task-async
 
     // #docregion fake-async-test-date
     it('should get Date diff correctly in fakeAsync', fakeAsync(() => {
-        const start = Date.now();
-        tick(100);
-        const end = Date.now();
-        expect(end - start).toBe(100);
-      }));
+         const start = Date.now();
+         tick(100);
+         const end = Date.now();
+         expect(end - start).toBe(100);
+       }));
     // #enddocregion fake-async-test-date
 
     // #docregion fake-async-test-rxjs
     it('should get Date diff correctly in fakeAsync with rxjs scheduler', fakeAsync(() => {
-        // need to add `import 'zone.js/dist/zone-patch-rxjs-fake-async'
-        // to patch rxjs scheduler
-        let result = null;
-        of ('hello').pipe(delay(1000)).subscribe(v => { result = v; });
-        expect(result).toBeNull();
-        tick(1000);
-        expect(result).toBe('hello');
+         // need to add `import 'zone.js/dist/zone-patch-rxjs-fake-async'
+         // to patch rxjs scheduler
+         let result = null;
+         of ('hello').pipe(delay(1000)).subscribe(v => { result = v; });
+         expect(result).toBeNull();
+         tick(1000);
+         expect(result).toBe('hello');
 
-        const start = new Date().getTime();
-        let dateDiff = 0;
-        interval(1000).pipe(take(2)).subscribe(() => dateDiff = (new Date().getTime() - start));
+         const start = new Date().getTime();
+         let dateDiff = 0;
+         interval(1000).pipe(take(2)).subscribe(() => dateDiff = (new Date().getTime() - start));
 
-        tick(1000);
-        expect(dateDiff).toBe(1000);
-        tick(1000);
-        expect(dateDiff).toBe(2000);
-      }));
+         tick(1000);
+         expect(dateDiff).toBe(1000);
+         tick(1000);
+         expect(dateDiff).toBe(2000);
+       }));
     // #enddocregion fake-async-test-rxjs
   });
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -1266,7 +1266,8 @@ You do have to call [tick()](api/core/testing/tick) to advance the (virtual) clo
 Calling [tick()](api/core/testing/tick) simulates the passage of time until all pending asynchronous activities finish.
 In this case, it waits for the error handler's `setTimeout()`.
 
-The [tick()](api/core/testing/tick) function accepts milliseconds as a parameter (defaults to 0 if not provided). The parameter represents how much the virtual clock advances. For example, if you have a `setTimeout(fn, 100)` in a `fakeAsync()` test, you need to use tick(100) to trigger the fn callback.
+The [tick()](api/core/testing/tick) function accepts milliseconds and tickOptions as parameters, the millisecond (defaults to 0 if not provided) parameter represents how much the virtual clock advances. For example, if you have a `setTimeout(fn, 100)` in a `fakeAsync()` test, you need to use tick(100) to trigger the fn callback. The tickOptions is an optional parameter with a property called processNewMacroTasksSynchronously (defaults is true) represents whether to invoke
+new generated macro tasks when ticking.
 
 <code-example
   path="testing/src/app/demo/async-helper.spec.ts"
@@ -1275,6 +1276,22 @@ The [tick()](api/core/testing/tick) function accepts milliseconds as a parameter
 
 The [tick()](api/core/testing/tick) function is one of the Angular testing utilities that you import with `TestBed`.
 It's a companion to `fakeAsync()` and you can only call it within a `fakeAsync()` body.
+
+#### tickOptions
+
+<code-example
+  path="testing/src/app/demo/async-helper.spec.ts"
+  region="fake-async-test-tick-new-macro-task-sync">
+</code-example>
+
+In this example, we have a new macro task (nested setTimeout), by default, when we `tick`, the setTimeout `outside` and `nested` will both be triggered.
+
+<code-example
+  path="testing/src/app/demo/async-helper.spec.ts"
+  region="fake-async-test-tick-new-macro-task-async">
+</code-example>
+
+And in some case, we don't want to trigger the new maco task when ticking, we can use `tick(milliseconds, {processNewMacroTasksSynchronously: false})` to not invoke new maco task.
 
 #### Comparing dates inside fakeAsync()
 

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -127,6 +127,31 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
            expect(ran).toEqual(true);
          }));
 
+      it('should run new macro tasks created by timer callback', fakeAsync(() => {
+           function nestedTimer(callback: () => any): void {
+             setTimeout(() => setTimeout(() => callback()));
+           }
+           const callback = jasmine.createSpy('callback');
+           nestedTimer(callback);
+           expect(callback).not.toHaveBeenCalled();
+           tick(0);
+           expect(callback).toHaveBeenCalled();
+         }));
+
+      it('should not queue nested timer on tick with processNewMacroTasksSynchronously=false',
+         fakeAsync(() => {
+           function nestedTimer(callback: () => any): void {
+             setTimeout(() => setTimeout(() => callback()));
+           }
+           const callback = jasmine.createSpy('callback');
+           nestedTimer(callback);
+           expect(callback).not.toHaveBeenCalled();
+           tick(0, {processNewMacroTasksSynchronously: false});
+           expect(callback).not.toHaveBeenCalled();
+           flush();
+           expect(callback).toHaveBeenCalled();
+         }));
+
       it('should run queued timer only once', fakeAsync(() => {
            let cycles = 0;
            setTimeout(() => { cycles++; }, 10);

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -62,13 +62,54 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
  *
  * {@example core/testing/ts/fake_async.ts region='basic'}
  *
+ * @param millis, the number of millisecond to advance the virtual timer
+ * @param tickOptions, the options of tick with a flag called
+ * processNewMacroTasksSynchronously, whether to invoke the new macroTasks, by default is
+ * false, means the new macroTasks will be invoked
+ *
+ * For example,
+ *
+ * it ('test with nested setTimeout', fakeAsync(() => {
+ *   let nestedTimeoutInvoked = false;
+ *   function funcWithNestedTimeout() {
+ *     setTimeout(() => {
+ *       nestedTimeoutInvoked = true;
+ *     });
+ *   };
+ *   setTimeout(funcWithNestedTimeout);
+ *   tick();
+ *   expect(nestedTimeoutInvoked).toBe(true);
+ * }));
+ *
+ * in this case, we have a nested timeout (new macroTask), when we tick, both the
+ * funcWithNestedTimeout and the nested timeout both will be invoked.
+ *
+ * it ('test with nested setTimeout', fakeAsync(() => {
+ *   let nestedTimeoutInvoked = false;
+ *   function funcWithNestedTimeout() {
+ *     setTimeout(() => {
+ *       nestedTimeoutInvoked = true;
+ *     });
+ *   };
+ *   setTimeout(funcWithNestedTimeout);
+ *   tick(0, {processNewMacroTasksSynchronously: false});
+ *   expect(nestedTimeoutInvoked).toBe(false);
+ * }));
+ *
+ * if we pass the tickOptions with processNewMacroTasksSynchronously to be false, the nested timeout
+ * will not be invoked.
+ *
+ *
  * @publicApi
  */
-export function tick(millis: number = 0): void {
+export function tick(
+    millis: number = 0, tickOptions: {processNewMacroTasksSynchronously: boolean} = {
+      processNewMacroTasksSynchronously: true
+    }): void {
   if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.tick(millis);
+    return fakeAsyncTestModule.tick(millis, tickOptions);
   } else {
-    return tickFallback(millis);
+    return tickFallback(millis, tickOptions);
   }
 }
 

--- a/packages/core/testing/src/fake_async_fallback.ts
+++ b/packages/core/testing/src/fake_async_fallback.ts
@@ -118,8 +118,11 @@ function _getFakeAsyncZoneSpec(): any {
  *
  * @publicApi
  */
-export function tickFallback(millis: number = 0): void {
-  _getFakeAsyncZoneSpec().tick(millis);
+export function tickFallback(
+    millis: number = 0, tickOptions: {processNewMacroTasksSynchronously: boolean} = {
+      processNewMacroTasksSynchronously: true
+    }): void {
+  _getFakeAsyncZoneSpec().tick(millis, null, tickOptions);
 }
 
 /**

--- a/packages/zone.js/lib/testing/fake-async.ts
+++ b/packages/zone.js/lib/testing/fake-async.ts
@@ -117,7 +117,9 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
    *
    * @experimental
    */
-  function tick(millis: number = 0): void { _getFakeAsyncZoneSpec().tick(millis); }
+  function tick(millis: number = 0, ignoreNestedTimeout = false): void {
+    _getFakeAsyncZoneSpec().tick(millis, null, ignoreNestedTimeout);
+  }
 
   /**
    * Simulates the asynchronous passage of time for the timers in the fakeAsync zone by

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -145,6 +145,22 @@ describe('FakeAsyncTestZoneSpec', () => {
          });
        }));
 
+    it('should not queue new macro task on tick with processNewMacroTasksSynchronously=false',
+       () => {
+         function nestedTimer(callback: () => any): void {
+           setTimeout(() => setTimeout(() => callback()));
+         }
+         fakeAsyncTestZone.run(() => {
+           const callback = jasmine.createSpy('callback');
+           nestedTimer(callback);
+           expect(callback).not.toHaveBeenCalled();
+           testZoneSpec.tick(0, null, {processNewMacroTasksSynchronously: false});
+           expect(callback).not.toHaveBeenCalled();
+           testZoneSpec.flush();
+           expect(callback).toHaveBeenCalled();
+         });
+       });
+
     it('should run queued timer after sufficient clock ticks', () => {
       fakeAsyncTestZone.run(() => {
         let ran = false;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -134,7 +134,9 @@ export declare type TestModuleMetadata = {
     aotSummaries?: () => any[];
 };
 
-export declare function tick(millis?: number): void;
+export declare function tick(millis?: number, tickOptions?: {
+    processNewMacroTasksSynchronously: boolean;
+}): void;
 
 export declare function withModule(moduleDef: TestModuleMetadata): InjectSetupWrapper;
 export declare function withModule(moduleDef: TestModuleMetadata, fn: Function): () => any;


### PR DESCRIPTION
Close #33799

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33799
```
function waitTwice(callback: () => any): void {
  setTimeout(() =>
    setTimeout(() => callback())
  );
}

describe('fakeAsync', () => {
  it('nested timers', fakeAsync(() => {
    const callback = jasmine.createSpy('callback');
    waitTwice(callback);
    expect(callback).not.toHaveBeenCalled();
    tick();
    expect(callback).toHaveBeenCalled();
    tick();
    expect(callback).toHaveBeenCalled();
  }));
});
```

By default, 
The `callback` will be called after the `first tick`.


```
describe('fakeAsync', () => {
  it('nested timers', fakeAsync(() => {
    const callback = jasmine.createSpy('callback');
    waitTwice(callback);
    expect(callback).not.toHaveBeenCalled();
    tick(0, true);
    expect(callback).not.toHaveBeenCalled();
    tick();
    expect(callback).toHaveBeenCalled();
  }));
});
```
````
## What is the new behavior?
with `tick(0, true)`, the second parameter is `ignoreNestedTimeout`, after the `first tick`, the `nested timeout` will not be invoked.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


