### PR TITLE
docs(forms): update async validation chapter to reference the correct example

### DIFF
--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -4,7 +4,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { forbiddenNameValidator } from '../shared/forbidden-name.directive';
-import { UniqueAlterEgoValidator } from '../shared/alter-ego.directive';
 
 @Component({
   selector: 'app-hero-form-reactive',
@@ -28,7 +27,6 @@ export class HeroFormReactiveComponent implements OnInit {
         forbiddenNameValidator(/bob/i)
       ]),
       'alterEgo': new FormControl(this.hero.alterEgo, {
-        asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
         updateOn: 'blur'
       }),
       'power': new FormControl(this.hero.power, Validators.required)
@@ -41,8 +39,4 @@ export class HeroFormReactiveComponent implements OnInit {
   get power() { return this.heroForm.get('power'); }
 
   get alterEgo() { return this.heroForm.get('alterEgo'); }
-
-  // #docregion async-validation
-  constructor(private alterEgoValidator: UniqueAlterEgoValidator) {}
-  // #enddocregion async-validation
 }

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.html
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.html
@@ -34,7 +34,7 @@
         <div class="form-group">
           <label for="alterEgo">Alter Ego</label>
           <input id="alterEgo" class="form-control"
-              formControlName="alterEgo"  >
+              formControlName="alterEgo" appUniqueAlterEgo>
 
           <div *ngIf="alterEgo.pending">Validating...</div>
           <div *ngIf="alterEgo.invalid" class="alert alert-danger alter-ego-errors">

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.ts
@@ -4,7 +4,6 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { forbiddenNameValidator } from '../shared/forbidden-name.directive';
 import { identityRevealedValidator } from '../shared/identity-revealed.directive';
-import { UniqueAlterEgoValidator } from '../shared/alter-ego.directive';
 
 @Component({
   selector: 'app-hero-form-reactive',
@@ -27,7 +26,6 @@ export class HeroFormReactiveComponent implements OnInit {
         forbiddenNameValidator(/bob/i)
       ]),
       'alterEgo': new FormControl(this.hero.alterEgo, {
-        asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
         updateOn: 'blur'
       }),
       'power': new FormControl(this.hero.power, Validators.required)
@@ -39,6 +37,4 @@ export class HeroFormReactiveComponent implements OnInit {
   get power() { return this.heroForm.get('power'); }
 
   get alterEgo() { return this.heroForm.get('alterEgo'); }
-
-  constructor(private alterEgoValidator: UniqueAlterEgoValidator) { }
 }

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, forwardRef, Injectable } from '@angular/core';
+import { Directive } from '@angular/core';
 import {
   AsyncValidator,
   AbstractControl,
@@ -7,23 +7,7 @@ import {
 } from '@angular/forms';
 import { catchError, map } from 'rxjs/operators';
 import { HeroesService } from './heroes.service';
-import { Observable } from 'rxjs';
-
-// #docregion async-validator
-@Injectable({ providedIn: 'root' })
-export class UniqueAlterEgoValidator implements AsyncValidator {
-  constructor(private heroesService: HeroesService) {}
-
-  validate(
-    ctrl: AbstractControl
-  ): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> {
-    return this.heroesService.isAlterEgoTaken(ctrl.value).pipe(
-      map(isTaken => (isTaken ? { uniqueAlterEgo: true } : null)),
-      catchError(() => null)
-    );
-  }
-}
-// #enddocregion async-validator
+import { Observable, of } from 'rxjs';
 
 // #docregion async-validator-directive
 @Directive({
@@ -31,16 +15,21 @@ export class UniqueAlterEgoValidator implements AsyncValidator {
   providers: [
     {
       provide: NG_ASYNC_VALIDATORS,
-      useExisting: forwardRef(() => UniqueAlterEgoValidator),
+      useExisting: UniqueAlterEgoValidatorDirective,
       multi: true
     }
   ]
 })
-export class UniqueAlterEgoValidatorDirective {
-  constructor(private validator: UniqueAlterEgoValidator) {}
+export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
+  constructor(private heroesService: HeroesService) {}
 
-  validate(control: AbstractControl) {
-    this.validator.validate(control);
+  validate(
+    ctrl: AbstractControl
+  ): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> {
+    return this.heroesService.isAlterEgoTaken(ctrl.value).pipe(
+      map(isTaken => (isTaken ? { uniqueAlterEgo: true } : null)),
+      catchError(() => of(null))
+    );
   }
 }
 // #enddocregion async-validator-directive

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -297,11 +297,11 @@ In the following section, validation is performed asynchronously to ensure that 
 
 To validate the potential alter ego, we need to consult a central database of all currently enlisted heroes. The process is asynchronous, so we need a special validator for that.
 
-Let's start by creating the validator class.
+Let's start by creating the directive:
 
-<code-example path="form-validation/src/app/shared/alter-ego.directive.ts" region="async-validator"></code-example>
+<code-example path="form-validation/src/app/shared/alter-ego.directive.ts" region="async-validator-directive"></code-example>
 
-As you can see, the `UniqueAlterEgoValidator` class implements the `AsyncValidator` interface. In the constructor, we inject the `HeroesService` that has the following interface:
+As you can see, the `UniqueAlterEgoValidatorDirective` class implements the `AsyncValidator` interface. The directive also registers itself with the `NG_ASYNC_VALIDATORS` provider, a provider with an extensible collection of asynchronous validators. In the constructor, we inject the `HeroesService` that has the following interface:
 
 ```typescript
 interface HeroesService {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33429

Currently, the code example is actually invalid. It refers to the service (which shouldn't be used) but doesn't show the example of how to register a custom directive with the NG_ASYNC_VALIDATORS provider. The directive should be bound to some `input` (that's what I've done in the e2e example).


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
