### PR TITLE
fix(docs-infra): make header full-width and panels full-width on mobile screens

### DIFF
--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -2,7 +2,7 @@
   <h1 class="banner-headline no-toc no-anchor">Events</h1>
 </header>
 
-<article>
+<article class="events-container">
   <p>Where we'll be presenting:</p>
   <table class="is-full-width">
     <thead>

--- a/aio/src/styles/1-layouts/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/_marketing-layout.scss
@@ -439,3 +439,7 @@ div[layout=row]{
 .page-features .marketing-banner {
   margin-bottom: 20px;
 }
+
+.events-container{
+  overflow-x: auto;
+}

--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -1,5 +1,8 @@
 .showcase {
   width: 80%;
+  @media (max-width: 600px) {
+    width: 100%;
+  }
 }
 
 .c-resource-nav {


### PR DESCRIPTION
Fixes #34163

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the current behavior, the width of the header is lesson events page in mobile screen and I made resources full screen on the mobile screen

Issue Number: #34163

## What is the new behavior?
The header is full screen and resources are full screens on mobile.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
