### PR TITLE
docs-infra: do not auto link code with ignored language

### DIFF
--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -6,7 +6,7 @@ This guide contains everything you need to know about updating to the next Angul
 
 If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script:
 
-```bash
+```sh
 ng update @angular/core@8 @angular/cli@8
 git add .
 git commit --all -m "build: update Angular packages to latest 8.x version"

--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -6,7 +6,7 @@ This guide contains everything you need to know about updating to the next Angul
 
 If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script:
 
-```
+```bash
 ng update @angular/core@8 @angular/cli@8
 git add .
 git commit --all -m "build: update Angular packages to latest 8.x version"

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -10,8 +10,9 @@
     "preinstall": "node ../../../../tools/yarn/check-yarn.js",
     "postinstall": "yarn webdriver:update"
   },
+  "//engines-comment": "Keep this in sync with aio/package.json",
   "engines": {
-    "node": ">=10.9.0 <11.0.0",
+    "node": ">=10.9.0 <13.0.0",
     "yarn": ">=1.17.3 <=1.19.1"
   },
   "keywords": [],

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -24,7 +24,7 @@ module.exports = function autoLinkCode(getDocFromAlias) {
   autoLinkCodeImpl.docTypes = [];
   autoLinkCodeImpl.customFilters = [];
   autoLinkCodeImpl.codeElements = ['code'];
-  autoLinkCodeImpl.ignoredLanguages = ['bash', 'json'];
+  autoLinkCodeImpl.ignoredLanguages = ['bash', 'sh', 'shell', 'json', 'markdown'];
   return autoLinkCodeImpl;
 
   function autoLinkCodeImpl() {

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -24,15 +24,19 @@ module.exports = function autoLinkCode(getDocFromAlias) {
   autoLinkCodeImpl.docTypes = [];
   autoLinkCodeImpl.customFilters = [];
   autoLinkCodeImpl.codeElements = ['code'];
+  autoLinkCodeImpl.ignoredLanguages = ['bash', 'json'];
   return autoLinkCodeImpl;
 
   function autoLinkCodeImpl() {
     return (ast) => {
       visit(ast, 'element', (node, ancestors) => {
-        // Only interested in code elements that are not inside links
+        // Only interested in code elements that:
+        // * do not have `no-auto-link` class
+        // * do not have an ignored language
+        // * are not inside links
         if (autoLinkCodeImpl.codeElements.some(elementType => is(node, elementType)) &&
-            (!node.properties.className ||
-             node.properties.className.indexOf('no-auto-link') === -1) &&
+            (!node.properties.className || !node.properties.className.includes('no-auto-link')) &&
+            !autoLinkCodeImpl.ignoredLanguages.includes(node.properties.language) &&
             ancestors.every(ancestor => !is(ancestor, 'a'))) {
           visit(node, 'text', (node, ancestors) => {
             // Only interested in text nodes that are not inside links

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -26,18 +26,17 @@ module.exports = function autoLinkCode(getDocFromAlias) {
   autoLinkCodeImpl.codeElements = ['code'];
   return autoLinkCodeImpl;
 
-  function autoLinkCodeImpl()  {
+  function autoLinkCodeImpl() {
     return (ast) => {
       visit(ast, 'element', (node, ancestors) => {
         // Only interested in code elements that are not inside links
-        if (autoLinkCodeImpl.codeElements.some(elementType =>
-            is(node, elementType)) &&
-            (!node.properties.className || node.properties.className.indexOf('no-auto-link') === -1) &&
+        if (autoLinkCodeImpl.codeElements.some(elementType => is(node, elementType)) &&
+            (!node.properties.className ||
+             node.properties.className.indexOf('no-auto-link') === -1) &&
             ancestors.every(ancestor => !is(ancestor, 'a'))) {
           visit(node, 'text', (node, ancestors) => {
             // Only interested in text nodes that are not inside links
             if (ancestors.every(ancestor => !is(ancestor, 'a'))) {
-
               const parent = ancestors[ancestors.length - 1];
               const index = parent.children.indexOf(node);
 
@@ -47,15 +46,20 @@ module.exports = function autoLinkCode(getDocFromAlias) {
                 parent.children.splice(index, 1, createLinkNode(docs[0], node.value));
               } else {
                 // Parse the text for words that we can convert to links
-                const nodes = textContent(node).split(/([A-Za-z0-9_.-]+)/)
-                  .filter(word => word.length)
-                  .map((word, index, words) => {
-                    // remove docs that fail the custom filter tests
-                    const filteredDocs = autoLinkCodeImpl.customFilters.reduce((docs, filter) => filter(docs, words, index), getDocFromAlias(word));
-                    return foundValidDoc(filteredDocs) ?
-                              createLinkNode(filteredDocs[0], word) : // Create a link wrapping the text node.
-                              { type: 'text', value: word };  // this is just text so push a new text node
-                  });
+                const nodes =
+                    textContent(node)
+                        .split(/([A-Za-z0-9_.-]+)/)
+                        .filter(word => word.length)
+                        .map((word, index, words) => {
+                          // remove docs that fail the custom filter tests
+                          const filteredDocs = autoLinkCodeImpl.customFilters.reduce(
+                              (docs, filter) => filter(docs, words, index), getDocFromAlias(word));
+                          return foundValidDoc(filteredDocs) ?
+                              // Create a link wrapping the text node.
+                              createLinkNode(filteredDocs[0], word) :
+                              // this is just text so push a new text node
+                              {type: 'text', value: word};
+                        });
 
                 // Replace the text node with the links and leftover text nodes
                 Array.prototype.splice.apply(parent.children, [index, 1].concat(nodes));
@@ -68,17 +72,16 @@ module.exports = function autoLinkCode(getDocFromAlias) {
   }
 
   function foundValidDoc(docs) {
-    return docs.length === 1 &&
-           !docs[0].internal &&
-           autoLinkCodeImpl.docTypes.indexOf(docs[0].docType) !== -1;
+    return docs.length === 1 && !docs[0].internal &&
+        autoLinkCodeImpl.docTypes.indexOf(docs[0].docType) !== -1;
   }
 
   function createLinkNode(doc, text) {
     return {
       type: 'element',
       tagName: 'a',
-      properties: { href: doc.path, class: 'code-anchor' },
-      children: [{ type: 'text', value: text }]
+      properties: {href: doc.path, class: 'code-anchor'},
+      children: [{type: 'text', value: text}]
     };
   }
 };

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -169,7 +169,7 @@ describe('autoLinkCode post-processor', () => {
     expect(doc.renderedContent).toEqual('<code class="no-auto-link">MyClass</code>');
   });
 
-  it('should ignore code blocks that are marked with an "ignored" languages', () => {
+  it('should ignore code blocks that are marked with an "ignored" language', () => {
     aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
     const doc = {docType: 'test-doc', renderedContent: '<code language="bash">MyClass</code>'};
     processor.$process([doc]);

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -18,101 +18,153 @@ describe('autoLinkCode post-processor', () => {
   });
 
   it('should insert an anchor into every code item that matches the id of an API doc', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>MyClass</code>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code><a href="a/b/myclass" class="code-anchor">MyClass</a></code>');
+    expect(doc.renderedContent)
+        .toEqual('<code><a href="a/b/myclass" class="code-anchor">MyClass</a></code>');
   });
 
   it('should insert an anchor into every code item that matches an alias of an API doc', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass', 'foo.MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>foo.MyClass</code>' };
+    aliasMap.addDoc({
+      docType: 'class',
+      id: 'MyClass',
+      aliases: ['MyClass', 'foo.MyClass'],
+      path: 'a/b/myclass'
+    });
+    const doc = {docType: 'test-doc', renderedContent: '<code>foo.MyClass</code>'};
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code><a href="a/b/myclass" class="code-anchor">foo.MyClass</a></code>');
+    expect(doc.renderedContent)
+        .toEqual('<code><a href="a/b/myclass" class="code-anchor">foo.MyClass</a></code>');
   });
 
-  it('should match code items within a block of code that contain a dot in their identifier', () => {
-    aliasMap.addDoc({ docType: 'member', id: 'MyEnum.Value', aliases: ['Value', 'MyEnum.Value'], path: 'a/b/myenum' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>someFn(): MyEnum.Value</code>' };
-    processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code>someFn(): <a href="a/b/myenum" class="code-anchor">MyEnum.Value</a></code>');
-  });
+  it('should match code items within a block of code that contain a dot in their identifier',
+     () => {
+       aliasMap.addDoc({
+         docType: 'member',
+         id: 'MyEnum.Value',
+         aliases: ['Value', 'MyEnum.Value'],
+         path: 'a/b/myenum'
+       });
+       const doc = {docType: 'test-doc', renderedContent: '<code>someFn(): MyEnum.Value</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent)
+           .toEqual(
+               '<code>someFn(): <a href="a/b/myenum" class="code-anchor">MyEnum.Value</a></code>');
+     });
 
   it('should ignore code items that do not match a link to an API doc', () => {
-    aliasMap.addDoc({ docType: 'guide', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>MyClass</code>' };
+    aliasMap.addDoc({docType: 'guide', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
     processor.$process([doc]);
     expect(doc.renderedContent).toEqual('<code>MyClass</code>');
   });
 
   it('should ignore code items that are already inside a link', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<a href="..."><div><code>MyClass</code></div></a>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {
+      docType: 'test-doc',
+      renderedContent: '<a href="..."><div><code>MyClass</code></div></a>'
+    };
     processor.$process([doc]);
     expect(doc.renderedContent).toEqual('<a href="..."><div><code>MyClass</code></div></a>');
   });
 
-  it('should ignore code items match an API doc but are not in the list of acceptable docTypes', () => {
-    aliasMap.addDoc({ docType: 'directive', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>MyClass</code>' };
-    processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code>MyClass</code>');
-  });
+  it('should ignore code items match an API doc but are not in the list of acceptable docTypes',
+     () => {
+       aliasMap.addDoc(
+           {docType: 'directive', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+       const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent).toEqual('<code>MyClass</code>');
+     });
 
-  it('should ignore code items that match an API doc but are attached to other text via a dash', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>xyz-MyClass</code>' };
-    processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code>xyz-MyClass</code>');
-  });
+  it('should ignore code items that match an API doc but are attached to other text via a dash',
+     () => {
+       aliasMap.addDoc(
+           {docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+       const doc = {docType: 'test-doc', renderedContent: '<code>xyz-MyClass</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent).toEqual('<code>xyz-MyClass</code>');
+     });
 
   it('should ignore code items that are filtered out by custom filters', () => {
     autoLinkCode.customFilters = [filterPipes];
-    aliasMap.addDoc({ docType: 'pipe', id: 'MyClass', aliases: ['MyClass', 'myClass'], path: 'a/b/myclass', pipeOptions: { name: '\'myClass\'' } });
-    const doc = { docType: 'test-doc', renderedContent: '<code>{ xyz | myClass } { xyz|myClass } MyClass myClass OtherClass|MyClass</code>' };
+    aliasMap.addDoc({
+      docType: 'pipe',
+      id: 'MyClass',
+      aliases: ['MyClass', 'myClass'],
+      path: 'a/b/myclass',
+      pipeOptions: {name: '\'myClass\''}
+    });
+    const doc = {
+      docType: 'test-doc',
+      renderedContent:
+          '<code>{ xyz | myClass } { xyz|myClass } MyClass myClass OtherClass|MyClass</code>'
+    };
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code>' +
-                                        '{ xyz | <a href="a/b/myclass" class="code-anchor">myClass</a> } '  +
-                                        '{ xyz|<a href="a/b/myclass" class="code-anchor">myClass</a> } ' +
-                                        '<a href="a/b/myclass" class="code-anchor">MyClass</a> ' +
-                                        'myClass OtherClass|<a href="a/b/myclass" class="code-anchor">MyClass</a>' +
-                                        '</code>');
+    expect(doc.renderedContent)
+        .toEqual(
+            '<code>' +
+            '{ xyz | <a href="a/b/myclass" class="code-anchor">myClass</a> } ' +
+            '{ xyz|<a href="a/b/myclass" class="code-anchor">myClass</a> } ' +
+            '<a href="a/b/myclass" class="code-anchor">MyClass</a> ' +
+            'myClass OtherClass|<a href="a/b/myclass" class="code-anchor">MyClass</a>' +
+            '</code>');
   });
 
   it('should ignore code items that match an internal API doc', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass', internal: true });
-    const doc = { docType: 'test-doc', renderedContent: '<code>MyClass</code>' };
+    aliasMap.addDoc({
+      docType: 'class',
+      id: 'MyClass',
+      aliases: ['MyClass'],
+      path: 'a/b/myclass',
+      internal: true
+    });
+    const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
     processor.$process([doc]);
     expect(doc.renderedContent).toEqual('<code>MyClass</code>');
   });
 
   it('should insert anchors for individual text nodes within a code block', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code><span>MyClass</span><span>MyClass</span></code>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {
+      docType: 'test-doc',
+      renderedContent: '<code><span>MyClass</span><span>MyClass</span></code>'
+    };
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code><span><a href="a/b/myclass" class="code-anchor">MyClass</a></span><span><a href="a/b/myclass" class="code-anchor">MyClass</a></span></code>');
+    expect(doc.renderedContent)
+        .toEqual(
+            '<code><span><a href="a/b/myclass" class="code-anchor">MyClass</a></span><span><a href="a/b/myclass" class="code-anchor">MyClass</a></span></code>');
   });
 
   it('should insert anchors for words that match within text nodes in a code block', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    aliasMap.addDoc({ docType: 'function', id: 'myFunc', aliases: ['myFunc'], path: 'ng/myfunc' });
-    aliasMap.addDoc({ docType: 'const', id: 'MY_CONST', aliases: ['MY_CONST'], path: 'ng/my_const' });
-    const doc = { docType: 'test-doc', renderedContent: '<code>myFunc() {\n  return new MyClass(MY_CONST);\n}</code>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    aliasMap.addDoc({docType: 'function', id: 'myFunc', aliases: ['myFunc'], path: 'ng/myfunc'});
+    aliasMap.addDoc({docType: 'const', id: 'MY_CONST', aliases: ['MY_CONST'], path: 'ng/my_const'});
+    const doc = {
+      docType: 'test-doc',
+      renderedContent: '<code>myFunc() {\n  return new MyClass(MY_CONST);\n}</code>'
+    };
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code><a href="ng/myfunc" class="code-anchor">myFunc</a>() {\n  return new <a href="a/b/myclass" class="code-anchor">MyClass</a>(<a href="ng/my_const" class="code-anchor">MY_CONST</a>);\n}</code>');
+    expect(doc.renderedContent)
+        .toEqual(
+            '<code><a href="ng/myfunc" class="code-anchor">myFunc</a>() {\n  return new <a href="a/b/myclass" class="code-anchor">MyClass</a>(<a href="ng/my_const" class="code-anchor">MY_CONST</a>);\n}</code>');
   });
 
   it('should work with custom elements', () => {
     autoLinkCode.codeElements = ['code-example'];
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code-example>MyClass</code-example>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {docType: 'test-doc', renderedContent: '<code-example>MyClass</code-example>'};
     processor.$process([doc]);
-    expect(doc.renderedContent).toEqual('<code-example><a href="a/b/myclass" class="code-anchor">MyClass</a></code-example>');
+    expect(doc.renderedContent)
+        .toEqual(
+            '<code-example><a href="a/b/myclass" class="code-anchor">MyClass</a></code-example>');
   });
 
   it('should ignore code blocks that are marked with a `no-auto-link` class', () => {
-    aliasMap.addDoc({ docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass' });
-    const doc = { docType: 'test-doc', renderedContent: '<code class="no-auto-link">MyClass</code>' };
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {docType: 'test-doc', renderedContent: '<code class="no-auto-link">MyClass</code>'};
     processor.$process([doc]);
     expect(doc.renderedContent).toEqual('<code class="no-auto-link">MyClass</code>');
   });

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -168,4 +168,11 @@ describe('autoLinkCode post-processor', () => {
     processor.$process([doc]);
     expect(doc.renderedContent).toEqual('<code class="no-auto-link">MyClass</code>');
   });
+
+  it('should ignore code blocks that are marked with an "ignored" languages', () => {
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+    const doc = {docType: 'test-doc', renderedContent: '<code language="bash">MyClass</code>'};
+    processor.$process([doc]);
+    expect(doc.renderedContent).toEqual('<code language="bash">MyClass</code>');
+  });
 });


### PR DESCRIPTION
Previously any code block, which was not marked with
`no-auto-link` css class would have its contents auto-linked to
API pages. Sometimes this results in false positive links being
generated.

This is problematic for triple backticked blocks, which cannot provide
the `no-auto-link` CSS class to prevent the linking.

This commit fixes the problem by allowing the auto-linker to be
configured not to auto-link code blocks that have been marked with an
"ignored" language. By default these are `bash` and `json`.

Triple backticked blocks are able to specify the language directly after
the first set of triple backticks.

---

By adding the `bash` language to the code snippet in the v9 update
guide it will no longer be auto-linked, which was causing a false positive
link to be rendered.

---

Fixes #33859

See https://pr33877-1635b2a.ngbuilds.io/guide/updating-to-version-9