### PR TITLE
refactor(language-service): Use only tsserverlibrary in language service

### DIFF
--- a/packages/language-service/bundles/banner.js.txt
+++ b/packages/language-service/bundles/banner.js.txt
@@ -4,20 +4,25 @@
  * License: MIT
  */
 
-var $reflect = {defineMetadata: function() {}, getOwnMetadata: function() {}};
-var Reflect = (typeof global !== 'undefined' ? global : {})['Reflect'] || {};
-Object.keys($reflect).forEach(function(key) { Reflect[key] = Reflect[key] || $reflect[key]; });
-var $deferred, $resolved, $provided;
-function $getModule(name) {
-  if (name === 'typescript/lib/tsserverlibrary') return $provided['typescript'] || require(name);
-  return $provided[name] || require(name);
+let $deferred;
+function define(modules, callback) {
+  $deferred = { modules, callback };
 }
-function define(modules, cb) { $deferred = { modules: modules, cb: cb }; }
 module.exports = function(provided) {
-  if ($resolved) return $resolved;
-  var result = {};
-  $provided = Object.assign({'reflect-metadata': $reflect}, provided || {}, { exports: result });
-  $deferred.cb.apply(this, $deferred.modules.map($getModule));
-  $resolved = result;
-  return result;
+  const ts = provided['typescript'];
+  if (!ts) {
+    throw new Error('Caller does not provide typescript module');
+  }
+  const results = {};
+  const resolvedModules = $deferred.modules.map(m => {
+    if (m === 'exports') {
+      return results;
+    }
+    if (m === 'typescript' || m === 'typescript/lib/tsserverlibrary') {
+      return ts;
+    }
+    return require(m);
+  })
+  $deferred.callback(...resolvedModules);
+  return results;
 }


### PR DESCRIPTION
Mixing both tsserverlibrary and typescript in the language service might
cause issues with tree-shaking. Instead, only tsserverlibrary should be
used throughout the language service package.
tsserverlibrary is a superset of typescript so there is no loss in API
coverage.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
