### PR TITLE
fix(ivy): recompile on template change in ngc watch mode on Windows

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -273,7 +273,7 @@ export class ComponentDecoratorHandler implements
         const resourceStr = this.resourceLoader.load(resourceUrl);
         styles.push(resourceStr);
         if (this.depTracker !== null) {
-          this.depTracker.addResourceDependency(node.getSourceFile(), resourceUrl);
+          this.depTracker.addResourceDependency(node.getSourceFile(), absoluteFrom(resourceUrl));
         }
       }
     }
@@ -675,7 +675,7 @@ export class ComponentDecoratorHandler implements
       resourceUrl: string): ParsedTemplateWithSource {
     const templateStr = this.resourceLoader.load(resourceUrl);
     if (this.depTracker !== null) {
-      this.depTracker.addResourceDependency(node.getSourceFile(), resourceUrl);
+      this.depTracker.addResourceDependency(node.getSourceFile(), absoluteFrom(resourceUrl));
     }
 
     const template = this._parseTemplate(

--- a/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     ]),
     deps = [
         ":api",
+        "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
@@ -24,6 +25,7 @@ ts_library(
     name = "api",
     srcs = ["api.ts"],
     deps = [
+        "//packages/compiler-cli/src/ngtsc/file_system",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/incremental/api.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/api.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {AbsoluteFsPath} from '../file_system';
 
 /**
  * Interface of the incremental build engine.
@@ -33,7 +34,7 @@ export interface DependencyTracker<T extends{fileName: string} = ts.SourceFile> 
   /**
    * Record that the file `from` depends on the resource file `on`.
    */
-  addResourceDependency(from: T, on: string): void;
+  addResourceDependency(from: T, on: AbsoluteFsPath): void;
 
   /**
    * Record that the file `from` depends on the file `on` as well as `on`'s direct dependencies.

--- a/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
@@ -8,6 +8,7 @@
 
 import * as ts from 'typescript';
 
+import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
 import {ClassRecord, TraitCompiler} from '../../transform';
 import {IncrementalBuild} from '../api';
 
@@ -52,7 +53,7 @@ export class IncrementalDriver implements IncrementalBuild<ClassRecord> {
       state = {
         kind: BuildStateKind.Pending,
         pendingEmit: oldDriver.state.pendingEmit,
-        changedResourcePaths: new Set<string>(),
+        changedResourcePaths: new Set<AbsoluteFsPath>(),
         changedTsPaths: new Set<string>(),
         lastGood: oldDriver.state.lastGood,
       };
@@ -61,7 +62,7 @@ export class IncrementalDriver implements IncrementalBuild<ClassRecord> {
     // Merge the freshly modified resource files with any prior ones.
     if (modifiedResourceFiles !== null) {
       for (const resFile of modifiedResourceFiles) {
-        state.changedResourcePaths.add(resFile);
+        state.changedResourcePaths.add(absoluteFrom(resFile));
       }
     }
 
@@ -153,7 +154,7 @@ export class IncrementalDriver implements IncrementalBuild<ClassRecord> {
     const state: PendingBuildState = {
       kind: BuildStateKind.Pending,
       pendingEmit: new Set<string>(tsFiles.map(sf => sf.fileName)),
-      changedResourcePaths: new Set<string>(),
+      changedResourcePaths: new Set<AbsoluteFsPath>(),
       changedTsPaths: new Set<string>(),
       lastGood: null,
     };
@@ -287,7 +288,7 @@ interface PendingBuildState extends BaseBuildState {
   /**
    * Set of resource file paths which have changed since the last successfully analyzed build.
    */
-  changedResourcePaths: Set<string>;
+  changedResourcePaths: Set<AbsoluteFsPath>;
 }
 
 interface AnalyzedBuildState extends BaseBuildState {

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -246,11 +246,13 @@ export function performWatchCompilation(host: PerformWatchHost):
   }
 
   function watchedFileChanged(event: FileChangeEvent, fileName: string) {
+    const normalizedPath = path.normalize(fileName);
+
     if (cachedOptions && event === FileChangeEvent.Change &&
         // TODO(chuckj): validate that this is sufficient to skip files that were written.
         // This assumes that the file path we write is the same file path we will receive in the
         // change notification.
-        path.normalize(fileName) === path.normalize(cachedOptions.project)) {
+        normalizedPath === path.normalize(cachedOptions.project)) {
       // If the configuration file changes, forget everything and start the recompilation timer
       resetOptions();
     } else if (
@@ -263,12 +265,12 @@ export function performWatchCompilation(host: PerformWatchHost):
     if (event === FileChangeEvent.CreateDeleteDir) {
       fileCache.clear();
     } else {
-      fileCache.delete(path.normalize(fileName));
+      fileCache.delete(normalizedPath);
     }
 
-    if (!ignoreFilesForWatch.has(path.normalize(fileName))) {
+    if (!ignoreFilesForWatch.has(normalizedPath)) {
       // Ignore the file if the file is one that was written by the compiler.
-      startTimerForRecompilation(fileName);
+      startTimerForRecompilation(normalizedPath);
     }
   }
 

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -64,7 +64,7 @@ describe('perform watch', () => {
     const watchResult = performWatchCompilation(host);
     expectNoDiagnostics(config.options, watchResult.firstCompileResult);
 
-    const htmlPath = path.posix.join(testSupport.basePath, 'src', 'main.html');
+    const htmlPath = path.join(testSupport.basePath, 'src', 'main.html');
     const genPath = ivyEnabled ? path.posix.join(outDir, 'src', 'main.js') :
                                  path.posix.join(outDir, 'src', 'main.ngfactory.js');
 


### PR DESCRIPTION
In #33551, a bug in `ngc --watch` mode was fixed so that a component is
recompiled when its template file is changed. Due to insufficient
normalization of files paths, this fix did not have the desired effect
on Windows.

Fixes #32869