### PR TITLE
fix(ngcc): do not crash on packages that specify typings as an array

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -108,7 +108,7 @@ export function getEntryPointInfo(
   // We must have a typings property
   const typings = entryPointPackageJson.typings || entryPointPackageJson.types ||
       guessTypingsFromPackageJson(fs, entryPointPath, entryPointPackageJson);
-  if (!typings) {
+  if (typeof typings !== 'string') {
     return null;
   }
 

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -184,6 +184,26 @@ runInEachFileSystem(() => {
       expect(entryPoint).toBe(null);
     });
 
+    it('should return null if the typings or types field is not a string in the package.json',
+       () => {
+         loadTestFiles([
+           {
+             name: _('/project/node_modules/some_package/typings_array/package.json'),
+             contents: createPackageJson('typings_array', {typingsIsArray: true})
+           },
+           {
+             name: _(
+                 '/project/node_modules/some_package/typings_array/missing_typings.metadata.json'),
+             contents: 'some meta data'
+           },
+         ]);
+         const config = new NgccConfiguration(fs, _('/project'));
+         const entryPoint = getEntryPointInfo(
+             fs, config, new MockLogger(), SOME_PACKAGE,
+             _('/project/node_modules/some_package/typings_array'));
+         expect(entryPoint).toBe(null);
+       });
+
     for (let prop of SUPPORTED_FORMAT_PROPERTIES) {
       // Ignore the UMD format
       if (prop === 'main') continue;
@@ -279,7 +299,7 @@ runInEachFileSystem(() => {
       loadTestFiles([
         {
           name: _('/project/node_modules/some_package/types_rather_than_typings/package.json'),
-          contents: createPackageJson('types_rather_than_typings', {}, 'types')
+          contents: createPackageJson('types_rather_than_typings', {typingsProp: 'types'})
         },
         {
           name: _(
@@ -443,11 +463,12 @@ runInEachFileSystem(() => {
   });
 
   function createPackageJson(
-      packageName: string, {excludes}: {excludes?: string[]} = {},
-      typingsProp: string = 'typings'): string {
+      packageName: string,
+      {excludes, typingsProp = 'typings', typingsIsArray}:
+          {excludes?: string[], typingsProp?: string, typingsIsArray?: boolean} = {}): string {
     const packageJson: any = {
       name: `some_package/${packageName}`,
-      [typingsProp]: `./${packageName}.d.ts`,
+      [typingsProp]: typingsIsArray ? [`./${packageName}.d.ts`] : `./${packageName}.d.ts`,
       fesm2015: `./fesm2015/${packageName}.js`,
       esm2015: `./esm2015/${packageName}.js`,
       es2015: `./es2015/${packageName}.js`,


### PR DESCRIPTION
In a package.json file, the "typings" or "types" field could be an array
of typings files. ngcc would previously crash unexpectedly for such
packages, as it assumed that the typings field would be a string. This
commit lets ngcc skip over such packages, as having multiple typing
entry-points is not supported for Angular packages so it is safe to
ignore them.

Fixes #33646