### PR TITLE
Import FormModule in app.module.ts

### DIFF
--- a/aio/content/tutorial/toh-pt1.md
+++ b/aio/content/tutorial/toh-pt1.md
@@ -129,6 +129,12 @@ Refactor the details area in the `HeroesComponent` template so it looks like thi
 
 <code-example path="toh-pt1/src/app/heroes/heroes.component.1.html" region="name-input" header="src/app/heroes/heroes.component.html (HeroesComponent's template)"></code-example>
 
+Add the following import to app.module.ts file: 
+
+import { FormsModule } from '@angular/forms';
+
+also, add FormsModule under imports in app.module.ts.
+
 **[(ngModel)]** is Angular's two-way data binding syntax.
 
 Here it binds the `hero.name` property to the HTML textbox so that data can flow _in both directions:_ from the `hero.name` property to the textbox, and from the textbox back to the `hero.name`.


### PR DESCRIPTION
In order to use the [(ngModel)] two way binding, this import should be added to app.module.ts:
import { FormsModule } from '@angular/forms';
also, FormsModule should be added under imports in app.module.ts.

Without this we get the error 'Can't bind to 'ngModel' since it isn't a known property of 'input'' in the browser console and the page does not load

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
