### PR TITLE
fix(bazel): add terser as an optional peer dependency

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -33,11 +33,17 @@
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
     "@bazel/typescript": "0.*",
+    "terser": "^4.3.1",
     "typescript": ">=3.6 <3.7",
     "rollup": ">=1.20.0",
     "rollup-plugin-commonjs": ">=9.0.0",
     "rollup-plugin-node-resolve": ">=4.2.0",
     "rollup-plugin-sourcemaps": ">=0.4.0"
+  },
+  "peerDependenciesMeta": {
+    "terser": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`ng_package` rule has an implicitly optional depedency on terser https://github.com/angular/angular/blob/a48573efe8eca12ccfbe0c11fb60f322387bf79a/packages/bazel/src/ng_package/ng_package.bzl#L36

When using this rule without terser being available we get the below error;
```
ERROR: /home/circleci/ng/modules/express-engine/BUILD.bazel:22:1: every rule of type ng_package implicitly depends upon the target '@npm//terser/bin:terser', but this target could not be found because of: no such package '@npm//terser/bin': BUILD file not found in directory 'terser/bin' of external repository @npm. Add a BUILD file to a directory to mark it as a package.
ERROR: Analysis of target '//modules/express-engine:npm_package' failed; build aborted: no such package '@npm//terser/bin': BUILD file not found in directory 'terser/bin' of external repository @npm. Add a BUILD file to a directory to mark it as a package.
```
