### PR TITLE
ci(docs-infra): fix failure in `aio_monitoring_stable` due to yarn version mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,19 +120,25 @@ commands:
       - attach_workspace:
           at: *workspace_location
 
+  # Overwrite the yarn installed in the docker container with our own version.
+  overwrite_yarn:
+    description: Overwrite yarn with our own version
+    steps:
+      - run:
+          name: Overwrite yarn
+          command: |
+            localYarnPath=`node ./.circleci/get-vendored-yarn-path.js`
+            sudo chmod a+x $localYarnPath
+            sudo ln -fs $localYarnPath /usr/local/bin/yarn
+      - run: node --version
+      - run: yarn --version
+
   # Initializes the CI environment by setting up common environment variables.
   init_environment:
     description: Initializing environment (setting up variables, overwriting Yarn)
     steps:
       - run: ./.circleci/env.sh
-      - run:
-          # Overwrite the yarn installed in the docker container with our own version.
-          name: Overwrite yarn with our own version
-          command: |
-            sudo chmod a+x $CI_LOCAL_YARN_PATH
-            sudo ln -fs $CI_LOCAL_YARN_PATH /usr/local/bin/yarn
-      - run: node --version
-      - run: yarn --version
+      - overwrite_yarn
       - run:
           # Configure git as the CircleCI `checkout` command does.
           # This is needed because we only checkout on the setup job.
@@ -657,10 +663,16 @@ jobs:
       - init_environment
       - run: setPublicVar_CI_STABLE_BRANCH
       - run:
-          name: Check out `aio/` from the stable branch
+          name: Check out `aio/` and `third_party/github.com/yarnpkg/` from the stable branch
           command: |
+            localYarnDir=third_party/github.com/yarnpkg/
+            # Remove the directory to ensure there will be only one version available (the one
+            # checked out from the stable branch below).
+            rm -rf $localYarnDir
             git fetch origin $CI_STABLE_BRANCH
-            git checkout --force origin/$CI_STABLE_BRANCH -- aio/
+            git checkout --force origin/$CI_STABLE_BRANCH -- aio/ $localYarnDir
+        # Overwrite yarn again to use the version from the checked out branch.
+      - overwrite_yarn
       - run:
           name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -35,7 +35,6 @@ setPublicVar CI_COMMIT_RANGE "`[[ ${CIRCLE_PR_NUMBER:-false} != false ]] && echo
 setPublicVar CI_PULL_REQUEST "${CIRCLE_PR_NUMBER:-false}";
 setPublicVar CI_REPO_NAME "$CIRCLE_PROJECT_REPONAME";
 setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";
-setPublicVar CI_LOCAL_YARN_PATH "`node $projectDir/.circleci/get-vendored-yarn-path.js`";
 
 
 ####################################################################################################


### PR DESCRIPTION
The `aio_monitoring_stable` CI job is triggered as a cronjob on the master branch and its purpose is to run some e2e tests against the deployed stable version of the docs web-app at https://angular.io/. In order for the tests to be compatible with the deployed version of the web-app (which gets deployed from the stable branch), the stable branch is checked out in git as part of the CI job.

Previously, we only checked out the `aio/` directory from the stable branch, leaving the rest of the code at master. This doesn't matter as long as the commands used to run the tests do not rely on code outside of `aio/`. However, it turns out that there _is_ code outside of `aio/` that affects the executed commands: It is our vendored version of yarn (in `third_party/github.com/yarnpkg/`), which overwrites the global yarn installed on the docker image on CI and must match the version range specified in `aio/package.json > engines`.

Using the yarn version checked out from the master branch with the `aio/` code checked out from the stable branch can lead to failures such as [this one][1].

This commit fixes the problem by checking out both the `aio/` and `third_party/github.com/yarnpkg/` directories from the stable branch and re-running the steps to overwrite the global yarn executable with our own version from `third_party/github.com/yarnpkg/`. This ensures that the version of yarn used will be compatible with the version range specified in `aio/package.json > engines`.

NOTE:
We cannot checkout everything from the stable branch, since the CI config (`.circleci/config.yml` from the master branch) may try to run certain scripts (such as `.circleci/get-vendored-yarn-path.js`) that are not available on the stable branch. Therefore, we should only check out the necessary bits from the stable branch.

[1]: https://circleci.com/gh/angular/angular/567315