### PR TITLE
fix(ivy): validate the NgModule declarations field

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -96,14 +96,15 @@ export class DecorationAnalyzer {
     // See the note in ngtsc about why this cast is needed.
     // clang-format off
     new DirectiveDecoratorHandler(
-        this.reflectionHost, this.evaluator, this.fullRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
-        this.isCore, /* annotateForClosureCompiler */ false) as DecoratorHandler<unknown, unknown, unknown>,
+        this.reflectionHost, this.evaluator, this.fullRegistry, this.scopeRegistry,
+        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
+        /* annotateForClosureCompiler */ false) as DecoratorHandler<unknown, unknown, unknown>,
     // clang-format on
     // Pipe handler must be before injectable handler in list so pipe factories are printed
     // before injectable factories (so injectable factories can delegate to them)
     new PipeDecoratorHandler(
-        this.reflectionHost, this.evaluator, this.metaRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
-        this.isCore),
+        this.reflectionHost, this.evaluator, this.metaRegistry, this.scopeRegistry,
+        NOOP_DEFAULT_IMPORT_RECORDER, this.isCore),
     new InjectableDecoratorHandler(
         this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
         /* strictCtorDeps */ false, /* errorOnDuplicateProv */ false),

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -49,7 +49,7 @@ runInEachFileSystem(() => {
           metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
           null);
       const handler = new DirectiveDecoratorHandler(
-          reflectionHost, evaluator, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+          reflectionHost, evaluator, scopeRegistry, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
           /* isCore */ false, /* annotateForClosureCompiler */ false);
 
       const analyzeDirective = (dirName: string) => {

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -71,6 +71,11 @@ export enum ErrorCode {
   NGMODULE_REEXPORT_NAME_COLLISION = 6006,
 
   /**
+   * Raised when a directive/pipe is part of the declarations of two or more NgModules.
+   */
+  NGMODULE_DECLARATION_NOT_UNIQUE = 6007,
+
+  /**
    * Raised when ngcc tries to inject a synthetic decorator over one that already exists.
    */
   NGCC_MIGRATION_DECORATOR_INJECTION_ERROR = 7001,

--- a/packages/compiler-cli/src/ngtsc/imports/src/references.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/references.ts
@@ -115,6 +115,26 @@ export class Reference<T extends ts.Node = ts.Node> {
     return this.identifiers.find(id => id.getSourceFile() === context) || null;
   }
 
+  /**
+   * Get a `ts.Identifier` for this `Reference` that exists within the given expression.
+   *
+   * This is very useful for producing `ts.Diagnostic`s that reference `Reference`s that were
+   * extracted from some larger expression, as it can be used to pinpoint the `ts.Identifier` within
+   * the expression from which the `Reference` originated.
+   */
+  getIdentityInExpression(expr: ts.Expression): ts.Identifier|null {
+    const sf = expr.getSourceFile();
+    return this.identifiers.find(id => {
+      if (id.getSourceFile() !== sf) {
+        return false;
+      }
+
+      // This identifier is a match if its position lies within the given expression.
+      return id.pos >= expr.pos && id.end <= expr.end;
+    }) ||
+        null;
+  }
+
   cloneWithAlias(alias: Expression): Reference<T> {
     const ref = new Reference(this.node, this.bestGuessOwningModule);
     ref.identifiers = [...this.identifiers];

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -7,9 +7,11 @@
  */
 
 import {DirectiveMeta as T2DirectiveMeta, SchemaMetadata} from '@angular/compiler';
+import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
+
 
 /**
  * Metadata collected for an `NgModule`.
@@ -20,6 +22,14 @@ export interface NgModuleMeta {
   imports: Reference<ClassDeclaration>[];
   exports: Reference<ClassDeclaration>[];
   schemas: SchemaMetadata[];
+
+  /**
+   * The raw `ts.Expression` which gave rise to `declarations`, if one exists.
+   *
+   * If this is `null`, then either no declarations exist, or no expression was available (likely
+   * because the module came from a .d.ts file).
+   */
+  rawDeclarations: ts.Expression|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -55,6 +55,7 @@ export class DtsMetadataReader implements MetadataReader {
       imports: extractReferencesFromType(
           this.checker, importMetadata, ref.ownedByModuleGuess, resolutionContext),
       schemas: [],
+      rawDeclarations: null,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -661,13 +661,16 @@ export class NgtscProgram implements api.Program {
           this.incrementalDriver.depGraph, this.closureCompilerEnabled),
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null` not
       // being assignable to `unknown` when wrapped in `Readonly`).
+      // clang-format off
       new DirectiveDecoratorHandler(
-          this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore,
-          this.closureCompilerEnabled) as Readonly<DecoratorHandler<unknown, unknown, unknown>>,
+          this.reflector, evaluator, metaRegistry, this.scopeRegistry, this.defaultImportTracker,
+          this.isCore, this.closureCompilerEnabled) as Readonly<DecoratorHandler<unknown, unknown, unknown>>,
+      // clang-format on
       // Pipe handler must be before injectable handler in list so pipe factories are printed
       // before injectable factories (so injectable factories can delegate to them)
       new PipeDecoratorHandler(
-          this.reflector, evaluator, metaRegistry, this.defaultImportTracker, this.isCore),
+          this.reflector, evaluator, metaRegistry, this.scopeRegistry, this.defaultImportTracker,
+          this.isCore),
       new InjectableDecoratorHandler(
           this.reflector, this.defaultImportTracker, this.isCore,
           this.options.strictInjectionParameters || false),

--- a/packages/compiler-cli/src/ngtsc/scope/index.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/index.ts
@@ -9,4 +9,4 @@
 export {ExportScope, ScopeData} from './src/api';
 export {ComponentScopeReader, CompoundComponentScopeReader} from './src/component_scope';
 export {DtsModuleScopeResolver, MetadataDtsModuleScopeResolver} from './src/dependency';
-export {LocalModuleScope, LocalModuleScopeRegistry, LocalNgModuleData} from './src/local';
+export {DeclarationData, LocalModuleScope, LocalModuleScopeRegistry, LocalNgModuleData} from './src/local';

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -53,6 +53,7 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [Dir1, Dir2, Pipe1],
       exports: [Dir1, Pipe1],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) !;
@@ -69,6 +70,7 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [DirA],
       exports: [],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -76,6 +78,7 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [DirB],
       imports: [],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
@@ -83,6 +86,7 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [DirCE],
       imports: [],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -99,6 +103,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       declarations: [],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -106,6 +111,7 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir],
       imports: [],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -122,6 +128,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [ModuleB, ModuleC],
       exports: [DirA, DirA, DirB, ModuleB],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -129,6 +136,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       exports: [DirB],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
@@ -136,6 +144,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       exports: [ModuleB],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -159,6 +168,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       declarations: [DirInModule],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) !;
@@ -174,6 +184,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [ModuleB],
       declarations: [],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -181,6 +192,7 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir],
       imports: [],
       schemas: [],
+      rawDeclarations: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) !;
@@ -196,6 +208,7 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       declarations: [],
       schemas: [],
+      rawDeclarations: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -203,6 +216,7 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir],
       imports: [],
       schemas: [],
+      rawDeclarations: null,
     });
 
     expect(scopeRegistry.getScopeOfModule(ModuleA.node)).toBe(null);


### PR DESCRIPTION
This commit adds three previously missing validations to
NgModule.declarations:

1. It checks that declared classes are actually within the current
   compilation.

2. It checks that declared classes are directives, components, or pipes.

3. It checks that classes are declared in at most one NgModule.
