### PR TITLE
fix: implement Symbol.species of Promise

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -256,6 +256,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
 
   const ZONE_AWARE_PROMISE_TO_STRING = 'function ZoneAwarePromise() { [native code] }';
 
+  const noop = function() {};
+
   class ZoneAwarePromise<R> implements Promise<R> {
     static toString() { return ZONE_AWARE_PROMISE_TO_STRING; }
 
@@ -374,12 +376,17 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
 
     get[Symbol.toStringTag]() { return 'Promise' as any; }
 
+    get[Symbol.species]() { return ZoneAwarePromise; }
+
     then<TResult1 = R, TResult2 = never>(
         onFulfilled?: ((value: R) => TResult1 | PromiseLike<TResult1>)|undefined|null,
         onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>)|undefined|
         null): Promise<TResult1|TResult2> {
-      const chainPromise: Promise<TResult1|TResult2> =
-          new (this.constructor as typeof ZoneAwarePromise)(null as any);
+      let C = (this.constructor as any)[Symbol.species];
+      if (!C || typeof C !== 'function') {
+        C = ZoneAwarePromise;
+      }
+      const chainPromise: Promise<TResult1|TResult2> = new (C as typeof ZoneAwarePromise)(noop);
       const zone = Zone.current;
       if ((this as any)[symbolState] == UNRESOLVED) {
         (<any[]>(this as any)[symbolValue]).push(zone, chainPromise, onFulfilled, onRejected);
@@ -395,8 +402,11 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     }
 
     finally<U>(onFinally?: () => U | PromiseLike<U>): Promise<R> {
-      const chainPromise: Promise<R|never> =
-          new (this.constructor as typeof ZoneAwarePromise)(null as any);
+      let C = (this.constructor as any)[Symbol.species];
+      if (!C || typeof C !== 'function') {
+        C = ZoneAwarePromise;
+      }
+      const chainPromise: Promise<R|never> = new (C as typeof ZoneAwarePromise)(noop);
       (chainPromise as any)[symbolFinally] = symbolFinally;
       const zone = Zone.current;
       if ((this as any)[symbolState] == UNRESOLVED) {

--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -103,11 +103,21 @@ describe(
         }).toThrowError('Must be an instanceof Promise.');
       });
 
-      xit('should allow subclassing', () => {
+      it('should allow subclassing with Promise.specices', () => {
         class MyPromise extends Promise<any> {
           constructor(fn: any) { super(fn); }
+
+          static get[Symbol.species]() { return MyPromise; }
         }
-        expect(new MyPromise(null).then(() => null) instanceof MyPromise).toBe(true);
+        expect(new MyPromise(() => {}).then(() => null) instanceof MyPromise).toBe(true);
+      });
+
+      it('Promise.specices should return ZoneAwarePromise', () => {
+        const empty = function() {};
+        const promise = Promise.resolve(1);
+        const FakePromise = ((promise.constructor = {} as any) as any)[Symbol.species] = function(
+            exec: any) { exec(empty, empty); };
+        expect(promise.then(empty) instanceof FakePromise).toBe(true);
       });
 
       it('should intercept scheduling of resolution and then', (done) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34105, #33989

`ZoneAwarePromise` should pass the following test

```
var USE_NATIVE = !!function () {
  try {
    // correct subclassing with @@species support
    var promise = $Promise.resolve(1);
    var FakePromise = (promise.constructor = {})[Symbol('species')] = function (exec) {
      exec(empty, empty);
    };
    // unhandled rejections tracking support, NodeJS Promise without it fails @@species test
    return (isNode || typeof PromiseRejectionEvent == 'function') && promise.then(empty) instanceof FakePromise;
  } catch (e) { /* empty */ }
}();
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

