### PR TITLE
fix(ivy): ensure url-based CSS variables are sanitized

### DIFF
--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -483,10 +483,13 @@ function registerIntoMap(map: Map<string, number>, key: string) {
   }
 }
 
+const HYPHEN_CHAR = 45;
+
 function isStyleSanitizable(prop: string): boolean {
   // Note that browsers support both the dash case and
   // camel case property names when setting through JS.
-  return prop === 'background-image' || prop === 'backgroundImage' || prop === 'background' ||
+  return (prop.charCodeAt(0) === HYPHEN_CHAR && prop.charCodeAt(1) === HYPHEN_CHAR) ||
+      prop === 'background-image' || prop === 'backgroundImage' || prop === 'background' ||
       prop === 'border-image' || prop === 'borderImage' || prop === 'filter' ||
       prop === 'list-style' || prop === 'listStyle' || prop === 'list-style-image' ||
       prop === 'listStyleImage' || prop === 'clip-path' || prop === 'clipPath';

--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -486,13 +486,12 @@ function registerIntoMap(map: Map<string, number>, key: string) {
 const HYPHEN_CHAR = 45;
 
 function isStyleSanitizable(prop: string): boolean {
-  // Note that browsers support both the dash case and
-  // camel case property names when setting through JS.
+  // before this function is called, the provided `prop` value should
+  // have already been converted from camel-case to hyphen-case.
   return (prop.charCodeAt(0) === HYPHEN_CHAR && prop.charCodeAt(1) === HYPHEN_CHAR) ||
-      prop === 'background-image' || prop === 'backgroundImage' || prop === 'background' ||
-      prop === 'border-image' || prop === 'borderImage' || prop === 'filter' ||
-      prop === 'list-style' || prop === 'listStyle' || prop === 'list-style-image' ||
-      prop === 'listStyleImage' || prop === 'clip-path' || prop === 'clipPath';
+      prop === 'background-image' || prop === 'background' || prop === 'border-image' ||
+      prop === 'filter' || prop === 'list-style' || prop === 'list-style-image' ||
+      prop === 'clip-path';
 }
 
 /**

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -190,15 +190,8 @@ const HYPHEN_CHAR = 45;
 export const ɵɵdefaultStyleSanitizer =
     (function(prop: string, value: string|null, mode?: StyleSanitizeMode): string | boolean | null {
       mode = mode || StyleSanitizeMode.ValidateAndSanitize;
-      let doSanitizeValue = true;
-      if (mode & StyleSanitizeMode.ValidateProperty) {
-        doSanitizeValue =
-            (prop.charCodeAt(0) === HYPHEN_CHAR && prop.charCodeAt(1) === HYPHEN_CHAR) ||
-            prop === 'background-image' || prop === 'background' || prop === 'border-image' ||
-            prop === 'filter' || prop === 'list-style' || prop === 'list-style-image' ||
-            prop === 'clip-path';
-      }
-
+      const doSanitizeValue =
+          (mode & StyleSanitizeMode.ValidateProperty) ? isStyleSanitizable(prop) : true;
       if (mode & StyleSanitizeMode.SanitizeOnly) {
         return doSanitizeValue ? ɵɵsanitizeStyle(value) : value;
       } else {
@@ -227,4 +220,13 @@ export function validateAgainstEventAttributes(name: string) {
 function getSanitizer(): Sanitizer|null {
   const lView = getLView();
   return lView && lView[SANITIZER];
+}
+
+function isStyleSanitizable(prop: string): boolean {
+  // before this function is called, the provided `prop` value should
+  // have already been converted from camel-case to hyphen-case.
+  return (prop.charCodeAt(0) === HYPHEN_CHAR && prop.charCodeAt(1) === HYPHEN_CHAR) ||
+      prop === 'background-image' || prop === 'background' || prop === 'border-image' ||
+      prop === 'filter' || prop === 'list-style' || prop === 'list-style-image' ||
+      prop === 'clip-path';
 }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -179,6 +179,8 @@ export function ɵɵsanitizeUrlOrResourceUrl(unsafeUrl: any, tag: string, prop: 
   return getUrlSanitizer(tag, prop)(unsafeUrl);
 }
 
+const HYPHEN_CHAR = 45;
+
 /**
  * The default style sanitizer will handle sanitization for style properties by
  * sanitizing any CSS property that can include a `url` value (usually image-based properties)
@@ -190,9 +192,11 @@ export const ɵɵdefaultStyleSanitizer =
       mode = mode || StyleSanitizeMode.ValidateAndSanitize;
       let doSanitizeValue = true;
       if (mode & StyleSanitizeMode.ValidateProperty) {
-        doSanitizeValue = prop === 'background-image' || prop === 'background' ||
-            prop === 'border-image' || prop === 'filter' || prop === 'list-style' ||
-            prop === 'list-style-image' || prop === 'clip-path';
+        doSanitizeValue =
+            (prop.charCodeAt(0) === HYPHEN_CHAR && prop.charCodeAt(1) === HYPHEN_CHAR) ||
+            prop === 'background-image' || prop === 'background' || prop === 'border-image' ||
+            prop === 'filter' || prop === 'list-style' || prop === 'list-style-image' ||
+            prop === 'clip-path';
       }
 
       if (mode & StyleSanitizeMode.SanitizeOnly) {


### PR DESCRIPTION
This patch ensures that [style] bindings properly sanitize
CSS variable values before they are written to the DOM. The
reasoning for this is because CSS variables may contain `url()`
entries which are a gateway for code injection. The additional
sanitization checks now fix this.

Jira issue: [FW-1684](https://angular-team.atlassian.net/browse/FW-1684)