### PR TITLE
refactor(ngcc): a couple of minor refactorings

### DIFF
--- a/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
@@ -39,7 +39,7 @@ export class ClusterExecutor implements Executor {
       return master.run();
     } else {
       // This process is a cluster worker.
-      const worker = new ClusterWorker(createCompileFn);
+      const worker = new ClusterWorker(this.logger, createCompileFn);
       return worker.run();
     }
   }

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -274,6 +274,8 @@ export function mainNgcc(
             `Failed to compile entry-point ${entryPoint.name} due to compilation errors:\n${errors}`);
       }
 
+      logger.debug(`  Successfully compiled ${entryPoint.name} : ${formatProperty}`);
+
       onTaskCompleted(task, TaskProcessingOutcome.Processed);
     };
   };


### PR DESCRIPTION
A couple of minor `ngcc` refactorings (see individual commits for details):
- refactor(ngcc): add debug messages to help with debugging in parallel mode
- refactor(ngcc): un-nest accidentally nested `describe()` blocks
