### PR TITLE
fix(language-service): function.bind() should not be an error

### DIFF
--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -271,7 +271,11 @@ class TypeWrapper implements Symbol {
   }
 
   members(): SymbolTable {
-    return new SymbolTableWrapper(this.tsType.getProperties(), this.context);
+    // Should call getApparentProperties() instead of getProperties() because
+    // the former includes properties on the base class whereas the latter does
+    // not. This provides properties like .bind(), .call(), .apply(), etc for
+    // functions.
+    return new SymbolTableWrapper(this.tsType.getApparentProperties(), this.context);
   }
 
   signatures(): Signature[] { return signaturesOf(this.tsType, this.context); }

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -128,6 +128,14 @@ describe('diagnostics', () => {
         .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
   });
 
+  it('should not produce errors on function.bind()', () => {
+    mockHost.override(TEST_TEMPLATE, `
+      <test-comp (test)="myClick.bind(this)">
+      </test-comp>`);
+    const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(diags).toEqual([]);
+  });
+
   describe('in expression-cases.ts', () => {
     it('should report access to an unknown field', () => {
       const diags = ngLS.getDiagnostics(EXPRESSION_CASES).map(d => d.messageText);


### PR DESCRIPTION
When performing diagnostic checks or completions, we should take into
account members and properties in the base class, if any. Otherwise, the
language service will produce a false error.

PR closes https://github.com/angular/vscode-ng-language-service/issues/93

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
