### PR TITLE
docs(upgrade): add example links to `downgradeComponent()` function docs

### DIFF
--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -41,6 +41,9 @@ import {LazyModuleRef, UpgradeAppType, controllerKey, getDowngradedModuleCount, 
  *
  * {@example upgrade/static/ts/full/module.ts region="ng2-heroes-wrapper"}
  *
+ * For more details and examples on downgrading Angular components to AngularJS components please
+ * visit the [Upgrade guide](guide/upgrade#using-angular-components-from-angularjs-code).
+ *
  * @param info contains information about the Component that is being downgraded:
  *
  * - `component: Type<any>`: The type of the Component that will be downgraded


### PR DESCRIPTION
There were some extra examples for downgradeComponent in the upgrade guide added the link to those examples in the downgradeComponent docs

Fixes #31584

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current downgradeComponent has only one example.

Issue Number: #31584


## What is the new behavior?

There were some extra examples for downgradeComponent in the upgrade guide added the link to those examples in the downgradeComponent docs


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
