### PR TITLE
ngcc: handle localized messages in ES5

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 312772,
+        "main-es2015": 267979,
         "polyfills-es2015": 36808,
         "5-es2015": 751
       }


### PR DESCRIPTION
Recently the ngtsc translator was modified to be more `ScriptTarget`
aware, which basically means that it will not generate non-ES5 code
when the output format is ES5 or similar.

This commit enhances that change by also "downleveling" localized
messages. In ES2015 the messages use tagged template literals, which
are not available in ES5.