### PR TITLE
fix(language-service): Make missing module suggestion instead of error

### DIFF
--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -26,7 +26,7 @@ export function getTemplateDiagnostics(ast: AstResult): ng.Diagnostic[] {
   if (parseErrors && parseErrors.length) {
     return parseErrors.map(e => {
       return {
-        kind: ng.DiagnosticKind.Error,
+        kind: ts.DiagnosticCategory.Error,
         span: offsetSpan(spanOf(e.span), template.span.start),
         message: e.msg,
       };
@@ -98,7 +98,7 @@ export function getDeclarationDiagnostics(
 
     for (const error of errors) {
       results.push({
-        kind: ng.DiagnosticKind.Error,
+        kind: ts.DiagnosticCategory.Error,
         message: error.message,
         span: error.span,
       });
@@ -109,7 +109,7 @@ export function getDeclarationDiagnostics(
     if (metadata.isComponent) {
       if (!modules.ngModuleByPipeOrDirective.has(declaration.type)) {
         results.push({
-          kind: ng.DiagnosticKind.Error,
+          kind: ts.DiagnosticCategory.Suggestion,
           message: missingDirective(type.name, metadata.isComponent),
           span: declarationSpan,
         });
@@ -117,14 +117,14 @@ export function getDeclarationDiagnostics(
       const {template, templateUrl, styleUrls} = metadata.template !;
       if (template === null && !templateUrl) {
         results.push({
-          kind: ng.DiagnosticKind.Error,
+          kind: ts.DiagnosticCategory.Error,
           message: `Component '${type.name}' must have a template or templateUrl`,
           span: declarationSpan,
         });
       } else if (templateUrl) {
         if (template) {
           results.push({
-            kind: ng.DiagnosticKind.Error,
+            kind: ts.DiagnosticCategory.Error,
             message: `Component '${type.name}' must not have both template and templateUrl`,
             span: declarationSpan,
           });
@@ -159,7 +159,7 @@ export function getDeclarationDiagnostics(
       }
     } else if (!directives.has(declaration.type)) {
       results.push({
-        kind: ng.DiagnosticKind.Error,
+        kind: ts.DiagnosticCategory.Suggestion,
         message: missingDirective(type.name, metadata.isComponent),
         span: declarationSpan,
       });
@@ -199,7 +199,7 @@ function validateUrls(
     if (tsLsHost.fileExists(url)) continue;
 
     allErrors.push({
-      kind: ng.DiagnosticKind.Error,
+      kind: ts.DiagnosticCategory.Error,
       message: `URL does not point to a valid file`,
       // Exclude opening and closing quotes in the url span.
       span: {start: urlNode.getStart() + 1, end: urlNode.end - 1},
@@ -233,7 +233,7 @@ export function ngDiagnosticToTsDiagnostic(
     start: d.span.start,
     length: d.span.end - d.span.start,
     messageText: typeof d.message === 'string' ? d.message : chainDiagnostics(d.message),
-    category: ts.DiagnosticCategory.Error,
+    category: d.kind,
     code: 0,
     source: 'ng',
   };

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -7,9 +7,11 @@
  */
 
 import {AST, AstPath, Attribute, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, CompileDirectiveSummary, CompileTypeMetadata, DirectiveAst, ElementAst, EmbeddedTemplateAst, Node, ParseSourceSpan, RecursiveTemplateAstVisitor, ReferenceAst, TemplateAst, TemplateAstPath, VariableAst, findNode, identifierName, templateVisitAll, tokenReference} from '@angular/compiler';
+import * as ts from 'typescript';
 
-import {AstType, DiagnosticKind, ExpressionDiagnosticsContext, TypeDiagnostic} from './expression_type';
+import {AstType, ExpressionDiagnosticsContext, TypeDiagnostic} from './expression_type';
 import {BuiltinType, Definition, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './symbols';
+import {Diagnostic} from './types';
 
 export interface DiagnosticTemplateInfo {
   fileName?: string;
@@ -20,14 +22,7 @@ export interface DiagnosticTemplateInfo {
   templateAst: TemplateAst[];
 }
 
-export interface ExpressionDiagnostic {
-  message: string;
-  span: Span;
-  kind: DiagnosticKind;
-}
-
-export function getTemplateExpressionDiagnostics(info: DiagnosticTemplateInfo):
-    ExpressionDiagnostic[] {
+export function getTemplateExpressionDiagnostics(info: DiagnosticTemplateInfo): Diagnostic[] {
   const visitor = new ExpressionDiagnosticsVisitor(
       info, (path: TemplateAstPath, includeEvent: boolean) =>
                 getExpressionScope(info, path, includeEvent));
@@ -202,7 +197,7 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
   // TODO(issue/24571): remove '!'.
   private directiveSummary !: CompileDirectiveSummary;
 
-  diagnostics: ExpressionDiagnostic[] = [];
+  diagnostics: Diagnostic[] = [];
 
   constructor(
       private info: DiagnosticTemplateInfo,
@@ -309,13 +304,13 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
   private reportError(message: string, span: Span|undefined) {
     if (span) {
       this.diagnostics.push(
-          {span: offsetSpan(span, this.info.offset), kind: DiagnosticKind.Error, message});
+          {span: offsetSpan(span, this.info.offset), kind: ts.DiagnosticCategory.Error, message});
     }
   }
 
   private reportWarning(message: string, span: Span) {
     this.diagnostics.push(
-        {span: offsetSpan(span, this.info.offset), kind: DiagnosticKind.Warning, message});
+        {span: offsetSpan(span, this.info.offset), kind: ts.DiagnosticCategory.Warning, message});
   }
 }
 

--- a/packages/language-service/src/expression_type.ts
+++ b/packages/language-service/src/expression_type.ts
@@ -7,18 +7,14 @@
  */
 
 import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, visitAstChildren} from '@angular/compiler';
+import * as ts from 'typescript';
 
-import {BuiltinType, Signature, Span, Symbol, SymbolQuery, SymbolTable} from './symbols';
+import {BuiltinType, Signature, Symbol, SymbolQuery, SymbolTable} from './symbols';
 
 export interface ExpressionDiagnosticsContext { event?: boolean; }
 
-export enum DiagnosticKind {
-  Error,
-  Warning,
-}
-
 export class TypeDiagnostic {
-  constructor(public kind: DiagnosticKind, public message: string, public ast: AST) {}
+  constructor(public kind: ts.DiagnosticCategory, public message: string, public ast: AST) {}
 }
 
 // AstType calculatetype of the ast given AST element.
@@ -412,14 +408,14 @@ export class AstType implements AstVisitor {
 
   private reportError(message: string, ast: AST): Symbol {
     if (this.diagnostics) {
-      this.diagnostics.push(new TypeDiagnostic(DiagnosticKind.Error, message, ast));
+      this.diagnostics.push(new TypeDiagnostic(ts.DiagnosticCategory.Error, message, ast));
     }
     return this.anyType;
   }
 
   private reportWarning(message: string, ast: AST): Symbol {
     if (this.diagnostics) {
-      this.diagnostics.push(new TypeDiagnostic(DiagnosticKind.Warning, message, ast));
+      this.diagnostics.push(new TypeDiagnostic(ts.DiagnosticCategory.Warning, message, ast));
     }
     return this.anyType;
   }

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -241,16 +241,6 @@ export interface Location {
 }
 
 /**
- * The kind of diagnostic message.
- *
- * @publicApi
- */
-export enum DiagnosticKind {
-  Error,
-  Warning,
-}
-
-/**
  * The type of Angular directive. Used for QuickInfo in template.
  */
 export enum DirectiveKind {
@@ -314,7 +304,7 @@ export interface Diagnostic {
   /**
    * The kind of diagnostic message
    */
-  kind: DiagnosticKind;
+  kind: ts.DiagnosticCategory;
 
   /**
    * The source span that should be highlighted.

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -15,7 +15,7 @@ import {AstResult, isAstResult} from './common';
 import {createLanguageService} from './language_service';
 import {ReflectorHost} from './reflector_host';
 import {ExternalTemplate, InlineTemplate, getClassDeclFromDecoratorProp, getPropertyAssignmentFromValue} from './template';
-import {Declaration, DeclarationError, Diagnostic, DiagnosticKind, DiagnosticMessageChain, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
+import {Declaration, DeclarationError, Diagnostic, DiagnosticMessageChain, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
 import {findTightestNode, getDirectiveClassLike} from './utils';
 
 
@@ -515,7 +515,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       const data = this.resolver.getNonNormalizedDirectiveMetadata(classSymbol);
       if (!data) {
         return {
-          kind: DiagnosticKind.Error,
+          kind: ts.DiagnosticCategory.Error,
           message: `No metadata found for '${classSymbol.name}' in ${fileName}.`,
           span: template.span,
         };
@@ -537,7 +537,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
           parser.tryParseHtml(htmlResult, data.metadata, directives, pipes, schemas);
       if (!parseResult.templateAst) {
         return {
-          kind: DiagnosticKind.Error,
+          kind: ts.DiagnosticCategory.Error,
           message: `Failed to parse template for '${classSymbol.name}' in ${fileName}`,
           span: template.span,
         };
@@ -550,7 +550,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       };
     } catch (e) {
       return {
-        kind: DiagnosticKind.Error,
+        kind: ts.DiagnosticCategory.Error,
         message: e.message,
         span:
             e.fileName === fileName && template.query.getSpanAt(e.line, e.column) || template.span,


### PR DESCRIPTION
If a Component or Directive is not part of any NgModule, the language
service currently produces an error message. This should not be an
error. Instead, it should be a suggestion.

This PR removes `ng.DiagnosticKind`, and instead reuses
`ts.DiagnosticCategory`.

PR closes https://github.com/angular/vscode-ng-language-service/issues/458

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
