### PR TITLE
ci: fix remote name in rebase instructions

### DIFF
--- a/tools/rebase-pr.js
+++ b/tools/rebase-pr.js
@@ -103,7 +103,7 @@ async function _main(repository, prNumber) {
 
           git fetch upstream ${target.baseRef};
           git checkout ${target.headRef};
-          git rebase origin/${target.baseRef};
+          git rebase upstream/${target.baseRef};
           git push --force-with-lease;
         `);
   } else {


### PR DESCRIPTION
Previously, the rebase instructions were asking the user to rebase from
`origin/master` instead of `upstream/master`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No