### PR TITLE
fix(ivy): reset style property using ngStyle

### DIFF
--- a/packages/core/src/render3/styling/bindings.ts
+++ b/packages/core/src/render3/styling/bindings.ts
@@ -1102,7 +1102,7 @@ function removeStylingValues(
     const value = getMapValue(arr, i);
     if (value) {
       const prop = getMapProp(arr, i);
-      applyFn(renderer, element, prop, false);
+      applyFn(renderer, element, prop, null);
     }
   }
 }

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1936,6 +1936,32 @@ describe('styling', () => {
     expect(div.classList.contains('bar')).toBeTruthy();
   });
 
+  it('should allow to reset style property value defined using ngStyle', () => {
+    @Component({
+      template: `
+        <div [ngStyle]="s"></div>
+      `
+    })
+    class Cmp {
+      s: any = {opacity: '1'};
+
+      clearStyle(): void { this.s = null; }
+    }
+
+    TestBed.configureTestingModule({declarations: [Cmp]});
+    const fixture = TestBed.createComponent(Cmp);
+    const comp = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const div = fixture.nativeElement.querySelector('div');
+    expect(div.style.opacity).toEqual('1');
+
+    comp.clearStyle();
+    fixture.detectChanges();
+
+    expect(div.style.opacity).toEqual('');
+  });
+
   it('should allow detectChanges to be run in a property change that causes additional styling to be rendered',
      () => {
        @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33650 


## What is the new behavior?
This resolves issue with styles still being present after clearing ngStyle. 
Although this is a small change I think types around ApplyStylingFn value property could be more strict.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
