### PR TITLE
test(ivy): update `ngI18nClosureMode` flag usage in tests

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -3463,7 +3463,7 @@ describe('i18n support in the template compiler', () => {
 
       const output = String.raw `
         var $I18N_0$;
-        if (ngI18nClosureMode) { … }
+        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {
             $I18N_0$ = $localize \`:␟ec93160d6d6a8822214060dd7938bf821c22b226␟6795333002533525253:Some Message\`;
         }
@@ -3478,7 +3478,7 @@ describe('i18n support in the template compiler', () => {
 
       const output = String.raw `
         var $I18N_0$;
-        if (ngI18nClosureMode) { … }
+        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {
             $I18N_0$ = $localize \`:␟ec93160d6d6a8822214060dd7938bf821c22b226␟6795333002533525253:Some Message\`;
         }


### PR DESCRIPTION
Commit that updated i18n message ids rendering (https://github.com/angular/angular/commit/e524322c43ce31c5c6d45bcdc320338b9bd66249) also introduced a couple tests that relied on a previous version of `ngI18nClosureMode` flag format. The `ngI18nClosureMode` usage format was changed in the followup commit (https://github.com/angular/angular/commit/c4ce24647bb45b54db9ad37a21c36e65658fea68) and triggered a problem with the mentioned tests. This commit updates the tests to a new `ngI18nClosureMode` flag usage format.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No