### PR TITLE
fix(common): ngStyle should ignore undefined values

### DIFF
--- a/packages/common/src/directives/styling_differ.ts
+++ b/packages/common/src/directives/styling_differ.ts
@@ -214,7 +214,10 @@ function bulidMapFromValues(
       let key = keys[i];
       key = trim ? key.trim() : key;
       const value = (values as{[key: string]: any})[key];
-      setMapValues(map, key, value, parseOutUnits, allowSubKeys);
+
+      if (value !== undefined) {
+        setMapValues(map, key, value, parseOutUnits, allowSubKeys);
+      }
     }
   } else {
     // case 2: array

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -157,6 +157,29 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
          expectNativeEl(fixture).not.toHaveCssStyle('max-width');
          expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
        }));
+
+    it('should skip keys that are set to undefined values', async(() => {
+         const template = `<div [ngStyle]="expr"></div>`;
+
+         fixture = createTestComponent(template);
+
+         getComponent().expr = {
+           'border-top-color': undefined,
+           'border-top-style': undefined,
+           'border-color': 'red',
+           'border-style': 'solid',
+           'border-width': '1rem',
+         };
+
+         fixture.detectChanges();
+
+         expectNativeEl(fixture).toHaveCssStyle({
+           'border-color': 'red',
+           'border-style': 'solid',
+           'border-width': '1rem',
+         });
+       }));
+
   });
 }
 


### PR DESCRIPTION
Prior to ivy, undefined values passed in an object to the ngStyle directive were ignored. Restore this behavior by ignoring keys that point to undefined values.

closes #34310

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] (N/A) Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Since ivy, objects with keys set to undefined passed to ngstyle will alter the computed styles.

Issue Number: 34310


## What is the new behavior?
Restore original behavior of keys set to undefined being ignored.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Note, when running (all) tests locally I had 8 failed tests on both tip of master, and this branch. I'm unsure if this is something I've done wrong, or just the state of master currently. I was however able to observe my new test failing without my changes, and passing with the changes applied.

It would be great if there could be a single "pre-flight" check script to run prior to pushing that would execute an equivalent of a full CI build locally, as the documentation for build/test/analyse feels quite fragmented at the moment.