### PR TITLE
Add AIO doc reference to npm package readme

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -3,4 +3,6 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
+Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+
 License: MIT

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -1111,4 +1111,5 @@ export * from './secondary/secondary';
 
 --- some-file.txt ---
 
+
 This file is just copied into the package.

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -58,6 +58,8 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
+Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+
 License: MIT
 
 
@@ -1110,4 +1112,3 @@ export * from './secondary/secondary';
 --- some-file.txt ---
 
 This file is just copied into the package.
-

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -1111,5 +1111,5 @@ export * from './secondary/secondary';
 
 --- some-file.txt ---
 
-
 This file is just copied into the package.
+

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -69,6 +69,8 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
+Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+
 License: MIT
 
 
@@ -982,4 +984,3 @@ export declare function dispatchFakeEvent(el: HTMLElement, ev: Event): void;
  */
 
 export * from './utils/index';
-

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -984,3 +984,4 @@ export declare function dispatchFakeEvent(el: HTMLElement, ev: Event): void;
  */
 
 export * from './utils/index';
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
 Current npm doc for Angular packages is a generic README that refers to sources in git, but no information on what the package does. 
For example: https://www.npmjs.com/package/@angular/router

Issue Number:  https://github.com/angular/angular/issues/33766

## What is the new behavior?
Adding a ref to AIO for usage/reference info on packages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
