### PR TITLE
fix(common): reflect input type in context

### DIFF
--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -149,14 +149,14 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  * @publicApi
  */
 @Directive({selector: '[ngIf]'})
-export class NgIf {
-  private _context: NgIfContext = new NgIfContext();
-  private _thenTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _elseTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _thenViewRef: EmbeddedViewRef<NgIfContext>|null = null;
-  private _elseViewRef: EmbeddedViewRef<NgIfContext>|null = null;
+export class NgIf<T> {
+  private _context: NgIfContext<T> = new NgIfContext<T>();
+  private _thenTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _elseTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _thenViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
+  private _elseViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
 
-  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>) {
+  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>) {
     this._thenTemplateRef = templateRef;
   }
 
@@ -164,7 +164,7 @@ export class NgIf {
    * The Boolean expression to evaluate as the condition for showing a template.
    */
   @Input()
-  set ngIf(condition: any) {
+  set ngIf(condition: T) {
     this._context.$implicit = this._context.ngIf = condition;
     this._updateView();
   }
@@ -173,7 +173,7 @@ export class NgIf {
    * A template to show if the condition expression evaluates to true.
    */
   @Input()
-  set ngIfThen(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfThen(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfThen', templateRef);
     this._thenTemplateRef = templateRef;
     this._thenViewRef = null;  // clear previous view if any.
@@ -184,7 +184,7 @@ export class NgIf {
    * A template to show if the condition expression evaluates to false.
    */
   @Input()
-  set ngIfElse(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfElse(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfElse', templateRef);
     this._elseTemplateRef = templateRef;
     this._elseViewRef = null;  // clear previous view if any.
@@ -225,14 +225,22 @@ export class NgIf {
    * narrow its type, which allows the strictNullChecks feature of TypeScript to work with `NgIf`.
    */
   static ngTemplateGuard_ngIf: 'binding';
+
+  /**
+   * Asserts the correct type of the context for the template that `NgIf` will render.
+   *
+   * The presence of this method is a signal to the Ivy template type-check compiler that the
+   * `NgIf` structural directive renders its template with a specific context type.
+   */
+  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T> { return true; }
 }
 
 /**
  * @publicApi
  */
-export class NgIfContext {
-  public $implicit: any = null;
-  public ngIf: any = null;
+export class NgIfContext<T> {
+  public $implicit: T = null !;
+  public ngIf: T = null !;
 }
 
 function assertTemplate(property: string, templateRef: TemplateRef<any>| null): void {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -64,10 +64,19 @@ export declare class NgForOf<T, U extends i0.NgIterable<T>> implements DoCheck {
   static ɵdir: i0.ɵɵDirectiveDefWithMeta<NgForOf<any>, '[ngFor][ngForOf]', never, {'ngForOf': 'ngForOf'}, {}, never>;
 }
 
-export declare class NgIf {
-  ngIf: any;
+export declare class NgIf<T> {
+  ngIf: T;
+  ngIfElse: TemplateRef<NgIfContext<T>> | null;
+  ngIfThen: TemplateRef<NgIfContext<T>> | null;
+  constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>);
   static ngTemplateGuard_ngIf: 'binding';
-  static ɵdir: i0.ɵɵDirectiveDefWithMeta<NgForOf<any>, '[ngIf]', never, {'ngIf': 'ngIf'}, {}, never>;
+  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T>;
+  static ɵdir: i0.ɵɵDirectiveDefWithMeta<NgIf<any>, '[ngIf]', never, {'ngIf': 'ngIf'}, {}, never>;
+}
+
+export declare class NgIfContext<T> {
+  $implicit: T;
+  ngIf: T;
 }
 
 export declare class CommonModule {
@@ -813,6 +822,33 @@ export declare class AnimationEvent {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(0);
+    });
+
+    it('should infer the context of NgIf', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictTemplates: true});
+      env.write('test.ts', `
+        import {CommonModule} from '@angular/common';
+        import {Component, NgModule} from '@angular/core';
+        @Component({
+          selector: 'test',
+          template: '<div *ngIf="getUser(); let user">{{user.nonExistingProp}}</div>',
+        })
+        class TestCmp {
+          getUser(): {name: string} {
+            return {name: 'frodo'};
+          }
+        }
+        @NgModule({
+          declarations: [TestCmp],
+          imports: [CommonModule],
+        })
+        class Module {}
+      `);
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText)
+          .toBe(`Property 'nonExistingProp' does not exist on type '{ name: string; }'.`);
     });
 
     it('should report an error with an unknown local ref target', () => {

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -12,7 +12,7 @@ import {IterableDiffers, NgIterable, TemplateRef, ViewContainerRef} from '@angul
 import {DirectiveType, ɵɵNgOnChangesFeature, ɵɵdefineDirective, ɵɵdirectiveInject} from '../../src/render3/index';
 
 export const NgForOf: DirectiveType<NgForOfDef<any, NgIterable<any>>> = NgForOfDef as any;
-export const NgIf: DirectiveType<NgIfDef> = NgIfDef as any;
+export const NgIf: DirectiveType<NgIfDef<any>> = NgIfDef as any;
 export const NgTemplateOutlet: DirectiveType<NgTemplateOutletDef> = NgTemplateOutletDef as any;
 
 NgForOf.ɵdir = ɵɵdefineDirective({

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -7,11 +7,11 @@
  */
 
 import {NgForOf as NgForOfDef, NgIf as NgIfDef, NgTemplateOutlet as NgTemplateOutletDef} from '@angular/common';
-import {IterableDiffers, TemplateRef, ViewContainerRef} from '@angular/core';
+import {IterableDiffers, NgIterable, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {DirectiveType, ɵɵNgOnChangesFeature, ɵɵdefineDirective, ɵɵdirectiveInject} from '../../src/render3/index';
 
-export const NgForOf: DirectiveType<NgForOfDef<any>> = NgForOfDef as any;
+export const NgForOf: DirectiveType<NgForOfDef<any, NgIterable<any>>> = NgForOfDef as any;
 export const NgIf: DirectiveType<NgIfDef> = NgIfDef as any;
 export const NgTemplateOutlet: DirectiveType<NgTemplateOutletDef> = NgTemplateOutletDef as any;
 

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -205,7 +205,8 @@ describe('instructions', () => {
 
   describe('performance counters', () => {
     it('should create tViews only once for each nested level', () => {
-      function ToDoAppComponent_NgForOf_Template_0(rf: RenderFlags, ctx0: NgForOfContext<any>) {
+      function ToDoAppComponent_NgForOf_Template_0(
+          rf: RenderFlags, ctx0: NgForOfContext<any, any>) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'ul');
           ɵɵtemplate(1, ToDoAppComponent_NgForOf_NgForOf_Template_1, 2, 1, 'li', 0);
@@ -219,7 +220,7 @@ describe('instructions', () => {
       }
 
       function ToDoAppComponent_NgForOf_NgForOf_Template_1(
-          rf: RenderFlags, ctx1: NgForOfContext<any>) {
+          rf: RenderFlags, ctx1: NgForOfContext<any, any>) {
         if (rf & RenderFlags.Create) {
           ɵɵelementStart(0, 'li');
           ɵɵtext(1);

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -214,25 +214,25 @@ export declare class NgComponentOutlet implements OnChanges, OnDestroy {
     ngOnDestroy(): void;
 }
 
-export declare class NgForOf<T> implements DoCheck {
-    ngForOf: NgIterable<T> | undefined | null;
-    ngForTemplate: TemplateRef<NgForOfContext<T>>;
+export declare class NgForOf<T, U extends NgIterable<T>> implements DoCheck {
+    ngForOf: (U & NgIterable<T>) | undefined | null;
+    ngForTemplate: TemplateRef<NgForOfContext<T, U>>;
     ngForTrackBy: TrackByFunction<T>;
-    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T>>, _differs: IterableDiffers);
+    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers);
     ngDoCheck(): void;
-    static ngTemplateContextGuard<T>(dir: NgForOf<T>, ctx: any): ctx is NgForOfContext<T>;
+    static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
 }
 
-export declare class NgForOfContext<T> {
+export declare class NgForOfContext<T, U extends NgIterable<T>> {
     $implicit: T;
     count: number;
     readonly even: boolean;
     readonly first: boolean;
     index: number;
     readonly last: boolean;
-    ngForOf: NgIterable<T>;
+    ngForOf: U;
     readonly odd: boolean;
-    constructor($implicit: T, ngForOf: NgIterable<T>, index: number, count: number);
+    constructor($implicit: T, ngForOf: U, index: number, count: number);
 }
 
 export declare class NgIf {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -235,17 +235,18 @@ export declare class NgForOfContext<T, U extends NgIterable<T>> {
     constructor($implicit: T, ngForOf: U, index: number, count: number);
 }
 
-export declare class NgIf {
-    ngIf: any;
-    ngIfElse: TemplateRef<NgIfContext> | null;
-    ngIfThen: TemplateRef<NgIfContext> | null;
-    constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>);
+export declare class NgIf<T> {
+    ngIf: T;
+    ngIfElse: TemplateRef<NgIfContext<T>> | null;
+    ngIfThen: TemplateRef<NgIfContext<T>> | null;
+    constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>);
     static ngTemplateGuard_ngIf: 'binding';
+    static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T>;
 }
 
-export declare class NgIfContext {
-    $implicit: any;
-    ngIf: any;
+export declare class NgIfContext<T> {
+    $implicit: T;
+    ngIf: T;
 }
 
 export declare class NgLocaleLocalization extends NgLocalization {


### PR DESCRIPTION
Fixes `NgForOf` not reflecting the type of its input in the `NgForOfContext`. Also fixes `NgIf` which was typed to `any`.

Fixes #33527.
Fixes #31556.