### PR TITLE
refactor(compiler): add details when throwing that host binding is bound to event

### DIFF
--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -85,7 +85,8 @@ export class DirectiveResolver {
         if (hostBinding.hostPropertyName) {
           const startWith = hostBinding.hostPropertyName[0];
           if (startWith === '(') {
-            throw new Error(`@HostBinding can not bind to events. Use @HostListener instead.`);
+            throw new Error(
+                `@HostBinding can not bind to events. Use @HostListener instead. Host binding: "${hostBinding.hostPropertyName}" located at "${directiveType.name}" and bound to "${propName}" property`);
           } else if (startWith === '[') {
             throw new Error(
                 `@HostBinding parameter should be a property name, 'class.<name>', or 'attr.<name>'.`);

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -312,7 +312,8 @@ class SomeDirectiveWithoutMetadata {}
 
       it('should throw when @HostBinding name starts with "("', () => {
         expect(() => resolver.resolve(SomeDirectiveWithMalformedHostBinding1))
-            .toThrowError('@HostBinding can not bind to events. Use @HostListener instead.');
+            .toThrowError(
+                '@HostBinding can not bind to events. Use @HostListener instead. Host binding: "(a)" located at "SomeDirectiveWithMalformedHostBinding1" and bound to "onA" property');
       });
 
       it('should throw when @HostBinding name starts with "["', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the current behavior, this exception is thrown at runtime, but without any details where this host binding is located. It only shows a stack trace as a part of the exception, but stack trace leads to `compiler.js`, which is not really informative.


## What is the new behavior?
Now there are location details of the host binding that is bound to some method. This can benefit more readily for debugging purposes as this exception is thrown only at runtime, but without any details where this host binding is located at.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
