### PR TITLE
ɵɵtemplate instruction refactor

### DIFF
--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -74,10 +74,11 @@ export function ɵɵtemplate(
   // TODO: consider a separate node type for templates
   const tContainerNode = containerInternal(
       lView, index, tagName || null, getConstant<TAttributes>(tViewConsts, attrsIndex));
-  const localRefs = getConstant<string[]>(tViewConsts, localRefsIndex);
+
   if (tView.firstCreatePass) {
     ngDevMode && ngDevMode.firstCreatePass++;
-    resolveDirectives(tView, lView, tContainerNode, localRefs);
+    resolveDirectives(
+        tView, lView, tContainerNode, getConstant<string[]>(tViewConsts, localRefsIndex));
     registerPostOrderHooks(tView, tContainerNode);
 
     const embeddedTView = tContainerNode.tViews = createTView(
@@ -96,7 +97,8 @@ export function ɵɵtemplate(
   if (isDirectiveHost(tContainerNode)) {
     createDirectivesInstances(tView, lView, tContainerNode);
   }
-  if (localRefs != null) {
+
+  if (localRefsIndex !== null) {
     saveResolvedLocalsInData(lView, tContainerNode, localRefExtractor);
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -555,7 +555,7 @@ export function saveResolvedLocalsInData(
     viewData: LView, tNode: TDirectiveHostNode,
     localRefExtractor: LocalRefExtractor = getNativeByTNode): void {
   const localNames = tNode.localNames;
-  if (localNames) {
+  if (localNames !== null) {
     let localIndex = tNode.index + 1;
     for (let i = 0; i < localNames.length; i += 2) {
       const index = localNames[i + 1] as number;

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -444,9 +444,6 @@
     "name": "concatString"
   },
   {
-    "name": "containerInternal"
-  },
-  {
     "name": "createContainerRef"
   },
   {
@@ -1300,6 +1297,9 @@
   },
   {
     "name": "syncViewWithBlueprint"
+  },
+  {
+    "name": "templateFirstCreatePass"
   },
   {
     "name": "textBindingInternal"


### PR DESCRIPTION
This refactoring clearly separates the first and subsequent creation execution
of the `template` instruction. This approach has the following benefits:
- it is clear what happens during the first vs. subsequent executions;
- we can avoid several memory reads and checks after the first creation pass
(there is measurable performance improvement on various benchmarks);
- the template instructions becomes smaller and should become a candidate
for optimisations / inlining faster;