### PR TITLE
fix(ivy): do not invoke change detection for destroyed views

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -380,8 +380,9 @@ export function renderView<T>(lView: LView, tView: TView, context: T): void {
 export function refreshView<T>(
     lView: LView, tView: TView, templateFn: ComponentTemplate<{}>| null, context: T) {
   ngDevMode && assertEqual(isCreationMode(lView), false, 'Should be run in update mode');
-  enterView(lView, lView[T_HOST]);
   const flags = lView[FLAGS];
+  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) return;
+  enterView(lView, lView[T_HOST]);
   try {
     resetPreOrderHookFlags(lView);
 

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, ComponentFactoryResolver, Directive, Input, NgModule, OnChanges, SimpleChanges, ViewChild, ViewContainerRef} from '@angular/core';
+import {ChangeDetectorRef, Component, ComponentFactoryResolver, ContentChildren, Directive, Input, NgModule, OnChanges, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {SimpleChange} from '@angular/core/src/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -3595,6 +3595,59 @@ describe('onDestroy', () => {
     expect(fixture.componentInstance.clicksToButton2).toBe(1);
 
     expect(events).toEqual(['comp']);
+  });
+
+  it('should not produce errors if change detection is triggered during ngOnDestroy', () => {
+    @Component({selector: 'child', template: `<ng-content></ng-content>`})
+    class Child {
+    }
+
+    @Component({selector: 'parent', template: `<ng-content></ng-content>`})
+    class Parent {
+      @ContentChildren(Child, {descendants: true}) child !: QueryList<Child>;
+    }
+
+    @Component({
+      selector: 'app',
+      template: `
+        <ng-template #tpl>
+          <parent>
+            <child></child>
+          </parent>
+        </ng-template>
+        <div #container dir></div>
+      `
+    })
+    class App {
+      @ViewChild('container', {read: ViewContainerRef, static: true})
+      container !: ViewContainerRef;
+
+      @ViewChild('tpl', {read: TemplateRef, static: true})
+      tpl !: TemplateRef<any>;
+
+      ngOnInit() { this.container.createEmbeddedView(this.tpl); }
+    }
+
+    @Directive({selector: '[dir]'})
+    class Dir {
+      constructor(public cdr: ChangeDetectorRef) {}
+
+      ngOnDestroy() {
+        // Important: calling detectChanges in destroy hook like that
+        // doesn’t have practical purpose, but in real-world cases it might
+        // happen, for example as a result of "focus()" call on a DOM element,
+        // in case ZoneJS is active.
+        this.cdr.detectChanges();
+      }
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, Parent, Child, Dir],
+    });
+    const fixture = TestBed.createComponent(App);
+    fixture.autoDetectChanges();
+
+    expect(() => fixture.destroy()).not.toThrow();
   });
 
   onlyInIvy(


### PR DESCRIPTION
Prior to this commit, calling change detection for destroyed views resulted in errors being thrown in some cases. This commit adds a check to make sure change detection is skipped in case a given view is marked as destroyed.

Note: I also ran micro benchmarks and the main observation is that `noop_change_detection` one is 2-3% slower, which is a bit surprising since the operation that this PR adds should be cheap. Other benchmarks have no perf changes.

This PR resolves FW-1636.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No