### PR TITLE
build: change visible compiler name during ng_module builds to be Ivy/ViewEngine

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -89,7 +89,7 @@ def _compiler_name(ctx):
       The name of the current compiler to be displayed in build output
     """
 
-    return "ngtsc" if _is_ivy_enabled(ctx) else "ngc"
+    return "Ivy" if _is_ivy_enabled(ctx) else "ViewEngine"
 
 def _is_view_engine_enabled(ctx):
     """Determines whether Angular outputs will be produced by the current compilation strategy.


### PR DESCRIPTION
Previously the visible compiler name during the ng_module build action was
ngc/ngtsc.  These names however are only really known to the compiler team.
Instead we should use more general terms for which compiler is used to match
how we speak about compiler choices.
