### PR TITLE
build: fix build scripts on macOS

### DIFF
--- a/scripts/package-builder.sh
+++ b/scripts/package-builder.sh
@@ -16,7 +16,7 @@ set -u -e -o pipefail
 cd "$(dirname "$0")"
 
 # basedir is the workspace root
-readonly base_dir="$(realpath "$(pwd)/..")"
+readonly base_dir="$(dirname "$(pwd)")"
 readonly bazel_bin="$(yarn run -s bazel info bazel-bin)"
 readonly script_path="$0"
 


### PR DESCRIPTION
In #33823, `scripts/package-builds.sh` (which is used by both `build-packages-dist.sh` and `build-ivy-npm-packages.sh`) was updated to use `realpath`. It turns out that `realpath` does not exist on macOS, so the build scripts do not work there.

This commit fixes it by switching from `realpath $(pwd)/..` to `dirname $(pwd)`, which does practically the same thing (in this situation) and works on macOS as well.

##
This is an alternative to #33840, which seems to increase the build time. 😞 