### PR TITLE
build: Enable ivy in google3 if ng_module attr is True

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -42,6 +42,11 @@ def is_ivy_enabled(ctx):
             attr = "ng_module",
         )
 
+    # This attribute is only defined in google's private ng_module rule and not
+    # available externally. For external users, this is effectively a no-op.
+    if hasattr(ctx.attr, "ivy") and ctx.attr.ivy == True:
+        return True
+
     # TODO(josephperrott): Remove configuration via compile=aot define flag.
     if ctx.var.get("compile", None) == "aot":
         # buildifier: disable=print


### PR DESCRIPTION
This commit creates a way for `ng_module` rule to compile with Ivy based
on the `ivy` attribute. This enables google3 targets to pick the
compiler without using `define` flags.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
