### PR TITLE
ci: update saucelabs to use angular-framework account

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -55,21 +55,13 @@ setSecretVar CI_SECRET_PAYLOAD_FIREBASE_TOKEN "$ANGULAR_PAYLOAD_TOKEN";
 ####################################################################################################
 # Define SauceLabs environment variables for CircleCI.
 ####################################################################################################
-# In order to have a meaningful SauceLabs badge on the repo page,
-# the angular2-ci account is used only when pushing commits to master;
-# in all other cases, the regular angular-ci account is used.
-if [ "${CI_PULL_REQUEST}" = "false" ] && [ "${CI_REPO_OWNER}" = "angular" ] && [ "${CI_BRANCH}" = "master" ]; then
-  setPublicVar SAUCE_USERNAME "angular2-ci";
-  setSecretVar SAUCE_ACCESS_KEY "693ebc16208a-0b5b-1614-8d66-a2662f4e";
-else
-  setPublicVar SAUCE_USERNAME "angular-ci";
-  setSecretVar SAUCE_ACCESS_KEY "9b988f434ff8-fbca-8aa4-4ae3-35442987";
-fi
+setPublicVar SAUCE_USERNAME "angular-framework";
+setSecretVar SAUCE_ACCESS_KEY "0c731274ed5f-cbc9-16f4-021a-9835e39f";
 # TODO(josephperrott): Remove environment variables once all saucelabs tests are via bazel method.
 setPublicVar SAUCE_LOG_FILE /tmp/angular/sauce-connect.log
 setPublicVar SAUCE_READY_FILE /tmp/angular/sauce-connect-ready-file.lock
 setPublicVar SAUCE_PID_FILE /tmp/angular/sauce-connect-pid-file.lock
-setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
+setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-framework-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
 # Amount of seconds we wait for sauceconnect to establish a tunnel instance. In order to not
 # acquire CircleCI instances for too long if sauceconnect failed, we need a connect timeout.
 setPublicVar SAUCE_READY_FILE_TIMEOUT 120


### PR DESCRIPTION
Currently all saucelabs usage in our repos is done using the same
account, `angular-ci`.  By migrating to use individual accounts
for each repo, we can better track the usage for each repo as well
as providing concurrency limiting on a per repo basis.

Additionally, we no longer use two separate accounts based on being
on master or a PR branch, so this logic can be removed.
