### PR TITLE
refactor(router): added type for pathMatch

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -166,11 +166,12 @@ export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParam
  * One of:
  * - `prefix` : Checks from the left to see if the URL matches a given path, and stops when there is a match. 
  * - `full` : Matches against the entire URL.
- *
+ * Default is 'prefix'.
+ * 
  * @see `Route#pathMatch`
  * @publicApi
  */
-export type PathMatch = 'prefix' | 'full';
+export type PathMatch = 'prefix' | 'full' | undefined;
 
 /**
  * A configuration object that defines a single route.

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -161,6 +161,18 @@ export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParam
     ((from: ActivatedRouteSnapshot, to: ActivatedRouteSnapshot) => boolean);
 
 /**
+ *
+ * How to match the given path in the URL.
+ * One of:
+ * - `prefix` : Checks from the left to see if the URL matches a given path, and stops when there is a match. 
+ * - `full` : Matches against the entire URL.
+ *
+ * @see `Route#pathMatch`
+ * @publicApi
+ */
+export type PathMatch = 'prefix' | 'full';
+
+/**
  * A configuration object that defines a single route.
  * A set of routes are collected in a `Routes` array to define a `Router` configuration.
  * The router attempts to match segments of a given URL against each route,
@@ -408,7 +420,7 @@ export interface Route {
    * to the redirect destination, creating an endless loop.
    *
    */
-  pathMatch?: string;
+  pathMatch?: PathMatch;
   /**
    * A custom URL-matching function. Cannot be used together with `path`.
    */

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -123,12 +123,6 @@ describe('config', () => {
          }).toThrowError(/Invalid configuration of route '{path: "", redirectTo: "b"}'/);
        });
 
-    it('should throw when pathMatch is invalid', () => {
-      expect(() => { validateConfig([{path: 'a', pathMatch: 'invalid', component: ComponentB}]); })
-          .toThrowError(
-              /Invalid configuration of route 'a': pathMatch can only be set to 'prefix' or 'full'/);
-    });
-
     it('should throw when path/outlet combination is invalid', () => {
       expect(() => { validateConfig([{path: 'a', outlet: 'aux'}]); })
           .toThrowError(


### PR DESCRIPTION
pathMatch will not have any value other than 'prefix' or 'full', so it would be better to define a type rather than declaring it as a string

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
