### PR TITLE
ci: set up window CI to use remote http caching

### DIFF
--- a/.circleci/bazel.windows.rc
+++ b/.circleci/bazel.windows.rc
@@ -11,4 +11,7 @@ import %workspace%/.circleci/bazel.common.rc
 build --repository_cache=C:/Users/circleci/bazel_repository_cache
 
 # All windows jobs run on master and should use http caching
-build --config=remote-http-caching
+build --remote_http_cache=https://storage.googleapis.com/angular-team-cache
+build --remote_accept_cached=true
+build --remote_upload_local_results=true
+build --google_default_credentials


### PR DESCRIPTION
Somehow https://github.com/angular/angular/commit/85f4d883f27d75c02c301d0a9bd66556798d75ac was dropped from #33907

This change includes the missing file change from the commit.  Fixing CI on master.