### PR TITLE
fix(ivy): handle SafeStyles in [style.prop] correctly

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -196,7 +196,7 @@ export const ɵɵdefaultStyleSanitizer =
       }
 
       if (mode & StyleSanitizeMode.SanitizeOnly) {
-        return doSanitizeValue ? ɵɵsanitizeStyle(value) : value;
+        return doSanitizeValue ? ɵɵsanitizeStyle(value) : unwrapSafeValue(value);
       } else {
         return doSanitizeValue;
       }

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1598,7 +1598,7 @@ describe('styling', () => {
     const comp = fixture.componentInstance;
     const style = fixture.nativeElement.firstChild.style;
 
-    expect(style.background).toBe('url("/1.png")');
+    expect(style.background).toContain('url("/1.png")');
     expect(style.width).toBe('calc(20%)');
     expect(style.height).toBe('10px');
     expect(style.color).toBe('red');
@@ -1610,7 +1610,7 @@ describe('styling', () => {
 
     fixture.detectChanges();
 
-    expect(style.background).toBe('url("/2.png")');
+    expect(style.background).toContain('url("/2.png")');
     expect(style.width).toBe('5px');
     expect(style.height).toBe('100%');
     expect(style.color).toBe('green');

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1564,14 +1564,18 @@ describe('styling', () => {
     expect(html).toMatch(/style=["|']clip-path:\s*url\(.*#test.*\)/);
   });
 
-  it('should not throw when bound to SafeValue', () => {
+  it('should handle values wrapped into SafeValue', () => {
     @Component({
       template: `
-        <div
-          [style.background]="getBackgroundSafe()"
-          [style.width]="getWidthSafe()"
-          [style.height]="getHeightSafe()"
-          [style.color]="getColorUnsafe()"></div>`,
+        <!-- Verify sanitizable style prop values wrapped in SafeValue -->
+        <div [style.background]="getBackgroundSafe()"></div>
+
+        <!-- Verify regular style prop values wrapped in SafeValue -->
+        <p [style.width]="getWidthSafe()" [style.height]="getHeightSafe()"></p>
+
+        <!-- Verify regular style prop values not wrapped in SafeValue -->
+        <span [style.color]="getColorUnsafe()"></span>
+      `,
     })
     class MyComp {
       constructor(private sanitizer: DomSanitizer) {}
@@ -1596,12 +1600,14 @@ describe('styling', () => {
     fixture.detectChanges();
 
     const comp = fixture.componentInstance;
-    const style = fixture.nativeElement.firstChild.style;
+    const div = fixture.nativeElement.querySelector('div');
+    const p = fixture.nativeElement.querySelector('p');
+    const span = fixture.nativeElement.querySelector('span');
 
-    expect(style.background).toContain('url("/1.png")');
-    expect(style.width).toBe('calc(20%)');
-    expect(style.height).toBe('10px');
-    expect(style.color).toBe('red');
+    expect(div.style.background).toContain('url("/1.png")');
+    expect(p.style.width).toBe('calc(20%)');
+    expect(p.style.height).toBe('10px');
+    expect(span.style.color).toBe('red');
 
     comp.background = '2.png';
     comp.width = '5px';
@@ -1610,10 +1616,10 @@ describe('styling', () => {
 
     fixture.detectChanges();
 
-    expect(style.background).toContain('url("/2.png")');
-    expect(style.width).toBe('5px');
-    expect(style.height).toBe('100%');
-    expect(style.color).toBe('green');
+    expect(div.style.background).toContain('url("/2.png")');
+    expect(p.style.width).toBe('5px');
+    expect(p.style.height).toBe('100%');
+    expect(span.style.color).toBe('green');
   });
 
   onlyInIvy('only ivy has style/class bindings debugging support')


### PR DESCRIPTION
Prior to this commit, values wrapped into SafeStyle were not handled correctly in [style.prop] bindings in case style sanitizer is present (when template contains some style props that require sanitization). Style sanitizer was not unwrapping values in case a given prop doesn't require sanitization.As a result, wrapped values were used as final styling values (see [styling/bindings.ts](https://github.com/angular/angular/blob/master/packages/core/src/render3/styling/bindings.ts#L620)). This commit updates the logic to unwrap safe values in sanitizer in case no sanitization is required.

This PR closes #34023.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No