### PR TITLE
Ng rollup bundle ng jit mode redo

### DIFF
--- a/tools/ng_rollup_bundle/BUILD.bazel
+++ b/tools/ng_rollup_bundle/BUILD.bazel
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
-exports_files(["rollup.config.js"])
+exports_files([
+    "rollup.config.js",
+    "terser_config.json",
+])
 
 nodejs_binary(
     name = "rollup_with_build_optimizer",

--- a/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
+++ b/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
@@ -391,6 +391,7 @@ def ng_rollup_bundle(name, **kwargs):
         # maintain the comments off behavior. We pass the --comments flag with
         # a regex that always evaluates to false to do this.
         "args": ["--comments", "/bogus_string_to_suppress_all_comments^/"],
+        "config_file": "//tools/ng_rollup_bundle:terser_config.json",
         "sourcemap": False,
     }
 

--- a/tools/ng_rollup_bundle/terser_config.json
+++ b/tools/ng_rollup_bundle/terser_config.json
@@ -1,0 +1,12 @@
+{
+    "compress": {
+        "global_defs": {"ngDevMode": false, "ngI18nClosureMode": false, "ngJitMode": false},
+        "keep_fnames": "bazel_no_debug",
+        "passes": 3,
+        "pure_getters": true,
+        "reduce_funcs": "bazel_no_debug",
+        "reduce_vars": "bazel_no_debug",
+        "sequences": "bazel_no_debug"
+    },
+    "mangle": "bazel_no_debug"
+}


### PR DESCRIPTION
Redo of #33773 which seems to break Windows CI on master and was reverted but trying it again Windows CI passed: https://app.circleci.com/github/angular/angular/pipelines/b0d8db91-3127-4c0d-84a2-1d790af99b80/workflows/fb2709f2-ff8d-4ccd-9c8c-51a87ac6c82c.

Windows CI failure on master was here: https://app.circleci.com/github/angular/angular/pipelines/547e04bf-07df-4a89-ad29-267bf0cfe660/workflows/3d092269-292a-4ed6-b548-3d036db8d1a6

Both test_win and test_ivy_aot_win failed right away with `The system cannot find the path specified.`. No idea what caused it.
