### PR TITLE
docs(changelog): Fixed consistency for default constructor

### DIFF
--- a/aio/content/examples/getting-started/src/app/cart/cart.component.ts
+++ b/aio/content/examples/getting-started/src/app/cart/cart.component.ts
@@ -23,7 +23,7 @@ export class CartComponent {
     private cartService: CartService,
     private formBuilder: FormBuilder,
   ) { }
-  
+
   ngOnInit() {
 // #enddocregion inject-form-builder
     this.items = this.cartService.getItems();

--- a/aio/content/examples/getting-started/src/app/cart/cart.component.ts
+++ b/aio/content/examples/getting-started/src/app/cart/cart.component.ts
@@ -27,7 +27,6 @@ export class CartComponent {
   ngOnInit() {
 // #enddocregion inject-form-builder
     this.items = this.cartService.getItems();
-
     this.checkoutForm = this.formBuilder.group({
       name: '',
       address: ''

--- a/aio/content/examples/getting-started/src/app/cart/cart.component.ts
+++ b/aio/content/examples/getting-started/src/app/cart/cart.component.ts
@@ -22,7 +22,9 @@ export class CartComponent {
   constructor(
     private cartService: CartService,
     private formBuilder: FormBuilder,
-  ) {
+  ) { }
+  
+  ngOnInit() {
 // #enddocregion inject-form-builder
     this.items = this.cartService.getItems();
 


### PR DESCRIPTION
I am not sure if this is better than defining it in the constructor, but if the example wants to stay consistent then this is a slightly better way. Especially because the `this.items = this.cartService.getItems();` was originally defined in `ngOnInit(){}`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`the behaviour will not change`
Issue Number: N/A


## What is the new behavior?
same

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
