### PR TITLE
fix(docs-infra): fix StackBlitz and zipped `http` examples

### DIFF
--- a/aio/content/examples/http/specs.stackblitz.json
+++ b/aio/content/examples/http/specs.stackblitz.json
@@ -1,6 +1,7 @@
 {
   "description": "Http Guide Testing",
   "files":[
+    "src/app/heroes/hero.ts",
     "src/app/heroes/heroes.service.ts",
     "src/app/heroes/heroes.service.spec.ts",
 

--- a/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
+++ b/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
@@ -28,9 +28,9 @@ describe('HeroesService', () => {
 
     // Inject the http, test controller, and service-under-test
     // as they will be referenced by each test.
-    httpClient = TestBed.inject(HttpClient);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    heroService = TestBed.inject(HeroesService);
+    httpClient = TestBed.get(HttpClient);
+    httpTestingController = TestBed.get(HttpTestingController);
+    heroService = TestBed.get(HeroesService);
   });
 
   afterEach(() => {
@@ -44,7 +44,7 @@ describe('HeroesService', () => {
     let expectedHeroes: Hero[];
 
     beforeEach(() => {
-      heroService = TestBed.inject(HeroesService);
+      heroService = TestBed.get(HeroesService);
       expectedHeroes = [
         { id: 1, name: 'A' },
         { id: 2, name: 'B' },

--- a/aio/content/examples/http/src/main.ts
+++ b/aio/content/examples/http/src/main.ts
@@ -1,5 +1,12 @@
 // #docregion
+import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
 import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
 
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/aio/content/examples/http/src/testing/http-client.spec.ts
+++ b/aio/content/examples/http/src/testing/http-client.spec.ts
@@ -27,8 +27,8 @@ describe('HttpClient testing', () => {
     });
 
     // Inject the http service and test controller for each test
-    httpClient = TestBed.inject(HttpClient);
-    httpTestingController = TestBed.inject(HttpTestingController);
+    httpClient = TestBed.get(HttpClient);
+    httpTestingController = TestBed.get(HttpTestingController);
   });
   // #enddocregion setup
   // #docregion afterEach
@@ -67,6 +67,7 @@ describe('HttpClient testing', () => {
     httpTestingController.verify();
   });
   // #enddocregion get-test
+
   it('can test HttpClient.get with matching header', () => {
     const testData: Data = {name: 'Test Data'};
 

--- a/aio/content/examples/http/stackblitz.json
+++ b/aio/content/examples/http/stackblitz.json
@@ -5,7 +5,8 @@
     "!**/*.js",
 
     "!src/testing/*.*",
-    "!src/index-specs.html"
+    "!src/index-specs.html",
+    "!src/main-specs.ts"
   ],
   "tags": ["http"]
 }


### PR DESCRIPTION
Previously, the generated StackBlitz examples as well as the corresponding downloadable zips for the `http` guide examples were not correct and thus trying to run the app and/or tests would fail.

This commit fixes the examples:

- Replace `TestBed.inject()` (which was [introduced in v9][1]) with `TestBed.get()` (which is available in v8 used in the examples).
  (NOTE: The examples will soon be updated to v9 (as part of [FW-1609][2] and switched back to `TestBed.inject()` then.)

- Include `src/app/heroes/hero.ts` in the zip, because it is referenced by some of the other files and the compilation fails without it.

- Ensure `src/main-specs.ts` is not included in the zip that does not include the tests. Including the file broke the app, because there is logic in our zip-builder that renamed `main-*.ts` files to `main.ts` and thus `main-specs.ts` ended up overwriting the actual `main.ts`.

[1]: https://next.angular.io/guide/deprecations#angularcoretesting
[2]: https://angular-team.atlassian.net/browse/FW-1609

Fixes #33874, #33945.

[FW-1609]: https://angular-team.atlassian.net/browse/FW-1609