### PR TITLE
fix(ivy): add flag to skip non-exported classes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -642,7 +642,8 @@ export class NgtscProgram implements api.Program {
 
     return new IvyCompilation(
         handlers, this.reflector, this.importRewriter, this.incrementalDriver, this.perfRecorder,
-        this.sourceToFactorySymbols, scopeRegistry);
+        this.sourceToFactorySymbols, scopeRegistry,
+        this.options.compileNonExportedClasses !== false);
   }
 
   private getI18nLegacyMessageFormat(): string {

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -392,6 +392,12 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * support these future imports.
    */
   generateDeepReexports?: boolean;
+
+  /**
+   * Whether the compiler should avoid generating code for classes that haven't been exported.
+   * This is only active when building with `enableIvy: true`. Defaults to `true`.
+   */
+  compileNonExportedClasses?: boolean;
 }
 
 export interface CompilerHost extends ts.CompilerHost {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5181,6 +5181,60 @@ export const Foo = Foo__PRE_R3__;
         expect(jsContents).toContain('styles: ["h1[_ngcontent-%COMP%] {font-size: larger}"]');
       });
     });
+
+    describe('non-exported classes', () => {
+      beforeEach(() => env.tsconfig({compileNonExportedClasses: false}));
+
+      it('should not emit directive definitions for non-exported classes if configured', () => {
+        env.write('test.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[test]'
+          })
+          class TestDirective {}
+        `);
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).not.toContain('defineDirective(');
+        expect(jsContents).toContain('Directive({');
+      });
+
+      it('should not emit component definitions for non-exported classes if configured', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test',
+            template: 'hello'
+          })
+          class TestComponent {}
+        `);
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).not.toContain('defineComponent(');
+        expect(jsContents).toContain('Component({');
+      });
+
+      it('should not emit module definitions for non-exported classes if configured', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({
+            declarations: []
+          })
+          class TestModule {}
+        `);
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).not.toContain('defineNgModule(');
+        expect(jsContents).toContain('NgModule({');
+      });
+    });
+
   });
 
   function expectTokenAtPosition<T extends ts.Node>(


### PR DESCRIPTION
In ViewEngine we were only generating code for exported classes, however with Ivy we do it no matter whether the class has been exported or not. These changes add an extra flag that allows consumers to opt into the ViewEngine behavior. The flag works by treating non-exported classes as if they're set to `jit: true`.

Fixes #33724.