### PR TITLE
build: set upper version limit for yarn to <2

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -80,10 +80,10 @@
     "post~~build": "yarn build-404-page",
     "~~light-server": "light-server --bind=localhost --historyindex=/index.html --no-reload"
   },
-  "//engines-comment": "Keep this in sync with ../package.json",
+  "//engines-comment": "Keep this in sync with /package.json and /aio/tools/examples/shared/package.json",
   "engines": {
     "node": ">=10.9.0 <13.0.0",
-    "yarn": ">=1.17.3 <1.20.0"
+    "yarn": ">=1.17.3 <2"
   },
   "private": true,
   "dependencies": {

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -10,10 +10,10 @@
     "preinstall": "node ../../../../tools/yarn/check-yarn.js",
     "postinstall": "yarn webdriver:update"
   },
-  "//engines-comment": "Keep this in sync with aio/package.json",
+  "//engines-comment": "Keep this in sync with /package.json and /aio/package.json",
   "engines": {
     "node": ">=10.9.0 <13.0.0",
-    "yarn": ">=1.17.3 <=1.19.1"
+    "yarn": ">=1.17.3 <2"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "homepage": "https://github.com/angular/angular",
   "bugs": "https://github.com/angular/angular/issues",
   "license": "MIT",
-  "//engines-comment": "Keep this in sync with aio/package.json",
+  "//engines-comment": "Keep this in sync with /aio/package.json and /aio/tools/examples/shared/package.json",
   "engines": {
     "node": ">=10.9.0 <13.0.0",
-    "yarn": ">=1.17.3 <1.20.0"
+    "yarn": ">=1.17.3 <2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rather than bumping up the allowed version of yarn on each release
we should instead just allow for anything within the major version
1 range.
