### PR TITLE
refactor(ivy): don't include removed classes in the styling debug

### DIFF
--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1212,8 +1212,7 @@ describe('styling', () => {
 
         classesSummary = classes.summary;
         abcSummary = classesSummary['abc'];
-        expect(abcSummary.prop).toEqual('abc');
-        expect(abcSummary.value).toBeFalsy();
+        expect(abcSummary).toBeUndefined();
 
         let defSummary = classesSummary['def'];
         expect(defSummary.prop).toEqual('def');


### PR DESCRIPTION
This PR aligns behaviour of styling debug with the `DebugElement.classes` (as proposed in #34328) and remove `Proxy` usage (since it is not supported in IE10/11).