### PR TITLE
fix(ngcc): render UMD imports even if no prior imports

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -200,8 +200,7 @@ function renderFactoryParameters(
     // function () { ... }
     // The AST does not give us a way to find the insertion point - between the two parentheses.
     // So we must use a regular expression on the text of the function.
-    const injectionPoint =
-        factoryFunction.getStart() + factoryFunction.getText().search(/\(\)/) + 1;
+    const injectionPoint = factoryFunction.getStart() + factoryFunction.getText().indexOf('()') + 1;
     output.appendLeft(injectionPoint, parameterString);
   }
 }

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -291,6 +291,42 @@ typeof define === 'function' && define.amd ? define('file', ['exports','/tslib',
            expect(output.toString())
                .toContain(`(function (exports,someSideEffect,localDep,core,i0,i1) {'use strict';`);
          });
+
+      it('should handle the case where there were no prior imports nor exports', () => {
+        const PROGRAM: TestFile = {
+          name: _('/node_modules/test-package/some/file.js'),
+          contents: `
+          /* A copyright notice */
+          (function (global, factory) {
+          typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+          typeof define === 'function' && define.amd ? define('file', factory) :
+          (factory());
+          }(this, (function () {'use strict';
+            var index = "";
+            return index;
+          })));`,
+        };
+        const {renderer, program} = setup(PROGRAM);
+        const file = getSourceFileOrError(program, _('/node_modules/test-package/some/file.js'));
+        const output = new MagicString(PROGRAM.contents);
+        renderer.addImports(
+            output,
+            [
+              {specifier: '@angular/core', qualifier: 'i0'},
+              {specifier: '@angular/common', qualifier: 'i1'}
+            ],
+            file);
+        const outputSrc = output.toString();
+
+        expect(output.toString())
+            .toContain(
+                `typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@angular/core'),require('@angular/common')) :`);
+        expect(output.toString())
+            .toContain(
+                `typeof define === 'function' && define.amd ? define('file',['@angular/core','@angular/common'], factory) :`);
+        expect(outputSrc).toContain(`(factory(global.ng.core,global.ng.common));`);
+        expect(outputSrc).toContain(`(function (i0,i1) {'use strict';`);
+      });
     });
 
     describe('addExports', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -302,7 +302,7 @@ typeof define === 'function' && define.amd ? define('file', ['exports','/tslib',
           typeof define === 'function' && define.amd ? define('file', factory) :
           (factory());
           }(this, (function () {'use strict';
-            var index = "";
+            var index = '';
             return index;
           })));`,
         };
@@ -318,12 +318,10 @@ typeof define === 'function' && define.amd ? define('file', ['exports','/tslib',
             file);
         const outputSrc = output.toString();
 
-        expect(output.toString())
-            .toContain(
-                `typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@angular/core'),require('@angular/common')) :`);
-        expect(output.toString())
-            .toContain(
-                `typeof define === 'function' && define.amd ? define('file',['@angular/core','@angular/common'], factory) :`);
+        expect(outputSrc).toContain(
+            `typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@angular/core'),require('@angular/common')) :`);
+        expect(outputSrc).toContain(
+            `typeof define === 'function' && define.amd ? define('file',['@angular/core','@angular/common'], factory) :`);
         expect(outputSrc).toContain(`(factory(global.ng.core,global.ng.common));`);
         expect(outputSrc).toContain(`(function (i0,i1) {'use strict';`);
       });


### PR DESCRIPTION
Previously the UMD rendering formatter assumed that
there would already be import (and an export) arguments
to the UMD factory function.

This commit adds support for this corner case.

Fixes #34138
