### PR TITLE
fix(ivy): reorder provider type checks to align with VE

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -482,10 +482,10 @@ export function providerToFactory(
   } else {
     if (isValueProvider(provider)) {
       factory = () => resolveForwardRef(provider.useValue);
-    } else if (isExistingProvider(provider)) {
-      factory = () => ɵɵinject(resolveForwardRef(provider.useExisting));
     } else if (isFactoryProvider(provider)) {
       factory = () => provider.useFactory(...injectArgs(provider.deps || []));
+    } else if (isExistingProvider(provider)) {
+      factory = () => ɵɵinject(resolveForwardRef(provider.useExisting));
     } else {
       const classRef = resolveForwardRef(
           provider &&


### PR DESCRIPTION
The orderering matters because we don't currently throw if multiple
configurations are provided (i.e. provider has *both* useExisting and
useFactory). We should actually throw an error in this case, but to
avoid another breaking change in v9, this PR simply aligns the Ivy
behavior with ViewEngine.

current Ivy: 
https://github.com/angular/angular/blob/d0a04bf30980a60629c22b332de29040cea8e703/packages/core/src/di/r3_injector.ts#L485-L488
VE: 
https://github.com/angular/angular/blob/d0a04bf30980a60629c22b332de29040cea8e703/packages/core/src/di/injector.ts#L206-L209