### PR TITLE
feat(forms): implement replaceControls(controls) formarray function

### DIFF
--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -179,6 +179,7 @@ export declare class FormArray extends AbstractControl {
     }): void;
     push(control: AbstractControl): void;
     removeAt(index: number): void;
+    replaceControls(controls: AbstractControl[]): void;
     reset(value?: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;


### PR DESCRIPTION
Implement `replaceControls(controls: AbstractControl[])` memberfunction for FormArray.
It replaces all existing FormControls, unregisters them, then adds the new form controls with registration.
In the end it runs `updateValueAndValidity` and `_onCollectionChange.`

Closes #34186

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently one has to use a FormArray in a custom ControlValueAccessor and has to manually remove/add controls based on the writeValues input.

Here is an example:

```ts
import { Component, forwardRef, OnDestroy } from '@angular/core';
import { ControlValueAccessor, FormArray, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
import { Observable, ReplaySubject, Subscription } from 'rxjs';
import { filter, map, takeUntil } from 'rxjs/operators';

@Component({
    template: `custom-value-accessor-template`,
    selector: 'my-custom-value-accessor',
    providers: [{
        provide: NG_VALUE_ACCESSOR,
        useExisting: forwardRef(() => MyCustomControlValueAccessor),
        multi: true
    }]
})
export class MyCustomControlValueAccessor<TValue extends unknown = unknown> implements ControlValueAccessor,
    OnDestroy {

    protected readonly control = new FormArray([]);
    protected readonly userValueChanges$: Observable<TValue[]>;
    protected readonly destroyed = new ReplaySubject<void>(1);

    private changesSubscription: Subscription | undefined;
    private pauseChanges = false;
    private _changeFn: (change: TValue[]) => void;
    private _touchedFn: () => void;

    constructor() {
        this.userValueChanges$ = this.control.valueChanges.pipe(
            filter(() => !this.pauseChanges),
            map(() => this.control.getRawValue())
        );
    }

    public writeValue(value: TValue[]): void {
        this.pauseChanges = true;

        while (this.control.length > 0) {
            this.control.removeAt(0);
        }

        value.forEach(item => {
            this.control.push(new FormControl(item));
        });

        this.pauseChanges = false;
    }

    public ngOnDestroy(): void {
        this.destroyed.next();
        this.destroyed.complete();
    }

    public registerOnChange(fn: (change: TValue[]) => void): void {
        this._changeFn = fn;

        if (!this.changesSubscription) {
            this.userValueChanges$.pipe(
                takeUntil(this.destroyed)
            ).subscribe(
                val => this.change(val)
            );
        }
    }

    public registerOnTouched(fn: any): void {
        this.touched = fn;
    }

    public change(value: TValue[]): void {
        if (this._changeFn) this._changeFn(value);
    }

    public touched(): void {
        if (this._touchedFn) this._touchedFn();
    }
}
```

Issue Number: #34186


## What is the new behavior?

The FormArray implements a `replaceControl` memberfunction and can be used as follows

```ts
const arr = new FormArray([
  new FormControl(1),
  new FormControl(2)
]);

const c3 = new FormControl(3);
arr.replaceControls([c3]);
console.log(arr.value)      // [3]
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
