### PR TITLE
build: prevent creating runfiles tree during remote builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -111,6 +111,9 @@ build:remote --project_id=internal-200822
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
 
+# When building remotely, runfile trees are created from in-memory manifests
+build:remote --build_runfile_manifests=false
+
 ###############################
 # NodeJS rules settings
 # These settings are required for rules_nodejs


### PR DESCRIPTION
Runfiles trees are not needed when building remotely as the trees
are actually created from in-memory manifests
