### PR TITLE
refactor(compiler-cli): avoid unnecessarily calling `getSourceFile()` twice in `PartialEvaluator`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
@@ -26,10 +26,11 @@ export class PartialEvaluator {
 
   evaluate(expr: ts.Expression, foreignFunctionResolver?: ForeignFunctionResolver): ResolvedValue {
     const interpreter = new StaticInterpreter(this.host, this.checker, this.dependencyTracker);
+    const sourceFile = expr.getSourceFile();
     return interpreter.visit(expr, {
-      originatingFile: expr.getSourceFile(),
+      originatingFile: sourceFile,
       absoluteModuleName: null,
-      resolutionContext: expr.getSourceFile().fileName,
+      resolutionContext: sourceFile.fileName,
       scope: new Map<ts.ParameterDeclaration, ResolvedValue>(), foreignFunctionResolver,
     });
   }


### PR DESCRIPTION
This is not expected to have any noticeable perf impact, but it wasteful nonetheless (and annoying when stepping through the code while debugging `ngtsc`/`ngcc`).
