### PR TITLE
docs: update npm install dev command to `npm install --save-dev`

### DIFF
--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -106,7 +106,7 @@ The packages listed in the `devDependencies` section of `package.json` help you 
 To add a new `devDependency`, use either one of the following commands:
 
 <code-example language="sh" class="code-shell">
-  npm install --dev &lt;package-name&gt;
+  npm install --save-dev &lt;package-name&gt;
 </code-example>
 
 <code-example language="sh" class="code-shell">


### PR DESCRIPTION
See: https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file

