### PR TITLE
fix(ivy): run pre-order hooks in injection order

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 15267,
+        "main-es2015": 15783,
         "polyfills-es2015": 36808
       }
     }

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -72,3 +72,14 @@ export function assertFirstCreatePass(tView: TView, errMessage?: string) {
   assertEqual(
       tView.firstCreatePass, true, errMessage || 'Should only be called in first create pass.');
 }
+
+/**
+ * This is a basic sanity check that an object is probably a directive def. DirectiveDef is
+ * an interface, so we can't do a direct instanceof check.
+ */
+export function assertDirectiveDef(obj: any) {
+  if (obj.type === undefined || obj.selectors == undefined || obj.inputs === undefined) {
+    throwError(
+        `Expected a DirectiveDef/ComponentDef and this object does not seem to have the expected shape.`);
+  }
+}

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -255,7 +255,6 @@ export function LifecycleHooksFeature(component: any, def: ComponentDef<any>): v
   const rootTView = readPatchedLView(component) ![TVIEW];
   const dirIndex = rootTView.data.length - 1;
 
-  registerPreOrderHooks(dirIndex, def, rootTView, -1, -1, -1);
   // TODO(misko): replace `as TNode` with createTNode call. (needs refactoring to lose dep on
   // LNode).
   registerPostOrderHooks(

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -215,13 +215,14 @@ function multiProvidersFactoryResolver(
  * This factory knows how to concatenate itself with the existing `multi` `providers`.
  */
 function multiViewProvidersFactoryResolver(
-    this: NodeInjectorFactory, _: undefined, tData: TData, lData: LView,
+    this: NodeInjectorFactory, _: undefined, tData: TData, lView: LView,
     tNode: TDirectiveHostNode): any[] {
   const factories = this.multi !;
   let result: any[];
   if (this.providerFactory) {
     const componentCount = this.providerFactory.componentProviders !;
-    const multiProviders = getNodeInjectable(tData, lData, this.providerFactory !.index !, tNode);
+    const multiProviders =
+        getNodeInjectable(lView, lView[TVIEW], this.providerFactory !.index !, tNode);
     // Copy the section of the array which contains `multi` `providers` from the component
     result = multiProviders.slice(0, componentCount);
     // Insert the `viewProvider` instances.

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -27,29 +27,11 @@ import {getCheckNoChangesMode} from './state';
  * @param directiveIndex The index of the directive in LView
  * @param directiveDef The definition containing the hooks to setup in tView
  * @param tView The current TView
- * @param nodeIndex The index of the node to which the directive is attached
- * @param initialPreOrderHooksLength the number of pre-order hooks already registered before the
- * current process, used to know if the node index has to be added to the array. If it is -1,
- * the node index is never added.
- * @param initialPreOrderCheckHooksLength same as previous for pre-order check hooks
  */
 export function registerPreOrderHooks(
-    directiveIndex: number, directiveDef: DirectiveDef<any>, tView: TView, nodeIndex: number,
-    initialPreOrderHooksLength: number, initialPreOrderCheckHooksLength: number): void {
+    directiveIndex: number, directiveDef: DirectiveDef<any>, tView: TView): void {
   ngDevMode && assertFirstCreatePass(tView);
   const {onChanges, onInit, doCheck} = directiveDef;
-  if (initialPreOrderHooksLength >= 0 &&
-      (!tView.preOrderHooks || initialPreOrderHooksLength === tView.preOrderHooks.length) &&
-      (onChanges || onInit || doCheck)) {
-    (tView.preOrderHooks || (tView.preOrderHooks = [])).push(nodeIndex);
-  }
-
-  if (initialPreOrderCheckHooksLength >= 0 &&
-      (!tView.preOrderCheckHooks ||
-       initialPreOrderCheckHooksLength === tView.preOrderCheckHooks.length) &&
-      (onChanges || doCheck)) {
-    (tView.preOrderCheckHooks || (tView.preOrderCheckHooks = [])).push(nodeIndex);
-  }
 
   if (onChanges) {
     (tView.preOrderHooks || (tView.preOrderHooks = [])).push(directiveIndex, onChanges);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1057,8 +1057,7 @@ export function instantiateRootComponent<T>(tView: TView, lView: LView, def: Com
     generateExpandoInstructionBlock(tView, rootTNode, 1);
     baseResolveDirective(tView, lView, def);
   }
-  const directive =
-      getNodeInjectable(tView.data, lView, lView.length - 1, rootTNode as TElementNode);
+  const directive = getNodeInjectable(lView, tView, lView.length - 1, rootTNode as TElementNode);
   attachPatchData(directive, lView);
   const native = getNativeByTNode(rootTNode, lView);
   if (native) {
@@ -1155,7 +1154,7 @@ function instantiateAllDirectives(
       addComponentLogic(lView, tNode as TElementNode, def as ComponentDef<any>);
     }
 
-    const directive = getNodeInjectable(tView.data, lView, i, tNode);
+    const directive = getNodeInjectable(lView, tView, i, tNode);
     attachPatchData(directive, lView);
 
     if (initialInputs !== null) {

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1097,14 +1097,11 @@ export function resolveDirectives(
       if (def.providersResolver) def.providersResolver(def);
     }
     generateExpandoInstructionBlock(tView, tNode, directives.length);
-    const initialPreOrderHooksLength = (tView.preOrderHooks && tView.preOrderHooks.length) || 0;
-    const initialPreOrderCheckHooksLength =
-        (tView.preOrderCheckHooks && tView.preOrderCheckHooks.length) || 0;
-    const nodeIndex = tNode.index - HEADER_OFFSET;
+    let preOrderHooksFound = false;
+    let preOrderCheckHooksFound = false;
     for (let i = 0; i < directives.length; i++) {
       const def = directives[i] as DirectiveDef<any>;
 
-      const directiveDefIdx = tView.data.length;
       baseResolveDirective(tView, lView, def);
 
       saveNameToExportMap(tView.data !.length - 1, def, exportsMap);
@@ -1112,11 +1109,21 @@ export function resolveDirectives(
       if (def.contentQueries !== null) tNode.flags |= TNodeFlags.hasContentQuery;
       if (def.hostBindings !== null) tNode.flags |= TNodeFlags.hasHostBindings;
 
-      // Init hooks are queued now so ngOnInit is called in host components before
-      // any projected components.
-      registerPreOrderHooks(
-          directiveDefIdx, def, tView, nodeIndex, initialPreOrderHooksLength,
-          initialPreOrderCheckHooksLength);
+      // Only push a node index into the preOrderHooks array if this is the first
+      // pre-order hook found on this node.
+      if (!preOrderHooksFound && (def.onChanges || def.onInit || def.doCheck)) {
+        // We will push the actual hook function into this array later during dir instantiation.
+        // We cannot do it now because we must ensure hooks are registered in the same
+        // order that directives are created (i.e. injection order).
+        (tView.preOrderHooks || (tView.preOrderHooks = [])).push(tNode.index - HEADER_OFFSET);
+        preOrderHooksFound = true;
+      }
+
+      if (!preOrderCheckHooksFound && (def.onChanges || def.doCheck)) {
+        (tView.preOrderCheckHooks || (tView.preOrderCheckHooks = [
+         ])).push(tNode.index - HEADER_OFFSET);
+        preOrderCheckHooksFound = true;
+      }
     }
 
     initializeInputAndOutputAliases(tView, tNode);

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -281,7 +281,7 @@ function createResultForNode(lView: LView, tNode: TNode, matchingIdx: number, re
     return createSpecialToken(lView, tNode, read);
   } else {
     // read a token
-    return getNodeInjectable(lView[TVIEW].data, lView, matchingIdx, tNode as TElementNode);
+    return getNodeInjectable(lView, lView[TVIEW], matchingIdx, tNode as TElementNode);
   }
 }
 

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -683,6 +683,62 @@ describe('onChanges', () => {
 
   });
 
+  it('should be called on multiple directives in injection order', () => {
+
+    const events: any[] = [];
+
+    @Directive({
+      selector: '[dir]',
+    })
+    class Dir {
+      @Input()
+      dir = '';
+
+      ngOnChanges(changes: SimpleChanges) { events.push({name: 'dir', changes}); }
+    }
+
+    @Directive({
+      selector: '[injectionDir]',
+    })
+    class InjectionDir {
+      @Input()
+      injectionDir = '';
+
+      constructor(public dir: Dir) {}
+
+      ngOnChanges(changes: SimpleChanges) { events.push({name: 'injectionDir', changes}); }
+    }
+
+    @Component({
+      template: `<div [injectionDir]="val" [dir]="val"></div>`,
+    })
+    class App {
+      val = 'a';
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, InjectionDir, Dir],
+    });
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(events).toEqual([
+      {
+        name: 'dir',
+        changes: {
+          dir: new SimpleChange(undefined, 'a', true),
+        }
+      },
+      {
+        name: 'injectionDir',
+        changes: {
+          injectionDir: new SimpleChange(undefined, 'a', true),
+        }
+      }
+    ]);
+  });
+
+
   it('should be called on directives on an element', () => {
     const events: any[] = [];
 
@@ -1531,6 +1587,50 @@ describe('onInit', () => {
     expect(initialized).toEqual(['app', 'comp 1', 'dir 1', 'comp 2', 'dir 2']);
   });
 
+  it('should be called on multiple directives in injection order', () => {
+
+    const events: any[] = [];
+
+    @Directive({
+      selector: '[dir]',
+    })
+    class Dir {
+      @Input()
+      dir = '';
+
+      ngOnInit() { events.push('dir'); }
+    }
+
+    @Directive({
+      selector: '[injectionDir]',
+    })
+    class InjectionDir {
+      @Input()
+      injectionDir = '';
+
+      constructor(public dir: Dir) {}
+
+      ngOnInit() { events.push('injectionDir'); }
+    }
+
+    @Component({
+      template: `<div [injectionDir]="val" [dir]="val"></div>`,
+    })
+    class App {
+      val = 'a';
+
+      ngOnInit() { events.push('app'); }
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, InjectionDir, Dir],
+    });
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(events).toEqual(['app', 'dir', 'injectionDir']);
+  });
+
   it('should be called on directives before component if component injects directives', () => {
     const initialized: string[] = [];
 
@@ -1867,6 +1967,50 @@ describe('doCheck', () => {
     fixture.detectChanges();
 
     expect(doChecks).toEqual(['app', 'dir 1', 'comp 1', 'dir 2', 'comp 2']);
+  });
+
+  it('should be called on multiple directives in injection order', () => {
+
+    const events: any[] = [];
+
+    @Directive({
+      selector: '[dir]',
+    })
+    class Dir {
+      @Input()
+      dir = '';
+
+      ngDoCheck() { events.push('dir'); }
+    }
+
+    @Directive({
+      selector: '[injectionDir]',
+    })
+    class InjectionDir {
+      @Input()
+      injectionDir = '';
+
+      constructor(public dir: Dir) {}
+
+      ngDoCheck() { events.push('injectionDir'); }
+    }
+
+    @Component({
+      template: `<div [injectionDir]="val" [dir]="val"></div>`,
+    })
+    class App {
+      val = 'a';
+
+      ngDoCheck() { events.push('app'); }
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, InjectionDir, Dir],
+    });
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(events).toEqual(['app', 'dir', 'injectionDir']);
   });
 
   it('should be called on directives on an element', () => {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -420,6 +420,9 @@
     "name": "refreshView"
   },
   {
+    "name": "registerPreOrderHooks"
+  },
+  {
     "name": "renderChildComponents"
   },
   {

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, EventEmitter, Input, Output, Type} from '@angular/core';
+import {Component, Directive, EventEmitter, Input, Output, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/testing';
 import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgForm, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
@@ -1055,6 +1055,16 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              expect(fixture.componentInstance.control.status).toEqual('DISABLED');
            });
+
+        it('should populate control in ngOnInit when injecting NgControl', () => {
+          const fixture = initTest(MyInputForm, MyInput);
+          fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.myInput !.control).toBeDefined();
+          expect(fixture.componentInstance.myInput !.control)
+              .toEqual(fixture.componentInstance.myInput !.cd.control);
+        });
       });
 
       describe('in template-driven forms', () => {
@@ -1359,7 +1369,11 @@ export class MyInput implements ControlValueAccessor {
   // TODO(issue/24571): remove '!'.
   value !: string;
 
-  constructor(cd: NgControl) { cd.valueAccessor = this; }
+  control: AbstractControl|null = null;
+
+  constructor(public cd: NgControl) { cd.valueAccessor = this; }
+
+  ngOnInit() { this.control = this.cd.control; }
 
   writeValue(value: any) { this.value = `!${value}!`; }
 
@@ -1380,6 +1394,7 @@ export class MyInput implements ControlValueAccessor {
 export class MyInputForm {
   // TODO(issue/24571): remove '!'.
   form !: FormGroup;
+  @ViewChild(MyInput) myInput: MyInput|null = null;
 }
 
 @Component({

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1063,7 +1063,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           expect(fixture.componentInstance.myInput !.control).toBeDefined();
           expect(fixture.componentInstance.myInput !.control)
-              .toEqual(fixture.componentInstance.myInput !.cd.control);
+              .toEqual(fixture.componentInstance.myInput !.controlDir.control);
         });
       });
 
@@ -1371,9 +1371,9 @@ export class MyInput implements ControlValueAccessor {
 
   control: AbstractControl|null = null;
 
-  constructor(public cd: NgControl) { cd.valueAccessor = this; }
+  constructor(public controlDir: NgControl) { controlDir.valueAccessor = this; }
 
-  ngOnInit() { this.control = this.cd.control; }
+  ngOnInit() { this.control = this.controlDir.control; }
 
   writeValue(value: any) { this.value = `!${value}!`; }
 


### PR DESCRIPTION
This commit fixes a compatibility bug where pre-order lifecycle
hooks (onInit, doCheck, OnChanges) for directives on the same
host node were executed based on the order the directives were
matched, rather than the order the directives were instantiated
(i.e. injection order).

This discrepancy can cause issues with forms, where it is common
to inject NgControl and try to extract its control property in
ngOnInit. As the NgControl directive is injected, it should be
instantiated before the control value accessor directive (and
thus its hooks should run first). This ensures that the NgControl
ngOnInit can set up the form control before the ngOnInit
for the control value accessor tries to access it.