### PR TITLE
refactor(common): add defaults to new generic parameters

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -11,7 +11,7 @@ import {Directive, DoCheck, EmbeddedViewRef, Input, IterableChangeRecord, Iterab
 /**
  * @publicApi
  */
-export class NgForOfContext<T, U extends NgIterable<T>> {
+export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
   constructor(public $implicit: T, public ngForOf: U, public index: number, public count: number) {}
 
   get first(): boolean { return this.index === 0; }
@@ -121,7 +121,7 @@ export class NgForOfContext<T, U extends NgIterable<T>> {
  * @publicApi
  */
 @Directive({selector: '[ngFor][ngForOf]'})
-export class NgForOf<T, U extends NgIterable<T>> implements DoCheck {
+export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
   /**
    * The value of the iterable expression, which can be used as a
    * [template input variable](guide/structural-directives#template-input-variable).

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -149,7 +149,7 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  * @publicApi
  */
 @Directive({selector: '[ngIf]'})
-export class NgIf<T> {
+export class NgIf<T = unknown> {
   private _context: NgIfContext<T> = new NgIfContext<T>();
   private _thenTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
   private _elseTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
@@ -238,7 +238,7 @@ export class NgIf<T> {
 /**
  * @publicApi
  */
-export class NgIfContext<T> {
+export class NgIfContext<T = unknown> {
   public $implicit: T = null !;
   public ngIf: T = null !;
 }

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -26,7 +26,7 @@ runInEachFileSystem(() => {
       env.write('node_modules/@angular/common/index.d.ts', `
 import * as i0 from '@angular/core';
 
-export declare class NgForOfContext<T, U extends NgIterable<T>> {
+export declare class NgForOfContext<T, U extends i0.NgIterable<T> = i0.NgIterable<T>> {
   $implicit: T;
   count: number;
   readonly even: boolean;
@@ -54,7 +54,7 @@ export declare class SlicePipe {
   static ɵpipe: i0.ɵPipeDefWithMeta<SlicePipe, 'slice'>;
 }
 
-export declare class NgForOf<T, U extends i0.NgIterable<T>> implements DoCheck {
+export declare class NgForOf<T, U extends i0.NgIterable<T> = i0.NgIterable<T>> implements DoCheck {
   ngForOf: (U & i0.NgIterable<T>) | undefined | null;
   ngForTemplate: TemplateRef<NgForOfContext<T, U>>;
   ngForTrackBy: TrackByFunction<T>;
@@ -64,7 +64,7 @@ export declare class NgForOf<T, U extends i0.NgIterable<T>> implements DoCheck {
   static ɵdir: i0.ɵɵDirectiveDefWithMeta<NgForOf<any>, '[ngFor][ngForOf]', never, {'ngForOf': 'ngForOf'}, {}, never>;
 }
 
-export declare class NgIf<T> {
+export declare class NgIf<T = unknown> {
   ngIf: T;
   ngIfElse: TemplateRef<NgIfContext<T>> | null;
   ngIfThen: TemplateRef<NgIfContext<T>> | null;
@@ -74,7 +74,7 @@ export declare class NgIf<T> {
   static ɵdir: i0.ɵɵDirectiveDefWithMeta<NgIf<any>, '[ngIf]', never, {'ngIf': 'ngIf'}, {}, never>;
 }
 
-export declare class NgIfContext<T> {
+export declare class NgIfContext<T = unknown> {
   $implicit: T;
   ngIf: T;
 }

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -214,7 +214,7 @@ export declare class NgComponentOutlet implements OnChanges, OnDestroy {
     ngOnDestroy(): void;
 }
 
-export declare class NgForOf<T, U extends NgIterable<T>> implements DoCheck {
+export declare class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
     ngForOf: (U & NgIterable<T>) | undefined | null;
     ngForTemplate: TemplateRef<NgForOfContext<T, U>>;
     ngForTrackBy: TrackByFunction<T>;
@@ -223,7 +223,7 @@ export declare class NgForOf<T, U extends NgIterable<T>> implements DoCheck {
     static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
 }
 
-export declare class NgForOfContext<T, U extends NgIterable<T>> {
+export declare class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
     $implicit: T;
     count: number;
     readonly even: boolean;
@@ -235,7 +235,7 @@ export declare class NgForOfContext<T, U extends NgIterable<T>> {
     constructor($implicit: T, ngForOf: U, index: number, count: number);
 }
 
-export declare class NgIf<T> {
+export declare class NgIf<T = unknown> {
     ngIf: T;
     ngIfElse: TemplateRef<NgIfContext<T>> | null;
     ngIfThen: TemplateRef<NgIfContext<T>> | null;
@@ -244,7 +244,7 @@ export declare class NgIf<T> {
     static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<T>;
 }
 
-export declare class NgIfContext<T> {
+export declare class NgIfContext<T = unknown> {
     $implicit: T;
     ngIf: T;
 }


### PR DESCRIPTION
This is a follow-up to #33997 where some new generic parameters were added without defaults which is technically a breaking change. These changes add the defaults.
