### PR TITLE
fix(ngcc): correctly associate decorators with aliased classes

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
@@ -68,6 +68,15 @@ __decorate([
   core.Input(),
 ], OtherDirective.prototype, "input2", void 0);
 exports.OtherDirective = OtherDirective;
+
+var AliasedDirective$1 = (function () {
+  function AliasedDirective() {}
+  return AliasedDirective;
+}());
+AliasedDirective$1 = __decorate([
+  core.Directive({ selector: '[someDirective]' }),
+], AliasedDirective$1);
+exports.AliasedDirective$1 = AliasedDirective$1;
 `
       };
     });
@@ -80,6 +89,27 @@ exports.OtherDirective = OtherDirective;
         const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
         const classNode = getDeclaration(
             program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+        expect(decorators.length).toEqual(1);
+
+        const decorator = decorators[0];
+        expect(decorator.name).toEqual('Directive');
+        expect(decorator.identifier !.getText()).toEqual('core.Directive');
+        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+          '{ selector: \'[someDirective]\' }',
+        ]);
+      });
+
+      it('should find the decorators on an aliased class at the top level', () => {
+        loadFakeCore(getFileSystem());
+        loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
+        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+        const classNode = getDeclaration(
+            program, TOPLEVEL_DECORATORS_FILE.name, 'AliasedDirective$1',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toEqual(1);

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -379,29 +379,13 @@ runInEachFileSystem(() => {
                  'TemplateRef',
                  null,
                ]);
+
+               const decorators = parameters ![2].decorators !;
+               expect(decorators.length).toEqual(1);
+               expect(decorators[0].name).toBe('Inject');
+               expect(decorators[0].import !.from).toBe('@angular/core');
+               expect(decorators[0].import !.name).toBe('Inject');
              });
-
-          describe('(returned parameters `decorators`)', () => {
-            it('should use `getImportOfIdentifier()` to retrieve import info', () => {
-              const mockImportInfo = {} as Import;
-              const spy = spyOn(Esm2015ReflectionHost.prototype, 'getImportOfIdentifier')
-                              .and.returnValue(mockImportInfo);
-
-              const {program} = makeTestBundleProgram(_('/some_directive.js'));
-              const host =
-                  new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-              const classNode = getDeclaration(
-                  program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
-              const parameters = host.getConstructorParameters(classNode);
-              const decorators = parameters ![2].decorators !;
-
-              expect(decorators.length).toEqual(1);
-              expect(decorators[0].import).toBe(mockImportInfo);
-
-              const typeIdentifier = spy.calls.mostRecent().args[0] as ts.Identifier;
-              expect(typeIdentifier.text).toBe('Inject');
-            });
-          });
         });
 
         describe('getDeclarationOfIdentifier', () => {

--- a/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
@@ -61,6 +61,15 @@ runInEachFileSystem(() => {
     return SomeDirective;
   }());
   exports.SomeDirective = SomeDirective;
+  
+  var AliasedDirective$1 = /** @class */ (function () {
+    function AliasedDirective() {}
+    AliasedDirective = __decorate([
+      core.Directive({ selector: '[someDirective]' }),
+    ], AliasedDirective);
+    return AliasedDirective;
+  }());
+  exports.AliasedDirective$1 = AliasedDirective$1;
 })));`,
       };
     });
@@ -72,6 +81,26 @@ runInEachFileSystem(() => {
         const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
         const classNode = getDeclaration(
             program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+        expect(decorators).toBeDefined();
+        expect(decorators.length).toEqual(1);
+
+        const decorator = decorators[0];
+        expect(decorator.name).toEqual('Directive');
+        expect(decorator.identifier !.getText()).toEqual('core.Directive');
+        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+          '{ selector: \'[someDirective]\' }',
+        ]);
+      });
+
+      it('should find the decorators on an aliased class', () => {
+        loadTestFiles([SOME_DIRECTIVE_FILE]);
+        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const classNode = getDeclaration(
+            program, SOME_DIRECTIVE_FILE.name, 'AliasedDirective$1', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();


### PR DESCRIPTION
In flat bundle formats, multiple classes that have the same name can be
suffixed to become unique. In ES5-like bundles this results in the outer
declaration from having a different name from the "implementation"
declaration within the class' IIFE, as the implementation declaration
may not have been suffixed.

As an example, the following code would fail to have a `Directive`
decorator as ngcc would search for `__decorate` calls that refer to
`AliasedDirective$1` by name, whereas the `__decorate` call actually
uses the `AliasedDirective` name.

```javascript
var AliasedDirective$1 = /** @Class */ (function () {
    function AliasedDirective() {}
    AliasedDirective = tslib_1.__decorate([
        Directive({ selector: '[someDirective]' }),
    ], AliasedDirective);
    return AliasedDirective;
}());
```

This commit fixes the problem by not relying on comparing names, but
instead finding the declaration and matching it with both the outer
and inner declaration.