### PR TITLE
refactor(upgrade): avoid mutable exports.

### DIFF
--- a/packages/upgrade/static/testing/src/create_angular_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angular_testing_module.ts
@@ -12,7 +12,7 @@ import * as angular from '../../../src/common/src/angular1';
 import {$INJECTOR, INJECTOR_KEY, UPGRADE_APP_TYPE_KEY} from '../../../src/common/src/constants';
 import {UpgradeAppType} from '../../../src/common/src/util';
 
-export let $injector: angular.IInjectorService|null = null;
+let $injector: angular.IInjectorService|null = null;
 let injector: Injector;
 
 export function $injectorFactory() {


### PR DESCRIPTION
Previously, create_angular_testing_module would export a mutable `let`
binding. The binding is already exporting using an accessor function
though, so the export on the let variable seems like an accidental
oversight.

This is functionally equivalent, but makes it easier for module
optimizers such as Closure Compiler to track down side effects and prune
modules.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type

- [x] Refactoring (no functional changes, no api changes)
