### PR TITLE
Update CircleCI config to use new determinisitc image types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,9 @@ executors:
         type: string
         default: medium
     docker:
-      - image: circleci/node:10.16@sha256:75c05084fff4afa3683a03c5a04a4a3ad95c536ff2439d8fe14e7e1f5c58b09a
+      # new cimg images from CircleCI, unlike legacy `circleci` type are determinisitc by version, 
+      # and only ever re-released in the case of critical CVEs.  For this reason, pinning is no longer needed.
+      - image: cimg/node:10.16
     resource_class: << parameters.resource_class >>
     working_directory: ~/ng
 


### PR DESCRIPTION
New `cimg` collection of images from CircleCI have the benefits of:
* More deterministic versioning
* Smaller images sizes
* More shared layers to other languages (more cache hits!)

More info on the new images can be found on https://github.com/CircleCI-Public/cimg-node


All this means more confidence and faster builds on CircleCI.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Uses `circleci` image types that have known concerns with determinism and stability.

Issue Number: N/A


## What is the new behavior?
 Use new more determinant image type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


The image is currently beta, but base image is being used ~20k builds each week, and gorwing every day.

Use and feedback from a community like Angular would be an important milestone for the new types.