### PR TITLE
build: update payload limits for `cli-hello-world-ivy-i18n` es2015 bundle

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 138032,
+        "main-es2015": 137209,
         "polyfills-es2015": 37494
       }
     }


### PR DESCRIPTION
Commit that removes wtf* apis (https://github.com/angular/angular/commit/ed55355363dad26778dfe61fe6fc0ffc521f0db6) decreased es2015 bundle for `cli-hello-world-ivy-i18n` app (was: 138032, actual: 137209). This commit updates the `_payload-limits.json` file to reflect that.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No