### PR TITLE
fix(service-worker): throw when using the unsupported `versionedFiles` option in config

### DIFF
--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -45,6 +45,12 @@ export class Generator {
       Promise<Object[]> {
     const seenMap = new Set<string>();
     return Promise.all((config.assetGroups || []).map(async(group) => {
+      if ((group.resources as any).versionedFiles) {
+        throw new Error(
+            `Asset-group '${group.name}' in 'ngsw-config.json' uses the 'versionedFiles' option, ` +
+            'which is no longer supported. Use \'files\' instead.');
+      }
+
       const fileMatcher = globListToMatcher(group.resources.files || []);
       const allFiles = await this.fs.list('/');
 

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -12,7 +12,7 @@ import {MockFilesystem} from '../testing/mock';
 describe('Generator', () => {
   beforeEach(() => spyOn(Date, 'now').and.returnValue(1234567890123));
 
-  it('generates a correct config', done => {
+  it('generates a correct config', async() => {
     const fs = new MockFilesystem({
       '/index.html': 'This is a test',
       '/main.css': 'This is a CSS file',
@@ -23,7 +23,7 @@ describe('Generator', () => {
       '/ignored/x.html': 'should be ignored',
     });
     const gen = new Generator(fs, '/test');
-    const res = gen.process({
+    const config = await gen.process({
       appData: {
         test: true,
       },
@@ -41,8 +41,8 @@ describe('Generator', () => {
             '/absolute/**',
             '/some/url?with+escaped+chars',
             'relative/*.txt',
-          ]
-        }
+          ],
+        },
       }],
       dataGroups: [{
         name: 'other',
@@ -55,7 +55,7 @@ describe('Generator', () => {
           maxSize: 100,
           maxAge: '3d',
           timeout: '1m',
-        }
+        },
       }],
       navigationUrls: [
         '/included/absolute/**',
@@ -67,92 +67,86 @@ describe('Generator', () => {
         '!http://example.com/excluded',
       ],
     });
-    res.then(config => {
-         expect(config).toEqual({
-           configVersion: 1,
-           timestamp: 1234567890123,
-           appData: {
-             test: true,
-           },
-           index: '/test/index.html',
-           assetGroups: [{
-             name: 'test',
-             installMode: 'prefetch',
-             updateMode: 'prefetch',
-             urls: [
-               '/test/foo/test.html',
-               '/test/index.html',
-               '/test/main.js',
-               '/test/main.ts',
-               '/test/test.txt',
-             ],
-             patterns: [
-               '\\/absolute\\/.*',
-               '\\/some\\/url\\?with\\+escaped\\+chars',
-               '\\/test\\/relative\\/[^/]*\\.txt',
-             ]
-           }],
-           dataGroups: [{
-             name: 'other',
-             patterns: [
-               '\\/api\\/.*',
-               '\\/test\\/relapi\\/.*',
-               'https:\\/\\/example\\.com\\/(?:.+\\/)?[^/]*\\?with\\+escaped\\+chars',
-             ],
-             strategy: 'performance',
-             maxSize: 100,
-             maxAge: 259200000,
-             timeoutMs: 60000,
-             version: 1,
-           }],
-           navigationUrls: [
-             {positive: true, regex: '^\\/included\\/absolute\\/.*$'},
-             {positive: false, regex: '^\\/excluded\\/absolute\\/.*$'},
-             {positive: true, regex: '^\\/included\\/some\\/url\\/with\\+escaped\\+chars$'},
-             {positive: false, regex: '^\\/test\\/excluded\\/relative\\/[^/]*\\.txt$'},
-             {positive: false, regex: '^\\/api\\/[^/][^/]*$'},
-             {positive: true, regex: '^http:\\/\\/example\\.com\\/included$'},
-             {positive: false, regex: '^http:\\/\\/example\\.com\\/excluded$'},
-           ],
-           hashTable: {
-             '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
-             '/test/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
-             '/test/main.js': '41347a66676cdc0516934c76d9d13010df420f2c',
-             '/test/main.ts': '7d333e31f0bfc4f8152732bb211a93629484c035',
-             '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643'
-           }
-         });
-         done();
-       })
-        .catch(err => done.fail(err));
+
+    expect(config).toEqual({
+      configVersion: 1,
+      timestamp: 1234567890123,
+      appData: {
+        test: true,
+      },
+      index: '/test/index.html',
+      assetGroups: [{
+        name: 'test',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: [
+          '/test/foo/test.html',
+          '/test/index.html',
+          '/test/main.js',
+          '/test/main.ts',
+          '/test/test.txt',
+        ],
+        patterns: [
+          '\\/absolute\\/.*',
+          '\\/some\\/url\\?with\\+escaped\\+chars',
+          '\\/test\\/relative\\/[^/]*\\.txt',
+        ],
+      }],
+      dataGroups: [{
+        name: 'other',
+        patterns: [
+          '\\/api\\/.*',
+          '\\/test\\/relapi\\/.*',
+          'https:\\/\\/example\\.com\\/(?:.+\\/)?[^/]*\\?with\\+escaped\\+chars',
+        ],
+        strategy: 'performance',
+        maxSize: 100,
+        maxAge: 259200000,
+        timeoutMs: 60000,
+        version: 1,
+      }],
+      navigationUrls: [
+        {positive: true, regex: '^\\/included\\/absolute\\/.*$'},
+        {positive: false, regex: '^\\/excluded\\/absolute\\/.*$'},
+        {positive: true, regex: '^\\/included\\/some\\/url\\/with\\+escaped\\+chars$'},
+        {positive: false, regex: '^\\/test\\/excluded\\/relative\\/[^/]*\\.txt$'},
+        {positive: false, regex: '^\\/api\\/[^/][^/]*$'},
+        {positive: true, regex: '^http:\\/\\/example\\.com\\/included$'},
+        {positive: false, regex: '^http:\\/\\/example\\.com\\/excluded$'},
+      ],
+      hashTable: {
+        '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
+        '/test/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
+        '/test/main.js': '41347a66676cdc0516934c76d9d13010df420f2c',
+        '/test/main.ts': '7d333e31f0bfc4f8152732bb211a93629484c035',
+        '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
+      },
+    });
   });
 
-  it('uses default `navigationUrls` if not provided', done => {
+  it('uses default `navigationUrls` if not provided', async() => {
     const fs = new MockFilesystem({
       '/index.html': 'This is a test',
     });
     const gen = new Generator(fs, '/test');
-    const res = gen.process({
+    const config = await gen.process({
       index: '/index.html',
     });
-    res.then(config => {
-         expect(config).toEqual({
-           configVersion: 1,
-           timestamp: 1234567890123,
-           appData: undefined,
-           index: '/test/index.html',
-           assetGroups: [],
-           dataGroups: [],
-           navigationUrls: [
-             {positive: true, regex: '^\\/.*$'},
-             {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
-             {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
-             {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
-           ],
-           hashTable: {}
-         });
-         done();
-       })
-        .catch(err => done.fail(err));
+
+    expect(config).toEqual({
+      configVersion: 1,
+      timestamp: 1234567890123,
+      appData: undefined,
+      index: '/test/index.html',
+      assetGroups: [],
+      dataGroups: [],
+      navigationUrls: [
+        {positive: true, regex: '^\\/.*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
+      ],
+      hashTable: {},
+    });
   });
 });

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {Generator} from '../src/generator';
+import {AssetGroup} from '../src/in';
 import {MockFilesystem} from '../testing/mock';
 
 describe('Generator', () => {
@@ -148,5 +149,36 @@ describe('Generator', () => {
       ],
       hashTable: {},
     });
+  });
+
+  it('throws if the obsolete `versionedFiles` is used', async() => {
+    const fs = new MockFilesystem({
+      '/index.html': 'This is a test',
+      '/main.js': 'This is a JS file',
+    });
+    const gen = new Generator(fs, '/test');
+
+    try {
+      await gen.process({
+        index: '/index.html',
+        assetGroups: [{
+          name: 'test',
+          resources: {
+            files: [
+              '/*.html',
+            ],
+            versionedFiles: [
+              '/*.js',
+            ],
+          } as AssetGroup['resources'] &
+              {versionedFiles: string[]},
+        }],
+      });
+      throw new Error('Processing should have failed due to \'versionedFiles\'.');
+    } catch (err) {
+      expect(err).toEqual(new Error(
+          'Asset-group \'test\' in \'ngsw-config.json\' uses the \'versionedFiles\' option, ' +
+          'which is no longer supported. Use \'files\' instead.'));
+    }
   });
 });


### PR DESCRIPTION
In 5d5c94d, the deprecated `versionedFiles` option from the SW asset-group configuration in `ngsw-config.json`. As a result, the option would be silently ignored and the runtime behavior of the SW would change (i.e. some files might not be cached and available offline any more). This change could be easily go unnoticed by the developer.

This commit ensures this does not happen by throwing a build-time error, when detecting the unsupported `versionedFiles` option with an error message prompting the user to use the `files` option instead.

Jira issue: [FW-1727](https://angular-team.atlassian.net/browse/FW-1727)