### PR TITLE
docs(ivy): document global debugging utilities and clean up API

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -97,7 +97,7 @@ module.exports =
             'common/testing/index.ts',
             'common/upgrade/index.ts',
             'core/index.ts',
-            'core/global.ts',
+            'core/global/index.ts',
             'core/testing/index.ts',
             'elements/index.ts',
             'forms/index.ts',

--- a/packages/core/global.ts
+++ b/packages/core/global.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */

--- a/packages/core/global/PACKAGE.md
+++ b/packages/core/global/PACKAGE.md
@@ -1,0 +1,5 @@
+Exposes a set of functions in the global namespace which are useful for debugging the current state
+of your application.
+These functions are exposed via the global `ng` "namespace" variable automatically when you import
+from `@angular/core` and run your application in development mode. These functions are not exposed
+when the application runs in a production mode.

--- a/packages/core/global/index.ts
+++ b/packages/core/global/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// The global utilities are re-exported through here so that they get their own separate `global`
+// section in the API docs which makes it more visible that they can't be imported directly.
+export * from '../src/render3/global_utils_api';

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -7,16 +7,16 @@
  */
 
 import {Injector} from '../di';
-import {getViewComponent} from '../render3/global_utils_api';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from '../render3/interfaces/container';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/node';
 import {isComponentHost, isLContainer} from '../render3/interfaces/type_checks';
 import {DECLARATION_COMPONENT_VIEW, LView, PARENT, TData, TVIEW, T_HOST} from '../render3/interfaces/view';
-import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext} from '../render3/util/discovery_utils';
+import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, getOwningComponent, loadLContext} from '../render3/util/discovery_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from '../render3/util/misc_utils';
 import {getComponentLViewByIndex, getNativeByTNodeOrNull} from '../render3/util/view_utils';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
+
 
 
 /**
@@ -217,14 +217,14 @@ class DebugNode__POST_R3__ implements DebugNode {
   get componentInstance(): any {
     const nativeElement = this.nativeNode;
     return nativeElement &&
-        (getComponent(nativeElement as Element) || getViewComponent(nativeElement));
+        (getComponent(nativeElement as Element) || getOwningComponent(nativeElement));
   }
   get context(): any {
     return getComponent(this.nativeNode as Element) || getContext(this.nativeNode as Element);
   }
 
   get listeners(): DebugEventListener[] {
-    return getListeners(this.nativeNode as Element).filter(isBrowserEvents);
+    return getListeners(this.nativeNode as Element).filter(listener => listener.type === 'dom');
   }
 
   get references(): {[key: string]: any;} { return getLocalRefs(this.nativeNode); }

--- a/packages/core/src/render3/global_utils_api.ts
+++ b/packages/core/src/render3/global_utils_api.ts
@@ -15,6 +15,5 @@
  * file in the public_api_guard test.
  */
 
-export {markDirty} from './instructions/all';
 export {applyChanges} from './util/change_detection_utils';
 export {Listener, getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './util/discovery_utils';

--- a/packages/core/src/render3/global_utils_api.ts
+++ b/packages/core/src/render3/global_utils_api.ts
@@ -16,4 +16,5 @@
  */
 
 export {markDirty} from './instructions/all';
-export {getComponent, getContext, getDebugNode, getDirectives, getHostElement, getInjector, getListeners, getRootComponents, getViewComponent} from './util/discovery_utils';
+export {applyChanges} from './util/change_detection_utils';
+export {Listener, getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './util/discovery_utils';

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -32,9 +32,6 @@ export function detectChanges(component: {}): void {
  * detection can be scheduled per component tree.
  *
  * @param component Component to mark as dirty.
- *
- * @publicApi
- * @globalApi ng
  */
 export function markDirty(component: {}): void {
   ngDevMode && assertDefined(component, 'component');

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -15,44 +15,35 @@ import {detectChangesInternal, markViewDirty, scheduleTick, tickRootContext} fro
 /**
  * Synchronously perform change detection on a component (and possibly its sub-components).
  *
- * This function triggers change detection in a synchronous way on a component. There should
- * be very little reason to call this function directly since a preferred way to do change
- * detection is to {@link markDirty} the component and wait for the scheduler to call this method
- * at some future point in time. This is because a single user action often results in many
- * components being invalidated and calling change detection on each component synchronously
- * would be inefficient. It is better to wait until all components are marked as dirty and
- * then perform single change detection across all of the components
+ * This function triggers change detection in a synchronous way on a component.
  *
  * @param component The component which the change detection should be performed on.
  */
-export function detectChanges<T>(component: T): void {
+export function detectChanges(component: {}): void {
   const view = getComponentViewByInstance(component);
-  detectChangesInternal<T>(view, component);
+  detectChangesInternal(view, component);
 }
 
 /**
- * Mark the component as dirty (needing change detection).
+ * Marks the component as dirty (needing change detection). Marking a component dirty will
+ * schedule a change detection on it at some point in the future.
  *
- * Marking a component dirty will schedule a change detection on this
- * component at some point in the future. Marking an already dirty
- * component as dirty is a noop. Only one outstanding change detection
- * can be scheduled per component tree. (Two components bootstrapped with
- * separate `renderComponent` will have separate schedulers)
- *
- * When the root component is bootstrapped with `renderComponent`, a scheduler
- * can be provided.
+ * Marking an already dirty component as dirty won't do anything. Only one outstanding change
+ * detection can be scheduled per component tree.
  *
  * @param component Component to mark as dirty.
  *
  * @publicApi
+ * @globalApi ng
  */
-export function markDirty<T>(component: T) {
+export function markDirty(component: {}): void {
   ngDevMode && assertDefined(component, 'component');
   const rootView = markViewDirty(getComponentViewByInstance(component)) !;
 
   ngDevMode && assertDefined(rootView[CONTEXT], 'rootContext should be defined');
   scheduleTick(rootView[CONTEXT] as RootContext, RootContextFlags.DetectChanges);
 }
+
 /**
  * Used to perform change detection on the whole application.
  *

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -57,8 +57,6 @@ export function ɵɵpipe(index: number, pipeName: string): any {
  * @param name Name of pipe to resolve
  * @param registry Full list of available pipes
  * @returns Matching PipeDef
- *
- * @publicApi
  */
 function getPipeDef(name: string, registry: PipeDefList | null): PipeDef<any> {
   if (registry) {

--- a/packages/core/src/render3/util/change_detection_utils.ts
+++ b/packages/core/src/render3/util/change_detection_utils.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {detectChanges, markDirty} from '../instructions/all';
+import {getRootComponents} from './discovery_utils';
+
+/**
+ * Marks a component for check (in case of OnPush components) and synchronously
+ * performs change detection on the application this component belongs to.
+ *
+ * @param component Component to {@link ChangeDetectorRef#markForCheck mark for check}.
+ *
+ * @publicApi
+ * @globalApi ng
+ */
+export function applyChanges(component: {}): void {
+  markDirty(component);
+  getRootComponents(component).forEach(rootComponent => detectChanges(rootComponent));
+}

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -7,8 +7,6 @@
  */
 import {assertDefined} from '../../util/assert';
 import {global} from '../../util/global';
-import {markDirty} from '../instructions/all';
-
 import {applyChanges} from './change_detection_utils';
 import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
 
@@ -50,7 +48,6 @@ export function publishDefaultGlobalUtils() {
     publishGlobalUtil('getInjector', getInjector);
     publishGlobalUtil('getRootComponents', getRootComponents);
     publishGlobalUtil('getDirectives', getDirectives);
-    publishGlobalUtil('markDirty', markDirty);
     publishGlobalUtil('applyChanges', applyChanges);
   }
 }

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -7,7 +7,10 @@
  */
 import {assertDefined} from '../../util/assert';
 import {global} from '../../util/global';
-import {getComponent, getContext, getDebugNode, getDirectives, getHostElement, getInjector, getListeners, getRootComponents, getViewComponent, markDirty} from '../global_utils_api';
+import {markDirty} from '../instructions/all';
+
+import {applyChanges} from './change_detection_utils';
+import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
 
 
 
@@ -42,13 +45,13 @@ export function publishDefaultGlobalUtils() {
     publishGlobalUtil('getComponent', getComponent);
     publishGlobalUtil('getContext', getContext);
     publishGlobalUtil('getListeners', getListeners);
-    publishGlobalUtil('getViewComponent', getViewComponent);
+    publishGlobalUtil('getOwningComponent', getOwningComponent);
     publishGlobalUtil('getHostElement', getHostElement);
     publishGlobalUtil('getInjector', getInjector);
     publishGlobalUtil('getRootComponents', getRootComponents);
     publishGlobalUtil('getDirectives', getDirectives);
-    publishGlobalUtil('getDebugNode', getDebugNode);
     publishGlobalUtil('markDirty', markDirty);
+    publishGlobalUtil('applyChanges', applyChanges);
   }
 }
 

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -15,7 +15,7 @@ import {expect} from '@angular/core/testing/src/testing_internal';
 import {onlyInIvy} from '@angular/private/testing';
 
 import {getHostElement, markDirty} from '../../src/render3/index';
-import {getComponent, getComponentLView, getContext, getDebugNode, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getRootComponents, getViewComponent, loadLContext} from '../../src/render3/util/discovery_utils';
+import {getComponent, getComponentLView, getContext, getDebugNode, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getOwningComponent, getRootComponents, loadLContext} from '../../src/render3/util/discovery_utils';
 
 onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
   let fixture: ComponentFixture<MyApp>;
@@ -81,8 +81,8 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
       expect(getComponent(p[0])).toEqual(null);
     });
     it('should throw when called on non-element', () => {
-      expect(() => getComponent(dirA[0] as any)).toThrowError(/Expecting instance of DOM Node/);
-      expect(() => getComponent(dirA[1] as any)).toThrowError(/Expecting instance of DOM Node/);
+      expect(() => getComponent(dirA[0] as any)).toThrowError(/Expecting instance of DOM Element/);
+      expect(() => getComponent(dirA[1] as any)).toThrowError(/Expecting instance of DOM Element/);
     });
     it('should return component from element', () => {
       expect(getComponent<MyApp>(fixture.nativeElement)).toEqual(myApp);
@@ -107,8 +107,8 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
 
   describe('getContext', () => {
     it('should throw when called on non-element', () => {
-      expect(() => getContext(dirA[0] as any)).toThrowError(/Expecting instance of DOM Node/);
-      expect(() => getContext(dirA[1] as any)).toThrowError(/Expecting instance of DOM Node/);
+      expect(() => getContext(dirA[0] as any)).toThrowError(/Expecting instance of DOM Element/);
+      expect(() => getContext(dirA[1] as any)).toThrowError(/Expecting instance of DOM Element/);
     });
     it('should return context from element', () => {
       expect(getContext<MyApp>(child[0])).toEqual(myApp);
@@ -161,30 +161,30 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
     });
   });
 
-  describe('getViewComponent', () => {
+  describe('getOwningComponent', () => {
     it('should return null when called on root component', () => {
-      expect(getViewComponent(fixture.nativeElement)).toEqual(null);
-      expect(getViewComponent(myApp)).toEqual(null);
+      expect(getOwningComponent(fixture.nativeElement)).toEqual(null);
+      expect(getOwningComponent(myApp)).toEqual(null);
     });
     it('should return containing component of child component', () => {
-      expect(getViewComponent<MyApp>(child[0])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(child[1])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(child[2])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(child[0])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(child[1])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(child[2])).toEqual(myApp);
 
-      expect(getViewComponent<MyApp>(childComponent[0])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(childComponent[1])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(childComponent[2])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(childComponent[0])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(childComponent[1])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(childComponent[2])).toEqual(myApp);
     });
     it('should return containing component of any view element', () => {
-      expect(getViewComponent<MyApp>(span[0])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(div[0])).toEqual(myApp);
-      expect(getViewComponent<Child>(p[0])).toEqual(childComponent[0]);
-      expect(getViewComponent<Child>(p[1])).toEqual(childComponent[1]);
-      expect(getViewComponent<Child>(p[2])).toEqual(childComponent[2]);
+      expect(getOwningComponent<MyApp>(span[0])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(div[0])).toEqual(myApp);
+      expect(getOwningComponent<Child>(p[0])).toEqual(childComponent[0]);
+      expect(getOwningComponent<Child>(p[1])).toEqual(childComponent[1]);
+      expect(getOwningComponent<Child>(p[2])).toEqual(childComponent[2]);
     });
     it('should return containing component of child directive', () => {
-      expect(getViewComponent<MyApp>(dirA[0])).toEqual(myApp);
-      expect(getViewComponent<MyApp>(dirA[1])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(dirA[0])).toEqual(myApp);
+      expect(getOwningComponent<MyApp>(dirA[1])).toEqual(myApp);
     });
   });
 
@@ -231,6 +231,7 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
       expect(listeners[0].name).toEqual('click');
       expect(listeners[0].element).toEqual(span[0]);
       expect(listeners[0].useCapture).toEqual(false);
+      expect(listeners[0].type).toEqual('dom');
       listeners[0].callback('CLICKED');
       expect(log).toEqual(['CLICKED']);
     });

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵmarkDirty as markDirty} from '@angular/core';
 
 import {applyChanges} from '../../src/render3/util/change_detection_utils';
 import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
@@ -44,8 +43,6 @@ describe('global utils', () => {
        () => { assertPublished('getHostElement', getHostElement); });
 
     it('should publish getInjector', () => { assertPublished('getInjector', getInjector); });
-
-    it('should publish markDirty', () => { assertPublished('markDirty', markDirty); });
 
     it('should publish applyChanges', () => { assertPublished('applyChanges', applyChanges); });
   });

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -7,7 +7,8 @@
  */
 import {ɵmarkDirty as markDirty} from '@angular/core';
 
-import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getRootComponents, getViewComponent} from '../../src/render3/util/discovery_utils';
+import {applyChanges} from '../../src/render3/util/change_detection_utils';
+import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
 import {GLOBAL_PUBLISH_EXPANDO_KEY, GlobalDevModeContainer, publishDefaultGlobalUtils, publishGlobalUtil} from '../../src/render3/util/global_utils';
 import {global} from '../../src/util/global';
 
@@ -31,8 +32,8 @@ describe('global utils', () => {
 
     it('should publish getListeners', () => { assertPublished('getListeners', getListeners); });
 
-    it('should publish getViewComponent',
-       () => { assertPublished('getViewComponent', getViewComponent); });
+    it('should publish getOwningComponent',
+       () => { assertPublished('getOwningComponent', getOwningComponent); });
 
     it('should publish getRootComponents',
        () => { assertPublished('getRootComponents', getRootComponents); });
@@ -45,6 +46,8 @@ describe('global utils', () => {
     it('should publish getInjector', () => { assertPublished('getInjector', getInjector); });
 
     it('should publish markDirty', () => { assertPublished('markDirty', markDirty); });
+
+    it('should publish applyChanges', () => { assertPublished('applyChanges', applyChanges); });
   });
 });
 

--- a/tools/public_api_guard/global_utils.d.ts
+++ b/tools/public_api_guard/global_utils.d.ts
@@ -23,5 +23,3 @@ export interface Listener {
     type: 'dom' | 'output';
     useCapture: boolean;
 }
-
-export declare function markDirty(component: {}): void;

--- a/tools/public_api_guard/global_utils.d.ts
+++ b/tools/public_api_guard/global_utils.d.ts
@@ -1,19 +1,27 @@
-export declare function getComponent<T = {}>(element: Element): T | null;
+export declare function applyChanges(component: {}): void;
 
-export declare function getContext<T = {}>(element: Element): T | null;
+export declare function getComponent<T>(element: Element): T | null;
 
-export declare function getDebugNode(element: Node): DebugNode | null;
+export declare function getContext<T>(element: Element): T | null;
 
-export declare function getDirectives(target: {}): Array<{}>;
+export declare function getDirectives(element: Element): {}[];
 
-export declare function getHostElement<T>(directive: T): Element;
+export declare function getHostElement(componentOrDirective: {}): Element;
 
-export declare function getInjector(target: {}): Injector;
+export declare function getInjector(elementOrDir: Element | {}): Injector;
 
 export declare function getListeners(element: Element): Listener[];
 
-export declare function getRootComponents(target: {}): any[];
+export declare function getOwningComponent<T>(elementOrDir: Element | {}): T | null;
 
-export declare function getViewComponent<T = {}>(element: Element | {}): T | null;
+export declare function getRootComponents(elementOrDir: Element | {}): {}[];
 
-export declare function markDirty<T>(component: T): void;
+export interface Listener {
+    callback: (value: any) => any;
+    element: Element;
+    name: string;
+    type: 'dom' | 'output';
+    useCapture: boolean;
+}
+
+export declare function markDirty(component: {}): void;


### PR DESCRIPTION
Cleans up the public API of the global debugging utilities, documents them and exposes them in the API docs.
