### PR TITLE
refactor(ivy): avoid type coercion in `saveNameToExportMap` function

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1300,7 +1300,7 @@ function saveNameToExportMap(
         exportsMap[def.exportAs[i]] = index;
       }
     }
-    if ((def as ComponentDef<any>).template) exportsMap[''] = index;
+    if (isComponentDef(def)) exportsMap[''] = index;
   }
 }
 


### PR DESCRIPTION
TypeScript 3.7 flags `if` conditions that implicitly coerce a function/method definition. While checking for the `template` presence on a def (actually checking whether we work with Component) in `saveNameToExportMap`, the `if` condition had implicit type coercion. This commit updates the condition to use the `isComponentDef` function (that checks `def.template` against `null` internally) to avoid compilation errors with TypeScript 3.7.

Note: similar change was originally proposed by @mprobst in g3. This PR applies the changes to main Angular repo, so we can sync them into g3.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
