### PR TITLE
fix(compiler): record correct end of expression 

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -12,17 +12,17 @@ describe('type check blocks diagnostics', () => {
   describe('parse spans', () => {
     it('should annotate binary ops', () => {
       expect(tcbWithSpans('{{ a + b }}'))
-          .toContain('"" + (((ctx).a /*3,5*/) + ((ctx).b /*7,9*/) /*3,9*/);');
+          .toContain('"" + (((ctx).a /*3,4*/) + ((ctx).b /*7,8*/) /*3,8*/);');
     });
 
     it('should annotate conditions', () => {
       expect(tcbWithSpans('{{ a ? b : c }}'))
-          .toContain('((ctx).a /*3,5*/ ? (ctx).b /*7,9*/ : (ctx).c /*11,13*/) /*3,13*/;');
+          .toContain('((ctx).a /*3,4*/ ? (ctx).b /*7,8*/ : (ctx).c /*11,12*/) /*3,12*/;');
     });
 
     it('should annotate interpolations', () => {
       expect(tcbWithSpans('{{ hello }} {{ world }}'))
-          .toContain('"" + (ctx).hello /*3,9*/ + (ctx).world /*15,21*/;');
+          .toContain('"" + (ctx).hello /*3,8*/ + (ctx).world /*15,20*/;');
     });
 
     it('should annotate literal map expressions', () => {
@@ -35,46 +35,46 @@ describe('type check blocks diagnostics', () => {
 
     it('should annotate literal array expressions', () => {
       const TEMPLATE = '{{ [a, b] }}';
-      expect(tcbWithSpans(TEMPLATE)).toContain('[(ctx).a /*4,5*/, (ctx).b /*7,8*/] /*3,10*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('[(ctx).a /*4,5*/, (ctx).b /*7,8*/] /*3,9*/;');
     });
 
     it('should annotate literals', () => {
       const TEMPLATE = '{{ 123 }}';
-      expect(tcbWithSpans(TEMPLATE)).toContain('123 /*3,7*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('123 /*3,6*/;');
     });
 
     it('should annotate non-null assertions', () => {
       const TEMPLATE = `{{ a! }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('(((ctx).a /*3,4*/)! /*3,6*/);');
+      expect(tcbWithSpans(TEMPLATE)).toContain('(((ctx).a /*3,4*/)! /*3,5*/);');
     });
 
     it('should annotate prefix not', () => {
       const TEMPLATE = `{{ !a }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('!((ctx).a /*4,6*/) /*3,6*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('!((ctx).a /*4,5*/) /*3,5*/;');
     });
 
     it('should annotate method calls', () => {
       const TEMPLATE = `{{ method(a, b) }}`;
       expect(tcbWithSpans(TEMPLATE))
-          .toContain('(ctx).method((ctx).a /*10,11*/, (ctx).b /*13,14*/) /*3,16*/;');
+          .toContain('(ctx).method((ctx).a /*10,11*/, (ctx).b /*13,14*/) /*3,15*/;');
     });
 
     it('should annotate method calls of variables', () => {
       const TEMPLATE = `<ng-template let-method>{{ method(a, b) }}</ng-template>`;
       expect(tcbWithSpans(TEMPLATE))
-          .toContain('(_t2 /*27,40*/).method((ctx).a /*34,35*/, (ctx).b /*37,38*/) /*27,40*/;');
+          .toContain('(_t2 /*27,39*/).method((ctx).a /*34,35*/, (ctx).b /*37,38*/) /*27,39*/;');
     });
 
     it('should annotate function calls', () => {
       const TEMPLATE = `{{ method(a)(b, c) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((ctx).method((ctx).a /*10,11*/) /*3,12*/)((ctx).b /*13,14*/, (ctx).c /*16,17*/) /*3,19*/;');
+              '((ctx).method((ctx).a /*10,11*/) /*3,12*/)((ctx).b /*13,14*/, (ctx).c /*16,17*/) /*3,18*/;');
     });
 
     it('should annotate property access', () => {
       const TEMPLATE = `{{ a.b.c }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('(((ctx).a /*3,4*/).b /*3,6*/).c /*3,9*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('(((ctx).a /*3,4*/).b /*3,6*/).c /*3,8*/;');
     });
 
     it('should annotate property writes', () => {
@@ -85,7 +85,7 @@ describe('type check blocks diagnostics', () => {
 
     it('should annotate keyed property access', () => {
       const TEMPLATE = `{{ a[b] }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('((ctx).a /*3,4*/)[(ctx).b /*5,6*/] /*3,8*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('((ctx).a /*3,4*/)[(ctx).b /*5,6*/] /*3,7*/;');
     });
 
     it('should annotate keyed property writes', () => {
@@ -98,19 +98,19 @@ describe('type check blocks diagnostics', () => {
       const TEMPLATE = `{{ a?.b }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '(((ctx).a /*3,4*/) /*ignore*/ != null ? ((ctx).a /*3,4*/)!.b : undefined) /*3,8*/;');
+              '(((ctx).a /*3,4*/) /*ignore*/ != null ? ((ctx).a /*3,4*/)!.b : undefined) /*3,7*/;');
     });
 
     it('should annotate safe method calls', () => {
       const TEMPLATE = `{{ a?.method(b) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '(((ctx).a /*3,4*/) /*ignore*/ != null ? ((ctx).a /*3,4*/)!.method((ctx).b /*13,14*/) : undefined) /*3,16*/;');
+              '(((ctx).a /*3,4*/) /*ignore*/ != null ? ((ctx).a /*3,4*/)!.method((ctx).b /*13,14*/) : undefined) /*3,15*/;');
     });
 
     it('should annotate $any casts', () => {
       const TEMPLATE = `{{ $any(a) }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('((ctx).a /*8,9*/ as any) /*3,11*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('((ctx).a /*8,9*/ as any) /*3,10*/;');
     });
 
     it('should annotate chained expressions', () => {
@@ -128,17 +128,17 @@ describe('type check blocks diagnostics', () => {
       }];
       const block = tcbWithSpans(TEMPLATE, PIPES);
       expect(block).toContain(
-          '(null as TestPipe).transform((ctx).a /*3,5*/, (ctx).b /*12,14*/) /*3,14*/;');
+          '(null as TestPipe).transform((ctx).a /*3,4*/, (ctx).b /*12,13*/) /*3,13*/;');
     });
 
     describe('attaching multiple comments for multiple references', () => {
       it('should be correct for element refs', () => {
         const TEMPLATE = `<span #a></span>{{ a || a }}`;
-        expect(tcbWithSpans(TEMPLATE)).toContain('((_t1 /*19,21*/) || (_t1 /*24,26*/) /*19,26*/);');
+        expect(tcbWithSpans(TEMPLATE)).toContain('((_t1 /*19,20*/) || (_t1 /*24,25*/) /*19,25*/);');
       });
       it('should be correct for template vars', () => {
         const TEMPLATE = `<ng-template let-a="b">{{ a || a }}</ng-template>`;
-        expect(tcbWithSpans(TEMPLATE)).toContain('((_t2 /*26,28*/) || (_t2 /*31,33*/) /*26,33*/);');
+        expect(tcbWithSpans(TEMPLATE)).toContain('((_t2 /*26,27*/) || (_t2 /*31,32*/) /*26,32*/);');
       });
       it('should be correct for directive refs', () => {
         const DIRECTIVES: TestDeclaration[] = [{
@@ -149,7 +149,7 @@ describe('type check blocks diagnostics', () => {
         }];
         const TEMPLATE = `<my-cmp #a></my-cmp>{{ a || a }}`;
         expect(tcbWithSpans(TEMPLATE, DIRECTIVES))
-            .toContain('((_t2 /*23,25*/) || (_t2 /*28,30*/) /*23,30*/);');
+            .toContain('((_t2 /*23,24*/) || (_t2 /*28,29*/) /*23,29*/);');
       });
     });
   });

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -176,9 +176,9 @@ runInEachFileSystem((os) => {
           expect(mappings).toContain(
               {source: 'items.push(', generated: 'ctx.items.push(', sourceUrl: '../test.ts'});
           expect(mappings).toContain(
-              {source: `'item' `, generated: `"item"`, sourceUrl: '../test.ts'});
+              {source: `'item'`, generated: `"item"`, sourceUrl: '../test.ts'});
           expect(mappings).toContain({
-            source: '+ items.length)',
+            source: ' + items.length)',
             generated: ' + ctx.items.length)',
             sourceUrl: '../test.ts'
           });

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -264,7 +264,14 @@ export class _ParseAST {
                                                this.inputLength + this.offset;
   }
 
-  span(start: number) { return new ParseSpan(start, this.inputIndex); }
+  span(start: number) {
+    // `end` is either the
+    //   - end index of the current token
+    //   - start of the first token (e.g. can happen when creating an implicit receiver)
+    const curToken = this.peek(-1);
+    const end = curToken ? curToken.end + this.offset : this.inputIndex;
+    return new ParseSpan(start, end);
+  }
 
   sourceSpan(start: number): AbsoluteSourceSpan {
     const serial = `${start}@${this.inputIndex}`;

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -12,48 +12,49 @@ function lex(text: string): any[] {
   return new Lexer().tokenize(text);
 }
 
-function expectToken(token: any, index: number) {
+function expectToken(token: any, index: number, end: number) {
   expect(token instanceof Token).toBe(true);
   expect(token.index).toEqual(index);
+  expect(token.end).toEqual(end);
 }
 
-function expectCharacterToken(token: any, index: number, character: string) {
+function expectCharacterToken(token: any, index: number, end: number, character: string) {
   expect(character.length).toBe(1);
-  expectToken(token, index);
+  expectToken(token, index, end);
   expect(token.isCharacter(character.charCodeAt(0))).toBe(true);
 }
 
-function expectOperatorToken(token: any, index: number, operator: string) {
-  expectToken(token, index);
+function expectOperatorToken(token: any, index: number, end: number, operator: string) {
+  expectToken(token, index, end);
   expect(token.isOperator(operator)).toBe(true);
 }
 
-function expectNumberToken(token: any, index: number, n: number) {
-  expectToken(token, index);
+function expectNumberToken(token: any, index: number, end: number, n: number) {
+  expectToken(token, index, end);
   expect(token.isNumber()).toBe(true);
   expect(token.toNumber()).toEqual(n);
 }
 
-function expectStringToken(token: any, index: number, str: string) {
-  expectToken(token, index);
+function expectStringToken(token: any, index: number, end: number, str: string) {
+  expectToken(token, index, end);
   expect(token.isString()).toBe(true);
   expect(token.toString()).toEqual(str);
 }
 
-function expectIdentifierToken(token: any, index: number, identifier: string) {
-  expectToken(token, index);
+function expectIdentifierToken(token: any, index: number, end: number, identifier: string) {
+  expectToken(token, index, end);
   expect(token.isIdentifier()).toBe(true);
   expect(token.toString()).toEqual(identifier);
 }
 
-function expectKeywordToken(token: any, index: number, keyword: string) {
-  expectToken(token, index);
+function expectKeywordToken(token: any, index: number, end: number, keyword: string) {
+  expectToken(token, index, end);
   expect(token.isKeyword()).toBe(true);
   expect(token.toString()).toEqual(keyword);
 }
 
-function expectErrorToken(token: Token, index: any, message: string) {
-  expectToken(token, index);
+function expectErrorToken(token: Token, index: any, end: number, message: string) {
+  expectToken(token, index, end);
   expect(token.isError()).toBe(true);
   expect(token.toString()).toEqual(message);
 }
@@ -64,88 +65,88 @@ function expectErrorToken(token: Token, index: any, message: string) {
       it('should tokenize a simple identifier', () => {
         const tokens: number[] = lex('j');
         expect(tokens.length).toEqual(1);
-        expectIdentifierToken(tokens[0], 0, 'j');
+        expectIdentifierToken(tokens[0], 0, 1, 'j');
       });
 
       it('should tokenize "this"', () => {
         const tokens: number[] = lex('this');
         expect(tokens.length).toEqual(1);
-        expectKeywordToken(tokens[0], 0, 'this');
+        expectKeywordToken(tokens[0], 0, 4, 'this');
       });
 
       it('should tokenize a dotted identifier', () => {
         const tokens: number[] = lex('j.k');
         expect(tokens.length).toEqual(3);
-        expectIdentifierToken(tokens[0], 0, 'j');
-        expectCharacterToken(tokens[1], 1, '.');
-        expectIdentifierToken(tokens[2], 2, 'k');
+        expectIdentifierToken(tokens[0], 0, 1, 'j');
+        expectCharacterToken(tokens[1], 1, 2, '.');
+        expectIdentifierToken(tokens[2], 2, 3, 'k');
       });
 
       it('should tokenize an operator', () => {
         const tokens: number[] = lex('j-k');
         expect(tokens.length).toEqual(3);
-        expectOperatorToken(tokens[1], 1, '-');
+        expectOperatorToken(tokens[1], 1, 2, '-');
       });
 
       it('should tokenize an indexed operator', () => {
         const tokens: number[] = lex('j[k]');
         expect(tokens.length).toEqual(4);
-        expectCharacterToken(tokens[1], 1, '[');
-        expectCharacterToken(tokens[3], 3, ']');
+        expectCharacterToken(tokens[1], 1, 2, '[');
+        expectCharacterToken(tokens[3], 3, 4, ']');
       });
 
       it('should tokenize numbers', () => {
         const tokens: number[] = lex('88');
         expect(tokens.length).toEqual(1);
-        expectNumberToken(tokens[0], 0, 88);
+        expectNumberToken(tokens[0], 0, 2, 88);
       });
 
       it('should tokenize numbers within index ops',
-         () => { expectNumberToken(lex('a[22]')[2], 2, 22); });
+         () => { expectNumberToken(lex('a[22]')[2], 2, 4, 22); });
 
       it('should tokenize simple quoted strings',
-         () => { expectStringToken(lex('"a"')[0], 0, 'a'); });
+         () => { expectStringToken(lex('"a"')[0], 0, 3, 'a'); });
 
       it('should tokenize quoted strings with escaped quotes',
-         () => { expectStringToken(lex('"a\\""')[0], 0, 'a"'); });
+         () => { expectStringToken(lex('"a\\""')[0], 0, 5, 'a"'); });
 
       it('should tokenize a string', () => {
         const tokens: Token[] = lex('j-a.bc[22]+1.3|f:\'a\\\'c\':"d\\"e"');
-        expectIdentifierToken(tokens[0], 0, 'j');
-        expectOperatorToken(tokens[1], 1, '-');
-        expectIdentifierToken(tokens[2], 2, 'a');
-        expectCharacterToken(tokens[3], 3, '.');
-        expectIdentifierToken(tokens[4], 4, 'bc');
-        expectCharacterToken(tokens[5], 6, '[');
-        expectNumberToken(tokens[6], 7, 22);
-        expectCharacterToken(tokens[7], 9, ']');
-        expectOperatorToken(tokens[8], 10, '+');
-        expectNumberToken(tokens[9], 11, 1.3);
-        expectOperatorToken(tokens[10], 14, '|');
-        expectIdentifierToken(tokens[11], 15, 'f');
-        expectCharacterToken(tokens[12], 16, ':');
-        expectStringToken(tokens[13], 17, 'a\'c');
-        expectCharacterToken(tokens[14], 23, ':');
-        expectStringToken(tokens[15], 24, 'd"e');
+        expectIdentifierToken(tokens[0], 0, 1, 'j');
+        expectOperatorToken(tokens[1], 1, 2, '-');
+        expectIdentifierToken(tokens[2], 2, 3, 'a');
+        expectCharacterToken(tokens[3], 3, 4, '.');
+        expectIdentifierToken(tokens[4], 4, 6, 'bc');
+        expectCharacterToken(tokens[5], 6, 7, '[');
+        expectNumberToken(tokens[6], 7, 9, 22);
+        expectCharacterToken(tokens[7], 9, 10, ']');
+        expectOperatorToken(tokens[8], 10, 11, '+');
+        expectNumberToken(tokens[9], 11, 14, 1.3);
+        expectOperatorToken(tokens[10], 14, 15, '|');
+        expectIdentifierToken(tokens[11], 15, 16, 'f');
+        expectCharacterToken(tokens[12], 16, 17, ':');
+        expectStringToken(tokens[13], 17, 23, 'a\'c');
+        expectCharacterToken(tokens[14], 23, 24, ':');
+        expectStringToken(tokens[15], 24, 30, 'd"e');
       });
 
       it('should tokenize undefined', () => {
         const tokens: Token[] = lex('undefined');
-        expectKeywordToken(tokens[0], 0, 'undefined');
+        expectKeywordToken(tokens[0], 0, 9, 'undefined');
         expect(tokens[0].isKeywordUndefined()).toBe(true);
       });
 
       it('should ignore whitespace', () => {
         const tokens: Token[] = lex('a \t \n \r b');
-        expectIdentifierToken(tokens[0], 0, 'a');
-        expectIdentifierToken(tokens[1], 8, 'b');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectIdentifierToken(tokens[1], 8, 9, 'b');
       });
 
       it('should tokenize quoted string', () => {
         const str = '[\'\\\'\', "\\""]';
         const tokens: Token[] = lex(str);
-        expectStringToken(tokens[1], 1, '\'');
-        expectStringToken(tokens[3], 7, '"');
+        expectStringToken(tokens[1], 1, 5, '\'');
+        expectStringToken(tokens[3], 7, 11, '"');
       });
 
       it('should tokenize escaped quoted string', () => {
@@ -163,86 +164,89 @@ function expectErrorToken(token: Token, index: any, message: string) {
 
       it('should tokenize relation', () => {
         const tokens: Token[] = lex('! == != < > <= >= === !==');
-        expectOperatorToken(tokens[0], 0, '!');
-        expectOperatorToken(tokens[1], 2, '==');
-        expectOperatorToken(tokens[2], 5, '!=');
-        expectOperatorToken(tokens[3], 8, '<');
-        expectOperatorToken(tokens[4], 10, '>');
-        expectOperatorToken(tokens[5], 12, '<=');
-        expectOperatorToken(tokens[6], 15, '>=');
-        expectOperatorToken(tokens[7], 18, '===');
-        expectOperatorToken(tokens[8], 22, '!==');
+        expectOperatorToken(tokens[0], 0, 1, '!');
+        expectOperatorToken(tokens[1], 2, 4, '==');
+        expectOperatorToken(tokens[2], 5, 7, '!=');
+        expectOperatorToken(tokens[3], 8, 9, '<');
+        expectOperatorToken(tokens[4], 10, 11, '>');
+        expectOperatorToken(tokens[5], 12, 14, '<=');
+        expectOperatorToken(tokens[6], 15, 17, '>=');
+        expectOperatorToken(tokens[7], 18, 21, '===');
+        expectOperatorToken(tokens[8], 22, 25, '!==');
       });
 
       it('should tokenize statements', () => {
         const tokens: Token[] = lex('a;b;');
-        expectIdentifierToken(tokens[0], 0, 'a');
-        expectCharacterToken(tokens[1], 1, ';');
-        expectIdentifierToken(tokens[2], 2, 'b');
-        expectCharacterToken(tokens[3], 3, ';');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectCharacterToken(tokens[1], 1, 2, ';');
+        expectIdentifierToken(tokens[2], 2, 3, 'b');
+        expectCharacterToken(tokens[3], 3, 4, ';');
       });
 
       it('should tokenize function invocation', () => {
         const tokens: Token[] = lex('a()');
-        expectIdentifierToken(tokens[0], 0, 'a');
-        expectCharacterToken(tokens[1], 1, '(');
-        expectCharacterToken(tokens[2], 2, ')');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectCharacterToken(tokens[1], 1, 2, '(');
+        expectCharacterToken(tokens[2], 2, 3, ')');
       });
 
       it('should tokenize simple method invocations', () => {
         const tokens: Token[] = lex('a.method()');
-        expectIdentifierToken(tokens[2], 2, 'method');
+        expectIdentifierToken(tokens[2], 2, 8, 'method');
       });
 
       it('should tokenize method invocation', () => {
         const tokens: Token[] = lex('a.b.c (d) - e.f()');
-        expectIdentifierToken(tokens[0], 0, 'a');
-        expectCharacterToken(tokens[1], 1, '.');
-        expectIdentifierToken(tokens[2], 2, 'b');
-        expectCharacterToken(tokens[3], 3, '.');
-        expectIdentifierToken(tokens[4], 4, 'c');
-        expectCharacterToken(tokens[5], 6, '(');
-        expectIdentifierToken(tokens[6], 7, 'd');
-        expectCharacterToken(tokens[7], 8, ')');
-        expectOperatorToken(tokens[8], 10, '-');
-        expectIdentifierToken(tokens[9], 12, 'e');
-        expectCharacterToken(tokens[10], 13, '.');
-        expectIdentifierToken(tokens[11], 14, 'f');
-        expectCharacterToken(tokens[12], 15, '(');
-        expectCharacterToken(tokens[13], 16, ')');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectCharacterToken(tokens[1], 1, 2, '.');
+        expectIdentifierToken(tokens[2], 2, 3, 'b');
+        expectCharacterToken(tokens[3], 3, 4, '.');
+        expectIdentifierToken(tokens[4], 4, 5, 'c');
+        expectCharacterToken(tokens[5], 6, 7, '(');
+        expectIdentifierToken(tokens[6], 7, 8, 'd');
+        expectCharacterToken(tokens[7], 8, 9, ')');
+        expectOperatorToken(tokens[8], 10, 11, '-');
+        expectIdentifierToken(tokens[9], 12, 13, 'e');
+        expectCharacterToken(tokens[10], 13, 14, '.');
+        expectIdentifierToken(tokens[11], 14, 15, 'f');
+        expectCharacterToken(tokens[12], 15, 16, '(');
+        expectCharacterToken(tokens[13], 16, 17, ')');
       });
 
-      it('should tokenize number', () => { expectNumberToken(lex('0.5')[0], 0, 0.5); });
+      it('should tokenize number', () => { expectNumberToken(lex('0.5')[0], 0, 3, 0.5); });
 
       it('should tokenize number with exponent', () => {
         let tokens: Token[] = lex('0.5E-10');
         expect(tokens.length).toEqual(1);
-        expectNumberToken(tokens[0], 0, 0.5E-10);
+        expectNumberToken(tokens[0], 0, 7, 0.5E-10);
         tokens = lex('0.5E+10');
-        expectNumberToken(tokens[0], 0, 0.5E+10);
+        expectNumberToken(tokens[0], 0, 7, 0.5E+10);
       });
 
       it('should return exception for invalid exponent', () => {
         expectErrorToken(
-            lex('0.5E-')[0], 4, 'Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
+            lex('0.5E-')[0], 4, 5,
+            'Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
 
         expectErrorToken(
-            lex('0.5E-A')[0], 4,
+            lex('0.5E-A')[0], 4, 5,
             'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
       });
 
       it('should tokenize number starting with a dot',
-         () => { expectNumberToken(lex('.5')[0], 0, 0.5); });
+         () => { expectNumberToken(lex('.5')[0], 0, 2, 0.5); });
 
       it('should throw error on invalid unicode', () => {
         expectErrorToken(
-            lex('\'\\u1\'\'bla\'')[0], 2,
+            lex('\'\\u1\'\'bla\'')[0], 2, 2,
             'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
       });
 
-      it('should tokenize hash as operator', () => { expectOperatorToken(lex('#')[0], 0, '#'); });
+      it('should tokenize hash as operator',
+         () => { expectOperatorToken(lex('#')[0], 0, 1, '#'); });
 
-      it('should tokenize ?. as operator', () => { expectOperatorToken(lex('?.')[0], 0, '?.'); });
+      it('should tokenize ?. as operator',
+         () => { expectOperatorToken(lex('?.')[0], 0, 2, '?.'); });
     });
   });
 }

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -393,7 +393,7 @@ describe('parser', () => {
         expect(keyValues(bindings)).toEqual([
           'ngFor', 'let person=$implicit', 'ngForOf=people in null'
         ]);
-        expect(keySpans(source, bindings)).toEqual(['', 'let person ', 'of people']);
+        expect(keySpans(source, bindings)).toEqual(['', 'let person', 'of people']);
       });
     });
   });

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -60,9 +60,7 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in a binary expression', () => {
       expect(humanizeExpressionSource(parse('<div>{{1 + 2}}<div>').nodes))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a binary expression. Look into fixing this.
-            ['1', new AbsoluteSourceSpan(7, 9)],
+            ['1', new AbsoluteSourceSpan(7, 8)],
             ['2', new AbsoluteSourceSpan(11, 12)],
           ]));
     });
@@ -78,10 +76,8 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in a conditional', () => {
       expect(humanizeExpressionSource(parse('<div>{{bool ? 1 : 0}}<div>').nodes))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a conditional expression. Look into fixing this.
-            ['bool', new AbsoluteSourceSpan(7, 12)],
-            ['1', new AbsoluteSourceSpan(14, 16)],
+            ['bool', new AbsoluteSourceSpan(7, 11)],
+            ['1', new AbsoluteSourceSpan(14, 15)],
             ['0', new AbsoluteSourceSpan(18, 19)],
           ]));
     });
@@ -133,9 +129,7 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in an interpolation', () => {
       expect(humanizeExpressionSource(parse('<div>{{1 + 2}}<div>').nodes))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a conditional expression. Look into fixing this.
-            ['1', new AbsoluteSourceSpan(7, 9)],
+            ['1', new AbsoluteSourceSpan(7, 8)],
             ['2', new AbsoluteSourceSpan(11, 12)],
           ]));
     });
@@ -197,9 +191,7 @@ describe('expression AST absolute source spans', () => {
   describe('literal map', () => {
     it('should provide absolute offsets of a literal map', () => {
       expect(humanizeExpressionSource(parse('<div>{{ {a: 0} }}<div>').nodes)).toContain([
-        // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-        // with trailing whitespace in a literal map. Look into fixing this.
-        '{a: 0}', new AbsoluteSourceSpan(8, 15)
+        '{a: 0}', new AbsoluteSourceSpan(8, 14)
       ]);
     });
 
@@ -248,9 +240,7 @@ describe('expression AST absolute source spans', () => {
 
     it('should provide absolute offsets expressions in a pipe', () => {
       expect(humanizeExpressionSource(parse('<div>{{prop | pipe}}<div>').nodes)).toContain([
-        // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-        // with trailing whitespace in a pipe. Look into fixing this.
-        'prop', new AbsoluteSourceSpan(7, 12)
+        'prop', new AbsoluteSourceSpan(7, 11)
       ]);
     });
   });

--- a/packages/compiler/test/template_parser/template_parser_absolute_span_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_absolute_span_spec.ts
@@ -94,9 +94,7 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in a binary expression', () => {
       expect(humanizeExpressionSource(parse('<div>{{1 + 2}}<div>')))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a binary expression. Look into fixing this.
-            ['1', new AbsoluteSourceSpan(7, 9)],
+            ['1', new AbsoluteSourceSpan(7, 8)],
             ['2', new AbsoluteSourceSpan(11, 12)],
           ]));
     });
@@ -112,10 +110,8 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in a conditional', () => {
       expect(humanizeExpressionSource(parse('<div>{{bool ? 1 : 0}}<div>')))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a conditional expression. Look into fixing this.
-            ['bool', new AbsoluteSourceSpan(7, 12)],
-            ['1', new AbsoluteSourceSpan(14, 16)],
+            ['bool', new AbsoluteSourceSpan(7, 11)],
+            ['1', new AbsoluteSourceSpan(14, 15)],
             ['0', new AbsoluteSourceSpan(18, 19)],
           ]));
     });
@@ -167,9 +163,7 @@ describe('expression AST absolute source spans', () => {
     it('should provide absolute offsets of expressions in an interpolation', () => {
       expect(humanizeExpressionSource(parse('<div>{{1 + 2}}<div>')))
           .toEqual(jasmine.arrayContaining([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a conditional expression. Look into fixing this.
-            ['1', new AbsoluteSourceSpan(7, 9)],
+            ['1', new AbsoluteSourceSpan(7, 8)],
             ['2', new AbsoluteSourceSpan(11, 12)],
           ]));
     });
@@ -231,9 +225,7 @@ describe('expression AST absolute source spans', () => {
   describe('literal map', () => {
     it('should provide absolute offsets of a literal map', () => {
       expect(humanizeExpressionSource(parse('<div>{{ {a: 0} }}<div>'))).toContain([
-        // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-        // with trailing whitespace in a literal map. Look into fixing this.
-        '{a: 0}', new AbsoluteSourceSpan(8, 15)
+        '{a: 0}', new AbsoluteSourceSpan(8, 14)
       ]);
     });
 
@@ -287,11 +279,7 @@ describe('expression AST absolute source spans', () => {
 
     it('should provide absolute offsets expressions in a pipe', () => {
       expect(humanizeExpressionSource(parse('<div>{{prop | test}}<div>', [], [testPipe])))
-          .toContain([
-            // TODO(ayazhafiz): The expression parser includes an extra whitespace on a expressions
-            // with trailing whitespace in a pipe. Look into fixing this.
-            'prop', new AbsoluteSourceSpan(7, 12)
-          ]);
+          .toContain(['prop', new AbsoluteSourceSpan(7, 11)]);
     });
   });
 


### PR DESCRIPTION
This commit fixes a bug with the expression parser wherein the end index
of an expression node was recorded as the start index of the next token,
and not the end index of the current token.

Closes #33477
Closes angular/vscode-ng-language-service#433

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No