### PR TITLE
fix(ivy): destroy componentRef unconditionally

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -253,7 +253,7 @@ export class ComponentRef<T> extends viewEngine_ComponentRef<T> {
     if (this.destroyCbs) {
       this.destroyCbs.forEach(fn => fn());
       this.destroyCbs = null;
-      !this.hostView.destroyed && this.hostView.destroy();
+      this.hostView.destroy();
     }
   }
 


### PR DESCRIPTION
[Ivy presubmit](https://test.corp.google.com/ui#id=OCL:283831496:BASE:283831536:1575497192186:a1419376)
[global presubmit](https://test.corp.google.com/ui#id=OCL:283831496:BASE:284223613:1575659842200:f354a12e) (no regressions related to this change)

The added test would fail without the change made to `component_ref`.