### PR TITLE
fix(ivy): skip field inheritance if InheritDefinitionFeature is present on parent def

### DIFF
--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -4234,9 +4234,7 @@ describe('inheritance', () => {
       })
       class BaseComponent {
         @HostListener('click')
-        clicked() {
-          events.push('BaseComponent.clicked');  //
-        }
+        clicked() { events.push('BaseComponent.clicked'); }
       }
 
       @Component({
@@ -4250,9 +4248,7 @@ describe('inheritance', () => {
         @HostListener('focus')
         focused() {}
 
-        clicked() {
-          events.push('ChildComponent.clicked');  //
-        }
+        clicked() { events.push('ChildComponent.clicked'); }
       }
 
       @Component({
@@ -4266,9 +4262,7 @@ describe('inheritance', () => {
         @HostListener('blur')
         focused() {}
 
-        clicked() {
-          events.push('GrandChildComponent.clicked');  //
-        }
+        clicked() { events.push('GrandChildComponent.clicked'); }
       }
 
       @Component({

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -4260,7 +4260,7 @@ describe('inheritance', () => {
         // component def, which would trigger `hostBindings` functions merge operation in
         // InheritDefinitionFeature logic (merging GrandChild and Child host binding functions)
         @HostListener('blur')
-        focused() {}
+        blurred() {}
 
         clicked() { events.push('GrandChildComponent.clicked'); }
       }

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -4293,7 +4293,7 @@ describe('inheritance', () => {
         fixture.debugElement.query(By.directive(component)).nativeElement.click();
       });
       expect(events).toEqual(
-          ['BaseComponent.clicked', 'ChildComponent.clicked', 'GrandChildComponent.clicked'])
+          ['BaseComponent.clicked', 'ChildComponent.clicked', 'GrandChildComponent.clicked']);
     });
 
     xdescribe(


### PR DESCRIPTION
The main logic of the `InheritDefinitionFeature` is to go through the prototype chain of a given Component and merge all Angular-specific information onto that Component def. The problem happens in case there is a Component in a hierarchy that also contains the `InheritDefinitionFeature` (i.e. it extends some other Component), so it inherits all Angular-specific information from its super class. As a result, the root Component may end up having duplicate information inherited from different Components in hierarchy.

Let's consider the following structure: `GrandChild` extends `Child` that extends `Base` and the `Base` class has a `HostListener`. In this scenario `GrandChild` and `Child` will have `InheritDefinitionFeature` included into the `features` list. The processing will happend in the following order:

- `Child` inherits `HostListener` from the `Base` class
- `GrandChild` inherits `HostListener` from the `Child` class
- since `Child` has a parent, `GrandChild` also inherits from the `Base` class

The result is that the `GrandChild` def has duplicated host listener, which is not correct.

This commit introduces additional logic that checks whether we came across a def that has `InheritDefinitionFeature` feature (which means that this def already inherited information from its super classes). If that's the case, we skip further fields-related inheritance logic, but keep going though the prototype chain to look for super classes that contain other features (like NgOnChanges), that we need to invoke for a given Component def.

This PR resolves #33300.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No