### PR TITLE
fix(service-worker): allow creating post api requests after cache failure

### DIFF
--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -275,7 +275,15 @@ export class DataGroup {
       return;
     }
     const table = await this.lruTable;
-    return table.write('lru', this._lru !.state);
+    try {
+      return table.write('lru', this._lru !.state);
+    } catch (err) {
+      // Writing lru cache table failed. This could be a result of a full storage.
+      // Continue serving clients as usual.
+      this.debugHandler.log(err, `DataGroup(${this.config.name}@${this.config.version}).syncLru()`);
+      // TODO: Better detect/handle full storage; e.g. using
+      // [navigator.storage](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorStorage/storage).
+    }
   }
 
   /**

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -110,6 +110,9 @@ export class MockRequest extends MockBody implements Request {
     if (init.credentials !== undefined) {
       this.credentials = init.credentials;
     }
+    if (init.method !== undefined) {
+      this.method = init.method;
+    }
   }
 
   clone(): Request {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Before creating a mutating http request, service-worker invalidates lru cache entry and writes to cache storage. Therefore, cache storage failure can prevent making post requests.


Issue Number: #33793


## What is the new behavior?

Cache storage error is catched and logged when trying to update lru cache table.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

