### PR TITLE
fix(language-service): Do not produce diagnostics if metadata for NgModule not found

### DIFF
--- a/packages/language-service/src/common.ts
+++ b/packages/language-service/src/common.ts
@@ -8,7 +8,7 @@
 
 import {CompileDirectiveMetadata, CompileDirectiveSummary, CompilePipeSummary, CssSelector, Node as HtmlAst, ParseError, Parser, TemplateAst} from '@angular/compiler';
 
-import {Diagnostic, TemplateSource} from './types';
+import {TemplateSource} from './types';
 
 export interface AstResult {
   htmlAst: HtmlAst[];
@@ -25,7 +25,3 @@ export type SelectorInfo = {
   selectors: CssSelector[],
   map: Map<CssSelector, CompileDirectiveSummary>
 };
-
-export function isAstResult(result: AstResult | Diagnostic): result is AstResult {
-  return result.hasOwnProperty('templateAst');
-}

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -8,7 +8,6 @@
 
 import * as tss from 'typescript/lib/tsserverlibrary';
 
-import {isAstResult} from './common';
 import {getTemplateCompletions} from './completions';
 import {getDefinitionAndBoundSpan, getTsDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic, uniqueBySpan} from './diagnostics';
@@ -34,11 +33,9 @@ class LanguageServiceImpl implements LanguageService {
     const templates = this.host.getTemplates(fileName);
 
     for (const template of templates) {
-      const astOrDiagnostic = this.host.getTemplateAst(template);
-      if (isAstResult(astOrDiagnostic)) {
-        results.push(...getTemplateDiagnostics(astOrDiagnostic));
-      } else {
-        results.push(astOrDiagnostic);
+      const ast = this.host.getTemplateAst(template);
+      if (ast) {
+        results.push(...getTemplateDiagnostics(ast));
       }
     }
 

--- a/packages/language-service/src/template.ts
+++ b/packages/language-service/src/template.ts
@@ -8,7 +8,6 @@
 
 import * as ts from 'typescript';
 
-import {isAstResult} from './common';
 import {createGlobalSymbolTable} from './global_symbols';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
@@ -73,7 +72,7 @@ abstract class BaseTemplate implements ng.TemplateSource {
         // TODO: There is circular dependency here between TemplateSource and
         // TypeScriptHost. Consider refactoring the code to break this cycle.
         const ast = this.host.getTemplateAst(this);
-        const pipes = isAstResult(ast) ? ast.pipes : [];
+        const pipes = (ast && ast.pipes) || [];
         return getPipesTable(sourceFile, program, typeChecker, pipes);
       });
     }

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -193,7 +193,7 @@ export interface LanguageServiceHost {
   /**
    * Return the AST for both HTML and template for the contextFile.
    */
-  getTemplateAst(template: TemplateSource): AstResult|Diagnostic;
+  getTemplateAst(template: TemplateSource): AstResult|undefined;
 
   /**
    * Return the template AST for the node that corresponds to the position.

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -804,4 +804,20 @@ describe('diagnostics', () => {
       expect(content.substring(start !, start ! + length !)).toBe(`line${i}`);
     }
   });
+
+  it('should not produce diagnostics for non-exported directives', () => {
+    const fileName = '/app/test.component.ts';
+    mockHost.addScript(fileName, `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<test-comp></test-comp>'
+      })
+      class TestHostComponent {}
+    `);
+    const tsDiags = tsLS.getSemanticDiagnostics(fileName);
+    expect(tsDiags).toEqual([]);
+    const ngDiags = ngLS.getDiagnostics(fileName);
+    expect(ngDiags).toEqual([]);
+  });
 });


### PR DESCRIPTION
The language service incorrectly reports an error if it fails to find
NgModule metadata for a particular Component / Directive. In many cases,
the use case is legit, particularly in test.

This commit removes such diagnostic message and cleans up the interface
for `TypeScriptHost.getTemplateAst()`.

This is a regression in version 9 due to recent refactorings.

PR closes https://github.com/angular/vscode-ng-language-service/issues/463

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
