### PR TITLE
fix(ivy): properly bootstrap components with attribute selectors

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 225787,
+        "main-es2015": 226288,
         "polyfills-es2015": 36808,
         "5-es2015": 779
       }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 136594,
+        "main-es2015": 137141,
         "polyfills-es2015": 37494
       }
     }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -29,7 +29,7 @@ import {ComponentDef} from './interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode} from './interfaces/node';
 import {RNode, RendererFactory3, domRendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
-import {stringifyCSSSelector} from './node_selector_matcher';
+import {stringifyCSSSelectorList} from './node_selector_matcher';
 import {enterView, leaveView} from './state';
 import {defaultScheduler} from './util/misc_utils';
 import {getTNode} from './util/view_utils';
@@ -114,7 +114,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       private componentDef: ComponentDef<any>, private ngModule?: viewEngine_NgModuleRef<any>) {
     super();
     this.componentType = componentDef.type;
-    this.selector = stringifyCSSSelector(componentDef.selectors[0]);
+    this.selector = stringifyCSSSelectorList(componentDef.selectors);
     this.ngContentSelectors =
         componentDef.ngContentSelectors ? componentDef.ngContentSelectors : [];
     this.isBoundToModule = !!ngModule;
@@ -134,7 +134,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     const hostRNode = rootSelectorOrNode ?
         locateHostElement(rendererFactory, rootSelectorOrNode, this.componentDef.encapsulation) :
-        // Determine a tag name used to creating host elements when this component is created
+        // Determine a tag name used for creating host elements when this component is created
         // dynamically. Default to 'div' if this component did not specify any tag name in its
         // selector.
         elementCreate(

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -36,6 +36,10 @@ import {getTNode} from './util/view_utils';
 import {createElementRef} from './view_engine_compatibility';
 import {RootViewRef, ViewRef} from './view_ref';
 
+// Default tag name to be used while creating a component dynamically in case tag name is not
+// specified in selector.
+const DEFAULT_TAG_NAME = 'div';
+
 export class ComponentFactoryResolver extends viewEngine_ComponentFactoryResolver {
   /**
    * @param ngModule The NgModuleRef to which all resolved factories are bound.
@@ -114,7 +118,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       private componentDef: ComponentDef<any>, private ngModule?: viewEngine_NgModuleRef<any>) {
     super();
     this.componentType = componentDef.type;
-    this.selector = stringifyCSSSelectorForBootstrap(componentDef.selectors[0]);
+    this.selector = stringifyCSSSelectorForBootstrap(componentDef.selectors[0]) || DEFAULT_TAG_NAME;
     this.ngContentSelectors =
         componentDef.ngContentSelectors ? componentDef.ngContentSelectors : [];
     this.isBoundToModule = !!ngModule;
@@ -138,7 +142,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
         // dynamically. Default to 'div' if this component did not specify any tag name in its
         // selector.
         elementCreate(
-            this.componentDef.selectors[0][0] as string || 'div',
+            this.componentDef.selectors[0][0] as string || DEFAULT_TAG_NAME,
             rendererFactory.createRenderer(null, this.componentDef), null);
 
     const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -36,7 +36,6 @@ import {getTNode} from './util/view_utils';
 import {createElementRef} from './view_engine_compatibility';
 import {RootViewRef, ViewRef} from './view_ref';
 
-
 export class ComponentFactoryResolver extends viewEngine_ComponentFactoryResolver {
   /**
    * @param ngModule The NgModuleRef to which all resolved factories are bound.

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -29,16 +29,13 @@ import {ComponentDef} from './interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode} from './interfaces/node';
 import {RNode, RendererFactory3, domRendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
-import {stringifyCSSSelectorForBootstrap} from './node_selector_matcher';
+import {stringifyCSSSelector} from './node_selector_matcher';
 import {enterView, leaveView} from './state';
 import {defaultScheduler} from './util/misc_utils';
 import {getTNode} from './util/view_utils';
 import {createElementRef} from './view_engine_compatibility';
 import {RootViewRef, ViewRef} from './view_ref';
 
-// Default tag name to be used while creating a component dynamically in case tag name is not
-// specified in selector.
-const DEFAULT_TAG_NAME = 'div';
 
 export class ComponentFactoryResolver extends viewEngine_ComponentFactoryResolver {
   /**
@@ -118,7 +115,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       private componentDef: ComponentDef<any>, private ngModule?: viewEngine_NgModuleRef<any>) {
     super();
     this.componentType = componentDef.type;
-    this.selector = stringifyCSSSelectorForBootstrap(componentDef.selectors[0]) || DEFAULT_TAG_NAME;
+    this.selector = stringifyCSSSelector(componentDef.selectors[0]);
     this.ngContentSelectors =
         componentDef.ngContentSelectors ? componentDef.ngContentSelectors : [];
     this.isBoundToModule = !!ngModule;
@@ -142,7 +139,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
         // dynamically. Default to 'div' if this component did not specify any tag name in its
         // selector.
         elementCreate(
-            this.componentDef.selectors[0][0] as string || DEFAULT_TAG_NAME,
+            this.componentDef.selectors[0][0] as string || 'div',
             rendererFactory.createRenderer(null, this.componentDef), null);
 
     const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -29,6 +29,7 @@ import {ComponentDef} from './interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode} from './interfaces/node';
 import {RNode, RendererFactory3, domRendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
+import {stringifyCSSSelectorForBootstrap} from './node_selector_matcher';
 import {enterView, leaveView} from './state';
 import {defaultScheduler} from './util/misc_utils';
 import {getTNode} from './util/view_utils';
@@ -113,9 +114,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       private componentDef: ComponentDef<any>, private ngModule?: viewEngine_NgModuleRef<any>) {
     super();
     this.componentType = componentDef.type;
-
-    // default to 'div' in case this component has an attribute selector
-    this.selector = componentDef.selectors[0][0] as string || 'div';
+    this.selector = stringifyCSSSelectorForBootstrap(componentDef.selectors[0]);
     this.ngContentSelectors =
         componentDef.ngContentSelectors ? componentDef.ngContentSelectors : [];
     this.isBoundToModule = !!ngModule;
@@ -135,7 +134,12 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     const hostRNode = rootSelectorOrNode ?
         locateHostElement(rendererFactory, rootSelectorOrNode, this.componentDef.encapsulation) :
-        elementCreate(this.selector, rendererFactory.createRenderer(null, this.componentDef), null);
+        // Determine a tag name used to creating host elements when this component is created
+        // dynamically. Default to 'div' if this component did not specify any tag name in its
+        // selector.
+        elementCreate(
+            this.componentDef.selectors[0][0] as string || 'div',
+            rendererFactory.createRenderer(null, this.componentDef), null);
 
     const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
                                                  LViewFlags.CheckAlways | LViewFlags.IsRoot;

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -302,7 +302,7 @@ function maybeWrapInNotSelector(isNegativeMode: boolean, chunk: string): string 
   return isNegativeMode ? ':not(' + chunk.trim() + ')' : chunk;
 }
 
-export function stringifyCSSSelector(selector: CssSelector): string {
+function stringifyCSSSelector(selector: CssSelector): string {
   let result = selector[0] as string;
   let i = 1;
   let mode = SelectorFlags.ATTRIBUTE;
@@ -353,4 +353,19 @@ export function stringifyCSSSelector(selector: CssSelector): string {
     result += maybeWrapInNotSelector(isNegativeMode, currentChunk);
   }
   return result;
+}
+
+/**
+ * Generates string representation of CSS selector in parsed form.
+ *
+ * ComponentDef and DirectiveDef are generated with the selector in parsed form to avoid doing
+ * additional parsing at runtime. However in some cases (for example while bootstrapping a component
+ * on a page), a string version of the selector is required. This function takes parsed form of a
+ * selector and returns its string representation.
+ *
+ * @param selectorList selector in parsed form
+ * @returns string representation of a given selector
+ */
+export function stringifyCSSSelectorList(selectorList: CssSelectorList): string {
+  return selectorList.map(stringifyCSSSelector).join(',');
 }

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -359,9 +359,10 @@ function stringifyCSSSelector(selector: CssSelector): string {
  * Generates string representation of CSS selector in parsed form.
  *
  * ComponentDef and DirectiveDef are generated with the selector in parsed form to avoid doing
- * additional parsing at runtime. However in some cases (for example while bootstrapping a component
- * on a page), a string version of the selector is required. This function takes parsed form of a
- * selector and returns its string representation.
+ * additional parsing at runtime (for example, for directive matching). However in some cases (for
+ * example, while bootstrapping a component), a string version of the selector is required to query
+ * for the host element on the page. This function takes the parsed form of a selector and returns
+ * its string representation.
  *
  * @param selectorList selector in parsed form
  * @returns string representation of a given selector

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -8,7 +8,7 @@
 
 import '../util/ng_dev_mode';
 
-import {assertDefined, assertEqual, assertNotEqual} from '../util/assert';
+import {assertDefined, assertNotEqual} from '../util/assert';
 
 import {AttributeMarker, TAttributes, TNode, TNodeType, unusedValueExportToPlacateAjd as unused1} from './interfaces/node';
 import {CssSelector, CssSelectorList, SelectorFlags, unusedValueExportToPlacateAjd as unused2} from './interfaces/projection';

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -7,16 +7,16 @@
  */
 
 import {Component, NgModule} from '@angular/core';
-import {getComponentDef} from '@angular/core/src/render3/definition';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {onlyInIvy, withBody} from '@angular/private/testing';
+import {withBody} from '@angular/private/testing';
 
 describe('bootstrap', () => {
-  it('should bootstrap using #id selector', withBody('<div #my-app>', async() => {
+  it('should bootstrap using #id selector',
+     withBody('<div>before|</div><button id="my-app"></button>', async() => {
        try {
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(MyAppModule);
-         expect(document.body.textContent).toEqual('works!');
+         expect(document.body.textContent).toEqual('before|works!');
          ngModuleRef.destroy();
        } catch (err) {
          console.error(err);

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -15,7 +15,19 @@ describe('bootstrap', () => {
   it('should bootstrap using #id selector',
      withBody('<div>before|</div><button id="my-app"></button>', async() => {
        try {
-         const ngModuleRef = await platformBrowserDynamic().bootstrapModule(MyAppModule);
+         const ngModuleRef = await platformBrowserDynamic().bootstrapModule(IdSelectorAppModule);
+         expect(document.body.textContent).toEqual('before|works!');
+         ngModuleRef.destroy();
+       } catch (err) {
+         console.error(err);
+       }
+     }));
+
+  it('should bootstrap using one of selectors from the list',
+     withBody('<div>before|</div><div class="bar"></div>', async() => {
+       try {
+         const ngModuleRef =
+             await platformBrowserDynamic().bootstrapModule(MultipleSelectorsAppModule);
          expect(document.body.textContent).toEqual('before|works!');
          ngModuleRef.destroy();
        } catch (err) {
@@ -28,9 +40,28 @@ describe('bootstrap', () => {
   selector: '#my-app',
   template: 'works!',
 })
-export class MyAppComponent {
+export class IdSelectorAppComponent {
 }
 
-@NgModule({imports: [BrowserModule], declarations: [MyAppComponent], bootstrap: [MyAppComponent]})
-export class MyAppModule {
+@NgModule({
+  imports: [BrowserModule],
+  declarations: [IdSelectorAppComponent],
+  bootstrap: [IdSelectorAppComponent],
+})
+export class IdSelectorAppModule {
+}
+
+@Component({
+  selector: '[foo],span,.bar',
+  template: 'works!',
+})
+export class MultipleSelectorsAppComponent {
+}
+
+@NgModule({
+  imports: [BrowserModule],
+  declarations: [MultipleSelectorsAppComponent],
+  bootstrap: [MultipleSelectorsAppComponent],
+})
+export class MultipleSelectorsAppModule {
 }

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -341,11 +341,9 @@ describe('component', () => {
   });
 
   it('should preserve component selector in a component factory', () => {
-
     @Component({selector: '[foo]', template: ''})
     class AttSelectorCmp {
     }
-
 
     @NgModule({
       declarations: [AttSelectorCmp],

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -340,7 +340,7 @@ describe('component', () => {
     expect(log).toEqual(['CompB:ngDoCheck']);
   });
 
-  it('should preserve component selector in a component factory', () => {
+  it('should preserve simple component selector in a component factory', () => {
     @Component({selector: '[foo]', template: ''})
     class AttSelectorCmp {
     }
@@ -357,6 +357,25 @@ describe('component', () => {
     const cmpFactory = cmpFactoryResolver.resolveComponentFactory(AttSelectorCmp);
 
     expect(cmpFactory.selector).toBe('[foo]');
+  });
+
+  it('should preserve complex component selector in a component factory', () => {
+    @Component({selector: '[foo],div:not(.bar)', template: ''})
+    class ComplexSelectorCmp {
+    }
+
+    @NgModule({
+      declarations: [ComplexSelectorCmp],
+      entryComponents: [ComplexSelectorCmp],
+    })
+    class AppModule {
+    }
+
+    TestBed.configureTestingModule({imports: [AppModule]});
+    const cmpFactoryResolver = TestBed.inject(ComponentFactoryResolver);
+    const cmpFactory = cmpFactoryResolver.resolveComponentFactory(ComplexSelectorCmp);
+
+    expect(cmpFactory.selector).toBe('[foo],div:not(.bar)');
   });
 
   describe('should clear host element if provided in ComponentFactory.create', () => {

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -340,6 +340,27 @@ describe('component', () => {
     expect(log).toEqual(['CompB:ngDoCheck']);
   });
 
+  it('should preserve component selector in a component factory', () => {
+
+    @Component({selector: '[foo]', template: ''})
+    class AttSelectorCmp {
+    }
+
+
+    @NgModule({
+      declarations: [AttSelectorCmp],
+      entryComponents: [AttSelectorCmp],
+    })
+    class AppModule {
+    }
+
+    TestBed.configureTestingModule({imports: [AppModule]});
+    const cmpFactoryResolver = TestBed.inject(ComponentFactoryResolver);
+    const cmpFactory = cmpFactoryResolver.resolveComponentFactory(AttSelectorCmp);
+
+    expect(cmpFactory.selector).toBe('[foo]');
+  });
+
   describe('should clear host element if provided in ComponentFactory.create', () => {
     function runTestWithRenderer(rendererProviders: any[]) {
       @Component({

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -32,7 +32,7 @@ describe('ComponentFactory', () => {
 
       const cf = cfr.resolveComponentFactory(TestComponent);
 
-      expect(cf.selector).toBe('test[foo]');
+      expect(cf.selector).toBe('test[foo],bar');
       expect(cf.componentType).toBe(TestComponent);
       expect(cf.ngContentSelectors).toEqual([]);
       expect(cf.inputs).toEqual([]);
@@ -65,7 +65,7 @@ describe('ComponentFactory', () => {
 
       expect(cf.componentType).toBe(TestComponent);
       expect(cf.ngContentSelectors).toEqual(['*', 'a', 'b']);
-      expect(cf.selector).toBe('test[foo]');
+      expect(cf.selector).toBe('test[foo],bar');
 
       expect(cf.inputs).toEqual([
         {propName: 'in1', templateName: 'in1'},

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -23,7 +23,7 @@ describe('ComponentFactory', () => {
         static ɵfac = () => new TestComponent();
         static ɵcmp = ɵɵdefineComponent({
           type: TestComponent,
-          selectors: [['test', 'foo'], ['bar']],
+          selectors: [['test', 'foo', ''], ['bar']],
           decls: 0,
           vars: 0,
           template: () => undefined,
@@ -32,7 +32,7 @@ describe('ComponentFactory', () => {
 
       const cf = cfr.resolveComponentFactory(TestComponent);
 
-      expect(cf.selector).toBe('test');
+      expect(cf.selector).toBe('test[foo]');
       expect(cf.componentType).toBe(TestComponent);
       expect(cf.ngContentSelectors).toEqual([]);
       expect(cf.inputs).toEqual([]);
@@ -45,7 +45,7 @@ describe('ComponentFactory', () => {
         static ɵcmp = ɵɵdefineComponent({
           type: TestComponent,
           encapsulation: ViewEncapsulation.None,
-          selectors: [['test', 'foo'], ['bar']],
+          selectors: [['test', 'foo', ''], ['bar']],
           decls: 0,
           vars: 0,
           template: () => undefined,
@@ -65,7 +65,7 @@ describe('ComponentFactory', () => {
 
       expect(cf.componentType).toBe(TestComponent);
       expect(cf.ngContentSelectors).toEqual(['*', 'a', 'b']);
-      expect(cf.selector).toBe('test');
+      expect(cf.selector).toBe('test[foo]');
 
       expect(cf.inputs).toEqual([
         {propName: 'in1', templateName: 'in1'},

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -10,7 +10,7 @@ import {createTNode} from '@angular/core/src/render3/instructions/shared';
 
 import {AttributeMarker, TAttributes, TNode, TNodeType} from '../../src/render3/interfaces/node';
 import {CssSelector, CssSelectorList, SelectorFlags} from '../../src/render3/interfaces/projection';
-import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList} from '../../src/render3/node_selector_matcher';
+import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList, stringifyCSSSelectorForBootstrap} from '../../src/render3/node_selector_matcher';
 
 function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
   return createTNode(null !, null, TNodeType.Element, 0, tagName, attrs);
@@ -507,4 +507,38 @@ describe('css selector matching', () => {
 
   });
 
+});
+
+describe('stringifyCSSSelectorForBootstrap', () => {
+
+  it('should stringify selector with a tag name only',
+     () => { expect(stringifyCSSSelectorForBootstrap(['button'])).toBe('button'); });
+
+  it('should stringify selector with attributes', () => {
+    expect(stringifyCSSSelectorForBootstrap(['', 'id', ''])).toBe('[id]');
+    expect(stringifyCSSSelectorForBootstrap(['button', 'id', ''])).toBe('button[id]');
+    expect(stringifyCSSSelectorForBootstrap(['button', 'id', 'value'])).toBe('button[id="value"]');
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', 'id', 'value', 'title', 'other'
+    ])).toBe('button[id="value"][title="other"]');
+  });
+
+  it('should stringify selector with class names', () => {
+    expect(stringifyCSSSelectorForBootstrap(['', SelectorFlags.CLASS, 'foo'])).toBe('.foo');
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', SelectorFlags.CLASS, 'foo'
+    ])).toBe('button.foo');
+
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', SelectorFlags.CLASS, 'foo', 'bar'
+    ])).toBe('button.foo.bar');
+
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', SelectorFlags.CLASS, 'foo'
+    ])).toBe('button.foo');
+
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', 'id', 'value', 'title', 'other', SelectorFlags.CLASS, 'foo', 'bar'
+    ])).toBe('button[id="value"][title="other"].foo.bar');
+  });
 });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -10,7 +10,7 @@ import {createTNode} from '@angular/core/src/render3/instructions/shared';
 
 import {AttributeMarker, TAttributes, TNode, TNodeType} from '../../src/render3/interfaces/node';
 import {CssSelector, CssSelectorList, SelectorFlags} from '../../src/render3/interfaces/projection';
-import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList, stringifyCSSSelector} from '../../src/render3/node_selector_matcher';
+import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList, stringifyCSSSelectorList} from '../../src/render3/node_selector_matcher';
 
 function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
   return createTNode(null !, null, TNodeType.Element, 0, tagName, attrs);
@@ -509,69 +509,83 @@ describe('css selector matching', () => {
 
 });
 
-describe('stringifyCSSSelectorForBootstrap', () => {
+describe('stringifyCSSSelectorList', () => {
 
   it('should stringify selector with a tag name only',
-     () => { expect(stringifyCSSSelector(['button'])).toBe('button'); });
+     () => { expect(stringifyCSSSelectorList([['button']])).toBe('button'); });
 
   it('should stringify selector with attributes', () => {
-    expect(stringifyCSSSelector(['', 'id', ''])).toBe('[id]');
-    expect(stringifyCSSSelector(['button', 'id', ''])).toBe('button[id]');
-    expect(stringifyCSSSelector(['button', 'id', 'value'])).toBe('button[id="value"]');
-    expect(stringifyCSSSelector([
-      'button', 'id', 'value', 'title', 'other'
-    ])).toBe('button[id="value"][title="other"]');
+    expect(stringifyCSSSelectorList([['', 'id', '']])).toBe('[id]');
+    expect(stringifyCSSSelectorList([['button', 'id', '']])).toBe('button[id]');
+    expect(stringifyCSSSelectorList([['button', 'id', 'value']])).toBe('button[id="value"]');
+    expect(stringifyCSSSelectorList([['button', 'id', 'value', 'title', 'other']]))
+        .toBe('button[id="value"][title="other"]');
   });
 
   it('should stringify selector with class names', () => {
-    expect(stringifyCSSSelector(['', SelectorFlags.CLASS, 'foo'])).toBe('.foo');
-    expect(stringifyCSSSelector(['button', SelectorFlags.CLASS, 'foo'])).toBe('button.foo');
+    expect(stringifyCSSSelectorList([['', SelectorFlags.CLASS, 'foo']])).toBe('.foo');
+    expect(stringifyCSSSelectorList([['button', SelectorFlags.CLASS, 'foo']])).toBe('button.foo');
 
-    expect(stringifyCSSSelector([
-      'button', SelectorFlags.CLASS, 'foo', 'bar'
-    ])).toBe('button.foo.bar');
+    expect(stringifyCSSSelectorList([['button', SelectorFlags.CLASS, 'foo', 'bar']]))
+        .toBe('button.foo.bar');
 
-    expect(stringifyCSSSelector(['button', SelectorFlags.CLASS, 'foo'])).toBe('button.foo');
-
-    expect(stringifyCSSSelector([
-      'button', 'id', 'value', 'title', 'other', SelectorFlags.CLASS, 'foo', 'bar'
+    expect(stringifyCSSSelectorList([
+      ['button', 'id', 'value', 'title', 'other', SelectorFlags.CLASS, 'foo', 'bar']
     ])).toBe('button[id="value"][title="other"].foo.bar');
   });
 
   it('should stringify selector with `:not()` rules', () => {
-    expect(stringifyCSSSelector([
-      '', SelectorFlags.CLASS | SelectorFlags.NOT, 'foo', 'bar'
-    ])).toBe(':not(.foo.bar)');
+    expect(stringifyCSSSelectorList([['', SelectorFlags.CLASS | SelectorFlags.NOT, 'foo', 'bar']]))
+        .toBe(':not(.foo.bar)');
 
-    expect(stringifyCSSSelector([
-      'button', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', 'bar'
+    expect(stringifyCSSSelectorList([
+      ['button', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', 'bar']
     ])).toBe('button:not([foo="bar"])');
 
-    expect(stringifyCSSSelector([
-      '', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'foo'
-    ])).toBe(':not(foo)');
+    expect(stringifyCSSSelectorList([['', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'foo']]))
+        .toBe(':not(foo)');
 
-    expect(stringifyCSSSelector([
-      'span', SelectorFlags.CLASS, 'foo', SelectorFlags.CLASS | SelectorFlags.NOT, 'bar', 'baz'
+    expect(stringifyCSSSelectorList([
+      ['span', SelectorFlags.CLASS, 'foo', SelectorFlags.CLASS | SelectorFlags.NOT, 'bar', 'baz']
     ])).toBe('span.foo:not(.bar.baz)');
 
-    expect(stringifyCSSSelector([
-      'span', 'id', 'value', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'title', 'other'
+    expect(stringifyCSSSelectorList([
+      ['span', 'id', 'value', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'title', 'other']
     ])).toBe('span[id="value"]:not([title="other"])');
 
-    expect(stringifyCSSSelector([
+    expect(stringifyCSSSelectorList([[
       '', SelectorFlags.CLASS, 'bar', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', '',
       SelectorFlags.ELEMENT | SelectorFlags.NOT, 'div'
-    ])).toBe('.bar:not([foo]):not(div)');
+    ]])).toBe('.bar:not([foo]):not(div)');
 
-    expect(stringifyCSSSelector([
+    expect(stringifyCSSSelectorList([[
       'div', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', '', SelectorFlags.CLASS, 'bar',
       SelectorFlags.CLASS | SelectorFlags.NOT, 'baz'
-    ])).toBe('div:not([foo].bar):not(.baz)');
+    ]])).toBe('div:not([foo].bar):not(.baz)');
 
-    expect(stringifyCSSSelector([
+    expect(stringifyCSSSelectorList([[
       'div', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'p', SelectorFlags.CLASS, 'bar',
       SelectorFlags.CLASS | SelectorFlags.NOT, 'baz'
-    ])).toBe('div:not(p.bar):not(.baz)');
+    ]])).toBe('div:not(p.bar):not(.baz)');
+  });
+
+  it('should stringify multiple comma-separated selectors', () => {
+    expect(stringifyCSSSelectorList([
+      ['', 'id', ''], ['button', 'id', 'value']
+    ])).toBe('[id],button[id="value"]');
+
+    expect(stringifyCSSSelectorList([
+      ['', 'id', ''], ['button', 'id', 'value'],
+      ['div', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', '']
+    ])).toBe('[id],button[id="value"],div:not([foo])');
+
+    expect(stringifyCSSSelectorList([
+      ['', 'id', ''], ['button', 'id', 'value'],
+      ['div', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', ''],
+      [
+        'div', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'p', SelectorFlags.CLASS, 'bar',
+        SelectorFlags.CLASS | SelectorFlags.NOT, 'baz'
+      ]
+    ])).toBe('[id],button[id="value"],div:not([foo]),div:not(p.bar):not(.baz)');
   });
 });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -541,4 +541,14 @@ describe('stringifyCSSSelectorForBootstrap', () => {
       'button', 'id', 'value', 'title', 'other', SelectorFlags.CLASS, 'foo', 'bar'
     ])).toBe('button[id="value"][title="other"].foo.bar');
   });
+
+  it('should return `null` in case selector contains `:not()` rule', () => {
+    expect(stringifyCSSSelectorForBootstrap([
+      '', SelectorFlags.CLASS | SelectorFlags.NOT, 'foo'
+    ])).toBe(null);
+
+    expect(stringifyCSSSelectorForBootstrap([
+      'button', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', 'bar'
+    ])).toBe(null);
+  });
 });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -10,7 +10,7 @@ import {createTNode} from '@angular/core/src/render3/instructions/shared';
 
 import {AttributeMarker, TAttributes, TNode, TNodeType} from '../../src/render3/interfaces/node';
 import {CssSelector, CssSelectorList, SelectorFlags} from '../../src/render3/interfaces/projection';
-import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList, stringifyCSSSelectorForBootstrap} from '../../src/render3/node_selector_matcher';
+import {getProjectAsAttrValue, isNodeMatchingSelector, isNodeMatchingSelectorList, stringifyCSSSelector} from '../../src/render3/node_selector_matcher';
 
 function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
   return createTNode(null !, null, TNodeType.Element, 0, tagName, attrs);
@@ -512,43 +512,66 @@ describe('css selector matching', () => {
 describe('stringifyCSSSelectorForBootstrap', () => {
 
   it('should stringify selector with a tag name only',
-     () => { expect(stringifyCSSSelectorForBootstrap(['button'])).toBe('button'); });
+     () => { expect(stringifyCSSSelector(['button'])).toBe('button'); });
 
   it('should stringify selector with attributes', () => {
-    expect(stringifyCSSSelectorForBootstrap(['', 'id', ''])).toBe('[id]');
-    expect(stringifyCSSSelectorForBootstrap(['button', 'id', ''])).toBe('button[id]');
-    expect(stringifyCSSSelectorForBootstrap(['button', 'id', 'value'])).toBe('button[id="value"]');
-    expect(stringifyCSSSelectorForBootstrap([
+    expect(stringifyCSSSelector(['', 'id', ''])).toBe('[id]');
+    expect(stringifyCSSSelector(['button', 'id', ''])).toBe('button[id]');
+    expect(stringifyCSSSelector(['button', 'id', 'value'])).toBe('button[id="value"]');
+    expect(stringifyCSSSelector([
       'button', 'id', 'value', 'title', 'other'
     ])).toBe('button[id="value"][title="other"]');
   });
 
   it('should stringify selector with class names', () => {
-    expect(stringifyCSSSelectorForBootstrap(['', SelectorFlags.CLASS, 'foo'])).toBe('.foo');
-    expect(stringifyCSSSelectorForBootstrap([
-      'button', SelectorFlags.CLASS, 'foo'
-    ])).toBe('button.foo');
+    expect(stringifyCSSSelector(['', SelectorFlags.CLASS, 'foo'])).toBe('.foo');
+    expect(stringifyCSSSelector(['button', SelectorFlags.CLASS, 'foo'])).toBe('button.foo');
 
-    expect(stringifyCSSSelectorForBootstrap([
+    expect(stringifyCSSSelector([
       'button', SelectorFlags.CLASS, 'foo', 'bar'
     ])).toBe('button.foo.bar');
 
-    expect(stringifyCSSSelectorForBootstrap([
-      'button', SelectorFlags.CLASS, 'foo'
-    ])).toBe('button.foo');
+    expect(stringifyCSSSelector(['button', SelectorFlags.CLASS, 'foo'])).toBe('button.foo');
 
-    expect(stringifyCSSSelectorForBootstrap([
+    expect(stringifyCSSSelector([
       'button', 'id', 'value', 'title', 'other', SelectorFlags.CLASS, 'foo', 'bar'
     ])).toBe('button[id="value"][title="other"].foo.bar');
   });
 
-  it('should return `null` in case selector contains `:not()` rule', () => {
-    expect(stringifyCSSSelectorForBootstrap([
-      '', SelectorFlags.CLASS | SelectorFlags.NOT, 'foo'
-    ])).toBe(null);
+  it('should stringify selector with `:not()` rules', () => {
+    expect(stringifyCSSSelector([
+      '', SelectorFlags.CLASS | SelectorFlags.NOT, 'foo', 'bar'
+    ])).toBe(':not(.foo.bar)');
 
-    expect(stringifyCSSSelectorForBootstrap([
+    expect(stringifyCSSSelector([
       'button', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', 'bar'
-    ])).toBe(null);
+    ])).toBe('button:not([foo="bar"])');
+
+    expect(stringifyCSSSelector([
+      '', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'foo'
+    ])).toBe(':not(foo)');
+
+    expect(stringifyCSSSelector([
+      'span', SelectorFlags.CLASS, 'foo', SelectorFlags.CLASS | SelectorFlags.NOT, 'bar', 'baz'
+    ])).toBe('span.foo:not(.bar.baz)');
+
+    expect(stringifyCSSSelector([
+      'span', 'id', 'value', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'title', 'other'
+    ])).toBe('span[id="value"]:not([title="other"])');
+
+    expect(stringifyCSSSelector([
+      '', SelectorFlags.CLASS, 'bar', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', '',
+      SelectorFlags.ELEMENT | SelectorFlags.NOT, 'div'
+    ])).toBe('.bar:not([foo]):not(div)');
+
+    expect(stringifyCSSSelector([
+      'div', SelectorFlags.ATTRIBUTE | SelectorFlags.NOT, 'foo', '', SelectorFlags.CLASS, 'bar',
+      SelectorFlags.CLASS | SelectorFlags.NOT, 'baz'
+    ])).toBe('div:not([foo].bar):not(.baz)');
+
+    expect(stringifyCSSSelector([
+      'div', SelectorFlags.ELEMENT | SelectorFlags.NOT, 'p', SelectorFlags.CLASS, 'bar',
+      SelectorFlags.CLASS | SelectorFlags.NOT, 'baz'
+    ])).toBe('div:not(p.bar):not(.baz)');
   });
 });


### PR DESCRIPTION
Before this change ivy didn't properly bootstrap components that used selectors more complex than a tag name. The crux of the issue is that we were trying to use the `selectors` property of a component definition in 2 different code paths:
* bootstrap;
* dynamic instantiation.

It tuns out that selector should be interpreted differently for those 2 scenarios:
* bootstrap: we need a selector as string (as written by a directive author);
* dynamic instantiation: we need a tag name only (defaulting to `div` if a given selector doesn't contain tag name).

This PR tries to fix the identified issue by clearly separating 2 usage scenario (and hence having 2 separate fields on a `ComponentFactory`: `selector` and `tagName`). Sadly this PR has one obvious issue - it doesn't _fully_ recreate a selector's string (as written by a user) - to do it properly we would have to add more code (non tree-shakable) to stringify a parsed selector in all cases.  

So it seems like we need to decide on the following trade-offs:
* correctness (as in this PR);
* fixed code size in the framework (fully re-create a selector string from its parsed version);
* generated code size (we could add oryginal selector string to a directive definition). 

I'm leaning on the "be correct and add more code to the framework) side, but opening a draft PR so we can discuss. 

Fixes #34349

