### PR TITLE
fix(bazel): reenable template type checking in ng_module

### DIFF
--- a/modules/benchmarks/src/largeform/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/ng2/BUILD.bazel
@@ -9,11 +9,7 @@ ng_module(
     name = "ng2",
     srcs = glob(["*.ts"]),
     generate_ve_shims = True,
-    # FIXME-IVY(FW-998): ExpressionTranslatorVisitor#visitWriteKeyExpr is not implemented.
-    tags = ["fixme-ivy-aot"],
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//modules/benchmarks/src:util_lib",
         "//packages/core",
@@ -36,13 +32,11 @@ ts_devserver(
         "//tools/rxjs:rxjs_umd_modules",
     ],
     static_files = ["index.html"],
-    tags = ["fixme-ivy-aot"],
     deps = [":ng2"],
 )
 
 benchmark_test(
     name = "perf",
     server = ":devserver",
-    tags = ["fixme-ivy-aot"],
     deps = ["//modules/benchmarks/src/largeform:tests_lib"],
 )

--- a/modules/benchmarks/src/largetable/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2/BUILD.bazel
@@ -11,8 +11,6 @@ ng_module(
     srcs = glob(["*.ts"]),
     generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//modules/benchmarks/src:util_lib",
         "//modules/benchmarks/src/largetable:util_lib",

--- a/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
@@ -8,8 +8,6 @@ ng_module(
     srcs = glob(["*.ts"]),
     generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//modules/benchmarks/src:util_lib",
         "//modules/benchmarks/src/largetable:util_lib",

--- a/modules/benchmarks/src/tree/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2/BUILD.bazel
@@ -11,8 +11,6 @@ ng_module(
     srcs = glob(["*.ts"]),
     generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//modules/benchmarks/src:util_lib",
         "//modules/benchmarks/src/tree:util_lib",

--- a/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
@@ -8,8 +8,6 @@ ng_module(
     srcs = glob(["*.ts"]),
     generate_ve_shims = True,
     tsconfig = "//modules/benchmarks:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//modules/benchmarks/src:util_lib",
         "//modules/benchmarks/src/tree:util_lib",

--- a/modules/playground/src/animate/BUILD.bazel
+++ b/modules/playground/src/animate/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = glob(["**/*.css"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/animations",
         "//packages/core",

--- a/modules/playground/src/async/BUILD.bazel
+++ b/modules/playground/src/async/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "async",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/gestures/BUILD.bazel
+++ b/modules/playground/src/gestures/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["template.html"],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/hello_world/BUILD.bazel
+++ b/modules/playground/src/hello_world/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "hello_world",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/http/BUILD.bazel
+++ b/modules/playground/src/http/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "http",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/http",

--- a/modules/playground/src/jsonp/BUILD.bazel
+++ b/modules/playground/src/jsonp/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "jsonp",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/http",

--- a/modules/playground/src/key_events/BUILD.bazel
+++ b/modules/playground/src/key_events/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "key_events",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/model_driven_forms/BUILD.bazel
+++ b/modules/playground/src/model_driven_forms/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "model_driven_forms",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/modules/playground/src/order_management/BUILD.bazel
+++ b/modules/playground/src/order_management/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "order_management",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/modules/playground/src/person_management/BUILD.bazel
+++ b/modules/playground/src/person_management/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "person_management",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/modules/playground/src/relative_assets/BUILD.bazel
+++ b/modules/playground/src/relative_assets/BUILD.bazel
@@ -13,8 +13,6 @@ ng_module(
     # need to disable resource inlining.
     inline_resources = False,
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/routing/BUILD.bazel
+++ b/modules/playground/src/routing/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = glob(["**/*.html"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/sourcemap/BUILD.bazel
+++ b/modules/playground/src/sourcemap/BUILD.bazel
@@ -10,8 +10,6 @@ ng_module(
     name = "sourcemap",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/svg/BUILD.bazel
+++ b/modules/playground/src/svg/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "svg",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/template_driven_forms/BUILD.bazel
+++ b/modules/playground/src/template_driven_forms/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "template_driven_forms",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/modules/playground/src/todo/BUILD.bazel
+++ b/modules/playground/src/todo/BUILD.bazel
@@ -10,8 +10,6 @@ ng_module(
         "css/base.css",
     ],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/modules/playground/src/web_workers/animations/BUILD.bazel
+++ b/modules/playground/src/web_workers/animations/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "animations",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/animations",
         "//packages/core",

--- a/modules/playground/src/web_workers/images/BUILD.bazel
+++ b/modules/playground/src/web_workers/images/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["image_demo.html"],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-webworker",

--- a/modules/playground/src/web_workers/input/BUILD.bazel
+++ b/modules/playground/src/web_workers/input/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "input",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-webworker",

--- a/modules/playground/src/web_workers/kitchen_sink/BUILD.bazel
+++ b/modules/playground/src/web_workers/kitchen_sink/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "kitchen_sink",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-webworker",

--- a/modules/playground/src/web_workers/message_broker/BUILD.bazel
+++ b/modules/playground/src/web_workers/message_broker/BUILD.bazel
@@ -6,8 +6,6 @@ ng_module(
     name = "message_broker",
     srcs = glob(["**/*.ts"]),
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-webworker",

--- a/modules/playground/src/web_workers/router/BUILD.bazel
+++ b/modules/playground/src/web_workers/router/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["app.html"],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-webworker",

--- a/modules/playground/src/web_workers/todo/BUILD.bazel
+++ b/modules/playground/src/web_workers/todo/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["todo.html"],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/modules/playground/src/zippy_component/BUILD.bazel
+++ b/modules/playground/src/zippy_component/BUILD.bazel
@@ -7,8 +7,6 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["app/zippy.html"],
     tsconfig = "//modules/playground:tsconfig-build.json",
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -297,6 +297,9 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": is_ivy_enabled(ctx),
         "fullTemplateTypeCheck": ctx.attr.type_check,
+        # TODO(alxhub/arick): template type-checking in g3 is currently disabled because of
+        # preexisting failures. Reenable once g3 is fixed: FW-1753
+        "ivyTemplateTypeCheck": _is_bazel(),
         # In Google3 we still want to use the symbol factory re-exports in order to
         # not break existing apps inside Google. Unlike Bazel, Google3 does not only
         # enforce strict dependencies of source files, but also for generated files

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -297,9 +297,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": is_ivy_enabled(ctx),
         "fullTemplateTypeCheck": ctx.attr.type_check,
-        # TODO(alxhub/arick): template type-checking for Ivy needs to be tested in g3 before it can
-        # be enabled here.
-        "ivyTemplateTypeCheck": False,
         # In Google3 we still want to use the symbol factory re-exports in order to
         # not break existing apps inside Google. Unlike Bazel, Google3 does not only
         # enforce strict dependencies of source files, but also for generated files

--- a/packages/examples/common/BUILD.bazel
+++ b/packages/examples/common/BUILD.bazel
@@ -9,8 +9,6 @@ ng_module(
         exclude = ["**/*_spec.ts"],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/examples/core/BUILD.bazel
+++ b/packages/examples/core/BUILD.bazel
@@ -12,11 +12,10 @@ ng_module(
         ],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/animations",
         "//packages/core",
+        "//packages/forms",
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",

--- a/packages/examples/core/ts/change_detect/change-detection.ts
+++ b/packages/examples/core/ts/change_detect/change-detection.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 /* tslint:disable:no-console  */
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Directive} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 
 
 // #docregion mark-for-check
@@ -42,7 +43,7 @@ class DataListProvider {
     `,
 })
 class GiantList {
-  constructor(private ref: ChangeDetectorRef, private dataProvider: DataListProvider) {
+  constructor(private ref: ChangeDetectorRef, public dataProvider: DataListProvider) {
     ref.detach();
     setInterval(() => { this.ref.detectChanges(); }, 5000);
   }
@@ -70,8 +71,9 @@ class DataProvider {
 
 @Component({selector: 'live-data', inputs: ['live'], template: 'Data: {{dataProvider.data}}'})
 class LiveData {
-  constructor(private ref: ChangeDetectorRef, private dataProvider: DataProvider) {}
+  constructor(private ref: ChangeDetectorRef, public dataProvider: DataProvider) {}
 
+  @Input()
   set live(value: boolean) {
     if (value) {
       this.ref.reattach();
@@ -94,3 +96,8 @@ class App1 {
   live = true;
 }
 // #enddocregion reattach
+
+
+@NgModule({declarations: [AppComponent, GiantList, App, LiveData, App1], imports: [FormsModule]})
+class CoreExamplesModule {
+}

--- a/packages/examples/forms/BUILD.bazel
+++ b/packages/examples/forms/BUILD.bazel
@@ -9,8 +9,6 @@ ng_module(
         exclude = ["**/*_spec.ts"],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/forms",

--- a/packages/examples/router/activated-route/BUILD.bazel
+++ b/packages/examples/router/activated-route/BUILD.bazel
@@ -8,8 +8,6 @@ ng_module(
         ["**/*.ts"],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/examples/service-worker/push/BUILD.bazel
+++ b/packages/examples/service-worker/push/BUILD.bazel
@@ -9,8 +9,6 @@ ng_module(
         exclude = ["**/*_spec.ts"],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/examples/service-worker/registration-options/BUILD.bazel
+++ b/packages/examples/service-worker/registration-options/BUILD.bazel
@@ -9,8 +9,6 @@ ng_module(
         exclude = ["**/*_spec.ts"],
     ),
     generate_ve_shims = True,
-    # TODO: FW-1004 Type checking is currently not complete.
-    type_check = False,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/examples/upgrade/upgrade_example.bzl
+++ b/packages/examples/upgrade/upgrade_example.bzl
@@ -12,8 +12,6 @@ def create_upgrade_example_targets(name, srcs, e2e_srcs, entry_module, assets = 
         name = "%s_sources" % name,
         srcs = srcs,
         generate_ve_shims = True,
-        # TODO: FW-1004 Type checking is currently not complete.
-        type_check = False,
         deps = [
             "@npm//@types/angular",
             "@npm//@types/jasmine",

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -36,7 +36,8 @@ jasmine_node_test(
         "//packages/forms:npm_package",
     ],
     tags = [
-        "fixme-ivy-aot",
+        # the language service is not yet compatible with Ivy
+        "no-ivy-aot",
     ],
     deps = [
         ":test_lib",


### PR DESCRIPTION
due to an unfortunate condition in https://github.com/angular/angular/blob/168abc6d6f52713383411b14980e104c99bfeef5/packages/compiler-cli/src/ngtsc/program.ts#L430-L434 the typechecking has been disabled when running under bazel + ivy.

As far as I can tell the ivyTemplateTypeCheck flag is now obsolete, so removing this
code from ng_module.bzl is desirable. I'll send a separate PR to remove the flag completely.
