### PR TITLE
fix(language-service): Proper completions for properties and events

### DIFF
--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AstPath, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, DirectiveAst, ElementAst, EmbeddedTemplateAst, HtmlAstPath, Node, ParseSourceSpan, RecursiveTemplateAstVisitor, RecursiveVisitor, TemplateAst, TemplateAstPath, identifierName, templateVisitAll, visitAll} from '@angular/compiler';
+import {AstPath, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, DirectiveAst, ElementAst, EmbeddedTemplateAst, HtmlAstPath, Identifiers, Node, ParseSourceSpan, RecursiveTemplateAstVisitor, RecursiveVisitor, TemplateAst, TemplateAstPath, identifierName, templateVisitAll, visitAll} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {AstResult, SelectorInfo} from './common';
@@ -57,11 +57,9 @@ export function isNarrower(spanA: Span, spanB: Span): boolean {
 }
 
 export function hasTemplateReference(type: CompileTypeMetadata): boolean {
-  if (type.diDeps) {
-    for (let diDep of type.diDeps) {
-      if (diDep.token && diDep.token.identifier &&
-          identifierName(diDep.token !.identifier !) === 'TemplateRef')
-        return true;
+  for (const diDep of type.diDeps) {
+    if (diDep.token && identifierName(diDep.token.identifier) === Identifiers.TemplateRef.name) {
+      return true;
     }
   }
   return false;

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -36,7 +36,6 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.CaseUnknown,
     ParsingCases.EmptyInterpolation,
     ParsingCases.EventBinding,
-    ParsingCases.FooComponent,
     ParsingCases.ForLetIEqual,
     ParsingCases.ForOfLetEmpty,
     ParsingCases.ForUsingComponent,

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -93,18 +93,6 @@ export class NumberModel {
   @Output('outputAlias') modelChange: EventEmitter<number> = new EventEmitter();
 }
 
-@Component({
-  selector: 'foo-component',
-  template: `
-    <div string-model ~{string-marker}="text"></div>
-    <div number-model ~{number-marker}="value"></div>
-  `,
-})
-export class FooComponent {
-  text: string = 'some text';
-  value: number = 42;
-}
-
 interface Person {
   name: string;
   age: number;

--- a/packages/language-service/test/project/app/test.ng
+++ b/packages/language-service/test/project/app/test.ng
@@ -4,7 +4,4 @@
 </h1>
 ~{after-h1}<h2>{{~{h2-hero}hero.~{h2-name}name}} details!</h2>
 <div><label>id: </label>{{~{label-hero}hero.~{label-id}id}}</div>
-<div ~{div-attributes}>
-  <label>name: </label>
-</div>
 &~{entity-amp}amp;

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -94,7 +94,7 @@ describe('TypeScriptServiceHost', () => {
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
     const templates = ngLSHost.getTemplates('/app/parsing-cases.ts');
-    expect(templates.length).toBe(17);
+    expect(templates.length).toBe(16);
   });
 
   it('should be able to find external template', () => {


### PR DESCRIPTION
This commit fixes autocompletions for properties and events bindings.

The language service will no longer provide bindings like (click) or [id].
Instead, it'll infer the context based on the brackets and provide suggestions
without any brackets.

This fix also adds support for alternative binding syntax such as
`bind-`, `on-`, and `bindon`.

PR closes https://github.com/angular/vscode-ng-language-service/issues/398
PR closes https://github.com/angular/vscode-ng-language-service/issues/474

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
