### PR TITLE
feat(platform-server): Expose XHR client used in platform-server/http

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -121,3 +121,10 @@ export const SERVER_HTTP_PROVIDERS: Provider[] = [
     deps: [HttpBackend, Injector]
   }
 ];
+
+/**
+ * The instance of the XHR Client used in platform-server.
+ *
+ * @publicApi
+ */
+export const PLATFORM_SERVER_XHR = xhr2;

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export {PLATFORM_SERVER_XHR} from './http';
 export {PlatformState} from './platform_state';
 export {ServerModule, platformDynamicServer, platformServer} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';

--- a/tools/public_api_guard/platform-server/platform-server.d.ts
+++ b/tools/public_api_guard/platform-server/platform-server.d.ts
@@ -2,6 +2,8 @@ export declare const BEFORE_APP_SERIALIZED: InjectionToken<(() => void)[]>;
 
 export declare const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 
+export declare const PLATFORM_SERVER_XHR: any;
+
 export interface PlatformConfig {
     document?: string;
     url?: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I wish to attach cookies to HTTP requests during SSR.
But `cookie` is a [restricted header in node-xhr2](https://github.com/pwnall/node-xhr2/blob/master/src/001-xml_http_request.coffee#L369)

So I'm using the following https://github.com/angular/angular/issues/15730#issuecomment-291578814
```typescript
import * as xhr2 from 'xhr2';
xhr2.prototype._restrictedHeaders.cookie = false;
```

Everything works fine.

But then I noticed that this works only if the `xhr2` resolved in `import * as xhr2 from 'xhr2'` is the actual one used by [platform-server/src/http.ts](https://github.com/angular/angular/blob/master/packages/platform-server/src/http.ts#L10).  
Meaning that, if I add the dependency `xhr2` in the `package.json` of my project, then the imported xhr2 will be considered as a new instance. Because of that, platform-server/http's xhr2 cookies setting remains unchanged (because I'm actually changing the settings of that new instance, not the one of platform-server/http).

## What is the new behavior?

This Pull Request is to expose the XHR client used in platform-server/http, so that anyone can tweak it the way they want, especially for SSR-related issues.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
