### PR TITLE
fix(ngcc): always add exports for `ModuleWithProviders` references

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -73,16 +73,20 @@ export function makeEntryPointBundle(
 function computePotentialDtsFilesFromJsFiles(
     fs: FileSystem, srcProgram: ts.Program, formatPath: AbsoluteFsPath,
     typingsPath: AbsoluteFsPath) {
-  const relativePath = fs.relative(fs.dirname(formatPath), fs.dirname(typingsPath));
+  const formatRoot = fs.dirname(formatPath);
+  const typingsRoot = fs.dirname(typingsPath);
   const additionalFiles: AbsoluteFsPath[] = [];
   for (const sf of srcProgram.getSourceFiles()) {
     if (!sf.fileName.endsWith('.js')) {
       continue;
     }
-    const dtsPath = fs.resolve(
-        fs.dirname(sf.fileName), relativePath, fs.basename(sf.fileName, '.js') + '.d.ts');
-    if (fs.exists(dtsPath)) {
-      additionalFiles.push(dtsPath);
+
+    // Given a source file at e.g. `esm2015/src/some/nested/index.js`, try to resolve the
+    // declaration file under the typings root in `src/some/nested/index.d.ts`.
+    const mirroredDtsPath =
+        fs.resolve(typingsRoot, fs.relative(formatRoot, sf.fileName.replace(/\.js$/, '.d.ts')));
+    if (fs.exists(mirroredDtsPath)) {
+      additionalFiles.push(mirroredDtsPath);
     }
   }
   return additionalFiles;

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -149,7 +149,7 @@ export class Transformer {
     const decorationAnalyses = decorationAnalyzer.analyzeProgram();
 
     const moduleWithProvidersAnalyzer =
-        bundle.dts && new ModuleWithProvidersAnalyzer(reflectionHost, referencesRegistry);
+        new ModuleWithProvidersAnalyzer(reflectionHost, referencesRegistry, bundle.dts !== null);
     const moduleWithProvidersAnalyses = moduleWithProvidersAnalyzer &&
         moduleWithProvidersAnalyzer.analyzeProgram(bundle.src.program);
 

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -19,7 +19,7 @@ import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTI
 import {Transformer} from '../../src/packages/transformer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
 import {MockLogger} from '../helpers/mock_logger';
-import {genNodeModules} from './util';
+import {compileIntoApf, compileIntoFlatEs5Package} from './util';
 
 
 const testFiles = loadStandardTestFiles({fakeCore: false, rxjs: true});
@@ -113,23 +113,21 @@ runInEachFileSystem(() => {
     });
 
     it('should generate correct metadata for decorated getter/setter properties', () => {
-      genNodeModules({
-        'test-package': {
-          '/index.ts': `
-            import {Directive, Input, NgModule} from '@angular/core';
-
-            @Directive({selector: '[foo]'})
-            export class FooDirective {
-              @Input() get bar() { return 'bar'; }
-              set bar(value: string) {}
-            }
-
-            @NgModule({
-              declarations: [FooDirective],
-            })
-            export class FooModule {}
-          `,
-        },
+      compileIntoFlatEs5Package('test-package', {
+        '/index.ts': `
+          import {Directive, Input, NgModule} from '@angular/core';
+  
+          @Directive({selector: '[foo]'})
+          export class FooDirective {
+            @Input() get bar() { return 'bar'; }
+            set bar(value: string) {}
+          }
+  
+          @NgModule({
+            declarations: [FooDirective],
+          })
+          export class FooModule {}
+        `,
       });
 
       mainNgcc({
@@ -148,24 +146,22 @@ runInEachFileSystem(() => {
     });
 
     it('should not add `const` in ES5 generated code', () => {
-      genNodeModules({
-        'test-package': {
-          '/index.ts': `
-            import {Directive, Input, NgModule} from '@angular/core';
-
-            @Directive({
-              selector: '[foo]',
-              host: {bar: ''},
-            })
-            export class FooDirective {
-            }
-
-            @NgModule({
-              declarations: [FooDirective],
-            })
-            export class FooModule {}
-          `,
-        },
+      compileIntoFlatEs5Package('test-package', {
+        '/index.ts': `
+          import {Directive, Input, NgModule} from '@angular/core';
+  
+          @Directive({
+            selector: '[foo]',
+            host: {bar: ''},
+          })
+          export class FooDirective {
+          }
+  
+          @NgModule({
+            declarations: [FooDirective],
+          })
+          export class FooModule {}
+        `,
       });
 
       mainNgcc({
@@ -823,9 +819,8 @@ runInEachFileSystem(() => {
     describe('undecorated child class migration', () => {
       it('should generate a directive definition with CopyDefinitionFeature for an undecorated child directive',
          () => {
-           genNodeModules({
-             'test-package': {
-               '/index.ts': `
+           compileIntoFlatEs5Package('test-package', {
+             '/index.ts': `
               import {Directive, NgModule} from '@angular/core';
 
               @Directive({
@@ -840,7 +835,6 @@ runInEachFileSystem(() => {
               })
               export class Module {}
             `,
-             },
            });
 
            mainNgcc({
@@ -864,9 +858,8 @@ runInEachFileSystem(() => {
 
       it('should generate a component definition with CopyDefinitionFeature for an undecorated child component',
          () => {
-           genNodeModules({
-             'test-package': {
-               '/index.ts': `
+           compileIntoFlatEs5Package('test-package', {
+             '/index.ts': `
            import {Component, NgModule} from '@angular/core';
 
            @Component({
@@ -882,7 +875,6 @@ runInEachFileSystem(() => {
            })
            export class Module {}
          `,
-             },
            });
 
            mainNgcc({
@@ -906,9 +898,8 @@ runInEachFileSystem(() => {
 
       it('should generate directive definitions with CopyDefinitionFeature for undecorated child directives in a long inheritance chain',
          () => {
-           genNodeModules({
-             'test-package': {
-               '/index.ts': `
+           compileIntoFlatEs5Package('test-package', {
+             '/index.ts': `
            import {Directive, NgModule} from '@angular/core';
 
            @Directive({
@@ -927,7 +918,6 @@ runInEachFileSystem(() => {
            })
            export class Module {}
          `,
-             },
            });
 
            mainNgcc({

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -76,7 +76,8 @@ function createTestRenderer(
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
   const moduleWithProvidersAnalyses =
-      new ModuleWithProvidersAnalyzer(host, referencesRegistry).analyzeProgram(bundle.src.program);
+      new ModuleWithProvidersAnalyzer(host, referencesRegistry, true)
+          .analyzeProgram(bundle.src.program);
   const privateDeclarationsAnalyses =
       new PrivateDeclarationsAnalyzer(host, referencesRegistry).analyzeProgram(bundle.src.program);
   const testFormatter = new TestRenderingFormatter();

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -574,7 +574,7 @@ export { D };
 
         const referencesRegistry = new NgccReferencesRegistry(host);
         const moduleWithProvidersAnalyses =
-            new ModuleWithProvidersAnalyzer(host, referencesRegistry)
+            new ModuleWithProvidersAnalyzer(host, referencesRegistry, true)
                 .analyzeProgram(bundle.src.program);
         const typingsFile = getSourceFileOrError(bundle.dts !.program, _('/typings/index.d.ts'));
         const moduleWithProvidersInfo = moduleWithProvidersAnalyses.get(typingsFile) !;
@@ -610,7 +610,7 @@ export { D };
 
            const referencesRegistry = new NgccReferencesRegistry(host);
            const moduleWithProvidersAnalyses =
-               new ModuleWithProvidersAnalyzer(host, referencesRegistry)
+               new ModuleWithProvidersAnalyzer(host, referencesRegistry, true)
                    .analyzeProgram(bundle.src.program);
            const typingsFile =
                getSourceFileOrError(bundle.dts !.program, _('/typings/module.d.ts'));


### PR DESCRIPTION
Please see individual commits for detailed descriptions.

Fixes #33701