### PR TITLE
fix(docs-infra): in small and medium screens the changes icon of menu…

### DIFF
--- a/aio/src/styles/2-modules/_toc.scss
+++ b/aio/src/styles/2-modules/_toc.scss
@@ -200,6 +200,8 @@ aio-toc.embedded {
 
     .toc-heading {
       margin: 0 0 8px;
+      display: flex;
+      align-items: center;
     }
   }
 


### PR DESCRIPTION
… does not align

In each and every page whenever screen size goes below 801px then the icon in fornt of the change icon does not align with the text

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Small css changes

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
In current behavior, the icon does not match with the text
![Desktop screenshot (19)](https://user-images.githubusercontent.com/39260684/70379917-886f4a00-1959-11ea-9afe-76486d660885.png)


Issue Number: N/A


## What is the new behavior?
In new behavior, the icon matches with the text

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
