### PR TITLE
perf(ivy): avoid duplicate state lookup and default function parameters

### DIFF
--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -302,7 +302,7 @@ function setActiveElementFlag(flag: ActiveElementFlags) {
  * @param elementIndex the element index value for the host element where
  *                     the directive/component instance lives
  */
-export function setActiveHostElement(elementIndex: number | null = null) {
+export function setActiveHostElement(elementIndex: number | null) {
   if (hasActiveElementFlag(ActiveElementFlags.RunExitFn)) {
     executeElementExitFn();
   }
@@ -330,7 +330,7 @@ export function executeElementExitFn() {
  */
 export function setElementExitFn(fn: () => void): void {
   setActiveElementFlag(ActiveElementFlags.RunExitFn);
-  if (instructionState.elementExitFn == null) {
+  if (instructionState.elementExitFn === null) {
     instructionState.elementExitFn = fn;
   }
   ngDevMode &&
@@ -592,9 +592,10 @@ export function leaveView() {
   instructionState.lFrame = instructionState.lFrame.parent;
 }
 
-export function nextContextImpl<T = any>(level: number = 1): T {
-  instructionState.lFrame.contextLView = walkUpViews(level, instructionState.lFrame.contextLView !);
-  return instructionState.lFrame.contextLView[CONTEXT] as T;
+export function nextContextImpl<T = any>(level: number): T {
+  const contextLView = instructionState.lFrame.contextLView =
+      walkUpViews(level, instructionState.lFrame.contextLView !);
+  return contextLView[CONTEXT] as T;
 }
 
 function walkUpViews(nestingLevel: number, currentView: LView): LView {


### PR DESCRIPTION
Includes a few minor performance improvements:
* In the `nextContext` instruction we assign a new LView to the `LFrame.contextLView` and then we immediately look it up to get its context. We don't need to do that since we know the view that was assigned already.
* Removes the default value for the `level` parameter of `nextContextImpl` because it generates more code in es5 and is internal-only.
* Removes the default parameter from `setActiveHostElement` since it generates extra code and it's an internal function.
* Makes a check in `setElementExitFn` more strict since we're guaranteed for the value to match the type.