### PR TITLE
fix(ivy): incorrectly validating html foreign objects inside svg

### DIFF
--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -100,18 +100,18 @@ export declare class AnimationEvent {
           {fullTemplateTypeCheck: true, strictInputTypes: true, strictAttributeTypes: true});
       env.write('test.ts', `
         import {Component, Directive, NgModule, Input} from '@angular/core';
-    
+
         @Component({
           selector: 'test',
           template: '<div dir foo="2"></div>',
         })
         class TestCmp {}
-    
+
         @Directive({selector: '[dir]'})
         class TestDir {
           @Input() foo: number;
         }
-    
+
         @NgModule({
           declarations: [TestCmp, TestDir],
         })
@@ -128,7 +128,7 @@ export declare class AnimationEvent {
           {fullTemplateTypeCheck: true, strictInputTypes: true, strictOutputEventTypes: true});
       env.write('test.ts', `
         import {Component, Directive, NgModule, EventEmitter} from '@angular/core';
-    
+
         @Component({
           selector: 'test',
           template: '<div dir [some-input.xs]="2" (some-output)="handleEvent($event)"></div>',
@@ -136,7 +136,7 @@ export declare class AnimationEvent {
         class TestCmp {
           handleEvent(event: number): void {}
         }
-    
+
         @Directive({
           selector: '[dir]',
           inputs: ['some-input.xs'],
@@ -146,7 +146,7 @@ export declare class AnimationEvent {
           'some-input.xs': string;
           'some-output': EventEmitter<string>;
         }
-    
+
         @NgModule({
           declarations: [TestCmp, TestDir],
         })
@@ -164,7 +164,7 @@ export declare class AnimationEvent {
       env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
       env.write('test.ts', `
         import {Component, Directive, EventEmitter, NgModule, Output} from '@angular/core';
-    
+
         @Component({
           selector: 'test',
           template: '<div dir (update)="update($event); updated = true" (focus)="update($event); focused = true"></div>',
@@ -172,12 +172,12 @@ export declare class AnimationEvent {
         class TestCmp {
           update(data: string) {}
         }
-    
+
         @Directive({selector: '[dir]'})
         class TestDir {
           @Output() update = new EventEmitter<number>();
         }
-    
+
         @NgModule({
           declarations: [TestCmp, TestDir],
         })
@@ -589,7 +589,7 @@ export declare class AnimationEvent {
       beforeEach(() => {
         env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
-      
+
           @Component({
             selector: 'test',
             template: '<div (focus)="invalid; update($event)"></div>',
@@ -597,7 +597,7 @@ export declare class AnimationEvent {
           class TestCmp {
             update(data: string) {}
           }
-   
+
           @NgModule({
             declarations: [TestCmp],
           })
@@ -915,7 +915,7 @@ export declare class AnimationEvent {
         env.write('test.ts', `
           import {CommonModule} from '@angular/common';
           import {Component, NgModule} from '@angular/core';
-      
+
           @Component({
             selector: 'test',
             template: \`<div *ngFor="let foo of foos as foos">
@@ -926,7 +926,7 @@ export declare class AnimationEvent {
           export class TestCmp {
             foos: {name: string}[];
           }
-      
+
           @NgModule({
             declarations: [TestCmp],
             imports: [CommonModule],
@@ -1015,7 +1015,7 @@ export declare class AnimationEvent {
 
           static ɵdir: i0.ɵɵDirectiveDefWithMeta<BaseDir, '[base]', never, {'fromBase': 'fromBase'}, never, never>;
         }
-        
+
         export declare class ExternalModule {
           static ɵmod: i0.ɵɵNgModuleDefWithMeta<ExternalModule, [typeof BaseDir], never, [typeof BaseDir]>;
         }
@@ -1024,20 +1024,20 @@ export declare class AnimationEvent {
       env.write('test.ts', `
         import {Component, Directive, Input, NgModule} from '@angular/core';
         import {BaseDir, ExternalModule} from 'external';
-    
+
         @Directive({
           selector: '[child]',
         })
         class ChildDir extends BaseDir {
           @Input() fromChild!: boolean;
         }
-    
+
         @Component({
           selector: 'test',
           template: '<div child [fromAbstract]="true" [fromBase]="3" [fromChild]="4"></div>',
         })
         class TestCmp {}
-    
+
         @NgModule({
           declarations: [TestCmp, ChildDir],
           imports: [ExternalModule],
@@ -1260,13 +1260,13 @@ export declare class AnimationEvent {
          () => {
            env.write('test.ts', `
             import {Component, NgModule, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
-      
+
             @Component({
               selector: 'blah',
               template: '<custom-element [foo]="1">test</custom-element>',
             })
             export class FooCmp {}
-      
+
             @NgModule({
               declarations: [FooCmp],
               schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -1280,13 +1280,13 @@ export declare class AnimationEvent {
       it('should not produce diagnostics when using the NO_ERRORS_SCHEMA', () => {
         env.write('test.ts', `
         import {Component, NgModule, NO_ERRORS_SCHEMA} from '@angular/core';
-  
+
         @Component({
           selector: 'blah',
           template: '<foo [bar]="1"></foo>',
         })
         export class FooCmp {}
-  
+
         @NgModule({
           declarations: [FooCmp],
           schemas: [NO_ERRORS_SCHEMA],
@@ -1295,6 +1295,55 @@ export declare class AnimationEvent {
       `);
         const diags = env.driveDiagnostics();
         expect(diags).toEqual([]);
+      });
+
+      it('should allow HTML elements inside SVG foreignObject', () => {
+        env.write('test.ts', `
+        import {Component, NgModule} from '@angular/core';
+        @Component({
+          selector: 'blah',
+          template: \`
+            <svg>
+              <svg:foreignObject>
+                <xhtml:div>Hello</xhtml:div>
+              </svg:foreignObject>
+            </svg>
+          \`,
+        })
+        export class FooCmp {}
+        @NgModule({
+          declarations: [FooCmp],
+        })
+        export class FooModule {}
+      `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should check for unknown elements inside an SVG foreignObject', () => {
+        env.write('test.ts', `
+        import {Component, NgModule} from '@angular/core';
+        @Component({
+          selector: 'blah',
+          template: \`
+            <svg>
+              <svg:foreignObject>
+                <xhtml:foo>Hello</xhtml:foo>
+              </svg:foreignObject>
+            </svg>
+          \`,
+        })
+        export class FooCmp {}
+        @NgModule({
+          declarations: [FooCmp],
+        })
+        export class FooModule {}
+      `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+1. If 'foo' is an Angular component, then verify that it is part of this module.
+2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`);
       });
     });
 
@@ -1314,7 +1363,7 @@ export declare class AnimationEvent {
         it('should be correct for direct templates', async() => {
           env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
-      
+
           @Component({
             selector: 'test',
             template: \`<p>
@@ -1334,7 +1383,7 @@ export declare class AnimationEvent {
         it('should be correct for indirect templates', async() => {
           env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
-      
+
           const TEMPLATE = \`<p>
             {{user.does_not_exist}}
           </p>\`;
@@ -1360,7 +1409,7 @@ export declare class AnimationEvent {
         </p>`);
           env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
-      
+
 
           @Component({
             selector: 'test',

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -311,5 +311,30 @@ describe('NgModule', () => {
       }).not.toThrow();
     });
 
+    it('should not throw for HTML elements inside an SVG foreignObject', () => {
+      @Component({
+        template: `
+          <svg>
+            <svg:foreignObject>
+              <xhtml:div>Hello</xhtml:div>
+            </svg:foreignObject>
+          </svg>
+        `,
+      })
+      class MyComp {
+      }
+
+      @NgModule({declarations: [MyComp]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(MyComp);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
   });
 });


### PR DESCRIPTION
Fixes ngtsc incorrectly logging an unknown element diagnostic for HTML elements that are inside an SVG `foreignObject` with the `xhtml` namespace.

Fixes #34171.
