### PR TITLE
ci: disable renovate for integration tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,11 +15,7 @@
 		"source-map",
 		"@types/node"
 	],
-	"packageFiles": [
-		"integration/cli-hello-world-ivy-compat/package.json",
-		"integration/cli-hello-world-ivy-minimal/package.json",
-		"integration/cli-hello-world/package.json"
-	],
+	"packageFiles": [],
 	"major": {
 		"devDependencies": {
 			"enabled": false


### PR DESCRIPTION
the package.json in these tests points to file:dist/packages-dist which
is not materialized on renovate-bot, so the bot freaks out and fails to
update the lock files.

This means that the bot currently just opens up PRs that can't be merged.

Example: https://github.com/angular/angular/pull/34071

(In the past this worked nicely because we didn't keep the yarn.lock files
in the git repo for these projects, but that had a problem with unpined
depenedencies and undeterministic build/test runs).

For now it's better to disable the bot by removing all the package.jsons
from the config. We should revisit this in the future have the bot update
the root package.json instead.
