### PR TITLE
fix(common): ngSwitchCase to handle undefined and null properly (#33873)

### DIFF
--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -132,7 +132,7 @@ export class NgSwitch {
 
   /** @internal */
   _matchCase(value: any): boolean {
-    const matched = value == this._ngSwitch;
+    const matched = value === this._ngSwitch;
     this._lastCasesMatched = this._lastCasesMatched || matched;
     this._lastCaseCheckIndex++;
     if (this._lastCaseCheckIndex === this._caseCount) {

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -185,6 +185,26 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         fixture.componentInstance.state = 'case1';
         detectChangesAndExpectText('Foo');
       });
+
+      it('should handle null and undefined separtely', () => {
+        const template = '<ul [ngSwitch]="switchValue">' +
+            '<li *ngSwitchDefault>when default1;</li>' +
+            '<li *ngSwitchCase="null">when null;</li>' +
+            '<li *ngSwitchCase="undefined">when undefined;</li>' +
+            '</ul>';
+
+        fixture = createTestComponent(template);
+
+        fixture.componentInstance.switchValue = 'Foo';
+        detectChangesAndExpectText('when default1;');
+
+        fixture.componentInstance.switchValue = null;
+        detectChangesAndExpectText('when null;');
+
+        fixture.componentInstance.switchValue = undefined;
+        detectChangesAndExpectText('when undefined;');
+
+      });
     });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://github.com/angular/angular/issues/33873

Issue Number: #33873


## What is the new behavior?
Now, ngSwitchCase will be able to handle undefined and null cases separately.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
