### PR TITLE
fix(ngcc): render UMD global imports correctly

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -240,8 +240,24 @@ function isCommaExpression(value: ts.Node): value is ts.BinaryExpression {
   return ts.isBinaryExpression(value) && value.operatorToken.kind === ts.SyntaxKind.CommaToken;
 }
 
-function getGlobalIdentifier(i: Import) {
-  return i.specifier.replace('@angular/', 'ng.').replace(/^\//, '');
+/**
+ * Compute a global identifier for the given import (`i`).
+ *
+ * Import specifiers must be camelCase after converting path separators to dots, and special-casing
+ * `@angular`. For example
+ *
+ * * `@ns/package/entry-point` => `ns.package.entryPoint`
+ * * `@angular/common/testing` => `ng.common.testing`
+ * * `@angular/platform-browser-dynamic` => `ng.platformBrowserDynamic`
+ *
+ * @param i the import whose global identifier we want to compute.
+ */
+function getGlobalIdentifier(i: Import): string {
+  return i.specifier.replace(/^@angular\//, 'ng.')
+      .replace(/^@/, '')
+      .replace(/\//g, '.')
+      .replace(/[-_]+(.)?/g, (_, c) => c ? c.toUpperCase() : '')
+      .replace(/^./, c => c.toLowerCase());
 }
 
 function find<T>(node: ts.Node, test: (node: ts.Node) => node is ts.Node & T): T|undefined {

--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -243,12 +243,24 @@ function isCommaExpression(value: ts.Node): value is ts.BinaryExpression {
 /**
  * Compute a global identifier for the given import (`i`).
  *
- * Import specifiers must be camelCase after converting path separators to dots, and special-casing
- * `@angular`. For example
+ * The identifier used to access a package when using the "global" form of a UMD bundle usually
+ * follows a special format where snake-case is conveted to camelCase and path separators are
+ * converted to dots. In addition there are special cases such as `@angular` is mapped to `ng`.
+ *
+ * For example
  *
  * * `@ns/package/entry-point` => `ns.package.entryPoint`
  * * `@angular/common/testing` => `ng.common.testing`
  * * `@angular/platform-browser-dynamic` => `ng.platformBrowserDynamic`
+ *
+ * It is possible for packages to specify completely different identifiers for attaching the package
+ * to the global, and so there is no guaranteed way to compute this.
+ * Currently, this approach appears to work for the known scenarios; also it is not known how common
+ * it is to use globals for importing packages.
+ *
+ * If it turns out that there are packages that are being used via globals, where this approach
+ * fails, we should consider implementing a configuration based solution, similar to what would go
+ * in a rollup configuration for mapping import paths to global indentifiers.
  *
  * @param i the import whose global identifier we want to compute.
  */
@@ -256,7 +268,7 @@ function getGlobalIdentifier(i: Import): string {
   return i.specifier.replace(/^@angular\//, 'ng.')
       .replace(/^@/, '')
       .replace(/\//g, '.')
-      .replace(/[-_]+(.)?/g, (_, c) => c ? c.toUpperCase() : '')
+      .replace(/[-_]+(.?)/g, (_, c) => c.toUpperCase())
       .replace(/^./, c => c.toLowerCase());
 }
 

--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -261,8 +261,6 @@ function isCommaExpression(value: ts.Node): value is ts.BinaryExpression {
  * If it turns out that there are packages that are being used via globals, where this approach
  * fails, we should consider implementing a configuration based solution, similar to what would go
  * in a rollup configuration for mapping import paths to global indentifiers.
- *
- * @param i the import whose global identifier we want to compute.
  */
 function getGlobalIdentifier(i: Import): string {
   return i.specifier.replace(/^@angular\//, 'ng.')

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -240,6 +240,25 @@ typeof define === 'function' && define.amd ? define('file', ['exports','/tslib',
                 `(factory(global.file,global.someSideEffect,global.localDep,global.ng.core,global.ng.core,global.ng.common));`);
       });
 
+      it('should remap import identifiers to valid global properties', () => {
+        const {renderer, program} = setup(PROGRAM);
+        const file = getSourceFileOrError(program, _('/node_modules/test-package/some/file.js'));
+        const output = new MagicString(PROGRAM.contents);
+        renderer.addImports(
+            output,
+            [
+              {specifier: '@ngrx/store', qualifier: 'i0'},
+              {specifier: '@angular/platform-browser-dynamic', qualifier: 'i1'},
+              {specifier: '@angular/common/testing', qualifier: 'i2'},
+              {specifier: '@angular-foo/package', qualifier: 'i3'}
+            ],
+            file);
+        expect(output.toString())
+            .toContain(
+                `(factory(global.file,global.someSideEffect,global.localDep,global.ng.core,` +
+                `global.ngrx.store,global.ng.platformBrowserDynamic,global.ng.common.testing,global.angularFoo.package));`);
+      });
+
       it('should append the given imports into the global initialization, if it has a global/self initializer',
          () => {
            const {renderer, program} = setup(PROGRAM_WITH_GLOBAL_INITIALIZER);
@@ -256,6 +275,7 @@ typeof define === 'function' && define.amd ? define('file', ['exports','/tslib',
                .toContain(
                    `(global = global || self, factory(global.file,global.someSideEffect,global.localDep,global.ng.core,global.ng.core,global.ng.common));`);
          });
+
       it('should append the given imports as parameters into the factory function definition',
          () => {
            const {renderer, program} = setup(PROGRAM);


### PR DESCRIPTION
The current UMD rendering formatter did not handle
a number of corner cases, such as imports from namespaced
packages.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
