### PR TITLE
fix(language-service): determine index types accessed using dot notation

### DIFF
--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -307,7 +307,13 @@ class SymbolWrapper implements Symbol {
   public readonly nullable: boolean = false;
   public readonly language: string = 'typescript';
 
-  constructor(symbol: ts.Symbol, private context: TypeContext, private _tsType?: ts.Type) {
+  constructor(
+      symbol: ts.Symbol,
+      /** TypeScript type context of the symbol. */
+      private context: TypeContext,
+      /** Type of the TypeScript symbol, if known. If not provided, the type of the symbol
+      * will be determined dynamically; see `SymbolWrapper#tsType`. */
+      private _tsType?: ts.Type) {
     this.symbol = symbol && context && (symbol.flags & ts.SymbolFlags.Alias) ?
         context.checker.getAliasedSymbol(symbol) :
         symbol;

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -138,7 +138,7 @@ describe('completions', () => {
         const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
         const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
         expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
-      })
+      });
     });
   });
 

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -117,18 +117,29 @@ describe('completions', () => {
     expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
   });
 
-  it('should be able to get property completions for members in an array', () => {
-    mockHost.override(TEST_TEMPLATE, `{{ heroes[0].~{heroes-number-index}}}`);
-    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-number-index');
-    const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
-    expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
-  });
+  describe('property completions for members of an indexed type', () => {
+    it('should work with numeric index signatures (arrays)', () => {
+      mockHost.override(TEST_TEMPLATE, `{{ heroes[0].~{heroes-number-index}}}`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-number-index');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
+    });
 
-  it('should be able to get property completions for members in an indexed type', () => {
-    mockHost.override(TEST_TEMPLATE, `{{ heroesByName['Jacky'].~{heroes-string-index}}}`);
-    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
-    const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
-    expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
+    describe('with string index signatures', () => {
+      it('should work with index notation', () => {
+        mockHost.override(TEST_TEMPLATE, `{{ heroesByName['Jacky'].~{heroes-string-index}}}`);
+        const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
+        const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+        expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
+      });
+
+      it('should work with dot notation', () => {
+        mockHost.override(TEST_TEMPLATE, `{{ heroesByName.jacky.~{heroes-string-index}}}`);
+        const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'heroes-string-index');
+        const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+        expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
+      })
+    });
   });
 
   it('should be able to return attribute names with an incompete attribute', () => {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -119,13 +119,35 @@ describe('diagnostics', () => {
     expect(diagnostics).toEqual([]);
   });
 
-  it('should produce diagnostics for invalid index type property access', () => {
-    mockHost.override(TEST_TEMPLATE, `
+  describe('diagnostics for invalid indexed type property access', () => {
+    it('should work with numeric index signatures (arrays)', () => {
+      mockHost.override(TEST_TEMPLATE, `
         {{heroes[0].badProperty}}`);
-    const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
-    expect(diags.length).toBe(1);
-    expect(diags[0].messageText)
-        .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
+      const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText)
+          .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
+    });
+
+    describe('with string index signatures', () => {
+      it('should work with index notation', () => {
+        mockHost.override(TEST_TEMPLATE, `
+        {{heroesByName['Jacky'].badProperty}}`);
+        const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
+      });
+
+      it('should work with dot notation', () => {
+        mockHost.override(TEST_TEMPLATE, `
+        {{heroesByName.jacky.badProperty}}`);
+        const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
+      });
+    })
   });
 
   it('should not produce errors on function.bind()', () => {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -147,7 +147,7 @@ describe('diagnostics', () => {
         expect(diags[0].messageText)
             .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
       });
-    })
+    });
   });
 
   it('should not produce errors on function.bind()', () => {


### PR DESCRIPTION
Commit 53fc2ed8bf345222e0c3d53ce7f13a4f27f3052e added support for
determining index types accessed using index signatures, but did not
include support for index types accessed using dot notation:

```typescript
const obj<T>: { [key: string]: T };
obj['stringKey']. // gets `T.` completions
obj.stringKey.    // did not peviously get `T.` completions
```

This adds support for determining an index type accessed via dot
notation by rigging an object's symbol table to return the string index
signature type a property access refers to, if that property does not
explicitly exist on the object. This is very similar to @ivanwonder's
work in #29811.

`SymbolWrapper` now takes an additional parameter to explicitly set the
type of the symbol wrapped. This is done because
`SymbolTableWrapper#get` only has access to the symbol of the index
type, _not_ the index signature symbol itself. An attempt to get the
type of the index type will give an error.

Closes #29811
Closes https://github.com/angular/vscode-ng-language-service/issues/126
Closes https://github.com/angular/vscode-ng-language-service/issues/149

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No