### PR TITLE
fix(common): ensure diffing in ngStyle/ngClass correctly emits value changes

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 266648,
+        "main-es2015": 267182,
         "polyfills-es2015": 36808,
         "5-es2015": 751
       }

--- a/packages/common/src/directives/ng_style_impl.ts
+++ b/packages/common/src/directives/ng_style_impl.ts
@@ -83,16 +83,16 @@ export class NgStyleR2Impl implements NgStyleImpl {
 @Injectable()
 export class NgStyleR3Impl implements NgStyleImpl {
   private _differ =
-      new StylingDiffer<{[key: string]: any}|null>('NgStyle', StylingDifferOptions.AllowUnits);
+      new StylingDiffer<{[key: string]: any}>('NgStyle', StylingDifferOptions.AllowUnits);
 
   private _value: {[key: string]: any}|null = null;
 
   getValue() { return this._value; }
 
-  setNgStyle(value: {[key: string]: any}|null) { this._differ.setValue(value); }
+  setNgStyle(value: {[key: string]: any}|null) { this._differ.setInput(value); }
 
   applyChanges() {
-    if (this._differ.hasValueChanged()) {
+    if (this._differ.updateValue()) {
       this._value = this._differ.value;
     }
   }

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -352,6 +352,21 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
            detectChangesAndExpectClassName('init baz');
          }));
     });
+
+    describe('non-regression', () => {
+
+      // https://github.com/angular/angular/issues/34336
+      it('should not write to native node when a bound expression doesnt change', () => {
+        fixture = createTestComponent(`<div [ngClass]="{'color-red': true}"></div>`);
+        detectChangesAndExpectClassName('color-red');
+
+        // Overwrite CSS classes to make sure that ngClass is not doing any DOM manipulation (as
+        // there was no change to the expression bound to [ngClass]).
+        fixture.debugElement.children[0].nativeElement.className = '';
+        detectChangesAndExpectClassName('');
+      });
+
+    });
   });
 }
 

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -196,7 +196,7 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
         fixture = createTestComponent(`<div [ngClass]="['foo', {}]"></div>`);
         expect(() => fixture !.detectChanges())
             .toThrowError(
-                /NgClass can only toggle CSS classes expressed as strings, got \[object Object\]/);
+                /NgClass can only toggle CSS classes expressed as strings, got: \[object Object\]/);
       });
     });
 
@@ -353,17 +353,23 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          }));
     });
 
-    describe('non-regression', () => {
+    describe('prevent regressions', () => {
 
       // https://github.com/angular/angular/issues/34336
-      it('should not write to native node when a bound expression doesnt change', () => {
-        fixture = createTestComponent(`<div [ngClass]="{'color-red': true}"></div>`);
+      it('should not write to the native node unless the bound expression has changed', () => {
+        fixture = createTestComponent(`<div [ngClass]="{'color-red': condition}"></div>`);
         detectChangesAndExpectClassName('color-red');
 
-        // Overwrite CSS classes to make sure that ngClass is not doing any DOM manipulation (as
-        // there was no change to the expression bound to [ngClass]).
+        // Overwrite CSS classes so that we can check if ngClass performed DOM manipulation to
+        // update it
         fixture.debugElement.children[0].nativeElement.className = '';
+        // Assert that the DOM node still has the same value after change detection
         detectChangesAndExpectClassName('');
+
+        fixture.componentInstance.condition = false;
+        fixture.detectChanges();
+        fixture.componentInstance.condition = true;
+        detectChangesAndExpectClassName('color-red');
       });
 
     });

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -158,27 +158,22 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
        }));
 
-    it('should skip keys that are set to undefined values', async(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
+    it('should not write to native node when a bound expression doesnt change', () => {
 
-         fixture = createTestComponent(template);
+      const template = `<div [ngStyle]="{'color': 'red'}"></div>`;
 
-         getComponent().expr = {
-           'border-top-color': undefined,
-           'border-top-style': undefined,
-           'border-color': 'red',
-           'border-style': 'solid',
-           'border-width': '1rem',
-         };
+      fixture = createTestComponent(template);
 
-         fixture.detectChanges();
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveCssStyle({'color': 'red'});
 
-         expectNativeEl(fixture).toHaveCssStyle({
-           'border-color': 'red',
-           'border-style': 'solid',
-           'border-width': '1rem',
-         });
-       }));
+      // Overwrite native styles to make sure that ngClass is not doing any DOM manipulation (as
+      // there was no change to the expression bound to [ngStyle]).
+      fixture.debugElement.children[0].nativeElement.style.color = 'blue';
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveCssStyle({'color': 'blue'});
+
+    });
 
   });
 }

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -12,7 +12,7 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 
 {
   describe('NgStyle', () => {
-    let fixture: ComponentFixture<any>;
+    let fixture: ComponentFixture<TestComponent>;
 
     function getComponent(): TestComponent { return fixture.componentInstance; }
 
@@ -158,21 +158,36 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
        }));
 
-    it('should not write to native node when a bound expression doesnt change', () => {
+    it('should not write to the native node unless the bound expression has changed', () => {
 
-      const template = `<div [ngStyle]="{'color': 'red'}"></div>`;
+      const template = `<div [ngStyle]="{'color': expr}"></div>`;
 
       fixture = createTestComponent(template);
+      fixture.componentInstance.expr = 'red';
 
       fixture.detectChanges();
       expectNativeEl(fixture).toHaveCssStyle({'color': 'red'});
 
-      // Overwrite native styles to make sure that ngClass is not doing any DOM manipulation (as
-      // there was no change to the expression bound to [ngStyle]).
+      // Overwrite native styles so that we can check if ngStyle has performed DOM manupulation to
+      // update it.
       fixture.debugElement.children[0].nativeElement.style.color = 'blue';
       fixture.detectChanges();
+      // Assert that the style hasn't been updated
       expectNativeEl(fixture).toHaveCssStyle({'color': 'blue'});
 
+      fixture.componentInstance.expr = 'yellow';
+      fixture.detectChanges();
+      // Assert that the style has changed now that the model has changed
+      expectNativeEl(fixture).toHaveCssStyle({'color': 'yellow'});
+    });
+
+    it('should correctly update style with units (.px) when the model is set to number', () => {
+      const template = `<div [ngStyle]="{'width.px': expr}"></div>`;
+      fixture = createTestComponent(template);
+      fixture.componentInstance.expr = 400;
+
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
     });
 
   });

--- a/packages/common/test/directives/styling_differ_spec.ts
+++ b/packages/common/test/directives/styling_differ_spec.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {StylingDiffer, StylingDifferOptions} from '@angular/common/src/directives/styling_differ';
+
+describe('StylingDiffer', () => {
+  it('should create a key/value object of values from a string', () => {
+    const d = new StylingDiffer(
+        'ngClass', StylingDifferOptions.ForceAsMap | StylingDifferOptions.AllowStringValue);
+    expect(d.value).toEqual(null);
+
+    d.setValue('one two');
+    expect(d.value).toEqual({one: true, two: true});
+
+    d.setValue('three');
+    expect(d.value).toEqual({three: true});
+  });
+
+  it('should not emit that a value has changed if a new non-collection value was not set', () => {
+    const d = new StylingDiffer(
+        'ngClass', StylingDifferOptions.ForceAsMap | StylingDifferOptions.AllowStringValue);
+    expect(d.value).toEqual(null);
+
+    d.setValue('one two');
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({one: true, two: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+    expect(d.value).toEqual({one: true, two: true});
+
+    d.setValue('three');
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({three: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+    expect(d.value).toEqual({three: true});
+
+    d.setValue(null);
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual(null);
+    expect(d.hasValueChanged()).toBeFalsy();
+    expect(d.value).toEqual(null);
+  });
+
+  it('should watch the contents of a StringMap value and emit new values if they change', () => {
+    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+
+    const myMap: {[key: string]: any} = {};
+    myMap['abc'] = true;
+
+    d.setValue(myMap);
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    myMap['def'] = true;
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true, def: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    delete myMap['abc'];
+    delete myMap['def'];
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({});
+    expect(d.hasValueChanged()).toBeFalsy();
+  });
+
+  it('should watch the contents of an Array value and emit new values if they change', () => {
+    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+
+    const myArray: string[] = [];
+    myArray.push('abc');
+
+    d.setValue(myArray);
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    myArray.push('def');
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true, def: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    myArray.length = 0;
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({});
+    expect(d.hasValueChanged()).toBeFalsy();
+  });
+
+  it('should watch the contents of a Set value and emit new values if they change', () => {
+    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+
+    const mySet = new Set<string>();
+    mySet.add('abc');
+
+    d.setValue(mySet);
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    mySet.add('def');
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({abc: true, def: true});
+    expect(d.hasValueChanged()).toBeFalsy();
+
+    mySet.clear();
+    expect(d.hasValueChanged()).toBeTruthy();
+    expect(d.value).toEqual({});
+    expect(d.hasValueChanged()).toBeFalsy();
+  });
+});

--- a/packages/common/test/directives/styling_differ_spec.ts
+++ b/packages/common/test/directives/styling_differ_spec.ts
@@ -13,101 +13,111 @@ describe('StylingDiffer', () => {
         'ngClass', StylingDifferOptions.ForceAsMap | StylingDifferOptions.AllowStringValue);
     expect(d.value).toEqual(null);
 
-    d.setValue('one two');
+    d.setInput('one two');
     expect(d.value).toEqual({one: true, two: true});
 
-    d.setValue('three');
+    d.setInput('three');
     expect(d.value).toEqual({three: true});
   });
 
-  it('should not emit that a value has changed if a new non-collection value was not set', () => {
-    const d = new StylingDiffer(
-        'ngClass', StylingDifferOptions.ForceAsMap | StylingDifferOptions.AllowStringValue);
-    expect(d.value).toEqual(null);
 
-    d.setValue('one two');
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({one: true, two: true});
-    expect(d.hasValueChanged()).toBeFalsy();
-    expect(d.value).toEqual({one: true, two: true});
+  describe('setInput', () => {
 
-    d.setValue('three');
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({three: true});
-    expect(d.hasValueChanged()).toBeFalsy();
-    expect(d.value).toEqual({three: true});
+    it('should not emit that a value has changed if a new non-collection value was not set', () => {
+      const d = new StylingDiffer(
+          'ngClass', StylingDifferOptions.ForceAsMap | StylingDifferOptions.AllowStringValue);
+      expect(d.value).toEqual(null);
 
-    d.setValue(null);
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual(null);
-    expect(d.hasValueChanged()).toBeFalsy();
-    expect(d.value).toEqual(null);
+      d.setInput('one two');
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({one: true, two: true});
+      expect(d.updateValue()).toBeFalsy();
+      expect(d.value).toEqual({one: true, two: true});
+
+      d.setInput('three');
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({three: true});
+      expect(d.updateValue()).toBeFalsy();
+      expect(d.value).toEqual({three: true});
+
+      d.setInput(null);
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual(null);
+      expect(d.updateValue()).toBeFalsy();
+      expect(d.value).toEqual(null);
+    });
   });
 
-  it('should watch the contents of a StringMap value and emit new values if they change', () => {
-    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
 
-    const myMap: {[key: string]: any} = {};
-    myMap['abc'] = true;
+  describe('updateValue', () => {
 
-    d.setValue(myMap);
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true});
-    expect(d.hasValueChanged()).toBeFalsy();
+    it('should update the differ value if the contents of a input StringMap change', () => {
+      const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
 
-    myMap['def'] = true;
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true, def: true});
-    expect(d.hasValueChanged()).toBeFalsy();
+      const myMap: {[key: string]: true} = {};
+      myMap['abc'] = true;
 
-    delete myMap['abc'];
-    delete myMap['def'];
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({});
-    expect(d.hasValueChanged()).toBeFalsy();
-  });
+      d.setInput(myMap);
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true});
+      expect(d.updateValue()).toBeFalsy();
 
-  it('should watch the contents of an Array value and emit new values if they change', () => {
-    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+      myMap['def'] = true;
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true, def: true});
+      expect(d.updateValue()).toBeFalsy();
 
-    const myArray: string[] = [];
-    myArray.push('abc');
+      delete myMap['abc'];
+      delete myMap['def'];
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({});
+      expect(d.updateValue()).toBeFalsy();
+    });
 
-    d.setValue(myArray);
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true});
-    expect(d.hasValueChanged()).toBeFalsy();
 
-    myArray.push('def');
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true, def: true});
-    expect(d.hasValueChanged()).toBeFalsy();
+    it('should update the differ value if the contents of an input Array change', () => {
+      const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
 
-    myArray.length = 0;
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({});
-    expect(d.hasValueChanged()).toBeFalsy();
-  });
+      const myArray: string[] = [];
+      myArray.push('abc');
 
-  it('should watch the contents of a Set value and emit new values if they change', () => {
-    const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+      d.setInput(myArray);
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true});
+      expect(d.updateValue()).toBeFalsy();
 
-    const mySet = new Set<string>();
-    mySet.add('abc');
+      myArray.push('def');
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true, def: true});
+      expect(d.updateValue()).toBeFalsy();
 
-    d.setValue(mySet);
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true});
-    expect(d.hasValueChanged()).toBeFalsy();
+      myArray.length = 0;
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({});
+      expect(d.updateValue()).toBeFalsy();
+    });
 
-    mySet.add('def');
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({abc: true, def: true});
-    expect(d.hasValueChanged()).toBeFalsy();
 
-    mySet.clear();
-    expect(d.hasValueChanged()).toBeTruthy();
-    expect(d.value).toEqual({});
-    expect(d.hasValueChanged()).toBeFalsy();
+    it('should update the differ value if the contents of an input Set change', () => {
+      const d = new StylingDiffer('ngClass', StylingDifferOptions.ForceAsMap);
+
+      const mySet = new Set<string>();
+      mySet.add('abc');
+
+      d.setInput(mySet);
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true});
+      expect(d.updateValue()).toBeFalsy();
+
+      mySet.add('def');
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({abc: true, def: true});
+      expect(d.updateValue()).toBeFalsy();
+
+      mySet.clear();
+      expect(d.updateValue()).toBeTruthy();
+      expect(d.value).toEqual({});
+      expect(d.updateValue()).toBeFalsy();
+    });
   });
 });

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -257,8 +257,7 @@ runInEachFileSystem(() => {
 
          // We need to make sure that the flat typings file exports this directly
          const dtsContents = fs.readFile(_('/node_modules/@angular/common/common.d.ts'));
-         expect(dtsContents)
-             .toContain(`export declare class ${exportedName} implements ɵNgClassImpl`);
+         expect(dtsContents).toContain(`export declare class ${exportedName} extends ɵNgClassImpl`);
          // And that ngcc's modifications to that class use the correct (exported) name
          expect(dtsContents).toContain(`static ɵprov: ɵngcc0.ɵɵInjectableDef<${exportedName}>`);
        });


### PR DESCRIPTION
Prior to this patch, ngStyle/ngClass would accidentally emit value
changes for static (string-based) values even if the value itself had
not changed. This patch ensures that the style/class diffing code is
more strict and when it signals ngClass/ngStyle that there has been a
value change.