### PR TITLE
perf(ivy): fix creation time micro-benchmarks

### DIFF
--- a/packages/core/test/render3/perf/directive_instantiate/index.ts
+++ b/packages/core/test/render3/perf/directive_instantiate/index.ts
@@ -5,9 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TViewType} from '@angular/core/src/render3/interfaces/view';
+import {LViewFlags, TViewType} from '@angular/core/src/render3/interfaces/view';
+
 import {ɵɵdefineDirective, ɵɵelementEnd, ɵɵelementStart, ɵɵtext} from '../../../../src/render3/index';
-import {createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {createLView, createTNode, createTView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
 import {createBenchmark} from '../micro_bench';
@@ -73,13 +74,17 @@ function testTemplate(rf: RenderFlags, ctx: any) {
   }
 }
 
+const rootLView = createLView(
+    null, createTView(TViewType.Root, -1, null, 0, 0, null, null, null, null, null), {},
+    LViewFlags.IsRoot, null, null);
+
 const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
 const embeddedTView = createTView(
     TViewType.Embedded, -1, testTemplate, 21, 10, [Tooltip.ɵdir], null, null, null,
     [['position', 'top', 3, 'tooltip']]);
 
-// create view once so we don't profile first template pass
-createAndRenderLView(null, embeddedTView, viewTNode);
+// create view once so we don't profile the first create pass
+createAndRenderLView(rootLView, embeddedTView, viewTNode);
 
 // scenario to benchmark
 const directiveInstantiate = createBenchmark('directive instantiate');
@@ -87,7 +92,7 @@ const createTime = directiveInstantiate('create');
 
 console.profile('directive_instantiate');
 while (createTime()) {
-  createAndRenderLView(null, embeddedTView, viewTNode);
+  createAndRenderLView(rootLView, embeddedTView, viewTNode);
 }
 console.profileEnd();
 

--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -5,28 +5,27 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TViewType} from '@angular/core/src/render3/interfaces/view';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
-import {createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {createLView, createTNode, createTView} from '../../../../src/render3/instructions/shared';
 import {ɵɵtext} from '../../../../src/render3/instructions/text';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
+import {LViewFlags, TViewType} from '../../../../src/render3/interfaces/view';
 import {createBenchmark} from '../micro_bench';
 import {createAndRenderLView} from '../setup';
 
 `<div>
-    <button>0</button>
-    <button>1</button>
-    <button>2</button>
-    <button>3</button>
-    <button>4</button>
-    <button>5</button>
-    <button>6</button>
-    <button>7</button>
-    <button>8</button>
-    <button>9</button>
-  </div>
-</ng-template>`;
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5">0</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>1</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>2</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>3</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>4</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>5</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>6</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>7</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>8</button>
+    <button name1="value1" name2="value2" name3="value3" name4="value4" name5="value5>9</button>
+  </div>`;
 function testTemplate(rf: RenderFlags, ctx: any) {
   if (rf & 1) {
     ɵɵelementStart(0, 'div');
@@ -64,14 +63,18 @@ function testTemplate(rf: RenderFlags, ctx: any) {
   }
 }
 
+const rootLView = createLView(
+    null, createTView(TViewType.Root, -1, null, 0, 0, null, null, null, null, null), {},
+    LViewFlags.IsRoot, null, null);
+
 const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
 const embeddedTView = createTView(
     TViewType.Embedded, -1, testTemplate, 21, 0, null, null, null, null, [[
       'name1', 'value1', 'name2', 'value2', 'name3', 'value3', 'name4', 'value4', 'name5', 'value5'
     ]]);
 
-// create view once so we don't profile first template pass
-createAndRenderLView(null, embeddedTView, viewTNode);
+// create view once so we don't profile the first create pass
+createAndRenderLView(rootLView, embeddedTView, viewTNode);
 
 // scenario to benchmark
 const elementTextCreate = createBenchmark('element and text create');
@@ -79,7 +82,7 @@ const createTime = elementTextCreate('create');
 
 console.profile('element_text_create');
 while (createTime()) {
-  createAndRenderLView(null, embeddedTView, viewTNode);
+  createAndRenderLView(rootLView, embeddedTView, viewTNode);
 }
 console.profileEnd();
 

--- a/packages/core/test/render3/perf/listeners/index.ts
+++ b/packages/core/test/render3/perf/listeners/index.ts
@@ -5,12 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TViewType} from '@angular/core/src/render3/interfaces/view';
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/instructions/element';
 import {ɵɵlistener} from '../../../../src/render3/instructions/listener';
-import {createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {createLView, createTNode, createTView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
+import {LViewFlags, TViewType} from '../../../../src/render3/interfaces/view';
 import {createBenchmark} from '../micro_bench';
 import {createAndRenderLView} from '../setup';
 
@@ -65,12 +65,16 @@ function testTemplate(rf: RenderFlags, ctx: any) {
   }
 }
 
+const rootLView = createLView(
+    null, createTView(TViewType.Root, -1, null, 0, 0, null, null, null, null, null), {},
+    LViewFlags.IsRoot, null, null);
+
 const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
 const embeddedTView = createTView(
     TViewType.Embedded, -1, testTemplate, 11, 0, null, null, null, null, [[3, 'click', 'input']]);
 
-// create view once so we don't profile first template pass
-createAndRenderLView(null, embeddedTView, viewTNode);
+// create view once so we don't profile the first create pass
+createAndRenderLView(rootLView, embeddedTView, viewTNode);
 
 const listenersCreate = createBenchmark('listeners create');
 const createTime = listenersCreate('create');
@@ -78,7 +82,7 @@ const createTime = listenersCreate('create');
 // profile create views (run templates in creation mode)
 console.profile('create listeners');
 while (createTime()) {
-  createAndRenderLView(null, embeddedTView, viewTNode);
+  createAndRenderLView(rootLView, embeddedTView, viewTNode);
 }
 console.profileEnd();
 

--- a/packages/core/test/render3/perf/ng_template/index.ts
+++ b/packages/core/test/render3/perf/ng_template/index.ts
@@ -5,12 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TViewType} from '@angular/core/src/render3/interfaces/view';
 import {ElementRef, TemplateRef, ViewContainerRef} from '../../../../src/linker';
 import {ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵtemplate} from '../../../../src/render3/index';
-import {createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {createLView, createTNode, createTView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType, TViewNode} from '../../../../src/render3/interfaces/node';
+import {LViewFlags, TViewType} from '../../../../src/render3/interfaces/view';
 import {injectTemplateRef, injectViewContainerRef} from '../../../../src/render3/view_engine_compatibility';
 import {createBenchmark} from '../micro_bench';
 import {createAndRenderLView} from '../setup';
@@ -58,13 +58,17 @@ function testTemplate(rf: RenderFlags, ctx: any) {
   }
 }
 
+const rootLView = createLView(
+    null, createTView(TViewType.Root, -1, null, 0, 0, null, null, null, null, null), {},
+    LViewFlags.IsRoot, null, null);
+
 const viewTNode = createTNode(null !, null, TNodeType.View, -1, null, null) as TViewNode;
 const embeddedTView = createTView(
     TViewType.Root, -1, testTemplate, 2, 0, [NgIfLike.ɵdir], null, null, null,
     [['viewManipulation', '']]);
 
 // create view once so we don't profile first template pass
-createAndRenderLView(null, embeddedTView, viewTNode);
+createAndRenderLView(rootLView, embeddedTView, viewTNode);
 
 // scenario to benchmark
 const elementTextCreate = createBenchmark('ng_template');
@@ -72,7 +76,7 @@ const createTime = elementTextCreate('create');
 
 console.profile('ng_template_create');
 while (createTime()) {
-  createAndRenderLView(null, embeddedTView, viewTNode);
+  createAndRenderLView(rootLView, embeddedTView, viewTNode);
 }
 console.profileEnd();
 

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -19,8 +19,7 @@ const rendererFactory: RendererFactory3 =
     isBrowser ? domRendererFactory3 : new MicroBenchmarkRendererFactory;
 const renderer = rendererFactory.createRenderer(null, null);
 
-export function createAndRenderLView(
-    parentLView: LView | null, tView: TView, hostTNode: TViewNode) {
+export function createAndRenderLView(parentLView: LView, tView: TView, hostTNode: TViewNode) {
   const embeddedLView = createLView(
       parentLView, tView, {}, LViewFlags.CheckAlways, null, hostTNode, rendererFactory, renderer);
   renderView(embeddedLView, tView, null);


### PR DESCRIPTION
Micro-benchmarks were broken after we've introduced concept of
DECLARATION_COMPONENT_VIEW on LView (after this change embedded
views must have a pointer to a parent LView).
