### PR TITLE
build: use vendored yarn version for bazel node toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,10 +40,9 @@ node_repositories(
     },
     node_version = "10.16.0",
     package_json = ["//:package.json"],
-    yarn_repositories = {
-        "1.21.1": ("yarn-v1.21.1.tar.gz", "yarn-v1.21.1", "d1d9f4a0f16f5ed484e814afeb98f39b82d4728c6c8beaafb5abc99c02db6674"),
-    },
-    yarn_version = "1.21.1",
+    # Label needs to explicitly specify the current workspace name because otherwise Bazel does
+    # not provide all needed data (like "workspace_root") to the repository context.
+    vendored_yarn = "@angular//:third_party/github.com/yarnpkg/yarn/releases/download/v1.21.1",
 )
 
 yarn_install(


### PR DESCRIPTION
Instead of downloading Yarn separately for Bazel, we could use
our existing copy of Yarn that we maintain for CI jobs that do
not use Bazel. This ensures we use consistent versions of Yarn
across our CI jobs, and also avoids unnecessary downloads to the
Bazel mirror server, or Yarn download servers.