### PR TITLE
fix(ngcc): dts declaration mapping

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
@@ -58,33 +58,11 @@ export class PrivateDeclarationsAnalyzer {
               if (declaration.node.name.text === exportedName) {
                 // This declaration is public so we can remove it from the list
                 privateDeclarations.delete(declaration.node.name);
-              } else if (!this.host.getDtsDeclaration(declaration.node)) {
+              } else {
                 // The referenced declaration is exported publicly but via an alias.
                 // In some cases the original declaration is missing from the dts program, such as
                 // when rolling up (flattening) the dts files.
                 // This is because the original declaration gets renamed to the exported alias.
-
-                // There is a constraint on this which we cannot handle. Consider the following
-                // code:
-                //
-                // /src/entry_point.js:
-                //     export {MyComponent as aliasedMyComponent} from './a';
-                //     export {MyComponent} from './b';`
-                //
-                // /src/a.js:
-                //     export class MyComponent {}
-                //
-                // /src/b.js:
-                //     export class MyComponent {}
-                //
-                // //typings/entry_point.d.ts:
-                //     export declare class aliasedMyComponent {}
-                //     export declare class MyComponent {}
-                //
-                // In this case we would end up matching the `MyComponent` from `/src/a.js` to the
-                // `MyComponent` declared in `/typings/entry_point.d.ts` even though that
-                // declaration is actually for the `MyComponent` in `/src/b.js`.
-
                 exportAliasDeclarations.set(declaration.node.name, exportedName);
               }
             }

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -21,7 +21,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
   protected topLevelHelperCalls = new Map<string, Map<ts.SourceFile, ts.CallExpression[]>>();
   protected program: ts.Program;
   protected compilerHost: ts.CompilerHost;
-  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts?: BundleProgram|null) {
+  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts: BundleProgram|null = null) {
     super(logger, isCore, src, dts);
     this.program = src.program;
     this.compilerHost = src.host;

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -19,10 +19,12 @@ import {NgccClassSymbol} from './ngcc_host';
 export class CommonJsReflectionHost extends Esm5ReflectionHost {
   protected commonJsExports = new Map<ts.SourceFile, Map<string, Declaration>|null>();
   protected topLevelHelperCalls = new Map<string, Map<ts.SourceFile, ts.CallExpression[]>>();
-  constructor(
-      logger: Logger, isCore: boolean, protected program: ts.Program,
-      protected compilerHost: ts.CompilerHost, dts?: BundleProgram|null) {
-    super(logger, isCore, program.getTypeChecker(), dts);
+  protected program: ts.Program;
+  protected compilerHost: ts.CompilerHost;
+  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts?: BundleProgram|null) {
+    super(logger, isCore, src, dts);
+    this.program = src.program;
+    this.compilerHost = src.host;
   }
 
   getImportOfIdentifier(id: ts.Identifier): Import|null {

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -11,7 +11,7 @@ import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
-import {isDefined} from '../utils';
+import {isDefined, stripExtension} from '../utils';
 
 import {Esm5ReflectionHost} from './esm5_host';
 import {NgccClassSymbol} from './ngcc_host';
@@ -152,12 +152,12 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
       return [];
     }
 
-    const viaModule = stripExtension(importedFile.fileName);
     const importedExports = this.getExportsOfModule(importedFile);
     if (importedExports === null) {
       return [];
     }
 
+    const viaModule = stripExtension(importedFile.fileName);
     const reexports: CommonJsExportDeclaration[] = [];
     importedExports.forEach((decl, name) => {
       if (decl.node !== null) {
@@ -257,10 +257,6 @@ function isReexportStatement(statement: ts.Statement): statement is ReexportStat
       ts.isIdentifier(statement.expression.expression) &&
       statement.expression.expression.text === '__export' &&
       statement.expression.arguments.length === 1;
-}
-
-function stripExtension(fileName: string): string {
-  return fileName.replace(/\..+$/, '');
 }
 
 function getOrDefault<K, V>(map: Map<K, V>, key: K, factory: (key: K) => V): V {

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -83,9 +83,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected decoratorCache = new Map<ClassDeclaration, DecoratorInfo>();
 
   constructor(
-      protected logger: Logger, protected isCore: boolean, checker: ts.TypeChecker,
+      protected logger: Logger, protected isCore: boolean, src: BundleProgram,
       dts?: BundleProgram|null) {
-    super(checker);
+    super(src.program.getTypeChecker());
     this.dtsDeclarationMap =
         dts && this.computeDtsDeclarationMap(dts.path, dts.program, dts.package) || null;
   }

--- a/packages/compiler-cli/ngcc/src/host/umd_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/umd_host.ts
@@ -21,7 +21,7 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
   protected umdImportPaths = new Map<ts.ParameterDeclaration, string|null>();
   protected program: ts.Program;
   protected compilerHost: ts.CompilerHost;
-  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts?: BundleProgram|null) {
+  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts: BundleProgram|null = null) {
     super(logger, isCore, src, dts);
     this.program = src.program;
     this.compilerHost = src.host;

--- a/packages/compiler-cli/ngcc/src/host/umd_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/umd_host.ts
@@ -18,10 +18,12 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
   protected umdModules = new Map<ts.SourceFile, UmdModule|null>();
   protected umdExports = new Map<ts.SourceFile, Map<string, Declaration>|null>();
   protected umdImportPaths = new Map<ts.ParameterDeclaration, string|null>();
-  constructor(
-      logger: Logger, isCore: boolean, protected program: ts.Program,
-      protected compilerHost: ts.CompilerHost, dts?: BundleProgram|null) {
-    super(logger, isCore, program.getTypeChecker(), dts);
+  protected program: ts.Program;
+  protected compilerHost: ts.CompilerHost;
+  constructor(logger: Logger, isCore: boolean, src: BundleProgram, dts?: BundleProgram|null) {
+    super(logger, isCore, src, dts);
+    this.program = src.program;
+    this.compilerHost = src.host;
   }
 
   getImportOfIdentifier(id: ts.Identifier): Import|null {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -271,7 +271,7 @@ export function mainNgcc(
         const errors = replaceTsWithNgInErrors(
             ts.formatDiagnosticsWithColorAndContext(result.diagnostics, bundle.src.host));
         throw new Error(
-            `Failed to compile entry-point ${entryPoint.name} due to compilation errors:\n${errors}`);
+            `Failed to compile entry-point ${entryPoint.name} (${formatProperty} as ${format}) due to compilation errors:\n${errors}`);
       }
 
       logger.debug(`  Successfully compiled ${entryPoint.name} : ${formatProperty}`);

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -100,18 +100,15 @@ export class Transformer {
   }
 
   getHost(bundle: EntryPointBundle): NgccReflectionHost {
-    const typeChecker = bundle.src.program.getTypeChecker();
     switch (bundle.format) {
       case 'esm2015':
-        return new Esm2015ReflectionHost(this.logger, bundle.isCore, typeChecker, bundle.dts);
+        return new Esm2015ReflectionHost(this.logger, bundle.isCore, bundle.src, bundle.dts);
       case 'esm5':
-        return new Esm5ReflectionHost(this.logger, bundle.isCore, typeChecker, bundle.dts);
+        return new Esm5ReflectionHost(this.logger, bundle.isCore, bundle.src, bundle.dts);
       case 'umd':
-        return new UmdReflectionHost(
-            this.logger, bundle.isCore, bundle.src.program, bundle.src.host, bundle.dts);
+        return new UmdReflectionHost(this.logger, bundle.isCore, bundle.src, bundle.dts);
       case 'commonjs':
-        return new CommonJsReflectionHost(
-            this.logger, bundle.isCore, bundle.src.program, bundle.src.host, bundle.dts);
+        return new CommonJsReflectionHost(this.logger, bundle.isCore, bundle.src, bundle.dts);
       default:
         throw new Error(`Reflection host for "${bundle.format}" not yet implemented.`);
     }

--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -156,7 +156,7 @@ export class DtsRenderer {
     // Capture the private declarations that need to be re-exported
     if (privateDeclarationsAnalyses.length) {
       privateDeclarationsAnalyses.forEach(e => {
-        if (!e.dtsFrom && !e.alias) {
+        if (!e.dtsFrom) {
           throw new Error(
               `There is no typings path for ${e.identifier} in ${e.from}.\n` +
               `We need to add an export for this class to a .d.ts typings file because ` +

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -55,9 +55,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
         exportFrom = entryPointBasePath !== basePath ? ` from '${relativePath}'` : '';
       }
 
-      // aliases should only be added in dts files as these are lost when rolling up dts file.
-      const exportStatement = e.alias && isDtsFile ? `${e.alias} as ${e.identifier}` : e.identifier;
-      const exportStr = `\nexport {${exportStatement}}${exportFrom};`;
+      const exportStr = `\nexport {${e.identifier}}${exportFrom};`;
       output.append(exportStr);
     });
   }

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -115,3 +115,7 @@ export function resolveFileWithPostfixes(
 export function stripDollarSuffix(value: string): string {
   return value.replace(/\$\d+$/, '');
 }
+
+export function stripExtension(fileName: string): string {
+  return fileName.replace(/\..+$/, '');
+}

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -110,8 +110,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
         program = bundle.src.program;
 
-        const reflectionHost =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const reflectionHost = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
         const referencesRegistry = new NgccReferencesRegistry(reflectionHost);
         diagnosticLogs = [];
         const analyzer = new DecorationAnalyzer(

--- a/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
@@ -334,8 +334,7 @@ runInEachFileSystem(() => {
             getRootFiles(TEST_DTS_PROGRAM));
         program = bundle.src.program;
         dtsProgram = bundle.dts !;
-        const host = new Esm2015ReflectionHost(
-            new MockLogger(), false, program.getTypeChecker(), dtsProgram);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src, dtsProgram);
         referencesRegistry = new NgccReferencesRegistry(host);
 
         const processDts = true;
@@ -538,8 +537,7 @@ runInEachFileSystem(() => {
           getRootFiles(TEST_DTS_PROGRAM));
       const program = bundle.src.program;
       const dtsProgram = bundle.dts !;
-      const host =
-          new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dtsProgram);
+      const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src, dtsProgram);
       const referencesRegistry = new NgccReferencesRegistry(host);
 
       const processDts = true;
@@ -569,8 +567,7 @@ runInEachFileSystem(() => {
       const bundle =
           makeTestEntryPointBundle('test-package', 'esm2015', false, getRootFiles(TEST_PROGRAM));
       const program = bundle.src.program;
-      const host =
-          new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), null);
+      const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src, null);
       const referencesRegistry = new NgccReferencesRegistry(host);
 
       const processDts = false;  // Emulate the scenario where typings have already been processed

--- a/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
@@ -161,74 +161,14 @@ runInEachFileSystem(() => {
                identifier: 'PrivateComponent1',
                from: _('/node_modules/test-package/src/b.js'),
                dtsFrom: null,
-               alias: null
              },
              {
                identifier: 'InternalComponent1',
                from: _('/node_modules/test-package/src/c.js'),
                dtsFrom: _('/node_modules/test-package/typings/c.d.ts'),
-               alias: null
              },
            ]);
          });
-
-      it('should find all non-public declarations that were aliased', () => {
-        const _ = absoluteFrom;
-        const ALIASED_EXPORTS_PROGRAM = [
-          {
-            name: _('/node_modules/test-package/src/entry_point.js'),
-            isRoot: true,
-            contents: `
-          // This component is only exported as an alias.
-          export {ComponentOne as aliasedComponentOne} from './a';
-          // This component is exported both as itself and an alias.
-          export {ComponentTwo as aliasedComponentTwo, ComponentTwo} from './a';
-        `
-          },
-          {
-            name: _('/node_modules/test-package/src/a.js'),
-            isRoot: false,
-            contents: `
-        import {Component} from '@angular/core';
-        export class ComponentOne {}
-        ComponentOne.decorators = [
-          {type: Component, args: [{selectors: 'a', template: ''}]}
-        ];
-
-        export class ComponentTwo {}
-        Component.decorators = [
-          {type: Component, args: [{selectors: 'a', template: ''}]}
-        ];
-      `
-          }
-        ];
-        const ALIASED_EXPORTS_DTS_PROGRAM = [
-          {
-            name: _('/node_modules/test-package/typings/entry_point.d.ts'),
-            isRoot: true,
-            contents: `
-          export declare class aliasedComponentOne {}
-          export declare class ComponentTwo {}
-          export {ComponentTwo as aliasedComponentTwo}
-        `
-          },
-        ];
-        const {program, referencesRegistry, analyzer} =
-            setup(ALIASED_EXPORTS_PROGRAM, ALIASED_EXPORTS_DTS_PROGRAM);
-
-        addToReferencesRegistry(
-            program, referencesRegistry, _('/node_modules/test-package/src/a.js'), 'ComponentOne');
-        addToReferencesRegistry(
-            program, referencesRegistry, _('/node_modules/test-package/src/a.js'), 'ComponentTwo');
-
-        const analyses = analyzer.analyzeProgram(program);
-        expect(analyses).toEqual([{
-          identifier: 'ComponentOne',
-          from: _('/node_modules/test-package/src/a.js'),
-          dtsFrom: _('/node_modules/test-package/typings/entry_point.d.ts'),
-          alias: 'aliasedComponentOne',
-        }]);
-      });
     });
   });
 

--- a/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
@@ -225,7 +225,7 @@ runInEachFileSystem(() => {
         expect(analyses).toEqual([{
           identifier: 'ComponentOne',
           from: _('/node_modules/test-package/src/a.js'),
-          dtsFrom: null,
+          dtsFrom: _('/node_modules/test-package/typings/entry_point.d.ts'),
           alias: 'aliasedComponentOne',
         }]);
       });

--- a/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/private_declarations_analyzer_spec.ts
@@ -235,12 +235,12 @@ runInEachFileSystem(() => {
   function setup(jsProgram: TestFile[], dtsProgram: TestFile[]) {
     loadTestFiles(jsProgram);
     loadTestFiles(dtsProgram);
-    const {src: {program}, dts} = makeTestEntryPointBundle(
+    const {src, dts} = makeTestEntryPointBundle(
         'test-package', 'esm2015', false, getRootFiles(jsProgram), getRootFiles(dtsProgram));
-    const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+    const host = new Esm2015ReflectionHost(new MockLogger(), false, src, dts);
     const referencesRegistry = new NgccReferencesRegistry(host);
     const analyzer = new PrivateDeclarationsAnalyzer(host, referencesRegistry);
-    return {program, referencesRegistry, analyzer};
+    return {program: src.program, referencesRegistry, analyzer};
   }
 
   /**

--- a/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
@@ -74,7 +74,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestEntryPointBundle(
             'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
         const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
         const analysis = analyzer.analyzeProgram(program);
 
@@ -105,7 +105,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestEntryPointBundle(
             'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
         const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
         const analysis = analyzer.analyzeProgram(program);
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_import_helper_spec.ts
@@ -85,10 +85,11 @@ exports.AliasedDirective$1 = AliasedDirective$1;
       it('should find the decorators on a class at the top level', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toEqual(1);
@@ -105,10 +106,10 @@ exports.AliasedDirective$1 = AliasedDirective$1;
       it('should find the decorators on an aliased class at the top level', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'AliasedDirective$1',
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'AliasedDirective$1',
             isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -887,10 +887,11 @@ exports.ExternalModule = ExternalModule;
       describe('getDecoratorsOfDeclaration()', () => {
         it('should find the decorators on a class', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators).toBeDefined();
@@ -906,11 +907,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find the decorators on a class at the top level', () => {
           loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators).toBeDefined();
@@ -926,40 +927,41 @@ exports.ExternalModule = ExternalModule;
 
         it('should return null if the symbol is not a class', () => {
           loadTestFiles([FOO_FUNCTION_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const functionNode =
-              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(functionNode);
           expect(decorators).toBe(null);
         });
 
         it('should return null if there are no decorators', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode);
           expect(decorators).toBe(null);
         });
 
         it('should ignore `decorators` if it is not an array literal', () => {
           loadTestFiles([INVALID_DECORATORS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral', isNamedVariableDeclaration);
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode);
           expect(decorators).toEqual([]);
         });
 
         it('should ignore decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_DECORATORS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -969,10 +971,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_DECORATORS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty', isNamedVariableDeclaration);
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators.length).toBe(1);
@@ -981,10 +984,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_DECORATORS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedVariableDeclaration);
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators.length).toBe(1);
@@ -994,11 +998,10 @@ exports.ExternalModule = ExternalModule;
         describe('(returned decorators `args`)', () => {
           it('should be an empty array if decorator has no `args` property', () => {
             loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1009,11 +1012,10 @@ exports.ExternalModule = ExternalModule;
 
           it('should be an empty array if decorator\'s `args` has no property assignment', () => {
             loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1024,11 +1026,10 @@ exports.ExternalModule = ExternalModule;
 
           it('should be an empty array if `args` property value is not an array literal', () => {
             loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1042,10 +1043,11 @@ exports.ExternalModule = ExternalModule;
       describe('getMembersOfClass()', () => {
         it('should find decorated members on a class', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           const input1 = members.find(member => member.name === 'input1') !;
@@ -1061,11 +1063,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find decorated members on a class at the top level', () => {
           loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           const input1 = members.find(member => member.name === 'input1') !;
@@ -1081,10 +1083,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find non decorated properties on a class', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -1096,10 +1099,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find static methods on a class', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -1110,10 +1114,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find static properties on a class', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -1125,10 +1130,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should throw if the symbol is not a class', () => {
           loadTestFiles([FOO_FUNCTION_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const functionNode =
-              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
           expect(() => {
             host.getMembersOfClass(functionNode);
           }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
@@ -1136,10 +1141,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return an empty array if there are no prop decorators', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
 
           expect(members).toEqual([]);
@@ -1148,12 +1153,10 @@ exports.ExternalModule = ExternalModule;
         it('should not process decorated properties in `propDecorators` if it is not an object literal',
            () => {
              loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-             const {program, host: compilerHost} =
-                 makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
+                 bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                  isNamedVariableDeclaration);
              const members = host.getMembersOfClass(classNode);
 
@@ -1162,11 +1165,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore prop decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
+              bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
               isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1178,11 +1180,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore prop decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
+              bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1194,11 +1195,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
+              bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
               isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1210,11 +1210,12 @@ exports.ExternalModule = ExternalModule;
 
         it('should have import information on decorators', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators.length).toEqual(1);
@@ -1224,11 +1225,10 @@ exports.ExternalModule = ExternalModule;
         describe('(returned prop decorators `args`)', () => {
           it('should be an empty array if prop decorator has no `args` property', () => {
             loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+                bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
                 isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
             const prop = members.find(m => m.name === 'prop') !;
@@ -1242,12 +1242,10 @@ exports.ExternalModule = ExternalModule;
           it('should be an empty array if prop decorator\'s `args` has no property assignment',
              () => {
                loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-               const {program, host: compilerHost} =
-                   makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-               const host =
-                   new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+               const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+               const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                   bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                    isNamedVariableDeclaration);
                const members = host.getMembersOfClass(classNode);
                const prop = members.find(m => m.name === 'prop') !;
@@ -1260,11 +1258,10 @@ exports.ExternalModule = ExternalModule;
 
           it('should be an empty array if `args` property value is not an array literal', () => {
             loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+                bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
                 isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
             const prop = members.find(m => m.name === 'prop') !;
@@ -1280,10 +1277,11 @@ exports.ExternalModule = ExternalModule;
       describe('getConstructorParameters', () => {
         it('should find the decorated constructor parameters', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
           expect(parameters).toBeDefined();
@@ -1299,11 +1297,11 @@ exports.ExternalModule = ExternalModule;
 
         it('should find the decorated constructor parameters at the top level', () => {
           loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
           expect(parameters).toBeDefined();
@@ -1319,11 +1317,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should accept `ctorParameters` as an array', () => {
           loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
+              bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1334,10 +1331,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should throw if the symbol is not a class', () => {
           loadTestFiles([FOO_FUNCTION_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const functionNode =
-              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
           expect(() => { host.getConstructorParameters(functionNode); })
               .toThrowError(
                   'Attempted to get constructor parameters of a non-class: "function foo() {}"');
@@ -1348,10 +1345,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return an array even if there are no decorators', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
+              bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1363,11 +1360,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return an empty array if there are no constructor parameters', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1379,11 +1375,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should ignore `ctorParameters` if it does not return an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1397,11 +1392,10 @@ exports.ExternalModule = ExternalModule;
         describe('(returned parameters `decorators`)', () => {
           it('should ignore param decorator elements that are not object literals', () => {
             loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
+                bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
                 isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
 
@@ -1418,11 +1412,10 @@ exports.ExternalModule = ExternalModule;
 
           it('should ignore param decorator elements that have no `type` property', () => {
             loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
+                bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
                 isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
             const decorators = parameters ![0].decorators !;
@@ -1434,12 +1427,10 @@ exports.ExternalModule = ExternalModule;
           it('should ignore param decorator elements whose `type` value is not an identifier',
              () => {
                loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-               const {program, host: compilerHost} =
-                   makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-               const host =
-                   new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+               const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+               const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
+                   bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
                    isNamedVariableDeclaration);
                const parameters = host.getConstructorParameters(classNode);
                const decorators = parameters ![0].decorators !;
@@ -1450,10 +1441,11 @@ exports.ExternalModule = ExternalModule;
 
           it('should have import information on decorators', () => {
             loadTestFiles([SOME_DIRECTIVE_FILE]);
-            const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+                isNamedVariableDeclaration);
 
             const parameters = host.getConstructorParameters(classNode);
             const decorators = parameters ![2].decorators !;
@@ -1467,11 +1459,10 @@ exports.ExternalModule = ExternalModule;
         describe('(returned parameters `decorators.args`)', () => {
           it('should be an empty array if param decorator has no `args` property', () => {
             loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+                bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
                 isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
             expect(parameters !.length).toBe(1);
@@ -1485,12 +1476,10 @@ exports.ExternalModule = ExternalModule;
           it('should be an empty array if param decorator\'s `args` has no property assignment',
              () => {
                loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-               const {program, host: compilerHost} =
-                   makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-               const host =
-                   new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+               const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+               const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                   bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                    isNamedVariableDeclaration);
                const parameters = host.getConstructorParameters(classNode);
                const decorators = parameters ![0].decorators !;
@@ -1502,11 +1491,10 @@ exports.ExternalModule = ExternalModule;
 
           it('should be an empty array if `args` property value is not an array literal', () => {
             loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-            const {program, host: compilerHost} =
-                makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-            const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+            const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+                bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
                 isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
             const decorators = parameters ![0].decorators !;
@@ -1522,12 +1510,11 @@ exports.ExternalModule = ExternalModule;
         it('should return an object describing the function declaration passed as an argument',
            () => {
              loadTestFiles([FUNCTION_BODY_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
              const fooNode = getDeclaration(
-                 program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
+                 bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
              const fooDef = host.getDefinitionOfFunction(fooNode) !;
              expect(fooDef.node).toBe(fooNode);
              expect(fooDef.body !.length).toEqual(1);
@@ -1537,7 +1524,7 @@ exports.ExternalModule = ExternalModule;
              expect(fooDef.parameters[0].initializer).toBe(null);
 
              const barNode = getDeclaration(
-                 program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
+                 bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
              const barDef = host.getDefinitionOfFunction(barNode) !;
              expect(barDef.node).toBe(barNode);
              expect(barDef.body !.length).toEqual(1);
@@ -1550,7 +1537,7 @@ exports.ExternalModule = ExternalModule;
              expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
 
              const bazNode = getDeclaration(
-                 program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
+                 bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
              const bazDef = host.getDefinitionOfFunction(bazNode) !;
              expect(bazDef.node).toBe(bazNode);
              expect(bazDef.body !.length).toEqual(3);
@@ -1559,7 +1546,7 @@ exports.ExternalModule = ExternalModule;
              expect(bazDef.parameters[0].initializer).toBe(null);
 
              const quxNode = getDeclaration(
-                 program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
+                 bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
              const quxDef = host.getDefinitionOfFunction(quxNode) !;
              expect(quxDef.node).toBe(quxNode);
              expect(quxDef.body !.length).toEqual(2);
@@ -1572,10 +1559,10 @@ exports.ExternalModule = ExternalModule;
       describe('getImportOfIdentifier', () => {
         it('should find the import of an identifier', () => {
           loadTestFiles(IMPORTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
           const identifier = (variableNode.initializer &&
                               ts.isPropertyAccessExpression(variableNode.initializer)) ?
               variableNode.initializer.name :
@@ -1599,10 +1586,10 @@ exports.ExternalModule = ExternalModule;
               contents: `export declare class MyClass {}`,
             }
           ]);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.d.ts'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.d.ts'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/index.d.ts'), 'a', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/index.d.ts'), 'a', isNamedVariableDeclaration);
           const identifier =
               ((variableNode.type as ts.TypeReferenceNode).typeName as ts.Identifier);
 
@@ -1612,10 +1599,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return null if the identifier was not imported', () => {
           loadTestFiles(IMPORTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
           const importOfIdent =
               host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
@@ -1624,10 +1611,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should handle factory functions not wrapped in parentheses', () => {
           loadTestFiles(IMPORTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
           const identifier = (variableNode.initializer &&
                               ts.isPropertyAccessExpression(variableNode.initializer)) ?
               variableNode.initializer.name :
@@ -1642,10 +1629,11 @@ exports.ExternalModule = ExternalModule;
       describe('getDeclarationOfIdentifier', () => {
         it('should return the declaration of a locally defined identifier', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const ctrDecorators = host.getConstructorParameters(classNode) !;
           const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                  local: true,
@@ -1654,7 +1642,8 @@ exports.ExternalModule = ExternalModule;
                                                }).expression;
 
           const expectedDeclarationNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef',
+              isNamedVariableDeclaration);
           const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
           expect(actualDeclaration).not.toBe(null);
           expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1664,10 +1653,11 @@ exports.ExternalModule = ExternalModule;
         it('should return the source-file of an import namespace', () => {
           loadFakeCore(getFileSystem());
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
           const identifierOfDirective = (((classDecorators[0].node as ts.ObjectLiteralExpression)
                                               .properties[0] as ts.PropertyAssignment)
@@ -1675,7 +1665,7 @@ exports.ExternalModule = ExternalModule;
                                             .expression as ts.Identifier;
 
           const expectedDeclarationNode =
-              getSourceFileOrError(program, _('/node_modules/@angular/core/index.d.ts'));
+              getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
           const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
           expect(actualDeclaration).not.toBe(null);
           expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1699,10 +1689,10 @@ exports.ExternalModule = ExternalModule;
             }
           ]);
 
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/index.js'), 'b', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/index.js'), 'b', isNamedVariableDeclaration);
           const identifier = variableNode.name as ts.Identifier;
 
           const importOfIdent = host.getDeclarationOfIdentifier(identifier !) !;
@@ -1725,10 +1715,10 @@ exports.ExternalModule = ExternalModule;
             },
           ]);
 
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const variableNode =
-              getDeclaration(program, _('/index.js'), 'b', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, _('/index.js'), 'b', isNamedVariableDeclaration);
           const identifier = (variableNode.initializer !as ts.PropertyAccessExpression).name;
 
           const importOfIdent = host.getDeclarationOfIdentifier(identifier !) !;
@@ -1740,9 +1730,9 @@ exports.ExternalModule = ExternalModule;
         it('should return a map of all the exports from a given module', () => {
           loadFakeCore(getFileSystem());
           loadTestFiles(EXPORTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const file = getSourceFileOrError(program, _('/b_module.js'));
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const file = getSourceFileOrError(bundle.program, _('/b_module.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())
@@ -1766,9 +1756,9 @@ exports.ExternalModule = ExternalModule;
         it('should handle wildcard re-exports of other modules', () => {
           loadFakeCore(getFileSystem());
           loadTestFiles(EXPORTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const file = getSourceFileOrError(program, _('/wildcard_reexports.js'));
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())
@@ -1793,9 +1783,9 @@ exports.ExternalModule = ExternalModule;
 
         it('should handle inline exports', () => {
           loadTestFiles([INLINE_EXPORT_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/inline_export.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const file = getSourceFileOrError(program, _('/inline_export.js'));
+          const bundle = makeTestBundleProgram(_('/inline_export.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const file = getSourceFileOrError(bundle.program, _('/inline_export.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBeNull();
           const decl = exportDeclarations !.get('directives') as InlineDeclaration;
@@ -1808,11 +1798,10 @@ exports.ExternalModule = ExternalModule;
       describe('getClassSymbol()', () => {
         it('should return the class symbol for an ES2015 class', () => {
           loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const node = getDeclaration(
-              program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+              bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
           const classSymbol = host.getClassSymbol(node);
 
           expect(classSymbol).toBeDefined();
@@ -1822,10 +1811,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const outerNode = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
           const classSymbol = host.getClassSymbol(outerNode);
 
@@ -1836,10 +1825,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return the class symbol for an ES5 class (inner function declaration)', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const outerNode = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
           const classSymbol = host.getClassSymbol(innerNode);
 
@@ -1851,11 +1840,10 @@ exports.ExternalModule = ExternalModule;
         it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
            () => {
              loadTestFiles([SIMPLE_CLASS_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const outerNode = getDeclaration(
-                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
 
@@ -1868,11 +1856,11 @@ exports.ExternalModule = ExternalModule;
         it('should return the class symbol for an ES5 class whose IIFE is not wrapped in parens',
            () => {
              loadTestFiles([SIMPLE_CLASS_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const outerNode = getDeclaration(
-                 program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass',
+                 isNamedVariableDeclaration);
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
              const classSymbol = host.getClassSymbol(outerNode);
@@ -1885,11 +1873,11 @@ exports.ExternalModule = ExternalModule;
         it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
            () => {
              loadTestFiles([SIMPLE_CLASS_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const outerNode = getDeclaration(
-                 program, SIMPLE_CLASS_FILE.name, 'InnerParensClass', isNamedVariableDeclaration);
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
+                 isNamedVariableDeclaration);
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
              const classSymbol = host.getClassSymbol(outerNode);
@@ -1901,10 +1889,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return undefined if node is not an ES5 class', () => {
           loadTestFiles([FOO_FUNCTION_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const node =
-              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const node = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
           const classSymbol = host.getClassSymbol(node);
 
           expect(classSymbol).toBeUndefined();
@@ -1917,11 +1905,10 @@ exports.ExternalModule = ExternalModule;
                contents: `var MyClass = null;`,
              };
              loadTestFiles([testFile]);
-             const {program, host: compilerHost} = makeTestBundleProgram(testFile.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-             const node =
-                 getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+             const bundle = makeTestBundleProgram(testFile.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+             const node = getDeclaration(
+                 bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
              const classSymbol = host.getClassSymbol(node);
 
              expect(classSymbol).toBeUndefined();
@@ -1931,33 +1918,30 @@ exports.ExternalModule = ExternalModule;
       describe('isClass()', () => {
         it('should return true if a given node is a TS class declaration', () => {
           loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const node = getDeclaration(
-              program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+              bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
           expect(host.isClass(node)).toBe(true);
         });
 
         it('should return true if a given node is the outer variable declaration of a class',
            () => {
              loadTestFiles([SIMPLE_CLASS_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const node = getDeclaration(
-                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
              expect(host.isClass(node)).toBe(true);
            });
 
         it('should return true if a given node is the inner variable declaration of a class',
            () => {
              loadTestFiles([SIMPLE_CLASS_FILE]);
-             const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
              const outerNode = getDeclaration(
-                 program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
              const innerNode =
                  getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
              expect(host.isClass(innerNode)).toBe(true);
@@ -1965,10 +1949,10 @@ exports.ExternalModule = ExternalModule;
 
         it('should return false if a given node is a function declaration', () => {
           loadTestFiles([FOO_FUNCTION_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const node =
-              getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const node = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
           expect(host.isClass(node)).toBe(false);
         });
       });
@@ -1981,10 +1965,10 @@ exports.ExternalModule = ExternalModule;
           };
 
           loadTestFiles([file]);
-          const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode =
-              getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
           return host.hasBaseClass(classNode);
         }
 
@@ -2028,10 +2012,10 @@ exports.ExternalModule = ExternalModule;
           };
 
           loadTestFiles([file]);
-          const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode =
-              getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
           const expression = host.getBaseClassExpression(classNode);
           if (expression !== null && !ts.isIdentifier(expression)) {
             throw new Error(
@@ -2100,10 +2084,10 @@ exports.ExternalModule = ExternalModule;
           };
 
           loadTestFiles([file]);
-          const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
           const classNode =
-              getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
           const expression = host.getBaseClassExpression(classNode) !;
           expect(expression.getText()).toBe('foo()');
         });
@@ -2112,11 +2096,10 @@ exports.ExternalModule = ExternalModule;
       describe('findClassSymbols()', () => {
         it('should return an array of all classes in the given source file', () => {
           loadTestFiles(DECORATED_FILES);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-          const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+          const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+          const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
           const classSymbolsPrimary = host.findClassSymbols(primaryFile);
           expect(classSymbolsPrimary.length).toEqual(2);
@@ -2131,11 +2114,10 @@ exports.ExternalModule = ExternalModule;
       describe('getDecoratorsOfSymbol()', () => {
         it('should return decorators of class symbol', () => {
           loadTestFiles(DECORATED_FILES);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-          const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+          const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+          const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
           const classSymbolsPrimary = host.findClassSymbols(primaryFile);
           const classDecoratorsPrimary =
@@ -2157,12 +2139,11 @@ exports.ExternalModule = ExternalModule;
            () => {
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
              const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
-             const class1 =
-                 getDeclaration(program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+             const class1 = getDeclaration(
+                 bundle.program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
              const dtsDeclaration = host.getDtsDeclaration(class1);
              expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2171,12 +2152,11 @@ exports.ExternalModule = ExternalModule;
         it('should find the dts declaration for exported functions', () => {
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+          const bundle = makeTestBundleProgram(_('/src/index.js'));
           const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const mooFn =
-              getDeclaration(program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
-          const host =
-              new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+              getDeclaration(bundle.program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
           const dtsDeclaration = host.getDtsDeclaration(mooFn);
           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/func1.d.ts'));
         });
@@ -2184,12 +2164,11 @@ exports.ExternalModule = ExternalModule;
         it('should return null if there is no matching class in the matching dts file', () => {
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+          const bundle = makeTestBundleProgram(_('/src/index.js'));
           const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const missingClass = getDeclaration(
-              program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
-          const host =
-              new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+              bundle.program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
           expect(host.getDtsDeclaration(missingClass)).toBe(null);
         });
@@ -2197,12 +2176,12 @@ exports.ExternalModule = ExternalModule;
         it('should return null if there is no matching dts file', () => {
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+          const bundle = makeTestBundleProgram(_('/src/index.js'));
           const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
           const missingClass = getDeclaration(
-              program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
-          const host =
-              new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+              bundle.program, _('/src/missing-class.js'), 'MissingClass2',
+              ts.isVariableDeclaration);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
           expect(host.getDtsDeclaration(missingClass)).toBe(null);
         });
@@ -2211,12 +2190,11 @@ exports.ExternalModule = ExternalModule;
            () => {
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
              const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const class1 = getDeclaration(
-                 program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+                 bundle.program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
              const dtsDeclaration = host.getDtsDeclaration(class1);
              expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2225,12 +2203,11 @@ exports.ExternalModule = ExternalModule;
         it('should find aliased exports', () => {
           loadTestFiles(TYPINGS_SRC_FILES);
           loadTestFiles(TYPINGS_DTS_FILES);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+          const bundle = makeTestBundleProgram(_('/src/index.js'));
           const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
-          const class3 =
-              getDeclaration(program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
-          const host =
-              new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+          const class3 = getDeclaration(
+              bundle.program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
           const dtsDeclaration = host.getDtsDeclaration(class3);
           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class3.d.ts'));
@@ -2240,12 +2217,11 @@ exports.ExternalModule = ExternalModule;
            () => {
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
              const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
              const internalClass = getDeclaration(
-                 program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+                 bundle.program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
              const dtsDeclaration = host.getDtsDeclaration(internalClass);
              expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/internal.d.ts'));
@@ -2255,14 +2231,13 @@ exports.ExternalModule = ExternalModule;
            () => {
              loadTestFiles(TYPINGS_SRC_FILES);
              loadTestFiles(TYPINGS_DTS_FILES);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
              const dts = makeTestDtsBundleProgram(_('/typings/index.d.ts'), _('/'));
-             const class2 =
-                 getDeclaration(program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
-             const internalClass2 =
-                 getDeclaration(program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+             const class2 = getDeclaration(
+                 bundle.program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
+             const internalClass2 = getDeclaration(
+                 bundle.program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle, dts);
 
              const class2DtsDeclaration = host.getDtsDeclaration(class2);
              expect(class2DtsDeclaration !.getSourceFile().fileName)
@@ -2277,23 +2252,23 @@ exports.ExternalModule = ExternalModule;
       describe('getInternalNameOfClass()', () => {
         it('should return the name of the inner class declaration', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
           const emptyClass = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
           const class1 = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
           expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
 
           const class2 = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
           expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
 
           const childClass = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
           expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
         });
       });
@@ -2301,23 +2276,23 @@ exports.ExternalModule = ExternalModule;
       describe('getAdjacentNameOfClass()', () => {
         it('should return the name of the inner class declaration', () => {
           loadTestFiles([SIMPLE_CLASS_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
           const emptyClass = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
           expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
           const class1 = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
           expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
 
           const class2 = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
           expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
 
           const childClass = getDeclaration(
-              program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+              bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
           expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
         });
       });
@@ -2326,10 +2301,9 @@ exports.ExternalModule = ExternalModule;
         it('should find every exported function that returns an object that looks like a ModuleWithProviders object',
            () => {
              loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-             const file = getSourceFileOrError(program, _('/src/functions.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+             const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
              const fns = host.getModuleWithProvidersFunctions(file);
              expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
                  .toEqual([
@@ -2343,10 +2317,9 @@ exports.ExternalModule = ExternalModule;
         it('should find every static method on exported classes that return an object that looks like a ModuleWithProviders object',
            () => {
              loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-             const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-             const host =
-                 new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-             const file = getSourceFileOrError(program, _('/src/methods.js'));
+             const bundle = makeTestBundleProgram(_('/src/index.js'));
+             const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+             const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
              const fn = host.getModuleWithProvidersFunctions(file);
              expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
                [
@@ -2371,9 +2344,9 @@ exports.ExternalModule = ExternalModule;
         // https://github.com/angular/angular/issues/29078
         it('should resolve aliased module references to their original declaration', () => {
           loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-          const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
-          const host = new CommonJsReflectionHost(new MockLogger(), false, program, compilerHost);
-          const file = getSourceFileOrError(program, _('/src/aliased_class.js'));
+          const bundle = makeTestBundleProgram(_('/src/index.js'));
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
           const fn = host.getModuleWithProvidersFunctions(file);
           expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
             ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -557,7 +557,8 @@ exports.xtra2 = xtra2;
     function __export(m) {
       for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
     }
-    __export(require("./b_module"));
+    var b_module = require("./b_module");
+    __export(b_module);
     __export(require("./xtra_module"));
     `
         },

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -163,11 +163,11 @@ runInEachFileSystem(() => {
 
         describe('getDecoratorsOfDeclaration()', () => {
           it('should find the decorators on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
             expect(decorators).toBeDefined();
@@ -184,11 +184,10 @@ runInEachFileSystem(() => {
 
           it('should find the decorators on a class when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -205,12 +204,11 @@ runInEachFileSystem(() => {
              });
 
           it('should support decorators being used inside @angular/core', () => {
-            const {program} =
+            const bundle =
                 makeTestBundleProgram(_('/node_modules/@angular/core/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), true, program.getTypeChecker());
+            const host = new Esm2015ReflectionHost(new MockLogger(), true, bundle);
             const classNode = getDeclaration(
-                program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
+                bundle.program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -229,11 +227,11 @@ runInEachFileSystem(() => {
 
         describe('getMembersOfClass()', () => {
           it('should find decorated members on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const input1 = members.find(member => member.name === 'input1') !;
@@ -249,11 +247,10 @@ runInEachFileSystem(() => {
 
           it('should find decorated members on a class when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const members = host.getMembersOfClass(classNode);
 
@@ -264,11 +261,11 @@ runInEachFileSystem(() => {
              });
 
           it('should find non decorated properties on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -279,11 +276,11 @@ runInEachFileSystem(() => {
           });
 
           it('should find static methods on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -293,11 +290,11 @@ runInEachFileSystem(() => {
           });
 
           it('should find static properties on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
 
             const members = host.getMembersOfClass(classNode);
             const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -309,11 +306,11 @@ runInEachFileSystem(() => {
 
           it('should find static properties on a class that has an intermediate variable assignment',
              () => {
-               const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-               const host =
-                   new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+               const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/ngmodule.js'), 'HttpClientXsrfModule', isNamedVariableDeclaration);
+                   bundle.program, _('/ngmodule.js'), 'HttpClientXsrfModule',
+                   isNamedVariableDeclaration);
 
                const members = host.getMembersOfClass(classNode);
                const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -324,12 +321,11 @@ runInEachFileSystem(() => {
              });
 
           it('should support decorators being used inside @angular/core', () => {
-            const {program} =
+            const bundle =
                 makeTestBundleProgram(_('/node_modules/@angular/core/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), true, program.getTypeChecker());
+            const host = new Esm2015ReflectionHost(new MockLogger(), true, bundle);
             const classNode = getDeclaration(
-                program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
+                bundle.program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
@@ -342,11 +338,11 @@ runInEachFileSystem(() => {
 
         describe('getConstructorParameters', () => {
           it('should find the decorated constructor parameters', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
 
             expect(parameters).toBeDefined();
@@ -362,11 +358,10 @@ runInEachFileSystem(() => {
 
           it('should find the decorated constructor parameters when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const parameters = host.getConstructorParameters(classNode);
 
@@ -390,11 +385,11 @@ runInEachFileSystem(() => {
 
         describe('getDeclarationOfIdentifier', () => {
           it('should return the declaration of a locally defined identifier', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const ctrDecorators = host.getConstructorParameters(classNode) !;
             const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                    local: true,
@@ -403,7 +398,7 @@ runInEachFileSystem(() => {
                                                  }).expression;
 
             const expectedDeclarationNode = getDeclaration(
-                program, _('/some_directive.js'), 'ViewContainerRef', ts.isClassDeclaration);
+                bundle.program, _('/some_directive.js'), 'ViewContainerRef', ts.isClassDeclaration);
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
             expect(actualDeclaration).not.toBe(null);
             expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -411,11 +406,11 @@ runInEachFileSystem(() => {
           });
 
           it('should return the declaration of an externally defined identifier', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
             const decoratorNode = classDecorators[0].node !;
             const identifierOfDirective =
@@ -424,7 +419,7 @@ runInEachFileSystem(() => {
                 null;
 
             const expectedDeclarationNode = getDeclaration(
-                program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
+                bundle.program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
                 isNamedVariableDeclaration);
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective !);
             expect(actualDeclaration).not.toBe(null);
@@ -435,11 +430,10 @@ runInEachFileSystem(() => {
 
         describe('getVariableValue', () => {
           it('should find the "actual" declaration of an aliased variable identifier', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const ngModuleRef = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'HttpClientXsrfModule_1');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'HttpClientXsrfModule_1');
 
             const value = host.getVariableValue(ngModuleRef !);
             expect(value).not.toBe(null);
@@ -451,21 +445,19 @@ runInEachFileSystem(() => {
           });
 
           it('should return null if the variable has no assignment', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const missingValue = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'missingValue');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'missingValue');
             const value = host.getVariableValue(missingValue !);
             expect(value).toBe(null);
           });
 
           it('should return null if the variable is not assigned from a call to __decorate', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const nonDecoratedVar = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'nonDecoratedVar');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'nonDecoratedVar');
             const value = host.getVariableValue(nonDecoratedVar !);
             expect(value).toBe(null);
           });
@@ -473,11 +465,10 @@ runInEachFileSystem(() => {
 
         describe('getEndOfClass()', () => {
           it('should return the last statement related to the class', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host =
-                new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
             const classSymbol =
-                host.findClassSymbols(program.getSourceFile(_('/ngmodule.js')) !)[0];
+                host.findClassSymbols(bundle.program.getSourceFile(_('/ngmodule.js')) !)[0];
             const endOfClass = host.getEndOfClass(classSymbol);
             expect(endOfClass.getText())
                 .toMatch(

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -705,10 +705,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfDeclaration()', () => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -724,10 +724,10 @@ runInEachFileSystem(() => {
 
       it('should find the decorators on an aliased class', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
-        const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
+            bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -743,40 +743,42 @@ runInEachFileSystem(() => {
 
       it('should return null if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(functionNode);
         expect(decorators).toBe(null);
       });
 
       it('should return null if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toBe(null);
       });
 
       it('should ignore `decorators` if it is not an array literal', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral', isNamedClassDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
+            isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toEqual([]);
       });
 
       it('should ignore decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral', isNamedClassDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
+            isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -785,10 +787,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty', isNamedClassDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
+            isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -797,10 +800,10 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedClassDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -809,10 +812,10 @@ runInEachFileSystem(() => {
 
       it('should have import information on decorators', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toEqual(1);
@@ -822,10 +825,11 @@ runInEachFileSystem(() => {
       describe('(returned decorators `args`)', () => {
         it('should be an empty array if decorator has no `args` property', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty', isNamedClassDeclaration);
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              isNamedClassDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
           expect(decorators.length).toBe(1);
@@ -835,10 +839,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if decorator\'s `args` has no property assignment', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
               isNamedClassDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -849,10 +853,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -866,10 +870,10 @@ runInEachFileSystem(() => {
     describe('getMembersOfClass()', () => {
       it('should find decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -887,10 +891,10 @@ runInEachFileSystem(() => {
 
       it('should find non decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -902,10 +906,10 @@ runInEachFileSystem(() => {
 
       it('should handle equally named getter/setter pairs correctly', () => {
         loadTestFiles([ACCESSORS_FILE]);
-        const {program} = makeTestBundleProgram(ACCESSORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode =
-            getDeclaration(program, ACCESSORS_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(ACCESSORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode = getDeclaration(
+            bundle.program, ACCESSORS_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const [combinedSetter, combinedGetter] =
@@ -924,10 +928,10 @@ runInEachFileSystem(() => {
 
       it('should find static methods on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -938,10 +942,10 @@ runInEachFileSystem(() => {
 
       it('should find static properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -954,10 +958,10 @@ runInEachFileSystem(() => {
       it('should ignore index signature properties', () => {
         loadTestFiles([INDEX_SIGNATURE_PROP_FILE]);
         const logger = new MockLogger();
-        const {program} = makeTestBundleProgram(INDEX_SIGNATURE_PROP_FILE.name);
-        const host = new Esm2015ReflectionHost(logger, false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INDEX_SIGNATURE_PROP_FILE.name);
+        const host = new Esm2015ReflectionHost(logger, false, bundle);
         const classNode = getDeclaration(
-            program, INDEX_SIGNATURE_PROP_FILE.name, 'IndexSignatureClass',
+            bundle.program, INDEX_SIGNATURE_PROP_FILE.name, 'IndexSignatureClass',
             isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
@@ -967,10 +971,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => {
           host.getMembersOfClass(functionNode);
         }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
@@ -978,10 +982,10 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no prop decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         expect(members).toEqual([]);
@@ -990,11 +994,10 @@ runInEachFileSystem(() => {
       it('should not process decorated properties in `propDecorators` if it is not an object literal',
          () => {
            loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-           const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const classNode = getDeclaration(
-               program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
+               bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                isNamedClassDeclaration);
            const members = host.getMembersOfClass(classNode);
 
@@ -1003,10 +1006,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
             isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1018,10 +1021,11 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty', isNamedClassDeclaration);
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
+            isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
         const decorators = prop.decorators !;
@@ -1032,10 +1036,11 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier', isNamedClassDeclaration);
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
+            isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
         const decorators = prop.decorators !;
@@ -1047,10 +1052,10 @@ runInEachFileSystem(() => {
       describe('(returned prop decorators `args`)', () => {
         it('should be an empty array if prop decorator has no `args` property', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedClassDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1064,11 +1069,10 @@ runInEachFileSystem(() => {
         it('should be an empty array if prop decorator\'s `args` has no property assignment',
            () => {
              loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-             const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-             const host =
-                 new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+             const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+             const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedClassDeclaration);
              const members = host.getMembersOfClass(classNode);
              const prop = members.find(m => m.name === 'prop') !;
@@ -1081,10 +1085,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1101,10 +1105,10 @@ runInEachFileSystem(() => {
       it('should find the decorated constructor parameters', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
         expect(parameters).toBeDefined();
@@ -1117,10 +1121,10 @@ runInEachFileSystem(() => {
 
       it('should accept `ctorParameters` as an array', () => {
         loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
-        const {program} = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
+            bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
             isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1131,10 +1135,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => { host.getConstructorParameters(functionNode); })
             .toThrowError(
                 'Attempted to get constructor parameters of a non-class: "function foo() {}"');
@@ -1142,20 +1146,20 @@ runInEachFileSystem(() => {
 
       it('should return `null` if there is no constructor', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode);
         expect(parameters).toBe(null);
       });
 
       it('should return an array even if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
+            bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
             isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1167,10 +1171,11 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no constructor parameters', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters', isNamedClassDeclaration);
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
+            isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toEqual([]);
@@ -1178,10 +1183,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorators that are not imported from core', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NotFromCore', isNamedClassDeclaration);
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotFromCore',
+            isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
         expect(parameters.length).toBe(1);
@@ -1193,10 +1199,10 @@ runInEachFileSystem(() => {
 
       it('should ignore `ctorParameters` if it is not an arrow function', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrowFunction',
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrowFunction',
             isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1209,10 +1215,11 @@ runInEachFileSystem(() => {
 
       it('should ignore `ctorParameters` if it does not return an array literal', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral', isNamedClassDeclaration);
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
+            isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
         expect(parameters.length).toBe(1);
@@ -1235,10 +1242,10 @@ runInEachFileSystem(() => {
           };
 
           loadTestFiles([file]);
-          const {program} = makeTestBundleProgram(file.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode =
-              getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
           return host.getConstructorParameters(classNode);
         }
 
@@ -1291,10 +1298,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators`)', () => {
         it('should ignore param decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1311,10 +1318,10 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1325,10 +1332,11 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier', isNamedClassDeclaration);
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
+              isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
 
@@ -1338,10 +1346,10 @@ runInEachFileSystem(() => {
 
         it('should have import information on decorators', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode) !;
           const decorators = parameters[2].decorators !;
 
@@ -1353,10 +1361,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators.args`)', () => {
         it('should be an empty array if param decorator has no `args` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           expect(parameters !.length).toBe(1);
@@ -1370,11 +1378,10 @@ runInEachFileSystem(() => {
         it('should be an empty array if param decorator\'s `args` has no property assignment',
            () => {
              loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-             const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host =
-                 new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+             const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+             const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedClassDeclaration);
              const parameters = host.getConstructorParameters(classNode);
              const decorators = parameters ![0].decorators !;
@@ -1386,10 +1393,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1405,12 +1412,11 @@ runInEachFileSystem(() => {
       it('should return an object describing the function declaration passed as an argument',
          () => {
            loadTestFiles([FUNCTION_BODY_FILE]);
-           const {program} = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
 
            const fooNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
            const fooDef = host.getDefinitionOfFunction(fooNode) !;
            expect(fooDef.node).toBe(fooNode);
            expect(fooDef.body !.length).toEqual(1);
@@ -1420,7 +1426,7 @@ runInEachFileSystem(() => {
            expect(fooDef.parameters[0].initializer).toBe(null);
 
            const barNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
            const barDef = host.getDefinitionOfFunction(barNode) !;
            expect(barDef.node).toBe(barNode);
            expect(barDef.body !.length).toEqual(1);
@@ -1433,7 +1439,7 @@ runInEachFileSystem(() => {
            expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
 
            const bazNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
            const bazDef = host.getDefinitionOfFunction(bazNode) !;
            expect(bazDef.node).toBe(bazNode);
            expect(bazDef.body !.length).toEqual(3);
@@ -1442,7 +1448,7 @@ runInEachFileSystem(() => {
            expect(bazDef.parameters[0].initializer).toBe(null);
 
            const quxNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
            const quxDef = host.getDefinitionOfFunction(quxNode) !;
            expect(quxDef.node).toBe(quxNode);
            expect(quxDef.body !.length).toEqual(2);
@@ -1451,14 +1457,14 @@ runInEachFileSystem(() => {
            expect(quxDef.parameters[0].initializer).toBe(null);
 
            const mooNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'moo', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'moo', isNamedFunctionDeclaration) !;
            const mooDef = host.getDefinitionOfFunction(mooNode) !;
            expect(mooDef.node).toBe(mooNode);
            expect(mooDef.body !.length).toEqual(3);
            expect(mooDef.parameters).toEqual([]);
 
            const juuNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'juu', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'juu', isNamedFunctionDeclaration) !;
            const juuDef = host.getDefinitionOfFunction(juuNode) !;
            expect(juuDef.node).toBe(juuNode);
            expect(juuDef.body !.length).toEqual(2);
@@ -1469,9 +1475,10 @@ runInEachFileSystem(() => {
     describe('getImportOfIdentifier()', () => {
       it('should find the import of an identifier', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'b', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'b', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
@@ -1479,9 +1486,10 @@ runInEachFileSystem(() => {
 
       it('should find the name by which the identifier was exported, not imported', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'c', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'c', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
@@ -1489,9 +1497,10 @@ runInEachFileSystem(() => {
 
       it('should return null if the identifier was not imported', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'd', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'd', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toBeNull();
@@ -1502,10 +1511,10 @@ runInEachFileSystem(() => {
       it('should return the declaration of a locally defined identifier', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(classNode.name);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(classNode);
@@ -1515,17 +1524,17 @@ runInEachFileSystem(() => {
       it('should return the declaration of an externally defined identifier', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
         const identifierOfDirective = ((classDecorators[0].node as ts.ObjectLiteralExpression)
                                            .properties[0] as ts.PropertyAssignment)
                                           .initializer as ts.Identifier;
 
         const expectedDeclarationNode = getDeclaration(
-            program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
+            bundle.program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
             isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
@@ -1536,10 +1545,10 @@ runInEachFileSystem(() => {
       it('should return the source-file of an import namespace', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([NAMESPACED_IMPORT_FILE]);
-        const {program} = makeTestBundleProgram(NAMESPACED_IMPORT_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(NAMESPACED_IMPORT_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, NAMESPACED_IMPORT_FILE.name, 'SomeDirective', ts.isClassDeclaration);
+            bundle.program, NAMESPACED_IMPORT_FILE.name, 'SomeDirective', ts.isClassDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
         const identifier = (((classDecorators[0].node as ts.ObjectLiteralExpression)
                                  .properties[0] as ts.PropertyAssignment)
@@ -1547,7 +1556,7 @@ runInEachFileSystem(() => {
                                .expression as ts.Identifier;
 
         const expectedDeclarationNode =
-            getSourceFileOrError(program, _('/node_modules/@angular/core/index.d.ts'));
+            getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1556,12 +1565,13 @@ runInEachFileSystem(() => {
 
       it('should return the original declaration of an aliased class', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
-        const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classDeclaration = getDeclaration(
-            program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', ts.isVariableDeclaration);
+            bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', ts.isVariableDeclaration);
         const usageOfAliasedClass = getDeclaration(
-            program, CLASS_EXPRESSION_FILE.name, 'usageOfAliasedClass', ts.isVariableDeclaration);
+            bundle.program, CLASS_EXPRESSION_FILE.name, 'usageOfAliasedClass',
+            ts.isVariableDeclaration);
         const aliasedClassIdentifier = usageOfAliasedClass.initializer as ts.Identifier;
         expect(aliasedClassIdentifier.text).toBe('AliasedClass_1');
         expect(host.getDeclarationOfIdentifier(aliasedClassIdentifier) !.node)
@@ -1573,9 +1583,9 @@ runInEachFileSystem(() => {
       it('should return a map of all the exports from a given module', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const file = getSourceFileOrError(program, _('/b.js'));
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/b.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
         expect(Array.from(exportDeclarations !.keys())).toEqual([
@@ -1608,10 +1618,10 @@ runInEachFileSystem(() => {
     describe('getClassSymbol()', () => {
       it('should return the class symbol for an ES2015 class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeDefined();
@@ -1622,11 +1632,11 @@ runInEachFileSystem(() => {
       it('should return the class symbol for a class expression (outer variable declaration)',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
-           const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+               bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass',
+               isNamedVariableDeclaration);
            const innerNode = (outerNode.initializer as ts.ClassExpression);
            const classSymbol = host.getClassSymbol(outerNode);
 
@@ -1637,10 +1647,10 @@ runInEachFileSystem(() => {
 
       it('should return the class symbol for a class expression (inner class expression)', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
-        const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const outerNode = getDeclaration(
-            program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = (outerNode.initializer as ts.ClassExpression);
         const classSymbol = host.getClassSymbol(innerNode);
 
@@ -1652,11 +1662,11 @@ runInEachFileSystem(() => {
       it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
-           const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+               bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass',
+               isNamedVariableDeclaration);
            const innerNode = (outerNode.initializer as ts.ClassExpression);
 
            const innerSymbol = host.getClassSymbol(innerNode) !;
@@ -1667,10 +1677,10 @@ runInEachFileSystem(() => {
 
       it('should return undefined if node is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeUndefined();
@@ -1683,11 +1693,10 @@ runInEachFileSystem(() => {
              contents: `var MyClass = null;`,
            };
            loadTestFiles([testFile]);
-           const {program} = makeTestBundleProgram(testFile.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(testFile.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const node =
-               getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+               getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
            const classSymbol = host.getClassSymbol(node);
 
            expect(classSymbol).toBeUndefined();
@@ -1697,41 +1706,40 @@ runInEachFileSystem(() => {
     describe('isClass()', () => {
       it('should return true if a given node is a TS class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.isClass(node)).toBe(true);
       });
 
       it('should return true if a given node is a class expression assigned into a variable',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
-           const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const node = getDeclaration(
-               program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+               bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
            expect(host.isClass(node)).toBe(true);
          });
 
       it('should return true if a given node is a class expression assigned into two variables',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
-           const {program} = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const node = getDeclaration(
-               program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', ts.isVariableDeclaration);
+               bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass',
+               ts.isVariableDeclaration);
            expect(host.isClass(node)).toBe(true);
          });
 
       it('should return false if a given node is a TS function declaration', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(host.isClass(node)).toBe(false);
       });
     });
@@ -1743,9 +1751,10 @@ runInEachFileSystem(() => {
           contents: `class TestClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode = getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode =
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(false);
       });
 
@@ -1757,9 +1766,10 @@ runInEachFileSystem(() => {
         class TestClass extends BaseClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode = getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode =
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(true);
       });
 
@@ -1772,10 +1782,10 @@ runInEachFileSystem(() => {
         let TestClass = TestClass_1 = class TestClass extends BaseClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(true);
       });
     });
@@ -1787,9 +1797,10 @@ runInEachFileSystem(() => {
           contents: `class TestClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode = getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode =
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.getBaseClassExpression(classNode)).toBe(null);
       });
 
@@ -1801,9 +1812,10 @@ runInEachFileSystem(() => {
         class TestClass extends BaseClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classNode = getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classNode =
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         const baseIdentifier = host.getBaseClassExpression(classNode) !;
         if (!ts.isIdentifier(baseIdentifier)) {
           throw new Error(`Expected ${baseIdentifier.getText()} to be an identifier.`);
@@ -1820,10 +1832,10 @@ runInEachFileSystem(() => {
         let TestClass = TestClass_1 = class TestClass extends BaseClass {}`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const baseIdentifier = host.getBaseClassExpression(classNode) !;
         if (!ts.isIdentifier(baseIdentifier)) {
           throw new Error(`Expected ${baseIdentifier.getText()} to be an identifier.`);
@@ -1841,11 +1853,10 @@ runInEachFileSystem(() => {
         class TestClass extends foo() {}`,
            };
            loadTestFiles([file]);
-           const {program} = makeTestBundleProgram(file.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(file.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
            const classNode =
-               getDeclaration(program, file.name, 'TestClass', isNamedClassDeclaration);
+               getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
            const baseExpression = host.getBaseClassExpression(classNode) !;
            expect(baseExpression.getText()).toEqual('foo()');
          });
@@ -1854,18 +1865,17 @@ runInEachFileSystem(() => {
     describe('getGenericArityOfClass()', () => {
       it('should properly count type parameters', () => {
         loadTestFiles(ARITY_CLASSES);
-        const {program} = makeTestBundleProgram(ARITY_CLASSES[0].name);
+        const bundle = makeTestBundleProgram(ARITY_CLASSES[0].name);
         const dts = makeTestBundleProgram(ARITY_CLASSES[1].name);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
-        const noTypeParamClass =
-            getDeclaration(program, _('/src/class.js'), 'NoTypeParam', isNamedClassDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const noTypeParamClass = getDeclaration(
+            bundle.program, _('/src/class.js'), 'NoTypeParam', isNamedClassDeclaration);
         expect(host.getGenericArityOfClass(noTypeParamClass)).toBe(0);
-        const oneTypeParamClass =
-            getDeclaration(program, _('/src/class.js'), 'OneTypeParam', isNamedClassDeclaration);
+        const oneTypeParamClass = getDeclaration(
+            bundle.program, _('/src/class.js'), 'OneTypeParam', isNamedClassDeclaration);
         expect(host.getGenericArityOfClass(oneTypeParamClass)).toBe(1);
-        const twoTypeParamsClass =
-            getDeclaration(program, _('/src/class.js'), 'TwoTypeParams', isNamedClassDeclaration);
+        const twoTypeParamsClass = getDeclaration(
+            bundle.program, _('/src/class.js'), 'TwoTypeParams', isNamedClassDeclaration);
         expect(host.getGenericArityOfClass(twoTypeParamsClass)).toBe(2);
       });
     });
@@ -1874,10 +1884,9 @@ runInEachFileSystem(() => {
       it('should return a collection of all the switchable variable declarations in the given module',
          () => {
            loadTestFiles([MARKER_FILE]);
-           const {program} = makeTestBundleProgram(MARKER_FILE.name);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-           const file = getSourceFileOrError(program, MARKER_FILE.name);
+           const bundle = makeTestBundleProgram(MARKER_FILE.name);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, MARKER_FILE.name);
            const declarations = host.getSwitchableDeclarations(file);
            expect(declarations.map(d => [d.name.getText(), d.initializer !.getText()])).toEqual([
              ['compileNgModuleFactory', 'compileNgModuleFactory__PRE_R3__']
@@ -1888,10 +1897,10 @@ runInEachFileSystem(() => {
     describe('findClassSymbols()', () => {
       it('should return an array of all classes in the given source file', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         expect(classSymbolsPrimary.length).toEqual(3);
@@ -1906,10 +1915,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfSymbol()', () => {
       it('should return decorators of class symbol', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
@@ -1927,10 +1936,10 @@ runInEachFileSystem(() => {
 
       it('should return a cloned array on each invocation', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
         const classDecl =
-            getDeclaration(program, DECORATED_FILES[0].name, 'A', ts.isClassDeclaration) !;
+            getDeclaration(bundle.program, DECORATED_FILES[0].name, 'A', ts.isClassDeclaration) !;
         const classSymbol = host.getClassSymbol(classDecl) !;
 
         const firstResult = host.getDecoratorsOfSymbol(classSymbol);
@@ -1945,12 +1954,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 =
-               getDeclaration(program, _('/ep/src/class1.js'), 'Class1', isNamedClassDeclaration);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+           const class1 = getDeclaration(
+               bundle.program, _('/ep/src/class1.js'), 'Class1', isNamedClassDeclaration);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
@@ -1959,12 +1967,11 @@ runInEachFileSystem(() => {
       it('should find the dts declaration for exported functions', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const mooFn =
-            getDeclaration(program, _('/ep/src/func1.js'), 'mooFn', isNamedFunctionDeclaration);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+        const mooFn = getDeclaration(
+            bundle.program, _('/ep/src/func1.js'), 'mooFn', isNamedFunctionDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
@@ -1973,12 +1980,12 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching class in the matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            program, _('/ep/src/missing-class.js'), 'MissingClass2', isNamedClassDeclaration);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+            bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
+            isNamedClassDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -1986,12 +1993,12 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            program, _('/ep/src/missing-class.js'), 'MissingClass2', isNamedClassDeclaration);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+            bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
+            isNamedClassDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -1999,14 +2006,13 @@ runInEachFileSystem(() => {
       it('should ignore dts files outside of the entrypoint', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(
+        const bundle = makeTestBundleProgram(
             getRootFiles(TYPINGS_SRC_FILES)[0], false, [_('/ep/src/shadow-class.js')]);
         const dts = makeTestBundleProgram(
             getRootFiles(TYPINGS_DTS_FILES)[0], false, [_('/ep/typings/shadow-class.d.ts')]);
         const missingClass = getDeclaration(
-            program, _('/ep/src/shadow-class.js'), 'ShadowClass', isNamedClassDeclaration);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+            bundle.program, _('/ep/src/shadow-class.js'), 'ShadowClass', isNamedClassDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDecl = host.getDtsDeclaration(missingClass) !;
         expect(dtsDecl).not.toBeNull();
@@ -2017,12 +2023,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
-               program, _('/ep/src/flat-file.js'), 'Class1', isNamedClassDeclaration);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+               bundle.program, _('/ep/src/flat-file.js'), 'Class1', isNamedClassDeclaration);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
@@ -2031,12 +2036,11 @@ runInEachFileSystem(() => {
       it('should find aliased exports', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const class3 =
-            getDeclaration(program, _('/ep/src/flat-file.js'), 'Class3', isNamedClassDeclaration);
-        const host =
-            new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+        const class3 = getDeclaration(
+            bundle.program, _('/ep/src/flat-file.js'), 'Class3', isNamedClassDeclaration);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(class3);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class3.d.ts'));
@@ -2046,12 +2050,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const internalClass = getDeclaration(
-               program, _('/ep/src/internal.js'), 'InternalClass', isNamedClassDeclaration);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+               bundle.program, _('/ep/src/internal.js'), 'InternalClass', isNamedClassDeclaration);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(internalClass);
            expect(dtsDeclaration !.getSourceFile().fileName)
@@ -2062,14 +2065,13 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class2 =
-               getDeclaration(program, _('/ep/src/class2.js'), 'Class2', isNamedClassDeclaration);
-           const internalClass2 =
-               getDeclaration(program, _('/ep/src/internal.js'), 'Class2', isNamedClassDeclaration);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+           const class2 = getDeclaration(
+               bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedClassDeclaration);
+           const internalClass2 = getDeclaration(
+               bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedClassDeclaration);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
            expect(class2DtsDeclaration !.getSourceFile().fileName)
@@ -2084,10 +2086,10 @@ runInEachFileSystem(() => {
     describe('getInternalNameOfClass()', () => {
       it('should return the name of the class (there is no separate inner class in ES2015)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.getInternalNameOfClass(node).text).toEqual('EmptyClass');
       });
     });
@@ -2095,10 +2097,10 @@ runInEachFileSystem(() => {
     describe('getAdjacentNameOfClass()', () => {
       it('should return the name of the class (there is no separate inner class in ES2015)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.getAdjacentNameOfClass(node).text).toEqual('EmptyClass');
       });
     });
@@ -2107,10 +2109,9 @@ runInEachFileSystem(() => {
       it('should find every exported function that returns an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program} = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-           const file = getSourceFileOrError(program, _('/src/functions.js'));
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
            const fns = host.getModuleWithProvidersFunctions(file);
            expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
                .toEqual([
@@ -2125,10 +2126,9 @@ runInEachFileSystem(() => {
       it('should find every static method on exported classes that return an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program} = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host =
-               new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-           const file = getSourceFileOrError(program, _('/src/methods.js'));
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
                .toEqual([
@@ -2143,9 +2143,9 @@ runInEachFileSystem(() => {
       // https://github.com/angular/angular/issues/29078
       it('should resolve aliased module references to their original declaration', () => {
         loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-        const {program} = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const file = getSourceFileOrError(program, _('/src/aliased_class.js'));
+        const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
         const fn = host.getModuleWithProvidersFunctions(file);
         expect(fn.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
             .toEqual([
@@ -2175,9 +2175,9 @@ runInEachFileSystem(() => {
               `var value = 100;\n`
         };
         loadTestFiles([testFile]);
-        const {program} = makeTestBundleProgram(testFile.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classSymbol = host.findClassSymbols(program.getSourceFile(testFile.name) !)[0];
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name) !)[0];
         const endOfClass = host.getEndOfClass(classSymbol);
         expect(endOfClass.getText())
             .toEqual(
@@ -2198,9 +2198,9 @@ runInEachFileSystem(() => {
               `var value = 100;\n`
         };
         loadTestFiles([testFile]);
-        const {program} = makeTestBundleProgram(testFile.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const classSymbol = host.findClassSymbols(program.getSourceFile(testFile.name) !)[0];
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name) !)[0];
         const endOfClass = host.getEndOfClass(classSymbol);
         expect(endOfClass.getText())
             .toEqual(

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -222,10 +222,11 @@ export { AliasedDirective$1 };
 
         describe('getDecoratorsOfDeclaration()', () => {
           it('should find the decorators on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
             expect(decorators).toBeDefined();
@@ -242,10 +243,10 @@ export { AliasedDirective$1 };
           });
 
           it('should find the decorators on a minified class', () => {
-            const {program} = makeTestBundleProgram(_('/some_minified_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_minified_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_minified_directive.js'), 'SomeDirective',
+                bundle.program, _('/some_minified_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -263,10 +264,10 @@ export { AliasedDirective$1 };
           });
 
           it('should find the decorators on an aliased class', () => {
-            const {program} = makeTestBundleProgram(_('/some_aliased_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_aliased_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_aliased_directive.js'), 'AliasedDirective$1',
+                bundle.program, _('/some_aliased_directive.js'), 'AliasedDirective$1',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -284,11 +285,10 @@ export { AliasedDirective$1 };
 
           it('should find the decorators on a class when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -305,11 +305,11 @@ export { AliasedDirective$1 };
              });
 
           it('should support decorators being used inside @angular/core', () => {
-            const {program} =
+            const bundle =
                 makeTestBundleProgram(_('/node_modules/@angular/core/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), true, program.getTypeChecker());
+            const host = new Esm5ReflectionHost(new MockLogger(), true, bundle);
             const classNode = getDeclaration(
-                program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
+                bundle.program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -328,10 +328,10 @@ export { AliasedDirective$1 };
 
         describe('getClassSymbol()', () => {
           it('should find a class that has been minified', () => {
-            const {program} = makeTestBundleProgram(_('/some_minified_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_minified_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_minified_directive.js'), 'SomeDirective',
+                bundle.program, _('/some_minified_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const innerNode =
                 getIifeBody(classNode) !.statements.find(isNamedFunctionDeclaration) !;
@@ -345,10 +345,11 @@ export { AliasedDirective$1 };
 
         describe('getMembersOfClass()', () => {
           it('should find decorated members on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const input1 = members.find(member => member.name === 'input1') !;
@@ -364,11 +365,10 @@ export { AliasedDirective$1 };
 
           it('should find decorated members on a class when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const members = host.getMembersOfClass(classNode);
 
@@ -379,10 +379,11 @@ export { AliasedDirective$1 };
              });
 
           it('should find non decorated properties on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -393,10 +394,11 @@ export { AliasedDirective$1 };
           });
 
           it('should find static methods on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -406,10 +408,11 @@ export { AliasedDirective$1 };
           });
 
           it('should find static properties on a class', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
             const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -420,11 +423,11 @@ export { AliasedDirective$1 };
           });
 
           it('should support decorators being used inside @angular/core', () => {
-            const {program} =
+            const bundle =
                 makeTestBundleProgram(_('/node_modules/@angular/core/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), true, program.getTypeChecker());
+            const host = new Esm5ReflectionHost(new MockLogger(), true, bundle);
             const classNode = getDeclaration(
-                program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
+                bundle.program, _('/node_modules/@angular/core/some_directive.js'), 'SomeDirective',
                 isNamedVariableDeclaration);
             const members = host.getMembersOfClass(classNode);
 
@@ -436,10 +439,11 @@ export { AliasedDirective$1 };
         });
         describe('getConstructorParameters', () => {
           it('should find the decorated constructor parameters', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const parameters = host.getConstructorParameters(classNode);
 
             expect(parameters).toBeDefined();
@@ -455,11 +459,10 @@ export { AliasedDirective$1 };
 
           it('should find the decorated constructor parameters when mixing `ctorParameters` and `__decorate`',
              () => {
-               const {program} = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
-               const host =
-                   new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+               const bundle = makeTestBundleProgram(_('/some_directive_ctor_parameters.js'));
+               const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
                const classNode = getDeclaration(
-                   program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
+                   bundle.program, _('/some_directive_ctor_parameters.js'), 'SomeDirective',
                    isNamedVariableDeclaration);
                const parameters = host.getConstructorParameters(classNode);
 
@@ -476,11 +479,11 @@ export { AliasedDirective$1 };
 
           describe('(returned parameters `decorators`)', () => {
             it('should have import information on decorators', () => {
-              const {program} = makeTestBundleProgram(_('/some_directive.js'));
-              const host =
-                  new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+              const bundle = makeTestBundleProgram(_('/some_directive.js'));
+              const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
               const classNode = getDeclaration(
-                  program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                  bundle.program, _('/some_directive.js'), 'SomeDirective',
+                  isNamedVariableDeclaration);
               const parameters = host.getConstructorParameters(classNode);
               const decorators = parameters ![2].decorators !;
 
@@ -492,15 +495,15 @@ export { AliasedDirective$1 };
 
         describe('findClassSymbols()', () => {
           it('should return an array of all classes in the given source file', () => {
-            const {program} = makeTestBundleProgram(_('/index.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/index.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-            const ngModuleFile = getSourceFileOrError(program, _('/ngmodule.js'));
+            const ngModuleFile = getSourceFileOrError(bundle.program, _('/ngmodule.js'));
             const ngModuleClasses = host.findClassSymbols(ngModuleFile);
             expect(ngModuleClasses.length).toEqual(1);
             expect(ngModuleClasses[0].name).toBe('HttpClientXsrfModule');
 
-            const someDirectiveFile = getSourceFileOrError(program, _('/some_directive.js'));
+            const someDirectiveFile = getSourceFileOrError(bundle.program, _('/some_directive.js'));
             const someDirectiveClasses = host.findClassSymbols(someDirectiveFile);
             expect(someDirectiveClasses.length).toEqual(3);
             expect(someDirectiveClasses[0].name).toBe('ViewContainerRef');
@@ -511,17 +514,17 @@ export { AliasedDirective$1 };
 
         describe('getDecoratorsOfSymbol()', () => {
           it('should return decorators of class symbol', () => {
-            const {program} = makeTestBundleProgram(_('/index.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/index.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-            const ngModuleFile = getSourceFileOrError(program, _('/ngmodule.js'));
+            const ngModuleFile = getSourceFileOrError(bundle.program, _('/ngmodule.js'));
             const ngModuleClasses = host.findClassSymbols(ngModuleFile);
             const ngModuleDecorators = ngModuleClasses.map(s => host.getDecoratorsOfSymbol(s));
 
             expect(ngModuleClasses.length).toEqual(1);
             expect(ngModuleDecorators[0] !.map(d => d.name)).toEqual(['NgModule']);
 
-            const someDirectiveFile = getSourceFileOrError(program, _('/some_directive.js'));
+            const someDirectiveFile = getSourceFileOrError(bundle.program, _('/some_directive.js'));
             const someDirectiveClasses = host.findClassSymbols(someDirectiveFile);
             const someDirectiveDecorators =
                 someDirectiveClasses.map(s => host.getDecoratorsOfSymbol(s));
@@ -535,10 +538,11 @@ export { AliasedDirective$1 };
 
         describe('getDeclarationOfIdentifier', () => {
           it('should return the declaration of a locally defined identifier', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const ctrDecorators = host.getConstructorParameters(classNode) !;
             const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                    local: true,
@@ -547,7 +551,8 @@ export { AliasedDirective$1 };
                                                  }).expression;
 
             const expectedDeclarationNode = getDeclaration(
-                program, _('/some_directive.js'), 'ViewContainerRef', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'ViewContainerRef',
+                isNamedVariableDeclaration);
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
             expect(actualDeclaration).not.toBe(null);
             expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -555,10 +560,11 @@ export { AliasedDirective$1 };
           });
 
           it('should return the declaration of an externally defined identifier', () => {
-            const {program} = makeTestBundleProgram(_('/some_directive.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/some_directive.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classNode = getDeclaration(
-                program, _('/some_directive.js'), 'SomeDirective', isNamedVariableDeclaration);
+                bundle.program, _('/some_directive.js'), 'SomeDirective',
+                isNamedVariableDeclaration);
             const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
             const decoratorNode = classDecorators[0].node !;
 
@@ -568,7 +574,7 @@ export { AliasedDirective$1 };
                 null;
 
             const expectedDeclarationNode = getDeclaration(
-                program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
+                bundle.program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
                 isNamedVariableDeclaration);
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective !);
             expect(actualDeclaration).not.toBe(null);
@@ -577,10 +583,10 @@ export { AliasedDirective$1 };
           });
 
           it('should find the "actual" declaration of an aliased variable identifier', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const ngModuleRef = findIdentifier(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'HttpClientXsrfModule_1',
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'HttpClientXsrfModule_1',
                 isNgModulePropertyAssignment);
 
             const declaration = host.getDeclarationOfIdentifier(ngModuleRef !);
@@ -590,10 +596,10 @@ export { AliasedDirective$1 };
         });
         describe('getVariableValue', () => {
           it('should find the "actual" declaration of an aliased variable identifier', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const ngModuleRef = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'HttpClientXsrfModule_1');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'HttpClientXsrfModule_1');
 
             const value = host.getVariableValue(ngModuleRef !);
             expect(value).not.toBe(null);
@@ -605,19 +611,19 @@ export { AliasedDirective$1 };
           });
 
           it('should return undefined if the variable has no assignment', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const missingValue = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'missingValue');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'missingValue');
             const value = host.getVariableValue(missingValue !);
             expect(value).toBe(null);
           });
 
           it('should return null if the variable is not assigned from a call to __decorate', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const nonDecoratedVar = findVariableDeclaration(
-                getSourceFileOrError(program, _('/ngmodule.js')), 'nonDecoratedVar');
+                getSourceFileOrError(bundle.program, _('/ngmodule.js')), 'nonDecoratedVar');
             const value = host.getVariableValue(nonDecoratedVar !);
             expect(value).toBe(null);
           });
@@ -625,10 +631,10 @@ export { AliasedDirective$1 };
 
         describe('getEndOfClass()', () => {
           it('should return the last statement related to the class', () => {
-            const {program} = makeTestBundleProgram(_('/ngmodule.js'));
-            const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+            const bundle = makeTestBundleProgram(_('/ngmodule.js'));
+            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
             const classSymbol =
-                host.findClassSymbols(program.getSourceFile(_('/ngmodule.js')) !)[0];
+                host.findClassSymbols(bundle.program.getSourceFile(_('/ngmodule.js')) !)[0];
             const endOfClass = host.getEndOfClass(classSymbol);
             expect(endOfClass.getText())
                 .toMatch(

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -16,7 +16,7 @@ import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
 import {Esm5ReflectionHost, getIifeBody} from '../../src/host/esm5_host';
 import {MockLogger} from '../helpers/mock_logger';
-import {getRootFiles, makeTestBundleProgram} from '../helpers/utils';
+import {getRootFiles, makeTestBundleProgram, makeTestDtsBundleProgram} from '../helpers/utils';
 
 import {expectTypeValueReferencesForParameters} from './util';
 
@@ -648,7 +648,7 @@ runInEachFileSystem(() => {
 
       TYPINGS_SRC_FILES = [
         {
-          name: _('/src/index.js'),
+          name: _('/ep/src/index.js'),
           contents: `
         import {InternalClass} from './internal';
         import * as func1 from './func1';
@@ -659,7 +659,7 @@ runInEachFileSystem(() => {
         `
         },
         {
-          name: _('/src/class1.js'),
+          name: _('/ep/src/class1.js'),
           contents: `
         var Class1 = (function() {
           function Class1() {}
@@ -673,7 +673,7 @@ runInEachFileSystem(() => {
         `
         },
         {
-          name: _('/src/class2.js'),
+          name: _('/ep/src/class2.js'),
           contents: `
         var Class2 = (function() {
           function Class2() {}
@@ -682,8 +682,8 @@ runInEachFileSystem(() => {
         export {Class2};
       `
         },
-        {name: _('/src/func1.js'), contents: 'function mooFn() {} export {mooFn}'}, {
-          name: _('/src/internal.js'),
+        {name: _('/ep/src/func1.js'), contents: 'function mooFn() {} export {mooFn}'}, {
+          name: _('/ep/src/internal.js'),
           contents: `
         var InternalClass = (function() {
           function InternalClass() {}
@@ -697,7 +697,7 @@ runInEachFileSystem(() => {
       `
         },
         {
-          name: _('/src/missing-class.js'),
+          name: _('/ep/src/missing-class.js'),
           contents: `
         var MissingClass2 = (function() {
           function MissingClass2() {}
@@ -707,7 +707,7 @@ runInEachFileSystem(() => {
       `
         },
         {
-          name: _('/src/flat-file.js'),
+          name: _('/ep/src/flat-file.js'),
           contents: `
         var Class1 = (function() {
           function Class1() {}
@@ -721,19 +721,20 @@ runInEachFileSystem(() => {
           function MissingClass2() {}
           return MissingClass2;
         }());
-        var Class3 = (function() {
-          function Class3() {}
-          return Class3;
+        var SourceClass = (function() {
+          function SourceClass() {}
+          return SourceClass;
         }());
-        export {Class1, Class3 as xClass3, MissingClass1, MissingClass2};
+        export {Class1, SourceClass as AliasedClass, MissingClass1, MissingClass2};
       `
         }
       ];
 
       TYPINGS_DTS_FILES = [
         {
-          name: _('/typings/index.d.ts'),
+          name: _('/ep/typings/index.d.ts'),
           contents: `
+            import '../../an_external_lib/index';
             import {InternalClass} from './internal';
             import {mooFn} from './func1';
             export * from './class1';
@@ -741,20 +742,28 @@ runInEachFileSystem(() => {
             `
         },
         {
-          name: _('/typings/class1.d.ts'),
+          name: _('/ep/typings/class1.d.ts'),
           contents: `export declare class Class1 {}\nexport declare class OtherClass {}`
         },
         {
-          name: _('/typings/class2.d.ts'),
-          contents:
-              `export declare class Class2 {}\nexport declare interface SomeInterface {}\nexport {Class3 as xClass3} from './class3';`
+          name: _('/ep/typings/class2.d.ts'),
+          contents: `
+            export declare class Class2 {}
+            export declare interface SomeInterface {}
+            export {TypingsClass as AliasedClass} from './typings-class';
+          `
         },
-        {name: _('/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
+        {name: _('/ep/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
         {
-          name: _('/typings/internal.d.ts'),
+          name: _('/ep/typings/internal.d.ts'),
           contents: `export declare class InternalClass {}\nexport declare class Class2 {}`
         },
-        {name: _('/typings/class3.d.ts'), contents: `export declare class Class3 {}`},
+        {
+          name: _('/ep/typings/typings-class.d.ts'),
+          contents: `export declare class TypingsClass {}`
+        },
+        {name: _('/ep/typings/shadow-class.d.ts'), contents: `export declare class ShadowClass {}`},
+        {name: _('/an_external_lib/index.d.ts'), contents: 'export declare class ShadowClass {}'},
       ];
 
       MODULE_WITH_PROVIDERS_PROGRAM = [
@@ -2369,24 +2378,24 @@ runInEachFileSystem(() => {
            const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
-               bundle.program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/class1.js'), 'Class1', ts.isVariableDeclaration);
            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
+           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find the dts declaration for exported functions', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const mooFn =
-            getDeclaration(bundle.program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
+        const bundle = makeTestBundleProgram(_('/ep/src/func1.js'));
+        const dts = makeTestDtsBundleProgram(_('/ep/typings/func1.d.ts'), _('/'));
+        const mooFn = getDeclaration(
+            bundle.program, _('/ep/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/func1.d.ts'));
+        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
       });
 
       it('should return null if there is no matching class in the matching dts file', () => {
@@ -2395,7 +2404,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            bundle.program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
+            bundle.program, _('/ep/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
@@ -2407,7 +2416,8 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            bundle.program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
+            bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
+            ts.isVariableDeclaration);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
@@ -2417,27 +2427,35 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
-               bundle.program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
+           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find aliased exports', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const class3 = getDeclaration(
-            bundle.program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
+        const sourceClass = getDeclaration(
+            bundle.program, _('/ep/src/flat-file.js'), 'SourceClass', ts.isVariableDeclaration);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
-        const dtsDeclaration = host.getDtsDeclaration(class3);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class3.d.ts'));
+        const dtsDeclaration = host.getDtsDeclaration(sourceClass);
+        if (dtsDeclaration === null) {
+          return fail('Expected dts class to be found');
+        }
+        if (!isNamedClassDeclaration(dtsDeclaration)) {
+          return fail('Expected a named class to be found.');
+        }
+        expect(dtsDeclaration.name.text).toEqual('TypingsClass');
+        expect(_(dtsDeclaration.getSourceFile().fileName))
+            .toEqual(_('/ep/typings/typings-class.d.ts'));
       });
 
       it('should find the dts file that contains a matching class declaration, even if the class is not publicly exported',
@@ -2447,32 +2465,33 @@ runInEachFileSystem(() => {
            const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const internalClass = getDeclaration(
-               bundle.program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(internalClass);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/internal.d.ts'));
+           expect(dtsDeclaration !.getSourceFile().fileName)
+               .toEqual(_('/ep/typings/internal.d.ts'));
          });
 
-      it('should prefer the publicly exported class if there are multiple classes with the same name',
+      it('should match publicly and internal exported classes correctly, even if they have the same name',
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
            const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class2 = getDeclaration(
-               bundle.program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
-           const internalClass2 = getDeclaration(
-               bundle.program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
            const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
+           const class2 = getDeclaration(
+               bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedVariableDeclaration);
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
            expect(class2DtsDeclaration !.getSourceFile().fileName)
-               .toEqual(_('/typings/class2.d.ts'));
+               .toEqual(_('/ep/typings/class2.d.ts'));
 
+           const internalClass2 = getDeclaration(
+               bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedVariableDeclaration);
            const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
            expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
-               .toEqual(_('/typings/class2.d.ts'));
+               .toEqual(_('/ep/typings/internal.d.ts'));
          });
     });
 

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -868,10 +868,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfDeclaration()', () => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -887,10 +887,11 @@ runInEachFileSystem(() => {
 
       it('should find the decorators on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -906,40 +907,42 @@ runInEachFileSystem(() => {
 
       it('should return null if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(functionNode);
         expect(decorators).toBe(null);
       });
 
       it('should return null if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toBe(null);
       });
 
       it('should ignore `decorators` if it is not an array literal', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toEqual([]);
       });
 
       it('should ignore decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -948,10 +951,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -960,10 +964,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -972,10 +977,10 @@ runInEachFileSystem(() => {
 
       it('should have import information on decorators', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toEqual(1);
@@ -985,10 +990,10 @@ runInEachFileSystem(() => {
       describe('(returned decorators `args`)', () => {
         it('should be an empty array if decorator has no `args` property', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -999,10 +1004,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if decorator\'s `args` has no property assignment', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1013,10 +1018,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1030,10 +1035,11 @@ runInEachFileSystem(() => {
     describe('getMembersOfClass()', () => {
       it('should find decorated members on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -1051,10 +1057,10 @@ runInEachFileSystem(() => {
 
       it('should find decorated members on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -1070,10 +1076,10 @@ runInEachFileSystem(() => {
 
       it('should find Object.defineProperty members on a class', () => {
         loadTestFiles([ACCESSORS_FILE]);
-        const {program} = makeTestBundleProgram(ACCESSORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(ACCESSORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, ACCESSORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, ACCESSORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const setter = members.find(member => member.name === 'setter') !;
@@ -1118,10 +1124,10 @@ runInEachFileSystem(() => {
 
       it('should find non decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -1133,10 +1139,10 @@ runInEachFileSystem(() => {
 
       it('should find static methods on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -1148,10 +1154,10 @@ runInEachFileSystem(() => {
 
       it('should find static properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -1163,10 +1169,10 @@ runInEachFileSystem(() => {
 
       it('should accept `ctorParameters` as an array', () => {
         loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
-        const {program} = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
+            bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1177,10 +1183,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => {
           host.getMembersOfClass(functionNode);
         }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
@@ -1188,10 +1194,10 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no prop decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         expect(members).toEqual([]);
@@ -1200,10 +1206,10 @@ runInEachFileSystem(() => {
       it('should not process decorated properties in `propDecorators` if it is not an object literal',
          () => {
            loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-           const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
            const classNode = getDeclaration(
-               program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
+               bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                isNamedVariableDeclaration);
            const members = host.getMembersOfClass(classNode);
 
@@ -1212,10 +1218,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1227,10 +1233,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1242,10 +1248,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1258,10 +1264,10 @@ runInEachFileSystem(() => {
       describe('(returned prop decorators `args`)', () => {
         it('should be an empty array if prop decorator has no `args` property', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1275,10 +1281,10 @@ runInEachFileSystem(() => {
         it('should be an empty array if prop decorator\'s `args` has no property assignment',
            () => {
              loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-             const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-             const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+             const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+             const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedVariableDeclaration);
              const members = host.getMembersOfClass(classNode);
              const prop = members.find(m => m.name === 'prop') !;
@@ -1291,10 +1297,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const members = host.getMembersOfClass(classNode);
           const prop = members.find(m => m.name === 'prop') !;
@@ -1309,10 +1315,11 @@ runInEachFileSystem(() => {
       it('should ignore the prototype pseudo-static property on class imported from typings files',
          () => {
            loadTestFiles([UNWANTED_PROTOTYPE_EXPORT_FILE]);
-           const {program} = makeTestBundleProgram(UNWANTED_PROTOTYPE_EXPORT_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(UNWANTED_PROTOTYPE_EXPORT_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
            const classNode = getDeclaration(
-               program, UNWANTED_PROTOTYPE_EXPORT_FILE.name, 'SomeParam', isNamedClassDeclaration);
+               bundle.program, UNWANTED_PROTOTYPE_EXPORT_FILE.name, 'SomeParam',
+               isNamedClassDeclaration);
            const members = host.getMembersOfClass(classNode);
            expect(members.find(m => m.name === 'prototype')).toBeUndefined();
          });
@@ -1321,10 +1328,10 @@ runInEachFileSystem(() => {
     describe('getConstructorParameters()', () => {
       it('should find the decorated constructor parameters', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
@@ -1340,10 +1347,11 @@ runInEachFileSystem(() => {
 
       it('should find the decorated constructor parameters at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
@@ -1359,10 +1367,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => { host.getConstructorParameters(functionNode); })
             .toThrowError(
                 'Attempted to get constructor parameters of a non-class: "function foo() {}"');
@@ -1373,10 +1381,10 @@ runInEachFileSystem(() => {
 
       it('should return an array even if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
+            bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
@@ -1388,10 +1396,11 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no constructor parameters', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters', isNamedVariableDeclaration);
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
+            isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toEqual([]);
@@ -1402,10 +1411,10 @@ runInEachFileSystem(() => {
 
       it('should ignore `ctorParameters` if it does not return an array literal', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
@@ -1419,10 +1428,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators`)', () => {
         it('should ignore param decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1439,10 +1448,10 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1453,10 +1462,10 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1467,10 +1476,11 @@ runInEachFileSystem(() => {
 
         it('should have import information on decorators', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![2].decorators !;
 
@@ -1493,10 +1503,10 @@ runInEachFileSystem(() => {
           };
 
           loadTestFiles([file]);
-          const {program} = makeTestBundleProgram(file.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode =
-              getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
           return host.getConstructorParameters(classNode);
         }
 
@@ -1562,10 +1572,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators.args`)', () => {
         it('should be an empty array if param decorator has no `args` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           expect(parameters !.length).toBe(1);
@@ -1579,10 +1589,10 @@ runInEachFileSystem(() => {
         it('should be an empty array if param decorator\'s `args` has no property assignment',
            () => {
              loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-             const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+             const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+             const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedVariableDeclaration);
              const parameters = host.getConstructorParameters(classNode);
              const decorators = parameters ![0].decorators !;
@@ -1594,10 +1604,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program} = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1613,11 +1623,11 @@ runInEachFileSystem(() => {
       it('should return an object describing the function declaration passed as an argument',
          () => {
            loadTestFiles([FUNCTION_BODY_FILE]);
-           const {program} = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
            const fooNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
            const fooDef = host.getDefinitionOfFunction(fooNode) !;
            expect(fooDef.node).toBe(fooNode);
            expect(fooDef.body !.length).toEqual(1);
@@ -1627,7 +1637,7 @@ runInEachFileSystem(() => {
            expect(fooDef.parameters[0].initializer).toBe(null);
 
            const barNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
            const barDef = host.getDefinitionOfFunction(barNode) !;
            expect(barDef.node).toBe(barNode);
            expect(barDef.body !.length).toEqual(1);
@@ -1640,7 +1650,7 @@ runInEachFileSystem(() => {
            expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
 
            const bazNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
            const bazDef = host.getDefinitionOfFunction(bazNode) !;
            expect(bazDef.node).toBe(bazNode);
            expect(bazDef.body !.length).toEqual(3);
@@ -1649,7 +1659,7 @@ runInEachFileSystem(() => {
            expect(bazDef.parameters[0].initializer).toBe(null);
 
            const quxNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
            const quxDef = host.getDefinitionOfFunction(quxNode) !;
            expect(quxDef.node).toBe(quxNode);
            expect(quxDef.body !.length).toEqual(2);
@@ -1664,10 +1674,11 @@ runInEachFileSystem(() => {
           contents: `export declare function __spread(...args: any[][]): any[];`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const node = getDeclaration(program, file.name, '__spread', isNamedFunctionDeclaration) !;
+        const node =
+            getDeclaration(bundle.program, file.name, '__spread', isNamedFunctionDeclaration) !;
 
         const definition = host.getDefinitionOfFunction(node) !;
         expect(definition.node).toBe(node);
@@ -1686,10 +1697,11 @@ runInEachFileSystem(() => {
               };`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const node = getDeclaration(program, file.name, '__spread', ts.isVariableDeclaration) !;
+        const node =
+            getDeclaration(bundle.program, file.name, '__spread', ts.isVariableDeclaration) !;
 
         const definition = host.getDefinitionOfFunction(node) !;
         expect(definition.node).toBe(node);
@@ -1709,11 +1721,11 @@ runInEachFileSystem(() => {
               };`,
            };
            loadTestFiles([file]);
-           const {program} = makeTestBundleProgram(file.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(file.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
            const node =
-               getDeclaration(program, file.name, '__spread$2', ts.isVariableDeclaration) !;
+               getDeclaration(bundle.program, file.name, '__spread$2', ts.isVariableDeclaration) !;
 
            const definition = host.getDefinitionOfFunction(node) !;
            expect(definition.node).toBe(node);
@@ -1728,11 +1740,11 @@ runInEachFileSystem(() => {
           contents: `export declare function __spreadArrays(...args: any[][]): any[];`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const node =
-            getDeclaration(program, file.name, '__spreadArrays', isNamedFunctionDeclaration) !;
+        const node = getDeclaration(
+            bundle.program, file.name, '__spreadArrays', isNamedFunctionDeclaration) !;
 
         const definition = host.getDefinitionOfFunction(node) !;
         expect(definition.node).toBe(node);
@@ -1754,11 +1766,11 @@ runInEachFileSystem(() => {
                 };`,
         };
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
         const node =
-            getDeclaration(program, file.name, '__spreadArrays', ts.isVariableDeclaration) !;
+            getDeclaration(bundle.program, file.name, '__spreadArrays', ts.isVariableDeclaration) !;
 
         const definition = host.getDefinitionOfFunction(node) !;
         expect(definition.node).toBe(node);
@@ -1781,11 +1793,11 @@ runInEachFileSystem(() => {
                 };`,
            };
            loadTestFiles([file]);
-           const {program} = makeTestBundleProgram(file.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(file.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-           const node =
-               getDeclaration(program, file.name, '__spreadArrays$2', ts.isVariableDeclaration) !;
+           const node = getDeclaration(
+               bundle.program, file.name, '__spreadArrays$2', ts.isVariableDeclaration) !;
 
            const definition = host.getDefinitionOfFunction(node) !;
            expect(definition.node).toBe(node);
@@ -1798,9 +1810,10 @@ runInEachFileSystem(() => {
     describe('getImportOfIdentifier()', () => {
       it('should find the import of an identifier', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'b', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'b', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
@@ -1808,9 +1821,10 @@ runInEachFileSystem(() => {
 
       it('should find the name by which the identifier was exported, not imported', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'c', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'c', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
@@ -1818,9 +1832,10 @@ runInEachFileSystem(() => {
 
       it('should return null if the identifier was not imported', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const variableNode = getDeclaration(program, _('/b.js'), 'd', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const variableNode =
+            getDeclaration(bundle.program, _('/b.js'), 'd', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toBeNull();
@@ -1830,10 +1845,10 @@ runInEachFileSystem(() => {
     describe('getDeclarationOfIdentifier()', () => {
       it('should return the declaration of a locally defined identifier', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const ctrDecorators = host.getConstructorParameters(classNode) !;
         const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                local: true,
@@ -1842,7 +1857,8 @@ runInEachFileSystem(() => {
                                              }).expression;
 
         const expectedDeclarationNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef',
+            isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1852,17 +1868,17 @@ runInEachFileSystem(() => {
       it('should return the declaration of an externally defined identifier', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
         const identifierOfDirective = ((classDecorators[0].node as ts.ObjectLiteralExpression)
                                            .properties[0] as ts.PropertyAssignment)
                                           .initializer as ts.Identifier;
 
         const expectedDeclarationNode = getDeclaration(
-            program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
+            bundle.program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
             isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
@@ -1873,10 +1889,11 @@ runInEachFileSystem(() => {
       it('should return the source-file of an import namespace', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([NAMESPACED_IMPORT_FILE]);
-        const {program} = makeTestBundleProgram(NAMESPACED_IMPORT_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(NAMESPACED_IMPORT_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, NAMESPACED_IMPORT_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, NAMESPACED_IMPORT_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
         const identifier = (((classDecorators[0].node as ts.ObjectLiteralExpression)
                                  .properties[0] as ts.PropertyAssignment)
@@ -1884,7 +1901,7 @@ runInEachFileSystem(() => {
                                .expression as ts.Identifier;
 
         const expectedDeclarationNode =
-            getSourceFileOrError(program, _('/node_modules/@angular/core/index.d.ts'));
+            getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1897,11 +1914,11 @@ runInEachFileSystem(() => {
                spyOn(Esm2015ReflectionHost.prototype, 'getDeclarationOfIdentifier')
                    .and.callThrough();
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
            const outerDeclaration = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
            const innerDeclaration = (((outerDeclaration.initializer as ts.ParenthesizedExpression)
                                           .expression as ts.CallExpression)
                                          .expression as ts.FunctionExpression)
@@ -1951,11 +1968,11 @@ runInEachFileSystem(() => {
            };
 
            loadTestFiles([PROGRAM_FILE]);
-           const {program} = makeTestBundleProgram(PROGRAM_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(PROGRAM_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
            const expectedDeclaration = getDeclaration(
-               program, PROGRAM_FILE.name, 'FroalaEditorModule', isNamedVariableDeclaration);
+               bundle.program, PROGRAM_FILE.name, 'FroalaEditorModule', isNamedVariableDeclaration);
            // Grab the `FroalaEditorModule_1` identifier returned from the `forRoot()` method
            const forRootMethod = ((((expectedDeclaration.initializer as ts.ParenthesizedExpression)
                                         .expression as ts.CallExpression)
@@ -1976,9 +1993,9 @@ runInEachFileSystem(() => {
       it('should return a map of all the exports from a given module', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
-        const {program} = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const file = getSourceFileOrError(program, _('/b.js'));
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/b.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
         expect(Array.from(exportDeclarations !.keys())).toEqual([
@@ -2017,10 +2034,10 @@ runInEachFileSystem(() => {
     describe('getClassSymbol()', () => {
       it('should return the class symbol for an ES2015 class', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const node = getDeclaration(
-            program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeDefined();
@@ -2030,10 +2047,10 @@ runInEachFileSystem(() => {
 
       it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const outerNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         const classSymbol = host.getClassSymbol(outerNode);
 
@@ -2044,10 +2061,10 @@ runInEachFileSystem(() => {
 
       it('should return the class symbol for an ES5 class (inner function declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const outerNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         const classSymbol = host.getClassSymbol(innerNode);
 
@@ -2059,10 +2076,10 @@ runInEachFileSystem(() => {
       it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
 
            const innerSymbol = host.getClassSymbol(innerNode) !;
@@ -2074,10 +2091,10 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES5 class whose IIFE is not wrapped in parens',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
            const classSymbol = host.getClassSymbol(outerNode);
 
@@ -2089,10 +2106,11 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'InnerParensClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
+               isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
            const classSymbol = host.getClassSymbol(outerNode);
 
@@ -2103,10 +2121,10 @@ runInEachFileSystem(() => {
 
       it('should return undefined if node is not an ES5 class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeUndefined();
@@ -2118,9 +2136,10 @@ runInEachFileSystem(() => {
           contents: `var MyClass = null;`,
         };
         loadTestFiles([testFile]);
-        const {program} = makeTestBundleProgram(testFile.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node = getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const node =
+            getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeUndefined();
@@ -2130,38 +2149,38 @@ runInEachFileSystem(() => {
     describe('isClass()', () => {
       it('should return true if a given node is a TS class declaration', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const node = getDeclaration(
-            program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.isClass(node)).toBe(true);
       });
 
       it('should return true if a given node is the outer variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
         expect(host.isClass(node)).toBe(true);
       });
 
       it('should return true if a given node is the inner variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const outerNode =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const outerNode = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         expect(host.isClass(innerNode)).toBe(true);
       });
 
       it('should return false if a given node is a function declaration', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(host.isClass(node)).toBe(false);
       });
     });
@@ -2174,10 +2193,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         return host.hasBaseClass(classNode);
       }
 
@@ -2221,10 +2240,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const expression = host.getBaseClassExpression(classNode);
         if (expression !== null && !ts.isIdentifier(expression)) {
           throw new Error(
@@ -2293,10 +2312,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program} = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const expression = host.getBaseClassExpression(classNode) !;
         expect(expression.getText()).toBe('foo()');
       });
@@ -2305,10 +2324,10 @@ runInEachFileSystem(() => {
     describe('findClassSymbols()', () => {
       it('should return an array of all classes in the given source file', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         expect(classSymbolsPrimary.length).toEqual(2);
@@ -2323,10 +2342,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfSymbol()', () => {
       it('should return decorators of class symbol', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
@@ -2347,12 +2366,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 =
-               getDeclaration(program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
-           const host =
-               new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+           const class1 = getDeclaration(
+               bundle.program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2361,11 +2379,11 @@ runInEachFileSystem(() => {
       it('should find the dts declaration for exported functions', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const mooFn =
-            getDeclaration(program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+            getDeclaration(bundle.program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/func1.d.ts'));
@@ -2374,11 +2392,11 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching class in the matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const missingClass =
-            getDeclaration(program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+        const missingClass = getDeclaration(
+            bundle.program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2386,11 +2404,11 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+            bundle.program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2399,12 +2417,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 =
-               getDeclaration(program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host =
-               new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+           const class1 = getDeclaration(
+               bundle.program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2413,11 +2430,11 @@ runInEachFileSystem(() => {
       it('should find aliased exports', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const class3 =
-            getDeclaration(program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+        const class3 = getDeclaration(
+            bundle.program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(class3);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class3.d.ts'));
@@ -2427,12 +2444,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const internalClass = getDeclaration(
-               program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
-           const host =
-               new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+               bundle.program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(internalClass);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/internal.d.ts'));
@@ -2442,14 +2458,13 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program} = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class2 =
-               getDeclaration(program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
-           const internalClass2 =
-               getDeclaration(program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
-           const host =
-               new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker(), dts);
+           const class2 = getDeclaration(
+               bundle.program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
+           const internalClass2 = getDeclaration(
+               bundle.program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle, dts);
 
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
            expect(class2DtsDeclaration !.getSourceFile().fileName)
@@ -2464,23 +2479,23 @@ runInEachFileSystem(() => {
     describe('getInternalNameOfClass()', () => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
         const emptyClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
         const class1 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
 
         const class2 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
 
         const childClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
       });
     });
@@ -2488,23 +2503,23 @@ runInEachFileSystem(() => {
     describe('getAdjacentNameOfClass()', () => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
         const emptyClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
         const class1 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
 
         const class2 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
 
         const childClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
       });
     });
@@ -2513,9 +2528,9 @@ runInEachFileSystem(() => {
       it('should find every exported function that returns an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program} = makeTestBundleProgram(_('/src/index.js'));
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-           const file = getSourceFileOrError(program, _('/src/functions.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
            const fns = host.getModuleWithProvidersFunctions(file);
            expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
                .toEqual([
@@ -2530,9 +2545,9 @@ runInEachFileSystem(() => {
       it('should find every static method on exported classes that return an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program} = makeTestBundleProgram(_('/src/index.js'));
-           const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-           const file = getSourceFileOrError(program, _('/src/methods.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
+           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
              [
@@ -2561,9 +2576,9 @@ runInEachFileSystem(() => {
       // https://github.com/angular/angular/issues/29078
       it('should resolve aliased module references to their original declaration', () => {
         loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-        const {program} = makeTestBundleProgram(_('/src/index.js'));
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
-        const file = getSourceFileOrError(program, _('/src/aliased_class.js'));
+        const bundle = makeTestBundleProgram(_('/src/index.js'));
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
         const fn = host.getModuleWithProvidersFunctions(file);
         expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
           ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],
@@ -2574,10 +2589,10 @@ runInEachFileSystem(() => {
     describe('getEndOfClass()', () => {
       it('should return the last static property of the class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
         const classSymbol =
-            host.findClassSymbols(program.getSourceFile(SOME_DIRECTIVE_FILE.name) !)[0];
+            host.findClassSymbols(bundle.program.getSourceFile(SOME_DIRECTIVE_FILE.name) !)[0];
         const endOfClass = host.getEndOfClass(classSymbol);
         expect(endOfClass.getText()).toEqual(`SomeDirective.propDecorators = {
         "input1": [{ type: Input },],

--- a/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_import_helper_spec.ts
@@ -77,10 +77,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfDeclaration()', () => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -97,10 +97,11 @@ runInEachFileSystem(() => {
 
       it('should find the decorators on an aliased class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'AliasedDirective$1', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'AliasedDirective$1',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -119,10 +120,10 @@ runInEachFileSystem(() => {
     describe('getMembersOfClass()', () => {
       it('should find decorated members on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -139,10 +140,11 @@ runInEachFileSystem(() => {
       describe('getConstructorParameters', () => {
         it('should find the decorated constructor parameters', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
           expect(parameters).toBeDefined();

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -720,7 +720,7 @@ __export(xtra_module);
 
       TYPINGS_SRC_FILES = [
         {
-          name: _('/src/index.js'),
+          name: _('/ep/src/index.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./internal'), require('./class1'), require('./class2'), require('./missing-class'), require('./flat-file'), require('./func1')) :
@@ -737,7 +737,7 @@ __export(xtra_module);
     `
         },
         {
-          name: _('/src/class1.js'),
+          name: _('/ep/src/class1.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
@@ -758,7 +758,7 @@ __export(xtra_module);
     `
         },
         {
-          name: _('/src/class2.js'),
+          name: _('/ep/src/class2.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
@@ -773,8 +773,8 @@ __export(xtra_module);
     })));
     `
         },
-        {name: _('/src/func1.js'), contents: 'function mooFn() {} export {mooFn}'}, {
-          name: _('/src/internal.js'),
+        {name: _('/ep/src/func1.js'), contents: 'function mooFn() {} export {mooFn}'}, {
+          name: _('/ep/src/internal.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
@@ -795,7 +795,7 @@ __export(xtra_module);
     `
         },
         {
-          name: _('/src/missing-class.js'),
+          name: _('/ep/src/missing-class.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
@@ -811,7 +811,7 @@ __export(xtra_module);
     `
         },
         {
-          name: _('/src/flat-file.js'),
+          name: _('/ep/src/flat-file.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
@@ -830,12 +830,12 @@ __export(xtra_module);
         function MissingClass2() {}
         return MissingClass2;
       }());
-      var Class3 = (function() {
-        function Class3() {}
-        return Class3;
+      var SourceClass = (function() {
+        function SourceClass() {}
+        return SourceClass;
       }());
-      exports.Class1 = Class1;
-      exports.xClass3 = Class3;
+    exports.Class1 = Class1;
+      exports.AliasedClass = SourceClass;
       exports.MissingClass1 = MissingClass1;
       exports.MissingClass2 = MissingClass2;
     })));
@@ -845,29 +845,38 @@ __export(xtra_module);
 
       TYPINGS_DTS_FILES = [
         {
-          name: _('/typings/index.d.ts'),
+          name: _('/ep/typings/index.d.ts'),
           contents: `
-              import {InternalClass} from './internal';
-              import {mooFn} from './func1';
-              export * from './class1';
-              export * from './class2';
-          `
+            import '../../an_external_lib/index';
+            import {InternalClass} from './internal';
+            import {mooFn} from './func1';
+            export * from './class1';
+            export * from './class2';
+            `
         },
         {
-          name: _('/typings/class1.d.ts'),
+          name: _('/ep/typings/class1.d.ts'),
           contents: `export declare class Class1 {}\nexport declare class OtherClass {}`
         },
         {
-          name: _('/typings/class2.d.ts'),
-          contents:
-              `export declare class Class2 {}\nexport declare interface SomeInterface {}\nexport {Class3 as xClass3} from './class3';`
+          name: _('/ep/typings/class2.d.ts'),
+          contents: `
+            export declare class Class2 {}
+            export declare interface SomeInterface {}
+            export {TypingsClass as AliasedClass} from './typings-class';
+          `
         },
-        {name: _('/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
+        {name: _('/ep/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
         {
-          name: _('/typings/internal.d.ts'),
+          name: _('/ep/typings/internal.d.ts'),
           contents: `export declare class InternalClass {}\nexport declare class Class2 {}`
         },
-        {name: _('/typings/class3.d.ts'), contents: `export declare class Class3 {}`},
+        {
+          name: _('/ep/typings/typings-class.d.ts'),
+          contents: `export declare class TypingsClass {}`
+        },
+        {name: _('/ep/typings/shadow-class.d.ts'), contents: `export declare class ShadowClass {}`},
+        {name: _('/an_external_lib/index.d.ts'), contents: 'export declare class ShadowClass {}'},
       ];
 
       MODULE_WITH_PROVIDERS_PROGRAM = [
@@ -2240,48 +2249,48 @@ __export(xtra_module);
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/src/index.js'));
-           const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
-               bundle.program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/class1.js'), 'Class1', ts.isVariableDeclaration);
            const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
+           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find the dts declaration for exported functions', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/src/index.js'));
-        const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-        const mooFn =
-            getDeclaration(bundle.program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
+        const bundle = makeTestBundleProgram(_('/ep/src/func1.js'));
+        const dts = makeTestBundleProgram(_('/ep/typings/func1.d.ts'));
+        const mooFn = getDeclaration(
+            bundle.program, _('/ep/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
         const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/func1.d.ts'));
+        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
       });
 
       it('should return null if there is no matching class in the matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/src/index.js'));
-        const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            bundle.program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
+            bundle.program, _('/ep/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
         const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
-
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
 
       it('should return null if there is no matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/src/index.js'));
-        const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
+        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
-            bundle.program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
+            bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
+            ts.isVariableDeclaration);
         const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
@@ -2291,62 +2300,91 @@ __export(xtra_module);
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/src/index.js'));
-           const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
-               bundle.program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
            const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
+           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+         });
+
+      it('should find the dts file that contains a matching class declaration, even if the source files do not match',
+         () => {
+           loadTestFiles(TYPINGS_SRC_FILES);
+           loadTestFiles(TYPINGS_DTS_FILES);
+           const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
+           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+           const class1 = getDeclaration(
+               bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+
+           const dtsDeclaration = host.getDtsDeclaration(class1);
+           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find aliased exports', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/src/index.js'));
-        const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-        const class3 = getDeclaration(
-            bundle.program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
+        const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
+        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+        const sourceClass = getDeclaration(
+            bundle.program, _('/ep/src/flat-file.js'), 'SourceClass', ts.isVariableDeclaration);
         const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
-        const dtsDeclaration = host.getDtsDeclaration(class3);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class3.d.ts'));
+        const dtsDeclaration = host.getDtsDeclaration(sourceClass);
+        if (dtsDeclaration === null) {
+          return fail('Expected dts class to be found');
+        }
+        if (!isNamedClassDeclaration(dtsDeclaration)) {
+          return fail('Expected a named class to be found.');
+        }
+        expect(dtsDeclaration.name.text).toEqual('TypingsClass');
+        expect(_(dtsDeclaration.getSourceFile().fileName))
+            .toEqual(_('/ep/typings/typings-class.d.ts'));
       });
 
-      it('should find the dts file that contains a matching class declaration, even if the class is not publicly exported',
+      it('should match publicly and internal exported classes correctly, even if they have the same name',
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/src/index.js'));
-           const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-           const internalClass = getDeclaration(
-               bundle.program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
+           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
-           const dtsDeclaration = host.getDtsDeclaration(internalClass);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/internal.d.ts'));
+           const class2 = getDeclaration(
+               bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedVariableDeclaration);
+           const class2DtsDeclaration = host.getDtsDeclaration(class2);
+           expect(class2DtsDeclaration !.getSourceFile().fileName)
+               .toEqual(_('/ep/typings/class2.d.ts'));
+
+           const internalClass2 = getDeclaration(
+               bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedVariableDeclaration);
+           const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
+           expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
+               .toEqual(_('/ep/typings/internal.d.ts'));
          });
 
       it('should prefer the publicly exported class if there are multiple classes with the same name',
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/src/index.js'));
-           const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
+           const bundle = makeTestBundleProgram(_('/ep/src/index.js'));
+           const dts = makeTestBundleProgram(_('/ep/typings/index.d.ts'));
            const class2 = getDeclaration(
-               bundle.program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/class2.js'), 'Class2', ts.isVariableDeclaration);
            const internalClass2 = getDeclaration(
-               bundle.program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
+               bundle.program, _('/ep/src/internal.js'), 'Class2', ts.isVariableDeclaration);
            const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
            expect(class2DtsDeclaration !.getSourceFile().fileName)
-               .toEqual(_('/typings/class2.d.ts'));
+               .toEqual(_('/ep/typings/class2.d.ts'));
 
            const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
            expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
-               .toEqual(_('/typings/class2.d.ts'));
+               .toEqual(_('/ep/typings/internal.d.ts'));
          });
     });
 

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -982,10 +982,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfDeclaration()', () => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -1001,10 +1001,11 @@ runInEachFileSystem(() => {
 
       it('should find the decorators on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators).toBeDefined();
@@ -1020,40 +1021,42 @@ runInEachFileSystem(() => {
 
       it('should return null if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(functionNode);
         expect(decorators).toBe(null);
       });
 
       it('should return null if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toBe(null);
       });
 
       it('should ignore `decorators` if it is not an array literal', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
         expect(decorators).toEqual([]);
       });
 
       it('should ignore decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -1062,10 +1065,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -1074,10 +1078,11 @@ runInEachFileSystem(() => {
 
       it('should ignore decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedVariableDeclaration);
+            bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier',
+            isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
@@ -1086,11 +1091,11 @@ runInEachFileSystem(() => {
 
       it('should have import information on decorators', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
 
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toEqual(1);
@@ -1099,10 +1104,11 @@ runInEachFileSystem(() => {
 
       it('should find decorated members on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -1119,11 +1125,10 @@ runInEachFileSystem(() => {
       describe('(returned decorators `args`)', () => {
         it('should be an empty array if decorator has no `args` property', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1134,11 +1139,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if decorator\'s `args` has no property assignment', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1149,11 +1153,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
@@ -1167,10 +1170,10 @@ runInEachFileSystem(() => {
     describe('getMembersOfClass()', () => {
       it('should find decorated members on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1') !;
@@ -1186,10 +1189,10 @@ runInEachFileSystem(() => {
 
       it('should find non decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
@@ -1201,10 +1204,10 @@ runInEachFileSystem(() => {
 
       it('should find static methods on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticMethod = members.find(member => member.name === 'staticMethod') !;
@@ -1215,10 +1218,10 @@ runInEachFileSystem(() => {
 
       it('should find static properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticProperty = members.find(member => member.name === 'staticProperty') !;
@@ -1230,10 +1233,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => {
           host.getMembersOfClass(functionNode);
         }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
@@ -1241,10 +1244,10 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no prop decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         expect(members).toEqual([]);
@@ -1253,11 +1256,10 @@ runInEachFileSystem(() => {
       it('should not process decorated properties in `propDecorators` if it is not an object literal',
          () => {
            loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-           const {program, host: compilerHost} =
-               makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const classNode = getDeclaration(
-               program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
+               bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                isNamedVariableDeclaration);
            const members = host.getMembersOfClass(classNode);
 
@@ -1266,11 +1268,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1282,11 +1283,10 @@ runInEachFileSystem(() => {
 
       it('should ignore prop decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1299,11 +1299,11 @@ runInEachFileSystem(() => {
 
     it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
       loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-      const {program, host: compilerHost} =
-          makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-      const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+      const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+      const host = new UmdReflectionHost(new MockLogger(), false, bundle);
       const classNode = getDeclaration(
-          program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier', isNamedVariableDeclaration);
+          bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
+          isNamedVariableDeclaration);
       const members = host.getMembersOfClass(classNode);
       const prop = members.find(m => m.name === 'prop') !;
       const decorators = prop.decorators !;
@@ -1314,11 +1314,11 @@ runInEachFileSystem(() => {
 
     it('should have import information on decorators', () => {
       loadTestFiles([SOME_DIRECTIVE_FILE]);
-      const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-      const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+      const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+      const host = new UmdReflectionHost(new MockLogger(), false, bundle);
 
       const classNode = getDeclaration(
-          program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+          bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toEqual(1);
@@ -1328,11 +1328,10 @@ runInEachFileSystem(() => {
     describe('(returned prop decorators `args`)', () => {
       it('should be an empty array if prop decorator has no `args` property', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1345,11 +1344,10 @@ runInEachFileSystem(() => {
 
       it('should be an empty array if prop decorator\'s `args` has no property assignment', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1362,11 +1360,10 @@ runInEachFileSystem(() => {
 
       it('should be an empty array if `args` property value is not an array literal', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
         const prop = members.find(m => m.name === 'prop') !;
@@ -1381,10 +1378,10 @@ runInEachFileSystem(() => {
     describe('getConstructorParameters', () => {
       it('should find the decorated constructor parameters', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
@@ -1400,10 +1397,11 @@ runInEachFileSystem(() => {
 
       it('should find the decorated constructor parameters at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
+            isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
@@ -1419,11 +1417,10 @@ runInEachFileSystem(() => {
 
       it('should accept `ctorParameters` as an array', () => {
         loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
+            bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode) !;
 
@@ -1434,10 +1431,10 @@ runInEachFileSystem(() => {
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const functionNode =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const functionNode = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => { host.getConstructorParameters(functionNode); })
             .toThrowError(
                 'Attempted to get constructor parameters of a non-class: "function foo() {}"');
@@ -1448,10 +1445,10 @@ runInEachFileSystem(() => {
 
       it('should return an array even if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
+            bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
@@ -1463,11 +1460,11 @@ runInEachFileSystem(() => {
 
       it('should return an empty array if there are no constructor parameters', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters', isNamedVariableDeclaration);
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
+            isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toEqual([]);
@@ -1478,11 +1475,10 @@ runInEachFileSystem(() => {
 
       it('should ignore `ctorParameters` if it does not return an array literal', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
+            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
@@ -1496,11 +1492,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators`)', () => {
         it('should ignore param decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
@@ -1517,11 +1512,10 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1532,11 +1526,10 @@ runInEachFileSystem(() => {
 
         it('should ignore param decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1547,10 +1540,11 @@ runInEachFileSystem(() => {
 
         it('should use `getImportOfIdentifier()` to retrieve import info', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
-          const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
+              isNamedVariableDeclaration);
           const mockImportInfo: Import = {from: '@angular/core', name: 'Directive'};
           const spy = spyOn(UmdReflectionHost.prototype, 'getImportOfIdentifier')
                           .and.returnValue(mockImportInfo);
@@ -1566,11 +1560,10 @@ runInEachFileSystem(() => {
       describe('(returned parameters `decorators.args`)', () => {
         it('should be an empty array if param decorator has no `args` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           expect(parameters !.length).toBe(1);
@@ -1584,11 +1577,10 @@ runInEachFileSystem(() => {
         it('should be an empty array if param decorator\'s `args` has no property assignment',
            () => {
              loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-             const {program, host: compilerHost} =
-                 makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+             const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+             const host = new UmdReflectionHost(new MockLogger(), false, bundle);
              const classNode = getDeclaration(
-                 program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedVariableDeclaration);
              const parameters = host.getConstructorParameters(classNode);
              const decorators = parameters ![0].decorators !;
@@ -1600,11 +1592,10 @@ runInEachFileSystem(() => {
 
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const {program, host: compilerHost} =
-              makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
           const classNode = getDeclaration(
-              program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
           const decorators = parameters ![0].decorators !;
@@ -1620,11 +1611,11 @@ runInEachFileSystem(() => {
       it('should return an object describing the function declaration passed as an argument',
          () => {
            loadTestFiles([FUNCTION_BODY_FILE]);
-           const {program, host: compilerHost} = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
 
            const fooNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
            const fooDef = host.getDefinitionOfFunction(fooNode) !;
            expect(fooDef.node).toBe(fooNode);
            expect(fooDef.body !.length).toEqual(1);
@@ -1634,7 +1625,7 @@ runInEachFileSystem(() => {
            expect(fooDef.parameters[0].initializer).toBe(null);
 
            const barNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
            const barDef = host.getDefinitionOfFunction(barNode) !;
            expect(barDef.node).toBe(barNode);
            expect(barDef.body !.length).toEqual(1);
@@ -1647,7 +1638,7 @@ runInEachFileSystem(() => {
            expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
 
            const bazNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
            const bazDef = host.getDefinitionOfFunction(bazNode) !;
            expect(bazDef.node).toBe(bazNode);
            expect(bazDef.body !.length).toEqual(3);
@@ -1656,7 +1647,7 @@ runInEachFileSystem(() => {
            expect(bazDef.parameters[0].initializer).toBe(null);
 
            const quxNode = getDeclaration(
-               program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
            const quxDef = host.getDefinitionOfFunction(quxNode) !;
            expect(quxDef.node).toBe(quxNode);
            expect(quxDef.body !.length).toEqual(2);
@@ -1669,10 +1660,10 @@ runInEachFileSystem(() => {
     describe('getImportOfIdentifier', () => {
       it('should find the import of an identifier', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const variableNode =
-            getDeclaration(program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
         const identifier =
             (variableNode.initializer && ts.isPropertyAccessExpression(variableNode.initializer)) ?
             variableNode.initializer.name :
@@ -1696,10 +1687,10 @@ runInEachFileSystem(() => {
             contents: `export declare class MyClass {}`,
           }
         ]);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/index.d.ts'));
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(_('/index.d.ts'));
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const variableNode =
-            getDeclaration(program, _('/index.d.ts'), 'a', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, _('/index.d.ts'), 'a', isNamedVariableDeclaration);
         const identifier = ((variableNode.type as ts.TypeReferenceNode).typeName as ts.Identifier);
 
         const importOfIdent = host.getImportOfIdentifier(identifier !);
@@ -1708,10 +1699,10 @@ runInEachFileSystem(() => {
 
       it('should return null if the identifier was not imported', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const variableNode =
-            getDeclaration(program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
         expect(importOfIdent).toBeNull();
@@ -1719,10 +1710,10 @@ runInEachFileSystem(() => {
 
       it('should handle factory functions not wrapped in parentheses', () => {
         loadTestFiles(IMPORTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const variableNode =
-            getDeclaration(program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
         const identifier =
             (variableNode.initializer && ts.isPropertyAccessExpression(variableNode.initializer)) ?
             variableNode.initializer.name :
@@ -1737,10 +1728,10 @@ runInEachFileSystem(() => {
     describe('getDeclarationOfIdentifier', () => {
       it('should return the declaration of a locally defined identifier', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const ctrDecorators = host.getConstructorParameters(classNode) !;
         const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                local: true,
@@ -1749,7 +1740,8 @@ runInEachFileSystem(() => {
                                              }).expression;
 
         const expectedDeclarationNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef',
+            isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1759,10 +1751,10 @@ runInEachFileSystem(() => {
       it('should return the source-file of an import namespace', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode = getDeclaration(
-            program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
         const identifierOfDirective = (((classDecorators[0].node as ts.ObjectLiteralExpression)
                                             .properties[0] as ts.PropertyAssignment)
@@ -1770,7 +1762,7 @@ runInEachFileSystem(() => {
                                           .expression as ts.Identifier;
 
         const expectedDeclarationNode =
-            getSourceFileOrError(program, _('/node_modules/@angular/core/index.d.ts'));
+            getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
@@ -1798,11 +1790,11 @@ runInEachFileSystem(() => {
              }
            ];
            loadTestFiles(FILES);
-           const {program, host: compilerHost} = makeTestBundleProgram(FILES[0].name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(FILES[0].name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const expectedDeclaration =
-               getDeclaration(program, FILES[2].name, 'SubModule', isNamedClassDeclaration);
-           const x = getDeclaration(program, FILES[0].name, 'x', isNamedVariableDeclaration);
+               getDeclaration(bundle.program, FILES[2].name, 'SubModule', isNamedClassDeclaration);
+           const x = getDeclaration(bundle.program, FILES[0].name, 'x', isNamedVariableDeclaration);
            if (x.initializer === undefined || !ts.isIdentifier(x.initializer)) {
              return fail('Expected constant `x` to have an identifer as an initializer.');
            }
@@ -1819,9 +1811,9 @@ runInEachFileSystem(() => {
       it('should return a map of all the exports from a given module', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const file = getSourceFileOrError(program, _('/b_module.js'));
+        const bundle = makeTestBundleProgram(_('/index.js'));
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/b_module.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
         expect(Array.from(exportDeclarations !.entries())
@@ -1859,10 +1851,10 @@ runInEachFileSystem(() => {
     describe('getClassSymbol()', () => {
       it('should return the class symbol for an ES2015 class', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const node = getDeclaration(
-            program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeDefined();
@@ -1872,10 +1864,10 @@ runInEachFileSystem(() => {
 
       it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const outerNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         const classSymbol = host.getClassSymbol(outerNode);
 
@@ -1886,10 +1878,10 @@ runInEachFileSystem(() => {
 
       it('should return the class symbol for an ES5 class (inner function declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const outerNode = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         const classSymbol = host.getClassSymbol(innerNode);
 
@@ -1901,10 +1893,10 @@ runInEachFileSystem(() => {
       it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
 
            const innerSymbol = host.getClassSymbol(innerNode) !;
@@ -1916,10 +1908,10 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES5 class whose IIFE is not wrapped in parens',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
            const classSymbol = host.getClassSymbol(outerNode);
 
@@ -1931,10 +1923,11 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
-           const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const outerNode = getDeclaration(
-               program, SIMPLE_CLASS_FILE.name, 'InnerParensClass', isNamedVariableDeclaration);
+               bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
+               isNamedVariableDeclaration);
            const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
            const classSymbol = host.getClassSymbol(outerNode);
 
@@ -1945,10 +1938,10 @@ runInEachFileSystem(() => {
 
       it('should return undefined if node is not an ES5 class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeUndefined();
@@ -1960,9 +1953,10 @@ runInEachFileSystem(() => {
           contents: `var MyClass = null;`,
         };
         loadTestFiles([testFile]);
-        const {program, host: compilerHost} = makeTestBundleProgram(testFile.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const node = getDeclaration(program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const node =
+            getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeUndefined();
@@ -1972,38 +1966,38 @@ runInEachFileSystem(() => {
     describe('isClass()', () => {
       it('should return true if a given node is a TS class declaration', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const node = getDeclaration(
-            program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.isClass(node)).toBe(true);
       });
 
       it('should return true if a given node is the outer variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const node =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
         expect(host.isClass(node)).toBe(true);
       });
 
       it('should return true if a given node is the inner variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const outerNode =
-            getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const outerNode = getDeclaration(
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
         const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
         expect(host.isClass(innerNode)).toBe(true);
       });
 
       it('should return false if a given node is a function declaration', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const node =
-            getDeclaration(program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const node = getDeclaration(
+            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(host.isClass(node)).toBe(false);
       });
     });
@@ -2016,10 +2010,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         return host.hasBaseClass(classNode);
       }
 
@@ -2063,10 +2057,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const expression = host.getBaseClassExpression(classNode);
         if (expression !== null && !ts.isIdentifier(expression)) {
           throw new Error(
@@ -2135,10 +2129,10 @@ runInEachFileSystem(() => {
         };
 
         loadTestFiles([file]);
-        const {program, host: compilerHost} = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
         const classNode =
-            getDeclaration(program, file.name, 'TestClass', isNamedVariableDeclaration);
+            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const expression = host.getBaseClassExpression(classNode) !;
         expect(expression.getText()).toBe('foo()');
       });
@@ -2147,10 +2141,10 @@ runInEachFileSystem(() => {
     describe('findClassSymbols()', () => {
       it('should return an array of all classes in the given source file', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         expect(classSymbolsPrimary.length).toEqual(2);
@@ -2165,10 +2159,10 @@ runInEachFileSystem(() => {
     describe('getDecoratorsOfSymbol()', () => {
       it('should return decorators of class symbol', () => {
         loadTestFiles(DECORATED_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const primaryFile = getSourceFileOrError(program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(program, DECORATED_FILES[1].name);
+        const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
@@ -2189,11 +2183,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
            const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-           const class1 =
-               getDeclaration(program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+           const class1 = getDeclaration(
+               bundle.program, _('/src/class1.js'), 'Class1', ts.isVariableDeclaration);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2202,11 +2196,11 @@ runInEachFileSystem(() => {
       it('should find the dts declaration for exported functions', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+        const bundle = makeTestBundleProgram(_('/src/index.js'));
         const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
         const mooFn =
-            getDeclaration(program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+            getDeclaration(bundle.program, _('/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/func1.d.ts'));
@@ -2215,11 +2209,11 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching class in the matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+        const bundle = makeTestBundleProgram(_('/src/index.js'));
         const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-        const missingClass =
-            getDeclaration(program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+        const missingClass = getDeclaration(
+            bundle.program, _('/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2227,11 +2221,11 @@ runInEachFileSystem(() => {
       it('should return null if there is no matching dts file', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+        const bundle = makeTestBundleProgram(_('/src/index.js'));
         const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
         const missingClass = getDeclaration(
-            program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+            bundle.program, _('/src/missing-class.js'), 'MissingClass2', ts.isVariableDeclaration);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2240,11 +2234,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
            const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-           const class1 =
-               getDeclaration(program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+           const class1 = getDeclaration(
+               bundle.program, _('/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class1.d.ts'));
@@ -2253,11 +2247,11 @@ runInEachFileSystem(() => {
       it('should find aliased exports', () => {
         loadTestFiles(TYPINGS_SRC_FILES);
         loadTestFiles(TYPINGS_DTS_FILES);
-        const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+        const bundle = makeTestBundleProgram(_('/src/index.js'));
         const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-        const class3 =
-            getDeclaration(program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+        const class3 = getDeclaration(
+            bundle.program, _('/src/flat-file.js'), 'Class3', ts.isVariableDeclaration);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
         const dtsDeclaration = host.getDtsDeclaration(class3);
         expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/class3.d.ts'));
@@ -2267,11 +2261,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
            const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
            const internalClass = getDeclaration(
-               program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+               bundle.program, _('/src/internal.js'), 'InternalClass', ts.isVariableDeclaration);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const dtsDeclaration = host.getDtsDeclaration(internalClass);
            expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/typings/internal.d.ts'));
@@ -2281,13 +2275,13 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(TYPINGS_SRC_FILES);
            loadTestFiles(TYPINGS_DTS_FILES);
-           const {program, host: compilerHost} = makeTestBundleProgram(_('/src/index.js'));
+           const bundle = makeTestBundleProgram(_('/src/index.js'));
            const dts = makeTestBundleProgram(_('/typings/index.d.ts'));
-           const class2 =
-               getDeclaration(program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
-           const internalClass2 =
-               getDeclaration(program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost, dts);
+           const class2 = getDeclaration(
+               bundle.program, _('/src/class2.js'), 'Class2', ts.isVariableDeclaration);
+           const internalClass2 = getDeclaration(
+               bundle.program, _('/src/internal.js'), 'Class2', ts.isVariableDeclaration);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
 
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
            expect(class2DtsDeclaration !.getSourceFile().fileName)
@@ -2302,23 +2296,23 @@ runInEachFileSystem(() => {
     describe('getInternalNameOfClass()', () => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
 
         const emptyClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
         const class1 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
 
         const class2 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
 
         const childClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
         expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
       });
     });
@@ -2326,23 +2320,23 @@ runInEachFileSystem(() => {
     describe('getAdjacentNameOfClass()', () => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
-        const {program, host: compilerHost} = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
+        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
 
         const emptyClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
 
         const class1 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
 
         const class2 = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
 
         const childClass = getDeclaration(
-            program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
+            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
         expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
       });
     });
@@ -2351,10 +2345,9 @@ runInEachFileSystem(() => {
       it('should find every exported function that returns an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program, host: compilerHost} =
-               makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-           const file = getSourceFileOrError(program, _('/src/functions.js'));
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
            const fns = host.getModuleWithProvidersFunctions(file);
            expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
                .toEqual([
@@ -2368,10 +2361,9 @@ runInEachFileSystem(() => {
       it('should find every static method on exported classes that return an object that looks like a ModuleWithProviders object',
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-           const {program, host: compilerHost} =
-               makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-           const file = getSourceFileOrError(program, _('/src/methods.js'));
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
              [
@@ -2396,10 +2388,9 @@ runInEachFileSystem(() => {
       // https://github.com/angular/angular/issues/29078
       it('should resolve aliased module references to their original declaration', () => {
         loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-        const {program, host: compilerHost} =
-            makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-        const host = new UmdReflectionHost(new MockLogger(), false, program, compilerHost);
-        const file = getSourceFileOrError(program, _('/src/aliased_class.js'));
+        const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
         const fn = host.getModuleWithProvidersFunctions(file);
         expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
           ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -797,7 +797,7 @@ runInEachFileSystem(() => {
           fail('should have thrown');
         } catch (e) {
           expect(e.message).toContain(
-              'Failed to compile entry-point fatal-error due to compilation errors:');
+              'Failed to compile entry-point fatal-error (es2015 as esm2015) due to compilation errors:');
           expect(e.message).toContain('NG2001');
           expect(e.message).toContain('component is missing a template');
         }

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -235,6 +235,34 @@ runInEachFileSystem(() => {
               `TestClass.ɵprov = ɵngcc0.ɵɵdefineInjectable({`);
     });
 
+    it('should use the correct type name in typings files when an export has a different name in source files',
+       () => {
+         // We need to make sure that changes to the typings files use the correct name
+         // static ɵprov: ɵngcc0.ɵɵInjectableDef<ɵangular_packages_common_common_a>;
+         mainNgcc({
+           basePath: '/node_modules',
+           targetEntryPointPath: '@angular/common',
+           propertiesToConsider: ['esm2015']
+         });
+
+         // In `@angular/common` the `NgClassR3Impl` class gets exported as something like
+         // `ɵangular_packages_common_common_a`.
+         const jsContents = fs.readFile(_(`/node_modules/@angular/common/fesm2015/common.js`));
+         const exportedNameMatch = jsContents.match(/export.* NgClassR3Impl as ([^ ,}]+)/);
+         if (exportedNameMatch === null) {
+           return fail(
+               'Expected `/node_modules/@angular/common/fesm2015/common.js` to export `NgClassR3Impl` via an alias');
+         }
+         const exportedName = exportedNameMatch[1];
+
+         // We need to make sure that the flat typings file exports this directly
+         const dtsContents = fs.readFile(_('/node_modules/@angular/common/common.d.ts'));
+         expect(dtsContents)
+             .toContain(`export declare class ${exportedName} implements ɵNgClassImpl`);
+         // And that ngcc's modifications to that class use the correct (exported) name
+         expect(dtsContents).toContain(`static ɵprov: ɵngcc0.ɵɵInjectableDef<${exportedName}>`);
+       });
+
     it('should add generic type for ModuleWithProviders and generate exports for private modules',
        () => {
          compileIntoApf('test-package', {

--- a/packages/compiler-cli/ngcc/test/migrations/missing_injectable_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/missing_injectable_migration_spec.ts
@@ -559,8 +559,7 @@ runInEachFileSystem(() => {
       const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
       const program = bundle.src.program;
 
-      const reflectionHost =
-          new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+      const reflectionHost = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
       const referencesRegistry = new NgccReferencesRegistry(reflectionHost);
       const analyzer = new DecorationAnalyzer(
           getFileSystem(), bundle, reflectionHost, referencesRegistry, error => errors.push(error));

--- a/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/migrations/undecorated_parent_migration_spec.ts
@@ -246,8 +246,7 @@ runInEachFileSystem(() => {
     const bundle = makeTestEntryPointBundle('test-package', 'esm2015', false, rootFiles);
     const program = bundle.src.program;
 
-    const reflectionHost =
-        new Esm2015ReflectionHost(new MockLogger(), false, program.getTypeChecker());
+    const reflectionHost = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
     const referencesRegistry = new NgccReferencesRegistry(reflectionHost);
     const analyzer = new DecorationAnalyzer(
         getFileSystem(), bundle, reflectionHost, referencesRegistry, error => errors.push(error));

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -151,8 +151,7 @@ exports.D = D;
       const fs = getFileSystem();
       const logger = new MockLogger();
       const bundle = makeTestEntryPointBundle('test-package', 'commonjs', false, [file.name]);
-      const typeChecker = bundle.src.program.getTypeChecker();
-      const host = new CommonJsReflectionHost(logger, false, bundle.src.program, bundle.src.host);
+      const host = new CommonJsReflectionHost(logger, false, bundle.src);
       const referencesRegistry = new NgccReferencesRegistry(host);
       const decorationAnalyses =
           new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -226,36 +226,6 @@ exports.ComponentA2 = i0.ComponentA2;
 exports.ComponentB = i1.ComponentB;
 exports.TopLevelComponent = TopLevelComponent;`);
       });
-
-      it('should not insert alias exports in js output', () => {
-        const {importManager, renderer, sourceFile} = setup(PROGRAM);
-        const output = new MagicString(PROGRAM.contents);
-        renderer.addExports(
-            output, _(PROGRAM.name.replace(/\.js$/, '')),
-            [
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA1',
-                identifier: 'ComponentA1'
-              },
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA2',
-                identifier: 'ComponentA2'
-              },
-              {
-                from: _('/node_modules/test-package/some/foo/b.js'),
-                alias: 'eComponentB',
-                identifier: 'ComponentB'
-              },
-              {from: PROGRAM.name, alias: 'eTopLevelComponent', identifier: 'TopLevelComponent'},
-            ],
-            importManager, sourceFile);
-        const outputString = output.toString();
-        expect(outputString).not.toContain(`{eComponentA1 as ComponentA1}`);
-        expect(outputString).not.toContain(`{eComponentB as ComponentB}`);
-        expect(outputString).not.toContain(`{eTopLevelComponent as TopLevelComponent}`);
-      });
     });
 
     describe('addConstants', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -70,8 +70,7 @@ function createTestRenderer(
   const isCore = packageName === '@angular/core';
   const bundle = makeTestEntryPointBundle(
       'test-package', 'esm2015', isCore, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles));
-  const typeChecker = bundle.src.program.getTypeChecker();
-  const host = new Esm2015ReflectionHost(logger, isCore, typeChecker, bundle.dts);
+  const host = new Esm2015ReflectionHost(logger, isCore, bundle.src, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -114,7 +114,7 @@ runInEachFileSystem(() => {
             `import { Directive } from '@angular/core';\nexport class A {\n    foo(x) {\n        return x;\n    }\n}\nA.decorators = [\n    { type: Directive, args: [{ selector: '[a]' }] }\n];\n`
       };
       INPUT_DTS_PROGRAM = {
-        name: _('/typings/file.d.ts'),
+        name: _('/node_modules/test-package/typings/file.d.ts'),
         contents: `export declare class A {\nfoo(x: number): number;\n}\n`
       };
     });
@@ -126,7 +126,8 @@ runInEachFileSystem(() => {
       const result = renderer.renderProgram(
           decorationAnalyses, privateDeclarationsAnalyses, moduleWithProvidersAnalyses);
 
-      const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
+      const typingsFile =
+          result.find(f => f.path === _('/node_modules/test-package/typings/file.d.ts')) !;
       expect(typingsFile.contents)
           .toContain(
               'foo(x: number): number;\n    static ɵfac: ɵngcc0.ɵɵFactoryDef<A>;\n    static ɵdir: ɵngcc0.ɵɵDirectiveDefWithMeta');
@@ -139,7 +140,8 @@ runInEachFileSystem(() => {
       const result = renderer.renderProgram(
           decorationAnalyses, privateDeclarationsAnalyses, moduleWithProvidersAnalyses);
 
-      const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
+      const typingsFile =
+          result.find(f => f.path === _('/node_modules/test-package/typings/file.d.ts')) !;
       expect(typingsFile.contents).toContain(`\n// ADD IMPORTS\n`);
     });
 
@@ -158,7 +160,8 @@ runInEachFileSystem(() => {
       const result = renderer.renderProgram(
           decorationAnalyses, privateDeclarationsAnalyses, moduleWithProvidersAnalyses);
 
-      const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
+      const typingsFile =
+          result.find(f => f.path === _('/node_modules/test-package/typings/file.d.ts')) !;
       expect(typingsFile.contents).toContain(`\n// ADD EXPORTS\n`);
     });
 
@@ -170,7 +173,8 @@ runInEachFileSystem(() => {
       const result = renderer.renderProgram(
           decorationAnalyses, privateDeclarationsAnalyses, moduleWithProvidersAnalyses);
 
-      const typingsFile = result.find(f => f.path === _('/typings/file.d.ts')) !;
+      const typingsFile =
+          result.find(f => f.path === _('/node_modules/test-package/typings/file.d.ts')) !;
       expect(typingsFile.contents).toContain(`\n// ADD MODUlE WITH PROVIDERS PARAMS\n`);
     });
   });

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -28,8 +28,7 @@ function setup(file: {name: AbsoluteFsPath, contents: string}) {
   const fs = getFileSystem();
   const logger = new MockLogger();
   const bundle = makeTestEntryPointBundle('test-package', 'esm5', false, [file.name]);
-  const typeChecker = bundle.src.program.getTypeChecker();
-  const host = new Esm5ReflectionHost(logger, false, typeChecker);
+  const host = new Esm5ReflectionHost(logger, false, bundle.src);
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -229,36 +229,6 @@ export {ComponentA2} from './a';
 export {ComponentB} from './foo/b';
 export {TopLevelComponent};`);
       });
-
-      it('should not insert alias exports in js output', () => {
-        const {importManager, renderer, sourceFile} = setup(PROGRAM);
-        const output = new MagicString(PROGRAM.contents);
-        renderer.addExports(
-            output, _(PROGRAM.name.replace(/\.js$/, '')),
-            [
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA1',
-                identifier: 'ComponentA1'
-              },
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA2',
-                identifier: 'ComponentA2'
-              },
-              {
-                from: _('/node_modules/test-package/some/foo/b.js'),
-                alias: 'eComponentB',
-                identifier: 'ComponentB'
-              },
-              {from: PROGRAM.name, alias: 'eTopLevelComponent', identifier: 'TopLevelComponent'},
-            ],
-            importManager, sourceFile);
-        const outputString = output.toString();
-        expect(outputString).not.toContain(`{eComponentA1 as ComponentA1}`);
-        expect(outputString).not.toContain(`{eComponentB as ComponentB}`);
-        expect(outputString).not.toContain(`{eTopLevelComponent as TopLevelComponent}`);
-      });
     });
 
     describe('addConstants', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -146,36 +146,6 @@ export {ComponentA2} from './a';
 export {ComponentB} from './foo/b';
 export {TopLevelComponent};`);
       });
-
-      it('should not insert alias exports in js output', () => {
-        const {importManager, renderer, sourceFile} = setup([PROGRAM]);
-        const output = new MagicString(PROGRAM.contents);
-        renderer.addExports(
-            output, _(PROGRAM.name.replace(/\.js$/, '')),
-            [
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA1',
-                identifier: 'ComponentA1'
-              },
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA2',
-                identifier: 'ComponentA2'
-              },
-              {
-                from: _('/node_modules/test-package/some/foo/b.js'),
-                alias: 'eComponentB',
-                identifier: 'ComponentB'
-              },
-              {from: PROGRAM.name, alias: 'eTopLevelComponent', identifier: 'TopLevelComponent'},
-            ],
-            importManager, sourceFile);
-        const outputString = output.toString();
-        expect(outputString).not.toContain(`{eComponentA1 as ComponentA1}`);
-        expect(outputString).not.toContain(`{eComponentB as ComponentB}`);
-        expect(outputString).not.toContain(`{eTopLevelComponent as TopLevelComponent}`);
-      });
     });
 
     describe('addConstants', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -33,8 +33,7 @@ function setup(files: TestFile[], dtsFiles?: TestFile[]) {
   const logger = new MockLogger();
   const bundle = makeTestEntryPointBundle(
       'test-package', 'esm2015', false, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles)) !;
-  const typeChecker = bundle.src.program.getTypeChecker();
-  const host = new Esm2015ReflectionHost(logger, false, typeChecker, bundle.dts);
+  const host = new Esm2015ReflectionHost(logger, false, bundle.src, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -483,7 +483,7 @@ export { D };
       beforeEach(() => {
         MODULE_WITH_PROVIDERS_PROGRAM = [
           {
-            name: _('/src/index.js'),
+            name: _('/node_modules/test-package/src/index.js'),
             contents: `
         import {ExternalModule} from './module';
         import {LibraryModule} from 'some-library';
@@ -510,7 +510,7 @@ export { D };
         `
           },
           {
-            name: _('/src/module.js'),
+            name: _('/node_modules/test-package/src/module.js'),
             contents: `
         export class ExternalModule {
           static withProviders1() { return {ngModule: ExternalModule}; }
@@ -525,7 +525,7 @@ export { D };
 
         MODULE_WITH_PROVIDERS_DTS_PROGRAM = [
           {
-            name: _('/typings/index.d.ts'),
+            name: _('/node_modules/test-package/typings/index.d.ts'),
             contents: `
         import {ModuleWithProviders} from '@angular/core';
         export declare class SomeClass {}
@@ -552,7 +552,7 @@ export { D };
         `
           },
           {
-            name: _('/typings/module.d.ts'),
+            name: _('/node_modules/test-package/typings/module.d.ts'),
             contents: `
         export interface ModuleWithProviders {}
         export declare class ExternalModule {
@@ -575,7 +575,8 @@ export { D };
         const moduleWithProvidersAnalyses =
             new ModuleWithProvidersAnalyzer(host, referencesRegistry, true)
                 .analyzeProgram(bundle.src.program);
-        const typingsFile = getSourceFileOrError(bundle.dts !.program, _('/typings/index.d.ts'));
+        const typingsFile = getSourceFileOrError(
+            bundle.dts !.program, _('/node_modules/test-package/typings/index.d.ts'));
         const moduleWithProvidersInfo = moduleWithProvidersAnalyses.get(typingsFile) !;
 
         const output = new MagicString(MODULE_WITH_PROVIDERS_DTS_PROGRAM[0].contents);
@@ -611,8 +612,8 @@ export { D };
            const moduleWithProvidersAnalyses =
                new ModuleWithProvidersAnalyzer(host, referencesRegistry, true)
                    .analyzeProgram(bundle.src.program);
-           const typingsFile =
-               getSourceFileOrError(bundle.dts !.program, _('/typings/module.d.ts'));
+           const typingsFile = getSourceFileOrError(
+               bundle.dts !.program, _('/node_modules/test-package/typings/module.d.ts'));
            const moduleWithProvidersInfo = moduleWithProvidersAnalyses.get(typingsFile) !;
 
            const output = new MagicString(MODULE_WITH_PROVIDERS_DTS_PROGRAM[1].contents);

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -83,9 +83,8 @@ function createTestRenderer(
   const isCore = packageName === '@angular/core';
   const bundle = makeTestEntryPointBundle(
       'test-package', 'esm5', isCore, getRootFiles(files), dtsFiles && getRootFiles(dtsFiles));
-  const typeChecker = bundle.src.program.getTypeChecker();
-  const host = isEs5 ? new Esm5ReflectionHost(logger, isCore, typeChecker, bundle.dts) :
-                       new Esm2015ReflectionHost(logger, isCore, typeChecker, bundle.dts);
+  const host = isEs5 ? new Esm5ReflectionHost(logger, isCore, bundle.src, bundle.dts) :
+                       new Esm2015ReflectionHost(logger, isCore, bundle.src, bundle.dts);
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -28,7 +28,7 @@ function setup(file: TestFile) {
   const logger = new MockLogger();
   const bundle = makeTestEntryPointBundle('test-package', 'esm5', false, [file.name]);
   const src = bundle.src;
-  const host = new UmdReflectionHost(logger, false, src.program, src.host);
+  const host = new UmdReflectionHost(logger, false, src);
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -359,36 +359,6 @@ exports.TopLevelComponent = TopLevelComponent;
         expect(generateNamedImportSpy).toHaveBeenCalledWith('./a', 'ComponentA2');
         expect(generateNamedImportSpy).toHaveBeenCalledWith('./foo/b', 'ComponentB');
       });
-
-      it('should not insert alias exports in js output', () => {
-        const {importManager, renderer, sourceFile} = setup(PROGRAM);
-        const output = new MagicString(PROGRAM.contents);
-        renderer.addExports(
-            output, PROGRAM.name.replace(/\.js$/, ''),
-            [
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA1',
-                identifier: 'ComponentA1'
-              },
-              {
-                from: _('/node_modules/test-package/some/a.js'),
-                alias: 'eComponentA2',
-                identifier: 'ComponentA2'
-              },
-              {
-                from: _('/node_modules/test-package/some/foo/b.js'),
-                alias: 'eComponentB',
-                identifier: 'ComponentB'
-              },
-              {from: PROGRAM.name, alias: 'eTopLevelComponent', identifier: 'TopLevelComponent'},
-            ],
-            importManager, sourceFile);
-        const outputString = output.toString();
-        expect(outputString).not.toContain(`eComponentA1`);
-        expect(outputString).not.toContain(`eComponentB`);
-        expect(outputString).not.toContain(`eTopLevelComponent`);
-      });
     });
 
     describe('addConstants', () => {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -20,7 +20,7 @@ import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFl
 
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getConstructorDependencies, isAngularDecorator, makeDuplicateDeclarationError, readBaseClass, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens} from './util';
+import {findAngularDecorator, getConstructorDependencies, isAngularDecorator, makeDuplicateDeclarationError, readBaseClass, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference} from './util';
 
 const EMPTY_OBJECT: {[key: string]: string} = {};
 const FIELD_DECORATORS = [
@@ -292,6 +292,9 @@ export function extractDirectiveMetadata(
 
   // Detect if the component inherits from another class
   const usesInheritance = reflector.hasBaseClass(clazz);
+  const type = wrapTypeReference(reflector, clazz);
+  const internalType = new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz));
+
   const metadata: R3DirectiveMetadata = {
     name: clazz.name.text,
     deps: ctorDeps, host,
@@ -300,9 +303,7 @@ export function extractDirectiveMetadata(
     },
     inputs: {...inputsFromMeta, ...inputsFromFields},
     outputs: {...outputsFromMeta, ...outputsFromFields}, queries, viewQueries, selector,
-    fullInheritance: !!(flags & HandlerFlags.FULL_INHERITANCE),
-    type: new WrappedNodeExpr(clazz.name),
-    internalType: new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz)),
+    fullInheritance: !!(flags & HandlerFlags.FULL_INHERITANCE), type, internalType,
     typeArgumentCount: reflector.getGenericArityOfClass(clazz) || 0,
     typeSourceSpan: EMPTY_SOURCE_SPAN, usesInheritance, exportAs, providers
   };

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -16,7 +16,7 @@ import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPr
 
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getConstructorDependencies, getValidConstructorDependencies, isAngularCore, unwrapConstructorDependencies, unwrapForwardRef, validateConstructorDependencies} from './util';
+import {findAngularDecorator, getConstructorDependencies, getValidConstructorDependencies, isAngularCore, unwrapConstructorDependencies, unwrapForwardRef, validateConstructorDependencies, wrapTypeReference} from './util';
 
 export interface InjectableHandlerData {
   meta: R3InjectableMetadata;
@@ -130,7 +130,7 @@ function extractInjectableMetadata(
     clazz: ClassDeclaration, decorator: Decorator,
     reflector: ReflectionHost): R3InjectableMetadata {
   const name = clazz.name.text;
-  const type = new WrappedNodeExpr(clazz.name);
+  const type = wrapTypeReference(reflector, clazz);
   const internalType = new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz));
   const typeArgumentCount = reflector.getGenericArityOfClass(clazz) || 0;
   if (decorator.args === null) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -22,7 +22,7 @@ import {getSourceFile} from '../../util/src/typescript';
 
 import {generateSetClassMetadataCall} from './metadata';
 import {ReferencesRegistry} from './references_registry';
-import {combineResolvers, findAngularDecorator, forwardRefResolver, getReferenceOriginForDiagnostics, getValidConstructorDependencies, isExpressionForwardReference, toR3Reference, unwrapExpression, wrapFunctionExpressionsInParens} from './util';
+import {combineResolvers, findAngularDecorator, forwardRefResolver, getReferenceOriginForDiagnostics, getValidConstructorDependencies, isExpressionForwardReference, toR3Reference, unwrapExpression, wrapFunctionExpressionsInParens, wrapTypeReference} from './util';
 
 export interface NgModuleAnalysis {
   mod: R3NgModuleMetadata;
@@ -220,10 +220,14 @@ export class NgModuleDecoratorHandler implements
         declarations.some(isForwardReference) || imports.some(isForwardReference) ||
         exports.some(isForwardReference);
 
+    const type = wrapTypeReference(this.reflector, node);
+    const internalType = new WrappedNodeExpr(this.reflector.getInternalNameOfClass(node));
+    const adjacentType = new WrappedNodeExpr(this.reflector.getAdjacentNameOfClass(node));
+
     const ngModuleDef: R3NgModuleMetadata = {
-      type: new WrappedNodeExpr(node.name),
-      internalType: new WrappedNodeExpr(this.reflector.getInternalNameOfClass(node)),
-      adjacentType: new WrappedNodeExpr(this.reflector.getAdjacentNameOfClass(node)),
+      type,
+      internalType,
+      adjacentType,
       bootstrap,
       declarations,
       exports,
@@ -256,8 +260,8 @@ export class NgModuleDecoratorHandler implements
 
     const ngInjectorDef: R3InjectorMetadata = {
       name,
-      type: new WrappedNodeExpr(node.name),
-      internalType: new WrappedNodeExpr(this.reflector.getInternalNameOfClass(node)),
+      type,
+      internalType,
       deps: getValidConstructorDependencies(
           node, this.reflector, this.defaultImportRecorder, this.isCore),
       providers,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -19,7 +19,7 @@ import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPr
 
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getValidConstructorDependencies, makeDuplicateDeclarationError, unwrapExpression} from './util';
+import {findAngularDecorator, getValidConstructorDependencies, makeDuplicateDeclarationError, unwrapExpression, wrapTypeReference} from './util';
 
 export interface PipeHandlerData {
   meta: R3PipeMetadata;
@@ -53,8 +53,9 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
   analyze(clazz: ClassDeclaration, decorator: Readonly<Decorator>):
       AnalysisOutput<PipeHandlerData> {
     const name = clazz.name.text;
-    const type = new WrappedNodeExpr(clazz.name);
+    const type = wrapTypeReference(this.reflector, clazz);
     const internalType = new WrappedNodeExpr(this.reflector.getInternalNameOfClass(clazz));
+
     if (decorator.args === null) {
       throw new FatalDiagnosticError(
           ErrorCode.DECORATOR_NOT_CALLED, Decorator.nodeForError(decorator),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -435,3 +435,18 @@ export function makeDuplicateDeclarationError(
       ErrorCode.NGMODULE_DECLARATION_NOT_UNIQUE, node.name,
       `The ${kind} '${node.name.text}' is declared by more than one NgModule.`, context);
 }
+
+/**
+ * Create an R3Reference for a class.
+ *
+ * The `value` is the exported declaration of the class from its source file.
+ * The `type` is an expression that would be used by ngcc in the typings (.d.ts) files.
+ */
+export function wrapTypeReference(reflector: ReflectionHost, clazz: ClassDeclaration): R3Reference {
+  const dtsClass = reflector.getDtsDeclaration(clazz);
+  const value = new WrappedNodeExpr(clazz.name);
+  const type = dtsClass !== null && isNamedClassDeclaration(dtsClass) ?
+      new WrappedNodeExpr(dtsClass.name) :
+      value;
+  return {value, type};
+}

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -9,7 +9,7 @@
 import {Identifiers} from './identifiers';
 import * as o from './output/output_ast';
 import {R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata, R3FactoryTarget, compileFactoryFunction} from './render3/r3_factory';
-import {mapToMapExpression, typeWithParameters} from './render3/util';
+import {R3Reference, mapToMapExpression, typeWithParameters} from './render3/util';
 
 export interface InjectableDef {
   expression: o.Expression;
@@ -19,7 +19,7 @@ export interface InjectableDef {
 
 export interface R3InjectableMetadata {
   name: string;
-  type: o.Expression;
+  type: R3Reference;
   internalType: o.Expression;
   typeArgumentCount: number;
   providedIn: o.Expression;
@@ -69,7 +69,7 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
       result = compileFactoryFunction(factoryMeta);
     } else {
       result = delegateToFactory(
-          meta.type as o.WrappedNodeExpr<any>, meta.useClass as o.WrappedNodeExpr<any>);
+          meta.type.value as o.WrappedNodeExpr<any>, meta.useClass as o.WrappedNodeExpr<any>);
     }
   } else if (meta.useFactory !== undefined) {
     if (meta.userDeps !== undefined) {
@@ -101,7 +101,7 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
     });
   } else {
     result = delegateToFactory(
-        meta.type as o.WrappedNodeExpr<any>, meta.internalType as o.WrappedNodeExpr<any>);
+        meta.type.value as o.WrappedNodeExpr<any>, meta.internalType as o.WrappedNodeExpr<any>);
   }
 
   const token = meta.internalType;
@@ -116,7 +116,7 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
   const expression =
       o.importExpr(Identifiers.ɵɵdefineInjectable).callFn([mapToMapExpression(injectableProps)]);
   const type = new o.ExpressionType(o.importExpr(
-      Identifiers.InjectableDef, [typeWithParameters(meta.type, meta.typeArgumentCount)]));
+      Identifiers.InjectableDef, [typeWithParameters(meta.type.type, meta.typeArgumentCount)]));
 
   return {
     expression,

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -39,7 +39,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       any {
     const metadata: R3PipeMetadata = {
       name: facade.name,
-      type: new WrappedNodeExpr(facade.type),
+      type: wrapReference(facade.type),
       internalType: new WrappedNodeExpr(facade.type),
       typeArgumentCount: facade.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(facade.deps),
@@ -55,7 +55,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       facade: R3InjectableMetadataFacade): any {
     const {expression, statements} = compileInjectable({
       name: facade.name,
-      type: new WrappedNodeExpr(facade.type),
+      type: wrapReference(facade.type),
       internalType: new WrappedNodeExpr(facade.type),
       typeArgumentCount: facade.typeArgumentCount,
       providedIn: computeProvidedIn(facade.providedIn),
@@ -74,7 +74,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       facade: R3InjectorMetadataFacade): any {
     const meta: R3InjectorMetadata = {
       name: facade.name,
-      type: new WrappedNodeExpr(facade.type),
+      type: wrapReference(facade.type),
       internalType: new WrappedNodeExpr(facade.type),
       deps: convertR3DependencyMetadataArray(facade.deps),
       providers: new WrappedNodeExpr(facade.providers),
@@ -88,7 +88,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
       facade: R3NgModuleMetadataFacade): any {
     const meta: R3NgModuleMetadata = {
-      type: new WrappedNodeExpr(facade.type),
+      type: wrapReference(facade.type),
       internalType: new WrappedNodeExpr(facade.type),
       adjacentType: new WrappedNodeExpr(facade.type),
       bootstrap: facade.bootstrap.map(wrapReference),
@@ -163,7 +163,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3FactoryDefMetadataFacade) {
     const factoryRes = compileFactoryFunction({
       name: meta.name,
-      type: new WrappedNodeExpr(meta.type),
+      type: wrapReference(meta.type),
       internalType: new WrappedNodeExpr(meta.type),
       typeArgumentCount: meta.typeArgumentCount,
       deps: convertR3DependencyMetadataArray(meta.deps),
@@ -252,7 +252,7 @@ function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3
   return {
     ...facade as R3DirectiveMetadataFacadeNoPropAndWhitespace,
     typeSourceSpan: facade.typeSourceSpan,
-    type: new WrappedNodeExpr(facade.type),
+    type: wrapReference(facade.type),
     internalType: new WrappedNodeExpr(facade.type),
     deps: convertR3DependencyMetadataArray(facade.deps),
     host: extractHostBindings(facade.propMetadata, facade.typeSourceSpan, facade.host),

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -15,7 +15,7 @@ import * as o from '../output/output_ast';
 import {Identifiers as R3} from '../render3/r3_identifiers';
 import {OutputContext} from '../util';
 
-import {typeWithParameters} from './util';
+import {R3Reference, typeWithParameters} from './util';
 import {unsupported} from './view/util';
 
 
@@ -32,7 +32,7 @@ export interface R3ConstructorFactoryMetadata {
   /**
    * An expression representing the interface type being constructed.
    */
-  type: o.Expression;
+  type: R3Reference;
 
   /**
    * An expression representing the constructor type, intended for use within a class definition
@@ -270,7 +270,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3FactoryFn {
         `${meta.name}_Factory`),
     statements,
     type: o.expressionType(
-        o.importExpr(R3.FactoryDef, [typeWithParameters(meta.type, meta.typeArgumentCount)]))
+        o.importExpr(R3.FactoryDef, [typeWithParameters(meta.type.type, meta.typeArgumentCount)]))
   };
 }
 

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -29,7 +29,7 @@ export interface R3NgModuleMetadata {
   /**
    * An expression representing the module type being compiled.
    */
-  type: o.Expression;
+  type: R3Reference;
 
   /**
    * An expression representing the module type being compiled, intended for use within a class
@@ -160,7 +160,7 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
 
   const expression = o.importExpr(R3.defineNgModule).callFn([mapToMapExpression(definitionMap)]);
   const type = new o.ExpressionType(o.importExpr(R3.NgModuleDefWithMeta, [
-    new o.ExpressionType(moduleType), tupleTypeOf(declarations), tupleTypeOf(imports),
+    new o.ExpressionType(moduleType.type), tupleTypeOf(declarations), tupleTypeOf(imports),
     tupleTypeOf(exports)
   ]));
 
@@ -228,7 +228,7 @@ export interface R3InjectorDef {
 
 export interface R3InjectorMetadata {
   name: string;
-  type: o.Expression;
+  type: R3Reference;
   internalType: o.Expression;
   deps: R3DependencyMetadata[]|null;
   providers: o.Expression|null;
@@ -259,7 +259,7 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
 
   const expression = o.importExpr(R3.defineInjector).callFn([mapToMapExpression(definitionMap)]);
   const type =
-      new o.ExpressionType(o.importExpr(R3.InjectorDef, [new o.ExpressionType(meta.type)]));
+      new o.ExpressionType(o.importExpr(R3.InjectorDef, [new o.ExpressionType(meta.type.type)]));
   return {expression, type, statements: result.statements};
 }
 

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -14,7 +14,7 @@ import {OutputContext, error} from '../util';
 
 import {R3DependencyMetadata, R3FactoryTarget, compileFactoryFunction, dependenciesFromGlobalMetadata} from './r3_factory';
 import {Identifiers as R3} from './r3_identifiers';
-import {typeWithParameters} from './util';
+import {R3Reference, typeWithParameters, wrapReference} from './util';
 
 export interface R3PipeMetadata {
   /**
@@ -25,7 +25,7 @@ export interface R3PipeMetadata {
   /**
    * An expression representing a reference to the pipe itself.
    */
-  type: o.Expression;
+  type: R3Reference;
 
   /**
    * An expression representing the pipe being compiled, intended for use within a class definition
@@ -64,14 +64,14 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata) {
   definitionMapValues.push({key: 'name', value: o.literal(metadata.pipeName), quoted: false});
 
   // e.g. `type: MyPipe`
-  definitionMapValues.push({key: 'type', value: metadata.type, quoted: false});
+  definitionMapValues.push({key: 'type', value: metadata.type.value, quoted: false});
 
   // e.g. `pure: true`
   definitionMapValues.push({key: 'pure', value: o.literal(metadata.pure), quoted: false});
 
   const expression = o.importExpr(R3.definePipe).callFn([o.literalMap(definitionMapValues)]);
   const type = new o.ExpressionType(o.importExpr(R3.PipeDefWithMeta, [
-    typeWithParameters(metadata.type, metadata.typeArgumentCount),
+    typeWithParameters(metadata.type.type, metadata.typeArgumentCount),
     new o.ExpressionType(new o.LiteralExpr(metadata.pipeName)),
   ]));
 
@@ -92,7 +92,7 @@ export function compilePipeFromRender2(
   const type = outputCtx.importExpr(pipe.type.reference);
   const metadata: R3PipeMetadata = {
     name,
-    type,
+    type: wrapReference(type),
     internalType: type,
     pipeName: pipe.name,
     typeArgumentCount: 0,

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -98,3 +98,8 @@ export function jitOnlyGuardedExpression(expr: o.Expression): o.Expression {
       /* sourceSpan */ undefined, true);
   return new o.BinaryOperatorExpr(o.BinaryOperator.And, jitFlagUndefinedOrTrue, expr);
 }
+
+export function wrapReference(value: any): R3Reference {
+  const wrapped = new o.WrappedNodeExpr(value);
+  return {value: wrapped, type: wrapped};
+}

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -12,6 +12,7 @@ import * as o from '../../output/output_ast';
 import {ParseSourceSpan} from '../../parse_util';
 import * as t from '../r3_ast';
 import {R3DependencyMetadata} from '../r3_factory';
+import {R3Reference} from '../util';
 
 
 /**
@@ -26,7 +27,7 @@ export interface R3DirectiveMetadata {
   /**
    * An expression representing a reference to the directive itself.
    */
-  type: o.Expression;
+  type: R3Reference;
 
   /**
    * An expression representing a reference to the directive being compiled, intended for use within

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -481,7 +481,7 @@ function createTypeForDef(meta: R3DirectiveMetadata, typeBase: o.ExternalReferen
   const selectorForType = meta.selector !== null ? meta.selector.replace(/\n/g, '') : null;
 
   return o.expressionType(o.importExpr(typeBase, [
-    typeWithParameters(meta.type, meta.typeArgumentCount),
+    typeWithParameters(meta.type.type, meta.typeArgumentCount),
     selectorForType !== null ? stringAsType(selectorForType) : o.NONE_TYPE,
     meta.exportAs !== null ? stringArrayAsType(meta.exportAs) : o.NONE_TYPE,
     stringMapAsType(meta.inputs),


### PR DESCRIPTION
The naïve matching algorithm we previously used to match declarations in
source files to declarations in typings files was based only on the name
of the thing being declared.  This did not handle cases where the declared
item has been exported via an alias. This is a common scenariow when one
of the two file sets (source or typings) has been flattened, while the other
has not.

The new algorithm tries to overcome this by creating two maps of export
name to declaration (i.e. `Map<string, ts.Declaration>`).
One for the source files and one for the typings files.
It then joins these two together by matching export names, resulting in a
new map that maps source declarations to typings declarations directly
(i.e. `Map<ts.Declaration, ts.Declaration>`).

This new map can handle the declaration names being different between the
source and typings as long as they are ultimately both exported with the
same alias name.

Fixes #33593
Fixes #34191
Fixes #32442