### PR TITLE
fix(common): update closure locales to include directionality data

### DIFF
--- a/packages/common/locales/closure-locale.ts
+++ b/packages/common/locales/closure-locale.ts
@@ -19,7 +19,9 @@ function plural_af(n: number): number {
 }
 
 export const locale_af = [
-  'af', [['v', 'n'], ['vm.', 'nm.'], u], u,
+  'af',
+  [['v', 'n'], ['vm.', 'nm.'], u],
+  u,
   [
     ['S', 'M', 'D', 'W', 'D', 'V', 'S'], ['So.', 'Ma.', 'Di.', 'Wo.', 'Do.', 'Vr.', 'Sa.'],
     ['Sondag', 'Maandag', 'Dinsdag', 'Woensdag', 'Donderdag', 'Vrydag', 'Saterdag'],
@@ -34,11 +36,18 @@ export const locale_af = [
       'Oktober', 'November', 'Desember'
     ]
   ],
-  u, [['v.C.', 'n.C.'], u, ['voor Christus', 'na Christus']], 0, [6, 0],
+  u,
+  [['v.C.', 'n.C.'], u, ['voor Christus', 'na Christus']],
+  0,
+  [6, 0],
   ['y-MM-dd', 'dd MMM y', 'dd MMMM y', 'EEEE dd MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'R', 'Suid-Afrikaanse rand', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'R',
+  'Suid-Afrikaanse rand',
+  {
     'CAD': [u, '$'],
     'JPY': ['JP¥', '¥'],
     'MXN': [u, '$'],
@@ -48,6 +57,7 @@ export const locale_af = [
     'USD': [u, '$'],
     'ZAR': ['R']
   },
+  'ltr',
   plural_af
 ];
 
@@ -58,7 +68,9 @@ function plural_am(n: number): number {
 }
 
 export const locale_am = [
-  'am', [['ጠ', 'ከ'], ['ጥዋት', 'ከሰዓት'], u], u,
+  'am',
+  [['ጠ', 'ከ'], ['ጥዋት', 'ከሰዓት'], u],
+  u,
   [
     ['እ', 'ሰ', 'ማ', 'ረ', 'ሐ', 'ዓ', 'ቅ'], ['እሑድ', 'ሰኞ', 'ማክሰ', 'ረቡዕ', 'ሐሙስ', 'ዓርብ', 'ቅዳሜ'],
     ['እሑድ', 'ሰኞ', 'ማክሰኞ', 'ረቡዕ', 'ሐሙስ', 'ዓርብ', 'ቅዳሜ'], ['እ', 'ሰ', 'ማ', 'ረ', 'ሐ', 'ዓ', 'ቅ']
@@ -72,11 +84,18 @@ export const locale_am = [
       'ዲሴምበር'
     ]
   ],
-  u, [['ዓ/ዓ', 'ዓ/ም'], u, ['ዓመተ ዓለም', 'ዓመተ ምሕረት']], 0, [6, 0],
+  u,
+  [['ዓ/ዓ', 'ዓ/ም'], u, ['ዓመተ ዓለም', 'ዓመተ ምሕረት']],
+  0,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'y MMMM d, EEEE'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'ብር', 'የኢትዮጵያ ብር', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'ብር',
+  'የኢትዮጵያ ብር',
+  {
     'AUD': ['AU$', '$'],
     'CNH': ['የቻይና ዩዋን'],
     'ETB': ['ብር'],
@@ -85,6 +104,7 @@ export const locale_am = [
     'TWD': ['NT$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_am
 ];
 
@@ -98,7 +118,9 @@ function plural_ar(n: number): number {
 }
 
 export const locale_ar = [
-  'ar', [['ص', 'م'], u, u], [['ص', 'م'], u, ['صباحًا', 'مساءً']],
+  'ar',
+  [['ص', 'م'], u, u],
+  [['ص', 'م'], u, ['صباحًا', 'مساءً']],
   [
     ['ح', 'ن', 'ث', 'ر', 'خ', 'ج', 'س'],
     ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'], u,
@@ -113,11 +135,18 @@ export const locale_ar = [
     ],
     u
   ],
-  u, [['ق.م', 'م'], u, ['قبل الميلاد', 'ميلادي']], 6, [5, 6],
+  u,
+  [['ق.م', 'م'], u, ['قبل الميلاد', 'ميلادي']],
+  6,
+  [5, 6],
   ['d\u200f/M\u200f/y', 'dd\u200f/MM\u200f/y', 'd MMMM y', 'EEEE، d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '\u200e%\u200e', '\u200e+', '\u200e-', 'E', '×', '‰', '∞', 'ليس رقمًا', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'ج.م.\u200f', 'جنيه مصري', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'ج.م.\u200f',
+  'جنيه مصري',
+  {
     'AED': ['د.إ.\u200f'],
     'ARS': [u, 'AR$'],
     'AUD': ['AU$'],
@@ -170,6 +199,7 @@ export const locale_ar = [
     'XXX': ['***'],
     'YER': ['ر.ي.\u200f']
   },
+  'rtl',
   plural_ar
 ];
 
@@ -183,7 +213,9 @@ function plural_ar_DZ(n: number): number {
 }
 
 export const locale_ar_DZ = [
-  'ar-DZ', [['ص', 'م'], u, u], [['ص', 'م'], u, ['صباحًا', 'مساءً']],
+  'ar-DZ',
+  [['ص', 'م'], u, u],
+  [['ص', 'م'], u, ['صباحًا', 'مساءً']],
   [
     ['ح', 'ن', 'ث', 'ر', 'خ', 'ج', 'س'],
     ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'], u,
@@ -198,11 +230,18 @@ export const locale_ar_DZ = [
     ],
     u
   ],
-  u, [['ق.م', 'م'], u, ['قبل الميلاد', 'ميلادي']], 6, [5, 6],
+  u,
+  [['ق.م', 'م'], u, ['قبل الميلاد', 'ميلادي']],
+  6,
+  [5, 6],
   ['d\u200f/M\u200f/y', 'dd\u200f/MM\u200f/y', 'd MMMM y', 'EEEE، d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '\u200e%\u200e', '\u200e+', '\u200e-', 'E', '×', '‰', '∞', 'ليس رقمًا', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'د.ج.\u200f', 'دينار جزائري', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'د.ج.\u200f',
+  'دينار جزائري',
+  {
     'AED': ['د.إ.\u200f'],
     'ARS': [u, 'AR$'],
     'AUD': ['AU$'],
@@ -255,6 +294,7 @@ export const locale_ar_DZ = [
     'XXX': ['***'],
     'YER': ['ر.ي.\u200f']
   },
+  'rtl',
   plural_ar_DZ
 ];
 
@@ -264,7 +304,9 @@ function plural_az(n: number): number {
 }
 
 export const locale_az = [
-  'az', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'az',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['7', '1', '2', '3', '4', '5', '6'], ['B.', 'B.e.', 'Ç.a.', 'Ç.', 'C.a.', 'C.', 'Ş.'],
     ['bazar', 'bazar ertəsi', 'çərşənbə axşamı', 'çərşənbə', 'cümə axşamı', 'cümə', 'şənbə'],
@@ -291,11 +333,17 @@ export const locale_az = [
       'Noyabr', 'dekabr'
     ]
   ],
-  [['e.ə.', 'y.e.'], u, ['eramızdan əvvəl', 'yeni era']], 1, [6, 0],
+  [['e.ə.', 'y.e.'], u, ['eramızdan əvvəl', 'yeni era']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'd MMM y', 'd MMMM y', 'd MMMM y, EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '₼', 'Azərbaycan Manatı', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '₼',
+  'Azərbaycan Manatı',
+  {
     'AZN': ['₼'],
     'JPY': ['JP¥', '¥'],
     'RON': [u, 'ley'],
@@ -304,6 +352,7 @@ export const locale_az = [
     'TWD': ['NT$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_az
 ];
 
@@ -319,7 +368,9 @@ function plural_be(n: number): number {
 }
 
 export const locale_be = [
-  'be', [['am', 'pm'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'be',
+  [['am', 'pm'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['н', 'п', 'а', 'с', 'ч', 'п', 'с'], ['нд', 'пн', 'аў', 'ср', 'чц', 'пт', 'сб'],
     ['нядзеля', 'панядзелак', 'аўторак', 'серада', 'чацвер', 'пятніца', 'субота'],
@@ -342,11 +393,17 @@ export const locale_be = [
       'кастрычнік', 'лістапад', 'снежань'
     ]
   ],
-  [['да н.э.', 'н.э.'], u, ['да нараджэння Хрыстова', 'ад нараджэння Хрыстова']], 1, [6, 0],
+  [['да н.э.', 'н.э.'], u, ['да нараджэння Хрыстова', 'ад нараджэння Хрыстова']],
+  1,
+  [6, 0],
   ['d.MM.yy', 'd.MM.y', 'd MMMM y \'г\'.', 'EEEE, d MMMM y \'г\'.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss, zzzz'], ['{1}, {0}', u, '{1} \'у\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss, zzzz'],
+  ['{1}, {0}', u, '{1} \'у\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'Br', 'беларускі рубель', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'Br',
+  'беларускі рубель',
+  {
     'AUD': ['A$'],
     'BBD': [u, 'Bds$'],
     'BMD': [u, 'BD$'],
@@ -375,6 +432,7 @@ export const locale_be = [
     'UYU': [u, '$U'],
     'XCD': ['EC$']
   },
+  'ltr',
   plural_be
 ];
 
@@ -384,7 +442,9 @@ function plural_bg(n: number): number {
 }
 
 export const locale_bg = [
-  'bg', [['am', 'pm'], u, ['пр.об.', 'сл.об.']], [['am', 'pm'], u, u],
+  'bg',
+  [['am', 'pm'], u, ['пр.об.', 'сл.об.']],
+  [['am', 'pm'], u, u],
   [
     ['н', 'п', 'в', 'с', 'ч', 'п', 'с'], ['нд', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'],
     ['неделя', 'понеделник', 'вторник', 'сряда', 'четвъртък', 'петък', 'събота'],
@@ -399,11 +459,18 @@ export const locale_bg = [
       'ноември', 'декември'
     ]
   ],
-  u, [['пр.Хр.', 'сл.Хр.'], u, ['преди Христа', 'след Христа']], 1, [6, 0],
+  u,
+  [['пр.Хр.', 'сл.Хр.'], u, ['преди Христа', 'след Христа']],
+  1,
+  [6, 0],
   ['d.MM.yy \'г\'.', 'd.MM.y \'г\'.', 'd MMMM y \'г\'.', 'EEEE, d MMMM y \'г\'.'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '0.00 ¤', '#E0'], 'лв.', 'Български лев', {
+  ['#,##0.###', '#,##0%', '0.00 ¤', '#E0'],
+  'лв.',
+  'Български лев',
+  {
     'ARS': [],
     'AUD': [],
     'BBD': [],
@@ -459,6 +526,7 @@ export const locale_bg = [
     'VND': [],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_bg
 ];
 
@@ -469,7 +537,9 @@ function plural_bn(n: number): number {
 }
 
 export const locale_bn = [
-  'bn', [['AM', 'PM'], u, u], u,
+  'bn',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['র', 'সো', 'ম', 'বু', 'বৃ', 'শু', 'শ'], ['রবি', 'সোম', 'মঙ্গল', 'বুধ', 'বৃহস্পতি', 'শুক্র', 'শনি'],
     ['রবিবার', 'সোমবার', 'মঙ্গলবার', 'বুধবার', 'বৃহস্পতিবার', 'শুক্রবার', 'শনিবার'],
@@ -495,12 +565,19 @@ export const locale_bn = [
     ],
     u
   ],
-  [['খ্রিস্টপূর্ব', 'খৃষ্টাব্দ'], u, ['খ্রিস্টপূর্ব', 'খ্রীষ্টাব্দ']], 0, [6, 0],
+  [['খ্রিস্টপূর্ব', 'খৃষ্টাব্দ'], u, ['খ্রিস্টপূর্ব', 'খ্রীষ্টাব্দ']],
+  0,
+  [6, 0],
   ['d/M/yy', 'd MMM, y', 'd MMMM, y', 'EEEE, d MMMM, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '#,##,##0.00¤', '#E0'], '৳', 'বাংলাদেশী টাকা',
-  {'BDT': ['৳'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']}, plural_bn
+  ['#,##,##0.###', '#,##,##0%', '#,##,##0.00¤', '#E0'],
+  '৳',
+  'বাংলাদেশী টাকা',
+  {'BDT': ['৳'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_bn
 ];
 
 function plural_br(n: number): number {
@@ -515,7 +592,9 @@ function plural_br(n: number): number {
 }
 
 export const locale_br = [
-  'br', [['am', 'gm'], ['A.M.', 'G.M.'], u], [['A.M.', 'G.M.'], u, u],
+  'br',
+  [['am', 'gm'], ['A.M.', 'G.M.'], u],
+  [['A.M.', 'G.M.'], u, u],
   [
     ['Su', 'L', 'Mz', 'Mc', 'Y', 'G', 'Sa'], ['Sul', 'Lun', 'Meu.', 'Mer.', 'Yaou', 'Gwe.', 'Sad.'],
     ['Sul', 'Lun', 'Meurzh', 'Mercʼher', 'Yaou', 'Gwener', 'Sadorn'],
@@ -533,12 +612,18 @@ export const locale_br = [
       'Here', 'Du', 'Kerzu'
     ]
   ],
-  u, [['a-raok J.K.', 'goude J.K.'], u, ['a-raok Jezuz-Krist', 'goude Jezuz-Krist']], 1, [6, 0],
+  u,
+  [['a-raok J.K.', 'goude J.K.'], u, ['a-raok Jezuz-Krist', 'goude Jezuz-Krist']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
   ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
   ['{1} {0}', '{1}, {0}', '{1} \'da\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AUD': ['$A', '$'],
     'BRL': [u, 'R$'],
     'CAD': ['$CA', '$'],
@@ -558,6 +643,7 @@ export const locale_br = [
     'XCD': [u, '$'],
     'XXX': []
   },
+  'ltr',
   plural_br
 ];
 
@@ -574,7 +660,9 @@ function plural_bs(n: number): number {
 }
 
 export const locale_bs = [
-  'bs', [['prijepodne', 'popodne'], ['AM', 'PM'], ['prijepodne', 'popodne']], u,
+  'bs',
+  [['prijepodne', 'popodne'], ['AM', 'PM'], ['prijepodne', 'popodne']],
+  u,
   [
     ['N', 'P', 'U', 'S', 'Č', 'P', 'S'], ['ned', 'pon', 'uto', 'sri', 'čet', 'pet', 'sub'],
     ['nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota'],
@@ -593,11 +681,18 @@ export const locale_bs = [
       'novembar', 'decembar'
     ]
   ],
-  u, [['p.n.e.', 'n.e.'], ['p. n. e.', 'n. e.'], ['prije nove ere', 'nove ere']], 1, [6, 0],
+  u,
+  [['p.n.e.', 'n.e.'], ['p. n. e.', 'n. e.'], ['prije nove ere', 'nove ere']],
+  1,
+  [6, 0],
   ['d. M. y.', 'd. MMM y.', 'd. MMMM y.', 'EEEE, d. MMMM y.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, '{1} \'u\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, '{1} \'u\' {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'KM', 'Bosanskohercegovačka konvertibilna marka', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'KM',
+  'Bosanskohercegovačka konvertibilna marka',
+  {
     'AUD': [u, '$'],
     'BAM': ['KM'],
     'BRL': [u, 'R$'],
@@ -616,6 +711,7 @@ export const locale_bs = [
     'XCD': [u, '$'],
     'XPF': []
   },
+  'ltr',
   plural_bs
 ];
 
@@ -626,7 +722,9 @@ function plural_ca(n: number): number {
 }
 
 export const locale_ca = [
-  'ca', [['a. m.', 'p. m.'], u, u], u,
+  'ca',
+  [['a. m.', 'p. m.'], u, u],
+  u,
   [
     ['dg', 'dl', 'dt', 'dc', 'dj', 'dv', 'ds'], ['dg.', 'dl.', 'dt.', 'dc.', 'dj.', 'dv.', 'ds.'],
     ['diumenge', 'dilluns', 'dimarts', 'dimecres', 'dijous', 'divendres', 'dissabte'],
@@ -654,12 +752,17 @@ export const locale_ca = [
       'novembre', 'desembre'
     ]
   ],
-  [['aC', 'dC'], u, ['abans de Crist', 'després de Crist']], 1, [6, 0],
+  [['aC', 'dC'], u, ['abans de Crist', 'després de Crist']],
+  1,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM \'de\' y', 'EEEE, d MMMM \'de\' y'],
   ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
   ['{1} {0}', '{1}, {0}', '{1} \'a\' \'les\' {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AUD': ['AU$', '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -672,6 +775,7 @@ export const locale_ca = [
     'XCD': [u, '$'],
     'XXX': []
   },
+  'ltr',
   plural_ca
 ];
 
@@ -681,7 +785,9 @@ function plural_chr(n: number): number {
 }
 
 export const locale_chr = [
-  'chr', [['Ꮜ', 'Ꮢ'], ['ᏌᎾᎴ', 'ᏒᎯᏱᎢ'], ['ᏌᎾᎴ', 'ᏒᎯᏱᎢᏗᏢ']], [['ᏌᎾᎴ', 'ᏒᎯᏱᎢ'], u, ['ᏌᎾᎴ', 'ᏒᎯᏱᎢᏗᏢ']],
+  'chr',
+  [['Ꮜ', 'Ꮢ'], ['ᏌᎾᎴ', 'ᏒᎯᏱᎢ'], ['ᏌᎾᎴ', 'ᏒᎯᏱᎢᏗᏢ']],
+  [['ᏌᎾᎴ', 'ᏒᎯᏱᎢ'], u, ['ᏌᎾᎴ', 'ᏒᎯᏱᎢᏗᏢ']],
   [
     ['Ꮖ', 'Ꮙ', 'Ꮤ', 'Ꮶ', 'Ꮕ', 'Ꮷ', 'Ꭴ'], ['ᏆᏍᎬ', 'ᏉᏅᎯ', 'ᏔᎵᏁ', 'ᏦᎢᏁ', 'ᏅᎩᏁ', 'ᏧᎾᎩ', 'ᏈᏕᎾ'],
     ['ᎤᎾᏙᏓᏆᏍᎬ', 'ᎤᎾᏙᏓᏉᏅᎯ', 'ᏔᎵᏁᎢᎦ', 'ᏦᎢᏁᎢᎦ', 'ᏅᎩᏁᎢᎦ', 'ᏧᎾᎩᎶᏍᏗ', 'ᎤᎾᏙᏓᏈᏕᎾ'],
@@ -693,11 +799,20 @@ export const locale_chr = [
     ['ᎤᏃ', 'ᎧᎦ', 'ᎠᏅ', 'ᎧᏬ', 'ᎠᏂ', 'ᏕᎭ', 'ᎫᏰ', 'ᎦᎶ', 'ᏚᎵ', 'ᏚᏂ', 'ᏅᏓ', 'ᎥᏍ'],
     ['ᎤᏃᎸᏔᏅ', 'ᎧᎦᎵ', 'ᎠᏅᏱ', 'ᎧᏬᏂ', 'ᎠᏂᏍᎬᏘ', 'ᏕᎭᎷᏱ', 'ᎫᏰᏉᏂ', 'ᎦᎶᏂ', 'ᏚᎵᏍᏗ', 'ᏚᏂᏅᏗ', 'ᏅᏓᏕᏆ', 'ᎥᏍᎩᏱ']
   ],
-  u, [['BC', 'AD'], u, ['ᏧᏓᎷᎸ ᎤᎷᎯᏍᏗ ᎦᎶᏁᏛ', 'ᎠᏃ ᏙᎻᏂ']], 0, [6, 0],
+  u,
+  [['BC', 'AD'], u, ['ᏧᏓᎷᎸ ᎤᎷᎯᏍᏗ ᎦᎶᏁᏛ', 'ᎠᏃ ᏙᎻᏂ']],
+  0,
+  [6, 0],
   ['M/d/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} ᎤᎾᎢ {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} ᎤᎾᎢ {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'US ᎠᏕᎳ', {'JPY': ['JP¥', '¥']}, plural_chr
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  'US ᎠᏕᎳ',
+  {'JPY': ['JP¥', '¥']},
+  'ltr',
+  plural_chr
 ];
 
 function plural_cs(n: number): number {
@@ -709,7 +824,9 @@ function plural_cs(n: number): number {
 }
 
 export const locale_cs = [
-  'cs', [['dop.', 'odp.'], u, u], u,
+  'cs',
+  [['dop.', 'odp.'], u, u],
+  u,
   [
     ['N', 'P', 'Ú', 'S', 'Č', 'P', 'S'], ['ne', 'po', 'út', 'st', 'čt', 'pá', 'so'],
     ['neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota'],
@@ -732,11 +849,17 @@ export const locale_cs = [
       'listopad', 'prosinec'
     ]
   ],
-  [['př.n.l.', 'n.l.'], ['př. n. l.', 'n. l.'], ['před naším letopočtem', 'našeho letopočtu']], 1,
-  [6, 0], ['dd.MM.yy', 'd. M. y', 'd. MMMM y', 'EEEE d. MMMM y'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  [['př.n.l.', 'n.l.'], ['př. n. l.', 'n. l.'], ['před naším letopočtem', 'našeho letopočtu']],
+  1,
+  [6, 0],
+  ['dd.MM.yy', 'd. M. y', 'd. MMMM y', 'EEEE d. MMMM y'],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'Kč', 'česká koruna', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'Kč',
+  'česká koruna',
+  {
     'AUD': ['AU$', '$'],
     'CSK': ['Kčs'],
     'CZK': ['Kč'],
@@ -750,6 +873,7 @@ export const locale_cs = [
     'XEU': ['ECU'],
     'XXX': []
   },
+  'ltr',
   plural_cs
 ];
 
@@ -763,7 +887,9 @@ function plural_cy(n: number): number {
 }
 
 export const locale_cy = [
-  'cy', [['b', 'h'], ['AM', 'PM'], ['yb', 'yh']], [['AM', 'PM'], u, u],
+  'cy',
+  [['b', 'h'], ['AM', 'PM'], ['yb', 'yh']],
+  [['AM', 'PM'], u, u],
   [
     ['S', 'Ll', 'M', 'M', 'I', 'G', 'S'], ['Sul', 'Llun', 'Maw', 'Mer', 'Iau', 'Gwen', 'Sad'],
     [
@@ -796,11 +922,17 @@ export const locale_cy = [
       'Hydref', 'Tachwedd', 'Rhagfyr'
     ]
   ],
-  [['C', 'O'], ['CC', 'OC'], ['Cyn Crist', 'Oed Crist']], 1, [6, 0],
+  [['C', 'O'], ['CC', 'OC'], ['Cyn Crist', 'Oed Crist']],
+  1,
+  [6, 0],
   ['dd/MM/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, '{1} \'am\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, '{1} \'am\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '£', 'Punt Prydain', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '£',
+  'Punt Prydain',
+  {
     'BDT': [u, 'TK'],
     'BWP': [],
     'HKD': ['HK$'],
@@ -813,6 +945,7 @@ export const locale_cy = [
     'ZAR': [],
     'ZMW': []
   },
+  'ltr',
   plural_cy
 ];
 
@@ -824,7 +957,9 @@ function plural_da(n: number): number {
 }
 
 export const locale_da = [
-  'da', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'da',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['S', 'M', 'T', 'O', 'T', 'F', 'L'], ['søn.', 'man.', 'tir.', 'ons.', 'tor.', 'fre.', 'lør.'],
     ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
@@ -843,11 +978,18 @@ export const locale_da = [
       'oktober', 'november', 'december'
     ]
   ],
-  u, [['fKr', 'eKr'], ['f.Kr.', 'e.Kr.'], u], 1, [6, 0],
+  u,
+  [['fKr', 'eKr'], ['f.Kr.', 'e.Kr.'], u],
+  1,
+  [6, 0],
   ['dd.MM.y', 'd. MMM y', 'd. MMMM y', 'EEEE \'den\' d. MMMM y'],
-  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'], ['{1} {0}', u, '{1} \'kl\'. {0}', u],
+  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'],
+  ['{1} {0}', u, '{1} \'kl\'. {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', '.'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'kr.', 'dansk krone', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'kr.',
+  'dansk krone',
+  {
     'AUD': ['AU$', '$'],
     'DKK': ['kr.'],
     'ISK': [u, 'kr.'],
@@ -859,6 +1001,7 @@ export const locale_da = [
     'TWD': ['NT$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_da
 ];
 
@@ -869,7 +1012,9 @@ function plural_de(n: number): number {
 }
 
 export const locale_de = [
-  'de', [['AM', 'PM'], u, u], u,
+  'de',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['S', 'M', 'D', 'M', 'D', 'F', 'S'], ['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
     ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
@@ -898,11 +1043,17 @@ export const locale_de = [
       'November', 'Dezember'
     ]
   ],
-  [['v. Chr.', 'n. Chr.'], u, u], 1, [6, 0],
+  [['v. Chr.', 'n. Chr.'], u, u],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'dd.MM.y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'um\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'um\' {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '·', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'Euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'Euro',
+  {
     'ATS': ['öS'],
     'AUD': ['AU$', '$'],
     'BGM': ['BGK'],
@@ -920,6 +1071,7 @@ export const locale_de = [
     'XXX': [],
     'ZMW': [u, 'K']
   },
+  'ltr',
   plural_de
 ];
 
@@ -930,7 +1082,9 @@ function plural_de_AT(n: number): number {
 }
 
 export const locale_de_AT = [
-  'de-AT', [['AM', 'PM'], u, u], [['vm.', 'nm.'], ['AM', 'PM'], u],
+  'de-AT',
+  [['AM', 'PM'], u, u],
+  [['vm.', 'nm.'], ['AM', 'PM'], u],
   [
     ['S', 'M', 'D', 'M', 'D', 'F', 'S'], ['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
     ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
@@ -957,11 +1111,17 @@ export const locale_de_AT = [
       'November', 'Dezember'
     ]
   ],
-  [['v. Chr.', 'n. Chr.'], u, u], 1, [6, 0],
+  [['v. Chr.', 'n. Chr.'], u, u],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'dd.MM.y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'um\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'um\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '·', '‰', '∞', 'NaN', ':', u, '.'],
-  ['#,##0.###', '#,##0 %', '¤ #,##0.00', '#E0'], '€', 'Euro', {
+  ['#,##0.###', '#,##0 %', '¤ #,##0.00', '#E0'],
+  '€',
+  'Euro',
+  {
     'ATS': ['öS'],
     'AUD': ['AU$', '$'],
     'BGM': ['BGK'],
@@ -979,6 +1139,7 @@ export const locale_de_AT = [
     'XXX': [],
     'ZMW': [u, 'K']
   },
+  'ltr',
   plural_de_AT
 ];
 
@@ -989,7 +1150,9 @@ function plural_de_CH(n: number): number {
 }
 
 export const locale_de_CH = [
-  'de-CH', [['AM', 'PM'], u, u], u,
+  'de-CH',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['S', 'M', 'D', 'M', 'D', 'F', 'S'], ['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
     ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
@@ -1018,11 +1181,17 @@ export const locale_de_CH = [
       'November', 'Dezember'
     ]
   ],
-  [['v. Chr.', 'n. Chr.'], u, u], 1, [6, 0],
+  [['v. Chr.', 'n. Chr.'], u, u],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'dd.MM.y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'um\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'um\' {0}', u],
   ['.', '’', ';', '%', '+', '-', 'E', '·', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00;¤-#,##0.00', '#E0'], 'CHF', 'Schweizer Franken', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00;¤-#,##0.00', '#E0'],
+  'CHF',
+  'Schweizer Franken',
+  {
     'ATS': ['öS'],
     'AUD': ['AU$', '$'],
     'BGM': ['BGK'],
@@ -1041,6 +1210,7 @@ export const locale_de_CH = [
     'XXX': [],
     'ZMW': [u, 'K']
   },
+  'ltr',
   plural_de_CH
 ];
 
@@ -1050,7 +1220,9 @@ function plural_el(n: number): number {
 }
 
 export const locale_el = [
-  'el', [['πμ', 'μμ'], ['π.μ.', 'μ.μ.'], u], u,
+  'el',
+  [['πμ', 'μμ'], ['π.μ.', 'μ.μ.'], u],
+  u,
   [
     ['Κ', 'Δ', 'Τ', 'Τ', 'Π', 'Π', 'Σ'], ['Κυρ', 'Δευ', 'Τρί', 'Τετ', 'Πέμ', 'Παρ', 'Σάβ'],
     ['Κυριακή', 'Δευτέρα', 'Τρίτη', 'Τετάρτη', 'Πέμπτη', 'Παρασκευή', 'Σάββατο'],
@@ -1073,12 +1245,19 @@ export const locale_el = [
       'Αύγουστος', 'Σεπτέμβριος', 'Οκτώβριος', 'Νοέμβριος', 'Δεκέμβριος'
     ]
   ],
-  [['π.Χ.', 'μ.Χ.'], u, ['προ Χριστού', 'μετά Χριστόν']], 1, [6, 0],
+  [['π.Χ.', 'μ.Χ.'], u, ['προ Χριστού', 'μετά Χριστόν']],
+  1,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} - {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} - {0}', u],
   [',', '.', ';', '%', '+', '-', 'e', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'Ευρώ',
-  {'GRD': ['Δρχ'], 'JPY': ['JP¥', '¥'], 'THB': ['฿']}, plural_el
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'Ευρώ',
+  {'GRD': ['Δρχ'], 'JPY': ['JP¥', '¥'], 'THB': ['฿']},
+  'ltr',
+  plural_el
 ];
 
 function plural_en_AU(n: number): number {
@@ -1088,7 +1267,9 @@ function plural_en_AU(n: number): number {
 }
 
 export const locale_en_AU = [
-  'en-AU', [['am', 'pm'], u, u], u,
+  'en-AU',
+  [['am', 'pm'], u, u],
+  u,
   [
     ['Su.', 'M.', 'Tu.', 'W.', 'Th.', 'F.', 'Sa.'],
     ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
@@ -1104,11 +1285,18 @@ export const locale_en_AU = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 0, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  0,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'e', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'Australian Dollar', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  'Australian Dollar',
+  {
     'AUD': ['$'],
     'BDT': [u, 'Tk'],
     'BOB': [u, '$b'],
@@ -1139,6 +1327,7 @@ export const locale_en_AU = [
     'XOF': [],
     'XPF': ['CFP']
   },
+  'ltr',
   plural_en_AU
 ];
 
@@ -1149,7 +1338,9 @@ function plural_en_CA(n: number): number {
 }
 
 export const locale_en_CA = [
-  'en-CA', [['am', 'pm'], ['a.m.', 'p.m.'], u], [['a.m.', 'pm'], ['a.m.', 'p.m.'], u],
+  'en-CA',
+  [['am', 'pm'], ['a.m.', 'p.m.'], u],
+  [['a.m.', 'pm'], ['a.m.', 'p.m.'], u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun.', 'Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1164,12 +1355,20 @@ export const locale_en_CA = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 0, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  0,
+  [6, 0],
   ['y-MM-dd', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'e', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'Canadian Dollar',
-  {'CAD': ['$'], 'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_en_CA
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  'Canadian Dollar',
+  {'CAD': ['$'], 'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_en_CA
 ];
 
 function plural_en_GB(n: number): number {
@@ -1179,7 +1378,9 @@ function plural_en_GB(n: number): number {
 }
 
 export const locale_en_GB = [
-  'en-GB', [['a', 'p'], ['am', 'pm'], u], [['am', 'pm'], u, u],
+  'en-GB',
+  [['a', 'p'], ['am', 'pm'], u],
+  [['am', 'pm'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1194,12 +1395,20 @@ export const locale_en_GB = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 1, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '£', 'British Pound',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_en_GB
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '£',
+  'British Pound',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_en_GB
 ];
 
 function plural_en_IE(n: number): number {
@@ -1209,7 +1418,9 @@ function plural_en_IE(n: number): number {
 }
 
 export const locale_en_IE = [
-  'en-IE', [['a', 'p'], ['am', 'pm'], ['a.m.', 'p.m.']], [['am', 'pm'], u, u],
+  'en-IE',
+  [['a', 'p'], ['am', 'pm'], ['a.m.', 'p.m.']],
+  [['am', 'pm'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1224,12 +1435,20 @@ export const locale_en_IE = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 1, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '€', 'Euro',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_en_IE
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '€',
+  'Euro',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_en_IE
 ];
 
 function plural_en_IN(n: number): number {
@@ -1239,7 +1458,9 @@ function plural_en_IN(n: number): number {
 }
 
 export const locale_en_IN = [
-  'en-IN', [['a', 'p'], ['am', 'pm'], u], [['am', 'pm'], u, u],
+  'en-IN',
+  [['a', 'p'], ['am', 'pm'], u],
+  [['am', 'pm'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1254,12 +1475,20 @@ export const locale_en_IN = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 0, [0, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  0,
+  [0, 0],
   ['dd/MM/yy', 'dd-MMM-y', 'd MMMM y', 'EEEE, d MMMM, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '#E0'], '₹', 'Indian Rupee',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_en_IN
+  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '#E0'],
+  '₹',
+  'Indian Rupee',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_en_IN
 ];
 
 function plural_en_SG(n: number): number {
@@ -1269,7 +1498,9 @@ function plural_en_SG(n: number): number {
 }
 
 export const locale_en_SG = [
-  'en-SG', [['a', 'p'], ['am', 'pm'], u], [['am', 'pm'], u, u],
+  'en-SG',
+  [['a', 'p'], ['am', 'pm'], u],
+  [['am', 'pm'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1284,12 +1515,20 @@ export const locale_en_SG = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 0, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  0,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'Singapore Dollar',
-  {'JPY': ['JP¥', '¥'], 'SGD': ['$'], 'USD': ['US$', '$']}, plural_en_SG
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  'Singapore Dollar',
+  {'JPY': ['JP¥', '¥'], 'SGD': ['$'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_en_SG
 ];
 
 function plural_en_ZA(n: number): number {
@@ -1299,7 +1538,9 @@ function plural_en_ZA(n: number): number {
 }
 
 export const locale_en_ZA = [
-  'en-ZA', [['a', 'p'], ['am', 'pm'], u], [['am', 'pm'], u, u],
+  'en-ZA',
+  [['a', 'p'], ['am', 'pm'], u],
+  [['am', 'pm'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
@@ -1314,12 +1555,20 @@ export const locale_en_ZA = [
       'October', 'November', 'December'
     ]
   ],
-  u, [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']], 0, [6, 0],
+  u,
+  [['B', 'A'], ['BC', 'AD'], ['Before Christ', 'Anno Domini']],
+  0,
+  [6, 0],
   ['y/MM/dd', 'dd MMM y', 'dd MMMM y', 'EEEE, dd MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'at\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'at\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'R', 'South African Rand',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$'], 'ZAR': ['R']}, plural_en_ZA
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'R',
+  'South African Rand',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$'], 'ZAR': ['R']},
+  'ltr',
+  plural_en_ZA
 ];
 
 function plural_es(n: number): number {
@@ -1328,7 +1577,9 @@ function plural_es(n: number): number {
 }
 
 export const locale_es = [
-  'es', [['a. m.', 'p. m.'], u, u], u,
+  'es',
+  [['a. m.', 'p. m.'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'X', 'J', 'V', 'S'], ['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
     ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
@@ -1346,11 +1597,18 @@ export const locale_es = [
       'octubre', 'noviembre', 'diciembre'
     ]
   ],
-  u, [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']], 1, [6, 0],
+  u,
+  [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']],
+  1,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss (zzzz)'], ['{1} {0}', u, '{1}, {0}', u],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss (zzzz)'],
+  ['{1} {0}', u, '{1}, {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CNY': [u, '¥'],
@@ -1372,6 +1630,7 @@ export const locale_es = [
     'XCD': [u, '$'],
     'XOF': []
   },
+  'ltr',
   plural_es
 ];
 
@@ -1381,7 +1640,9 @@ function plural_es_419(n: number): number {
 }
 
 export const locale_es_419 = [
-  'es-419', [['a. m.', 'p. m.'], ['a.m.', 'p.m.'], u], u,
+  'es-419',
+  [['a. m.', 'p. m.'], ['a.m.', 'p.m.'], u],
+  u,
   [
     ['d', 'l', 'm', 'm', 'j', 'v', 's'], ['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
     ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
@@ -1402,11 +1663,18 @@ export const locale_es_419 = [
       'octubre', 'noviembre', 'diciembre'
     ]
   ],
-  u, [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']], 1, [6, 0],
+  u,
+  [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']],
+  1,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, '{1} \'a\' \'las\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, '{1} \'a\' \'las\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'], 'EUR', 'euro', {
+  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'],
+  'EUR',
+  'euro',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -1433,6 +1701,7 @@ export const locale_es_419 = [
     'XCD': [u, '$'],
     'XOF': []
   },
+  'ltr',
   plural_es_419
 ];
 
@@ -1442,7 +1711,9 @@ function plural_es_MX(n: number): number {
 }
 
 export const locale_es_MX = [
-  'es-MX', [['a. m.', 'p. m.'], u, u], u,
+  'es-MX',
+  [['a. m.', 'p. m.'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
     ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
@@ -1459,11 +1730,18 @@ export const locale_es_MX = [
       'octubre', 'noviembre', 'diciembre'
     ]
   ],
-  u, [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']], 0, [6, 0],
+  u,
+  [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']],
+  0,
+  [6, 0],
   ['dd/MM/yy', 'd MMM y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'], ['{1} {0}', u, '{1} \'a\' \'las\' {0}', u],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1} {0}', u, '{1} \'a\' \'las\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'], '$', 'peso mexicano', {
+  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'],
+  '$',
+  'peso mexicano',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'BYN': [u, 'p.'],
@@ -1488,6 +1766,7 @@ export const locale_es_MX = [
     'XCD': [u, '$'],
     'XOF': []
   },
+  'ltr',
   plural_es_MX
 ];
 
@@ -1497,7 +1776,9 @@ function plural_es_US(n: number): number {
 }
 
 export const locale_es_US = [
-  'es-US', [['a. m.', 'p. m.'], u, u], u,
+  'es-US',
+  [['a. m.', 'p. m.'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
     ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
@@ -1514,12 +1795,18 @@ export const locale_es_US = [
       'octubre', 'noviembre', 'diciembre'
     ]
   ],
-  u, [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']], 0, [6, 0],
+  u,
+  [['a. C.', 'd. C.'], u, ['antes de Cristo', 'después de Cristo']],
+  0,
+  [6, 0],
   ['d/M/y', 'd MMM y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
   ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
   ['{1} {0}', u, '{1} \'a\' \'las\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'], '$', 'dólar estadounidense', {
+  ['#,##0.###', '#,##0 %', '¤#,##0.00', '#E0'],
+  '$',
+  'dólar estadounidense',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'BYN': [u, 'p.'],
@@ -1540,6 +1827,7 @@ export const locale_es_US = [
     'XCD': [u, '$'],
     'XOF': []
   },
+  'ltr',
   plural_es_US
 ];
 
@@ -1550,7 +1838,9 @@ function plural_et(n: number): number {
 }
 
 export const locale_et = [
-  'et', [['AM', 'PM'], u, u], u,
+  'et',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['P', 'E', 'T', 'K', 'N', 'R', 'L'], u,
     ['pühapäev', 'esmaspäev', 'teisipäev', 'kolmapäev', 'neljapäev', 'reede', 'laupäev'],
@@ -1565,12 +1855,20 @@ export const locale_et = [
       'oktoober', 'november', 'detsember'
     ]
   ],
-  u, [['eKr', 'pKr'], u, ['enne Kristust', 'pärast Kristust']], 1, [6, 0],
+  u,
+  [['eKr', 'pKr'], u, ['enne Kristust', 'pärast Kristust']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'd. MMM y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '−', '×10^', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'euro',
-  {'AUD': ['AU$', '$'], 'EEK': ['kr'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_et
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {'AUD': ['AU$', '$'], 'EEK': ['kr'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_et
 ];
 
 function plural_eu(n: number): number {
@@ -1579,7 +1877,9 @@ function plural_eu(n: number): number {
 }
 
 export const locale_eu = [
-  'eu', [['g', 'a'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'eu',
+  [['g', 'a'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['I', 'A', 'A', 'A', 'O', 'O', 'L'], ['ig.', 'al.', 'ar.', 'az.', 'og.', 'or.', 'lr.'],
     ['igandea', 'astelehena', 'asteartea', 'asteazkena', 'osteguna', 'ostirala', 'larunbata'],
@@ -1596,15 +1896,23 @@ export const locale_eu = [
       'iraila', 'urria', 'azaroa', 'abendua'
     ]
   ],
-  u, [['K.a.', 'K.o.'], u, ['K.a.', 'Kristo ondoren']], 1, [6, 0],
+  u,
+  [['K.a.', 'K.o.'], u, ['K.a.', 'Kristo ondoren']],
+  1,
+  [6, 0],
   [
     'yy/M/d', 'y(\'e\')\'ko\' MMM d(\'a\')', 'y(\'e\')\'ko\' MMMM\'ren\' d(\'a\')',
     'y(\'e\')\'ko\' MMMM\'ren\' d(\'a\'), EEEE'
   ],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss (z)', 'HH:mm:ss (zzzz)'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss (z)', 'HH:mm:ss (zzzz)'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '−', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '% #,##0', '#,##0.00 ¤', '#E0'], '€', 'euroa',
-  {'ESP': ['₧'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']}, plural_eu
+  ['#,##0.###', '% #,##0', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euroa',
+  {'ESP': ['₧'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_eu
 ];
 
 function plural_fa(n: number): number {
@@ -1614,7 +1922,9 @@ function plural_fa(n: number): number {
 }
 
 export const locale_fa = [
-  'fa', [['ق', 'ب'], ['ق.ظ.', 'ب.ظ.'], ['قبل\u200cازظهر', 'بعدازظهر']], u,
+  'fa',
+  [['ق', 'ب'], ['ق.ظ.', 'ب.ظ.'], ['قبل\u200cازظهر', 'بعدازظهر']],
+  u,
   [
     ['ی', 'د', 'س', 'چ', 'پ', 'ج', 'ش'],
     ['یکشنبه', 'دوشنبه', 'سه\u200cشنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'], u,
@@ -1637,11 +1947,17 @@ export const locale_fa = [
     ],
     u
   ],
-  [['ق', 'م'], ['ق.م.', 'م.'], ['قبل از میلاد', 'میلادی']], 6, [5, 5],
+  [['ق', 'م'], ['ق.م.', 'م.'], ['قبل از میلاد', 'میلادی']],
+  6,
+  [5, 5],
   ['y/M/d', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss (z)', 'H:mm:ss (zzzz)'], ['{1}،\u200f {0}', u, '{1}، ساعت {0}', u],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss (z)', 'H:mm:ss (zzzz)'],
+  ['{1}،\u200f {0}', u, '{1}، ساعت {0}', u],
   ['.', ',', ';', '%', '\u200e+', '\u200e−', 'E', '×', '‰', '∞', 'ناعدد', ':'],
-  ['#,##0.###', '#,##0%', '\u200e¤ #,##0.00', '#E0'], 'ریال', 'ریال ایران', {
+  ['#,##0.###', '#,##0%', '\u200e¤ #,##0.00', '#E0'],
+  'ریال',
+  'ریال ایران',
+  {
     'AFN': ['؋'],
     'CAD': ['$CA', '$'],
     'CNY': ['¥CN', '¥'],
@@ -1652,6 +1968,7 @@ export const locale_fa = [
     'THB': ['฿'],
     'XCD': ['$EC', '$']
   },
+  'rtl',
   plural_fa
 ];
 
@@ -1662,7 +1979,9 @@ function plural_fi(n: number): number {
 }
 
 export const locale_fi = [
-  'fi', [['ap.', 'ip.'], u, u], u,
+  'fi',
+  [['ap.', 'ip.'], u, u],
+  u,
   [
     ['S', 'M', 'T', 'K', 'T', 'P', 'L'], ['su', 'ma', 'ti', 'ke', 'to', 'pe', 'la'],
     [
@@ -1699,10 +2018,16 @@ export const locale_fi = [
     ]
   ],
   [['eKr', 'jKr'], ['eKr.', 'jKr.'], ['ennen Kristuksen syntymää', 'jälkeen Kristuksen syntymän']],
-  1, [6, 0], ['d.M.y', u, 'd. MMMM y', 'cccc d. MMMM y'],
-  ['H.mm', 'H.mm.ss', 'H.mm.ss z', 'H.mm.ss zzzz'], ['{1} {0}', '{1} \'klo\' {0}', u, u],
+  1,
+  [6, 0],
+  ['d.M.y', u, 'd. MMMM y', 'cccc d. MMMM y'],
+  ['H.mm', 'H.mm.ss', 'H.mm.ss z', 'H.mm.ss zzzz'],
+  ['{1} {0}', '{1} \'klo\' {0}', u, u],
   [',', ' ', ';', '%', '+', '−', 'E', '×', '‰', '∞', 'epäluku', '.'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AOA': [],
     'ARS': [],
     'AUD': [],
@@ -1800,6 +2125,7 @@ export const locale_fi = [
     'ZAR': [],
     'ZMW': []
   },
+  'ltr',
   plural_fi
 ];
 
@@ -1810,7 +2136,9 @@ function plural_fr(n: number): number {
 }
 
 export const locale_fr = [
-  'fr', [['AM', 'PM'], u, u], u,
+  'fr',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
     ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
@@ -1828,11 +2156,18 @@ export const locale_fr = [
       'octobre', 'novembre', 'décembre'
     ]
   ],
-  u, [['av. J.-C.', 'ap. J.-C.'], u, ['avant Jésus-Christ', 'après Jésus-Christ']], 1, [6, 0],
+  u,
+  [['av. J.-C.', 'ap. J.-C.'], u, ['avant Jésus-Christ', 'après Jésus-Christ']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', '{1} \'à\' {0}', u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', '{1} \'à\' {0}', u, u],
   [',', '\u202f', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'ARS': ['$AR', '$'],
     'AUD': ['$AU', '$'],
     'BEF': ['FB'],
@@ -1878,6 +2213,7 @@ export const locale_fr = [
     'XPF': ['FCFP'],
     'ZMW': [u, 'Kw']
   },
+  'ltr',
   plural_fr
 ];
 
@@ -1888,7 +2224,9 @@ function plural_fr_CA(n: number): number {
 }
 
 export const locale_fr_CA = [
-  'fr-CA', [['a', 'p'], ['a.m.', 'p.m.'], u], [['a.m.', 'p.m.'], u, u],
+  'fr-CA',
+  [['a', 'p'], ['a.m.', 'p.m.'], u],
+  [['a.m.', 'p.m.'], u, u],
   [
     ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
     ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
@@ -1906,7 +2244,10 @@ export const locale_fr_CA = [
       'octobre', 'novembre', 'décembre'
     ]
   ],
-  u, [['av. J.-C.', 'ap. J.-C.'], u, ['avant Jésus-Christ', 'après Jésus-Christ']], 0, [6, 0],
+  u,
+  [['av. J.-C.', 'ap. J.-C.'], u, ['avant Jésus-Christ', 'après Jésus-Christ']],
+  0,
+  [6, 0],
   ['y-MM-dd', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
   [
     'HH \'h\' mm', 'HH \'h\' mm \'min\' ss \'s\'', 'HH \'h\' mm \'min\' ss \'s\' z',
@@ -1914,7 +2255,10 @@ export const locale_fr_CA = [
   ],
   ['{1} {0}', u, '{1} \'à\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '$', 'dollar canadien', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '$',
+  'dollar canadien',
+  {
     'AUD': ['$ AU', '$'],
     'BEF': ['FB'],
     'BYN': [u, 'Br'],
@@ -1947,6 +2291,7 @@ export const locale_fr_CA = [
     'XOF': [],
     'XPF': []
   },
+  'ltr',
   plural_fr_CA
 ];
 
@@ -1959,7 +2304,9 @@ function plural_ga(n: number): number {
 }
 
 export const locale_ga = [
-  'ga', [['r.n.', 'i.n.'], u, u], u,
+  'ga',
+  [['r.n.', 'i.n.'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'C', 'D', 'A', 'S'], ['Domh', 'Luan', 'Máirt', 'Céad', 'Déar', 'Aoine', 'Sath'],
     [
@@ -1979,12 +2326,20 @@ export const locale_ga = [
       'Meán Fómhair', 'Deireadh Fómhair', 'Samhain', 'Nollaig'
     ]
   ],
-  u, [['RC', 'AD'], u, ['Roimh Chríost', 'Anno Domini']], 1, [6, 0],
+  u,
+  [['RC', 'AD'], u, ['Roimh Chríost', 'Anno Domini']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '€', 'Euro',
-  {'THB': ['฿'], 'TWD': ['NT$'], 'XXX': []}, plural_ga
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '€',
+  'Euro',
+  {'THB': ['฿'], 'TWD': ['NT$'], 'XXX': []},
+  'ltr',
+  plural_ga
 ];
 
 function plural_gl(n: number): number {
@@ -1994,7 +2349,9 @@ function plural_gl(n: number): number {
 }
 
 export const locale_gl = [
-  'gl', [['a.m.', 'p.m.'], u, u], u,
+  'gl',
+  [['a.m.', 'p.m.'], u, u],
+  u,
   [
     ['d.', 'l.', 'm.', 'm.', 'x.', 'v.', 's.'],
     ['dom.', 'luns', 'mar.', 'mér.', 'xov.', 'ven.', 'sáb.'],
@@ -2026,11 +2383,17 @@ export const locale_gl = [
       'Outubro', 'Novembro', 'Decembro'
     ]
   ],
-  [['a.C.', 'd.C.'], u, ['antes de Cristo', 'despois de Cristo']], 1, [6, 0],
+  [['a.C.', 'd.C.'], u, ['antes de Cristo', 'despois de Cristo']],
+  1,
+  [6, 0],
   ['dd/MM/yy', 'd \'de\' MMM \'de\' y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{0}, {1}', u, '{0} \'do\' {1}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{0}, {1}', u, '{0} \'do\' {1}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'BYN': [u, 'Br'],
     'ESP': ['₧'],
     'JPY': ['JP¥', '¥'],
@@ -2041,6 +2404,7 @@ export const locale_gl = [
     'TWD': ['NT$'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_gl
 ];
 
@@ -2050,7 +2414,8 @@ function plural_gsw(n: number): number {
 }
 
 export const locale_gsw = [
-  'gsw', [['vorm.', 'nam.'], u, ['am Vormittag', 'am Namittag']],
+  'gsw',
+  [['vorm.', 'nam.'], u, ['am Vormittag', 'am Namittag']],
   [['vorm.', 'nam.'], u, ['Vormittag', 'Namittag']],
   [
     ['S', 'M', 'D', 'M', 'D', 'F', 'S'], ['Su.', 'Mä.', 'Zi.', 'Mi.', 'Du.', 'Fr.', 'Sa.'],
@@ -2066,11 +2431,19 @@ export const locale_gsw = [
       'Oktoober', 'Novämber', 'Dezämber'
     ]
   ],
-  u, [['v. Chr.', 'n. Chr.'], u, u], 1, [6, 0],
+  u,
+  [['v. Chr.', 'n. Chr.'], u, u],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'dd.MM.y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', '’', ';', '%', '+', '−', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'CHF', 'Schwiizer Franke', {'ATS': ['öS']},
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'CHF',
+  'Schwiizer Franke',
+  {'ATS': ['öS']},
+  'ltr',
   plural_gsw
 ];
 
@@ -2081,7 +2454,9 @@ function plural_gu(n: number): number {
 }
 
 export const locale_gu = [
-  'gu', [['AM', 'PM'], u, u], u,
+  'gu',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['ર', 'સો', 'મં', 'બુ', 'ગુ', 'શુ', 'શ'], ['રવિ', 'સોમ', 'મંગળ', 'બુધ', 'ગુરુ', 'શુક્ર', 'શનિ'],
     ['રવિવાર', 'સોમવાર', 'મંગળવાર', 'બુધવાર', 'ગુરુવાર', 'શુક્રવાર', 'શનિવાર'],
@@ -2096,12 +2471,19 @@ export const locale_gu = [
       'ડિસેમ્બર'
     ]
   ],
-  u, [['ઇ સ પુ', 'ઇસ'], ['ઈ.સ.પૂર્વે', 'ઈ.સ.'], ['ઈસવીસન પૂર્વે', 'ઇસવીસન']], 0, [0, 0],
+  u,
+  [['ઇ સ પુ', 'ઇસ'], ['ઈ.સ.પૂર્વે', 'ઈ.સ.'], ['ઈસવીસન પૂર્વે', 'ઇસવીસન']],
+  0,
+  [0, 0],
   ['d/M/yy', 'd MMM, y', 'd MMMM, y', 'EEEE, d MMMM, y'],
-  ['hh:mm a', 'hh:mm:ss a', 'hh:mm:ss a z', 'hh:mm:ss a zzzz'], ['{1} {0}', u, '{1} એ {0} વાગ્યે', u],
+  ['hh:mm a', 'hh:mm:ss a', 'hh:mm:ss a z', 'hh:mm:ss a zzzz'],
+  ['{1} {0}', u, '{1} એ {0} વાગ્યે', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '[#E0]'], '₹', 'ભારતીય રૂપિયા',
+  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '[#E0]'],
+  '₹',
+  'ભારતીય રૂપિયા',
   {'JPY': ['JP¥', '¥'], 'MUR': [u, 'રૂ.'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']},
+  'ltr',
   plural_gu
 ];
 
@@ -2111,7 +2493,9 @@ function plural_haw(n: number): number {
 }
 
 export const locale_haw = [
-  'haw', [['AM', 'PM'], u, u], u,
+  'haw',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['LP', 'P1', 'P2', 'P3', 'P4', 'P5', 'P6'],
     ['Lāpule', 'Poʻakahi', 'Poʻalua', 'Poʻakolu', 'Poʻahā', 'Poʻalima', 'Poʻaono'],
@@ -2126,10 +2510,20 @@ export const locale_haw = [
       'ʻOkakopa', 'Nowemapa', 'Kekemapa'
     ]
   ],
-  u, [['BCE', 'CE'], u, u], 0, [6, 0], ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  u,
+  [['BCE', 'CE'], u, u],
+  0,
+  [6, 0],
+  ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'USD', {'JPY': ['JP¥', '¥']}, plural_haw
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  'USD',
+  {'JPY': ['JP¥', '¥']},
+  'ltr',
+  plural_haw
 ];
 
 function plural_hi(n: number): number {
@@ -2139,7 +2533,9 @@ function plural_hi(n: number): number {
 }
 
 export const locale_hi = [
-  'hi', [['am', 'pm'], u, u], u,
+  'hi',
+  [['am', 'pm'], u, u],
+  u,
   [
     ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'], ['रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र', 'शनि'],
     ['रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरुवार', 'शुक्रवार', 'शनिवार'],
@@ -2154,12 +2550,20 @@ export const locale_hi = [
       'दिसंबर'
     ]
   ],
-  u, [['ईसा-पूर्व', 'ईस्वी'], u, ['ईसा-पूर्व', 'ईसवी सन']], 0, [0, 0],
+  u,
+  [['ईसा-पूर्व', 'ईस्वी'], u, ['ईसा-पूर्व', 'ईसवी सन']],
+  0,
+  [0, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} को {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} को {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '[#E0]'], '₹', 'भारतीय रुपया',
-  {'JPY': ['JP¥', '¥'], 'RON': [u, 'लेई'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_hi
+  ['#,##,##0.###', '#,##,##0%', '¤#,##,##0.00', '[#E0]'],
+  '₹',
+  'भारतीय रुपया',
+  {'JPY': ['JP¥', '¥'], 'RON': [u, 'लेई'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_hi
 ];
 
 function plural_hr(n: number): number {
@@ -2175,7 +2579,9 @@ function plural_hr(n: number): number {
 }
 
 export const locale_hr = [
-  'hr', [['AM', 'PM'], u, u], u,
+  'hr',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['N', 'P', 'U', 'S', 'Č', 'P', 'S'], ['ned', 'pon', 'uto', 'sri', 'čet', 'pet', 'sub'],
     ['nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota'],
@@ -2202,11 +2608,17 @@ export const locale_hr = [
       'listopad', 'studeni', 'prosinac'
     ]
   ],
-  [['pr.n.e.', 'AD'], ['pr. Kr.', 'po. Kr.'], ['prije Krista', 'poslije Krista']], 1, [6, 0],
+  [['pr.n.e.', 'AD'], ['pr. Kr.', 'po. Kr.'], ['prije Krista', 'poslije Krista']],
+  1,
+  [6, 0],
   ['dd. MM. y.', 'd. MMM y.', 'd. MMMM y.', 'EEEE, d. MMMM y.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss (zzzz)'], ['{1} {0}', u, '{1} \'u\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss (zzzz)'],
+  ['{1} {0}', u, '{1} \'u\' {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'HRK', 'hrvatska kuna', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'HRK',
+  'hrvatska kuna',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -2227,6 +2639,7 @@ export const locale_hr = [
     'XPF': [],
     'XXX': []
   },
+  'ltr',
   plural_hr
 ];
 
@@ -2236,7 +2649,9 @@ function plural_hu(n: number): number {
 }
 
 export const locale_hu = [
-  'hu', [['de.', 'du.'], u, u], u,
+  'hu',
+  [['de.', 'du.'], u, u],
+  u,
   [
     ['V', 'H', 'K', 'Sz', 'Cs', 'P', 'Sz'], ['V', 'H', 'K', 'Sze', 'Cs', 'P', 'Szo'],
     ['vasárnap', 'hétfő', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat'],
@@ -2254,11 +2669,18 @@ export const locale_hu = [
       'szeptember', 'október', 'november', 'december'
     ]
   ],
-  u, [['ie.', 'isz.'], ['i. e.', 'i. sz.'], ['Krisztus előtt', 'időszámításunk szerint']], 1,
-  [6, 0], ['y. MM. dd.', 'y. MMM d.', 'y. MMMM d.', 'y. MMMM d., EEEE'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  u,
+  [['ie.', 'isz.'], ['i. e.', 'i. sz.'], ['Krisztus előtt', 'időszámításunk szerint']],
+  1,
+  [6, 0],
+  ['y. MM. dd.', 'y. MMM d.', 'y. MMMM d.', 'y. MMMM d., EEEE'],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'Ft', 'magyar forint', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'Ft',
+  'magyar forint',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -2277,6 +2699,7 @@ export const locale_hu = [
     'VND': [u, '₫'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_hu
 ];
 
@@ -2287,7 +2710,9 @@ function plural_hy(n: number): number {
 }
 
 export const locale_hy = [
-  'hy', [['ա', 'հ'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'hy',
+  [['ա', 'հ'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['Կ', 'Ե', 'Ե', 'Չ', 'Հ', 'Ո', 'Շ'], ['կիր', 'երկ', 'երք', 'չրք', 'հնգ', 'ուր', 'շբթ'],
     ['կիրակի', 'երկուշաբթի', 'երեքշաբթի', 'չորեքշաբթի', 'հինգշաբթի', 'ուրբաթ', 'շաբաթ'],
@@ -2310,12 +2735,19 @@ export const locale_hy = [
       'հոկտեմբեր', 'նոյեմբեր', 'դեկտեմբեր'
     ]
   ],
-  [['մ.թ.ա.', 'մ.թ.'], u, ['Քրիստոսից առաջ', 'Քրիստոսից հետո']], 1, [6, 0],
+  [['մ.թ.ա.', 'մ.թ.'], u, ['Քրիստոսից առաջ', 'Քրիստոսից հետո']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'dd MMM, y թ.', 'dd MMMM, y թ.', 'y թ. MMMM d, EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'ՈչԹ', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '֏', 'հայկական դրամ',
-  {'AMD': ['֏'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_hy
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '֏',
+  'հայկական դրամ',
+  {'AMD': ['֏'], 'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_hy
 ];
 
 function plural_in(n: number): number {
@@ -2323,7 +2755,9 @@ function plural_in(n: number): number {
 }
 
 export const locale_in = [
-  'id', [['AM', 'PM'], u, u], u,
+  'id',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['M', 'S', 'S', 'R', 'K', 'J', 'S'], ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
     ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu'],
@@ -2338,11 +2772,18 @@ export const locale_in = [
       'Oktober', 'November', 'Desember'
     ]
   ],
-  u, [['SM', 'M'], u, ['Sebelum Masehi', 'Masehi']], 0, [6, 0],
+  u,
+  [['SM', 'M'], u, ['Sebelum Masehi', 'Masehi']],
+  0,
+  [6, 0],
   ['dd/MM/yy', 'd MMM y', 'd MMMM y', 'EEEE, dd MMMM y'],
-  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', '.'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'Rp', 'Rupiah Indonesia', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'Rp',
+  'Rupiah Indonesia',
+  {
     'AUD': ['AU$', '$'],
     'IDR': ['Rp'],
     'INR': ['Rs', '₹'],
@@ -2352,6 +2793,7 @@ export const locale_in = [
     'USD': ['US$', '$'],
     'XXX': []
   },
+  'ltr',
   plural_in
 ];
 
@@ -2363,7 +2805,9 @@ function plural_is(n: number): number {
 }
 
 export const locale_is = [
-  'is', [['f.', 'e.'], ['f.h.', 'e.h.'], u], [['f.h.', 'e.h.'], u, u],
+  'is',
+  [['f.', 'e.'], ['f.h.', 'e.h.'], u],
+  [['f.h.', 'e.h.'], u, u],
   [
     ['S', 'M', 'Þ', 'M', 'F', 'F', 'L'], ['sun.', 'mán.', 'þri.', 'mið.', 'fim.', 'fös.', 'lau.'],
     [
@@ -2381,11 +2825,18 @@ export const locale_is = [
       'nóvember', 'desember'
     ]
   ],
-  u, [['f.k.', 'e.k.'], ['f.Kr.', 'e.Kr.'], ['fyrir Krist', 'eftir Krist']], 1, [6, 0],
+  u,
+  [['f.k.', 'e.k.'], ['f.Kr.', 'e.Kr.'], ['fyrir Krist', 'eftir Krist']],
+  1,
+  [6, 0],
   ['d.M.y', 'd. MMM y', 'd. MMMM y', 'EEEE, d. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'kl\'. {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'kl\'. {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'ISK', 'íslensk króna', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'ISK',
+  'íslensk króna',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -2400,6 +2851,7 @@ export const locale_is = [
     'USD': [u, '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_is
 ];
 
@@ -2410,7 +2862,9 @@ function plural_it(n: number): number {
 }
 
 export const locale_it = [
-  'it', [['m.', 'p.'], ['AM', 'PM'], u], u,
+  'it',
+  [['m.', 'p.'], ['AM', 'PM'], u],
+  u,
   [
     ['D', 'L', 'M', 'M', 'G', 'V', 'S'], ['dom', 'lun', 'mar', 'mer', 'gio', 'ven', 'sab'],
     ['domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato'],
@@ -2425,11 +2879,18 @@ export const locale_it = [
       'ottobre', 'novembre', 'dicembre'
     ]
   ],
-  u, [['aC', 'dC'], ['a.C.', 'd.C.'], ['avanti Cristo', 'dopo Cristo']], 1, [6, 0],
+  u,
+  [['aC', 'dC'], ['a.C.', 'd.C.'], ['avanti Cristo', 'dopo Cristo']],
+  1,
+  [6, 0],
   ['dd/MM/yy', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'BRL': [u, 'R$'],
     'BYN': [u, 'Br'],
     'EGP': [u, '£E'],
@@ -2442,6 +2903,7 @@ export const locale_it = [
     'TWD': [u, 'NT$'],
     'USD': [u, '$']
   },
+  'ltr',
   plural_it
 ];
 
@@ -2454,7 +2916,9 @@ function plural_iw(n: number): number {
 }
 
 export const locale_iw = [
-  'he', [['לפנה״צ', 'אחה״צ'], u, u], [['לפנה״צ', 'אחה״צ'], ['AM', 'PM'], u],
+  'he',
+  [['לפנה״צ', 'אחה״צ'], u, u],
+  [['לפנה״צ', 'אחה״צ'], ['AM', 'PM'], u],
   [
     ['א׳', 'ב׳', 'ג׳', 'ד׳', 'ה׳', 'ו׳', 'ש׳'],
     ['יום א׳', 'יום ב׳', 'יום ג׳', 'יום ד׳', 'יום ה׳', 'יום ו׳', 'שבת'],
@@ -2470,12 +2934,19 @@ export const locale_iw = [
       'נובמבר', 'דצמבר'
     ]
   ],
-  u, [['לפנה״ס', 'לספירה'], u, ['לפני הספירה', 'לספירה']], 0, [5, 6],
+  u,
+  [['לפנה״ס', 'לספירה'], u, ['לפני הספירה', 'לספירה']],
+  0,
+  [5, 6],
   ['d.M.y', 'd בMMM y', 'd בMMMM y', 'EEEE, d בMMMM y'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'], ['{1}, {0}', u, '{1} בשעה {0}', u],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} בשעה {0}', u],
   ['.', ',', ';', '%', '\u200e+', '\u200e-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤', '#E0'], '₪', 'שקל חדש',
+  ['#,##0.###', '#,##0%', '\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤', '#E0'],
+  '₪',
+  'שקל חדש',
   {'BYN': [u, 'р'], 'CNY': ['\u200eCN¥\u200e', '¥'], 'ILP': ['ל״י'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'rtl',
   plural_iw
 ];
 
@@ -2484,7 +2955,9 @@ function plural_ja(n: number): number {
 }
 
 export const locale_ja = [
-  'ja', [['午前', '午後'], u, u], u,
+  'ja',
+  [['午前', '午後'], u, u],
+  u,
   [
     ['日', '月', '火', '水', '木', '金', '土'], u,
     ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'],
@@ -2495,11 +2968,20 @@ export const locale_ja = [
     ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'], u
   ],
-  u, [['BC', 'AD'], ['紀元前', '西暦'], u], 0, [6, 0], ['y/MM/dd', u, 'y年M月d日', 'y年M月d日EEEE'],
-  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H時mm分ss秒 zzzz'], ['{1} {0}', u, u, u],
+  u,
+  [['BC', 'AD'], ['紀元前', '西暦'], u],
+  0,
+  [6, 0],
+  ['y/MM/dd', u, 'y年M月d日', 'y年M月d日EEEE'],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H時mm分ss秒 zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '￥', '日本円',
-  {'CNY': ['元', '￥'], 'JPY': ['￥'], 'RON': [u, 'レイ'], 'XXX': []}, plural_ja
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '￥',
+  '日本円',
+  {'CNY': ['元', '￥'], 'JPY': ['￥'], 'RON': [u, 'レイ'], 'XXX': []},
+  'ltr',
+  plural_ja
 ];
 
 function plural_ka(n: number): number {
@@ -2508,7 +2990,9 @@ function plural_ka(n: number): number {
 }
 
 export const locale_ka = [
-  'ka', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'ka',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['კ', 'ო', 'ს', 'ო', 'ხ', 'პ', 'შ'], ['კვი', 'ორშ', 'სამ', 'ოთხ', 'ხუთ', 'პარ', 'შაბ'],
     ['კვირა', 'ორშაბათი', 'სამშაბათი', 'ოთხშაბათი', 'ხუთშაბათი', 'პარასკევი', 'შაბათი'],
@@ -2523,11 +3007,18 @@ export const locale_ka = [
       'სექტემბერი', 'ოქტომბერი', 'ნოემბერი', 'დეკემბერი'
     ]
   ],
-  u, [['ძვ. წ.', 'ახ. წ.'], u, ['ძველი წელთაღრიცხვით', 'ახალი წელთაღრიცხვით']], 1, [6, 0],
+  u,
+  [['ძვ. წ.', 'ახ. წ.'], u, ['ძველი წელთაღრიცხვით', 'ახალი წელთაღრიცხვით']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'd MMM. y', 'd MMMM, y', 'EEEE, dd MMMM, y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'არ არის რიცხვი', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '₾', 'ქართული ლარი', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '₾',
+  'ქართული ლარი',
+  {
     'AUD': [u, '$'],
     'CNY': [u, '¥'],
     'GEL': ['₾'],
@@ -2541,6 +3032,7 @@ export const locale_ka = [
     'USD': ['US$', '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_ka
 ];
 
@@ -2550,7 +3042,9 @@ function plural_kk(n: number): number {
 }
 
 export const locale_kk = [
-  'kk', [['AM', 'PM'], u, u], u,
+  'kk',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['Ж', 'Д', 'С', 'С', 'Б', 'Ж', 'С'], ['жс', 'дс', 'сс', 'ср', 'бс', 'жм', 'сб'],
     ['жексенбі', 'дүйсенбі', 'сейсенбі', 'сәрсенбі', 'бейсенбі', 'жұма', 'сенбі'],
@@ -2577,12 +3071,19 @@ export const locale_kk = [
       'Қазан', 'Қараша', 'Желтоқсан'
     ]
   ],
-  [['б.з.д.', 'б.з.'], u, ['Біздің заманымызға дейін', 'біздің заманымыз']], 1, [6, 0],
+  [['б.з.д.', 'б.з.'], u, ['Біздің заманымызға дейін', 'біздің заманымыз']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'y \'ж\'. dd MMM', 'y \'ж\'. d MMMM', 'y \'ж\'. d MMMM, EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'сан емес', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '₸', 'Қазақстан теңгесі',
-  {'JPY': ['JP¥', '¥'], 'KZT': ['₸'], 'RUB': ['₽'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_kk
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '₸',
+  'Қазақстан теңгесі',
+  {'JPY': ['JP¥', '¥'], 'KZT': ['₸'], 'RUB': ['₽'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_kk
 ];
 
 function plural_km(n: number): number {
@@ -2590,7 +3091,9 @@ function plural_km(n: number): number {
 }
 
 export const locale_km = [
-  'km', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'km',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['អ', 'ច', 'អ', 'ព', 'ព', 'ស', 'ស'], ['អាទិត្យ', 'ចន្ទ', 'អង្គារ', 'ពុធ', 'ព្រហ', 'សុក្រ', 'សៅរ៍'],
     ['អាទិត្យ', 'ច័ន្ទ', 'អង្គារ', 'ពុធ', 'ព្រហស្បតិ៍', 'សុក្រ', 'សៅរ៍'], ['អា', 'ច', 'អ', 'ពុ', 'ព្រ', 'សុ', 'ស']
@@ -2603,13 +3106,20 @@ export const locale_km = [
     ['ម', 'ក', 'ម', 'ម', 'ឧ', 'ម', 'ក', 'ស', 'ក', 'ត', 'វ', 'ធ'],
     ['មករា', 'កុម្ភៈ', 'មីនា', 'មេសា', 'ឧសភា', 'មិថុនា', 'កក្កដា', 'សីហា', 'កញ្ញា', 'តុលា', 'វិច្ឆិកា', 'ធ្នូ'], u
   ],
-  u, [['មុន គ.ស.', 'គ.ស.'], u, ['មុន​គ្រិស្តសករាជ', 'គ្រិស្តសករាជ']], 0,
-  [6, 0], ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
+  u,
+  [['មុន គ.ស.', 'គ.ស.'], u, ['មុន​គ្រិស្តសករាជ', 'គ្រិស្តសករាជ']],
+  0,
+  [6, 0],
+  ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
   ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
   ['{1}, {0}', u, '{1} នៅ​ម៉ោង {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00¤', '#E0'], '៛', 'រៀល​កម្ពុជា',
-  {'JPY': ['JP¥', '¥'], 'KHR': ['៛'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_km
+  ['#,##0.###', '#,##0%', '#,##0.00¤', '#E0'],
+  '៛',
+  'រៀល​កម្ពុជា',
+  {'JPY': ['JP¥', '¥'], 'KHR': ['៛'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_km
 ];
 
 function plural_kn(n: number): number {
@@ -2619,7 +3129,9 @@ function plural_kn(n: number): number {
 }
 
 export const locale_kn = [
-  'kn', [['ಪೂ', 'ಅ'], ['ಪೂರ್ವಾಹ್ನ', 'ಅಪರಾಹ್ನ'], u], [['ಪೂರ್ವಾಹ್ನ', 'ಅಪರಾಹ್ನ'], u, u],
+  'kn',
+  [['ಪೂ', 'ಅ'], ['ಪೂರ್ವಾಹ್ನ', 'ಅಪರಾಹ್ನ'], u],
+  [['ಪೂರ್ವಾಹ್ನ', 'ಅಪರಾಹ್ನ'], u, u],
   [
     ['ಭಾ', 'ಸೋ', 'ಮಂ', 'ಬು', 'ಗು', 'ಶು', 'ಶ'], ['ಭಾನು', 'ಸೋಮ', 'ಮಂಗಳ', 'ಬುಧ', 'ಗುರು', 'ಶುಕ್ರ', 'ಶನಿ'],
     ['ಭಾನುವಾರ', 'ಸೋಮವಾರ', 'ಮಂಗಳವಾರ', 'ಬುಧವಾರ', 'ಗುರುವಾರ', 'ಶುಕ್ರವಾರ', 'ಶನಿವಾರ'],
@@ -2642,12 +3154,19 @@ export const locale_kn = [
       'ಡಿಸೆಂಬರ್'
     ]
   ],
-  [['ಕ್ರಿ.ಪೂ', 'ಕ್ರಿ.ಶ'], u, ['ಕ್ರಿಸ್ತ ಪೂರ್ವ', 'ಕ್ರಿಸ್ತ ಶಕ']], 0, [0, 0],
+  [['ಕ್ರಿ.ಪೂ', 'ಕ್ರಿ.ಶ'], u, ['ಕ್ರಿಸ್ತ ಪೂರ್ವ', 'ಕ್ರಿಸ್ತ ಶಕ']],
+  0,
+  [0, 0],
   ['d/M/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['hh:mm a', 'hh:mm:ss a', 'hh:mm:ss a z', 'hh:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['hh:mm a', 'hh:mm:ss a', 'hh:mm:ss a z', 'hh:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '₹', 'ಭಾರತೀಯ ರೂಪಾಯಿ',
-  {'JPY': ['JP¥', '¥'], 'RON': [u, 'ಲೀ'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_kn
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '₹',
+  'ಭಾರತೀಯ ರೂಪಾಯಿ',
+  {'JPY': ['JP¥', '¥'], 'RON': [u, 'ಲೀ'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_kn
 ];
 
 function plural_ko(n: number): number {
@@ -2655,7 +3174,9 @@ function plural_ko(n: number): number {
 }
 
 export const locale_ko = [
-  'ko', [['AM', 'PM'], u, ['오전', '오후']], u,
+  'ko',
+  [['AM', 'PM'], u, ['오전', '오후']],
+  u,
   [
     ['일', '월', '화', '수', '목', '금', '토'], u,
     ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'],
@@ -2663,12 +3184,19 @@ export const locale_ko = [
   ],
   u,
   [['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'], u, u],
-  u, [['BC', 'AD'], u, ['기원전', '서기']], 0, [6, 0],
+  u,
+  [['BC', 'AD'], u, ['기원전', '서기']],
+  0,
+  [6, 0],
   ['yy. M. d.', 'y. M. d.', 'y년 M월 d일', 'y년 M월 d일 EEEE'],
-  ['a h:mm', 'a h:mm:ss', 'a h시 m분 s초 z', 'a h시 m분 s초 zzzz'], ['{1} {0}', u, u, u],
+  ['a h:mm', 'a h:mm:ss', 'a h시 m분 s초 z', 'a h시 m분 s초 zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '₩', '대한민국 원',
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '₩',
+  '대한민국 원',
   {'AUD': ['AU$', '$'], 'JPY': ['JP¥', '¥'], 'RON': [u, 'L'], 'TWD': ['NT$'], 'USD': ['US$', '$']},
+  'ltr',
   plural_ko
 ];
 
@@ -2678,7 +3206,9 @@ function plural_ky(n: number): number {
 }
 
 export const locale_ky = [
-  'ky', [['тң', 'тк'], u, ['таңкы', 'түштөн кийинки']], u,
+  'ky',
+  [['тң', 'тк'], u, ['таңкы', 'түштөн кийинки']],
+  u,
   [
     ['Ж', 'Д', 'Ш', 'Ш', 'Б', 'Ж', 'И'],
     ['жек.', 'дүй.', 'шейш.', 'шарш.', 'бейш.', 'жума', 'ишм.'],
@@ -2702,11 +3232,17 @@ export const locale_ky = [
       'Ноябрь', 'Декабрь'
     ]
   ],
-  [['б.з.ч.', 'б.з.'], u, ['биздин заманга чейин', 'биздин заман']], 1, [6, 0],
+  [['б.з.ч.', 'б.з.'], u, ['биздин заманга чейин', 'биздин заман']],
+  1,
+  [6, 0],
   ['d/M/yy', 'y-\'ж\'., d-MMM', 'y-\'ж\'., d-MMMM', 'y-\'ж\'., d-MMMM, EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'сан эмес', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'сом', 'Кыргызстан сому', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'сом',
+  'Кыргызстан сому',
+  {
     'AUD': [u, '$'],
     'BMD': [u, 'BD$'],
     'BRL': [u, 'R$'],
@@ -2732,6 +3268,7 @@ export const locale_ky = [
     'USD': [u, '$'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_ky
 ];
 
@@ -2741,7 +3278,9 @@ function plural_ln(n: number): number {
 }
 
 export const locale_ln = [
-  'ln', [['ntɔ́ngɔ́', 'mpókwa'], u, u], u,
+  'ln',
+  [['ntɔ́ngɔ́', 'mpókwa'], u, u],
+  u,
   [
     ['e', 'y', 'm', 'm', 'm', 'm', 'p'], ['eye', 'ybo', 'mbl', 'mst', 'min', 'mtn', 'mps'],
     [
@@ -2760,12 +3299,20 @@ export const locale_ln = [
       'sánzá ya zómi na mɔ̌kɔ́', 'sánzá ya zómi na míbalé'
     ]
   ],
-  u, [['libóso ya', 'nsima ya Y'], u, ['Yambo ya Yézu Krís', 'Nsima ya Yézu Krís']], 1, [6, 0],
+  u,
+  [['libóso ya', 'nsima ya Y'], u, ['Yambo ya Yézu Krís', 'Nsima ya Yézu Krís']],
+  1,
+  [6, 0],
   ['d/M/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'FC', 'Falánga ya Kongó',
-  {'CDF': ['FC'], 'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_ln
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'FC',
+  'Falánga ya Kongó',
+  {'CDF': ['FC'], 'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_ln
 ];
 
 function plural_lo(n: number): number {
@@ -2773,7 +3320,9 @@ function plural_lo(n: number): number {
 }
 
 export const locale_lo = [
-  'lo', [['ກ່ອນທ່ຽງ', 'ຫຼັງທ່ຽງ'], u, u], u,
+  'lo',
+  [['ກ່ອນທ່ຽງ', 'ຫຼັງທ່ຽງ'], u, u],
+  u,
   [
     ['ອາ', 'ຈ', 'ອ', 'ພ', 'ພຫ', 'ສຸ', 'ສ'], ['ອາທິດ', 'ຈັນ', 'ອັງຄານ', 'ພຸດ', 'ພະຫັດ', 'ສຸກ', 'ເສົາ'],
     ['ວັນອາທິດ', 'ວັນຈັນ', 'ວັນອັງຄານ', 'ວັນພຸດ', 'ວັນພະຫັດ', 'ວັນສຸກ', 'ວັນເສົາ'],
@@ -2790,15 +3339,23 @@ export const locale_lo = [
       'ທັນວາ'
     ]
   ],
-  u, [['ກ່ອນ ຄ.ສ.', 'ຄ.ສ.'], u, ['ກ່ອນຄຣິດສັກກະລາດ', 'ຄຣິດສັກກະລາດ']], 0, [6, 0],
+  u,
+  [['ກ່ອນ ຄ.ສ.', 'ຄ.ສ.'], u, ['ກ່ອນຄຣິດສັກກະລາດ', 'ຄຣິດສັກກະລາດ']],
+  0,
+  [6, 0],
   ['d/M/y', 'd MMM y', 'd MMMM y', 'EEEE ທີ d MMMM G y'],
-  ['H:mm', 'H:mm:ss', 'H ໂມງ m ນາທີ ss ວິນາທີ z', 'H ໂມງ m ນາທີ ss ວິນາທີ zzzz'], ['{1}, {0}', u, u, u],
+  ['H:mm', 'H:mm:ss', 'H ໂມງ m ນາທີ ss ວິນາທີ z', 'H ໂມງ m ນາທີ ss ວິນາທີ zzzz'],
+  ['{1}, {0}', u, u, u],
   [
     ',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞',
     'ບໍ່​ແມ່ນ​ໂຕ​ເລກ', ':'
   ],
-  ['#,##0.###', '#,##0%', '¤#,##0.00;¤-#,##0.00', '#'], '₭', 'ລາວ ກີບ',
-  {'JPY': ['JP¥', '¥'], 'LAK': ['₭'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']}, plural_lo
+  ['#,##0.###', '#,##0%', '¤#,##0.00;¤-#,##0.00', '#'],
+  '₭',
+  'ລາວ ກີບ',
+  {'JPY': ['JP¥', '¥'], 'LAK': ['₭'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_lo
 ];
 
 function plural_lt(n: number): number {
@@ -2812,7 +3369,9 @@ function plural_lt(n: number): number {
 }
 
 export const locale_lt = [
-  'lt', [['pr. p.', 'pop.'], ['priešpiet', 'popiet'], u], u,
+  'lt',
+  [['pr. p.', 'pop.'], ['priešpiet', 'popiet'], u],
+  u,
   [
     ['S', 'P', 'A', 'T', 'K', 'P', 'Š'], ['sk', 'pr', 'an', 'tr', 'kt', 'pn', 'št'],
     [
@@ -2844,11 +3403,17 @@ export const locale_lt = [
       'rugsėjis', 'spalis', 'lapkritis', 'gruodis'
     ]
   ],
-  [['pr. Kr.', 'po Kr.'], u, ['prieš Kristų', 'po Kristaus']], 1, [6, 0],
+  [['pr. Kr.', 'po Kr.'], u, ['prieš Kristų', 'po Kristaus']],
+  1,
+  [6, 0],
   ['y-MM-dd', u, 'y \'m\'. MMMM d \'d\'.', 'y \'m\'. MMMM d \'d\'., EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '−', '×10^', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'Euras', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'Euras',
+  {
     'AUD': [u, '$'],
     'BDT': [],
     'BRL': [u, 'R$'],
@@ -2877,6 +3442,7 @@ export const locale_lt = [
     'XOF': [],
     'XPF': []
   },
+  'ltr',
   plural_lt
 ];
 
@@ -2893,7 +3459,8 @@ function plural_lv(n: number): number {
 }
 
 export const locale_lv = [
-  'lv', [['priekšp.', 'pēcp.'], u, ['priekšpusdienā', 'pēcpusdienā']],
+  'lv',
+  [['priekšp.', 'pēcp.'], u, ['priekšpusdienā', 'pēcpusdienā']],
   [['priekšp.', 'pēcpusd.'], u, ['priekšpusdiena', 'pēcpusdiena']],
   [
     ['S', 'P', 'O', 'T', 'C', 'P', 'S'],
@@ -2918,12 +3485,20 @@ export const locale_lv = [
       'septembris', 'oktobris', 'novembris', 'decembris'
     ]
   ],
-  u, [['p.m.ē.', 'm.ē.'], u, ['pirms mūsu ēras', 'mūsu ērā']], 1, [6, 0],
+  u,
+  [['p.m.ē.', 'm.ē.'], u, ['pirms mūsu ēras', 'mūsu ērā']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'y. \'gada\' d. MMM', 'y. \'gada\' d. MMMM', 'EEEE, y. \'gada\' d. MMMM'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NS', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'eiro',
-  {'AUD': ['AU$', '$'], 'LVL': ['Ls'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_lv
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'eiro',
+  {'AUD': ['AU$', '$'], 'LVL': ['Ls'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_lv
 ];
 
 function plural_mk(n: number): number {
@@ -2934,7 +3509,9 @@ function plural_mk(n: number): number {
 }
 
 export const locale_mk = [
-  'mk', [['претпл.', 'попл.'], u, ['претпладне', 'попладне']], u,
+  'mk',
+  [['претпл.', 'попл.'], u, ['претпладне', 'попладне']],
+  u,
   [
     ['н', 'п', 'в', 'с', 'ч', 'п', 'с'], ['нед.', 'пон.', 'вт.', 'сре.', 'чет.', 'пет.', 'саб.'],
     ['недела', 'понеделник', 'вторник', 'среда', 'четврток', 'петок', 'сабота'],
@@ -2956,11 +3533,18 @@ export const locale_mk = [
       'октомври', 'ноември', 'декември'
     ]
   ],
-  u, [['пр.н.е.', 'н.е.'], u, ['пред нашата ера', 'од нашата ера']], 1, [6, 0],
+  u,
+  [['пр.н.е.', 'н.е.'], u, ['пред нашата ера', 'од нашата ера']],
+  1,
+  [6, 0],
   ['d.M.yy', 'd.M.y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'ден.', 'Македонски денар', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'ден.',
+  'Македонски денар',
+  {
     'AUD': [u, '$'],
     'CNY': [u, '¥'],
     'GBP': [u, '£'],
@@ -2975,6 +3559,7 @@ export const locale_mk = [
     'USD': ['US$', '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_mk
 ];
 
@@ -2984,7 +3569,9 @@ function plural_ml(n: number): number {
 }
 
 export const locale_ml = [
-  'ml', [['AM', 'PM'], u, u], u,
+  'ml',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['ഞ', 'തി', 'ചൊ', 'ബു', 'വ്യാ', 'വെ', 'ശ'],
     ['ഞായർ', 'തിങ്കൾ', 'ചൊവ്വ', 'ബുധൻ', 'വ്യാഴം', 'വെള്ളി', 'ശനി'],
@@ -3011,11 +3598,19 @@ export const locale_ml = [
       'നവംബർ', 'ഡിസംബർ'
     ]
   ],
-  u, [['ക്രി.മു.', 'എഡി'], u, ['ക്രിസ്\u200cതുവിന് മുമ്പ്', 'ആന്നോ ഡൊമിനി']], 0, [0, 0],
+  u,
+  [['ക്രി.മു.', 'എഡി'], u, ['ക്രിസ്\u200cതുവിന് മുമ്പ്', 'ആന്നോ ഡൊമിനി']],
+  0,
+  [0, 0],
   ['d/M/yy', 'y, MMM d', 'y, MMMM d', 'y, MMMM d, EEEE'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '₹', 'ഇന്ത്യൻ രൂപ', {'THB': ['฿'], 'TWD': ['NT$']},
+  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '₹',
+  'ഇന്ത്യൻ രൂപ',
+  {'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
   plural_ml
 ];
 
@@ -3025,7 +3620,9 @@ function plural_mn(n: number): number {
 }
 
 export const locale_mn = [
-  'mn', [['ү.ө.', 'ү.х.'], u, u], u,
+  'mn',
+  [['ү.ө.', 'ү.х.'], u, u],
+  u,
   [
     ['Ня', 'Да', 'Мя', 'Лх', 'Пү', 'Ба', 'Бя'], u,
     ['ням', 'даваа', 'мягмар', 'лхагва', 'пүрэв', 'баасан', 'бямба'],
@@ -3060,15 +3657,22 @@ export const locale_mn = [
       'Арван нэгдүгээр сар', 'Арван хоёрдугаар сар'
     ]
   ],
-  [['МЭӨ', 'МЭ'], u, ['манай эриний өмнөх', 'манай эриний']], 1, [6, 0],
+  [['МЭӨ', 'МЭ'], u, ['манай эриний өмнөх', 'манай эриний']],
+  1,
+  [6, 0],
   [
     'y.MM.dd', 'y \'оны\' MMM\'ын\' d', 'y \'оны\' MMMM\'ын\' d',
     'y \'оны\' MMMM\'ын\' d, EEEE \'гараг\''
   ],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss (z)', 'HH:mm:ss (zzzz)'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss (z)', 'HH:mm:ss (zzzz)'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], '₮', 'Монгол төгрөг',
-  {'JPY': ['JP¥', '¥'], 'MNT': ['₮'], 'SEK': [u, 'кр'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_mn
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  '₮',
+  'Монгол төгрөг',
+  {'JPY': ['JP¥', '¥'], 'MNT': ['₮'], 'SEK': [u, 'кр'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_mn
 ];
 
 function plural_mo(n: number): number {
@@ -3081,7 +3685,9 @@ function plural_mo(n: number): number {
 }
 
 export const locale_mo = [
-  'ro-MD', [['a.m.', 'p.m.'], u, u], u,
+  'ro-MD',
+  [['a.m.', 'p.m.'], u, u],
+  u,
   [
     ['D', 'L', 'Ma', 'Mi', 'J', 'V', 'S'], ['Dum', 'Lun', 'Mar', 'Mie', 'Joi', 'Vin', 'Sâm'],
     ['duminică', 'luni', 'marți', 'miercuri', 'joi', 'vineri', 'sâmbătă'],
@@ -3098,11 +3704,18 @@ export const locale_mo = [
       'octombrie', 'noiembrie', 'decembrie'
     ]
   ],
-  u, [['î.Hr.', 'd.Hr.'], u, ['înainte de Hristos', 'după Hristos']], 1, [6, 0],
+  u,
+  [['î.Hr.', 'd.Hr.'], u, ['înainte de Hristos', 'după Hristos']],
+  1,
+  [6, 0],
   ['dd.MM.y', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'L', 'leu moldovenesc', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'L',
+  'leu moldovenesc',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -3122,6 +3735,7 @@ export const locale_mo = [
     'VND': [u, '₫'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_mo
 ];
 
@@ -3132,7 +3746,9 @@ function plural_mr(n: number): number {
 }
 
 export const locale_mr = [
-  'mr', [['स', 'सं'], ['म.पू.', 'म.उ.'], u], [['म.पू.', 'म.उ.'], u, u],
+  'mr',
+  [['स', 'सं'], ['म.पू.', 'म.उ.'], u],
+  [['म.पू.', 'म.उ.'], u, u],
   [
     ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'], ['रवि', 'सोम', 'मंगळ', 'बुध', 'गुरु', 'शुक्र', 'शनि'],
     ['रविवार', 'सोमवार', 'मंगळवार', 'बुधवार', 'गुरुवार', 'शुक्रवार', 'शनिवार'],
@@ -3147,12 +3763,20 @@ export const locale_mr = [
       'डिसेंबर'
     ]
   ],
-  u, [['इ. स. पू.', 'इ. स.'], u, ['ईसवीसनपूर्व', 'ईसवीसन']], 0, [0, 0],
+  u,
+  [['इ. स. पू.', 'इ. स.'], u, ['ईसवीसनपूर्व', 'ईसवीसन']],
+  0,
+  [0, 0],
   ['d/M/yy', 'd MMM, y', 'd MMMM, y', 'EEEE, d MMMM, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} रोजी {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} रोजी {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '[#E0]'], '₹', 'भारतीय रुपया',
-  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_mr
+  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '[#E0]'],
+  '₹',
+  'भारतीय रुपया',
+  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_mr
 ];
 
 function plural_ms(n: number): number {
@@ -3160,7 +3784,9 @@ function plural_ms(n: number): number {
 }
 
 export const locale_ms = [
-  'ms', [['a', 'p'], ['PG', 'PTG'], u], u,
+  'ms',
+  [['a', 'p'], ['PG', 'PTG'], u],
+  u,
   [
     ['A', 'I', 'S', 'R', 'K', 'J', 'S'], ['Ahd', 'Isn', 'Sel', 'Rab', 'Kha', 'Jum', 'Sab'],
     ['Ahad', 'Isnin', 'Selasa', 'Rabu', 'Khamis', 'Jumaat', 'Sabtu'],
@@ -3175,10 +3801,18 @@ export const locale_ms = [
       'November', 'Disember'
     ]
   ],
-  u, [['S.M.', 'TM'], u, u], 1, [6, 0], ['d/MM/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} {0}', u],
+  u,
+  [['S.M.', 'TM'], u, u],
+  1,
+  [6, 0],
+  ['d/MM/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'RM', 'Ringgit Malaysia', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'RM',
+  'Ringgit Malaysia',
+  {
     'CAD': [u, '$'],
     'JPY': ['JP¥', '¥'],
     'MXN': [u, '$'],
@@ -3186,6 +3820,7 @@ export const locale_ms = [
     'TWD': ['NT$'],
     'USD': [u, '$']
   },
+  'ltr',
   plural_ms
 ];
 
@@ -3197,7 +3832,9 @@ function plural_mt(n: number): number {
 }
 
 export const locale_mt = [
-  'mt', [['am', 'pm'], ['AM', 'PM'], u], u,
+  'mt',
+  [['am', 'pm'], ['AM', 'PM'], u],
+  u,
   [
     ['Ħd', 'T', 'Tl', 'Er', 'Ħm', 'Ġm', 'Sb'], ['Ħad', 'Tne', 'Tli', 'Erb', 'Ħam', 'Ġim', 'Sib'],
     ['Il-Ħadd', 'It-Tnejn', 'It-Tlieta', 'L-Erbgħa', 'Il-Ħamis', 'Il-Ġimgħa', 'Is-Sibt'],
@@ -3224,12 +3861,19 @@ export const locale_mt = [
       'Ottubru', 'Novembru', 'Diċembru'
     ]
   ],
-  [['QK', 'WK'], u, ['Qabel Kristu', 'Wara Kristu']], 0, [6, 0],
+  [['QK', 'WK'], u, ['Qabel Kristu', 'Wara Kristu']],
+  0,
+  [6, 0],
   ['dd/MM/y', 'dd MMM y', 'd \'ta\'’ MMMM y', 'EEEE, d \'ta\'’ MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '€', 'ewro',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']}, plural_mt
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '€',
+  'ewro',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_mt
 ];
 
 function plural_my(n: number): number {
@@ -3237,7 +3881,9 @@ function plural_my(n: number): number {
 }
 
 export const locale_my = [
-  'my', [['နံနက်', 'ညနေ'], u, u], u,
+  'my',
+  [['နံနက်', 'ညနေ'], u, u],
+  u,
   [
     ['တ', 'တ', 'အ', 'ဗ', 'က', 'သ', 'စ'],
     ['တနင်္ဂနွေ', 'တနင်္လာ', 'အင်္ဂါ', 'ဗုဒ္ဓဟူး', 'ကြာသပတေး', 'သောကြာ', 'စနေ'], u, u
@@ -3251,11 +3897,18 @@ export const locale_my = [
       'ဒီဇင်ဘာ'
     ]
   ],
-  u, [['ဘီစီ', 'အဒေီ'], u, ['ခရစ်တော် မပေါ်မီနှစ်', 'ခရစ်နှစ်']], 0, [6, 0],
+  u,
+  [['ဘီစီ', 'အဒေီ'], u, ['ခရစ်တော် မပေါ်မီနှစ်', 'ခရစ်နှစ်']],
+  0,
+  [6, 0],
   ['dd-MM-yy', 'y၊ MMM d', 'y၊ d MMMM', 'y၊ MMMM d၊ EEEE'],
-  ['B H:mm', 'B HH:mm:ss', 'z HH:mm:ss', 'zzzz HH:mm:ss'], ['{1} {0}', u, u, u],
+  ['B H:mm', 'B HH:mm:ss', 'z HH:mm:ss', 'zzzz HH:mm:ss'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'ဂဏန်းမဟုတ်သော', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'K', 'မြန်မာ ကျပ်', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'K',
+  'မြန်မာ ကျပ်',
+  {
     'ANG': ['NAf'],
     'AWG': ['Afl'],
     'BBD': [u, 'Bds$'],
@@ -3268,6 +3921,7 @@ export const locale_my = [
     'TTD': ['TT$', '$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_my
 ];
 
@@ -3277,7 +3931,9 @@ function plural_ne(n: number): number {
 }
 
 export const locale_ne = [
-  'ne', [['पूर्वाह्न', 'अपराह्न'], u, u], u,
+  'ne',
+  [['पूर्वाह्न', 'अपराह्न'], u, u],
+  u,
   [
     ['आ', 'सो', 'म', 'बु', 'बि', 'शु', 'श'], ['आइत', 'सोम', 'मङ्गल', 'बुध', 'बिहि', 'शुक्र', 'शनि'],
     ['आइतबार', 'सोमबार', 'मङ्गलबार', 'बुधबार', 'बिहिबार', 'शुक्रबार', 'शनिबार'],
@@ -3300,11 +3956,19 @@ export const locale_ne = [
     ],
     u
   ],
-  [['ईसा पूर्व', 'सन्'], u, u], 0, [6, 0], ['yy/M/d', 'y MMM d', 'y MMMM d', 'y MMMM d, EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} {0}', u],
+  [['ईसा पूर्व', 'सन्'], u, u],
+  0,
+  [6, 0],
+  ['yy/M/d', 'y MMM d', 'y MMMM d', 'y MMMM d, EEEE'],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'नेरू', 'नेपाली रूपैयाँ',
-  {'JPY': ['JP¥', '¥'], 'NPR': ['नेरू', 'रू'], 'THB': ['฿'], 'USD': ['US$', '$']}, plural_ne
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'नेरू',
+  'नेपाली रूपैयाँ',
+  {'JPY': ['JP¥', '¥'], 'NPR': ['नेरू', 'रू'], 'THB': ['฿'], 'USD': ['US$', '$']},
+  'ltr',
+  plural_ne
 ];
 
 function plural_nl(n: number): number {
@@ -3314,7 +3978,9 @@ function plural_nl(n: number): number {
 }
 
 export const locale_nl = [
-  'nl', [['a.m.', 'p.m.'], u, u], u,
+  'nl',
+  [['a.m.', 'p.m.'], u, u],
+  u,
   [
     ['Z', 'M', 'D', 'W', 'D', 'V', 'Z'], ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
     ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
@@ -3329,11 +3995,18 @@ export const locale_nl = [
       'oktober', 'november', 'december'
     ]
   ],
-  u, [['v.C.', 'n.C.'], ['v.Chr.', 'n.Chr.'], ['voor Christus', 'na Christus']], 1, [6, 0],
+  u,
+  [['v.C.', 'n.C.'], ['v.Chr.', 'n.Chr.'], ['voor Christus', 'na Christus']],
+  1,
+  [6, 0],
   ['dd-MM-y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, '{1} \'om\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, '{1} \'om\' {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00;¤ -#,##0.00', '#E0'], '€', 'Euro', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00;¤ -#,##0.00', '#E0'],
+  '€',
+  'Euro',
+  {
     'AUD': ['AU$', '$'],
     'CAD': ['C$', '$'],
     'FJD': ['FJ$', '$'],
@@ -3345,6 +4018,7 @@ export const locale_nl = [
     'XPF': [],
     'XXX': []
   },
+  'ltr',
   plural_nl
 ];
 
@@ -3354,7 +4028,9 @@ function plural_no(n: number): number {
 }
 
 export const locale_no = [
-  'nb', [['a', 'p'], ['a.m.', 'p.m.'], u], [['a.m.', 'p.m.'], u, u],
+  'nb',
+  [['a', 'p'], ['a.m.', 'p.m.'], u],
+  [['a.m.', 'p.m.'], u, u],
   [
     ['S', 'M', 'T', 'O', 'T', 'F', 'L'], ['søn.', 'man.', 'tir.', 'ons.', 'tor.', 'fre.', 'lør.'],
     ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
@@ -3377,12 +4053,17 @@ export const locale_no = [
       'november', 'desember'
     ]
   ],
-  [['f.Kr.', 'e.Kr.'], u, ['før Kristus', 'etter Kristus']], 1, [6, 0],
+  [['f.Kr.', 'e.Kr.'], u, ['før Kristus', 'etter Kristus']],
+  1,
+  [6, 0],
   ['dd.MM.y', 'd. MMM y', 'd. MMMM y', 'EEEE d. MMMM y'],
   ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
   ['{1}, {0}', u, '{1} \'kl\'. {0}', '{1} {0}'],
   [',', ' ', ';', '%', '+', '−', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '¤ #,##0.00', '#E0'], 'kr', 'norske kroner', {
+  ['#,##0.###', '#,##0 %', '¤ #,##0.00', '#E0'],
+  'kr',
+  'norske kroner',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -3404,6 +4085,7 @@ export const locale_no = [
     'XPF': [],
     'XXX': []
   },
+  'ltr',
   plural_no
 ];
 
@@ -3413,7 +4095,9 @@ function plural_or(n: number): number {
 }
 
 export const locale_or = [
-  'or', [['ପୂ', 'ଅ'], ['AM', 'PM'], u], [['AM', 'ଅପରାହ୍ନ'], ['ପୂର୍ବାହ୍ନ', 'ଅପରାହ୍ନ'], u],
+  'or',
+  [['ପୂ', 'ଅ'], ['AM', 'PM'], u],
+  [['AM', 'ଅପରାହ୍ନ'], ['ପୂର୍ବାହ୍ନ', 'ଅପରାହ୍ନ'], u],
   [
     ['ର', 'ସୋ', 'ମ', 'ବୁ', 'ଗୁ', 'ଶୁ', 'ଶ'], ['ରବି', 'ସୋମ', 'ମଙ୍ଗଳ', 'ବୁଧ', 'ଗୁରୁ', 'ଶୁକ୍ର', 'ଶନି'],
     ['ରବିବାର', 'ସୋମବାର', 'ମଙ୍ଗଳବାର', 'ବୁଧବାର', 'ଗୁରୁବାର', 'ଶୁକ୍ରବାର', 'ଶନିବାର'],
@@ -3428,11 +4112,20 @@ export const locale_or = [
     ],
     u
   ],
-  u, [['BC', 'AD'], u, ['ଖ୍ରୀଷ୍ଟପୂର୍ବ', 'ଖ୍ରୀଷ୍ଟାବ୍ଦ']], 0, [0, 0],
+  u,
+  [['BC', 'AD'], u, ['ଖ୍ରୀଷ୍ଟପୂର୍ବ', 'ଖ୍ରୀଷ୍ଟାବ୍ଦ']],
+  0,
+  [0, 0],
   ['M/d/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{0} ଠାରେ {1}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{0} ଠାରେ {1}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '₹', 'ଭାରତୀୟ ଟଙ୍କା', {}, plural_or
+  ['#,##,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '₹',
+  'ଭାରତୀୟ ଟଙ୍କା',
+  {},
+  'ltr',
+  plural_or
 ];
 
 function plural_pa(n: number): number {
@@ -3441,7 +4134,9 @@ function plural_pa(n: number): number {
 }
 
 export const locale_pa = [
-  'pa', [['ਸ.', 'ਸ਼.'], ['ਪੂ.ਦੁ.', 'ਬਾ.ਦੁ.'], u], [['ਪੂ.ਦੁ.', 'ਬਾ.ਦੁ.'], u, u],
+  'pa',
+  [['ਸ.', 'ਸ਼.'], ['ਪੂ.ਦੁ.', 'ਬਾ.ਦੁ.'], u],
+  [['ਪੂ.ਦੁ.', 'ਬਾ.ਦੁ.'], u, u],
   [
     ['ਐ', 'ਸੋ', 'ਮੰ', 'ਬੁੱ', 'ਵੀ', 'ਸ਼ੁੱ', 'ਸ਼'], ['ਐਤ', 'ਸੋਮ', 'ਮੰਗਲ', 'ਬੁੱਧ', 'ਵੀਰ', 'ਸ਼ੁੱਕਰ', 'ਸ਼ਨਿੱਚਰ'],
     ['ਐਤਵਾਰ', 'ਸੋਮਵਾਰ', 'ਮੰਗਲਵਾਰ', 'ਬੁੱਧਵਾਰ', 'ਵੀਰਵਾਰ', 'ਸ਼ੁੱਕਰਵਾਰ', 'ਸ਼ਨਿੱਚਰਵਾਰ'],
@@ -3455,12 +4150,20 @@ export const locale_pa = [
       'ਜਨਵਰੀ', 'ਫ਼ਰਵਰੀ', 'ਮਾਰਚ', 'ਅਪ੍ਰੈਲ', 'ਮਈ', 'ਜੂਨ', 'ਜੁਲਾਈ', 'ਅਗਸਤ', 'ਸਤੰਬਰ', 'ਅਕਤੂਬਰ', 'ਨਵੰਬਰ', 'ਦਸੰਬਰ'
     ]
   ],
-  u, [['ਈ.ਪੂ.', 'ਸੰਨ'], ['ਈ. ਪੂ.', 'ਸੰਨ'], ['ਈਸਵੀ ਪੂਰਵ', 'ਈਸਵੀ ਸੰਨ']], 0, [0, 0],
+  u,
+  [['ਈ.ਪੂ.', 'ਸੰਨ'], ['ਈ. ਪੂ.', 'ਸੰਨ'], ['ਈਸਵੀ ਪੂਰਵ', 'ਈਸਵੀ ਸੰਨ']],
+  0,
+  [0, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '¤ #,##,##0.00', '[#E0]'], '₹', 'ਭਾਰਤੀ ਰੁਪਇਆ',
-  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$'], 'XXX': []}, plural_pa
+  ['#,##,##0.###', '#,##,##0%', '¤ #,##,##0.00', '[#E0]'],
+  '₹',
+  'ਭਾਰਤੀ ਰੁਪਇਆ',
+  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$'], 'XXX': []},
+  'ltr',
+  plural_pa
 ];
 
 function plural_pl(n: number): number {
@@ -3477,7 +4180,9 @@ function plural_pl(n: number): number {
 }
 
 export const locale_pl = [
-  'pl', [['a', 'p'], ['AM', 'PM'], u], u,
+  'pl',
+  [['a', 'p'], ['AM', 'PM'], u],
+  u,
   [
     ['n', 'p', 'w', 'ś', 'c', 'p', 's'], ['niedz.', 'pon.', 'wt.', 'śr.', 'czw.', 'pt.', 'sob.'],
     ['niedziela', 'poniedziałek', 'wtorek', 'środa', 'czwartek', 'piątek', 'sobota'],
@@ -3504,11 +4209,17 @@ export const locale_pl = [
       'październik', 'listopad', 'grudzień'
     ]
   ],
-  [['p.n.e.', 'n.e.'], u, ['przed naszą erą', 'naszej ery']], 1, [6, 0],
+  [['p.n.e.', 'n.e.'], u, ['przed naszą erą', 'naszej ery']],
+  1,
+  [6, 0],
   ['dd.MM.y', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'zł', 'złoty polski', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'zł',
+  'złoty polski',
+  {
     'AUD': [u, '$'],
     'CAD': [u, '$'],
     'CNY': [u, '¥'],
@@ -3526,6 +4237,7 @@ export const locale_pl = [
     'USD': [u, '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_pl
 ];
 
@@ -3536,7 +4248,9 @@ function plural_pt(n: number): number {
 }
 
 export const locale_pt = [
-  'pt', [['AM', 'PM'], u, u], u,
+  'pt',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['D', 'S', 'T', 'Q', 'Q', 'S', 'S'], ['dom.', 'seg.', 'ter.', 'qua.', 'qui.', 'sex.', 'sáb.'],
     [
@@ -3556,11 +4270,18 @@ export const locale_pt = [
       'outubro', 'novembro', 'dezembro'
     ]
   ],
-  u, [['a.C.', 'd.C.'], u, ['antes de Cristo', 'depois de Cristo']], 0, [6, 0],
+  u,
+  [['a.C.', 'd.C.'], u, ['antes de Cristo', 'depois de Cristo']],
+  0,
+  [6, 0],
   ['dd/MM/y', 'd \'de\' MMM \'de\' y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'R$', 'Real brasileiro', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'R$',
+  'Real brasileiro',
+  {
     'AUD': ['AU$', '$'],
     'JPY': ['JP¥', '¥'],
     'PTE': ['Esc.'],
@@ -3570,6 +4291,7 @@ export const locale_pt = [
     'TWD': ['NT$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_pt
 ];
 
@@ -3580,7 +4302,8 @@ function plural_pt_PT(n: number): number {
 }
 
 export const locale_pt_PT = [
-  'pt-PT', [['a.m.', 'p.m.'], u, ['da manhã', 'da tarde']],
+  'pt-PT',
+  [['a.m.', 'p.m.'], u, ['da manhã', 'da tarde']],
   [['a.m.', 'p.m.'], u, ['manhã', 'tarde']],
   [
     ['D', 'S', 'T', 'Q', 'Q', 'S', 'S'],
@@ -3602,11 +4325,18 @@ export const locale_pt_PT = [
       'outubro', 'novembro', 'dezembro'
     ]
   ],
-  u, [['a.C.', 'd.C.'], u, ['antes de Cristo', 'depois de Cristo']], 0, [6, 0],
+  u,
+  [['a.C.', 'd.C.'], u, ['antes de Cristo', 'depois de Cristo']],
+  0,
+  [6, 0],
   ['dd/MM/yy', 'dd/MM/y', 'd \'de\' MMMM \'de\' y', 'EEEE, d \'de\' MMMM \'de\' y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'às\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'às\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AUD': ['AU$', '$'],
     'JPY': ['JP¥', '¥'],
     'PTE': ['​'],
@@ -3615,6 +4345,7 @@ export const locale_pt_PT = [
     'TWD': ['NT$'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_pt_PT
 ];
 
@@ -3628,7 +4359,9 @@ function plural_ro(n: number): number {
 }
 
 export const locale_ro = [
-  'ro', [['a.m.', 'p.m.'], u, u], u,
+  'ro',
+  [['a.m.', 'p.m.'], u, u],
+  u,
   [
     ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dum.', 'lun.', 'mar.', 'mie.', 'joi', 'vin.', 'sâm.'],
     ['duminică', 'luni', 'marți', 'miercuri', 'joi', 'vineri', 'sâmbătă'],
@@ -3645,11 +4378,18 @@ export const locale_ro = [
       'octombrie', 'noiembrie', 'decembrie'
     ]
   ],
-  u, [['î.Hr.', 'd.Hr.'], u, ['înainte de Hristos', 'după Hristos']], 1, [6, 0],
+  u,
+  [['î.Hr.', 'd.Hr.'], u, ['înainte de Hristos', 'după Hristos']],
+  1,
+  [6, 0],
   ['dd.MM.y', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'RON', 'leu românesc', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'RON',
+  'leu românesc',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -3668,6 +4408,7 @@ export const locale_ro = [
     'VND': [u, '₫'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_ro
 ];
 
@@ -3685,7 +4426,9 @@ function plural_ru(n: number): number {
 }
 
 export const locale_ru = [
-  'ru', [['AM', 'PM'], u, u], u,
+  'ru',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'], u,
     ['воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота'],
@@ -3719,10 +4462,16 @@ export const locale_ru = [
     ]
   ],
   [['до н.э.', 'н.э.'], ['до н. э.', 'н. э.'], ['до Рождества Христова', 'от Рождества Христова']],
-  1, [6, 0], ['dd.MM.y', 'd MMM y \'г\'.', 'd MMMM y \'г\'.', 'EEEE, d MMMM y \'г\'.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, u, u],
+  1,
+  [6, 0],
+  ['dd.MM.y', 'd MMM y \'г\'.', 'd MMMM y \'г\'.', 'EEEE, d MMMM y \'г\'.'],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'не число', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '₽', 'российский рубль', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '₽',
+  'российский рубль',
+  {
     'GEL': [u, 'ლ'],
     'RON': [u, 'L'],
     'RUB': ['₽'],
@@ -3733,6 +4482,7 @@ export const locale_ru = [
     'UAH': ['₴'],
     'XXX': ['XXXX']
   },
+  'ltr',
   plural_ru
 ];
 
@@ -3741,7 +4491,9 @@ function plural_sh(n: number): number {
 }
 
 export const locale_sh = [
-  'sr-Latn', [['a', 'p'], ['pre podne', 'po podne'], u], [['pre podne', 'po podne'], u, u],
+  'sr-Latn',
+  [['a', 'p'], ['pre podne', 'po podne'], u],
+  [['pre podne', 'po podne'], u, u],
   [
     ['n', 'p', 'u', 's', 'č', 'p', 's'], ['ned', 'pon', 'uto', 'sre', 'čet', 'pet', 'sub'],
     ['nedelja', 'ponedeljak', 'utorak', 'sreda', 'četvrtak', 'petak', 'subota'],
@@ -3756,11 +4508,18 @@ export const locale_sh = [
       'novembar', 'decembar'
     ]
   ],
-  u, [['p.n.e.', 'n.e.'], ['p. n. e.', 'n. e.'], ['pre nove ere', 'nove ere']], 1, [6, 0],
+  u,
+  [['p.n.e.', 'n.e.'], ['p. n. e.', 'n. e.'], ['pre nove ere', 'nove ere']],
+  1,
+  [6, 0],
   ['d.M.yy.', 'dd.MM.y.', 'dd. MMMM y.', 'EEEE, dd. MMMM y.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'RSD', 'Srpski dinar', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'RSD',
+  'Srpski dinar',
+  {
     'AUD': [u, '$'],
     'BAM': ['KM'],
     'BYN': [u, 'r.'],
@@ -3771,6 +4530,7 @@ export const locale_sh = [
     'USD': ['US$', '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_sh
 ];
 
@@ -3781,7 +4541,9 @@ function plural_si(n: number): number {
 }
 
 export const locale_si = [
-  'si', [['පෙ', 'ප'], ['පෙ.ව.', 'ප.ව.'], u], [['පෙ.ව.', 'ප.ව.'], u, u],
+  'si',
+  [['පෙ', 'ප'], ['පෙ.ව.', 'ප.ව.'], u],
+  [['පෙ.ව.', 'ප.ව.'], u, u],
   [
     ['ඉ', 'ස', 'අ', 'බ', 'බ්\u200dර', 'සි', 'සෙ'],
     ['ඉරිදා', 'සඳුදා', 'අඟහ', 'බදාදා', 'බ්\u200dරහස්', 'සිකු', 'සෙන'],
@@ -3805,11 +4567,17 @@ export const locale_si = [
       'නොවැම්බර්', 'දෙසැම්බර්'
     ]
   ],
-  [['ක්\u200dරි.පූ.', 'ක්\u200dරි.ව.'], u, ['ක්\u200dරිස්තු පූර්ව', 'ක්\u200dරිස්තු වර්ෂ']], 1, [6, 0],
+  [['ක්\u200dරි.පූ.', 'ක්\u200dරි.ව.'], u, ['ක්\u200dරිස්තු පූර්ව', 'ක්\u200dරිස්තු වර්ෂ']],
+  1,
+  [6, 0],
   ['y-MM-dd', 'y MMM d', 'y MMMM d', 'y MMMM d, EEEE'],
-  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', '.'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#'], 'රු.', 'ශ්\u200dරී ලංකා රුපියල', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#'],
+  'රු.',
+  'ශ්\u200dරී ලංකා රුපියල',
+  {
     'JPY': ['JP¥', '¥'],
     'LKR': ['රු.'],
     'THB': ['฿'],
@@ -3817,6 +4585,7 @@ export const locale_si = [
     'USD': ['US$', '$'],
     'XOF': ['සිෆ්එ']
   },
+  'ltr',
   plural_si
 ];
 
@@ -3829,7 +4598,9 @@ function plural_sk(n: number): number {
 }
 
 export const locale_sk = [
-  'sk', [['AM', 'PM'], u, u], u,
+  'sk',
+  [['AM', 'PM'], u, u],
+  u,
   [
     ['n', 'p', 'u', 's', 'š', 'p', 's'], ['ne', 'po', 'ut', 'st', 'št', 'pi', 'so'],
     ['nedeľa', 'pondelok', 'utorok', 'streda', 'štvrtok', 'piatok', 'sobota'],
@@ -3852,10 +4623,17 @@ export const locale_sk = [
       'november', 'december'
     ]
   ],
-  [['pred Kr.', 'po Kr.'], u, ['pred Kristom', 'po Kristovi']], 1, [6, 0],
-  ['d. M. y', u, 'd. MMMM y', 'EEEE d. MMMM y'], ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
-  ['{1} {0}', '{1}, {0}', u, u], [',', ' ', ';', '%', '+', '-', 'e', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'euro', {
+  [['pred Kr.', 'po Kr.'], u, ['pred Kristom', 'po Kristovi']],
+  1,
+  [6, 0],
+  ['d. M. y', u, 'd. MMMM y', 'EEEE d. MMMM y'],
+  ['H:mm', 'H:mm:ss', 'H:mm:ss z', 'H:mm:ss zzzz'],
+  ['{1} {0}', '{1}, {0}', u, u],
+  [',', ' ', ';', '%', '+', '-', 'e', '×', '‰', '∞', 'NaN', ':'],
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'euro',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -3872,6 +4650,7 @@ export const locale_sk = [
     'VND': [u, '₫'],
     'XXX': []
   },
+  'ltr',
   plural_sk
 ];
 
@@ -3885,7 +4664,9 @@ function plural_sl(n: number): number {
 }
 
 export const locale_sl = [
-  'sl', [['d', 'p'], ['dop.', 'pop.'], u], [['d', 'p'], ['dop.', 'pop.'], ['dopoldne', 'popoldne']],
+  'sl',
+  [['d', 'p'], ['dop.', 'pop.'], u],
+  [['d', 'p'], ['dop.', 'pop.'], ['dopoldne', 'popoldne']],
   [
     ['n', 'p', 't', 's', 'č', 'p', 's'], ['ned.', 'pon.', 'tor.', 'sre.', 'čet.', 'pet.', 'sob.'],
     ['nedelja', 'ponedeljek', 'torek', 'sreda', 'četrtek', 'petek', 'sobota'],
@@ -3900,11 +4681,18 @@ export const locale_sl = [
       'oktober', 'november', 'december'
     ]
   ],
-  u, [['pr. Kr.', 'po Kr.'], u, ['pred Kristusom', 'po Kristusu']], 1, [6, 0],
+  u,
+  [['pr. Kr.', 'po Kr.'], u, ['pred Kristusom', 'po Kristusu']],
+  1,
+  [6, 0],
   ['d. MM. yy', 'd. MMM y', 'dd. MMMM y', 'EEEE, dd. MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '−', 'e', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], '€', 'evro', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  '€',
+  'evro',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -3914,6 +4702,7 @@ export const locale_sl = [
     'TWD': [u, 'NT$'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_sl
 ];
 
@@ -3923,7 +4712,8 @@ function plural_sq(n: number): number {
 }
 
 export const locale_sq = [
-  'sq', [['p.d.', 'm.d.'], u, ['e paradites', 'e pasdites']],
+  'sq',
+  [['p.d.', 'm.d.'], u, ['e paradites', 'e pasdites']],
   [['p.d.', 'm.d.'], u, ['paradite', 'pasdite']],
   [
     ['d', 'h', 'm', 'm', 'e', 'p', 'sh'], ['Die', 'Hën', 'Mar', 'Mër', 'Enj', 'Pre', 'Sht'],
@@ -3943,11 +4733,18 @@ export const locale_sq = [
       'nëntor', 'dhjetor'
     ]
   ],
-  u, [['p.K.', 'mb.K.'], u, ['para Krishtit', 'mbas Krishtit']], 1, [6, 0],
+  u,
+  [['p.K.', 'mb.K.'], u, ['para Krishtit', 'mbas Krishtit']],
+  1,
+  [6, 0],
   ['d.M.yy', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a, z', 'h:mm:ss a, zzzz'], ['{1}, {0}', u, '{1} \'në\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a, z', 'h:mm:ss a, zzzz'],
+  ['{1}, {0}', u, '{1} \'në\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'Lekë', 'Leku shqiptar', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'Lekë',
+  'Leku shqiptar',
+  {
     'ALL': ['Lekë'],
     'AOA': [],
     'ARS': [],
@@ -4043,6 +4840,7 @@ export const locale_sq = [
     'ZAR': [],
     'ZMW': []
   },
+  'ltr',
   plural_sq
 ];
 
@@ -4059,7 +4857,9 @@ function plural_sr(n: number): number {
 }
 
 export const locale_sr = [
-  'sr', [['a', 'p'], ['пре подне', 'по подне'], u], [['пре подне', 'по подне'], u, u],
+  'sr',
+  [['a', 'p'], ['пре подне', 'по подне'], u],
+  [['пре подне', 'по подне'], u, u],
   [
     ['н', 'п', 'у', 'с', 'ч', 'п', 'с'], ['нед', 'пон', 'уто', 'сре', 'чет', 'пет', 'суб'],
     ['недеља', 'понедељак', 'уторак', 'среда', 'четвртак', 'петак', 'субота'],
@@ -4074,11 +4874,18 @@ export const locale_sr = [
       'новембар', 'децембар'
     ]
   ],
-  u, [['п.н.е.', 'н.е.'], ['п. н. е.', 'н. е.'], ['пре нове ере', 'нове ере']], 1, [6, 0],
+  u,
+  [['п.н.е.', 'н.е.'], ['п. н. е.', 'н. е.'], ['пре нове ере', 'нове ере']],
+  1,
+  [6, 0],
   ['d.M.yy.', 'dd.MM.y.', 'dd. MMMM y.', 'EEEE, dd. MMMM y.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'RSD', 'Српски динар', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'RSD',
+  'Српски динар',
+  {
     'AUD': [u, '$'],
     'BAM': ['КМ', 'KM'],
     'GEL': [u, 'ლ'],
@@ -4088,6 +4895,7 @@ export const locale_sr = [
     'USD': ['US$', '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_sr
 ];
 
@@ -4098,7 +4906,9 @@ function plural_sv(n: number): number {
 }
 
 export const locale_sv = [
-  'sv', [['fm', 'em'], u, u], [['fm', 'em'], ['f.m.', 'e.m.'], ['förmiddag', 'eftermiddag']],
+  'sv',
+  [['fm', 'em'], u, u],
+  [['fm', 'em'], ['f.m.', 'e.m.'], ['förmiddag', 'eftermiddag']],
   [
     ['S', 'M', 'T', 'O', 'T', 'F', 'L'], ['sön', 'mån', 'tis', 'ons', 'tors', 'fre', 'lör'],
     ['söndag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lördag'],
@@ -4113,11 +4923,18 @@ export const locale_sv = [
       'oktober', 'november', 'december'
     ]
   ],
-  u, [['f.Kr.', 'e.Kr.'], u, ['före Kristus', 'efter Kristus']], 1, [6, 0],
+  u,
+  [['f.Kr.', 'e.Kr.'], u, ['före Kristus', 'efter Kristus']],
+  1,
+  [6, 0],
   ['y-MM-dd', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', '\'kl\'. HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', '\'kl\'. HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', ' ', ';', '%', '+', '−', '×10^', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'], 'kr', 'svensk krona', {
+  ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
+  'kr',
+  'svensk krona',
+  {
     'AUD': [u, '$'],
     'BBD': ['Bds$', '$'],
     'BMD': ['BM$', '$'],
@@ -4146,6 +4963,7 @@ export const locale_sv = [
     'USD': ['US$', '$'],
     'VND': [u, '₫']
   },
+  'ltr',
   plural_sv
 ];
 
@@ -4156,7 +4974,9 @@ function plural_sw(n: number): number {
 }
 
 export const locale_sw = [
-  'sw', [['am', 'pm'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'sw',
+  [['am', 'pm'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
     ['Jumapili', 'Jumatatu', 'Jumanne', 'Jumatano', 'Alhamisi', 'Ijumaa', 'Jumamosi'], u, u
@@ -4170,11 +4990,18 @@ export const locale_sw = [
       'Oktoba', 'Novemba', 'Desemba'
     ]
   ],
-  u, [['KK', 'BK'], u, ['Kabla ya Kristo', 'Baada ya Kristo']], 1, [6, 0],
+  u,
+  [['KK', 'BK'], u, ['Kabla ya Kristo', 'Baada ya Kristo']],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE, d MMMM y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'TSh', 'Shilingi ya Tanzania', {
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'TSh',
+  'Shilingi ya Tanzania',
+  {
     'JPY': ['JP¥', '¥'],
     'KES': ['Ksh'],
     'THB': ['฿'],
@@ -4182,6 +5009,7 @@ export const locale_sw = [
     'TZS': ['TSh'],
     'USD': ['US$', '$']
   },
+  'ltr',
   plural_sw
 ];
 
@@ -4191,7 +5019,9 @@ function plural_ta(n: number): number {
 }
 
 export const locale_ta = [
-  'ta', [['மு.ப', 'பி.ப'], ['முற்பகல்', 'பிற்பகல்'], u], u,
+  'ta',
+  [['மு.ப', 'பி.ப'], ['முற்பகல்', 'பிற்பகல்'], u],
+  u,
   [
     ['ஞா', 'தி', 'செ', 'பு', 'வி', 'வெ', 'ச'],
     ['ஞாயி.', 'திங்.', 'செவ்.', 'புத.', 'வியா.', 'வெள்.', 'சனி'],
@@ -4207,12 +5037,20 @@ export const locale_ta = [
       'டிசம்பர்'
     ]
   ],
-  u, [['கி.மு.', 'கி.பி.'], u, ['கிறிஸ்துவுக்கு முன்', 'அன்னோ டோமினி']], 0, [0, 0],
+  u,
+  [['கி.மு.', 'கி.பி.'], u, ['கிறிஸ்துவுக்கு முன்', 'அன்னோ டோமினி']],
+  0,
+  [0, 0],
   ['d/M/yy', 'd MMM, y', 'd MMMM, y', 'EEEE, d MMMM, y'],
-  ['a h:mm', 'a h:mm:ss', 'a h:mm:ss z', 'a h:mm:ss zzzz'], ['{1}, {0}', u, '{1} ’அன்று’ {0}', u],
+  ['a h:mm', 'a h:mm:ss', 'a h:mm:ss z', 'a h:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} ’அன்று’ {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##,##0%', '¤ #,##,##0.00', '#E0'], '₹', 'இந்திய ரூபாய்',
-  {'THB': ['฿'], 'TWD': ['NT$']}, plural_ta
+  ['#,##,##0.###', '#,##,##0%', '¤ #,##,##0.00', '#E0'],
+  '₹',
+  'இந்திய ரூபாய்',
+  {'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_ta
 ];
 
 function plural_te(n: number): number {
@@ -4221,7 +5059,9 @@ function plural_te(n: number): number {
 }
 
 export const locale_te = [
-  'te', [['ఉ', 'సా'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'te',
+  [['ఉ', 'సా'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['ఆ', 'సో', 'మ', 'బు', 'గు', 'శు', 'శ'], ['ఆది', 'సోమ', 'మంగళ', 'బుధ', 'గురు', 'శుక్ర', 'శని'],
     ['ఆదివారం', 'సోమవారం', 'మంగళవారం', 'బుధవారం', 'గురువారం', 'శుక్రవారం', 'శనివారం'],
@@ -4236,12 +5076,20 @@ export const locale_te = [
       'డిసెంబర్'
     ]
   ],
-  u, [['క్రీపూ', 'క్రీశ'], u, ['క్రీస్తు పూర్వం', 'క్రీస్తు శకం']], 0, [0, 0],
+  u,
+  [['క్రీపూ', 'క్రీశ'], u, ['క్రీస్తు పూర్వం', 'క్రీస్తు శకం']],
+  0,
+  [0, 0],
   ['dd-MM-yy', 'd MMM, y', 'd MMMM, y', 'd, MMMM y, EEEE'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, '{1} {0}కి', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, '{1} {0}కి', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##,##0.###', '#,##0%', '¤#,##,##0.00', '#E0'], '₹', 'రూపాయి',
-  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_te
+  ['#,##,##0.###', '#,##0%', '¤#,##,##0.00', '#E0'],
+  '₹',
+  'రూపాయి',
+  {'JPY': ['JP¥', '¥'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_te
 ];
 
 function plural_th(n: number): number {
@@ -4249,7 +5097,9 @@ function plural_th(n: number): number {
 }
 
 export const locale_th = [
-  'th', [['a', 'p'], ['ก่อนเที่ยง', 'หลังเที่ยง'], u], [['ก่อนเที่ยง', 'หลังเที่ยง'], u, u],
+  'th',
+  [['a', 'p'], ['ก่อนเที่ยง', 'หลังเที่ยง'], u],
+  [['ก่อนเที่ยง', 'หลังเที่ยง'], u, u],
   [
     ['อา', 'จ', 'อ', 'พ', 'พฤ', 'ศ', 'ส'], ['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
     ['วันอาทิตย์', 'วันจันทร์', 'วันอังคาร', 'วันพุธ', 'วันพฤหัสบดี', 'วันศุกร์', 'วันเสาร์'],
@@ -4267,12 +5117,20 @@ export const locale_th = [
       'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
     ]
   ],
-  u, [['ก่อน ค.ศ.', 'ค.ศ.'], u, ['ปีก่อนคริสตกาล', 'คริสต์ศักราช']], 0, [6, 0],
+  u,
+  [['ก่อน ค.ศ.', 'ค.ศ.'], u, ['ปีก่อนคริสตกาล', 'คริสต์ศักราช']],
+  0,
+  [6, 0],
   ['d/M/yy', 'd MMM y', 'd MMMM G y', 'EEEEที่ d MMMM G y'],
   ['HH:mm', 'HH:mm:ss', 'H นาฬิกา mm นาที ss วินาที z', 'H นาฬิกา mm นาที ss วินาที zzzz'],
-  ['{1} {0}', u, u, u], ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '฿', 'บาท',
-  {'AUD': ['AU$', '$'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$'], 'XXX': []}, plural_th
+  ['{1} {0}', u, u, u],
+  ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '฿',
+  'บาท',
+  {'AUD': ['AU$', '$'], 'THB': ['฿'], 'TWD': ['NT$'], 'USD': ['US$', '$'], 'XXX': []},
+  'ltr',
+  plural_th
 ];
 
 function plural_tl(n: number): number {
@@ -4286,7 +5144,9 @@ function plural_tl(n: number): number {
 }
 
 export const locale_tl = [
-  'fil', [['am', 'pm'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'fil',
+  [['am', 'pm'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['Lin', 'Lun', 'Mar', 'Miy', 'Huw', 'Biy', 'Sab'], u,
     ['Linggo', 'Lunes', 'Martes', 'Miyerkules', 'Huwebes', 'Biyernes', 'Sabado'],
@@ -4308,12 +5168,19 @@ export const locale_tl = [
       'Oktubre', 'Nobyembre', 'Disyembre'
     ]
   ],
-  [['BC', 'AD'], u, ['Before Christ', 'Anno Domini']], 0, [6, 0],
+  [['BC', 'AD'], u, ['Before Christ', 'Anno Domini']],
+  0,
+  [6, 0],
   ['M/d/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1}, {0}', u, '{1} \'nang\' {0}', u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1}, {0}', u, '{1} \'nang\' {0}', u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '₱', 'Piso ng Pilipinas',
-  {'PHP': ['₱'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_tl
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '₱',
+  'Piso ng Pilipinas',
+  {'PHP': ['₱'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'ltr',
+  plural_tl
 ];
 
 function plural_tr(n: number): number {
@@ -4322,7 +5189,9 @@ function plural_tr(n: number): number {
 }
 
 export const locale_tr = [
-  'tr', [['öö', 'ös'], ['ÖÖ', 'ÖS'], u], [['ÖÖ', 'ÖS'], u, u],
+  'tr',
+  [['öö', 'ös'], ['ÖÖ', 'ÖS'], u],
+  [['ÖÖ', 'ÖS'], u, u],
   [
     ['P', 'P', 'S', 'Ç', 'P', 'C', 'C'], ['Paz', 'Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt'],
     ['Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi'],
@@ -4337,12 +5206,20 @@ export const locale_tr = [
       'Kasım', 'Aralık'
     ]
   ],
-  u, [['MÖ', 'MS'], u, ['Milattan Önce', 'Milattan Sonra']], 1, [6, 0],
+  u,
+  [['MÖ', 'MS'], u, ['Milattan Önce', 'Milattan Sonra']],
+  1,
+  [6, 0],
   ['d.MM.y', 'd MMM y', 'd MMMM y', 'd MMMM y EEEE'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '%#,##0', '¤#,##0.00', '#E0'], '₺', 'Türk Lirası',
-  {'AUD': ['AU$', '$'], 'RON': [u, 'L'], 'THB': ['฿'], 'TRY': ['₺'], 'TWD': ['NT$']}, plural_tr
+  ['#,##0.###', '%#,##0', '¤#,##0.00', '#E0'],
+  '₺',
+  'Türk Lirası',
+  {'AUD': ['AU$', '$'], 'RON': [u, 'L'], 'THB': ['฿'], 'TRY': ['₺'], 'TWD': ['NT$']},
+  'ltr',
+  plural_tr
 ];
 
 function plural_uk(n: number): number {
@@ -4359,7 +5236,9 @@ function plural_uk(n: number): number {
 }
 
 export const locale_uk = [
-  'uk', [['дп', 'пп'], u, u], u,
+  'uk',
+  [['дп', 'пп'], u, u],
+  u,
   [
     ['Н', 'П', 'В', 'С', 'Ч', 'П', 'С'], ['нд', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'],
     ['неділя', 'понеділок', 'вівторок', 'середа', 'четвер', 'пʼятниця', 'субота'],
@@ -4385,11 +5264,17 @@ export const locale_uk = [
       'вересень', 'жовтень', 'листопад', 'грудень'
     ]
   ],
-  [['до н.е.', 'н.е.'], ['до н. е.', 'н. е.'], ['до нашої ери', 'нашої ери']], 1, [6, 0],
+  [['до н.е.', 'н.е.'], ['до н. е.', 'н. е.'], ['до нашої ери', 'нашої ери']],
+  1,
+  [6, 0],
   ['dd.MM.yy', 'd MMM y \'р\'.', 'd MMMM y \'р\'.', 'EEEE, d MMMM y \'р\'.'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1}, {0}', u, '{1} \'о\' {0}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1}, {0}', u, '{1} \'о\' {0}', u],
   [',', ' ', ';', '%', '+', '-', 'Е', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '₴', 'українська гривня', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '₴',
+  'українська гривня',
+  {
     'AUD': [u, '$'],
     'BRL': [u, 'R$'],
     'CAD': [u, '$'],
@@ -4409,6 +5294,7 @@ export const locale_uk = [
     'VND': [u, '₫'],
     'XCD': [u, '$']
   },
+  'ltr',
   plural_uk
 ];
 
@@ -4419,7 +5305,9 @@ function plural_ur(n: number): number {
 }
 
 export const locale_ur = [
-  'ur', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'ur',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['S', 'M', 'T', 'W', 'T', 'F', 'S'], ['اتوار', 'پیر', 'منگل', 'بدھ', 'جمعرات', 'جمعہ', 'ہفتہ'],
     u, u
@@ -4433,12 +5321,20 @@ export const locale_ur = [
     ],
     u
   ],
-  u, [['قبل مسیح', 'عیسوی'], u, u], 0, [6, 0],
+  u,
+  [['قبل مسیح', 'عیسوی'], u, u],
+  0,
+  [6, 0],
   ['d/M/yy', 'd MMM، y', 'd MMMM، y', 'EEEE، d MMMM، y'],
-  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'], ['{1} {0}', u, u, u],
+  ['h:mm a', 'h:mm:ss a', 'h:mm:ss a z', 'h:mm:ss a zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '\u200e+', '\u200e-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'], 'Rs', 'پاکستانی روپیہ',
-  {'JPY': ['JP¥', '¥'], 'PKR': ['Rs'], 'THB': ['฿'], 'TWD': ['NT$']}, plural_ur
+  ['#,##0.###', '#,##0%', '¤ #,##0.00', '#E0'],
+  'Rs',
+  'پاکستانی روپیہ',
+  {'JPY': ['JP¥', '¥'], 'PKR': ['Rs'], 'THB': ['฿'], 'TWD': ['NT$']},
+  'rtl',
+  plural_ur
 ];
 
 function plural_uz(n: number): number {
@@ -4447,7 +5343,9 @@ function plural_uz(n: number): number {
 }
 
 export const locale_uz = [
-  'uz', [['TO', 'TK'], u, u], u,
+  'uz',
+  [['TO', 'TK'], u, u],
+  u,
   [
     ['Y', 'D', 'S', 'C', 'P', 'J', 'S'], ['Yak', 'Dush', 'Sesh', 'Chor', 'Pay', 'Jum', 'Shan'],
     ['yakshanba', 'dushanba', 'seshanba', 'chorshanba', 'payshanba', 'juma', 'shanba'],
@@ -4470,12 +5368,19 @@ export const locale_uz = [
       'Noyabr', 'Dekabr'
     ]
   ],
-  [['m.a.', 'milodiy'], u, ['miloddan avvalgi', 'milodiy']], 1, [6, 0],
+  [['m.a.', 'milodiy'], u, ['miloddan avvalgi', 'milodiy']],
+  1,
+  [6, 0],
   ['dd/MM/yy', 'd-MMM, y', 'd-MMMM, y', 'EEEE, d-MMMM, y'],
-  ['HH:mm', 'HH:mm:ss', 'H:mm:ss (z)', 'H:mm:ss (zzzz)'], ['{1}, {0}', u, u, u],
+  ['HH:mm', 'HH:mm:ss', 'H:mm:ss (z)', 'H:mm:ss (zzzz)'],
+  ['{1}, {0}', u, u, u],
   [',', ' ', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'son emas', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], 'soʻm', 'O‘zbekiston so‘mi',
-  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$'], 'UZS': ['soʻm']}, plural_uz
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  'soʻm',
+  'O‘zbekiston so‘mi',
+  {'JPY': ['JP¥', '¥'], 'USD': ['US$', '$'], 'UZS': ['soʻm']},
+  'ltr',
+  plural_uz
 ];
 
 function plural_vi(n: number): number {
@@ -4483,7 +5388,9 @@ function plural_vi(n: number): number {
 }
 
 export const locale_vi = [
-  'vi', [['s', 'c'], ['SA', 'CH'], u], [['SA', 'CH'], u, u],
+  'vi',
+  [['s', 'c'], ['SA', 'CH'], u],
+  [['SA', 'CH'], u, u],
   [
     ['CN', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7'],
     ['CN', 'Th 2', 'Th 3', 'Th 4', 'Th 5', 'Th 6', 'Th 7'],
@@ -4513,11 +5420,17 @@ export const locale_vi = [
       'Tháng 9', 'Tháng 10', 'Tháng 11', 'Tháng 12'
     ]
   ],
-  [['tr. CN', 'sau CN'], ['Trước CN', 'sau CN'], u], 1, [6, 0],
+  [['tr. CN', 'sau CN'], ['Trước CN', 'sau CN'], u],
+  1,
+  [6, 0],
   ['dd/MM/y', 'd MMM, y', 'd MMMM, y', 'EEEE, d MMMM, y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{0}, {1}', u, '{0} {1}', u],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{0}, {1}', u, '{0} {1}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'], '₫', 'Đồng Việt Nam', {
+  ['#,##0.###', '#,##0%', '#,##0.00 ¤', '#E0'],
+  '₫',
+  'Đồng Việt Nam',
+  {
     'AUD': ['AU$', '$'],
     'JPY': ['JP¥', '¥'],
     'THB': ['฿'],
@@ -4525,6 +5438,7 @@ export const locale_vi = [
     'USD': ['US$', '$'],
     'XXX': []
   },
+  'ltr',
   plural_vi
 ];
 
@@ -4533,7 +5447,9 @@ function plural_zh(n: number): number {
 }
 
 export const locale_zh = [
-  'zh', [['上午', '下午'], u, u], u,
+  'zh',
+  [['上午', '下午'], u, u],
+  u,
   [
     ['日', '一', '二', '三', '四', '五', '六'],
     ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
@@ -4549,10 +5465,18 @@ export const locale_zh = [
       '十二月'
     ]
   ],
-  u, [['公元前', '公元'], u, u], 0, [6, 0], ['y/M/d', 'y年M月d日', u, 'y年M月d日EEEE'],
-  ['ah:mm', 'ah:mm:ss', 'z ah:mm:ss', 'zzzz ah:mm:ss'], ['{1} {0}', u, u, u],
+  u,
+  [['公元前', '公元'], u, u],
+  0,
+  [6, 0],
+  ['y/M/d', 'y年M月d日', u, 'y年M月d日EEEE'],
+  ['ah:mm', 'ah:mm:ss', 'z ah:mm:ss', 'zzzz ah:mm:ss'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '¥', '人民币', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '¥',
+  '人民币',
+  {
     'AUD': ['AU$', '$'],
     'CNY': ['¥'],
     'ILR': ['ILS'],
@@ -4562,6 +5486,7 @@ export const locale_zh = [
     'USD': ['US$', '$'],
     'XXX': []
   },
+  'ltr',
   plural_zh
 ];
 
@@ -4570,7 +5495,9 @@ function plural_zh_CN(n: number): number {
 }
 
 export const locale_zh_CN = [
-  'zh-Hans', [['上午', '下午'], u, u], u,
+  'zh-Hans',
+  [['上午', '下午'], u, u],
+  u,
   [
     ['日', '一', '二', '三', '四', '五', '六'],
     ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
@@ -4586,10 +5513,18 @@ export const locale_zh_CN = [
       '十二月'
     ]
   ],
-  u, [['公元前', '公元'], u, u], 0, [6, 0], ['y/M/d', 'y年M月d日', u, 'y年M月d日EEEE'],
-  ['ah:mm', 'ah:mm:ss', 'z ah:mm:ss', 'zzzz ah:mm:ss'], ['{1} {0}', u, u, u],
+  u,
+  [['公元前', '公元'], u, u],
+  0,
+  [6, 0],
+  ['y/M/d', 'y年M月d日', u, 'y年M月d日EEEE'],
+  ['ah:mm', 'ah:mm:ss', 'z ah:mm:ss', 'zzzz ah:mm:ss'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '¥', '人民币', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '¥',
+  '人民币',
+  {
     'AUD': ['AU$', '$'],
     'CNY': ['¥'],
     'ILR': ['ILS'],
@@ -4599,6 +5534,7 @@ export const locale_zh_CN = [
     'USD': ['US$', '$'],
     'XXX': []
   },
+  'ltr',
   plural_zh_CN
 ];
 
@@ -4607,7 +5543,9 @@ function plural_zh_HK(n: number): number {
 }
 
 export const locale_zh_HK = [
-  'zh-Hant-HK', [['上午', '下午'], u, u], u,
+  'zh-Hant-HK',
+  [['上午', '下午'], u, u],
+  u,
   [
     ['日', '一', '二', '三', '四', '五', '六'],
     ['週日', '週一', '週二', '週三', '週四', '週五', '週六'],
@@ -4619,11 +5557,20 @@ export const locale_zh_HK = [
     ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'], u
   ],
-  u, [['公元前', '公元'], u, u], 0, [6, 0], ['d/M/y', 'y年M月d日', u, 'y年M月d日EEEE'],
-  ['ah:mm', 'ah:mm:ss', 'ah:mm:ss [z]', 'ah:mm:ss [zzzz]'], ['{1} {0}', u, u, u],
+  u,
+  [['公元前', '公元'], u, u],
+  0,
+  [6, 0],
+  ['d/M/y', 'y年M月d日', u, 'y年M月d日EEEE'],
+  ['ah:mm', 'ah:mm:ss', 'ah:mm:ss [z]', 'ah:mm:ss [zzzz]'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', '非數值', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'HK$', '港元',
-  {'AUD': ['AU$', '$'], 'RON': [u, 'L'], 'USD': ['US$', '$'], 'XXX': []}, plural_zh_HK
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'HK$',
+  '港元',
+  {'AUD': ['AU$', '$'], 'RON': [u, 'L'], 'USD': ['US$', '$'], 'XXX': []},
+  'ltr',
+  plural_zh_HK
 ];
 
 function plural_zh_TW(n: number): number {
@@ -4631,7 +5578,9 @@ function plural_zh_TW(n: number): number {
 }
 
 export const locale_zh_TW = [
-  'zh-Hant', [['上午', '下午'], u, u], u,
+  'zh-Hant',
+  [['上午', '下午'], u, u],
+  u,
   [
     ['日', '一', '二', '三', '四', '五', '六'],
     ['週日', '週一', '週二', '週三', '週四', '週五', '週六'],
@@ -4643,10 +5592,18 @@ export const locale_zh_TW = [
     ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'], u
   ],
-  u, [['西元前', '西元'], u, u], 0, [6, 0], ['y/M/d', 'y年M月d日', u, 'y年M月d日 EEEE'],
-  ['ah:mm', 'ah:mm:ss', 'ah:mm:ss [z]', 'ah:mm:ss [zzzz]'], ['{1} {0}', u, u, u],
+  u,
+  [['西元前', '西元'], u, u],
+  0,
+  [6, 0],
+  ['y/M/d', 'y年M月d日', u, 'y年M月d日 EEEE'],
+  ['ah:mm', 'ah:mm:ss', 'ah:mm:ss [z]', 'ah:mm:ss [zzzz]'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', '非數值', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', '新台幣', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  '$',
+  '新台幣',
+  {
     'AUD': ['AU$', '$'],
     'KRW': ['￦', '₩'],
     'RON': [u, 'L'],
@@ -4654,6 +5611,7 @@ export const locale_zh_TW = [
     'USD': ['US$', '$'],
     'XXX': []
   },
+  'ltr',
   plural_zh_TW
 ];
 
@@ -4664,7 +5622,9 @@ function plural_zu(n: number): number {
 }
 
 export const locale_zu = [
-  'zu', [['a', 'p'], ['AM', 'PM'], u], [['AM', 'PM'], u, u],
+  'zu',
+  [['a', 'p'], ['AM', 'PM'], u],
+  [['AM', 'PM'], u, u],
   [
     ['S', 'M', 'B', 'T', 'S', 'H', 'M'], ['Son', 'Mso', 'Bil', 'Tha', 'Sin', 'Hla', 'Mgq'],
     ['ISonto', 'UMsombuluko', 'ULwesibili', 'ULwesithathu', 'ULwesine', 'ULwesihlanu', 'UMgqibelo'],
@@ -4687,10 +5647,17 @@ export const locale_zu = [
       'Okthoba', 'Novemba', 'Disemba'
     ]
   ],
-  [['BC', 'AD'], u, u], 0, [6, 0], ['M/d/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
-  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'], ['{1} {0}', u, u, u],
+  [['BC', 'AD'], u, u],
+  0,
+  [6, 0],
+  ['M/d/yy', 'MMM d, y', 'MMMM d, y', 'EEEE, MMMM d, y'],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
+  ['{1} {0}', u, u, u],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], 'R', 'i-South African Rand', {
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'],
+  'R',
+  'i-South African Rand',
+  {
     'BYN': [u, 'P.'],
     'DKK': [u, 'Kr'],
     'HRK': [u, 'Kn'],
@@ -4703,6 +5670,7 @@ export const locale_zu = [
     'TWD': ['NT$'],
     'ZAR': ['R']
   },
+  'ltr',
   plural_zu
 ];
 


### PR DESCRIPTION
When directionality data was added to @angular/common locales, only
the externally used locales were updated.  We need to additionally
update the closure locales which are synced into google3.
