### PR TITLE
fix(ngcc): several fixes

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
@@ -71,14 +71,11 @@ export class CommonJsDependencyHost extends DependencyHostBase {
           } else if (ts.isObjectLiteralExpression(stmt.expression.right)) {
             // Import in object literal. E.g.:
             // `module.exports = {foo: require('...')}`
-            const requireCallsFromProperties: RequireCall[] =
-                stmt.expression.right.properties
-                    .filter(
-                        (prop): prop is ts.PropertyAssignment & {initializer: RequireCall} =>
-                            ts.isPropertyAssignment(prop) && isRequireCall(prop.initializer))
-                    .map(prop => prop.initializer);
-
-            requireCalls.push(...requireCallsFromProperties);
+            stmt.expression.right.properties.forEach(prop => {
+              if (ts.isPropertyAssignment(prop) && isRequireCall(prop.initializer)) {
+                requireCalls.push(prop.initializer);
+              }
+            });
           }
         }
       }

--- a/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
-import {isRequireCall} from '../host/commonjs_host';
+import {RequireCall, isReexportStatement, isRequireCall} from '../host/commonjs_host';
 import {DependencyHostBase} from './dependency_host';
 import {ResolvedDeepImport, ResolvedRelativeModule} from './module_resolver';
 
@@ -40,33 +40,66 @@ export class CommonJsDependencyHost extends DependencyHostBase {
     // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
     const sf =
         ts.createSourceFile(file, fromContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
+    const requireCalls: RequireCall[] = [];
 
-    for (const statement of sf.statements) {
-      const declarations =
-          ts.isVariableStatement(statement) ? statement.declarationList.declarations : [];
-      for (const declaration of declarations) {
-        if (declaration.initializer && isRequireCall(declaration.initializer)) {
-          const importPath = declaration.initializer.arguments[0].text;
-          const resolvedModule = this.moduleResolver.resolveModuleImport(importPath, file);
-          if (resolvedModule) {
-            if (resolvedModule instanceof ResolvedRelativeModule) {
-              const internalDependency = resolvedModule.modulePath;
-              if (!alreadySeen.has(internalDependency)) {
-                alreadySeen.add(internalDependency);
-                this.recursivelyFindDependencies(
-                    internalDependency, dependencies, missing, deepImports, alreadySeen);
-              }
-            } else {
-              if (resolvedModule instanceof ResolvedDeepImport) {
-                deepImports.add(resolvedModule.importPath);
-              } else {
-                dependencies.add(resolvedModule.entryPointPath);
-              }
-            }
-          } else {
-            missing.add(importPath);
+    for (const stmt of sf.statements) {
+      if (ts.isVariableStatement(stmt)) {
+        // Regular import(s):
+        // `var foo = require('...')` or `var foo = require('...'), bar = require('...')`
+        const declarations = stmt.declarationList.declarations;
+        for (const declaration of declarations) {
+          if ((declaration.initializer !== undefined) && isRequireCall(declaration.initializer)) {
+            requireCalls.push(declaration.initializer);
           }
         }
+      } else if (ts.isExpressionStatement(stmt)) {
+        if (isRequireCall(stmt.expression)) {
+          // Import for the side-effects only:
+          // `require('...')`
+          requireCalls.push(stmt.expression);
+        } else if (isReexportStatement(stmt)) {
+          // Re-export:
+          // `__export(require('...'))` or `tslib_1.__exportStar(require('...'), exports)`
+          requireCalls.push(stmt.expression.arguments[0]);
+        } else if (
+            ts.isBinaryExpression(stmt.expression) &&
+            (stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken)) {
+          if (isRequireCall(stmt.expression.right)) {
+            // Import with assignment. E.g.:
+            // `exports.foo = require('...')`
+            requireCalls.push(stmt.expression.right);
+          } else if (ts.isObjectLiteralExpression(stmt.expression.right)) {
+            // Import in object literal. E.g.:
+            // `module.exports = {foo: require('...')}`
+            const requireCallsFromProperties: RequireCall[] =
+                stmt.expression.right.properties
+                    .filter(
+                        (prop): prop is ts.PropertyAssignment & {initializer: RequireCall} =>
+                            ts.isPropertyAssignment(prop) && isRequireCall(prop.initializer))
+                    .map(prop => prop.initializer);
+
+            requireCalls.push(...requireCallsFromProperties);
+          }
+        }
+      }
+    }
+
+    const importPaths = new Set(requireCalls.map(call => call.arguments[0].text));
+    for (const importPath of importPaths) {
+      const resolvedModule = this.moduleResolver.resolveModuleImport(importPath, file);
+      if (resolvedModule === null) {
+        missing.add(importPath);
+      } else if (resolvedModule instanceof ResolvedRelativeModule) {
+        const internalDependency = resolvedModule.modulePath;
+        if (!alreadySeen.has(internalDependency)) {
+          alreadySeen.add(internalDependency);
+          this.recursivelyFindDependencies(
+              internalDependency, dependencies, missing, deepImports, alreadySeen);
+        }
+      } else if (resolvedModule instanceof ResolvedDeepImport) {
+        deepImports.add(resolvedModule.importPath);
+      } else {
+        dependencies.add(resolvedModule.entryPointPath);
       }
     }
   }

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -249,8 +249,8 @@ function findNamespaceOfIdentifier(id: ts.Identifier): ts.Identifier|null {
  * In all cases, we only care about the `require()` call, which is the first argument of the
  * re-export call expression.)
  */
-type ReexportStatement = ts.ExpressionStatement & {expression: {arguments: [RequireCall]}};
-function isReexportStatement(statement: ts.Statement): statement is ReexportStatement {
+export type ReexportStatement = ts.ExpressionStatement & {expression: {arguments: [RequireCall]}};
+export function isReexportStatement(statement: ts.Statement): statement is ReexportStatement {
   // Ensure it is a call expression statement.
   if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) {
     return false;

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -262,8 +262,9 @@ function isReexportStatement(statement: ts.Statement): statement is ReexportStat
   //       ([source](https://github.com/microsoft/TypeScript/blob/d7c83f023/src/compiler/transformers/module/module.ts#L1796-L1797)).
   //       So, theoretically, we only care about the formats `__export(require('...'))` and
   //       `tslib.__exportStar(require('...'), exports)`.
-  //       The accepts the other two formats (`__exportStar(...)` and `tslib.__export(...)`) to be
-  //       more future-proof (given that it is unlikely that they will introduce false positives).
+  //       The current implementation accepts the other two formats (`__exportStar(...)` and
+  //       `tslib.__export(...)`) as well to be more future-proof (given that it is unlikely that
+  //       they will introduce false positives).
   let fnName: string|null = null;
   if (ts.isIdentifier(statement.expression.expression)) {
     // Statement of the form `someFn(...)`.
@@ -275,7 +276,7 @@ function isReexportStatement(statement: ts.Statement): statement is ReexportStat
     fnName = statement.expression.expression.name.text;
   }
 
-  // Esnure the called function is either `__export()` or `__exportStar()`.
+  // Ensure the called function is either `__export()` or `__exportStar()`.
   if ((fnName !== '__export') && (fnName !== '__exportStar')) {
     return false;
   }

--- a/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
@@ -12,29 +12,6 @@ import {loadTestFiles} from '../../../test/helpers';
 import {CommonJsDependencyHost} from '../../src/dependencies/commonjs_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 
-interface ImportsPerType {
-  // var foo = require('...');
-  varDeclaration?: string[];
-
-  // var foo = require('...'), bar = require('...');
-  varDeclarations?: string[][];
-
-  // exports.foo = require('...');
-  propAssignment?: string[];
-
-  // module.exports = {foo: require('...')};
-  inObjectLiteral?: string[];
-
-  // require('...');
-  forSideEffects?: string[];
-
-  // __export(require('...'));
-  reExportsWithEmittedHelper?: string[];
-
-  // tslib_1.__exportStar(require('...'), exports);
-  reExportsWithImportedHelper?: string[];
-}
-
 runInEachFileSystem(() => {
   describe('CommonJsDependencyHost', () => {
     let _: typeof absoluteFrom;
@@ -347,6 +324,29 @@ runInEachFileSystem(() => {
       });
     });
   });
+
+  interface ImportsPerType {
+    // var foo = require('...');
+    varDeclaration?: string[];
+
+    // var foo = require('...'), bar = require('...');
+    varDeclarations?: string[][];
+
+    // exports.foo = require('...');
+    propAssignment?: string[];
+
+    // module.exports = {foo: require('...')};
+    inObjectLiteral?: string[];
+
+    // require('...');
+    forSideEffects?: string[];
+
+    // __export(require('...'));
+    reExportsWithEmittedHelper?: string[];
+
+    // tslib_1.__exportStar(require('...'), exports);
+    reExportsWithImportedHelper?: string[];
+  }
 
   function commonJs(importsPerType: ImportsPerType | string[], exportNames: string[] = []): string {
     if (Array.isArray(importsPerType)) {

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -118,7 +118,7 @@ exports.SomeDirective = SomeDirective;
         contents: `
         var core = require('@angular/core');
         var CtorDecoratedAsArray = (function() {
-        function CtorDecoratedAsArray(arg1) {
+          function CtorDecoratedAsArray(arg1) {
           }
           CtorDecoratedAsArray.ctorParameters = [{ type: ParamType, decorators: [{ type: Inject },] }];
           return CtorDecoratedAsArray;
@@ -511,6 +511,7 @@ var c = file_a.a;
           var b_module = require('./b_module');
           var xtra_module = require('./xtra_module');
           var wildcard_reexports = require('./wildcard_reexports');
+          var wildcard_reexports_2 = require('./wildcard_reexports_2');
           `
         },
         {
@@ -554,12 +555,20 @@ exports.xtra2 = xtra2;
         {
           name: _('/wildcard_reexports.js'),
           contents: `
-    function __export(m) {
-      for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-    }
-    __export(require("./b_module"));
-    __export(require("./xtra_module"));
-    `
+function __export(m) {
+  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+__export(require("./b_module"));
+__export(require("./xtra_module"));
+`,
+        },
+        {
+          name: _('/wildcard_reexports_2.js'),
+          contents: `
+var tslib_1 = require("tslib");
+tslib_1.__exportStar(require("./b_module"), exports);
+tslib_1.__exportStar(require("./xtra_module"), exports);
+`,
         },
       ];
 
@@ -1763,12 +1772,40 @@ exports.ExternalModule = ExternalModule;
               ]);
         });
 
-        it('should handle wildcard re-exports of other modules', () => {
+        it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
           loadFakeCore(getFileSystem());
           loadTestFiles(EXPORTS_FILES);
           const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
           const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
           const file = getSourceFileOrError(program, _('/wildcard_reexports.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations !.entries())
+                     .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n  function SomeClass() {}\n  return SomeClass;\n}())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
+
+        it('should handle wildcard re-exports of other modules (with imported helpers)', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const file = getSourceFileOrError(program, _('/wildcard_reexports_2.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1970,6 +1970,68 @@ runInEachFileSystem(() => {
            const actualDeclaration = host.getDeclarationOfIdentifier(identifier) !;
            expect(actualDeclaration.node !.getText()).toBe(expectedDeclaration.getText());
          });
+
+      it('should return a function declaration for known TS helpers', () => {
+        const PROGRAM_FILE: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            // A known emitted TS helper.
+            var __spread = (this && this.__spread) || function () {
+              // ...
+            };
+
+            // A known emitted TS helper with a dollar suffix.
+            var __spreadArrays$42 = (this && this.__spreadArrays) || function () {
+              // ...
+            };
+
+            // An unknown emitted helper.
+            var __whoAreYou = (this && this.__whoAreYou) || function () {
+              // ...
+            };
+
+            var foo = __spread([]);
+            var bar = __spreadArrays$42([]);
+            var baz = __whoAreYou([]);
+          `,
+        };
+        const getHelperIdentifier = (varName: string): ts.Identifier => {
+          const decl =
+              getDeclaration(program, PROGRAM_FILE.name, varName, ts.isVariableDeclaration);
+
+          if (!decl.initializer || !ts.isCallExpression(decl.initializer) ||
+              !ts.isIdentifier(decl.initializer.expression)) {
+            throw new Error(`Unable to retrieve helper identifier for variable '${varName}'.`);
+          }
+
+          return decl.initializer.expression;
+        };
+
+        loadTestFiles([PROGRAM_FILE]);
+        const {program} = makeTestBundleProgram(PROGRAM_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+
+        const spreadIdent = getHelperIdentifier('foo');
+        const spreadArraysIdent = getHelperIdentifier('bar');
+        const whoAreYouIdent = getHelperIdentifier('baz');
+
+        const spreadDecl = host.getDeclarationOfIdentifier(spreadIdent) !;
+        const spreadArraysDecl = host.getDeclarationOfIdentifier(spreadArraysIdent) !;
+        const whoAreYouDecl = host.getDeclarationOfIdentifier(whoAreYouIdent) !;
+
+        // `__spread()` should be recognized as a known helper function.
+        expect(spreadDecl.viaModule).toBeNull();
+        expect(ts.isFunctionDeclaration(spreadDecl.node !)).toBe(true);
+
+        // `__spreadArrays()` should be recognized as a known helper function.
+        expect(spreadArraysDecl.viaModule).toBeNull();
+        expect(ts.isFunctionDeclaration(spreadArraysDecl.node !)).toBe(true);
+
+        // `__whoAreYou()` should not be recognized as a known helper function.
+        expect(whoAreYouDecl.viaModule).toBeNull();
+        expect(ts.isFunctionDeclaration(whoAreYouDecl.node !)).toBe(false);
+        expect(ts.isVariableDeclaration(whoAreYouDecl.node !)).toBe(true);
+      });
     });
 
     describe('getExportsOfModule()', () => {

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1814,6 +1814,68 @@ runInEachFileSystem(() => {
              expect(decl.viaModule).toEqual('sub_module');
              expect(decl.node).toBe(expectedDeclaration);
            });
+
+        it('should return a function declaration for known TS helpers', () => {
+          const PROGRAM_FILE: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              // A known emitted TS helper.
+              var __spread = (this && this.__spread) || function () {
+                // ...
+              };
+
+              // A known emitted TS helper with a dollar suffix.
+              var __spreadArrays$42 = (this && this.__spreadArrays) || function () {
+                // ...
+              };
+
+              // An unknown emitted helper.
+              var __whoAreYou = (this && this.__whoAreYou) || function () {
+                // ...
+              };
+
+              var foo = __spread([]);
+              var bar = __spreadArrays$42([]);
+              var baz = __whoAreYou([]);
+            `,
+          };
+          const getHelperIdentifier = (varName: string): ts.Identifier => {
+            const decl =
+                getDeclaration(program, PROGRAM_FILE.name, varName, ts.isVariableDeclaration);
+
+            if (!decl.initializer || !ts.isCallExpression(decl.initializer) ||
+                !ts.isIdentifier(decl.initializer.expression)) {
+              throw new Error(`Unable to retrieve helper identifier for variable '${varName}'.`);
+            }
+
+            return decl.initializer.expression;
+          };
+
+          loadTestFiles([PROGRAM_FILE]);
+          const {program, host: compilerHost} = makeTestBundleProgram(PROGRAM_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+
+          const spreadIdent = getHelperIdentifier('foo');
+          const spreadArraysIdent = getHelperIdentifier('bar');
+          const whoAreYouIdent = getHelperIdentifier('baz');
+
+          const spreadDecl = host.getDeclarationOfIdentifier(spreadIdent) !;
+          const spreadArraysDecl = host.getDeclarationOfIdentifier(spreadArraysIdent) !;
+          const whoAreYouDecl = host.getDeclarationOfIdentifier(whoAreYouIdent) !;
+
+          // `__spread()` should be recognized as a known helper function.
+          expect(spreadDecl.viaModule).toBeNull();
+          expect(ts.isFunctionDeclaration(spreadDecl.node !)).toBe(true);
+
+          // `__spreadArrays()` should be recognized as a known helper function.
+          expect(spreadArraysDecl.viaModule).toBeNull();
+          expect(ts.isFunctionDeclaration(spreadArraysDecl.node !)).toBe(true);
+
+          // `__whoAreYou()` should not be recognized as a known helper function.
+          expect(whoAreYouDecl.viaModule).toBeNull();
+          expect(ts.isFunctionDeclaration(whoAreYouDecl.node !)).toBe(false);
+          expect(ts.isVariableDeclaration(whoAreYouDecl.node !)).toBe(true);
+        });
       });
 
       describe('getExportsOfModule()', () => {


### PR DESCRIPTION
This PR includes several ngcc fixes. With these fixes, ngcc should be able to successfully process NativeScript. See individual commits for details.

Jira issue: [FW-1689][1]

##
TODO:

- [ ] Determine whether it is problematic that the synthetically created [function declaration][2] for TS helpers will be recognized as [non-synthetic][3] in `StaticInterpreter` (and how to fix it).
- [x] Implement the CommonJS fixes for UMD as well.
- [ ] Add integration tests.

[1]: https://angular-team.atlassian.net/browse/FW-1689
[2]: https://github.com/angular/angular/commit/e28ac708e#diff-3814db5d5b51f278653eb80c9ac981c1R235
[3]: https://github.com/angular/angular/blob/023c9bebe/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts#L242-L244



[FW-1689]: https://angular-team.atlassian.net/browse/FW-1689