### PR TITLE
Static styling

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -171,7 +171,7 @@ export function ɵɵelement(
 }
 
 function setDirectiveStylingInput(
-    context: TStylingContext | StylingMapArray | null, lView: LView,
+    context: TStylingContext | StylingMapArray | string | null, lView: LView,
     stylingInputs: (string | number)[], propName: string) {
   // older versions of Angular treat the input as `null` in the
   // event that the value does not exist at all. For this reason

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -553,7 +553,8 @@ export function registerInitialStylingOnTNode(
   return hasAdditionalInitialStyling;
 }
 
-function updateRawValueOnContext(context: TStylingContext | StylingMapArray, value: string) {
+function updateRawValueOnContext(
+    context: TStylingContext | StylingMapArray | string, value: string) {
   const stylingMapArr = getStylingMapArray(context) !;
   stylingMapArr[StylingMapArrayIndex.RawValuePosition] = value;
 }

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -600,7 +600,8 @@ export interface TNode {
    * are encountered. If and when this happens then the existing `StylingMapArray` value
    * will be placed into the initial styling slot in the newly created `TStylingContext`.
    */
-  styles: StylingMapArray|TStylingContext|null;
+  // TODO(misko): `Remove StylingMapArray|TStylingContext|null` in follow up PR.
+  styles: StylingMapArray|TStylingContext|string|null;
 
   /**
    * A collection of all class bindings and/or static class values for an element.
@@ -620,7 +621,8 @@ export interface TNode {
    * are encountered. If and when this happens then the existing `StylingMapArray` value
    * will be placed into the initial styling slot in the newly created `TStylingContext`.
    */
-  classes: StylingMapArray|TStylingContext|null;
+  // TODO(misko): `Remove StylingMapArray|TStylingContext|null` in follow up PR.
+  classes: StylingMapArray|TStylingContext|string|null;
 
   /**
    * Stores the head/tail index of the class bindings.

--- a/packages/core/src/render3/styling/bindings.ts
+++ b/packages/core/src/render3/styling/bindings.ts
@@ -1030,8 +1030,8 @@ export const setStyleAttr = (renderer: Renderer3 | null, native: RElement, value
  * initial styling values on an element.
  */
 export function renderStylingMap(
-    renderer: Renderer3, element: RElement, stylingValues: TStylingContext | StylingMapArray | null,
-    isClassBased: boolean): void {
+    renderer: Renderer3, element: RElement,
+    stylingValues: TStylingContext | StylingMapArray | string | null, isClassBased: boolean): void {
   const stylingMapArr = getStylingMapArray(stylingValues);
   if (stylingMapArr) {
     for (let i = StylingMapArrayIndex.ValuesStartPosition; i < stylingMapArr.length;

--- a/packages/core/src/render3/styling/class_differ.ts
+++ b/packages/core/src/render3/styling/class_differ.ts
@@ -7,7 +7,9 @@
 */
 
 import {CharCode} from '../../util/char_code';
-import {consumeClassToken, consumeWhitespace} from './styling_parser';
+
+import {consumeWhitespace, getLastParsedKey, parseClassName, parseClassNameNext} from './styling_parser';
+
 
 /**
  * Computes the diff between two class-list strings.
@@ -50,15 +52,8 @@ export function computeClassChanges(oldValue: string, newValue: string): Map<str
  */
 export function splitClassList(
     text: string, changes: Map<string, boolean|null>, isNewValue: boolean): void {
-  const end = text.length;
-  let index = 0;
-  while (index < end) {
-    index = consumeWhitespace(text, index, end);
-    const tokenEnd = consumeClassToken(text, index, end);
-    if (tokenEnd !== index) {
-      processClassToken(changes, text.substring(index, tokenEnd), isNewValue);
-    }
-    index = tokenEnd;
+  for (let i = parseClassName(text); i >= 0; i = parseClassNameNext(text, i)) {
+    processClassToken(changes, getLastParsedKey(text), isNewValue);
   }
 }
 

--- a/packages/core/src/render3/styling/static_styling.ts
+++ b/packages/core/src/render3/styling/static_styling.ts
@@ -1,0 +1,43 @@
+/**
+* @license
+* Copyright Google Inc. All Rights Reserved.
+*
+* Use of this source code is governed by an MIT-style license that can be
+* found in the LICENSE file at https://angular.io/license
+*/
+
+import {concatStringsWithSpace} from '../../util/stringify';
+import {assertFirstCreatePass} from '../assert';
+import {AttributeMarker, TAttributes, TNode} from '../interfaces/node';
+import {TVIEW} from '../interfaces/view';
+import {getLView} from '../state';
+
+/**
+ * Compute the static styling (class/style) from `TAttributes`.
+ *
+ * This function should be called during `firstCreatePass` only.
+ *
+ * @param tNode The `TNode` into which the styling information should be loaded.
+ * @param attrs `TAttributes` containing the styling information.
+ */
+export function computeStaticStyling(tNode: TNode, attrs: TAttributes): void {
+  ngDevMode && assertFirstCreatePass(
+                   getLView()[TVIEW], 'Expecting to be called in first template pass only');
+  let styles: string|null = tNode.styles as string | null;
+  let classes: string|null = tNode.classes as string | null;
+  let mode: AttributeMarker|0 = 0;
+  for (let i = 0; i < attrs.length; i++) {
+    const value = attrs[i];
+    if (typeof value === 'number') {
+      mode = value;
+    } else if (mode == AttributeMarker.Classes) {
+      classes = concatStringsWithSpace(classes, value as string);
+    } else if (mode == AttributeMarker.Styles) {
+      const style = value as string;
+      const styleValue = attrs[++i] as string;
+      styles = concatStringsWithSpace(styles, style + ': ' + styleValue + ';');
+    }
+  }
+  styles !== null && (tNode.styles = styles);
+  classes !== null && (tNode.classes = classes);
+}

--- a/packages/core/src/render3/util/styling_utils.ts
+++ b/packages/core/src/render3/util/styling_utils.ts
@@ -219,8 +219,10 @@ export function hyphenate(value: string): string {
  * will copy over an initial styling values from the tNode (which are stored as a
  * `StylingMapArray` on the `tNode.classes` or `tNode.styles` values).
  */
-export function getStylingMapArray(value: TStylingContext | StylingMapArray | null):
+export function getStylingMapArray(value: TStylingContext | StylingMapArray | string | null):
     StylingMapArray|null {
+  // TODO(misko): remove after TNode.classes/styles becomes `string` only
+  if (typeof value === 'string') return null;
   return isStylingContext(value) ?
       (value as TStylingContext)[TStylingContextIndex.InitialStylingValuePosition] :
       value as StylingMapArray;
@@ -240,7 +242,10 @@ export function isStylingMapArray(value: any): boolean {
       (typeof(value as StylingMapArray)[StylingMapArrayIndex.ValuesStartPosition] === 'string');
 }
 
-export function getInitialStylingValue(context: TStylingContext | StylingMapArray | null): string {
+export function getInitialStylingValue(context: TStylingContext | StylingMapArray | string | null):
+    string {
+  // TODO(misko): remove after TNode.classes/styles becomes `string` only
+  if (typeof context === 'string') return context;
   const map = getStylingMapArray(context);
   return map && (map[StylingMapArrayIndex.RawValuePosition] as string | null) || '';
 }

--- a/packages/core/src/util/stringify.ts
+++ b/packages/core/src/util/stringify.ts
@@ -36,3 +36,18 @@ export function stringify(token: any): string {
   const newLineIndex = res.indexOf('\n');
   return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
 }
+
+
+/**
+ * Concatenates two strings with separator, allocating new strings only when necessary.
+ *
+ * @param before before string.
+ * @param separator separator string.
+ * @param after after string.
+ * @returns concatenated string.
+ */
+export function concatStringsWithSpace(before: string | null, after: string | null): string {
+  return (before == null || before === '') ?
+      (after === null ? '' : after) :
+      ((after == null || after === '') ? before : before + ' ' + after);
+}

--- a/packages/core/test/render3/styling_next/static_styling_spec.ts
+++ b/packages/core/test/render3/styling_next/static_styling_spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {createTNode} from '@angular/core/src/render3/instructions/shared';
+import {AttributeMarker, TAttributes, TNode, TNodeType} from '@angular/core/src/render3/interfaces/node';
+import {LView} from '@angular/core/src/render3/interfaces/view';
+import {enterView} from '@angular/core/src/render3/state';
+import {computeStaticStyling} from '@angular/core/src/render3/styling/static_styling';
+
+describe('static styling', () => {
+  const mockFirstCreatePassLView: LView = [null, {firstCreatePass: true}] as any;
+  let tNode !: TNode;
+  beforeEach(() => {
+    enterView(mockFirstCreatePassLView, null);
+    tNode = createTNode(null !, null !, TNodeType.Element, 0, '', null);
+  });
+  it('should initialize when no attrs', () => {
+    computeStaticStyling(tNode, []);
+    expect(tNode.classes).toEqual(null);
+    expect(tNode.styles).toEqual(null);
+  });
+
+  it('should initialize from attrs', () => {
+    const tAttrs: TAttributes = [
+      'ignore',                               //
+      AttributeMarker.Classes, 'my-class',    //
+      AttributeMarker.Styles, 'color', 'red'  //
+    ];
+    computeStaticStyling(tNode, tAttrs);
+    expect(tNode.classes).toEqual('my-class');
+    expect(tNode.styles).toEqual('color: red;');
+  });
+
+  it('should initialize from attrs when multiple', () => {
+    const tAttrs: TAttributes = [
+      'ignore',                                                 //
+      AttributeMarker.Classes, 'my-class', 'other',             //
+      AttributeMarker.Styles, 'color', 'red', 'width', '100px'  //
+    ];
+    computeStaticStyling(tNode, tAttrs);
+    expect(tNode.classes).toEqual('my-class other');
+    expect(tNode.styles).toEqual('color: red; width: 100px;');
+  });
+});

--- a/packages/core/test/render3/styling_next/style_binding_list_spec.ts
+++ b/packages/core/test/render3/styling_next/style_binding_list_spec.ts
@@ -115,6 +115,7 @@ describe('TNode styling linked list', () => {
       //   ɵɵstyleProp('color', '#008');  // Binding index: 30
 
       const tNode = createTNode(null !, null !, TNodeType.Element, 0, '', null);
+      tNode.styles = '';
       const tData: TData = newArray(32, null);
       const STYLE = STYLE_MAP_STYLING_KEY;
 
@@ -408,7 +409,7 @@ describe('TNode styling linked list', () => {
 
     it('should mark duplicate on static fields', () => {
       const tNode = createTNode(null !, null !, TNodeType.Element, 0, '', null);
-      tNode.styles = [null, 'color', 'blue'];
+      tNode.styles = 'color: blue;';
       const tData: TData = [null, null];
       insertTStylingBinding(tData, tNode, 'width', 2, false, false);
       expectPriorityOrder(tData, tNode, false).toEqual([
@@ -636,6 +637,8 @@ class StylingFixture {
   lView: LView = [null, null !] as any;
   tNode: TNode = createTNode(null !, null !, TNodeType.Element, 0, '', null);
   constructor(bindingSources: TStylingKey[][], public isClassBinding: boolean) {
+    this.tNode.classes = '';
+    this.tNode.styles = '';
     let bindingIndex = this.tData.length;
     for (let i = 0; i < bindingSources.length; i++) {
       const bindings = bindingSources[i];

--- a/packages/core/test/render3/styling_next/style_differ_spec.ts
+++ b/packages/core/test/render3/styling_next/style_differ_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {StyleChangesMap, parseKeyValue, removeStyle} from '@angular/core/src/render3/styling/style_differ';
-import {consumeSeparator, consumeStyleValue} from '@angular/core/src/render3/styling/styling_parser';
+import {consumeSeparatorWithWhitespace, consumeStyleValue} from '@angular/core/src/render3/styling/styling_parser';
 import {CharCode} from '@angular/core/src/util/char_code';
 import {sortedForEach} from './class_differ_spec';
 
@@ -92,6 +92,7 @@ describe('style differ', () => {
 
     it('should remove some of the style', () => {
       expect(removeStyle('a: a; foo: bar; b: b', 'foo')).toEqual('a: a; b: b');
+      expect(removeStyle('a: a;    foo: bar;   b: b', 'foo')).toEqual('a: a; b: b');
       expect(removeStyle('a: a; foo: bar; b: b; foo: bar; c: c', 'foo'))
           .toEqual('a: a; b: b; c: c');
     });
@@ -113,9 +114,9 @@ function expectParseValue(
     text: string) {
   let stopIndex = text.indexOf('🛑');
   if (stopIndex < 0) stopIndex = text.length;
-  const valueStart = consumeSeparator(text, 0, text.length, CharCode.COLON);
+  const valueStart = consumeSeparatorWithWhitespace(text, 0, text.length, CharCode.COLON);
   const valueEnd = consumeStyleValue(text, valueStart, text.length);
-  const valueSep = consumeSeparator(text, valueEnd, text.length, CharCode.SEMI_COLON);
+  const valueSep = consumeSeparatorWithWhitespace(text, valueEnd, text.length, CharCode.SEMI_COLON);
   expect(valueSep).toBe(stopIndex);
   return expect(text.substring(valueStart, valueEnd));
 }

--- a/packages/core/test/util/stringify_spec.ts
+++ b/packages/core/test/util/stringify_spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {concatStringsWithSpace} from '@angular/core/src/util/stringify';
+
+describe('stringify', () => {
+  describe('concatStringsWithSpace', () => {
+    it('should concat with null', () => {
+      expect(concatStringsWithSpace(null, null)).toEqual('');
+      expect(concatStringsWithSpace('a', null)).toEqual('a');
+      expect(concatStringsWithSpace(null, 'b')).toEqual('b');
+    });
+
+    it('should concat when empty', () => {
+      expect(concatStringsWithSpace('', '')).toEqual('');
+      expect(concatStringsWithSpace('a', '')).toEqual('a');
+      expect(concatStringsWithSpace('', 'b')).toEqual('b');
+    });
+
+    it('should concat when not empty',
+       () => { expect(concatStringsWithSpace('before', 'after')).toEqual('before after'); });
+  });
+});


### PR DESCRIPTION
# refactor(ivy): create better styling parsing API

Parsing styling is now simplifed to be used like so:
```
for (let i = parseStyle(text); i >=0; i = parseStyleNext(text, i)) {
  const key = getLastParsedKey();
  const value = getLastParsedValue();
  ...
}
```

This change makes it easier to invoke the parser from other locations in the system without paying the cost of creating and iterating over `Map` of styles.

# refactor(ivy): Implement `computeStaticStyling`

The `computeStaticStyling` will be used for computing static styling value during `firstCreatePass`.

The function takes into account static styling from the template as well as from the host bindings. The host bindings need to be merged in front of the template so that they have the correct priority.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
