### PR TITLE
build: change extraction of web_test_archives to run phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,101 +794,101 @@ workflows:
           filters:
             branches:
               ignore: g3
-      - lint:
-          requires:
-            - setup
-      - test:
-          requires:
-            - setup
+      # - lint:
+      #     requires:
+      #       - setup
+      # - test:
+      #     requires:
+      #       - setup
       - test_ivy_aot:
           requires:
             - setup
-      - build-npm-packages:
-          requires:
-            - setup
-      - build-ivy-npm-packages:
-          requires:
-            - setup
-      - legacy-misc-tests:
-          requires:
-            - build-npm-packages
-      - legacy-unit-tests-saucelabs:
-          requires:
-            - setup
-      - test_saucelabs_bazel:
-          # This job is currently a PoC and a subset of `legacy-unit-tests-saucelabs`. Running on
-          # master only to avoid wasting resources.
-          #
-          # TODO: Run this job on all branches (including PRs) as soon as it is not a PoC.
-          <<: *only_on_master
-          requires:
-            - setup
-      - test_aio:
-          requires:
-            - setup
-      - deploy_aio:
-          requires:
-            - test_aio
-      - test_aio_local:
-          requires:
-            - build-npm-packages
-      - test_aio_local:
-          name: test_aio_local_viewengine
-          viewengine: true
-          requires:
-            - build-npm-packages
-      - test_aio_tools:
-          requires:
-            - build-npm-packages
-      - test_docs_examples:
-          requires:
-            - build-npm-packages
-      - test_docs_examples:
-          name: test_docs_examples_ivy
-          ivy: true
-          requires:
-            - build-ivy-npm-packages
-      - aio_preview:
-          # Only run on PR builds. (There can be no previews for non-PR builds.)
-          <<: *only_on_pull_requests
-          requires:
-            - setup
-      - test_aio_preview:
-          requires:
-            - aio_preview
-      - integration_test:
-          requires:
-            - build-npm-packages
-      - publish_packages_as_artifacts:
-          requires:
-            - build-npm-packages
-      - publish_snapshot:
-          # Note: no filters on this job because we want it to run for all upstream branches
-          # We'd really like to filter out pull requests here, but not yet available:
-          # https://discuss.circleci.com/t/workflows-pull-request-filter/14396/4
-          # Instead, the job just exits immediately at the first step.
-          requires:
-            # Only publish if tests and integration tests pass
-            - test
-            - test_ivy_aot
-            - integration_test
-            # Only publish if `aio`/`docs` tests using the locally built Angular packages pass
-            - test_aio_local
-            - test_aio_local_viewengine
-            - test_docs_examples
-            - test_docs_examples_ivy
-            # Get the artifacts to publish from the build-packages-dist job
-            # since the publishing script expects the legacy outputs layout.
-            - build-npm-packages
-            - build-ivy-npm-packages
-            - legacy-unit-tests-saucelabs
-            - legacy-misc-tests
-      - material-unit-tests:
-          requires:
-            - build-npm-packages
-      - test_zonejs:
-          requires:
-            - setup
+      # - build-npm-packages:
+      #     requires:
+      #       - setup
+      # - build-ivy-npm-packages:
+      #     requires:
+      #       - setup
+      # - legacy-misc-tests:
+      #     requires:
+      #       - build-npm-packages
+      # - legacy-unit-tests-saucelabs:
+      #     requires:
+      #       - setup
+      # - test_saucelabs_bazel:
+      #     # This job is currently a PoC and a subset of `legacy-unit-tests-saucelabs`. Running on
+      #     # master only to avoid wasting resources.
+      #     #
+      #     # TODO: Run this job on all branches (including PRs) as soon as it is not a PoC.
+      #     <<: *only_on_master
+      #     requires:
+      #       - setup
+      # - test_aio:
+      #     requires:
+      #       - setup
+      # - deploy_aio:
+      #     requires:
+      #       - test_aio
+      # - test_aio_local:
+      #     requires:
+      #       - build-npm-packages
+      # - test_aio_local:
+      #     name: test_aio_local_viewengine
+      #     viewengine: true
+      #     requires:
+      #       - build-npm-packages
+      # - test_aio_tools:
+      #     requires:
+      #       - build-npm-packages
+      # - test_docs_examples:
+      #     requires:
+      #       - build-npm-packages
+      # - test_docs_examples:
+      #     name: test_docs_examples_ivy
+      #     ivy: true
+      #     requires:
+      #       - build-ivy-npm-packages
+      # - aio_preview:
+      #     # Only run on PR builds. (There can be no previews for non-PR builds.)
+      #     <<: *only_on_pull_requests
+      #     requires:
+      #       - setup
+      # - test_aio_preview:
+      #     requires:
+      #       - aio_preview
+      # - integration_test:
+      #     requires:
+      #       - build-npm-packages
+      # - publish_packages_as_artifacts:
+      #     requires:
+      #       - build-npm-packages
+      # - publish_snapshot:
+      #     # Note: no filters on this job because we want it to run for all upstream branches
+      #     # We'd really like to filter out pull requests here, but not yet available:
+      #     # https://discuss.circleci.com/t/workflows-pull-request-filter/14396/4
+      #     # Instead, the job just exits immediately at the first step.
+      #     requires:
+      #       # Only publish if tests and integration tests pass
+      #       - test
+      #       - test_ivy_aot
+      #       - integration_test
+      #       # Only publish if `aio`/`docs` tests using the locally built Angular packages pass
+      #       - test_aio_local
+      #       - test_aio_local_viewengine
+      #       - test_docs_examples
+      #       - test_docs_examples_ivy
+      #       # Get the artifacts to publish from the build-packages-dist job
+      #       # since the publishing script expects the legacy outputs layout.
+      #       - build-npm-packages
+      #       - build-ivy-npm-packages
+      #       - legacy-unit-tests-saucelabs
+      #       - legacy-misc-tests
+      # - material-unit-tests:
+      #     requires:
+      #       - build-npm-packages
+      # - test_zonejs:
+      #     requires:
+      #       - setup
       # Windows Jobs
       # These are very slow so we run them on non-PRs only for now.
       # TODO: remove the filter when CircleCI makes Windows FS faster.

--- a/tools/browsers/BUILD.bazel
+++ b/tools/browsers/BUILD.bazel
@@ -25,6 +25,7 @@ web_test_archive(
         "@io_bazel_rules_webtesting//common/conditions:mac": "@org_chromium_chromium_macos//file",
         "@io_bazel_rules_webtesting//common/conditions:windows": "@org_chromium_chromium_windows//file",
     }),
+
     extract = "build",
     named_files = select({
         "@io_bazel_rules_webtesting//common/conditions:linux": {"CHROMIUM": "chrome-linux/chrome"},


### PR DESCRIPTION
By moving extract to the run value, we only extract it once we are sure
it will be used.  With the build value, it is extracted during the build
phase, so we might upload it before the build completes.  If the build
fails along the way, we have uploaded it for "no reason."  By moving to
run we ensure that we only upload after we are sure something builds,
and increase the likelihood of action cache hits.