### PR TITLE
fix(language-service): The pipe method should not include parentheses

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -469,11 +469,15 @@ class ExpressionVisitor extends NullTemplateVisitor {
       if (s.name.startsWith('__') || !s.public || this.completions.has(s.name)) {
         continue;
       }
+
+      // The pipe method should not include parentheses.
+      // e.g. {{ value_expression | slice : start [ : end ] }}
+      const shouldInsertParentheses = s.callable && s.kind !== ng.CompletionKind.PIPE;
       this.completions.set(s.name, {
         name: s.name,
         kind: s.kind as ng.CompletionKind,
         sortText: s.name,
-        insertText: s.callable ? `${s.name}()` : s.name,
+        insertText: shouldInsertParentheses ? `${s.name}()` : s.name,
       });
     }
   }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -208,6 +208,18 @@ describe('completions', () => {
     }));
   });
 
+  it('for methods of pipe should not include parentheses', () => {
+    mockHost.override(TEST_TEMPLATE, `<h1>{{title | lowe~{pipe-method} }}`);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'pipe-method');
+    const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+    expect(completions).toBeDefined();
+    expect(completions !.entries).toContain(jasmine.objectContaining({
+      name: 'lowercase',
+      kind: CompletionKind.PIPE as any,
+      insertText: 'lowercase',
+    }));
+  });
+
   describe('in external template', () => {
     it('should be able to get entity completions in external template', () => {
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'entity-amp');


### PR DESCRIPTION
The pipe method should not include parentheses.
e.g. `{{ value_expression | slice : start [ : end ] }}`.
https://angular.io/api/common/SlicePipe
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
