### PR TITLE
refactor(ivy): remove usage of Proxy for IE10/11 compatibility

### DIFF
--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -57,3 +57,7 @@ If the errors are gone, switch back to Ivy by removing the changes to the `tscon
 * ICU parsing happens at runtime, so only text, HTML tags and text bindings are allowed inside ICU cases (previously, directives were also permitted inside ICUs).
 
 * Providers formatted as `{provide: X}` without a `useValue`, `useFactory`, `useExisting`, or `useClass` property are treated like `{provide: X, useClass: X}` (previously, it defaulted to `{provide: X, useValue: undefined}`).
+
+* `DebugElement.attributes` returns `undefined` for attributes that were added and then subsequently removed (previously, attributes added and later removed would have a value of `null`).
+
+* `DebugElement.classes` returns `undefined` for classes that were added and then subsequently removed (previously, classes added and later removed would have a value of `false`).

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -957,7 +957,7 @@ describe('AppComponent', () => {
         triggerDocViewerEvent('docRendered');
         fixture.detectChanges();
         expect(component.isTransitioning).toBe(false);
-        expect(toolbar.classes['transitioning']).toBe(false);
+        expect(toolbar.classes['transitioning']).toBeFalsy();
 
         // While a document is being rendered, `isTransitoning` is set to true.
         triggerDocViewerEvent('docReady');
@@ -968,7 +968,7 @@ describe('AppComponent', () => {
         triggerDocViewerEvent('docRendered');
         fixture.detectChanges();
         expect(component.isTransitioning).toBe(false);
-        expect(toolbar.classes['transitioning']).toBe(false);
+        expect(toolbar.classes['transitioning']).toBeFalsy();
       });
 
       it('should update the sidenav state as soon as a new document is inserted (but not before)', () => {

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -18,9 +18,6 @@ import {getComponentLViewByIndex, getNativeByTNodeOrNull} from '../render3/util/
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
-import {createProxy} from './proxy';
-
-
 
 /**
  * @publicApi
@@ -204,6 +201,7 @@ function _queryNodeChildren(
     });
   }
 }
+
 class DebugNode__POST_R3__ implements DebugNode {
   readonly nativeNode: Node;
 
@@ -348,35 +346,14 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     return {};
   }
 
-  private _classesProxy !: {};
   get classes(): {[key: string]: boolean;} {
-    if (!this._classesProxy) {
-      const element = this.nativeElement;
+    const result: {[key: string]: boolean;} = {};
+    const element = this.nativeElement as HTMLElement;
+    const classNames = element.className.split(' ');
 
-      // we use a proxy here because VE code expects `.classes` to keep
-      // track of which classes have been added and removed. Because we
-      // do not make use of a debug renderer anymore, the return value
-      // must always be `false` in the event that a class does not exist
-      // on the element (even if it wasn't added and removed beforehand).
-      this._classesProxy = createProxy({
-        get(target: {}, prop: string) {
-          return element ? element.classList.contains(prop) : false;
-        },
-        set(target: {}, prop: string, value: any) {
-          return element ? element.classList.toggle(prop, !!value) : false;
-        },
-        ownKeys() { return element ? Array.from(element.classList).sort() : []; },
-        getOwnPropertyDescriptor(k: any) {
-          // we use a special property descriptor here so that enumeration operations
-          // such as `Object.keys` will work on this proxy.
-          return {
-            enumerable: true,
-            configurable: true,
-          };
-        },
-      });
-    }
-    return this._classesProxy;
+    classNames.forEach((value: string) => result[value] = true);
+
+    return result;
   }
 
   get childNodes(): DebugNode[] {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2238,9 +2238,9 @@ describe('styling', () => {
       constructor(public elementRef: ElementRef, public renderer: Renderer2) { dirInstance = this; }
 
       setStyles() {
-        this.renderer.setStyle(
-            this.elementRef.nativeElement, 'transform', 'translate3d(0px, 0px, 0px)');
-        this.renderer.addClass(this.elementRef.nativeElement, 'my-class');
+        const nativeEl = this.elementRef.nativeElement;
+        this.renderer.setStyle(nativeEl, 'transform', 'translate3d(0px, 0px, 0px)');
+        this.renderer.addClass(nativeEl, 'my-class');
       }
     }
 
@@ -2258,16 +2258,6 @@ describe('styling', () => {
     const div = fixture.debugElement.children[0];
     expect(div.styles.transform).toMatch(/translate3d\(0px\s*,\s*0px\s*,\s*0px\)/);
     expect(div.classes['my-class']).toBe(true);
-
-    div.classes['other-class'] = true;
-    div.styles['width'] = '200px';
-    expect(div.styles.width).toEqual('200px');
-    expect(div.classes['other-class']).toBe(true);
-
-    if (ivyEnabled) {
-      expect(div.nativeElement.classList.contains('other-class')).toBeTruthy();
-      expect(div.nativeElement.style['width']).toEqual('200px');
-    }
   });
 
   it('should not set classes when falsy value is passed while a sanitizer is present', () => {

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -354,7 +354,7 @@ class TestCmptWithPropInterpolation {
       const bankElem = fixture.debugElement.children[0];
 
       expect(bankElem.classes['closed']).toBe(true);
-      expect(bankElem.classes['open']).toBe(false);
+      expect(bankElem.classes['open']).toBeFalsy();
     });
 
     it('should get element classes from host bindings', () => {
@@ -365,7 +365,7 @@ class TestCmptWithPropInterpolation {
       expect(debugElement.classes['present-class'])
           .toBe(true, 'Expected bound host CSS class "present-class" to be present');
       expect(debugElement.classes['absent-class'])
-          .toBe(false, 'Expected bound host CSS class "absent-class" to be absent');
+          .toBeFalsy('Expected bound host CSS class "absent-class" to be absent');
     });
 
     it('should list element styles', () => {


### PR DESCRIPTION
Opening a PR to gauge impact of a breaking change in `DebugElement.classes`.

### Context

The `DebugElement` exposes the `classes` getter with the following structure signature: `readonly classes: {[key: string]: boolean};`. The idea behind this data structure is to expose information about CSS classes present on a given element.

To illustrate it let's consider the following example:
`<div class="foo {{exp}}"">` where `exp` is initially an empty string (`''`).

Given the above we would expect the following:
* `expect(debugElement.classes['foo']).toBe(true)`
* `expect(debugElement.classes['bar']).toBe(undefined)`
and this is the case. 

Now let's assume that `exp` flips to `'bar'` so we can expect the following:
* `expect(debugElement.classes['foo']).toBe(true)`
* `expect(debugElement.classes['bar']).toBe(true)`
and this holds true.

Now, let's flip `exp` back to `'bar'` to an empty string (`''`):
* `expect(debugElement.classes['foo']).toBe(true)`
* `expect(debugElement.classes['bar']).toBe(???)`

The question here is this: what the value of `debugElement.classes['bar']` should be? `undefined` or `false`?

In VE the answer was `false` - in other words, VE was tracking not only _presence_ of a given class but also its _state_ in the past. Tracking such state would require a testing-only, mutable data structure.

### Implementation choices

The VE implementation based on debug services was a source of memory leaks and increased complexity so we've decided to change this implementation in ivy. Unfortunately, the side effect of this implementation change is that to support VE semantics we had to resort to usage of `Proxy` [which is not supported in IE10/11](https://caniuse.com/#search=proxy).

Seems like we are facing a choice here between  IE10/11 support and a breaking change to the data structure returned by `DebugElement.classes`

### Breaking change

Removal of `Proxy` usage would result in a breaking change for the following situation:
* a CSS class is added to an element and then _subsequently removed_;
* a test asserts on the _lack_ of a CSS class in the following way:  `expect(debugElement.classes['bar']).toBe(false)`
 
A change in a test is simple (`expect(debugElement.classes['bar']).toBe(false)` => `expect(debugElement.classes['bar']).toBeFalsy()`) but it is a breaking change that might have negligible impact on the existing code.

As the additional data point - so far we've decided to go with such breaking change for the similar  `debugElement.attributes` collection (the reasoning being that the "never present" vs. "was there at one point but got removed" situations should be indistinguishable from a test point of view). 

### Notes on the API design

We are having those discussions partly to the API design choices. The `debugElement.classes`, as it stands today, exposes too much implementation details. A better API might look like follows:
`debugElement.hasClass('foo')`
