### PR TITLE
fix(ivy): i18n - ensure that escaped chars are handled in localized s…

### DIFF
--- a/packages/compiler-cli/test/compliance/mock_compile.ts
+++ b/packages/compiler-cli/test/compliance/mock_compile.ts
@@ -78,7 +78,7 @@ function tokenizeBackTickString(str: string): Piece[] {
   const pieces: Piece[] = ['`'];
   // Unescape backticks that are inside the backtick string
   // (we had to double escape them in the test string so they didn't look like string markers)
-  str = str.replace(/\\\\\\`/, '\\`');
+  str = str.replace(/\\\\\\`/g, '\\`');
   const backTickPieces = str.slice(2, -2).split(BACKTICK_INTERPOLATION);
   backTickPieces.forEach((backTickPiece) => {
     if (BACKTICK_INTERPOLATION.test(backTickPiece)) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -956,20 +956,37 @@ describe('i18n support in the template compiler', () => {
 
     it('should properly escape quotes in content', () => {
       const input = `
-        <div i18n>Some text 'with single quotes', "with double quotes" and without quotes.</div>
+        <div i18n>Some text 'with single quotes', "with double quotes", \`with backticks\` and without quotes.</div>
       `;
 
       const output = String.raw `
         var $I18N_0$;
         if (ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$ = goog.getMsg("Some text 'with single quotes', \"with double quotes\" and without quotes.");
+            const $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$ = goog.getMsg("Some text 'with single quotes', \"with double quotes\", ` +
+          '`with backticks`' + String.raw ` and without quotes.");
             $I18N_0$ = $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$;
         }
         else {
-            $I18N_0$ = $localize \`Some text 'with single quotes', "with double quotes" and without quotes.\`;
+            $I18N_0$ = $localize \`Some text 'with single quotes', "with double quotes", \\\`with backticks\\\` and without quotes.\`;
         }
       `;
 
+      verify(input, output);
+    });
+
+    it('should handle interpolations wrapped in backticks', () => {
+      const input = '<div i18n>`{{ count }}`</div>';
+      const output = String.raw `
+      var $I18N_0$;
+      if (ngI18nClosureMode) {
+          const $MSG_APP_SPEC_TS_1$ = goog.getMsg("` +
+          '`{$interpolation}`' + String.raw `", { "interpolation": "\uFFFD0\uFFFD" });
+          $I18N_0$ = $MSG_APP_SPEC_TS_1$;
+      }
+      else {
+          $I18N_0$ = $localize \`\\\`$` +
+          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\\\`\`;
+      }`;
       verify(input, output);
     });
 


### PR DESCRIPTION
…trings

When creating synthesized tagged template literals, one must provide both
the "cooked" text and the "raw" (unparsed) text. Previously there were no
good APIs for creating the AST nodes with raw text for such literals.
Recently the APIs were improved to support this, and they do an extra
check to ensure that the raw text parses to be equal to the cooked text.

It turns out there is a bug in this check -
see https://github.com/microsoft/TypeScript/issues/35374.

This commit works around the bug by synthesizing a "head" node and morphing
it by changing its `kind` into the required node type.

// FW-1747
