### PR TITLE
build/ci: remove remote-http-cache config for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,21 +68,6 @@ test --test_output=errors
 # any bazel target. This is a temporary flag until codebase is permanently switched to Ivy.
 build --define=compile=legacy
 
-#######################
-# Remote HTTP Caching #
-#######################
-build --remote_http_cache=https://storage.googleapis.com/angular-team-cache
-build --remote_accept_cached=true
-build --remote_upload_local_results=false
-
-######################################
-# Remote HTTP Caching writes support #
-# Turn on these settings with        #
-#  --config=-http-caching            #
-######################################
-build:remote-http-caching --remote_upload_local_results=true
-build:remote-http-caching --google_default_credentials
-
 ##################################
 # Remote Build Execution support #
 # Turn on these settings with    #

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -224,15 +224,11 @@ It will automatically recognize `*.bazel` and `*.bzl` files.
 
 
 ### Remote Build Execution and Remote Caching
-Bazel builds in the Angular repository use a shared http cache.  When a build occurs a hash of the inputs is computed
-and checked against available outputs in the shared http cache.  If an output is found, it is used as the output for the
+Bazel builds in the Angular repository use a shared cache.  When a build occurs a hash of the inputs is computed
+and checked against available outputs in the shared cache.  If an output is found, it is used as the output for the
 build action rather than performing the build locally.
 
-> Remote Build Execution and uploading to the Remote Cache requires authentication as a google.com or angular.io account.
-
-#### --config=remote-http-caching flag
-The `--config=remote-http-caching` flag can be added to enable uploading of build results to the shared http cache.  This flag
-can be added to the `.bazelrc.user` file using the script at `scripts/local-dev/setup-rbe.sh`.
+> Remote Build Execution requires authentication as a google.com or angular.io account.
 
 #### --config=remote flag
 The `--config=remote` flag can be added to enable remote execution of builds.  This flag can be added to

--- a/scripts/local-dev/setup-rbe.sh
+++ b/scripts/local-dev/setup-rbe.sh
@@ -98,8 +98,3 @@ echo
 echo "The ${bold}remote${normal} flag enables RBE, builds run remotely when possible and caching"
 echo "occurs in the RBE context"
 add_flag "build --config=remote"
-
-# Remote HTTP Caching
-echo "The ${bold}remote-http-caching${normal} flag enables uploading build results to the http cache,"
-echo "but not does enable remote builds"
-add_flag "build --config=remote-http-caching"


### PR DESCRIPTION
We have determined that the upload time cost of remote caching via http is too costly
to be effective for our distributed usage scenario.  However this cost is still worth
it for us for Windows CI runs on a full cache hit move from a ~60 minute task to ~10
minutes.

It is worth noting that this remote http-caching is entirely separate from RBE caching
mechanisms