### PR TITLE
feat(language-service): completions support for template reference variables

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -681,6 +681,22 @@ describe('completions', () => {
         expectContain(completions, CompletionKind.METHOD, ['substring']);
       });
     });
+
+    describe('with template reference variables', () => {
+      it('should be able to get the completions (ref- prefix)', () => {
+        mockHost.override(TEST_TEMPLATE, `<form ref-itemForm="ngF~{reference}"></form>`);
+        const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'reference');
+        const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start) !;
+        expectContain(completions, CompletionKind.REFERENCE, ['ngForm']);
+      });
+
+      it('should be able to get the completions (# prefix)', () => {
+        mockHost.override(TEST_TEMPLATE, `<form #itemForm="ngF~{reference}"></form>`);
+        const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'reference');
+        const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start) !;
+        expectContain(completions, CompletionKind.REFERENCE, ['ngForm']);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
https://angular.io/guide/template-syntax#how-a-reference-variable-gets-its-value
get completions from option `exportAs` of `Directive`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
