### PR TITLE
ci: use more descriptive names for published build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,14 +578,14 @@ jobs:
       # Publish `@angular/*` packages.
       - run:
           name: Create artifacts for @angular/* packages
-          command: ./scripts/ci/create-package-archives.sh $CI_PULL_REQUEST $CI_COMMIT $NG_PACKAGES_DIR $NG_PACKAGES_ARCHIVES_DIR
+          command: ./scripts/ci/create-package-archives.sh $CI_BRANCH $CI_COMMIT $NG_PACKAGES_DIR $NG_PACKAGES_ARCHIVES_DIR
       - store_artifacts:
           path: *ng_packages_archives_dir
           destination: angular
       # Publish `zone.js` package.
       - run:
           name: Create artifacts for zone.js package
-          command: ./scripts/ci/create-package-archives.sh $CI_PULL_REQUEST $CI_COMMIT $ZONEJS_PACKAGES_DIR $ZONEJS_PACKAGES_ARCHIVES_DIR
+          command: ./scripts/ci/create-package-archives.sh $CI_BRANCH $CI_COMMIT $ZONEJS_PACKAGES_DIR $ZONEJS_PACKAGES_ARCHIVES_DIR
       - store_artifacts:
           path: *zonejs_packages_archives_dir
           destination: zone.js

--- a/scripts/ci/create-package-archives.sh
+++ b/scripts/ci/create-package-archives.sh
@@ -2,11 +2,11 @@
 
 set -eu -o pipefail
 
-readonly prNumber="$1"
-readonly prLastSha="${2:0:7}"
+readonly safeBranchName="$(echo $1 | sed 's/^pull\//pr/' | sed 's/[^A-Za-z0-9_.-]/_/g')"
+readonly shortLastSha="$(git rev-parse --short $2)"
 readonly inputDir="$PROJECT_ROOT/$3"
 readonly outputDir="$PROJECT_ROOT/$4"
-readonly fileSuffix="-pr$prNumber-$prLastSha.tgz"
+readonly fileSuffix="-$safeBranchName-$shortLastSha.tgz"
 
 echo "Creating compressed archives for packages in '$inputDir'."
 


### PR DESCRIPTION
In efbbae5a4, the `publish_packages_as_artifacts` CircleCI job was created to publish the build artifacts of PR builds on CI. In a8f4f14bd, its scope was expanded to also publish build artifacts on non-PR builds.

The published artifacts names are constructed based on the PR number (e.g. include `-pr12345-`), so on non-PR builds the names do not reflect the source branch (instead, they include `-prfalse-`).

This commit fixes this by using the current branch name. For example, artifact names for the `master` or `9.0.x` branch will include `-master-` and `-9.0.x-` respectively (instead of `-prfalse-`).
(NOTE: For PRs, where branch name is `pull/12345`, the branch name is transformed to `pr12345`.)
