### PR TITLE
fix(common): HttpHeaders lazyInit type check

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -75,7 +75,7 @@ export class HttpHeaders {
           if (typeof values === 'string') {
             values = [values];
           }
-          if (values !== undefined && values !== null && values.length > 0) {
+          if (values && values.length > 0) {
             this.headers.set(key, values);
             this.maybeSetNormalizedName(name, key);
           }

--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -75,7 +75,7 @@ export class HttpHeaders {
           if (typeof values === 'string') {
             values = [values];
           }
-          if (values.length > 0) {
+          if (values !== undefined && values !== null && values.length > 0) {
             this.headers.set(key, values);
             this.maybeSetNormalizedName(name, key);
           }

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -47,6 +47,16 @@ import {HttpHeaders} from '@angular/common/http/src/headers';
 
         expect(headers.getAll('foo')).toEqual(['second']);
       });
+      
+      it('should initialize with null values', () => {
+        const headers = new HttpHeaders({
+          'X-Key-1': '1',
+          'X-Key-2': (null as any),
+        });
+
+        expect(headers.getAll('X-Key-1')).toEqual(['1']);
+        expect(headers.getAll('X-Key-2')).toEqual(null);
+      });
     });
 
     describe('.set()', () => {

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -47,7 +47,7 @@ import {HttpHeaders} from '@angular/common/http/src/headers';
 
         expect(headers.getAll('foo')).toEqual(['second']);
       });
-      
+
       it('should initialize with null values', () => {
         const headers = new HttpHeaders({
           'X-Key-1': '1',


### PR DESCRIPTION
Add an undefined and null check to the possible value(s) when running the lazyInit of HttpHeaders with a key/value pair object.

fixes #34059

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34059


## What is the new behavior?

No error thrown when attempting to initialize HttpHeaders with a null value. Instead, the key/value is simply not added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
