### PR TITLE
refactor(core): update undecorated-classes-with-di migration rerun command

### DIFF
--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -24,7 +24,7 @@ import {UndecoratedClassesTransform} from './transform';
 import {UpdateRecorder} from './update_recorder';
 
 const MIGRATION_RERUN_MESSAGE = 'Migration can be rerun with: "ng update @angular/core ' +
-    '--from 8.0.0 --to 9.0.0 --migrate-only"';
+    '--migrate-only migration-v9-undecorated-classes-with-di"';
 
 const MIGRATION_AOT_FAILURE = 'This migration uses the Angular compiler internally and ' +
     'therefore projects that no longer build successfully after the update cannot run ' +


### PR DESCRIPTION
With Angular CLI version 9 RC 3 we can run a single migration for a package using the name of the migration schematic.

We need to pass the schematic name as a value to the `migrate-only` option.
Ex:
```
ng update @angular/core --migrate-only migration-v9-undecorated-classes-with-di
```

See: https://github.com/angular/angular-cli/pull/16174


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
