### PR TITLE
docs(core): fix typo in API docs

### DIFF
--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Defines template and style encapsulation options available for Component's {@link Component}.
+ * Defines template and style encapsulation options available for Component's {@link View}.
  *
  * See {@link Component#encapsulation encapsulation}.
  *


### PR DESCRIPTION
## fix typo in definition of *ViewEncapsulation* enum

*from* - Defines template and style encapsulation options available for Component's ~~**Component**~~
*to* -Defines template and style encapsulation options available for Component's **View**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Semantically incorrect definition of ViewEncapsulation enum from @angular/core package.
*Defines template and style encapsulation options available for Component's **Component***
 
P.S. I believe this is just a typo.

## What is the new behavior?

Replace the word **Component** with **View** in definition to get correct meaning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
