### PR TITLE
fix(bazel): pin terser to 4.4.0

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -51,8 +51,13 @@ function testNonBazel() {
   rm -rf dist src/main.dev.ts src/main.prod.ts
   # disable CLI's version check (if version is 0.0.0, then no version check happens)
   yarn --cwd node_modules/@angular/cli version --new-version 0.0.0 --no-git-tag-version
-  # re-add build-angular
+
+  # Work-around for https://github.com/terser/terser/issues/527 which should be fixed in terser 4.4.2
+  # This will cause a hoisting issue since terser is a direct dependency of terser-webpack-plugin
+  sed -i '$s/}/,\n"resolutions":{"terser":"4.4.0"}}/' package.json
+
   yarn add --dev @angular-devkit/build-angular@0.900.0-rc.3
+
   yarn webdriver-manager update --gecko=false --standalone=false ${CI_CHROMEDRIVER_VERSION_ARG:---versions.chrome 2.45}
   ng build --progress=false
   ng test --progress=false --watch=false

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -59,7 +59,7 @@ function addDevDependenciesToPackageJson(options: Schema) {
       'rollup': '^1.25.2',
       'rollup-plugin-commonjs': '^10.1.0',
       'rollup-plugin-node-resolve': '^5.2.0',
-      'terser': '^4.3.9',
+      'terser': '4.4.0',
     };
 
     const recorder = host.beginUpdate(packageJson);


### PR DESCRIPTION
4.4.1 caused a regression https://github.com/terser/terser/issues/527 which is breaking our CI with such errors
```
'http://localhost:4200/main.57ce335e666ac98d65ad.js 0:370275 TypeError: e is not a function
```

Example of failing build https://circleci.com/gh/angular/angular/549169?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

