### PR TITLE
refactor(ivy): do not generate providedIn: null

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 462449,
+        "main-es2015": 461697,
         "polyfills-es2015": 52503
       }
     }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 137209,
+        "main-es2015": 136594,
         "polyfills-es2015": 37494
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 267389,
+        "main-es2015": 266648,
         "polyfills-es2015": 36808,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 226528,
+        "main-es2015": 225787,
         "polyfills-es2015": 36808,
         "5-es2015": 779
       }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -90,8 +90,7 @@ describe('compiler compliance: dependency injection', () => {
     const def = `
       MyService.ɵprov = $r3$.ɵɵdefineInjectable({
         token: MyService,
-        factory: MyService.ɵfac,
-        providedIn: null
+        factory: MyService.ɵfac
       });
     `;
 
@@ -146,8 +145,7 @@ describe('compiler compliance: dependency injection', () => {
             token: MyService,
             factory: function() {
               return alternateFactory();
-            },
-            providedIn: null
+            }
           });
         `;
 
@@ -186,8 +184,7 @@ describe('compiler compliance: dependency injection', () => {
                 r = (() => new MyAlternateFactory())($r3$.ɵɵinject(SomeDep));
               }
               return r;
-            },
-            providedIn: null
+            }
           });
         `;
 
@@ -219,8 +216,7 @@ describe('compiler compliance: dependency injection', () => {
             token: MyService,
             factory: function(t) {
               return MyAlternateService.ɵfac(t);
-            },
-            providedIn: null
+            }
           });
         `;
 
@@ -261,8 +257,7 @@ describe('compiler compliance: dependency injection', () => {
                 r = new MyAlternateService($r3$.ɵɵinject(SomeDep));
               }
               return r;
-            },
-            providedIn: null
+            }
           });
         `;
 
@@ -344,14 +339,14 @@ describe('compiler compliance: dependency injection', () => {
        const MyPipeDefs = `
         MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)(i0.ɵɵdirectiveInject(Service)); };
         MyPipe.ɵpipe = i0.ɵɵdefinePipe({ name: "myPipe", type: MyPipe, pure: true });
-        MyPipe.ɵprov = i0.ɵɵdefineInjectable({ token: MyPipe, factory: MyPipe.ɵfac, providedIn: null });
+        MyPipe.ɵprov = i0.ɵɵdefineInjectable({ token: MyPipe, factory: MyPipe.ɵfac });
       `;
 
        // The prov definition must be last so MyOtherPipe.fac is defined
        const MyOtherPipeDefs = `
         MyOtherPipe.ɵfac = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵdirectiveInject(Service)); };
         MyOtherPipe.ɵpipe = i0.ɵɵdefinePipe({ name: "myOtherPipe", type: MyOtherPipe, pure: true });
-        MyOtherPipe.ɵprov = i0.ɵɵdefineInjectable({ token: MyOtherPipe, factory: MyOtherPipe.ɵfac, providedIn: null });
+        MyOtherPipe.ɵprov = i0.ɵɵdefineInjectable({ token: MyOtherPipe, factory: MyOtherPipe.ɵfac });
       `;
 
        expectEmit(source, MyPipeDefs, 'Invalid pipe factory function');

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -106,11 +106,12 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
 
   const token = meta.internalType;
 
+  const injectableProps: {[key: string]: o.Expression} = {token, factory: result.factory};
+
   // Only generate providedIn property if it has a non-null value
-  const injectableProps: {[key: string]: o.Expression} =
-      (meta.providedIn as o.LiteralExpr).value === null ?
-      {token, factory: result.factory} :
-      {token, factory: result.factory, providedIn: meta.providedIn};
+  if ((meta.providedIn as o.LiteralExpr).value !== null) {
+    injectableProps.providedIn = meta.providedIn;
+  }
 
   const expression =
       o.importExpr(Identifiers.ɵɵdefineInjectable).callFn([mapToMapExpression(injectableProps)]);

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -105,10 +105,15 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
   }
 
   const token = meta.internalType;
-  const providedIn = meta.providedIn;
 
-  const expression = o.importExpr(Identifiers.ɵɵdefineInjectable).callFn([mapToMapExpression(
-      {token, factory: result.factory, providedIn})]);
+  // Only generate providedIn property if it has a non-null value
+  const injectableProps: {[key: string]: o.Expression} =
+      (meta.providedIn as o.LiteralExpr).value === null ?
+      {token, factory: result.factory} :
+      {token, factory: result.factory, providedIn: meta.providedIn};
+
+  const expression =
+      o.importExpr(Identifiers.ɵɵdefineInjectable).callFn([mapToMapExpression(injectableProps)]);
   const type = new o.ExpressionType(o.importExpr(
       Identifiers.InjectableDef, [typeWithParameters(meta.type, meta.typeArgumentCount)]));
 


### PR DESCRIPTION
We should only generate the `providedIn` property in injectable
defs if it has a non-null value. `null` does not communicate
any information to the runtime that isn't communicated already
by the absence of the property.

This should give us some modest code size savings (~1 KB in AIO main bundle)