### PR TITLE
test(ivy): `class_binding` benchmark fixes

### DIFF
--- a/packages/core/test/render3/perf/class_binding/index.ts
+++ b/packages/core/test/render3/perf/class_binding/index.ts
@@ -18,6 +18,11 @@ const PROFILE_CREATE = true;
 const PROFILE_UPDATE = true;
 const PROFILE_NOOP = true;
 
+const consts: TAttributes[] = [
+  [AttributeMarker.Classes, 'A', 'B']  // 0
+];
+const context: any = {};
+const benchmarks: Benchmark[] = [];
 
 function benchmark(
     name: string, template: ComponentTemplate<any>, baselineTemplate: ComponentTemplate<any>) {
@@ -88,12 +93,6 @@ const A_10 = 'one two three four five six seven eight nine ten';
 const B_10 = A_10.toUpperCase();
 let toggle = true;
 
-const consts: TAttributes[] = [
-  [AttributeMarker.Classes, 'A', 'B']  // 0
-];
-const context: any = {};
-const benchmarks: Benchmark[] = [];
-
 benchmark(
     `<div class="A B">`,
     function(rf: RenderFlags, ctx: any) {
@@ -103,7 +102,7 @@ benchmark(
     },
     function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
-        ɵɵelement(0, 'div', 1);
+        ɵɵelement(0, 'div', 0);
       }
     });
 
@@ -177,7 +176,7 @@ benchmark(
     },
     function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
-        ɵɵelement(0, 'div', 1);
+        ɵɵelement(0, 'div', 0);
       }
       if (rf & 2) {
         ɵɵproperty('className', toggle ? A_1 : B_1);
@@ -196,7 +195,7 @@ benchmark(
     },
     function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
-        ɵɵelement(0, 'div', 1);
+        ɵɵelement(0, 'div', 0);
       }
       if (rf & 2) {
         ɵɵproperty('className', toggle ? A_10 : B_10);
@@ -216,7 +215,7 @@ benchmark(
     },
     function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
-        ɵɵelement(0, 'div', 1);
+        ɵɵelement(0, 'div', 0);
       }
       if (rf & 2) {
         ɵɵproperty('className', toggle ? A_1 + 'foo' : B_1);


### PR DESCRIPTION
This commit fixes a couple issues that prevent `class_binding` benchmark from running: moving constants requires by the `benchmark` function before function declaration and referencing correct consts in template instructions.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No