### PR TITLE
docs: add products.ts file on getting started page

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -50,6 +50,11 @@ expect, save and then click the refresh button.
 * StackBlitz is continually improving, so there may be
 slight differences in generated code, but the app's
 behavior will be the same.
+* When you generate the StackBlitz example apps that
+accompany the tutorials, StackBlitz creates the starter
+files and mock data for you. The files you'll use throughout
+the tutorials are in the `src` folder of the StackBlitz
+example apps.
 
 </div>
 
@@ -70,7 +75,7 @@ This section introduces template syntax by enhancing the "Products" area.
 
 <div class="alert is-helpful">
 
-To help you get going, the following steps use predefined product data and methods from the `product-list.component.ts` file.
+To help you get going, the following steps use predefined product data from the `products.ts` file (already created in StackBlitz example) and methods from the `product-list.component.ts` file.
 
 </div>
 


### PR DESCRIPTION
Fixes #34291

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the current behavior, products.ts page is not visible on the getting started page.

Issue Number: 34291


## What is the new behavior?
Products.ts page is visible on the new getting started page.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
