### PR TITLE
fix(ivy): generate a better error for template var writes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -96,6 +96,20 @@ export enum ErrorCode {
   MISSING_PIPE = 8004,
 
   /**
+   * The left-hand side of an assignment expression was a template variable. Effectively, the
+   * template looked like:
+   *
+   * ```
+   * <ng-template let-something>
+   *   <button (click)="something = ...">...</button>
+   * </ng-template>
+   * ```
+   *
+   * Template variables are read-only.
+   */
+  WRITE_TO_READ_ONLY_VARIABLE = 8005,
+
+  /**
    * An injectable already has a `ɵprov` property.
    */
   INJECTABLE_DUPLICATE_PROV = 9001

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_semantics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_semantics.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AST, BoundTarget, ImplicitReceiver, ParseSourceSpan, PropertyWrite, RecursiveAstVisitor, TmplAstVariable} from '@angular/compiler';
+
+import {toAbsoluteSpan} from './diagnostics';
+import {OutOfBandDiagnosticRecorder} from './oob';
+
+/**
+ * Visits a template and records any semantic errors within its expressions.
+ */
+export class ExpressionSemanticVisitor extends RecursiveAstVisitor {
+  constructor(
+      private templateId: string, private boundTarget: BoundTarget<any>,
+      private oob: OutOfBandDiagnosticRecorder, private sourceSpan: ParseSourceSpan) {
+    super();
+  }
+
+  visitPropertyWrite(ast: PropertyWrite, context: any): void {
+    super.visitPropertyWrite(ast, context);
+
+    if (!(ast.receiver instanceof ImplicitReceiver)) {
+      return;
+    }
+
+    const target = this.boundTarget.getExpressionTarget(ast);
+    if (target instanceof TmplAstVariable) {
+      // Template variables are read-only.
+      const astSpan = toAbsoluteSpan(ast.span, this.sourceSpan);
+      this.oob.illegalAssignmentToTemplateVar(this.templateId, ast, astSpan, target);
+    }
+  }
+
+  static visit(
+      ast: AST, sourceSpan: ParseSourceSpan, id: string, boundTarget: BoundTarget<any>,
+      oob: OutOfBandDiagnosticRecorder): void {
+    ast.visit(new ExpressionSemanticVisitor(id, boundTarget, oob, sourceSpan));
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -389,4 +389,5 @@ export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {
   get diagnostics(): ReadonlyArray<ts.Diagnostic> { return []; }
   missingReferenceTarget(): void {}
   missingPipe(): void {}
+  illegalAssignmentToTemplateVar(): void {}
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -280,6 +280,12 @@ describe('type check blocks', () => {
           '_t1.addEventListener("event", ($event): any => (ctx).foo(($event as any)));');
     });
 
+    it('should detect writes to template variables', () => {
+      const TEMPLATE = `<ng-template let-v><div (event)="v = 3"></div></ng-template>`;
+      const block = tcb(TEMPLATE);
+      expect(block).toContain('_t3.addEventListener("event", ($event): any => (_t2 = 3))');
+    });
+
   });
 
   describe('config', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1121,6 +1121,34 @@ export declare class AnimationEvent {
       expect(getSourceCodeForDiagnostic(diags[2])).toEqual('[fromChild]="4"');
     });
 
+    it('should detect an illegal write to a template variable', () => {
+      env.write('test.ts', `
+        import {Component, NgModule} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+
+        @Component({
+          selector: 'test',
+          template: \`
+            <div *ngIf="x as y">
+              <button (click)="y = !y">Toggle</button>
+            </div>
+          \`,
+        })
+        export class TestCmp {
+          x!: boolean;
+        }
+
+        @NgModule({
+          declarations: [TestCmp],
+          imports: [CommonModule],
+        })
+        export class Module {}
+      `);
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toEqual(1);
+      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('y = !y');
+    });
+
     describe('input coercion', () => {
       beforeEach(() => {
         env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});


### PR DESCRIPTION
In Ivy it's illegal for a template to write to a template variable. So the
template:

```html
<ng-template let-somevar>
  <button (click)="somevar = 3">Set var to 3</button>
</ng-template>
```

is erroneous and previously would fail to compile with an assertion error
from the `TemplateDefinitionBuilder`. This error wasn't particularly user-
friendly, though, as it lacked the context of which template or where the
error occurred.

In this commit, a new check in template type-checking is added which detects
such erroneous writes and produces a true diagnostic with the appropriate
context information.
