### PR TITLE
refactor(platform-browser): avoid mutable exports.

### DIFF
--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -9,8 +9,6 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {NgZone, ɵglobal as global} from '@angular/core';
 
-export let browserDetection: BrowserDetection;
-
 export class BrowserDetection {
   private _overrideUa: string|null;
   private get _ua(): string {
@@ -21,7 +19,7 @@ export class BrowserDetection {
     return getDOM() ? getDOM().getUserAgent() : '';
   }
 
-  static setup() { browserDetection = new BrowserDetection(null); }
+  static setup() { return new BrowserDetection(null); }
 
   constructor(ua: string|null) { this._overrideUa = ua; }
 
@@ -88,7 +86,7 @@ export class BrowserDetection {
   }
 }
 
-BrowserDetection.setup();
+export const browserDetection: BrowserDetection = BrowserDetection.setup();
 
 export function dispatchEvent(element: any, eventType: any): void {
   const evt: Event = getDOM().getDefaultDocument().createEvent('Event');


### PR DESCRIPTION
Previously, browser_util would export a mutable `let` binding that was
initialized as a side-effect of `BrowserDetection.setup()`. This change
refactors the mutable binding into a `const` binding that is immediately
initialized in its initialized.

This is functionally equivalent, but makes it easier for module
optimizers such as Closure Compiler to track down side effects and prune
modules. It is also arguably cleaner to read (no worries about later
changes to the apparently mutable but effectively const binding).

- [x] Refactoring (no functional changes, no api changes)