### PR TITLE
ci: fix tracking and checking of payload size data

### DIFF
--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -12,4 +12,4 @@ source ../scripts/ci/payload-size.sh
 # Provide node_modules from aio
 NODE_MODULES_BIN=$PROJECT_ROOT/aio/node_modules/.bin/
 
-trackPayloadSize "$target" "dist/*.js" true true "${thisDir}/_payload-limits.json"
+trackPayloadSize "$target" "dist/*.js" true "${thisDir}/_payload-limits.json"

--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -64,7 +64,7 @@ for testDir in ${TEST_DIRS}; do
         yarn build
       fi
 
-      trackPayloadSize "$testDir" "dist/*.js" true false "${basedir}/integration/_payload-limits.json"
+      trackPayloadSize "$testDir" "dist/*.js" true "${basedir}/integration/_payload-limits.json"
     fi
 
     # remove the temporary node modules directory to keep the source folder clean.
@@ -73,5 +73,5 @@ for testDir in ${TEST_DIRS}; do
 done
 
 if $CI; then
-  trackPayloadSize "umd" "../dist/packages-dist/*/bundles/*.umd.min.js" false false
+  trackPayloadSize "umd" "../dist/packages-dist/*/bundles/*.umd.min.js" false
 fi

--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -72,6 +72,6 @@ for testDir in ${TEST_DIRS}; do
   )
 done
 
-if $CI; then
+if $CI && [[ "$SHARD_INDEX" == "0" ]]; then
   trackPayloadSize "umd" "../dist/packages-dist/*/bundles/*.umd.min.js" false
 fi

--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -103,8 +103,9 @@ addChangeType() {
   elif [[ $allChangedFiles -gt 0 ]]; then
     change='application'
   else
-    # Nothing changed in aio/
-    exit 0
+    # Nothing changed inside $parentDir (but size may still be affected; e.g. when using the locally
+    # built packages)
+    change='other'
   fi
   payloadData="$payloadData\"change\": \"$change\", "
 }


### PR DESCRIPTION
This PR mainly addresses two issues:
- Ensure that payload size data for angular.io is always uploaded/checked.
- Remove unreliable info (change type) from uploaded payload size data.

See individual commits for details.

##
BTW, if we are concerned about recording lots of irrelevant data, we could still skip uploading/checking for code changes that could not have affected bundle sizes. For example, we could only run the script for commit ranges that touched `yarn.lock` or files inside `packages/`, `scripts/` or the target project directory (`aio/` for example).