### PR TITLE
docs: change in deployment section of getting started

### DIFF
--- a/aio/content/start/deployment.md
+++ b/aio/content/start/deployment.md
@@ -18,7 +18,7 @@ Whether you came here directly from [Your First App](start "Getting Started: You
 StackBlitz projects are public by default, allowing you to share your Angular app via the project URL. Keep in mind that this is a great way to share ideas and prototypes, but it is not intended for production hosting.
 
 1. In your StackBlitz project, make sure you have forked or saved your project.
-1. In the preview pane, you should see a URL that looks like `https://<Project ID>.stackblitz.io`.
+1. In the preview page, you should see a URL that looks like `https://<Project ID>.stackblitz.io`.
 1. Share this URL with a friend or colleague.
 1. Users that visit your URL will see a development server start up, and then your application will load.
 


### PR DESCRIPTION
rename 'pane' to 'page' for better understanding among people

issue: 34400

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 34400

## What is the new behavior?
The 'pane' mentioned in the second line of the "Share Application" area in the "Deployment" page of the "Getting Started" section of the docs, might confuse non-native English speakers with the intent of the actual word. Therefore, updated it to 'page'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
