### PR TITLE
refactor(ivy): move all projection attribute creation code into shared class

### DIFF
--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -284,3 +284,5 @@ export interface R3HostMetadata {
 
   specialAttributes: {styleAttr?: string; classAttr?: string;};
 }
+
+export interface AttributeBuilder { build(): (o.LiteralExpr|o.LiteralArrayExpr)[]; }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -648,13 +648,13 @@ function createHostBindingsFunction(
   for (let i = 0; i < hostAttrNames.length; i++) {
     const name = hostAttrNames[i];
     const value = attrsMap[name];
-    attrsBuilder.registerAttribute(name, value);
+    attrsBuilder.setAttribute(name, value);
   }
 
   const hostAttrs = attrsBuilder.build();
   if (hostAttrs.length !== 0) {
     // convert the array into a constant if possible
-    const attrArray = !hostAttrs.some(attr => attr instanceof o.WrappedNodeExpr) ?
+    const attrArray = hostAttrs.every(attr => attr.isConstant()) ?
         getConstantLiteralFromArray(constantPool, hostAttrs) :
         o.literalArr(hostAttrs);
 

--- a/packages/compiler/src/render3/view/projection_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/projection_attributes_builder.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {SelectorFlags} from '../../core';
+import * as o from '../../output/output_ast';
+
+import {AttributeBuilder} from './api';
+import {populateProjectAsSelectors} from './static_attributes_builder';
+
+
+
+/**
+ * Used to generate the `TAttributes` array for projection instructions
+ */
+export class ProjectionAttributesBuilder implements AttributeBuilder {
+  /**
+   * Key/value array of entries in the form of [key1, value1, key2, value2,...]
+   */
+  private _attrs: any[]|null = null;
+  private _projectAsSelectors: (string|number)[]|null = null;
+
+  constructor(private _slotIndex: number, private _projectionSlotIndex: number) {}
+
+  setProjectAsSelector(selector: string|(string|SelectorFlags)[]) {
+    this._projectAsSelectors = Array.isArray(selector) ? selector : [selector];
+  }
+
+  registerAttribute(attrName: string, value: any) {
+    this._attrs = this._attrs || [];
+    if (attrsIndexOf(this._attrs, attrName) === -1) {
+      this._attrs.push(attrName, value);
+    }
+  }
+
+  /**
+   * Generates an array of each attribute registered in this class (where each entry is an instance
+   * of an Expression).
+   *
+   * The output format looks like this:
+   *
+   * ```typescript
+   * [
+   *   SLOT_INDEX,
+   *   PROJECTION_SLOT_INDEX,
+   *   [...content attribute entries...]
+   * ]
+   * ```
+   *
+   * The content attribute entries are in the form of:
+   *
+   * ```typescript
+   * [
+   *   key1, value1, key2, value2,
+   *   ProjectAs,
+   *   [selector]
+   * ]
+   * ```
+   */
+  build(): (o.LiteralExpr|o.LiteralArrayExpr)[] {
+    const attrs: (o.LiteralExpr | o.LiteralArrayExpr)[] = [o.literal(this._slotIndex)];
+    let attrsForContentSlot: o.Expression[]|null = null;
+
+    // ... [values], ...
+    if (this._attrs !== null) {
+      attrsForContentSlot = attrsForContentSlot || [];
+      populateKeyValueEntries(attrsForContentSlot, this._attrs);
+    }
+
+    // ... PROJECT_AS, ['s1', 's2', 's3', ... ] ...
+    if (this._projectAsSelectors !== null) {
+      attrsForContentSlot = attrsForContentSlot || [];
+      populateProjectAsSelectors(attrsForContentSlot, this._projectAsSelectors);
+    }
+
+    // ... PROJECTION_SLOT_INDEX ...
+    if (attrsForContentSlot !== null || this._projectionSlotIndex !== 0) {
+      attrs.push(o.literal(this._projectionSlotIndex));
+    }
+
+    // ... [values], ...
+    if (attrsForContentSlot !== null) {
+      attrs.push(o.literalArr(attrsForContentSlot));
+    }
+
+    return attrs;
+  }
+}
+
+function attrsIndexOf(attrs: any[], attrName: string): number {
+  for (let i = 0; i < attrs.length; i += 2) {
+    if (attrs[i] === attrName) return i;
+  }
+  return -1;
+}
+
+function populateKeyValueEntries(attrs: o.Expression[], entries: any[]): void {
+  for (let i = 0; i < entries.length; i += 2) {
+    const key = o.literal(entries[i]);
+    const value = o.literal(entries[i + 1]);
+    attrs.push(key, value);
+  }
+}

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -41,9 +41,15 @@ export class StaticAttributesBuilder {
     }
   }
 
-  setClassAttribute(value: string) { this._classAttr = value; }
+  setClassAttribute(value: string) {
+    value = value.trim();
+    this._classAttr = value.length === 0 ? null : value;
+  }
 
-  setStyleAttribute(value: string) { this._stylesAttr = value; }
+  setStyleAttribute(value: string) {
+    value = value.trim();
+    this._stylesAttr = value.length === 0 ? null : value;
+  }
 
   private _registerAttribute(attrName: string, value: any) {
     if (!this._keyValueAttrs) {

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -26,7 +26,7 @@ export class StaticAttributesBuilder {
   private _i18nNameAttrs: string[]|null = null;
 
   setAttribute(attrName: string, value: string|o.Expression) {
-    if (!this._keyValueAttrs) {
+    if (this._keyValueAttrs === null) {
       this._keyValueAttrs = [];
     }
 
@@ -204,7 +204,7 @@ function populateNameAttributeEntries(attrs: o.Expression[], names: any[]): void
   }
 }
 
-function toLiteralArr(values: any[]) {
+function toLiteralArr(values: (string | number)[]) {
   return o.literalArr(values.map(v => o.literal(v)));
 }
 

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -9,14 +9,16 @@ import {AttributeMarker, SelectorFlags} from '../../core';
 import {splitNsName} from '../../ml_parser/tags';
 import * as o from '../../output/output_ast';
 
+import {AttributeBuilder} from './api';
 import {parse as parseStyle} from './style_parser';
+
 
 
 /**
  * Used to generate the `TAttributes` array (which is used by the `element`, `elementStart` and
  * `elementHostAttrs` instructions).
  */
-export class StaticAttributesBuilder {
+export class StaticAttributesBuilder implements AttributeBuilder {
   private _keyValueAttrs: KeyValueEntry[]|null = null;
   private _classAttr: string|null = null;
   private _stylesAttr: string|null = null;

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AttributeMarker, SelectorFlags} from '../../core';
+import {splitNsName} from '../../ml_parser/tags';
+import * as o from '../../output/output_ast';
+
+import {parse as parseStyle} from './style_parser';
+
+
+/**
+ * Used to generate the `TAttributes` array (which is used by the `element`, `elementStart` and
+ * `elementHostAttrs` instructions).
+ */
+export class StaticAttributesBuilder {
+  private _keyValueAttrs: KeyValueEntry[]|null = null;
+  private _classAttr: string|null = null;
+  private _stylesAttr: string|null = null;
+  private _templateNameAttrs: string[]|null = null;
+  private _bindingNameAttrs: string[]|null = null;
+  private _projectAsSelectors: (string|number)[]|null = null;
+  private _i18nNameAttrs: string[]|null = null;
+
+  registerAttribute(attrName: string, value: any) {
+    switch (attrName) {
+      case 'style':
+        this.setStyleAttribute(value);
+        break;
+
+      case 'class':
+        this.setClassAttribute(value);
+        break;
+
+      default:
+        this._registerAttribute(attrName, value);
+        break;
+    }
+  }
+
+  setClassAttribute(value: string) { this._classAttr = value; }
+
+  setStyleAttribute(value: string) { this._stylesAttr = value; }
+
+  private _registerAttribute(attrName: string, value: any) {
+    if (!this._keyValueAttrs) {
+      this._keyValueAttrs = [];
+    }
+
+    if (keyValueAttrsIndexOf(this._keyValueAttrs, attrName) === -1) {
+      const [ns, nsAttr] = splitNsName(attrName);
+      const prop = ns !== null ? {namespace: ns, attr: nsAttr, fullName: attrName} : attrName;
+      this._keyValueAttrs.push({prop, value});
+    }
+  }
+
+  registerTemplateName(value: string) {
+    if (!this._templateNameAttrs) {
+      this._templateNameAttrs = [];
+    }
+    if (this._templateNameAttrs.indexOf(value) === -1) {
+      this._templateNameAttrs.push(value);
+    }
+  }
+
+  registerBindingName(value: string) {
+    if (!this._bindingNameAttrs) {
+      this._bindingNameAttrs = [];
+    }
+    if (this._bindingNameAttrs.indexOf(value) === -1) {
+      this._bindingNameAttrs.push(value);
+    }
+  }
+
+  registerI18nName(value: string) {
+    if (!this._i18nNameAttrs) {
+      this._i18nNameAttrs = [];
+    }
+    this._i18nNameAttrs.push(value);
+  }
+
+  setProjectAsSelector(selector: string|(string|SelectorFlags)[]) {
+    this._projectAsSelectors = Array.isArray(selector) ? selector : [selector];
+  }
+
+  /**
+   * Generates an array of each attribute registered in this class (where each entry is an instance
+   * of an Expression).
+   *
+   * The output format looks like this:
+   *
+   * ```typescript
+   * [
+   *   prop, value, prop2, value2, NAMESPACE_URI, ns, attr, value
+   *   CLASSES, class1, class2,
+   *   STYLES, style1, value1, style2, value2,
+   *   BINDINGS, name1, name2, name3,
+   *   TEMPLATE, name4, name5, name6,
+   *   PROJECT_AS, selector,
+   *   I18N, name7, name8
+   * ]
+   * ```
+   */
+  build(): (o.LiteralExpr|o.LiteralArrayExpr)[] {
+    let attrs: (o.LiteralExpr | o.LiteralArrayExpr)[] = [];
+
+    // ... 'prop', 'value', 'prop', NAMESPACE_URI, 'ns', 'prop', 'value' ...
+    if (this._keyValueAttrs !== null) {
+      populateKeyValueEntries(attrs, this._keyValueAttrs);
+    }
+
+    // ... CLASSES, 'foo', 'bar', 'baz' ...
+    if (this._classAttr !== null) {
+      populateClassAttributeEntries(attrs, this._classAttr);
+    }
+
+    // ... STYLES, 'width', '200px', 'height', '100px', ...
+    if (this._stylesAttr !== null) {
+      populateStyleAttributeEntries(attrs, this._stylesAttr);
+    }
+
+    // ... BINDINGS, 'name1', 'name2', 'name3' ...
+    if (this._bindingNameAttrs !== null) {
+      populateBindingNameEntries(attrs, this._bindingNameAttrs);
+    }
+
+    // ... TEMPLATE, 'name1', 'name2', 'name3' ...
+    if (this._templateNameAttrs !== null) {
+      populateTemplateNameEntries(attrs, this._templateNameAttrs);
+    }
+
+    // ... PROJECT_AS, ['s1', 's2', 's3', ... ] ...
+    if (this._projectAsSelectors !== null) {
+      populateProjectAsSelectors(attrs, this._projectAsSelectors);
+    }
+
+    // ... I18N, 'name1', 'name2', 'name3' ...
+    if (this._i18nNameAttrs !== null) {
+      populateI18nNameEntries(attrs, this._i18nNameAttrs);
+    }
+
+    return attrs;
+  }
+}
+
+/**
+ * Prop entry within `KeyValueEntry` for namespaced properties
+ */
+interface NamespacedPropEntry {
+  namespace: string;
+  attr: string;
+  fullName: string;
+}
+
+/**
+ * Key/value entry for key/value attributes added to the `StaticAttributesBuilder`
+ */
+interface KeyValueEntry {
+  prop: string|NamespacedPropEntry;
+  value: any;
+}
+
+function generateClassesArray(classAttr: string): string[] {
+  return classAttr.split(/\s+/);
+}
+
+function generateStylePropAndValuesArray(stylesAttr: string): string[] {
+  return parseStyle(stylesAttr);
+}
+
+function populateStyleAttributeEntries(attrs: o.Expression[], stylesAttr: string): void {
+  attrs.push(o.literal(AttributeMarker.Styles));
+  const styles = generateStylePropAndValuesArray(stylesAttr);
+  for (let i = 0; i < styles.length; i += 2) {
+    const prop = styles[i];
+    const value = styles[i + 1];
+    attrs.push(o.literal(prop), o.literal(value));
+  }
+}
+
+function populateClassAttributeEntries(attrs: o.Expression[], classAttr: string): void {
+  attrs.push(o.literal(AttributeMarker.Classes));
+  const classes = generateClassesArray(classAttr);
+  populateNameAttributeEntries(attrs, classes);
+}
+
+function populateKeyValueEntries(attrs: o.Expression[], entries: KeyValueEntry[]): void {
+  for (let i = 0; i < entries.length; i++) {
+    let {prop, value} = entries[i];
+    if (typeof prop === 'string') {  // case 1: prop is not namespaced
+      attrs.push(o.literal(prop));
+    } else {  // case 2: prop is namespaced
+      const namespaceDef = prop as NamespacedPropEntry;
+      attrs.push(
+          o.literal(AttributeMarker.NamespaceURI),  // MARKER
+          o.literal(namespaceDef.namespace),        // ns (before :)
+          o.literal(namespaceDef.attr),             // prop (after :)
+          );
+    }
+
+    if (!(value instanceof o.Expression)) {
+      value = Array.isArray(value) ? toLiteralArr(value) : o.literal(value);
+    }
+    attrs.push(value);
+  }
+}
+
+function populateNameAttributeEntries(attrs: o.Expression[], names: any[]): void {
+  for (let i = 0; i < names.length; i++) {
+    attrs.push(o.literal(names[i]));
+  }
+}
+
+function toLiteralArr(values: any[]) {
+  return o.literalArr(values.map(v => o.literal(v)));
+}
+
+export function populateProjectAsSelectors(
+    attrs: o.Expression[], selectors: (string | SelectorFlags)[]): void {
+  attrs.push(o.literal(AttributeMarker.ProjectAs), toLiteralArr(selectors));
+}
+
+function populateI18nNameEntries(attrs: o.Expression[], names: string[]): void {
+  attrs.push(o.literal(AttributeMarker.I18n));
+  populateNameAttributeEntries(attrs, names);
+}
+
+function populateTemplateNameEntries(attrs: o.Expression[], names: string[]): void {
+  attrs.push(o.literal(AttributeMarker.Template));
+  populateNameAttributeEntries(attrs, names);
+}
+
+function populateBindingNameEntries(attrs: o.Expression[], names: string[]): void {
+  attrs.push(o.literal(AttributeMarker.Bindings));
+  populateNameAttributeEntries(attrs, names);
+}
+
+function keyValueAttrsIndexOf(attrs: KeyValueEntry[], key: any) {
+  let index = -1;
+  for (let i = 0; i < attrs.length; i++) {
+    const entry = attrs[i];
+    const isMatch =
+        typeof entry.prop === 'string' ? entry.prop === key : entry.prop.fullName === key;
+    if (isMatch) {
+      index = i;
+      break;
+    }
+  }
+  return index;
+}

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -13,7 +13,6 @@ import {AttributeBuilder} from './api';
 import {parse as parseStyle} from './style_parser';
 
 
-
 /**
  * Used to generate the `TAttributes` array (which is used by the `element`, `elementStart` and
  * `elementHostAttrs` instructions).

--- a/packages/compiler/src/render3/view/static_attributes_builder.ts
+++ b/packages/compiler/src/render3/view/static_attributes_builder.ts
@@ -25,19 +25,15 @@ export class StaticAttributesBuilder {
   private _projectAsSelectors: (string|number)[]|null = null;
   private _i18nNameAttrs: string[]|null = null;
 
-  registerAttribute(attrName: string, value: any) {
-    switch (attrName) {
-      case 'style':
-        this.setStyleAttribute(value);
-        break;
+  setAttribute(attrName: string, value: string|o.Expression) {
+    if (!this._keyValueAttrs) {
+      this._keyValueAttrs = [];
+    }
 
-      case 'class':
-        this.setClassAttribute(value);
-        break;
-
-      default:
-        this._registerAttribute(attrName, value);
-        break;
+    if (keyValueAttrsIndexOf(this._keyValueAttrs, attrName) === -1) {
+      const [ns, nsAttr] = splitNsName(attrName);
+      const prop = ns !== null ? {namespace: ns, attr: nsAttr, fullName: attrName} : attrName;
+      this._keyValueAttrs.push({prop, value});
     }
   }
 
@@ -49,18 +45,6 @@ export class StaticAttributesBuilder {
   setStyleAttribute(value: string) {
     value = value.trim();
     this._stylesAttr = value.length === 0 ? null : value;
-  }
-
-  private _registerAttribute(attrName: string, value: any) {
-    if (!this._keyValueAttrs) {
-      this._keyValueAttrs = [];
-    }
-
-    if (keyValueAttrsIndexOf(this._keyValueAttrs, attrName) === -1) {
-      const [ns, nsAttr] = splitNsName(attrName);
-      const prop = ns !== null ? {namespace: ns, attr: nsAttr, fullName: attrName} : attrName;
-      this._keyValueAttrs.push({prop, value});
-    }
   }
 
   registerTemplateName(value: string) {
@@ -166,7 +150,7 @@ interface NamespacedPropEntry {
  */
 interface KeyValueEntry {
   prop: string|NamespacedPropEntry;
-  value: any;
+  value: string|o.Expression;
 }
 
 function generateClassesArray(classAttr: string): string[] {

--- a/packages/compiler/test/render3/view/projection_attributes_builder_spec.ts
+++ b/packages/compiler/test/render3/view/projection_attributes_builder_spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AttributeMarker} from '../../../src/core';
+import {ProjectionAttributesBuilder} from '../../../src/render3/view/projection_attributes_builder';
+import {expectAttributeValues} from './util';
+
+describe('ProjectionAttributesBuilder', () => {
+  it('should generate a projectAs selector value', () => {
+    const b = new ProjectionAttributesBuilder(1, 2);
+
+    b.setProjectAsSelector('.my-app');
+    expectAttributeValues(b).toEqual([
+      1,
+      2,
+      [AttributeMarker.ProjectAs, ['.my-app']],
+    ]);
+
+    b.setProjectAsSelector('.their-app');
+    expectAttributeValues(b).toEqual([
+      1,
+      2,
+      [AttributeMarker.ProjectAs, ['.their-app']],
+    ]);
+  });
+
+  it('should generate a key/value attribute entries as its own sub array', () => {
+    const b = new ProjectionAttributesBuilder(1, 2);
+    b.registerAttribute('key1', 'value1');
+
+    expectAttributeValues(b).toEqual([1, 2, ['key1', 'value1']]);
+
+    b.registerAttribute('key2', 'value2');
+    expectAttributeValues(b).toEqual([
+      1,
+      2,
+      ['key1', 'value1', 'key2', 'value2'],
+    ]);
+  });
+
+  it('should generate key/value and projectAs attribute values', () => {
+    const b = new ProjectionAttributesBuilder(1, 2);
+    b.registerAttribute('key1', 'value1');
+    b.registerAttribute('key2', 'value2');
+    b.setProjectAsSelector('.my-selector');
+
+    expectAttributeValues(b).toEqual([
+      1,
+      2,
+      ['key1', 'value1', 'key2', 'value2', AttributeMarker.ProjectAs, ['.my-selector']],
+    ]);
+  });
+});

--- a/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
+++ b/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
@@ -56,11 +56,14 @@ describe('StaticAttributesBuilder', () => {
       'baz',
     ]);
 
-    b.setClassAttribute('oof');
+    b.setClassAttribute(' oof ');
     expectStaticAttributes(b).toEqual([
       AttributeMarker.Classes,
       'oof',
     ]);
+
+    b.setClassAttribute(' ');
+    expectStaticAttributes(b).toEqual([]);
   });
 
   it('should set the class attribute even if registered as a normal attribute', () => {

--- a/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
+++ b/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AttributeMarker} from '../../../src/core';
-import * as o from '../../../src/output/output_ast';
 import {StaticAttributesBuilder} from '../../../src/render3/view/static_attributes_builder';
+import {expectAttributeValues} from './util';
 
 describe('StaticAttributesBuilder', () => {
   it('should generate key/value attribute values', () => {
@@ -15,7 +15,7 @@ describe('StaticAttributesBuilder', () => {
     b.setAttribute('key1', 'value1');
     b.setAttribute('key2', 'value2');
 
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       'key1',
       'value1',
       'key2',
@@ -27,32 +27,31 @@ describe('StaticAttributesBuilder', () => {
     const b = new StaticAttributesBuilder();
 
     b.setStyleAttribute('width:200px; height:400px');
-    expectStaticAttributes(b).toEqual(
-        [AttributeMarker.Styles, 'width', '200px', 'height', '400px']);
+    expectAttributeValues(b).toEqual([AttributeMarker.Styles, 'width', '200px', 'height', '400px']);
 
     b.setStyleAttribute('opacity:0.5');
-    expectStaticAttributes(b).toEqual([AttributeMarker.Styles, 'opacity', '0.5']);
+    expectAttributeValues(b).toEqual([AttributeMarker.Styles, 'opacity', '0.5']);
   });
 
   it('should generate class attribute values', () => {
     const b = new StaticAttributesBuilder();
 
     b.setClassAttribute('foo bar baz');
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.Classes,
       'foo',
       'bar',
       'baz',
     ]);
 
-    b.setClassAttribute(' oof ');
-    expectStaticAttributes(b).toEqual([
+    b.setClassAttribute('oof');
+    expectAttributeValues(b).toEqual([
       AttributeMarker.Classes,
       'oof',
     ]);
 
     b.setClassAttribute(' ');
-    expectStaticAttributes(b).toEqual([]);
+    expectAttributeValues(b).toEqual([]);
   });
 
   it('should generate template name attribute values', () => {
@@ -61,7 +60,7 @@ describe('StaticAttributesBuilder', () => {
     b.registerTemplateName('name2');
     b.registerTemplateName('name3');
 
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.Template,
       'name1',
       'name2',
@@ -75,7 +74,7 @@ describe('StaticAttributesBuilder', () => {
     b.registerBindingName('name2');
     b.registerBindingName('name3');
 
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.Bindings,
       'name1',
       'name2',
@@ -89,7 +88,7 @@ describe('StaticAttributesBuilder', () => {
     b.registerI18nName('name2');
     b.registerI18nName('name3');
 
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.I18n,
       'name1',
       'name2',
@@ -101,13 +100,13 @@ describe('StaticAttributesBuilder', () => {
     const b = new StaticAttributesBuilder();
 
     b.setProjectAsSelector('.my-app');
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.ProjectAs,
       ['.my-app'],
     ]);
 
     b.setProjectAsSelector('.their-app');
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       AttributeMarker.ProjectAs,
       ['.their-app'],
     ]);
@@ -131,7 +130,7 @@ describe('StaticAttributesBuilder', () => {
     b.setStyleAttribute('width: 200px; height: 400px');
     b.setProjectAsSelector('.my-app');
 
-    expectStaticAttributes(b).toEqual([
+    expectAttributeValues(b).toEqual([
       'title1',
       'titleValue1',
       AttributeMarker.NamespaceURI,
@@ -166,21 +165,3 @@ describe('StaticAttributesBuilder', () => {
     ]);
   });
 });
-
-function expectStaticAttributes(builder: StaticAttributesBuilder) {
-  return expect(expArrayToRawValues(builder.build()));
-}
-
-function expArrayToRawValues(exp: (o.LiteralExpr | o.LiteralArrayExpr)[]) {
-  return exp.map(entry => {
-    if (entry instanceof o.LiteralArrayExpr) {
-      return entry.entries.map(e => toRawValue(e as o.LiteralExpr));
-    } else {
-      return toRawValue(entry);
-    }
-  });
-}
-
-function toRawValue(exp: o.LiteralExpr): any {
-  return exp.value;
-}

--- a/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
+++ b/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
@@ -12,8 +12,8 @@ import {StaticAttributesBuilder} from '../../../src/render3/view/static_attribut
 describe('StaticAttributesBuilder', () => {
   it('should generate key/value attribute values', () => {
     const b = new StaticAttributesBuilder();
-    b.registerAttribute('key1', 'value1');
-    b.registerAttribute('key2', 'value2');
+    b.setAttribute('key1', 'value1');
+    b.setAttribute('key2', 'value2');
 
     expectStaticAttributes(b).toEqual([
       'key1',
@@ -32,17 +32,6 @@ describe('StaticAttributesBuilder', () => {
 
     b.setStyleAttribute('opacity:0.5');
     expectStaticAttributes(b).toEqual([AttributeMarker.Styles, 'opacity', '0.5']);
-  });
-
-  it('should set the style attribute even if registered as a normal attribute', () => {
-    const b = new StaticAttributesBuilder();
-
-    b.registerAttribute('style', 'z-index:1000');
-    expectStaticAttributes(b).toEqual([
-      AttributeMarker.Styles,
-      'z-index',
-      '1000',
-    ]);
   });
 
   it('should generate class attribute values', () => {
@@ -64,13 +53,6 @@ describe('StaticAttributesBuilder', () => {
 
     b.setClassAttribute(' ');
     expectStaticAttributes(b).toEqual([]);
-  });
-
-  it('should set the class attribute even if registered as a normal attribute', () => {
-    const b = new StaticAttributesBuilder();
-
-    b.registerAttribute('class', 'foo');
-    expectStaticAttributes(b).toEqual([AttributeMarker.Classes, 'foo']);
   });
 
   it('should generate template name attribute values', () => {
@@ -133,9 +115,9 @@ describe('StaticAttributesBuilder', () => {
 
   it('should generate key/value, class, style and template attribute values', () => {
     const b = new StaticAttributesBuilder();
-    b.registerAttribute('title1', 'titleValue1');
-    b.registerAttribute(':ns:title2', 'titleValue2');
-    b.registerAttribute('title3', 'titleValue3');
+    b.setAttribute('title1', 'titleValue1');
+    b.setAttribute(':ns:title2', 'titleValue2');
+    b.setAttribute('title3', 'titleValue3');
     b.registerBindingName('name1');
     b.registerBindingName('name2');
     b.registerBindingName('name3');

--- a/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
+++ b/packages/compiler/test/render3/view/static_attributes_builder_spec.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AttributeMarker} from '../../../src/core';
+import * as o from '../../../src/output/output_ast';
+import {StaticAttributesBuilder} from '../../../src/render3/view/static_attributes_builder';
+
+describe('StaticAttributesBuilder', () => {
+  it('should generate key/value attribute values', () => {
+    const b = new StaticAttributesBuilder();
+    b.registerAttribute('key1', 'value1');
+    b.registerAttribute('key2', 'value2');
+
+    expectStaticAttributes(b).toEqual([
+      'key1',
+      'value1',
+      'key2',
+      'value2',
+    ]);
+  });
+
+  it('should generate style attribute values', () => {
+    const b = new StaticAttributesBuilder();
+
+    b.setStyleAttribute('width:200px; height:400px');
+    expectStaticAttributes(b).toEqual(
+        [AttributeMarker.Styles, 'width', '200px', 'height', '400px']);
+
+    b.setStyleAttribute('opacity:0.5');
+    expectStaticAttributes(b).toEqual([AttributeMarker.Styles, 'opacity', '0.5']);
+  });
+
+  it('should set the style attribute even if registered as a normal attribute', () => {
+    const b = new StaticAttributesBuilder();
+
+    b.registerAttribute('style', 'z-index:1000');
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.Styles,
+      'z-index',
+      '1000',
+    ]);
+  });
+
+  it('should generate class attribute values', () => {
+    const b = new StaticAttributesBuilder();
+
+    b.setClassAttribute('foo bar baz');
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.Classes,
+      'foo',
+      'bar',
+      'baz',
+    ]);
+
+    b.setClassAttribute('oof');
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.Classes,
+      'oof',
+    ]);
+  });
+
+  it('should set the class attribute even if registered as a normal attribute', () => {
+    const b = new StaticAttributesBuilder();
+
+    b.registerAttribute('class', 'foo');
+    expectStaticAttributes(b).toEqual([AttributeMarker.Classes, 'foo']);
+  });
+
+  it('should generate template name attribute values', () => {
+    const b = new StaticAttributesBuilder();
+    b.registerTemplateName('name1');
+    b.registerTemplateName('name2');
+    b.registerTemplateName('name3');
+
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.Template,
+      'name1',
+      'name2',
+      'name3',
+    ]);
+  });
+
+  it('should generate binding name attribute values', () => {
+    const b = new StaticAttributesBuilder();
+    b.registerBindingName('name1');
+    b.registerBindingName('name2');
+    b.registerBindingName('name3');
+
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.Bindings,
+      'name1',
+      'name2',
+      'name3',
+    ]);
+  });
+
+  it('should generate i18n name attribute values', () => {
+    const b = new StaticAttributesBuilder();
+    b.registerI18nName('name1');
+    b.registerI18nName('name2');
+    b.registerI18nName('name3');
+
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.I18n,
+      'name1',
+      'name2',
+      'name3',
+    ]);
+  });
+
+  it('should generate a projectAs selector value', () => {
+    const b = new StaticAttributesBuilder();
+
+    b.setProjectAsSelector('.my-app');
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.ProjectAs,
+      ['.my-app'],
+    ]);
+
+    b.setProjectAsSelector('.their-app');
+    expectStaticAttributes(b).toEqual([
+      AttributeMarker.ProjectAs,
+      ['.their-app'],
+    ]);
+  });
+
+  it('should generate key/value, class, style and template attribute values', () => {
+    const b = new StaticAttributesBuilder();
+    b.registerAttribute('title1', 'titleValue1');
+    b.registerAttribute(':ns:title2', 'titleValue2');
+    b.registerAttribute('title3', 'titleValue3');
+    b.registerBindingName('name1');
+    b.registerBindingName('name2');
+    b.registerBindingName('name3');
+    b.registerTemplateName('name4');
+    b.registerTemplateName('name5');
+    b.registerTemplateName('name6');
+    b.registerI18nName('name7');
+    b.registerI18nName('name8');
+    b.registerI18nName('name9');
+    b.setClassAttribute('foo bar baz');
+    b.setStyleAttribute('width: 200px; height: 400px');
+    b.setProjectAsSelector('.my-app');
+
+    expectStaticAttributes(b).toEqual([
+      'title1',
+      'titleValue1',
+      AttributeMarker.NamespaceURI,
+      'ns',
+      'title2',
+      'titleValue2',
+      'title3',
+      'titleValue3',
+      AttributeMarker.Classes,
+      'foo',
+      'bar',
+      'baz',
+      AttributeMarker.Styles,
+      'width',
+      '200px',
+      'height',
+      '400px',
+      AttributeMarker.Bindings,
+      'name1',
+      'name2',
+      'name3',
+      AttributeMarker.Template,
+      'name4',
+      'name5',
+      'name6',
+      AttributeMarker.ProjectAs,
+      ['.my-app'],
+      AttributeMarker.I18n,
+      'name7',
+      'name8',
+      'name9',
+    ]);
+  });
+});
+
+function expectStaticAttributes(builder: StaticAttributesBuilder) {
+  return expect(expArrayToRawValues(builder.build()));
+}
+
+function expArrayToRawValues(exp: (o.LiteralExpr | o.LiteralArrayExpr)[]) {
+  return exp.map(entry => {
+    if (entry instanceof o.LiteralArrayExpr) {
+      return entry.entries.map(e => toRawValue(e as o.LiteralExpr));
+    } else {
+      return toRawValue(entry);
+    }
+  });
+}
+
+function toRawValue(exp: o.LiteralExpr): any {
+  return exp.value;
+}

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AttributeBuilder} from '@angular/compiler/src/compiler';
+
 import * as e from '../../../src/expression_parser/ast';
 import {Lexer} from '../../../src/expression_parser/lexer';
 import {Parser} from '../../../src/expression_parser/parser';
@@ -13,6 +15,7 @@ import * as html from '../../../src/ml_parser/ast';
 import {HtmlParser, ParseTreeResult} from '../../../src/ml_parser/html_parser';
 import {WhitespaceVisitor} from '../../../src/ml_parser/html_whitespaces';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
+import * as o from '../../../src/output/output_ast';
 import * as a from '../../../src/render3/r3_ast';
 import {Render3ParseResult, htmlAstToRender3Ast} from '../../../src/render3/r3_template_transform';
 import {I18nMetaVisitor} from '../../../src/render3/view/i18n/meta';
@@ -112,4 +115,19 @@ export function processI18nMeta(
           new I18nMetaVisitor(interpolationConfig, /* keepI18nAttrs */ false),
           htmlAstWithErrors.rootNodes),
       htmlAstWithErrors.errors);
+}
+
+/**
+ * Sets up an assert to test that an array of expressions matches a value
+ */
+export function expectAttributeValues(builder: AttributeBuilder) {
+  return expect(expArrayToRawValues(builder.build()));
+}
+
+function expArrayToRawValues(exp: (o.LiteralExpr | o.LiteralArrayExpr)[]): any[] {
+  return exp.map(entry => {
+    return (entry instanceof o.LiteralArrayExpr) ?
+        expArrayToRawValues(entry.entries as(o.LiteralExpr | o.LiteralArrayExpr)[]) :
+        entry.value;
+  });
 }

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -7,7 +7,6 @@
  */
 
 import {AttributeBuilder} from '@angular/compiler/src/compiler';
-
 import * as e from '../../../src/expression_parser/ast';
 import {Lexer} from '../../../src/expression_parser/lexer';
 import {Parser} from '../../../src/expression_parser/parser';


### PR DESCRIPTION
This patch moves all projection attribute creation code (e.g. attributes,
and ngProjectAs entries) into a shared class which is used by the compiler
code that creates projection instruction code.