### PR TITLE
fix(language-service): bug of accessing a string index signature using dot notation

### DIFF
--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -246,7 +246,13 @@ class TypeWrapper implements Symbol {
 
   get name(): string {
     const symbol = this.tsType.symbol;
-    return (symbol && symbol.name) || '<anonymous>';
+    if (symbol) {
+      return symbol.name;
+    } else {
+      // the js primitive type(e.g. 'string') doesn't have Symbol.
+      // use the ts.TypeChecker to get the type name.
+      return this.context.checker.typeToString(this.tsType);
+    }
   }
 
   public readonly kind: DeclarationKind = 'type';

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -244,16 +244,7 @@ class TypeWrapper implements Symbol {
     }
   }
 
-  get name(): string {
-    const symbol = this.tsType.symbol;
-    if (symbol) {
-      return symbol.name;
-    } else {
-      // A primitive type (e.g. 'string') doesn't have Symbol,
-      // so use the ts.TypeChecker to get the type name.
-      return this.context.checker.typeToString(this.tsType);
-    }
-  }
+  get name(): string { return this.context.checker.typeToString(this.tsType); }
 
   public readonly kind: DeclarationKind = 'type';
 
@@ -617,15 +608,10 @@ class PipeSymbol implements Symbol {
         let resultType: ts.Type|undefined = undefined;
         switch (this.name) {
           case 'async':
-            switch (parameterType.name) {
-              case 'Observable':
-              case 'Promise':
-              case 'EventEmitter':
-                resultType = getTypeParameterOf(parameterType.tsType, parameterType.name);
-                break;
-              default:
-                resultType = getTsTypeFromBuiltinType(BuiltinType.Any, this.context);
-                break;
+            // Get symbol of 'Observable', 'Promise', or 'EventEmitter' type.
+            const symbol = parameterType.tsType.symbol;
+            if (symbol) {
+              resultType = getTypeParameterOf(parameterType.tsType, symbol.name);
             }
             break;
           case 'slice':

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -308,6 +308,10 @@ class TypeWrapper implements Symbol {
   }
 }
 
+class StringIndexTypeWrappr extends TypeWrapper {
+  public readonly type = new TypeWrapper(this.tsType, this.context);
+}
+
 class SymbolWrapper implements Symbol {
   private symbol: ts.Symbol;
   private _members?: SymbolTable;
@@ -506,10 +510,11 @@ class SymbolTableWrapper implements SymbolTable {
       //   obj.stringIndex // equivalent to obj['stringIndex'];
       //
       // In this case, return the type indexed by an arbitrary string key.
-      const symbol = this.stringIndexType.getSymbol();
-      if (symbol) {
-        return new SymbolWrapper(symbol, this.context, this.stringIndexType);
-      }
+
+      // if stringIndexType is js primitive type(e.g. 'string'), the Symbol is undefined;
+      // and In AstType.resolvePropertyRead method, the Symbol.type should get the right type.
+      // so I add a new Symbol type, 'StringIndexTypeWrappr'
+      return new StringIndexTypeWrappr(this.stringIndexType, this.context);
     }
 
     return undefined;

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -249,8 +249,8 @@ class TypeWrapper implements Symbol {
     if (symbol) {
       return symbol.name;
     } else {
-      // the js primitive type(e.g. 'string') doesn't have Symbol.
-      // use the ts.TypeChecker to get the type name.
+      // A primitive type (e.g. 'string') doesn't have Symbol,
+      // so use the ts.TypeChecker to get the type name.
       return this.context.checker.typeToString(this.tsType);
     }
   }
@@ -314,7 +314,9 @@ class TypeWrapper implements Symbol {
   }
 }
 
-class StringIndexTypeWrappr extends TypeWrapper {
+// If stringIndexType a primitive type(e.g. 'string'), the Symbol is undefined;
+// and in AstType.resolvePropertyRead method, the Symbol.type should get the right type.
+class StringIndexTypeWrapper extends TypeWrapper {
   public readonly type = new TypeWrapper(this.tsType, this.context);
 }
 
@@ -516,11 +518,7 @@ class SymbolTableWrapper implements SymbolTable {
       //   obj.stringIndex // equivalent to obj['stringIndex'];
       //
       // In this case, return the type indexed by an arbitrary string key.
-
-      // if stringIndexType is js primitive type(e.g. 'string'), the Symbol is undefined;
-      // and In AstType.resolvePropertyRead method, the Symbol.type should get the right type.
-      // so I add a new Symbol type, 'StringIndexTypeWrappr'
-      return new StringIndexTypeWrappr(this.stringIndexType, this.context);
+      return new StringIndexTypeWrapper(this.stringIndexType, this.context);
     }
 
     return undefined;

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -146,6 +146,13 @@ describe('completions', () => {
         const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
         expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
       });
+
+      it('should work with dot notation if stringIndexType is a primitive type', () => {
+        mockHost.override(TEST_TEMPLATE, `{{ primitiveIndexType.test.~{string-primitive-type}}}`);
+        const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'string-primitive-type');
+        const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+        expectContain(completions, CompletionKind.METHOD, ['substring']);
+      });
     });
   });
 

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -148,10 +148,9 @@ describe('diagnostics', () => {
             .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
       });
 
-      it('should not produce errors with dot notation if stringIndexType is js primitive type',
+      it('should not produce errors with dot notation if stringIndexType is a primitive type',
          () => {
-           mockHost.override(TEST_TEMPLATE, `
-        {{primitiveType.test}}`);
+           mockHost.override(TEST_TEMPLATE, `{{primitiveIndexType.test}}`);
            const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
            expect(diags.length).toBe(0);
          });

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -147,6 +147,14 @@ describe('diagnostics', () => {
         expect(diags[0].messageText)
             .toBe(`Identifier 'badProperty' is not defined. 'Hero' does not contain such a member`);
       });
+
+      it('should not produce errors with dot notation if stringIndexType is js primitive type',
+         () => {
+           mockHost.override(TEST_TEMPLATE, `
+        {{primitiveType.test}}`);
+           const diags = ngLS.getDiagnostics(TEST_TEMPLATE);
+           expect(diags.length).toBe(0);
+         });
     });
   });
 

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -192,6 +192,7 @@ export class TemplateReference {
   tupleArray: [string, Hero] = ['test', this.hero];
   league: Hero[][] = [this.heroes];
   heroesByName: {[name: string]: Hero} = {};
+  primitiveType: {[name: string]: string} = {};
   anyValue: any;
   myClick(event: any) {}
 }

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -192,7 +192,7 @@ export class TemplateReference {
   tupleArray: [string, Hero] = ['test', this.hero];
   league: Hero[][] = [this.heroes];
   heroesByName: {[name: string]: Hero} = {};
-  primitiveType: {[name: string]: string} = {};
+  primitiveIndexType: {[name: string]: string} = {};
   anyValue: any;
   myClick(event: any) {}
 }


### PR DESCRIPTION
fix bug of the pr #33884 @ayazhafiz 
```
primitiveType: {[name: string]: string} = {};
```
`{{primitiveType.test}}` this will produce errors. because the `string` type doesn't have Symbol.
https://github.com/angular/angular/blob/168abc6d6f52713383411b14980e104c99bfeef5/packages/language-service/src/typescript_symbols.ts#L509

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
