### PR TITLE
build: add karma-sauce-launcher dependency for karma_web_test macro

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -182,6 +182,7 @@ def karma_web_test(bootstrap = [], deps = [], data = [], runtime_deps = [], **kw
         bootstrap = ["//:web_test_bootstrap_scripts"]
     local_deps = [
         "@npm//karma-browserstack-launcher",
+        "@npm//karma-sauce-launcher",
         "@npm//:node_modules/tslib/tslib.js",
         "//tools/rxjs:rxjs_umd_modules",
         "//packages/zone.js:npm_package",


### PR DESCRIPTION
Currently our bazel saucelabs tests silently fail as it does not have
karma-sauce-launcher available from npm.  By providing it as expected
we will properly run the bazel saucelabs tests once more
