### PR TITLE
fix(ivy): improve ExpressionChangedAfterChecked error

### DIFF
--- a/packages/core/src/render3/bindings.ts
+++ b/packages/core/src/render3/bindings.ts
@@ -8,7 +8,8 @@
 
 import {devModeEqual} from '../change_detection/change_detection_util';
 import {assertDataInRange, assertLessThan, assertNotSame} from '../util/assert';
-import {throwErrorIfNoChangesMode} from './errors';
+
+import {getExpressionChangedErrorDetails, throwErrorIfNoChangesMode} from './errors';
 import {LView} from './interfaces/view';
 import {getCheckNoChangesMode} from './state';
 import {NO_CHANGE} from './tokens';
@@ -44,7 +45,10 @@ export function bindingUpdated(lView: LView, bindingIndex: number, value: any): 
       // (before the change detection was run).
       const oldValueToCompare = oldValue !== NO_CHANGE ? oldValue : undefined;
       if (!devModeEqual(oldValueToCompare, value)) {
-        throwErrorIfNoChangesMode(oldValue === NO_CHANGE, oldValueToCompare, value);
+        const details =
+            getExpressionChangedErrorDetails(lView, bindingIndex, oldValueToCompare, value);
+        throwErrorIfNoChangesMode(
+            oldValue === NO_CHANGE, details.oldValue, details.newValue, details.propName);
       }
     }
     lView[bindingIndex] = value;

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -51,9 +51,10 @@ export function throwErrorIfNoChangesMode(
   if (creationMode) {
     msg +=
         ` It seems like the view has been created after its parent and its children have been dirty checked.` +
-        ` Has it been created in a change detection hook ?`;
+        ` Has it been created in a change detection hook?`;
   }
-  // TODO: include debug context
+  // TODO: include debug context, see `viewDebugError` function in
+  // `packages/core/src/view/errors.ts` for reference.
   throw new Error(msg);
 }
 

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -11,7 +11,6 @@ import {stringify} from '../util/stringify';
 
 import {TNode} from './interfaces/node';
 import {LView, TVIEW} from './interfaces/view';
-import {getBindingRoot} from './state';
 import {INTERPOLATION_DELIMITER} from './util/misc_utils';
 
 
@@ -46,9 +45,9 @@ export function throwInvalidProviderError(
 /** Throws an ExpressionChangedAfterChecked error if checkNoChanges mode is on. */
 export function throwErrorIfNoChangesMode(
     creationMode: boolean, oldValue: any, currValue: any, propName?: string): never|void {
-  const field = propName ? `${propName}: ` : '';
+  const field = propName ? ` for '${propName}'` : '';
   let msg =
-      `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: '${field}${oldValue}'. Current value: '${field}${currValue}'.`;
+      `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value${field}: '${oldValue}'. Current value: '${currValue}'.`;
   if (creationMode) {
     msg +=
         ` It seems like the view has been created after its parent and its children have been dirty checked.` +
@@ -79,7 +78,8 @@ function constructDetailsForInterpolation(
  * function description.
  */
 export function getExpressionChangedErrorDetails(
-    lView: LView, bindingIndex: number, oldValue: any, newValue: any): any {
+    lView: LView, bindingIndex: number, oldValue: any,
+    newValue: any): {propName?: string, oldValue: any, newValue: any} {
   const tData = lView[TVIEW].data;
   const metadata = tData[bindingIndex];
 
@@ -93,13 +93,13 @@ export function getExpressionChangedErrorDetails(
     return {propName: metadata, oldValue, newValue};
   }
 
-  // metadata is not available for this expression, check if this expressions is a part of the
+  // metadata is not available for this expression, check if this expression is a part of the
   // property interpolation by going from the current binding index left and look for a string that
   // contains INTERPOLATION_DELIMITER, the layout in tView.data for this case will look like this:
   // [..., 'id�Prefix � and � suffix', null, null, null, ...]
   if (metadata === null) {
     let idx = bindingIndex - 1;
-    while (typeof tData[idx] !== 'string' && tData[idx + 1] === null && idx >= getBindingRoot()) {
+    while (typeof tData[idx] !== 'string' && tData[idx + 1] === null) {
       idx--;
     }
     const meta = tData[idx];

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -10,6 +10,10 @@ import {InjectorType} from '../di/interface/defs';
 import {stringify} from '../util/stringify';
 
 import {TNode} from './interfaces/node';
+import {LView, TVIEW} from './interfaces/view';
+import {getBindingRoot} from './state';
+import {INTERPOLATION_DELIMITER} from './util/misc_utils';
+
 
 
 /** Called when directives inject each other (creating a circular dependency) */
@@ -20,20 +24,6 @@ export function throwCyclicDependencyError(token: any): never {
 /** Called when there are multiple component selectors that match a given node */
 export function throwMultipleComponentError(tNode: TNode): never {
   throw new Error(`Multiple components match node with tagname ${tNode.tagName}`);
-}
-
-/** Throws an ExpressionChangedAfterChecked error if checkNoChanges mode is on. */
-export function throwErrorIfNoChangesMode(
-    creationMode: boolean, oldValue: any, currValue: any): never|void {
-  let msg =
-      `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: '${oldValue}'. Current value: '${currValue}'.`;
-  if (creationMode) {
-    msg +=
-        ` It seems like the view has been created after its parent and its children have been dirty checked.` +
-        ` Has it been created in a change detection hook ?`;
-  }
-  // TODO: include debug context
-  throw new Error(msg);
 }
 
 export function throwMixedMultiProviderError() {
@@ -51,4 +41,76 @@ export function throwInvalidProviderError(
 
   throw new Error(
       `Invalid provider for the NgModule '${stringify(ngModuleType)}'` + ngModuleDetail);
+}
+
+/** Throws an ExpressionChangedAfterChecked error if checkNoChanges mode is on. */
+export function throwErrorIfNoChangesMode(
+    creationMode: boolean, oldValue: any, currValue: any, propName?: string): never|void {
+  const field = propName ? `${propName}: ` : '';
+  let msg =
+      `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: '${field}${oldValue}'. Current value: '${field}${currValue}'.`;
+  if (creationMode) {
+    msg +=
+        ` It seems like the view has been created after its parent and its children have been dirty checked.` +
+        ` Has it been created in a change detection hook ?`;
+  }
+  // TODO: include debug context
+  throw new Error(msg);
+}
+
+function constructDetailsForInterpolation(
+    lView: LView, rootIndex: number, expressionIndex: number, meta: string, changedValue: any) {
+  const [propName, prefix, ...chunks] = meta.split(INTERPOLATION_DELIMITER);
+  let oldValue = prefix, newValue = prefix;
+  for (let i = 0; i < chunks.length; i++) {
+    const slotIdx = rootIndex + i;
+    oldValue += `${lView[slotIdx]}${chunks[i]}`;
+    newValue += `${slotIdx === expressionIndex ? changedValue : lView[slotIdx]}${chunks[i]}`;
+  }
+  return {propName, oldValue, newValue};
+}
+
+/**
+ * Constructs an object that contains details for the ExpressionChangedAfterItHasBeenCheckedError:
+ * - property name (for property bindings or interpolations)
+ * - old and new values, enriched using information from metadata
+ *
+ * More information on the metadata storage format can be found in `storePropertyBindingMetadata`
+ * function description.
+ */
+export function getExpressionChangedErrorDetails(
+    lView: LView, bindingIndex: number, oldValue: any, newValue: any): any {
+  const tData = lView[TVIEW].data;
+  const metadata = tData[bindingIndex];
+
+  if (typeof metadata === 'string') {
+    // metadata for property interpolation
+    if (metadata.indexOf(INTERPOLATION_DELIMITER) > -1) {
+      return constructDetailsForInterpolation(
+          lView, bindingIndex, bindingIndex, metadata, newValue);
+    }
+    // metadata for property binding
+    return {propName: metadata, oldValue, newValue};
+  }
+
+  // metadata is not available for this expression, check if this expressions is a part of the
+  // property interpolation by going from the current binding index left and look for a string that
+  // contains INTERPOLATION_DELIMITER, the layout in tView.data for this case will look like this:
+  // [..., 'id�Prefix � and � suffix', null, null, null, ...]
+  if (metadata === null) {
+    let idx = bindingIndex - 1;
+    while (typeof tData[idx] !== 'string' && tData[idx + 1] === null && idx >= getBindingRoot()) {
+      idx--;
+    }
+    const meta = tData[idx];
+    if (typeof meta === 'string') {
+      const matches = meta.match(new RegExp(INTERPOLATION_DELIMITER, 'g'));
+      // first interpolation delimiter separates property name from interpolation parts (in case of
+      // property interpolations), so we subtract one from total number of found delimiters
+      if (matches && (matches.length - 1) > bindingIndex - idx) {
+        return constructDetailsForInterpolation(lView, idx, bindingIndex, meta, newValue);
+      }
+    }
+  }
+  return {propName: undefined, oldValue, newValue};
 }

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -191,7 +191,7 @@ function stylingProp(
   if (ngDevMode && getCheckNoChangesMode()) {
     const oldValue = getValue(lView, bindingIndex);
     if (hasValueChangedUnwrapSafeValue(oldValue, value)) {
-      throwErrorIfNoChangesMode(false, oldValue, value);
+      throwErrorIfNoChangesMode(false, oldValue, value, prop);
     }
   }
 
@@ -369,7 +369,10 @@ function stylingMap(
   // For this reason, the checkNoChanges situation must also be handled here
   // as well.
   if (ngDevMode && valueHasChanged && getCheckNoChangesMode()) {
-    throwErrorIfNoChangesMode(false, oldValue, value);
+    // check if the value is a StylingMapArray, in which case take the first value (which stores raw
+    // value) from the array
+    const previousValue = Array.isArray(oldValue) && oldValue.length ? oldValue[0] : oldValue;
+    throwErrorIfNoChangesMode(false, previousValue, value);
   }
 
   // Direct Apply Case: bypass context resolution and apply the

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -20,7 +20,7 @@ import {activateStylingMapFeature} from '../styling/map_based_bindings';
 import {attachStylingDebugObject} from '../styling/styling_debug';
 import {NO_CHANGE} from '../tokens';
 import {renderStringify} from '../util/misc_utils';
-import {addItemToStylingMap, allocStylingMapArray, allocTStylingContext, allowDirectStyling, concatString, forceClassesAsString, forceStylesAsString, getInitialStylingValue, getStylingMapArray, getValue, hasClassInput, hasStyleInput, hasValueChanged, hasValueChangedUnwrapSafeValue, isHostStylingActive, isStylingContext, isStylingValueDefined, normalizeIntoStylingMap, patchConfig, selectClassBasedInputName, setValue, stylingMapToString} from '../util/styling_utils';
+import {addItemToStylingMap, allocStylingMapArray, allocTStylingContext, allowDirectStyling, concatString, forceClassesAsString, forceStylesAsString, getInitialStylingValue, getStylingMapArray, getValue, hasClassInput, hasStyleInput, hasValueChanged, hasValueChangedUnwrapSafeValue, isHostStylingActive, isStylingContext, isStylingMapArray, isStylingValueDefined, normalizeIntoStylingMap, patchConfig, selectClassBasedInputName, setValue, stylingMapToString} from '../util/styling_utils';
 import {getNativeByTNode, getTNode} from '../util/view_utils';
 
 
@@ -191,7 +191,8 @@ function stylingProp(
   if (ngDevMode && getCheckNoChangesMode()) {
     const oldValue = getValue(lView, bindingIndex);
     if (hasValueChangedUnwrapSafeValue(oldValue, value)) {
-      throwErrorIfNoChangesMode(false, oldValue, value, prop);
+      const field = isClassBased ? `class.${prop}` : `style.${prop}`;
+      throwErrorIfNoChangesMode(false, oldValue, value, field);
     }
   }
 
@@ -371,7 +372,8 @@ function stylingMap(
   if (ngDevMode && valueHasChanged && getCheckNoChangesMode()) {
     // check if the value is a StylingMapArray, in which case take the first value (which stores raw
     // value) from the array
-    const previousValue = Array.isArray(oldValue) && oldValue.length ? oldValue[0] : oldValue;
+    const previousValue =
+        isStylingMapArray(oldValue) ? oldValue[StylingMapArrayIndex.RawValuePosition] : oldValue;
     throwErrorIfNoChangesMode(false, previousValue, value);
   }
 

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1249,7 +1249,7 @@ describe('change detection', () => {
     });
   });
 
-  describe('ExpressionChangedAfterItHasBeenCheckedError', () => {
+  fdescribe('ExpressionChangedAfterItHasBeenCheckedError', () => {
     @Component({template: '...'})
     class MyApp {
       a: string = 'a';
@@ -1277,16 +1277,20 @@ describe('change detection', () => {
     }
 
     it('should include field name in case of property binding', () => {
+      const message = ivyEnabled ? `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                                   `Previous value: 'id: initial'. Current value: 'id: changed'`;
       expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'))
-          .toThrowError(/Previous value: 'id: initial'. Current value: 'id: changed'/);
+          .toThrowError(new RegExp(message));
     });
 
     it('should include field name in case of property interpolation', () => {
+      const message = ivyEnabled ?
+          `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+          `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
       expect(
           () => initWithTemplate(
               '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-          .toThrowError(
-              /Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'/);
+          .toThrowError(new RegExp(message));
     });
 
     it('should only display a value of an expression that was changed in text interpolation',
@@ -1307,23 +1311,30 @@ describe('change detection', () => {
        });
 
     it('should include style prop name', () => {
+      const message = ivyEnabled ?
+          `Previous value for 'style.color': 'red'. Current value: 'green'` :
+          `Previous value: 'color: red'. Current value: 'color: green'`;
       expect(() => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'))
-          .toThrowError(/Previous value: 'color: red'. Current value: 'color: green'/);
+          .toThrowError(new RegExp(message));
     });
 
     it('should include class name', () => {
+      const message = ivyEnabled ?
+          `Previous value for 'class.someClass': 'true'. Current value: 'false'` :
+          `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
       expect(() => initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'))
-          .toThrowError(/Previous value: 'someClass: true'. Current value: 'someClass: false'/);
+          .toThrowError(new RegExp(message));
     });
 
-    onlyInIvy('VE doesn\'t throw in case of [style] binding change')
-        .it('should throw for style maps', () => {
-          expect(() => initWithTemplate('<div [style]="unstableStyleMapExpression"></div>'))
-              .toThrowError(
-                  /Previous value: '\[object Object\]'. Current value: '\[object Object\]'/);
-        });
+    // Note: the test below currently fails in Ivy, but not in VE. VE behavior is correct and Ivy's
+    // logic should be fixed by the upcoming styling refactor, we keep this test to verify that.
+    //
+    // it('should NOT throw for style maps', () => {
+    //  expect(() => initWithTemplate('<div [style]="unstableStyleMapExpression"></div>'))
+    //      .not.toThrowError();
+    // });
 
-    onlyInIvy('VE doesn\'t throw in case of [style] binding change')
+    onlyInIvy('VE doesn\'t throw in case of [class] binding change')
         .it('should throw for class maps', () => {
           expect(() => initWithTemplate('<div [class]="unstableStyleMapExpression"></div>'))
               .toThrowError(

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1249,7 +1249,7 @@ describe('change detection', () => {
     });
   });
 
-  fdescribe('ExpressionChangedAfterItHasBeenCheckedError', () => {
+  describe('ExpressionChangedAfterItHasBeenCheckedError', () => {
     @Component({template: '...'})
     class MyApp {
       a: string = 'a';

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1403,12 +1403,12 @@ describe('change detection', () => {
     //       .not.toThrowError();
     // });
     //
-    // it('should include style prop name in case of host style bindings', () => {
+    // it('should not throw for style maps as host bindings', () => {
     //   expect(() => initWithHostBindings({'[style]': 'unstableStyleMapExpression'}))
     //       .not.toThrowError();
     // });
     //
-    // it('should include class name in case of host class bindings', () => {
+    // it('should not throw for class maps as host binding', () => {
     //   expect(() => initWithHostBindings({'[class]': 'unstableClassMapExpression'}))
     //       .not.toThrowError();
     // });


### PR DESCRIPTION
Prior to this change, the ExpressionChangedAfterChecked error thrown in Ivy was missing useful information that was available in View Engine, specifically: missing property name for property bindings and also the content of the entire property interpolation (only a changed value was displayed) if one of expressions was changed unexpectedly. This commit improves the error message by including the mentioned information into the error text.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No