### PR TITLE
feat(ivy): error in ivy when inheriting a ctor from an undecorated base

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -97,7 +97,7 @@ export class DecorationAnalyzer {
     // clang-format off
     new DirectiveDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.scopeRegistry,
-        this.metaRegistry, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
+        this.fullMetaReader, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
         /* annotateForClosureCompiler */ false) as DecoratorHandler<unknown, unknown, unknown>,
     // clang-format on
     // Pipe handler must be before injectable handler in list so pipe factories are printed

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -97,7 +97,7 @@ export class DecorationAnalyzer {
     // clang-format off
     new DirectiveDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.scopeRegistry,
-        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
+        this.metaRegistry, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
         /* annotateForClosureCompiler */ false) as DecoratorHandler<unknown, unknown, unknown>,
     // clang-format on
     // Pipe handler must be before injectable handler in list so pipe factories are printed

--- a/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
@@ -204,38 +204,6 @@ runInEachFileSystem(() => {
          expect(decorator.import).toEqual({from: '@angular/core', name: 'Directive'});
          expect(decorator.args !.length).toEqual(0);
        });
-
-    it('should skip the base class if it is in a different package from the derived class', () => {
-      const BASE_FILENAME = _('/node_modules/other-package/index.js');
-      const {program, analysis, errors} = setUpAndAnalyzeProgram([
-        {
-          name: INDEX_FILENAME,
-          contents: `
-       import {Directive, ViewContainerRef} from '@angular/core';
-       import {BaseClass} from 'other-package';
-       export class DerivedClass extends BaseClass {
-       }
-       DerivedClass.decorators = [
-         { type: Directive, args: [{ selector: '[dir]' }] }
-       ];
-     `
-        },
-        {
-          name: BASE_FILENAME,
-          contents: `
-          export class BaseClass {
-            constructor(private vcr: ViewContainerRef) {}
-          }
-          BaseClass.ctorParameters = () => [
-            { type: ViewContainerRef, }
-          ];
-      `
-        }
-      ]);
-      expect(errors).toEqual([]);
-      const file = analysis.get(program.getSourceFile(BASE_FILENAME) !);
-      expect(file).toBeUndefined();
-    });
   });
 
   function setUpAndAnalyzeProgram(testFiles: TestFile[]) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -497,8 +497,8 @@ export class ComponentDecoratorHandler implements
       }
     }
 
-    const diagnostics =
-        getDirectiveDiagnostics(node, this.metaReader, this.reflector, this.evaluator);
+    const diagnostics = getDirectiveDiagnostics(
+        node, this.metaReader, this.evaluator, this.reflector, this.scopeRegistry);
     return {
       data,
       diagnostics: diagnostics !== null ? diagnostics : undefined,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -497,7 +497,8 @@ export class ComponentDecoratorHandler implements
       }
     }
 
-    const diagnostics = getDirectiveDiagnostics(node, this.metaReader, this.evaluator);
+    const diagnostics =
+        getDirectiveDiagnostics(node, this.metaReader, this.reflector, this.evaluator);
     return {
       data,
       diagnostics: diagnostics !== null ? diagnostics : undefined,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -26,6 +26,7 @@ import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 import {SubsetOfKeys} from '../../util/src/typescript';
 
 import {ResourceLoader} from './api';
+import {getDirectiveDiagnostics} from './diagnostics';
 import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
@@ -495,7 +496,12 @@ export class ComponentDecoratorHandler implements
         this.scopeRegistry.setComponentAsRequiringRemoteScoping(node);
       }
     }
-    return {data};
+
+    const diagnostics = getDirectiveDiagnostics(node, this.metaReader, this.evaluator);
+    return {
+      data,
+      diagnostics: diagnostics !== null ? diagnostics : undefined,
+    };
   }
 
   compile(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -84,7 +84,7 @@ export function checkInheritanceOfDirective(
     }
 
     const newParentClass = readBaseClass(baseClass.node, reflector, evaluator);
-    if (newParentClass) {
+    if (newParentClass !== null) {
       // If we found another parent class, keep going.
       baseClass = newParentClass;
     } else if (!baseClassConstructor) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {ErrorCode, makeDiagnostic} from '../../diagnostics';
+import {Reference} from '../../imports';
+import {MetadataReader} from '../../metadata';
+import {PartialEvaluator} from '../../partial_evaluator';
+import {ClassDeclaration, isNamedClassDeclaration} from '../../reflection';
+import {LocalModuleScopeRegistry} from '../../scope';
+import {makeDuplicateDeclarationError} from './util';
+
+export function getDirectiveDiagnostics(
+    node: ClassDeclaration, reader: MetadataReader, evaluator: PartialEvaluator,
+    scopeRegistry: LocalModuleScopeRegistry): ts.Diagnostic[]|null {
+  let diagnostics: ts.Diagnostic[]|null = [];
+
+  const addDiagnostics = (more: ts.Diagnostic | ts.Diagnostic[] | null) => {
+    if (more === null) {
+      return;
+    } else if (diagnostics === null) {
+      diagnostics = Array.isArray(more) ? more : [more];
+    } else if (Array.isArray(more)) {
+      diagnostics.push(...more);
+    } else {
+      diagnostics.push(more);
+    }
+  };
+
+  const duplicateDeclarations = scopeRegistry.getDuplicateDeclarations(node);
+
+  if (duplicateDeclarations !== null) {
+    addDiagnostics(makeDuplicateDeclarationError(node, duplicateDeclarations, 'Directive'));
+  }
+
+  addDiagnostics(checkInheritanceOfDirective(node, reader, evaluator));
+
+  return diagnostics;
+}
+
+export function checkInheritanceOfDirective(
+    node: ClassDeclaration, reader: MetadataReader, evaluator: PartialEvaluator): ts.Diagnostic|
+    null {
+  if (!ts.isClassDeclaration(node) || node.heritageClauses === undefined) {
+    return null;
+  }
+
+  const extendsClause =
+      node.heritageClauses.find(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
+  if (extendsClause === undefined) {
+    return null;
+  }
+
+  if (node.members.find(member => ts.isConstructorDeclaration(member)) !== undefined) {
+    // If a constructor exists, then no base class definition is required on the runtime side -
+    // it's legal to inherit from any class.
+    return null;
+  }
+
+
+  // The extends clause is an expression which can be as dynamic as the user wants. Try to
+  // evaluate
+  // it, but fall back on ignoring the clause if it can't be understood. This is a View Engine
+  // compatibility hack: View Engine ignores 'extends' expressions that it cannot understand.
+  const type = extendsClause.types[0];
+  const baseClass = evaluator.evaluate(type.expression);
+  if (!(baseClass instanceof Reference) || !isNamedClassDeclaration(baseClass.node)) {
+    return null;
+  }
+
+  const baseClassMeta = reader.getDirectiveMetadata(baseClass as Reference<ClassDeclaration>);
+  if (baseClassMeta !== null) {
+    return null;
+  }
+
+  const subclassMeta = reader.getDirectiveMetadata(new Reference(node)) !;
+
+  const dirOrComp = subclassMeta.isComponent ? 'Component' : 'Directive';
+
+  return makeDiagnostic(
+      ErrorCode.DIRECTIVE_INHERITS_UNDECORATED_CTOR, type,
+      `The ${dirOrComp.toLowerCase()} ${node.name.text} inherits its constructor from ${baseClass.debugName}, ` +
+          `but the latter does not have an Angular decorator of its own. Dependency injection will not be able to ` +
+          `resolve the parameters of ${baseClass.debugName}'s constructor. Either add an @Directive annotation ` +
+          `to ${baseClass.debugName}, or add an explicit constructor to ${node.name.text}.`);
+}

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -12,7 +12,7 @@ import {ErrorCode, makeDiagnostic} from '../../diagnostics';
 import {Reference} from '../../imports';
 import {MetadataReader} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, ReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
 
 import {makeDuplicateDeclarationError, readBaseClass} from './util';
@@ -48,9 +48,8 @@ export function checkInheritanceOfDirective(
     node: ClassDeclaration, reader: MetadataReader, reflector: ReflectionHost,
     evaluator: PartialEvaluator): ts.Diagnostic|null {
   if (!reflector.isClass(node) || reflector.getConstructorParameters(node) !== null) {
-    // We should skip classes that aren't classes.
-    // If a constructor exists, then no base class definition is required
-    // on the runtime side - it's legal to inherit from any class.
+    // We should skip nodes that aren't classes. If a constructor exists, then no base class
+    // definition is required on the runtime side - it's legal to inherit from any class.
     return null;
   }
 
@@ -60,7 +59,7 @@ export function checkInheritanceOfDirective(
   let baseClass = readBaseClass(node, reflector, evaluator);
 
   while (baseClass !== null) {
-    if (baseClass === 'dynamic' || !isNamedClassDeclaration(baseClass.node)) {
+    if (baseClass === 'dynamic') {
       return null;
     }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -57,36 +57,48 @@ export function checkInheritanceOfDirective(
     return null;
   }
 
-  if (node.members.find(member => ts.isConstructorDeclaration(member)) !== undefined) {
+  if (getConstructor(node) !== undefined) {
     // If a constructor exists, then no base class definition is required on the runtime side -
     // it's legal to inherit from any class.
     return null;
   }
 
-
   // The extends clause is an expression which can be as dynamic as the user wants. Try to
-  // evaluate
-  // it, but fall back on ignoring the clause if it can't be understood. This is a View Engine
-  // compatibility hack: View Engine ignores 'extends' expressions that it cannot understand.
+  // evaluate it, but fall back on ignoring the clause if it can't be understood. This is a View
+  // Engine compatibility hack: View Engine ignores 'extends' expressions that it cannot understand.
   const type = extendsClause.types[0];
   const baseClass = evaluator.evaluate(type.expression);
   if (!(baseClass instanceof Reference) || !isNamedClassDeclaration(baseClass.node)) {
     return null;
   }
 
+  // If the base class doesn't have a constructor or the constructor
+  // doesn't have parameters, it won't be using DI so we can skip it.
+  const baseClassConstructor = getConstructor(baseClass.node);
+  if (baseClassConstructor === undefined || baseClassConstructor.parameters.length === 0) {
+    return null;
+  }
+
+  // We can skip the base class if it has metadata.
   const baseClassMeta = reader.getDirectiveMetadata(baseClass as Reference<ClassDeclaration>);
   if (baseClassMeta !== null) {
     return null;
   }
 
   const subclassMeta = reader.getDirectiveMetadata(new Reference(node)) !;
-
   const dirOrComp = subclassMeta.isComponent ? 'Component' : 'Directive';
 
   return makeDiagnostic(
       ErrorCode.DIRECTIVE_INHERITS_UNDECORATED_CTOR, type,
       `The ${dirOrComp.toLowerCase()} ${node.name.text} inherits its constructor from ${baseClass.debugName}, ` +
           `but the latter does not have an Angular decorator of its own. Dependency injection will not be able to ` +
-          `resolve the parameters of ${baseClass.debugName}'s constructor. Either add an @Directive annotation ` +
+          `resolve the parameters of ${baseClass.debugName}'s constructor. Either add a @Directive decorator ` +
           `to ${baseClass.debugName}, or add an explicit constructor to ${node.name.text}.`);
+}
+
+
+/** Gets the constructor of a class declaration. */
+function getConstructor(node: ts.ClassDeclaration): ts.ConstructorDeclaration|undefined {
+  const constructor = node.members.find(member => ts.isConstructorDeclaration(member));
+  return constructor as ts.ConstructorDeclaration | undefined;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -119,8 +119,8 @@ export class DirectiveDecoratorHandler implements
   }
 
   resolve(node: ClassDeclaration, analysis: DirectiveHandlerData): ResolveResult<unknown> {
-    const diagnostics =
-        getDirectiveDiagnostics(node, this.metaReader, this.evaluator, this.scopeRegistry);
+    const diagnostics = getDirectiveDiagnostics(
+        node, this.metaReader, this.evaluator, this.reflector, this.scopeRegistry);
 
     return {
       diagnostics: diagnostics !== null ? diagnostics : undefined,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -49,7 +49,8 @@ runInEachFileSystem(() => {
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
       const handler = new DirectiveDecoratorHandler(
-          reflectionHost, evaluator, scopeRegistry, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+          reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader,
+          NOOP_DEFAULT_IMPORT_RECORDER,
           /* isCore */ false, /* annotateForClosureCompiler */ false);
 
       const analyzeDirective = (dirName: string) => {

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -117,7 +117,13 @@ export enum ErrorCode {
   /**
    * An injectable already has a `ɵprov` property.
    */
-  INJECTABLE_DUPLICATE_PROV = 9001
+  INJECTABLE_DUPLICATE_PROV = 9001,
+
+  /**
+   * Raised when a Directive inherits its constructor from a base class without an Angular
+   * decorator.
+   */
+  DIRECTIVE_INHERITS_UNDECORATED_CTOR = 10001,
 }
 
 export function ngErrorCode(code: ErrorCode): number {

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -26,6 +26,12 @@ export enum ErrorCode {
   PARAM_MISSING_TOKEN = 2003,
   DIRECTIVE_MISSING_SELECTOR = 2004,
 
+  /**
+   * Raised when a Directive inherits its constructor from a base class without an Angular
+   * decorator.
+   */
+  DIRECTIVE_INHERITS_UNDECORATED_CTOR = 2005,
+
   SYMBOL_NOT_EXPORTED = 3001,
   SYMBOL_EXPORTED_UNDER_DIFFERENT_NAME = 3002,
 
@@ -118,12 +124,6 @@ export enum ErrorCode {
    * An injectable already has a `ɵprov` property.
    */
   INJECTABLE_DUPLICATE_PROV = 9001,
-
-  /**
-   * Raised when a Directive inherits its constructor from a base class without an Angular
-   * decorator.
-   */
-  DIRECTIVE_INHERITS_UNDECORATED_CTOR = 10001,
 }
 
 export function ngErrorCode(code: ErrorCode): number {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -30,6 +30,10 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
     return this.pipes.has(ref.node) ? this.pipes.get(ref.node) ! : null;
   }
 
+  forEachDirective(fn: (dir: ClassDeclaration, meta: DirectiveMeta) => void): void {
+    this.directives.forEach((meta, dir) => fn(dir, meta));
+  }
+
   registerDirectiveMetadata(meta: DirectiveMeta): void { this.directives.set(meta.ref.node, meta); }
   registerNgModuleMetadata(meta: NgModuleMeta): void { this.ngModules.set(meta.ref.node, meta); }
   registerPipeMetadata(meta: PipeMeta): void { this.pipes.set(meta.ref.node, meta); }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -30,10 +30,6 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
     return this.pipes.has(ref.node) ? this.pipes.get(ref.node) ! : null;
   }
 
-  forEachDirective(fn: (dir: ClassDeclaration, meta: DirectiveMeta) => void): void {
-    this.directives.forEach((meta, dir) => fn(dir, meta));
-  }
-
   registerDirectiveMetadata(meta: DirectiveMeta): void { this.directives.set(meta.ref.node, meta); }
   registerNgModuleMetadata(meta: NgModuleMeta): void { this.ngModules.set(meta.ref.node, meta); }
   registerPipeMetadata(meta: PipeMeta): void { this.pipes.set(meta.ref.node, meta); }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -663,7 +663,7 @@ export class NgtscProgram implements api.Program {
       // being assignable to `unknown` when wrapped in `Readonly`).
       // clang-format off
       new DirectiveDecoratorHandler(
-          this.reflector, evaluator, metaRegistry, this.scopeRegistry, this.defaultImportTracker,
+          this.reflector, evaluator, metaRegistry, this.scopeRegistry, this.metaReader, this.defaultImportTracker,
           this.isCore, this.closureCompilerEnabled) as Readonly<DecoratorHandler<unknown, unknown, unknown>>,
       // clang-format on
       // Pipe handler must be before injectable handler in list so pipe factories are printed

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -363,7 +363,7 @@ export class TraitCompiler {
           }
         }
 
-        if (result.diagnostics !== undefined) {
+        if (result.diagnostics !== undefined && result.diagnostics.length > 0) {
           trait = trait.toErrored(result.diagnostics);
         } else {
           if (result.data !== undefined) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2895,6 +2895,9 @@ runInEachFileSystem(os => {
       env.write(`test.ts`, `
         import {Directive} from '@angular/core';
 
+        @Directive({
+          selector: '[base]',
+        })
         class Base {}
 
         @Directive({
@@ -5129,6 +5132,128 @@ export const Foo = Foo__PRE_R3__;
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toContain('but 3.4.0 was found instead');
       });
+    });
+
+    describe('inherited directives', () => {
+      beforeEach(() => {
+        env.write('local.ts', `
+          import {Component, Directive} from '@angular/core';
+
+          export class BasePlain {}
+
+          @Component({
+            selector: 'base-cmp',
+            template: 'BaseCmp',
+          })
+          export class BaseCmp {}
+
+          @Directive({
+            selector: '[base]',
+          })
+          export class BaseDir {}
+        `);
+
+        env.write('lib.d.ts', `
+          import {ɵɵComponentDefWithMeta, ɵɵDirectiveDefWithMeta} from '@angular/core';
+
+          export declare class BasePlain {}
+
+          export declare class BaseCmp {
+            static ngComponentDef: ɵɵComponentDefWithMeta<BaseCmp, "base-cmp", never, {}, {}, never>
+          }
+
+          export declare class BaseDir {
+            static ngDirectiveDef: ɵɵDirectiveDefWithMeta<BaseDir, '[base]', never, never, never, never>;
+          }
+        `);
+      });
+
+      it('should not error when inheriting a constructor from a decorated directive class', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {Directive, Component} from '@angular/core';
+          import {BaseDir, BaseCmp} from './local';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir extends BaseDir {}
+
+          @Component({
+            selector: 'test-cmp',
+            template: 'TestCmp',
+          })
+          export class Cmp extends BaseCmp {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should error when inheriting a constructor from an undecorated class', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {Directive, Component} from '@angular/core';
+          import {BasePlain} from './local';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir extends BasePlain {}
+
+          @Component({
+            selector: 'test-cmp',
+            template: 'TestCmp',
+          })
+          export class Cmp extends BasePlain {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText).toContain('Dir');
+        expect(diags[0].messageText).toContain('BasePlain');
+        expect(diags[1].messageText).toContain('Cmp');
+        expect(diags[1].messageText).toContain('BasePlain');
+      });
+
+      it('should not error when inheriting a constructor from decorated directive or component classes in a .d.ts file',
+         () => {
+           env.tsconfig();
+           env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+              import {BaseDir, BaseCmp} from './lib';
+
+              @Directive({
+                selector: '[dir]',
+              })
+              export class Dir extends BaseDir {}
+
+              @Component({
+                selector: 'test-cmp',
+                template: 'TestCmp',
+              })
+              export class Cmp extends BaseCmp {}
+           `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(0);
+         });
+
+      it('should error when inheriting a constructor from an undecorated class in a .d.ts file',
+         () => {
+           env.tsconfig();
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+
+              import {BasePlain} from './lib';
+
+              @Directive({
+                selector: '[dir]',
+              })
+              export class Dir extends BasePlain {}
+            `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText).toContain('Dir');
+           expect(diags[0].messageText).toContain('Base');
+         });
     });
 
     describe('inline resources', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5272,6 +5272,65 @@ export const Foo = Foo__PRE_R3__;
         expect(diags[1].messageText).toContain('BasePlainWithConstructorParameters');
       });
 
+      it('should error when inheriting a constructor from undecorated grand super class', () => {
+        env.tsconfig();
+        env.write('test.ts', `
+          import {Directive, Component} from '@angular/core';
+          import {BasePlainWithConstructorParameters} from './local';
+
+          class Parent extends BasePlainWithConstructorParameters {}
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir extends Parent {}
+
+          @Component({
+            selector: 'test-cmp',
+            template: 'TestCmp',
+          })
+          export class Cmp extends Parent {}
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(2);
+        expect(diags[0].messageText).toContain('Dir');
+        expect(diags[0].messageText).toContain('BasePlainWithConstructorParameters');
+        expect(diags[1].messageText).toContain('Cmp');
+        expect(diags[1].messageText).toContain('BasePlainWithConstructorParameters');
+      });
+
+      it('should error when inheriting a constructor from undecorated grand grand super class',
+         () => {
+           env.tsconfig();
+           env.write('test.ts', `
+              import {Directive, Component} from '@angular/core';
+              import {BasePlainWithConstructorParameters} from './local';
+
+              class GrandParent extends BasePlainWithConstructorParameters {}
+
+              class Parent extends GrandParent {}
+
+              @Directive({
+                selector: '[dir]',
+              })
+              export class Dir extends Parent {}
+
+              @Component({
+                selector: 'test-cmp',
+                template: 'TestCmp',
+              })
+              export class Cmp extends Parent {}
+            `);
+
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(2);
+           expect(diags[0].messageText).toContain('Dir');
+           expect(diags[0].messageText).toContain('BasePlainWithConstructorParameters');
+           expect(diags[1].messageText).toContain('Cmp');
+           expect(diags[1].messageText).toContain('BasePlainWithConstructorParameters');
+         });
+
       it('should not error when inheriting a constructor from decorated directive or component classes in a .d.ts file',
          () => {
            env.tsconfig();


### PR DESCRIPTION
**Note:** this is a resubmit of https://github.com/angular/angular/pull/31271. I took the code from the original PR, rebased it against master, fixed the unit test failures and addressed the PR feedback. Sorry @alxhub, but for some reason the ownership of the original commit was switched when I rebased it. My changes are isolated to the second `fixup` commit.

--------------------------

Angular View Engine uses global knowledge to compile the following code:

```typescript
export class Base {
  constructor(private vcr: ViewContainerRef) {}
}

@Directive({...})
export class Dir extends Base {
  // constructor inherited from base
}
```

Here, `Dir` extends `Base` and inherits its constructor. To create a `Dir`
the arguments to this inherited constructor must be obtained via dependency
injection. View Engine is able to generate a correct factory for `Dir` to do
this because via metadata it knows the arguments of `Base`'s constructor,
even if `Base` is declared in a different library.

In Ivy, DI is entirely a runtime concept. Currently `Dir` is compiled with
an ngDirectiveDef field that delegates its factory to `getInheritedFactory`.
This looks for some kind of factory function on `Base`, which comes up
empty. This case looks identical to an inheritance chain with no
constructors, which works today in Ivy.

Both of these cases will now become an error in this commit. If a decorated
class inherits from an undecorated base class, a diagnostic is produced
informing the user of the need to either explicitly declare a constructor or
to decorate the base class.