### PR TITLE
ci: update material-unit-tests job to include commit that reduced test flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ var_4_win: &cache_key_win_fallback v5-angular-win-node-12.0-
 
 # Cache key for the Material unit tests job. **Note** when updating the SHA in the cache keys,
 # also update the SHA for the "MATERIAL_REPO_COMMIT" environment variable.
-var_5: &material_unit_tests_cache_key v5-angular-material-c1d898661b6055c67090f0cb8b7727b6335733b8
+var_5: &material_unit_tests_cache_key v5-angular-material-c734deb14bb28579ba59e7e065a39e3c4ed54458
 var_6: &material_unit_tests_cache_key_fallback v5-angular-material-
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages` and

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -76,7 +76,7 @@ setPublicVar MATERIAL_REPO_TMP_DIR "/tmp/material2"
 setPublicVar MATERIAL_REPO_URL "https://github.com/angular/material2.git"
 setPublicVar MATERIAL_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI "config.yml".
-setPublicVar MATERIAL_REPO_COMMIT "c1d898661b6055c67090f0cb8b7727b6335733b8"
+setPublicVar MATERIAL_REPO_COMMIT "c734deb14bb28579ba59e7e065a39e3c4ed54458"
 
 # Source `$BASH_ENV` to make the variables available immediately.
 source $BASH_ENV;


### PR DESCRIPTION
Updates the material-unit-tests job commit SHA to the most recent
commit at the time of writing. The goal is to run the unit tests
with https://github.com/angular/components/commit/6ae74a0eb21268d4b107a052a8cf8ae63078bf99 that improved stability of a
few menu tests that were flaky.

e.g. https://circleci.com/gh/angular/angular/564650