### PR TITLE
fix(ivy): correctly support `ngProjectAs` on templates

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1510,6 +1510,51 @@ describe('compiler compliance', () => {
             result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
       });
 
+      it('should include parsed ngProjectAs selectors into template attrs', () => {
+        const files = {
+          app: {
+            'spec.ts': `
+              import {Component} from '@angular/core';
+
+              @Component({
+                selector: 'my-app',
+                template: '<div *ngIf="show" ngProjectAs=".someclass"></div>'
+              })
+              export class MyApp {
+                show = true;
+              }
+            `
+          }
+        };
+
+        const SimpleComponentDefinition = `
+          MyApp.ɵcmp = i0.ɵɵdefineComponent({
+            type: MyApp,
+            selectors: [
+                ["my-app"]
+            ],
+            decls: 1,
+            vars: 1,
+            consts: [
+                ["ngProjectAs", ".someclass", ${AttributeMarker.Template}, "ngIf", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]],
+                ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]]
+            ],
+            template: function MyApp_Template(rf, ctx) {
+                if (rf & 1) {
+                    i0.ɵɵtemplate(0, MyApp_div_0_Template, 1, 0, "div", 0);
+                }
+                if (rf & 2) {
+                    i0.ɵɵproperty("ngIf", ctx.show);
+                }
+            },
+            encapsulation: 2
+          });
+        `;
+
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, SimpleComponentDefinition, 'Incorrect MyApp definition');
+      });
+
     });
 
     describe('queries', () => {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -841,6 +841,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   visitTemplate(template: t.Template) {
     const NG_TEMPLATE_TAG_NAME = 'ng-template';
     const templateIndex = this.allocateDataSlot();
+    let ngProjectAsAttr: t.TextAttribute|undefined;
 
     if (this.i18n) {
       this.i18n.appendTemplate(template.i18n !, templateIndex);
@@ -864,10 +865,15 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     // prepare attributes parameter (including attributes used for directive matching)
     const attrsExprs: o.Expression[] = [];
-    template.attributes.forEach(
-        (a: t.TextAttribute) => { attrsExprs.push(asLiteral(a.name), asLiteral(a.value)); });
+    template.attributes.forEach((attr: t.TextAttribute) => {
+      if (attr.name === NG_PROJECT_AS_ATTR_NAME) {
+        ngProjectAsAttr = attr;
+      }
+      attrsExprs.push(asLiteral(attr.name), asLiteral(attr.value));
+    });
     attrsExprs.push(...this.prepareNonRenderAttrs(
-        template.inputs, template.outputs, undefined, template.templateAttrs));
+        template.inputs, template.outputs, undefined, template.templateAttrs, undefined,
+        ngProjectAsAttr));
     parameters.push(this.addAttrsToConsts(attrsExprs));
 
     // local refs (ex.: <ng-template #foo>)

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1169,44 +1169,22 @@ describe('projection', () => {
       @Component({
         selector: 'projector-app',
         template: `
-            App selector: <ng-content select="app-selector"></ng-content>
-            Attribute-based: <ng-content select="[foo]"></ng-content>
-            Class-based: <ng-content select=".bar"></ng-content>
-            Other: <ng-content></ng-content>
-          `,
+          Projected
+          <ng-content select="foo"></ng-content>
+          <ng-content select="[foo]"></ng-content>
+          <ng-content select=".foo"></ng-content>
+        `,
       })
       class ProjectorApp {
-      }
-
-      @Component({
-        selector: 'app-selector',
-        template: ' App {{ marker }} ',
-      })
-      class ChildApp {
-        @Input() marker: string = '';
       }
 
       @Component({
         selector: 'root-comp',
         template: `
           <projector-app>
-            <div>Text content with no selectors</div>
-
-            <div *ngIf="show" foo> Attr A </div>
-            <ng-container *ngIf="show" ngProjectAs="[foo]">
-              <div foo> Attr B </div>
-            </ng-container>
-
-            <div *ngIf="show" class="bar"> Class A </div>
-            <ng-container *ngIf="show" ngProjectAs=".bar">
-              <div class="bar"> Class B </div>
-            </ng-container>
-
-            <app-selector *ngIf="show" marker="A"></app-selector>
-            <ng-container *ngIf="show" ngProjectAs="app-selector">
-              <app-selector marker="B"></app-selector>
-            </ng-container>
-
+            <div *ngIf="show" ngProjectAs="foo">as element</div>
+            <div *ngIf="show" ngProjectAs="[foo]">as attribute</div>
+            <div *ngIf="show" ngProjectAs=".foo">as class</div>
           </projector-app>
         `,
       })
@@ -1215,25 +1193,23 @@ describe('projection', () => {
       }
 
       TestBed.configureTestingModule({
-        declarations: [ChildApp, ProjectorApp, RootComp],
+        declarations: [ProjectorApp, RootComp],
       });
       const fixture = TestBed.createComponent(RootComp);
       fixture.detectChanges();
 
       let content = fixture.nativeElement.textContent;
-      expect(content).toContain('App selector:  App A  App B');
-      expect(content).toContain('Attribute-based:  Attr A  Attr B');
-      expect(content).toContain('Class-based:  Class A  Class B');
-      expect(content).toContain('Other: Text content with no selectors');
+      expect(content).toContain('as element');
+      expect(content).toContain('as attribute');
+      expect(content).toContain('as class');
 
       fixture.componentInstance.show = false;
       fixture.detectChanges();
 
       content = fixture.nativeElement.textContent;
-      expect(content).not.toContain('App selector:  App A  App B');
-      expect(content).not.toContain('Attribute-based:  Attr A  Attr B');
-      expect(content).not.toContain('Class-based:  Class A  Class B');
-      expect(content).toContain('Other: Text content with no selectors');
+      expect(content).not.toContain('as element');
+      expect(content).not.toContain('as attribute');
+      expect(content).not.toContain('as class');
     });
 
     describe('on containers', () => {


### PR DESCRIPTION
Prior to this commit, if a template (for example, generated using structural directive such as *ngIf) contains `ngProjectAs` attribute, it was not included into attributes array in generated code and as a result, these templates were not matched at runtime during content projection. This commit adds the logic to append `ngProjectAs` values into corresponding element's attribute arrays, so content projection works as expected.

This PR resolves #34120.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No