### PR TITLE
fix(ivy): i18n - remove `translate` function when clearing translations

### DIFF
--- a/packages/localize/src/translate.ts
+++ b/packages/localize/src/translate.ts
@@ -52,6 +52,7 @@ export function loadTranslations(translations: Record<MessageId, TargetMessage>)
  * @publicApi
  */
 export function clearTranslations() {
+  $localize.translate = undefined;
   $localize.TRANSLATIONS = {};
 }
 


### PR DESCRIPTION
The `loadTranslations()` function will attach the `translate()` function
to `$localize.translate` to cause runtime translation to occur.

We should cleanup after ourselves by unattaching this function when
we call `clearTranslations()`.

Fixes #32781
