### PR TITLE
build: remove --define=compile=aot for determining if ivy should be used for building

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -35,6 +35,13 @@ def is_ivy_enabled(ctx):
     Returns:
       Boolean, Whether the ivy compiler should be used.
     """
+    if "compile" in ctx.var and ctx.workspace_name == "angular":
+        fail(
+            msg = "Setting ViewEngine/Ivy using --define=compile is deprecated, please use " +
+                  "--config=ivy or --config=view-engine instead.",
+            attr = "ng_module",
+        )
+
     # TODO(josephperrott): Remove configuration via compile=aot define flag.
     if ctx.var.get("compile", None) == "aot":
         print("Setting ViewEngine/Ivy using the compile build variable (--define=compile=*) "+

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -35,9 +35,10 @@ def is_ivy_enabled(ctx):
     Returns:
       Boolean, Whether the ivy compiler should be used.
     """
-
     # TODO(josephperrott): Remove configuration via compile=aot define flag.
     if ctx.var.get("compile", None) == "aot":
+        print("Setting ViewEngine/Ivy using the compile build variable (--define=compile=*) "+
+              "is deprecated, please use the angular_ivy_enabled build variable instead.")
         return True
 
     if ctx.var.get("angular_ivy_enabled", None) == "True":

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -44,7 +44,7 @@ def is_ivy_enabled(ctx):
 
     # TODO(josephperrott): Remove configuration via compile=aot define flag.
     if ctx.var.get("compile", None) == "aot":
-        print("Setting ViewEngine/Ivy using the compile build variable (--define=compile=*) "+
+        print("Setting ViewEngine/Ivy using the compile build variable (--define=compile=*) " +
               "is deprecated, please use the angular_ivy_enabled build variable instead.")
         return True
 


### PR DESCRIPTION
Now that all usages of --define=compile=aot has been removed google3
and our other repos we are able to remove this final reference from
angular/angular.  All determination of enabling ivy should instead be
done using angular_ivy_enabled.

Adds a failure message whenever builds are attempted using compile=aot
instructing the user to instead set the angular_ivy_enabled value via
the --define flag.