### PR TITLE
refactor: remove extraneous then call

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -127,7 +127,7 @@ export class TraitCompiler {
     visit(sf);
 
     if (preanalyze && promises.length > 0) {
-      return Promise.all(promises).then(() => undefined as void);
+      return Promise.all(promises) as unknown as Promise<void>;
     } else {
       return undefined;
     }


### PR DESCRIPTION
The purpose of this "then" call is to ensure that the return type is Promise< void >, however this may be done by adding a type assertion instead of adding a call to "then". Using a type assertion leads to more efficient code.

## PR Checklist
Please check if your PR fulfills the following requirements:


- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [no] Tests for the changes have been added (for bug fixes / features)
- [no] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation content changes
- [ ] Code style update (formatting, local variables)
- [ ] Build related changes
- [ ] CI related changes
- [x] Refactoring (no functional changes, no api changes)
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

unnecessary "then" call is included in transpiled JS output

## What is the new behavior?

it isn't

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No