### PR TITLE
Size tracking improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -946,6 +946,14 @@ testing/**                                                      @angular/fw-test
 
 
 # ================================================
+#  Size tracking
+# ================================================
+
+/aio/scripts/_payload-limits.json                               @kara @IgorMinar
+/integration/_payload-limits.json                               @kara @IgorMinar
+
+
+# ================================================
 #  Special cases
 # ================================================
 

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3097,
-        "main-es2015": 436779,
+        "main-es2015": 439352,
         "polyfills-es2015": 52503
       }
     }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 141575,
+        "main-es2015": 142186,
         "polyfills-es2015": 36808
       }
     }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 147719,
+        "main-es2015": 148320,
         "polyfills-es2015": 36808
       }
     }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 227998,
+        "main-es2015": 227232,
         "polyfills-es2015": 36808,
         "5-es2015": 779
       }
@@ -60,7 +60,7 @@
       "uncompressed": {
         "bundle": "TODO(i): temporarily increase the payload size limit from 105779 - this is due to a closure issue related to ESM reexports that still needs to be investigated",
         "bundle": "TODO(i): we should define ngDevMode to false in Closure, but --define only works in the global scope.",
-        "bundle": 177447
+        "bundle": 176433
       }
     }
   }

--- a/scripts/ci/payload-size.js
+++ b/scripts/ci/payload-size.js
@@ -28,16 +28,20 @@ for (const compressionType in limitSizes) {
         console.log(
             `Commit ${commit} ${compressionType} ${filename} meassurement is missing. ` +
             'Maybe the file was renamed or removed.');
-      } else if (Math.abs(actualSize - expectedSize) > expectedSize / 100) {
-        failed = true;
-        // We must also catch when the size is significantly lower than the payload limit, so
-        // we are forced to update the expected payload number when the payload size reduces.
-        // Otherwise, we won't be able to catch future regressions that happen to be below
-        // the artificially inflated limit.
-        const operator = actualSize > expectedSize ? 'exceeded' : 'fell below';
-        console.log(
-            `Commit ${commit} ${compressionType} ${filename} ${operator} expected size by >1% ` +
+      } else {
+        const absoluteSizeDiff = Math.abs(actualSize - expectedSize);
+        // If size diff is larger than 1% or 500 bytes...
+        if (absoluteSizeDiff > 500 || absoluteSizeDiff > expectedSize / 100) {
+          failed = true;
+          // We must also catch when the size is significantly lower than the payload limit, so
+          // we are forced to update the expected payload number when the payload size reduces.
+          // Otherwise, we won't be able to catch future regressions that happen to be below
+          // the artificially inflated limit.
+          const operator = actualSize > expectedSize ? 'exceeded' : 'fell below';
+          console.log(
+            `Commit ${commit} ${compressionType} ${filename} ${operator} expected size by 500 bytes or >1% ` +
             `(expected: ${expectedSize}, actual: ${actualSize}).`);
+        }
       }
     }
   }
@@ -47,5 +51,5 @@ if (failed) {
   console.log(`If this is a desired change, please update the size limits in file '${limitFile}'.`);
   process.exit(1);
 } else {
-  console.log('Payload size <1% change check passed.');
+  console.log('Payload size check passed. The diff is less than 1% or 500 bytes.');
 }


### PR DESCRIPTION
*ci: tighten code owners for size tracking*

It will be easier to track regressions in size if fewer people
are approving size diffs in PRs. That way, we will have a few
people that have a fuller picture of where size changes are
coming from.
 
*ci: tighten size threshold to 1% or 500 bytes*

The size diff threshold of 1% has proven to be too lenient for us
to catch size regressions in AIO. Since the AIO main bundle is
between 400-500 KB, a size regression must be between 4-5 KB before
it will cause the tests to fail. As a result, we may merge many
changes with smaller regressions of a few KB before the size test
eventually lets us know that the number has increased. The hope is
that lowering the threshold will help us catch the smaller
regressions during code review and prevent the size tests failing at
a random later time when someone catches the size "hot potato".

---

![Screen Shot 2019-11-21 at 5 17 57 PM](https://user-images.githubusercontent.com/3871688/69390112-0ad1eb80-0c83-11ea-9818-7d15c0f237d9.png)
