### PR TITLE
perf(ivy): R3TestBed - Do not process NgModuleDefs that have already …

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -486,6 +486,9 @@ export class R3TestBedCompiler {
   }
 
   private queueTypesFromModulesArray(arr: any[]): void {
+    // Because we may encounter the same NgModule while processing the imports and exports of an
+    // NgModule tree, we cache them in this set so we can skip ones that have already been seen
+    // encountered. In some test setups, this caching resulted in 10X runtime improvement.
     const processedNgModuleDefs = new Set();
     const queueTypesFromModulesArrayRecur = (arr: any[]): void => {
       for (const value of arr) {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -497,7 +497,7 @@ export class R3TestBedCompiler {
         } else if (hasNgModuleDef(value)) {
           const def = value.ɵmod;
           if (processedNgModuleDefs.has(def)) {
-            return;
+            continue;
           }
           processedNgModuleDefs.add(def);
           // Look through declarations, imports, and exports, and queue


### PR DESCRIPTION
…been processed

I was observing 10x slower test times in Ivy vs VE and this change made Ivy perform as fast as VE. Perf analysis showed that 96% of the time was spent in `queueTypesFromModulesArray`. This can happen with deep trees of imports that have duplicated NgModule imports throughout.