### PR TITLE
fix(core): Ensure checkNoChanges runs for OnPush components

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1679,7 +1679,7 @@ function refreshComponent(hostLView: LView, componentHostIdx: number): void {
     refreshView(componentTView, componentView, componentTView.template, componentView[CONTEXT]);
 =======
       (componentView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty) ||
-       // Check needed as part of checkNoChanges pass
+       // Refresh needed as part of checkNoChanges pass
        (getCheckNoChangesMode() && componentView[FLAGS] & LViewFlags.CheckNoChanges))) {
     const tView = componentView[TVIEW];
     refreshView(componentView, tView, tView.template, componentView[CONTEXT]);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -500,6 +500,14 @@ export function refreshView<T>(
       lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
     }
   } finally {
+    // If this refresh was a checkNoChanges pass, remove the checkNoChanges flag. Otherwise, mark
+    // the LView as needing a checkNoChanges pass after a "regular" refresh.
+    if (checkNoChangesMode) {
+      lView[FLAGS] &= ~LViewFlags.CheckNoChanges;
+    } else {
+      lView[FLAGS] |= LViewFlags.CheckNoChanges;
+    }
+    lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
     leaveView();
   }
 }
@@ -1665,9 +1673,17 @@ function refreshComponent(hostLView: LView, componentHostIdx: number): void {
   const componentView = getComponentLViewByIndex(componentHostIdx, hostLView);
   // Only attached components that are CheckAlways or OnPush and dirty should be refreshed
   if (viewAttachedToChangeDetector(componentView) &&
+<<<<<<< HEAD
       componentView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
     const componentTView = componentView[TVIEW];
     refreshView(componentTView, componentView, componentTView.template, componentView[CONTEXT]);
+=======
+      (componentView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty) ||
+       // Check needed as part of checkNoChanges pass
+       (getCheckNoChangesMode() && componentView[FLAGS] & LViewFlags.CheckNoChanges))) {
+    const tView = componentView[TVIEW];
+    refreshView(componentView, tView, tView.template, componentView[CONTEXT]);
+>>>>>>> fix(core): Ensure checkNoChanges runs for OnPush components
   }
 }
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -298,7 +298,7 @@ export const enum LViewFlags {
    * back into the parent view, `data` will be defined and `creationMode` will be
    * improperly reported as false.
    */
-  CreationMode = 0b00000000100,
+  CreationMode = 1 << 2,
 
   /**
    * Whether or not this LView instance is on its first processing pass.
@@ -307,10 +307,10 @@ export const enum LViewFlags {
    * has completed one creation mode run and one update mode run. At this
    * time, the flag is turned off.
    */
-  FirstLViewPass = 0b00000001000,
+  FirstLViewPass = 1 << 3,
 
   /** Whether this view has default change detection strategy (checks always) or onPush */
-  CheckAlways = 0b00000010000,
+  CheckAlways = 1 << 4,
 
   /**
    * Whether or not manual change detection is turned on for onPush components.
@@ -327,26 +327,28 @@ export const enum LViewFlags {
    *
    * TODO: Add a public API to ChangeDetectionStrategy to turn this mode on
    */
-  ManualOnPush = 0b00000100000,
+  ManualOnPush = 1 << 5,
 
   /** Whether or not this view is currently dirty (needing check) */
-  Dirty = 0b000001000000,
+  Dirty = 1 << 6,
 
   /** Whether or not this view is currently attached to change detection tree. */
-  Attached = 0b000010000000,
+  Attached = 1 << 7,
 
   /** Whether or not this view is destroyed. */
-  Destroyed = 0b000100000000,
+  Destroyed = 1 << 8,
 
   /** Whether or not this view is the root view */
-  IsRoot = 0b001000000000,
+  IsRoot = 1 << 9,
+
+  CheckNoChanges = 1 << 10,
 
   /**
    * Index of the current init phase on last 22 bits
    */
-  IndexWithinInitPhaseIncrementer = 0b010000000000,
-  IndexWithinInitPhaseShift = 10,
-  IndexWithinInitPhaseReset = 0b001111111111,
+  IndexWithinInitPhaseIncrementer = 1 << 11,
+  IndexWithinInitPhaseShift = 11,
+  IndexWithinInitPhaseReset = ((1 << 12) - 1),
 }
 
 /**

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -341,6 +341,7 @@ export const enum LViewFlags {
   /** Whether or not this view is the root view */
   IsRoot = 1 << 9,
 
+  /** Whether this view should be checked during CheckNoChanges pass. */
   CheckNoChanges = 1 << 10,
 
   /**

--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -375,14 +375,16 @@ export const enum ViewState {
   CheckProjectedView = 1 << 5,
   CheckProjectedViews = 1 << 6,
   Destroyed = 1 << 7,
+  /** Indicates that the view needs to be checked during checkNoChanges pass */
+  CheckNoChanges = 1 << 8,
 
   // InitState Uses 3 bits
-  InitState_Mask = 7 << 8,
-  InitState_BeforeInit = 0 << 8,
-  InitState_CallingOnInit = 1 << 8,
-  InitState_CallingAfterContentInit = 2 << 8,
-  InitState_CallingAfterViewInit = 3 << 8,
-  InitState_AfterInit = 4 << 8,
+  InitState_Mask = 7 << 9,
+  InitState_BeforeInit = 0 << 9,
+  InitState_CallingOnInit = 1 << 9,
+  InitState_CallingAfterContentInit = 2 << 9,
+  InitState_CallingAfterViewInit = 3 << 9,
+  InitState_AfterInit = 4 << 9,
 
   CatDetectChanges = Attached | ChecksEnabled,
   CatInit = BeforeFirstCheck | CatDetectChanges | InitState_BeforeInit

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1350,6 +1350,7 @@ describe('change detection', () => {
     });
   });
 
+<<<<<<< HEAD
   describe('OnPush markForCheck in lifecycle hooks', () => {
     describe('with check no changes enabled', () => createOnPushMarkForCheckTests(true));
     describe('with check no changes disabled', () => createOnPushMarkForCheckTests(false));
@@ -1609,6 +1610,21 @@ describe('change detection', () => {
     //   expect(() => initWithHostBindings({'[class]': 'unstableClassMapExpression'}))
     //       .not.toThrowError();
     // });
+
+    it('throws ExpressionChangedAfterItWasCheckedError for OnPush components', () => {
+      @Component({template: '{{binding}}', changeDetection: ChangeDetectionStrategy.OnPush})
+      class MyComp {
+        binding = 'initial';
+
+        ngAfterViewInit() {
+          this.binding = 'updated';
+        }
+      }
+
+      const fixture =
+        TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+      expect(() => fixture.detectChanges()).toThrow();
+    });
   });
 });
 

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -89,24 +89,24 @@ describe('change detection', () => {
       const vm: ViewManipulation = fixture.debugElement.childNodes[2].references['vm'];
       const button = fixture.nativeElement.querySelector('button');
       const viewRef = vm.insertIntoVcRef();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counters).toEqual({componentView: 1, embeddedView: 1});
 
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
       expect(counters).toEqual({componentView: 2, embeddedView: 2});
 
       viewRef.detach();
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counters).toEqual({componentView: 3, embeddedView: 2});
 
       // Re-attach the view to ensure that the process can be reversed.
       viewRef.reattach();
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counters).toEqual({componentView: 4, embeddedView: 3});
     });
@@ -149,24 +149,24 @@ describe('change detection', () => {
       const factory = TestBed.get(ComponentFactoryResolver).resolveComponentFactory(DynamicComp);
       const componentRef = vm.vcRef.createComponent(factory);
       const button = fixture.nativeElement.querySelector('button');
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counter).toBe(1);
 
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
       expect(counter).toBe(2);
 
       componentRef.changeDetectorRef.detach();
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counter).toBe(2);
 
       // Re-attach the change detector to ensure that the process can be reversed.
       componentRef.changeDetectorRef.reattach();
       button.click();
-      fixture.detectChanges();
+      fixture.detectChanges(false);
 
       expect(counter).toBe(3);
     });
@@ -1350,7 +1350,6 @@ describe('change detection', () => {
     });
   });
 
-<<<<<<< HEAD
   describe('OnPush markForCheck in lifecycle hooks', () => {
     describe('with check no changes enabled', () => createOnPushMarkForCheckTests(true));
     describe('with check no changes disabled', () => createOnPushMarkForCheckTests(false));
@@ -1616,13 +1615,11 @@ describe('change detection', () => {
       class MyComp {
         binding = 'initial';
 
-        ngAfterViewInit() {
-          this.binding = 'updated';
-        }
+        ngAfterViewInit() { this.binding = 'updated'; }
       }
 
       const fixture =
-        TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+          TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
       expect(() => fixture.detectChanges()).toThrow();
     });
   });

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -575,6 +575,7 @@ function declareTests(config?: {useJit: boolean}) {
       describe('OnPush components', () => {
 
         it('should use ChangeDetectorRef to manually request a check', () => {
+          // Note, numberOfChecks is double what you might think because of the checkNoChanges pass
           TestBed.configureTestingModule({declarations: [MyComp, [[PushCmpWithRef]]]});
           const template = '<push-cmp-with-ref #cmp></push-cmp-with-ref>';
           TestBed.overrideComponent(MyComp, {set: {template}});
@@ -583,18 +584,19 @@ function declareTests(config?: {useJit: boolean}) {
           const cmp = fixture.debugElement.children[0].references !['cmp'];
 
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(1);
+          expect(cmp.numberOfChecks).toEqual(2);
 
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(1);
+          expect(cmp.numberOfChecks).toEqual(2);
 
           cmp.propagate();
 
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(2);
+          expect(cmp.numberOfChecks).toEqual(4);
         });
 
         it('should be checked when its bindings got updated', () => {
+          // Note, numberOfChecks is double what you might think because of the checkNoChanges pass
           TestBed.configureTestingModule(
               {declarations: [MyComp, PushCmp, EventCmp], imports: [CommonModule]});
           const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
@@ -605,11 +607,11 @@ function declareTests(config?: {useJit: boolean}) {
 
           fixture.componentInstance.ctxProp = 'one';
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(1);
+          expect(cmp.numberOfChecks).toEqual(2);
 
           fixture.componentInstance.ctxProp = 'two';
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(2);
+          expect(cmp.numberOfChecks).toEqual(4);
         });
 
         if (getDOM().supportsDOMEvents()) {
@@ -632,6 +634,7 @@ function declareTests(config?: {useJit: boolean}) {
         }
 
         it('should be checked when an event is fired', () => {
+          // Note, numberOfChecks is double what you might think because of the checkNoChanges pass
           TestBed.configureTestingModule(
               {declarations: [MyComp, PushCmp, EventCmp], imports: [CommonModule]});
           const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
@@ -642,31 +645,31 @@ function declareTests(config?: {useJit: boolean}) {
           const cmp = cmpEl.componentInstance;
           fixture.detectChanges();
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(1);
+          expect(cmp.numberOfChecks).toEqual(2);
 
           // regular element
           cmpEl.children[0].triggerEventHandler('click', <Event>{});
           fixture.detectChanges();
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(2);
+          expect(cmp.numberOfChecks).toEqual(4);
 
           // element inside of an *ngIf
           cmpEl.children[1].triggerEventHandler('click', <Event>{});
           fixture.detectChanges();
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(3);
+          expect(cmp.numberOfChecks).toEqual(6);
 
           // element inside a nested component
           cmpEl.children[2].children[0].triggerEventHandler('click', <Event>{});
           fixture.detectChanges();
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(4);
+          expect(cmp.numberOfChecks).toEqual(8);
 
           // host element
           cmpEl.triggerEventHandler('click', <Event>{});
           fixture.detectChanges();
           fixture.detectChanges();
-          expect(cmp.numberOfChecks).toEqual(5);
+          expect(cmp.numberOfChecks).toEqual(10);
         });
 
         it('should not affect updating properties on the component', () => {
@@ -687,6 +690,8 @@ function declareTests(config?: {useJit: boolean}) {
         });
 
         it('should be checked when an async pipe requests a check', fakeAsync(() => {
+             // Note, numberOfChecks is double what you might think because of the checkNoChanges
+             // pass
              TestBed.configureTestingModule(
                  {declarations: [MyComp, PushCmpWithAsyncPipe], imports: [CommonModule]});
              const template = '<push-cmp-with-async #cmp></push-cmp-with-async>';
@@ -697,17 +702,17 @@ function declareTests(config?: {useJit: boolean}) {
 
              const cmp: PushCmpWithAsyncPipe = fixture.debugElement.children[0].references !['cmp'];
              fixture.detectChanges();
-             expect(cmp.numberOfChecks).toEqual(1);
+             expect(cmp.numberOfChecks).toEqual(2);
 
              fixture.detectChanges();
              fixture.detectChanges();
-             expect(cmp.numberOfChecks).toEqual(1);
+             expect(cmp.numberOfChecks).toEqual(2);
 
              cmp.resolve(2);
              tick();
 
              fixture.detectChanges();
-             expect(cmp.numberOfChecks).toEqual(2);
+             expect(cmp.numberOfChecks).toEqual(4);
            }));
       });
 


### PR DESCRIPTION
Add additional CheckNoChanges flag to indicate the view needs to be checked during CheckNoChanges pass. This fixes the problem of the dirty flag being cleared during regular change detection and the view subsequently being skipped in CheckNoChanges mode because it's not dirty.