### PR TITLE
feat(ivy): throw compilation error when providing undecorated classes

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ConstantPool} from '@angular/compiler';
-import {InjectableClassRegistry} from '@angular/compiler-cli/src/ngtsc/metadata/src/registry';
 import * as ts from 'typescript';
 import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ReferencesRegistry, ResourceLoader} from '../../../src/ngtsc/annotations';
 import {CycleAnalyzer, ImportGraph} from '../../../src/ngtsc/cycles';
@@ -14,6 +13,7 @@ import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
 import {FileSystem, LogicalFileSystem, absoluteFrom, dirname, resolve} from '../../../src/ngtsc/file_system';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, PrivateExportAliasingHost, Reexport, ReferenceEmitter} from '../../../src/ngtsc/imports';
 import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, LocalMetadataRegistry} from '../../../src/ngtsc/metadata';
+import {InjectableClassRegistry} from '../../../src/ngtsc/metadata/src/registry';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
 import {ClassDeclaration} from '../../../src/ngtsc/reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../src/ngtsc/scope';

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ConstantPool} from '@angular/compiler';
+import {InjectableClassRegistry} from '@angular/compiler-cli/src/ngtsc/metadata/src/registry';
 import * as ts from 'typescript';
 import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ReferencesRegistry, ResourceLoader} from '../../../src/ngtsc/annotations';
 import {CycleAnalyzer, ImportGraph} from '../../../src/ngtsc/cycles';
@@ -85,6 +86,7 @@ export class DecorationAnalyzer {
       new PartialEvaluator(this.reflectionHost, this.typeChecker, /* dependencyTracker */ null);
   importGraph = new ImportGraph(this.moduleResolver);
   cycleAnalyzer = new CycleAnalyzer(this.importGraph);
+  injectableRegistry = new InjectableClassRegistry();
   handlers: DecoratorHandler<unknown, unknown, unknown>[] = [
     new ComponentDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.fullMetaReader,
@@ -92,28 +94,28 @@ export class DecorationAnalyzer {
         /* defaultPreserveWhitespaces */ false,
         /* i18nUseExternalIds */ true, this.bundle.enableI18nLegacyMessageIdFormat,
         this.moduleResolver, this.cycleAnalyzer, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER,
-        NOOP_DEPENDENCY_TRACKER, /* annotateForClosureCompiler */ false),
+        NOOP_DEPENDENCY_TRACKER, this.injectableRegistry, /* annotateForClosureCompiler */ false),
     // See the note in ngtsc about why this cast is needed.
     // clang-format off
     new DirectiveDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.scopeRegistry,
-        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
+        NOOP_DEFAULT_IMPORT_RECORDER, this.injectableRegistry, this.isCore,
         /* annotateForClosureCompiler */ false) as DecoratorHandler<unknown, unknown, unknown>,
     // clang-format on
     // Pipe handler must be before injectable handler in list so pipe factories are printed
     // before injectable factories (so injectable factories can delegate to them)
     new PipeDecoratorHandler(
         this.reflectionHost, this.evaluator, this.metaRegistry, this.scopeRegistry,
-        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore),
+        NOOP_DEFAULT_IMPORT_RECORDER, this.injectableRegistry, this.isCore),
     new InjectableDecoratorHandler(
         this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
-        /* strictCtorDeps */ false, /* errorOnDuplicateProv */ false),
+        /* strictCtorDeps */ false, this.injectableRegistry, /* errorOnDuplicateProv */ false),
     new NgModuleDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullMetaReader, this.fullRegistry,
         this.scopeRegistry, this.referencesRegistry, this.isCore, /* routeAnalyzer */ null,
         this.refEmitter,
         /* factoryTracker */ null, NOOP_DEFAULT_IMPORT_RECORDER,
-        /* annotateForClosureCompiler */ false),
+        /* annotateForClosureCompiler */ false, this.injectableRegistry),
   ];
   migrations: Migration[] = [
     new UndecoratedParentMigration(),

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -86,7 +86,7 @@ export class DecorationAnalyzer {
       new PartialEvaluator(this.reflectionHost, this.typeChecker, /* dependencyTracker */ null);
   importGraph = new ImportGraph(this.moduleResolver);
   cycleAnalyzer = new CycleAnalyzer(this.importGraph);
-  injectableRegistry = new InjectableClassRegistry();
+  injectableRegistry = new InjectableClassRegistry(this.reflectionHost);
   handlers: DecoratorHandler<unknown, unknown, unknown>[] = [
     new ComponentDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.fullMetaReader,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -198,7 +198,7 @@ export class ComponentDecoratorHandler implements
             this.annotateForClosureCompiler ? wrapFunctionExpressionsInParens(rawViewProviders) :
                                               rawViewProviders) :
         null;
-    const viewProvidersRequiringFactory = rawViewProviders ?
+    const viewProvidersRequiringFactory = rawViewProviders !== undefined ?
         resolveProvidersRequiringFactory(rawViewProviders, this.evaluator) :
         null;
     const providersRequiringFactory = component.has('providers') ?
@@ -336,7 +336,7 @@ export class ComponentDecoratorHandler implements
       baseClass: analysis.baseClass, ...analysis.guards,
     });
 
-    this.injectableRegistry.registerClass(node);
+    this.injectableRegistry.registerInjectable(node);
   }
 
   index(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -55,8 +55,8 @@ export interface ComponentAnalysisData {
   guards: ReturnType<typeof extractDirectiveGuards>;
   template: ParsedTemplateWithSource;
   metadataStmt: Statement|null;
-  providersRequiringFactory: Set<ClassDeclaration>|null;
-  viewProvidersRequiringFactory: Set<ClassDeclaration>|null;
+  providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
+  viewProvidersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
 }
 
 export type ComponentResolutionData = Pick<R3ComponentMetadata, ComponentMetadataResolvedFields>;
@@ -196,22 +196,22 @@ export class ComponentDecoratorHandler implements
     // Note that we could technically combine the `viewProvidersRequiringFactory` and
     // `providersRequiringFactory` into a single set, but we keep the separate so that
     // we can distinguish where an error is coming from when logging the diagnostics in `resolve`.
-    let viewProvidersRequiringFactory: Set<ClassDeclaration>|null = null;
-    let providersRequiringFactory: Set<ClassDeclaration>|null = null;
+    let viewProvidersRequiringFactory: Set<Reference<ClassDeclaration>>|null = null;
+    let providersRequiringFactory: Set<Reference<ClassDeclaration>>|null = null;
     let wrappedViewProviders: Expression|null = null;
 
     if (component.has('viewProviders')) {
       const viewProviders = component.get('viewProviders') !;
       viewProvidersRequiringFactory =
-          resolveProvidersRequiringFactory(viewProviders, this.evaluator);
+          resolveProvidersRequiringFactory(viewProviders, this.reflector, this.evaluator);
       wrappedViewProviders = new WrappedNodeExpr(
           this.annotateForClosureCompiler ? wrapFunctionExpressionsInParens(viewProviders) :
                                             viewProviders);
     }
 
     if (component.has('providers')) {
-      providersRequiringFactory =
-          resolveProvidersRequiringFactory(component.get('providers') !, this.evaluator);
+      providersRequiringFactory = resolveProvidersRequiringFactory(
+          component.get('providers') !, this.reflector, this.evaluator);
     }
 
     // Parse the template.

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -25,25 +25,27 @@ export function getProviderDiagnostics(
   const diagnostics: ts.Diagnostic[] = [];
 
   for (const provider of providerClasses) {
-    if (!registry.isInjectable(provider.node)) {
-      const identity = provider.getIdentityIn(providersDeclaration.getSourceFile());
-      let highlightNode: ts.Node;
-
-      // Try to narrow down the node in which the provider is declared so we can show a more
-      // accurate diagnostic. If the can find the `Identifier` and it is contained within the
-      // providers array we can use it, otherwise fall back to the array itself.
-      if (identity !== null && identity.pos >= providersDeclaration.pos &&
-          identity.end <= providersDeclaration.end) {
-        highlightNode = identity;
-      } else {
-        highlightNode = providersDeclaration;
-      }
-
-      diagnostics.push(makeDiagnostic(
-          ErrorCode.UNDECORATED_PROVIDER, highlightNode,
-          `Provider ${provider.node.name.text} is not injectable, because it doesn't have ` +
-              `an Angular decorator. This will result in an error at runtime.`));
+    if (registry.isInjectable(provider.node)) {
+      continue;
     }
+
+    const identity = provider.getIdentityIn(providersDeclaration.getSourceFile());
+    let highlightNode: ts.Node;
+
+    // Try to narrow down the node in which the provider is declared so we can show a more
+    // accurate diagnostic. If the can find the `Identifier` and it is contained within the
+    // providers array we can use it, otherwise fall back to the array itself.
+    if (identity !== null && identity.pos >= providersDeclaration.pos &&
+        identity.end <= providersDeclaration.end) {
+      highlightNode = identity;
+    } else {
+      highlightNode = providersDeclaration;
+    }
+
+    diagnostics.push(makeDiagnostic(
+        ErrorCode.UNDECORATED_PROVIDER, highlightNode,
+        `Provider ${provider.node.name.text} is not injectable, because it doesn't have ` +
+            `an Angular decorator. This will result in an error at runtime.`));
   }
 
   return diagnostics;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {ErrorCode, makeDiagnostic} from '../../diagnostics';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
+import {ClassDeclaration} from '../../reflection';
+
+/**
+ * Gets the diagnostics for a set of provider classes.
+ * @param providerClasses Classes that should be checked.
+ * @param highlightNode Node that should be highlighted in the diagnostic.
+ *    Usually the place where the providers are being used.
+ * @param registry Registry that keeps track of the registered injectable classes.
+ */
+export function getProviderDiagnostics(
+    providerClasses: Set<ClassDeclaration>, highlightNode: ts.Node,
+    registry: InjectableClassRegistry): ts.Diagnostic[] {
+  const diagnostics: ts.Diagnostic[] = [];
+
+  providerClasses.forEach(provider => {
+    if (!registry.hasClass(provider)) {
+      diagnostics.push(makeDiagnostic(
+          ErrorCode.UNDECORATED_PROVIDER, highlightNode,
+          `Provider ${provider.name.text} is not injectable, because it doesn't have an Angular decorator. This will result in an error at runtime.`));
+    }
+  });
+
+  return diagnostics;
+}

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -25,7 +25,7 @@ export function getProviderDiagnostics(
   const diagnostics: ts.Diagnostic[] = [];
 
   providerClasses.forEach(provider => {
-    if (!registry.hasClass(provider)) {
+    if (!registry.isInjectable(provider)) {
       diagnostics.push(makeDiagnostic(
           ErrorCode.UNDECORATED_PROVIDER, highlightNode,
           `Provider ${provider.name.text} is not injectable, because it doesn't have an Angular decorator. This will result in an error at runtime.`));

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -12,15 +12,17 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder, Reference} from '../../imports';
 import {MetadataRegistry} from '../../metadata';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {extractDirectiveGuards} from '../../metadata/src/util';
 import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost, filterToMembersWithDecorator, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFlags, HandlerPrecedence, ResolveResult} from '../../transform';
 
+import {getProviderDiagnostics} from './diagnostics';
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
-import {findAngularDecorator, getConstructorDependencies, isAngularDecorator, makeDuplicateDeclarationError, readBaseClass, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens} from './util';
+import {findAngularDecorator, getConstructorDependencies, isAngularDecorator, makeDuplicateDeclarationError, readBaseClass, resolveProvidersRequiringFactory, unwrapConstructorDependencies, unwrapExpression, unwrapForwardRef, validateConstructorDependencies, wrapFunctionExpressionsInParens} from './util';
 
 const EMPTY_OBJECT: {[key: string]: string} = {};
 const FIELD_DECORATORS = [
@@ -37,13 +39,16 @@ export interface DirectiveHandlerData {
   guards: ReturnType<typeof extractDirectiveGuards>;
   meta: R3DirectiveMetadata;
   metadataStmt: Statement|null;
+  providersRequiringFactory: Set<ClassDeclaration>|null;
 }
+
 export class DirectiveDecoratorHandler implements
     DecoratorHandler<Decorator|null, DirectiveHandlerData, unknown> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
-      private defaultImportRecorder: DefaultImportRecorder, private isCore: boolean,
+      private defaultImportRecorder: DefaultImportRecorder,
+      private injectableRegistry: InjectableClassRegistry, private isCore: boolean,
       private annotateForClosureCompiler: boolean) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
@@ -96,6 +101,10 @@ export class DirectiveDecoratorHandler implements
             this.annotateForClosureCompiler),
         baseClass: readBaseClass(node, this.reflector, this.evaluator),
         guards: extractDirectiveGuards(node, this.reflector),
+        providersRequiringFactory: directiveResult !.decorator.has('providers') ?
+            resolveProvidersRequiringFactory(
+                directiveResult !.decorator.get('providers') !, this.evaluator) :
+            null
       }
     };
   }
@@ -115,18 +124,28 @@ export class DirectiveDecoratorHandler implements
       isComponent: false,
       baseClass: analysis.baseClass, ...analysis.guards,
     });
+
+    this.injectableRegistry.registerClass(node);
   }
 
-  resolve(node: ClassDeclaration): ResolveResult<unknown> {
+  resolve(node: ClassDeclaration, analysis: DirectiveHandlerData): ResolveResult<unknown> {
+    const diagnostics: ts.Diagnostic[] = [];
+
+    if (analysis.providersRequiringFactory !== null &&
+        analysis.meta.providers instanceof WrappedNodeExpr) {
+      const providerDiagnostics = getProviderDiagnostics(
+          analysis.providersRequiringFactory, analysis.meta.providers !.node,
+          this.injectableRegistry);
+      diagnostics.push(...providerDiagnostics);
+    }
+
     const duplicateDeclData = this.scopeRegistry.getDuplicateDeclarations(node);
     if (duplicateDeclData !== null) {
       // This directive was declared twice (or more).
-      return {
-        diagnostics: [makeDuplicateDeclarationError(node, duplicateDeclData, 'Directive')],
-      };
+      diagnostics.push(makeDuplicateDeclarationError(node, duplicateDeclData, 'Directive'));
     }
 
-    return {};
+    return {diagnostics};
   }
 
   compile(
@@ -160,10 +179,8 @@ export function extractDirectiveMetadata(
     clazz: ClassDeclaration, decorator: Readonly<Decorator|null>, reflector: ReflectionHost,
     evaluator: PartialEvaluator, defaultImportRecorder: DefaultImportRecorder, isCore: boolean,
     flags: HandlerFlags, annotateForClosureCompiler: boolean,
-    defaultSelector: string | null = null): {
-  decorator: Map<string, ts.Expression>,
-  metadata: R3DirectiveMetadata,
-}|undefined {
+    defaultSelector: string | null =
+        null): {decorator: Map<string, ts.Expression>, metadata: R3DirectiveMetadata}|undefined {
   let directive: Map<string, ts.Expression>;
   if (decorator === null || decorator.args === null || decorator.args.length === 0) {
     directive = new Map<string, ts.Expression>();
@@ -389,7 +406,6 @@ export function extractQueriesFromDecorator(
   view: R3QueryMetadata[],
 } {
   const content: R3QueryMetadata[] = [], view: R3QueryMetadata[] = [];
-  const expr = unwrapExpression(queryData);
   if (!ts.isObjectLiteralExpression(queryData)) {
     throw new Error(`queries metadata must be an object literal`);
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -125,7 +125,7 @@ export class DirectiveDecoratorHandler implements
       baseClass: analysis.baseClass, ...analysis.guards,
     });
 
-    this.injectableRegistry.registerClass(node);
+    this.injectableRegistry.registerInjectable(node);
   }
 
   resolve(node: ClassDeclaration, analysis: DirectiveHandlerData): ResolveResult<unknown> {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -93,6 +93,12 @@ export class DirectiveDecoratorHandler implements
       return {};
     }
 
+    let providersRequiringFactory: Set<ClassDeclaration>|null = null;
+    if (directiveResult !== undefined && directiveResult.decorator.has('providers')) {
+      providersRequiringFactory = resolveProvidersRequiringFactory(
+          directiveResult.decorator.get('providers') !, this.evaluator);
+    }
+
     return {
       analysis: {
         meta: analysis,
@@ -100,11 +106,7 @@ export class DirectiveDecoratorHandler implements
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),
         baseClass: readBaseClass(node, this.reflector, this.evaluator),
-        guards: extractDirectiveGuards(node, this.reflector),
-        providersRequiringFactory: directiveResult !.decorator.has('providers') ?
-            resolveProvidersRequiringFactory(
-                directiveResult !.decorator.get('providers') !, this.evaluator) :
-            null
+        guards: extractDirectiveGuards(node, this.reflector), providersRequiringFactory
       }
     };
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -39,7 +39,7 @@ export interface DirectiveHandlerData {
   guards: ReturnType<typeof extractDirectiveGuards>;
   meta: R3DirectiveMetadata;
   metadataStmt: Statement|null;
-  providersRequiringFactory: Set<ClassDeclaration>|null;
+  providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
 }
 
 export class DirectiveDecoratorHandler implements
@@ -93,10 +93,10 @@ export class DirectiveDecoratorHandler implements
       return {};
     }
 
-    let providersRequiringFactory: Set<ClassDeclaration>|null = null;
+    let providersRequiringFactory: Set<Reference<ClassDeclaration>>|null = null;
     if (directiveResult !== undefined && directiveResult.decorator.has('providers')) {
       providersRequiringFactory = resolveProvidersRequiringFactory(
-          directiveResult.decorator.get('providers') !, this.evaluator);
+          directiveResult.decorator.get('providers') !, this.reflector, this.evaluator);
     }
 
     return {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -11,6 +11,7 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder} from '../../imports';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
@@ -33,6 +34,7 @@ export class InjectableDecoratorHandler implements
   constructor(
       private reflector: ReflectionHost, private defaultImportRecorder: DefaultImportRecorder,
       private isCore: boolean, private strictCtorDeps: boolean,
+      private injectableRegistry: InjectableClassRegistry,
       /**
        * What to do if the injectable already contains a ɵprov property.
        *
@@ -63,6 +65,8 @@ export class InjectableDecoratorHandler implements
       AnalysisOutput<InjectableHandlerData> {
     const meta = extractInjectableMetadata(node, decorator, this.reflector);
     const decorators = this.reflector.getDecoratorsOfDeclaration(node);
+
+    this.injectableRegistry.registerClass(node);
 
     return {
       analysis: {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -66,7 +66,7 @@ export class InjectableDecoratorHandler implements
     const meta = extractInjectableMetadata(node, decorator, this.reflector);
     const decorators = this.reflector.getDecoratorsOfDeclaration(node);
 
-    this.injectableRegistry.registerClass(node);
+    this.injectableRegistry.registerInjectable(node);
 
     return {
       analysis: {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -37,7 +37,7 @@ export interface NgModuleAnalysis {
   exports: Reference<ClassDeclaration>[];
   id: Expression|null;
   factorySymbolName: string;
-  providersRequiringFactory: Set<ClassDeclaration>|null;
+  providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
   providers: ts.Expression|null;
 }
 
@@ -279,8 +279,9 @@ export class NgModuleDecoratorHandler implements
         imports: importRefs,
         exports: exportRefs,
         providers: rawProviders,
-        providersRequiringFactory:
-            rawProviders ? resolveProvidersRequiringFactory(rawProviders, this.evaluator) : null,
+        providersRequiringFactory: rawProviders ?
+            resolveProvidersRequiringFactory(rawProviders, this.reflector, this.evaluator) :
+            null,
         metadataStmt: generateSetClassMetadataCall(
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -12,6 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder, Reference} from '../../imports';
 import {MetadataRegistry} from '../../metadata';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
@@ -30,7 +31,8 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
-      private defaultImportRecorder: DefaultImportRecorder, private isCore: boolean) {}
+      private defaultImportRecorder: DefaultImportRecorder,
+      private injectableRegistry: InjectableClassRegistry, private isCore: boolean) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
   readonly name = PipeDecoratorHandler.name;
@@ -93,6 +95,8 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
       }
       pure = pureValue;
     }
+
+    this.injectableRegistry.registerClass(clazz);
 
     return {
       analysis: {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -96,7 +96,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
       pure = pureValue;
     }
 
-    this.injectableRegistry.registerClass(clazz);
+    this.injectableRegistry.registerInjectable(clazz);
 
     return {
       analysis: {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -465,7 +465,7 @@ export function resolveProvidersRequiringFactory(
     resolvedProviders.forEach(function processProviders(provider) {
       if (provider instanceof Reference) {
         handleReference(provider);
-      } else if (provider instanceof Map) {
+      } else if (provider instanceof Map && provider.has('useClass')) {
         const useExisting = provider.get('useClass');
         if (useExisting instanceof Reference) {
           handleReference(useExisting);

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -447,33 +447,35 @@ export function resolveProvidersRequiringFactory(
   const providers = new Set<Reference<ClassDeclaration>>();
   const resolvedProviders = evaluator.evaluate(rawProviders);
 
-  if (Array.isArray(resolvedProviders)) {
-    resolvedProviders.forEach(function processProviders(provider) {
-      let tokenClass: Reference|null = null;
-
-      if (Array.isArray(provider)) {
-        // If we ran into an array, recurse into it until we've resolve all the classes.
-        provider.forEach(processProviders);
-      } else if (provider instanceof Reference) {
-        tokenClass = provider;
-      } else if (provider instanceof Map && provider.has('useClass')) {
-        const useExisting = provider.get('useClass') !;
-        if (useExisting instanceof Reference) {
-          tokenClass = useExisting;
-        }
-      }
-
-      if (tokenClass !== null && reflector.isClass(tokenClass.node)) {
-        const constructorParameters = reflector.getConstructorParameters(tokenClass.node);
-
-        // Note that we only want to capture providers with a non-trivial constructor,
-        // because they're the ones that might be using DI and need to be decorated.
-        if (constructorParameters !== null && constructorParameters.length > 0) {
-          providers.add(tokenClass as Reference<ClassDeclaration>);
-        }
-      }
-    });
+  if (!Array.isArray(resolvedProviders)) {
+    return providers;
   }
+
+  resolvedProviders.forEach(function processProviders(provider) {
+    let tokenClass: Reference|null = null;
+
+    if (Array.isArray(provider)) {
+      // If we ran into an array, recurse into it until we've resolve all the classes.
+      provider.forEach(processProviders);
+    } else if (provider instanceof Reference) {
+      tokenClass = provider;
+    } else if (provider instanceof Map && provider.has('useClass') && !provider.has('deps')) {
+      const useExisting = provider.get('useClass') !;
+      if (useExisting instanceof Reference) {
+        tokenClass = useExisting;
+      }
+    }
+
+    if (tokenClass !== null && reflector.isClass(tokenClass.node)) {
+      const constructorParameters = reflector.getConstructorParameters(tokenClass.node);
+
+      // Note that we only want to capture providers with a non-trivial constructor,
+      // because they're the ones that might be using DI and need to be decorated.
+      if (constructorParameters !== null && constructorParameters.length > 0) {
+        providers.add(tokenClass as Reference<ClassDeclaration>);
+      }
+    }
+  });
 
   return providers;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -449,9 +449,7 @@ export function resolveProvidersRequiringFactory(
   if (Array.isArray(resolvedProviders)) {
     const handleReference = (reference: Reference) => {
       const node = reference.node;
-
-      // Skip declarations from external libraries since the consumer can't do much about them.
-      if (!node.getSourceFile().isDeclarationFile && isNamedClassDeclaration(node)) {
+      if (isNamedClassDeclaration(node)) {
         const constructor = node.members.find(ts.isConstructorDeclaration);
 
         // Note that we only want to capture providers with a non-trivial constructor,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -11,6 +11,7 @@ import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, LocalMetadataRegistry} from '../../metadata';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -59,13 +60,14 @@ runInEachFileSystem(() => {
           new ReferenceEmitter([]), null);
       const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
       const refEmitter = new ReferenceEmitter([]);
+      const injectableRegistry = new InjectableClassRegistry();
 
       const handler = new ComponentDecoratorHandler(
           reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry,
           /* isCore */ false, new NoopResourceLoader(), /* rootDirs */[''],
           /* defaultPreserveWhitespaces */ false, /* i18nUseExternalIds */ true,
           /* enableI18nLegacyMessageIdFormat */ false, moduleResolver, cycleAnalyzer, refEmitter,
-          NOOP_DEFAULT_IMPORT_RECORDER, /* depTracker */ null,
+          NOOP_DEFAULT_IMPORT_RECORDER, /* depTracker */ null, injectableRegistry,
           /* annotateForClosureCompiler */ false);
       const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
       const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -60,7 +60,7 @@ runInEachFileSystem(() => {
           new ReferenceEmitter([]), null);
       const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
       const refEmitter = new ReferenceEmitter([]);
-      const injectableRegistry = new InjectableClassRegistry();
+      const injectableRegistry = new InjectableClassRegistry(reflectionHost);
 
       const handler = new ComponentDecoratorHandler(
           reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -9,6 +9,7 @@ import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {DtsMetadataReader, LocalMetadataRegistry} from '../../metadata';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -48,8 +49,10 @@ runInEachFileSystem(() => {
       const scopeRegistry = new LocalModuleScopeRegistry(
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
+      const injectableRegistry = new InjectableClassRegistry();
       const handler = new DirectiveDecoratorHandler(
           reflectionHost, evaluator, scopeRegistry, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+          injectableRegistry,
           /* isCore */ false, /* annotateForClosureCompiler */ false);
 
       const analyzeDirective = (dirName: string) => {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -49,7 +49,7 @@ runInEachFileSystem(() => {
       const scopeRegistry = new LocalModuleScopeRegistry(
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
-      const injectableRegistry = new InjectableClassRegistry();
+      const injectableRegistry = new InjectableClassRegistry(reflectionHost);
       const handler = new DirectiveDecoratorHandler(
           reflectionHost, evaluator, scopeRegistry, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
           injectableRegistry,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -68,7 +68,7 @@ function setupHandler(errorOnDuplicateProv: boolean) {
   ]);
   const checker = program.getTypeChecker();
   const reflectionHost = new TypeScriptReflectionHost(checker);
-  const injectableRegistry = new InjectableClassRegistry();
+  const injectableRegistry = new InjectableClassRegistry(reflectionHost);
   const handler = new InjectableDecoratorHandler(
       reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, /* isCore */ false,
       /* strictCtorDeps */ false, injectableRegistry, errorOnDuplicateProv);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -9,6 +9,7 @@ import {ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER} from '../../imports';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {InjectableDecoratorHandler} from '../src/injectable';
@@ -67,9 +68,10 @@ function setupHandler(errorOnDuplicateProv: boolean) {
   ]);
   const checker = program.getTypeChecker();
   const reflectionHost = new TypeScriptReflectionHost(checker);
+  const injectableRegistry = new InjectableClassRegistry();
   const handler = new InjectableDecoratorHandler(
       reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, /* isCore */ false,
-      /* strictCtorDeps */ false, errorOnDuplicateProv);
+      /* strictCtorDeps */ false, injectableRegistry, errorOnDuplicateProv);
   const TestClass = getDeclaration(program, ENTRY_FILE, 'TestClass', isNamedClassDeclaration);
   const ɵprov = reflectionHost.getMembersOfClass(TestClass).find(member => member.name === 'ɵprov');
   if (ɵprov === undefined) {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -13,6 +13,7 @@ import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {LocalIdentifierStrategy, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, LocalMetadataRegistry} from '../../metadata';
+import {InjectableClassRegistry} from '../../metadata/src/registry';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -66,11 +67,12 @@ runInEachFileSystem(() => {
           metaRegistry, new MetadataDtsModuleScopeResolver(dtsReader, null),
           new ReferenceEmitter([]), null);
       const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
+      const injectableRegistry = new InjectableClassRegistry();
 
       const handler = new NgModuleDecoratorHandler(
           reflectionHost, evaluator, metaReader, metaRegistry, scopeRegistry, referencesRegistry,
           /* isCore */ false, /* routeAnalyzer */ null, refEmitter, /* factoryTracker */ null,
-          NOOP_DEFAULT_IMPORT_RECORDER, /* annotateForClosureCompiler */ false);
+          NOOP_DEFAULT_IMPORT_RECORDER, /* annotateForClosureCompiler */ false, injectableRegistry);
       const TestModule =
           getDeclaration(program, _('/entry.ts'), 'TestModule', isNamedClassDeclaration);
       const detected =

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -67,7 +67,7 @@ runInEachFileSystem(() => {
           metaRegistry, new MetadataDtsModuleScopeResolver(dtsReader, null),
           new ReferenceEmitter([]), null);
       const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
-      const injectableRegistry = new InjectableClassRegistry();
+      const injectableRegistry = new InjectableClassRegistry(reflectionHost);
 
       const handler = new NgModuleDecoratorHandler(
           reflectionHost, evaluator, metaReader, metaRegistry, scopeRegistry, referencesRegistry,

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -26,6 +26,9 @@ export enum ErrorCode {
   PARAM_MISSING_TOKEN = 2003,
   DIRECTIVE_MISSING_SELECTOR = 2004,
 
+  /** Raised when an undecorated class is passed in as a provider to a module or a directive. */
+  UNDECORATED_PROVIDER = 2005,
+
   SYMBOL_NOT_EXPORTED = 3001,
   SYMBOL_EXPORTED_UNDER_DIFFERENT_NAME = 3002,
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -59,3 +59,13 @@ export class CompoundMetadataRegistry implements MetadataRegistry {
     }
   }
 }
+
+/**
+ * Registry that keeps track of classes that can be injected (e.g. injectables, components, pipes).
+ */
+export class InjectableClassRegistry {
+  private classes = new Set<ClassDeclaration>();
+
+  registerClass(declaration: ClassDeclaration): void { this.classes.add(declaration); }
+  hasClass(declaration: ClassDeclaration): boolean { return this.classes.has(declaration); }
+}

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -66,6 +66,6 @@ export class CompoundMetadataRegistry implements MetadataRegistry {
 export class InjectableClassRegistry {
   private classes = new Set<ClassDeclaration>();
 
-  registerClass(declaration: ClassDeclaration): void { this.classes.add(declaration); }
-  hasClass(declaration: ClassDeclaration): boolean { return this.classes.has(declaration); }
+  registerInjectable(declaration: ClassDeclaration): void { this.classes.add(declaration); }
+  isInjectable(declaration: ClassDeclaration): boolean { return this.classes.has(declaration); }
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -7,9 +7,10 @@
  */
 
 import {Reference} from '../../imports';
-import {ClassDeclaration} from '../../reflection';
+import {ClassDeclaration, ReflectionHost} from '../../reflection';
 
 import {DirectiveMeta, MetadataReader, MetadataRegistry, NgModuleMeta, PipeMeta} from './api';
+import {hasInjectableFields} from './util';
 
 /**
  * A registry of directive, pipe, and module metadata for types defined in the current compilation
@@ -66,6 +67,14 @@ export class CompoundMetadataRegistry implements MetadataRegistry {
 export class InjectableClassRegistry {
   private classes = new Set<ClassDeclaration>();
 
+  constructor(private host: ReflectionHost) {}
+
   registerInjectable(declaration: ClassDeclaration): void { this.classes.add(declaration); }
-  isInjectable(declaration: ClassDeclaration): boolean { return this.classes.has(declaration); }
+
+  isInjectable(declaration: ClassDeclaration): boolean {
+    // Figure out whether the class is injectable based on the registered classes, otherwise
+    // fall back to looking at its members since we might not have been able register the class
+    // if it was compiled already.
+    return this.classes.has(declaration) || hasInjectableFields(declaration, this.host);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -174,3 +174,9 @@ function afterUnderscore(str: string): string {
   }
   return str.substr(pos + 1);
 }
+
+/** Returns whether a class declaration has the necessary class fields to make it injectable. */
+export function hasInjectableFields(clazz: ClassDeclaration, host: ReflectionHost): boolean {
+  const members = host.getMembersOfClass(clazz);
+  return members.some(({isStatic, name}) => isStatic && (name === 'ɵprov' || name === 'ɵfac'));
+}

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -630,7 +630,7 @@ export class NgtscProgram implements api.Program {
         localMetaReader, depScopeReader, this.refEmitter, this.aliasingHost);
     const scopeReader: ComponentScopeReader = this.scopeRegistry;
     const metaRegistry = new CompoundMetadataRegistry([localMetaRegistry, this.scopeRegistry]);
-    const injectableRegistry = new InjectableClassRegistry();
+    const injectableRegistry = new InjectableClassRegistry(this.reflector);
 
     this.metaReader = new CompoundMetadataReader([localMetaReader, dtsReader]);
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -363,7 +363,7 @@ export class TraitCompiler {
           }
         }
 
-        if (result.diagnostics !== undefined) {
+        if (result.diagnostics !== undefined && result.diagnostics.length > 0) {
           trait = trait.toErrored(result.diagnostics);
         } else {
           if (result.data !== undefined) {

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -89,3 +89,5 @@ export class EventEmitter<T> {
 export interface QueryList<T>/* implements Iterable<T> */ { [Symbol.iterator]: () => Iterator<T>; }
 
 export type NgIterable<T> = Array<T>| Iterable<T>;
+
+export class NgZone {}

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5271,6 +5271,27 @@ export const Foo = Foo__PRE_R3__;
                 `Angular decorator. This will result in an error at runtime.`);
       });
 
+      it('should not error when an undecorated class is provided via useClass with deps', () => {
+        env.write('test.ts', `
+          import {NgModule, Injectable, NgZone} from '@angular/core';
+
+          @Injectable({providedIn: 'root'})
+          class Service {}
+
+          class NotAService {
+            constructor(ngZone: NgZone) {}
+          }
+
+          @NgModule({
+            providers: [{provide: Service, useClass: NotAService, deps: [NgZone]}]
+          })
+          export class SomeModule {}
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
       it('should error when an undecorated class is provided via an array', () => {
         env.write('test.ts', `
           import {NgModule, Injectable, NgZone} from '@angular/core';


### PR DESCRIPTION
Adds a compilation error if the consumer tries to pass in an undecorated class into the `providers` of an `NgModule`, or the `providers`/`viewProviders` arrays of a `Directive`/`Component`.
