### PR TITLE
fix(ivy): remove TNodeType assertion from `directiveInject` instruction

### DIFF
--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -46,9 +46,6 @@ export function ɵɵdirectiveInject<T>(
   // if inject utilities are used before bootstrapping.
   if (lView == null) return ɵɵinject(token, flags);
   const tNode = getPreviousOrParentTNode();
-  ngDevMode && assertNodeOfPossibleTypes(
-                   tNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer,
-                   TNodeType.IcuContainer);
   return getOrCreateInjectable<T>(
       tNode as TDirectiveHostNode, lView, resolveForwardRef(token), flags);
 }


### PR DESCRIPTION
The assertion that we have in the `directiveInject` instruction is too restrictive and we came across some pattern where it throws unnecessarily. This commit removes that assertion for now and more detailed investigation is needed to decide is we need to restrict the set of TNodeType again.

This commit also adds a test which triggered the TNodeType.View to come up in the `directiveInject` instruction, so it might be useful to avoid regressions during further refactoring.

This PR resolves FW-1734.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No