### PR TITLE
docs: removed non-supported versions from LTS

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -122,12 +122,8 @@ Version | Status | Released     | Active Ends  | LTS Ends
 ------- | ------ | ------------ | ------------ | ------------ 
 ^8.0.0  | Active | May 28, 2019 | Nov 28, 2019 | Nov 28, 2020
 ^7.0.0  | LTS    | Oct 18, 2018 | Apr 18, 2019 | Apr 18, 2020
-^6.0.0  | LTS    | May 3, 2018  | Nov 3, 2018  | Nov 3, 2019
 
-Angular versions ^4.0.0 and ^5.0.0 are no longer under support. 
-
-
-
+Angular versions ^4.0.0, ^5.0.0 and ^6.0.0 are no longer under support. 
 
 {@a deprecation}
 ## Deprecation practices


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other


## What is the current behavior?
On https://angular.io/guide/releases#support-policy-and-schedule we are past date of angular 6 LTS support. So we can remove that from the table.

Issue Number: N/A


## What is the new behavior?
Removed angular6 from the Lts support table

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

