### PR TITLE
fix(ngcc): capture entry-point dependencies from typings as well as source

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
@@ -27,7 +27,7 @@ export class CommonJsDependencyHost extends DependencyHostBase {
    * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
    * in a circular dependency loop.
    */
-  protected recursivelyFindDependencies(
+  protected recursivelyCollectDependencies(
       file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
       deepImports: Set<AbsoluteFsPath>, alreadySeen: Set<AbsoluteFsPath>): void {
     const fromContents = this.fs.readFile(file);
@@ -53,7 +53,7 @@ export class CommonJsDependencyHost extends DependencyHostBase {
               const internalDependency = resolvedModule.modulePath;
               if (!alreadySeen.has(internalDependency)) {
                 alreadySeen.add(internalDependency);
-                this.recursivelyFindDependencies(
+                this.recursivelyCollectDependencies(
                     internalDependency, dependencies, missing, deepImports, alreadySeen);
               }
             } else {

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -11,7 +11,7 @@ import {resolveFileWithPostfixes} from '../utils';
 import {ModuleResolver} from './module_resolver';
 
 export interface DependencyHost {
-  findDependencies(
+  collectDependencies(
       entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void;
 }
 
@@ -35,7 +35,7 @@ export abstract class DependencyHostBase implements DependencyHost {
    * @returns Information about the dependencies of the entry-point, including those that were
    * missing or deep imports into other entry-points.
    */
-  findDependencies(
+  collectDependencies(
       entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void {
     const resolvedFile =
         resolveFileWithPostfixes(this.fs, entryPointPath, ['', '.js', '/index.js']);

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -11,13 +11,18 @@ import {resolveFileWithPostfixes} from '../utils';
 import {ModuleResolver} from './module_resolver';
 
 export interface DependencyHost {
-  findDependencies(entryPointPath: AbsoluteFsPath): DependencyInfo;
+  findDependencies(
+      entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void;
 }
 
 export interface DependencyInfo {
   dependencies: Set<AbsoluteFsPath>;
   missing: Set<AbsoluteFsPath|PathSegment>;
   deepImports: Set<AbsoluteFsPath>;
+}
+
+export function createDependencyInfo(): DependencyInfo {
+  return {dependencies: new Set(), missing: new Set(), deepImports: new Set()};
 }
 
 export abstract class DependencyHostBase implements DependencyHost {
@@ -30,11 +35,8 @@ export abstract class DependencyHostBase implements DependencyHost {
    * @returns Information about the dependencies of the entry-point, including those that were
    * missing or deep imports into other entry-points.
    */
-  findDependencies(entryPointPath: AbsoluteFsPath): DependencyInfo {
-    const dependencies = new Set<AbsoluteFsPath>();
-    const missing = new Set<AbsoluteFsPath|PathSegment>();
-    const deepImports = new Set<AbsoluteFsPath>();
-
+  findDependencies(
+      entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void {
     const resolvedFile =
         resolveFileWithPostfixes(this.fs, entryPointPath, ['', '.js', '/index.js']);
     if (resolvedFile !== null) {
@@ -42,8 +44,6 @@ export abstract class DependencyHostBase implements DependencyHost {
       this.recursivelyFindDependencies(
           resolvedFile, dependencies, missing, deepImports, alreadySeen);
     }
-
-    return {dependencies, missing, deepImports};
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -32,8 +32,9 @@ export abstract class DependencyHostBase implements DependencyHost {
    * Find all the dependencies for the entry-point at the given path.
    *
    * @param entryPointPath The absolute path to the JavaScript file that represents an entry-point.
-   * @returns Information about the dependencies of the entry-point, including those that were
-   * missing or deep imports into other entry-points.
+   * @param dependencyInfo An object containing information about the dependencies of the
+   * entry-point, including those that were missing or deep imports into other entry-points. The
+   * sets in this object will be updated with new information about the entry-point's dependencies.
    */
   collectDependencies(
       entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void {
@@ -41,7 +42,7 @@ export abstract class DependencyHostBase implements DependencyHost {
         resolveFileWithPostfixes(this.fs, entryPointPath, ['', '.js', '/index.js']);
     if (resolvedFile !== null) {
       const alreadySeen = new Set<AbsoluteFsPath>();
-      this.recursivelyFindDependencies(
+      this.recursivelyCollectDependencies(
           resolvedFile, dependencies, missing, deepImports, alreadySeen);
     }
   }
@@ -58,7 +59,7 @@ export abstract class DependencyHostBase implements DependencyHost {
    * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
    * in a circular dependency loop.
    */
-  protected abstract recursivelyFindDependencies(
+  protected abstract recursivelyCollectDependencies(
       file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
       deepImports: Set<AbsoluteFsPath>, alreadySeen: Set<AbsoluteFsPath>): void;
 }

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -39,7 +39,7 @@ export abstract class DependencyHostBase implements DependencyHost {
   collectDependencies(
       entryPointPath: AbsoluteFsPath, {dependencies, missing, deepImports}: DependencyInfo): void {
     const resolvedFile =
-        resolveFileWithPostfixes(this.fs, entryPointPath, ['', '.js', '/index.js']);
+        resolveFileWithPostfixes(this.fs, entryPointPath, this.moduleResolver.relativeExtensions);
     if (resolvedFile !== null) {
       const alreadySeen = new Set<AbsoluteFsPath>();
       this.recursivelyCollectDependencies(

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -11,7 +11,7 @@ import {AbsoluteFsPath, FileSystem, resolve} from '../../../src/ngtsc/file_syste
 import {Logger} from '../logging/logger';
 import {EntryPoint, EntryPointFormat, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from '../packages/entry_point';
 import {PartiallyOrderedList} from '../utils';
-import {DependencyHost, DependencyInfo} from './dependency_host';
+import {DependencyHost, DependencyInfo, createDependencyInfo} from './dependency_host';
 
 const builtinNodeJsModules = new Set<string>(require('module').builtinModules);
 
@@ -123,7 +123,9 @@ export class DependencyResolver {
       throw new Error(
           `Could not find a suitable format for computing dependencies of entry-point: '${entryPoint.path}'.`);
     }
-    return host.findDependencies(formatInfo.path);
+    const depInfo = createDependencyInfo();
+    host.findDependencies(formatInfo.path, depInfo);
+    return depInfo;
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -124,7 +124,7 @@ export class DependencyResolver {
           `Could not find a suitable format for computing dependencies of entry-point: '${entryPoint.path}'.`);
     }
     const depInfo = createDependencyInfo();
-    host.findDependencies(formatInfo.path, depInfo);
+    host.collectDependencies(formatInfo.path, depInfo);
     return depInfo;
   }
 

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -82,7 +82,8 @@ export interface SortedEntryPointsInfo extends DependencyDiagnostics {
 export class DependencyResolver {
   constructor(
       private fs: FileSystem, private logger: Logger,
-      private hosts: Partial<Record<EntryPointFormat, DependencyHost>>) {}
+      private hosts: Partial<Record<EntryPointFormat, DependencyHost>>,
+      private typingsHost: DependencyHost) {}
   /**
    * Sort the array of entry points so that the dependant entry points always come later than
    * their dependencies in the array.
@@ -125,6 +126,7 @@ export class DependencyResolver {
     }
     const depInfo = createDependencyInfo();
     host.collectDependencies(formatInfo.path, depInfo);
+    this.typingsHost.collectDependencies(entryPoint.typings, depInfo);
     return depInfo;
   }
 

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -26,7 +26,7 @@ export class EsmDependencyHost extends DependencyHostBase {
    * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
    * in a circular dependency loop.
    */
-  protected recursivelyFindDependencies(
+  protected recursivelyCollectDependencies(
       file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
       deepImports: Set<string>, alreadySeen: Set<AbsoluteFsPath>): void {
     const fromContents = this.fs.readFile(file);
@@ -52,7 +52,7 @@ export class EsmDependencyHost extends DependencyHostBase {
               const internalDependency = resolvedModule.modulePath;
               if (!alreadySeen.has(internalDependency)) {
                 alreadySeen.add(internalDependency);
-                this.recursivelyFindDependencies(
+                this.recursivelyCollectDependencies(
                     internalDependency, dependencies, missing, deepImports, alreadySeen);
               }
             } else {

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -24,7 +24,7 @@ import {PathMappings, isRelativePath, resolveFileWithPostfixes} from '../utils';
 export class ModuleResolver {
   private pathMappings: ProcessedPathMapping[];
 
-  constructor(private fs: FileSystem, pathMappings?: PathMappings, private relativeExtensions = [
+  constructor(private fs: FileSystem, pathMappings?: PathMappings, readonly relativeExtensions = [
     '', '.js', '/index.js'
   ]) {
     this.pathMappings = pathMappings ? this.processPathMappings(pathMappings) : [];

--- a/packages/compiler-cli/ngcc/src/dependencies/umd_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/umd_dependency_host.ts
@@ -27,7 +27,7 @@ export class UmdDependencyHost extends DependencyHostBase {
    * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
    * in a circular dependency loop.
    */
-  protected recursivelyFindDependencies(
+  protected recursivelyCollectDependencies(
       file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
       deepImports: Set<string>, alreadySeen: Set<AbsoluteFsPath>): void {
     const fromContents = this.fs.readFile(file);
@@ -58,7 +58,7 @@ export class UmdDependencyHost extends DependencyHostBase {
           const internalDependency = resolvedModule.modulePath;
           if (!alreadySeen.has(internalDependency)) {
             alreadySeen.add(internalDependency);
-            this.recursivelyFindDependencies(
+            this.recursivelyCollectDependencies(
                 internalDependency, dependencies, missing, deepImports, alreadySeen);
           }
         } else {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -35,7 +35,7 @@ import {NgccConfiguration} from './packages/configuration';
 import {EntryPoint, EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
 import {makeEntryPointBundle} from './packages/entry_point_bundle';
 import {Transformer} from './packages/transformer';
-import {PathMappings} from './utils';
+import {PathMappings, createDtsDependencyHost} from './utils';
 import {FileWriter} from './writing/file_writer';
 import {InPlaceFileWriter} from './writing/in_place_file_writer';
 import {NewEntryPointFileWriter} from './writing/new_entry_point_file_writer';
@@ -164,8 +164,7 @@ export function mainNgcc(
     const esmDependencyHost = new EsmDependencyHost(fileSystem, moduleResolver);
     const umdDependencyHost = new UmdDependencyHost(fileSystem, moduleResolver);
     const commonJsDependencyHost = new CommonJsDependencyHost(fileSystem, moduleResolver);
-    const dtsDependencyHost = new EsmDependencyHost(
-        fileSystem, new ModuleResolver(fileSystem, pathMappings, ['', '.d.ts', '/index.d.ts']));
+    const dtsDependencyHost = createDtsDependencyHost(fileSystem, pathMappings);
     const dependencyResolver = new DependencyResolver(
         fileSystem, logger, {
           esm5: esmDependencyHost,

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -164,12 +164,16 @@ export function mainNgcc(
     const esmDependencyHost = new EsmDependencyHost(fileSystem, moduleResolver);
     const umdDependencyHost = new UmdDependencyHost(fileSystem, moduleResolver);
     const commonJsDependencyHost = new CommonJsDependencyHost(fileSystem, moduleResolver);
-    const dependencyResolver = new DependencyResolver(fileSystem, logger, {
-      esm5: esmDependencyHost,
-      esm2015: esmDependencyHost,
-      umd: umdDependencyHost,
-      commonjs: commonJsDependencyHost
-    });
+    const dtsDependencyHost = new EsmDependencyHost(
+        fileSystem, new ModuleResolver(fileSystem, pathMappings, ['', '.d.ts', '/index.d.ts']));
+    const dependencyResolver = new DependencyResolver(
+        fileSystem, logger, {
+          esm5: esmDependencyHost,
+          esm2015: esmDependencyHost,
+          umd: umdDependencyHost,
+          commonjs: commonJsDependencyHost
+        },
+        dtsDependencyHost);
 
     const absBasePath = absoluteFrom(basePath);
     const config = new NgccConfiguration(fileSystem, dirname(absBasePath));

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -7,6 +7,8 @@
  */
 import * as ts from 'typescript';
 import {AbsoluteFsPath, FileSystem, absoluteFrom} from '../../src/ngtsc/file_system';
+import {EsmDependencyHost} from './dependencies/esm_dependency_host';
+import {ModuleResolver} from './dependencies/module_resolver';
 
 /**
  * A list (`Array`) of partially ordered `T` items.
@@ -118,4 +120,9 @@ export function stripDollarSuffix(value: string): string {
 
 export function stripExtension(fileName: string): string {
   return fileName.replace(/\..+$/, '');
+}
+
+export function createDtsDependencyHost(fileSystem: FileSystem, pathMappings?: PathMappings) {
+  return new EsmDependencyHost(
+      fileSystem, new ModuleResolver(fileSystem, pathMappings, ['', '.d.ts', '/index.d.ts']));
 }

--- a/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
@@ -117,13 +117,13 @@ runInEachFileSystem(() => {
     describe('getDependencies()', () => {
       it('should not generate a TS AST if the source does not contain any require calls', () => {
         spyOn(ts, 'createSourceFile');
-        host.findDependencies(_('/no/imports/or/re-exports/index.js'), createDependencyInfo());
+        host.collectDependencies(_('/no/imports/or/re-exports/index.js'), createDependencyInfo());
         expect(ts.createSourceFile).not.toHaveBeenCalled();
       });
 
       it('should resolve all the external imports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/imports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
@@ -134,7 +134,7 @@ runInEachFileSystem(() => {
 
       it('should resolve all the external re-exports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/re-exports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
@@ -145,7 +145,7 @@ runInEachFileSystem(() => {
 
       it('should capture missing external imports', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/imports-missing/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
@@ -160,7 +160,7 @@ runInEachFileSystem(() => {
         // is found that does not map to an entry-point but still exists on disk, i.e. a deep
         // import. Such deep imports are captured for diagnostics purposes.
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/deep-import/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(0);
@@ -171,7 +171,8 @@ runInEachFileSystem(() => {
 
       it('should recurse into internal dependencies', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/internal/outer/index.js'), {dependencies, missing, deepImports});
+        host.collectDependencies(
+            _('/internal/outer/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib_1/sub_1'))).toBe(true);
@@ -181,7 +182,7 @@ runInEachFileSystem(() => {
 
       it('should handle circular internal dependencies', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/internal/circular_a/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(dependencies.has(_('/node_modules/lib_1'))).toBe(true);
@@ -200,7 +201,7 @@ runInEachFileSystem(() => {
                                             }
                                           }));
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
+        host.collectDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(4);
         expect(dependencies.has(_('/dist/components'))).toBe(true);
         expect(dependencies.has(_('/dist/shared'))).toBe(true);
@@ -212,7 +213,8 @@ runInEachFileSystem(() => {
 
       it('should handle entry-point paths with no extension', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/external/imports/index'), {dependencies, missing, deepImports});
+        host.collectDependencies(
+            _('/external/imports/index'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);

--- a/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/commonjs_dependency_host_spec.ts
@@ -10,6 +10,7 @@ import {absoluteFrom, getFileSystem, relativeFrom} from '../../../src/ngtsc/file
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {CommonJsDependencyHost} from '../../src/dependencies/commonjs_dependency_host';
+import {createDependencyInfo} from '../../src/dependencies/dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 
 runInEachFileSystem(() => {
@@ -116,13 +117,14 @@ runInEachFileSystem(() => {
     describe('getDependencies()', () => {
       it('should not generate a TS AST if the source does not contain any require calls', () => {
         spyOn(ts, 'createSourceFile');
-        host.findDependencies(_('/no/imports/or/re-exports/index.js'));
+        host.findDependencies(_('/no/imports/or/re-exports/index.js'), createDependencyInfo());
         expect(ts.createSourceFile).not.toHaveBeenCalled();
       });
 
       it('should resolve all the external imports of the source file', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/imports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);
@@ -131,8 +133,9 @@ runInEachFileSystem(() => {
       });
 
       it('should resolve all the external re-exports of the source file', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/re-exports/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/re-exports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);
@@ -141,8 +144,9 @@ runInEachFileSystem(() => {
       });
 
       it('should capture missing external imports', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports-missing/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/imports-missing/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib_1'))).toBe(true);
@@ -155,8 +159,9 @@ runInEachFileSystem(() => {
         // This scenario verifies the behavior of the dependency analysis when an external import
         // is found that does not map to an entry-point but still exists on disk, i.e. a deep
         // import. Such deep imports are captured for diagnostics purposes.
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/deep-import/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/deep-import/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(0);
         expect(missing.size).toBe(0);
@@ -165,8 +170,8 @@ runInEachFileSystem(() => {
       });
 
       it('should recurse into internal dependencies', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/internal/outer/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/internal/outer/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib_1/sub_1'))).toBe(true);
@@ -175,8 +180,9 @@ runInEachFileSystem(() => {
       });
 
       it('should handle circular internal dependencies', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/internal/circular_a/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/internal/circular_a/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(dependencies.has(_('/node_modules/lib_1'))).toBe(true);
         expect(dependencies.has(_('/node_modules/lib_1/sub_1'))).toBe(true);
@@ -193,8 +199,8 @@ runInEachFileSystem(() => {
                                               '@lib/*/test': ['lib/*/test'],
                                             }
                                           }));
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/path-alias/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(4);
         expect(dependencies.has(_('/dist/components'))).toBe(true);
         expect(dependencies.has(_('/dist/shared'))).toBe(true);
@@ -205,8 +211,8 @@ runInEachFileSystem(() => {
       });
 
       it('should handle entry-point paths with no extension', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports/index'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/external/imports/index'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -15,6 +15,7 @@ import {DependencyResolver, SortedEntryPointsInfo} from '../../src/dependencies/
 import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {EntryPoint} from '../../src/packages/entry_point';
+import {createDtsDependencyHost} from '../../src/utils';
 import {MockLogger} from '../helpers/mock_logger';
 
 
@@ -26,6 +27,7 @@ runInEachFileSystem(() => {
   describe('DependencyResolver', () => {
     let _: typeof absoluteFrom;
     let host: EsmDependencyHost;
+    let dtsHost: EsmDependencyHost;
     let resolver: DependencyResolver;
     let fs: FileSystem;
     let moduleResolver: ModuleResolver;
@@ -35,7 +37,8 @@ runInEachFileSystem(() => {
       fs = getFileSystem();
       moduleResolver = new ModuleResolver(fs);
       host = new EsmDependencyHost(fs, moduleResolver);
-      resolver = new DependencyResolver(fs, new MockLogger(), {esm5: host, esm2015: host}, host);
+      dtsHost = createDtsDependencyHost(fs);
+      resolver = new DependencyResolver(fs, new MockLogger(), {esm5: host, esm2015: host}, dtsHost);
     });
 
     describe('sortEntryPointsByDependency()', () => {
@@ -46,6 +49,7 @@ runInEachFileSystem(() => {
       let fifth: EntryPoint;
       let sixthIgnoreMissing: EntryPoint;
       let dependencies: DepMap;
+      let dtsDependencies: DepMap;
 
       beforeEach(() => {
         first = {
@@ -99,6 +103,8 @@ runInEachFileSystem(() => {
           [_('/third/index.js')]: {resolved: [fourth.path, _('/ignored-2')], missing: []},
           [_('/fourth/sub2/index.js')]: {resolved: [fifth.path], missing: []},
           [_('/fifth/index.js')]: {resolved: [], missing: []},
+        };
+        dtsDependencies = {
           [_('/first/index.d.ts')]:
               {resolved: [second.path, third.path, _('/ignored-1')], missing: []},
           [_('/second/sub/index.d.ts')]: {resolved: [third.path, fifth.path], missing: []},
@@ -111,6 +117,8 @@ runInEachFileSystem(() => {
       it('should order the entry points by their dependency on each other', () => {
         spyOn(host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
+        spyOn(dtsHost, 'collectDependencies')
+            .and.callFake(createFakeComputeDependencies(dtsDependencies));
         const result = resolver.sortEntryPointsByDependency([fifth, first, fourth, second, third]);
         expect(result.entryPoints).toEqual([fifth, fourth, third, second, first]);
       });
@@ -119,6 +127,8 @@ runInEachFileSystem(() => {
         spyOn(host, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.js')]: {resolved: [], missing: [_('/missing')]},
           [_('/second/sub/index.js')]: {resolved: [], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
           [_('/second/sub/index.d.ts')]: {resolved: [], missing: []},
         }));
@@ -134,6 +144,8 @@ runInEachFileSystem(() => {
           [_('/first/index.js')]: {resolved: [second.path, third.path], missing: []},
           [_('/second/sub/index.js')]: {resolved: [], missing: [_('/missing')]},
           [_('/third/index.js')]: {resolved: [], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [second.path, third.path], missing: []},
           [_('/second/sub/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
           [_('/third/index.d.ts')]: {resolved: [], missing: []},
@@ -152,6 +164,8 @@ runInEachFileSystem(() => {
           [_('/first/index.js')]: {resolved: [second.path, third.path], missing: []},
           [_('/second/sub/index.js')]: {resolved: [], missing: [_('/missing')]},
           [_('/third/index.js')]: {resolved: [], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [second.path, third.path], missing: []},
           [_('/second/sub/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
           [_('/third/index.d.ts')]: {resolved: [], missing: []},
@@ -170,6 +184,8 @@ runInEachFileSystem(() => {
            spyOn(host, 'collectDependencies').and.callFake(createFakeComputeDependencies({
              [_('/first/index.js')]: {resolved: [sixthIgnoreMissing.path], missing: []},
              [_('/sixth/index.js')]: {resolved: [], missing: [_('/missing')]},
+           }));
+           spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
              [_('/first/index.d.ts')]: {resolved: [sixthIgnoreMissing.path], missing: []},
              [_('/sixth/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
            }));
@@ -184,6 +200,8 @@ runInEachFileSystem(() => {
           [_('/first/index.js')]: {resolved: [], missing: [_('/missing')]},
           [_('/second/sub/index.js')]: {resolved: [first.path], missing: []},
           [_('/sixth/index.js')]: {resolved: [second.path], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
           [_('/second/sub/index.d.ts')]: {resolved: [first.path], missing: []},
           [_('/sixth/index.d.ts')]: {resolved: [second.path], missing: []},
@@ -199,6 +217,8 @@ runInEachFileSystem(() => {
           [_('/first/index.js')]: {resolved: [], missing: [_('/missing1')]},
           [_('/second/sub/index.js')]: {resolved: [], missing: [_('/missing2')]},
           [_('/third/index.js')]: {resolved: [first.path, second.path], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: [_('/missing1')]},
           [_('/second/sub/index.d.ts')]: {resolved: [], missing: [_('/missing2')]},
           [_('/third/index.d.ts')]: {resolved: [first.path, second.path], missing: []},
@@ -228,6 +248,8 @@ runInEachFileSystem(() => {
       it('should capture any dependencies that were ignored', () => {
         spyOn(host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
+        spyOn(dtsHost, 'collectDependencies')
+            .and.callFake(createFakeComputeDependencies(dtsDependencies));
         const result = resolver.sortEntryPointsByDependency([fifth, first, fourth, second, third]);
         expect(result.ignoredDependencies).toEqual([
           {entryPoint: first, dependencyPath: _('/ignored-1')},
@@ -238,6 +260,8 @@ runInEachFileSystem(() => {
       it('should return the computed dependency graph', () => {
         spyOn(host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
+        spyOn(dtsHost, 'collectDependencies')
+            .and.callFake(createFakeComputeDependencies(dtsDependencies));
         const result = resolver.sortEntryPointsByDependency([fifth, first, fourth, second, third]);
 
         expect(result.graph).toEqual(jasmine.any(DepGraph));
@@ -248,6 +272,8 @@ runInEachFileSystem(() => {
       it('should only return dependencies of the target, if provided', () => {
         spyOn(host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
+        spyOn(dtsHost, 'collectDependencies')
+            .and.callFake(createFakeComputeDependencies(dtsDependencies));
         const entryPoints = [fifth, first, fourth, second, third];
         let sorted: SortedEntryPointsInfo;
 
@@ -266,6 +292,8 @@ runInEachFileSystem(() => {
       it('should not process the provided target if it has missing dependencies', () => {
         spyOn(host, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.js')]: {resolved: [], missing: [_('/missing')]},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: [_('/missing')]},
         }));
         const entryPoints = [first];
@@ -280,6 +308,8 @@ runInEachFileSystem(() => {
       it('should not consider builtin NodeJS modules as missing dependency', () => {
         spyOn(host, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.js')]: {resolved: [], missing: ['fs']},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: ['fs']},
         }));
         const entryPoints = [first];
@@ -294,12 +324,15 @@ runInEachFileSystem(() => {
       it('should use the appropriate DependencyHost for each entry-point', () => {
         const esm5Host = new EsmDependencyHost(fs, moduleResolver);
         const esm2015Host = new EsmDependencyHost(fs, moduleResolver);
+        const dtsHost = createDtsDependencyHost(fs);
         resolver = new DependencyResolver(
-            fs, new MockLogger(), {esm5: esm5Host, esm2015: esm2015Host}, esm2015Host);
+            fs, new MockLogger(), {esm5: esm5Host, esm2015: esm2015Host}, dtsHost);
         spyOn(esm5Host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
         spyOn(esm2015Host, 'collectDependencies')
             .and.callFake(createFakeComputeDependencies(dependencies));
+        spyOn(dtsHost, 'collectDependencies')
+            .and.callFake(createFakeComputeDependencies(dtsDependencies));
         const result = resolver.sortEntryPointsByDependency([fifth, first, fourth, second, third]);
         expect(result.entryPoints).toEqual([fifth, fourth, third, second, first]);
 
@@ -325,6 +358,17 @@ runInEachFileSystem(() => {
             .toHaveBeenCalledWith(fs.resolve(fourth.path, 'sub2/index.js'), jasmine.any(Object));
         expect(esm2015Host.collectDependencies)
             .not.toHaveBeenCalledWith(fs.resolve(fifth.path, 'index.js'), jasmine.any(Object));
+
+        expect(dtsHost.collectDependencies)
+            .toHaveBeenCalledWith(fs.resolve(first.path, 'index.d.ts'), jasmine.any(Object));
+        expect(dtsHost.collectDependencies)
+            .toHaveBeenCalledWith(fs.resolve(second.path, 'sub/index.d.ts'), jasmine.any(Object));
+        expect(dtsHost.collectDependencies)
+            .toHaveBeenCalledWith(fs.resolve(third.path, 'index.d.ts'), jasmine.any(Object));
+        expect(dtsHost.collectDependencies)
+            .toHaveBeenCalledWith(fs.resolve(fourth.path, 'sub2/index.d.ts'), jasmine.any(Object));
+        expect(dtsHost.collectDependencies)
+            .toHaveBeenCalledWith(fs.resolve(fifth.path, 'index.d.ts'), jasmine.any(Object));
       });
 
       it('should merge "typings-only" dependencies with source dependencies', () => {
@@ -332,6 +376,8 @@ runInEachFileSystem(() => {
           [_('/first/index.js')]: {resolved: [], missing: []},
           [_('/second/sub/index.js')]: {resolved: [], missing: [_('/missing1')]},
           [_('/third/index.js')]: {resolved: [first.path], missing: []},
+        }));
+        spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
           [_('/first/index.d.ts')]: {resolved: [], missing: []},
           [_('/second/sub/index.d.ts')]: {resolved: [], missing: [_('/missing2')]},
           [_('/third/index.d.ts')]: {resolved: [second.path], missing: []},

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -152,7 +152,7 @@ runInEachFileSystem(() => {
         // Default JS mode will not pick up `internal-typings.d.ts` dependency
         const jsHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
         const jsDeps = createDependencyInfo();
-        jsHost.findDependencies(_('/external/index.d.ts'), jsDeps);
+        jsHost.collectDependencies(_('/external/index.d.ts'), jsDeps);
         expect(jsDeps.dependencies.size).toEqual(0);
         expect(jsDeps.deepImports.size).toEqual(0);
         expect(jsDeps.missing.size).toEqual(1);
@@ -162,7 +162,7 @@ runInEachFileSystem(() => {
         const dtsHost = new EsmDependencyHost(
             fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
         const dtsDeps = createDependencyInfo();
-        dtsHost.findDependencies(_('/external/index.d.ts'), dtsDeps);
+        dtsHost.collectDependencies(_('/external/index.d.ts'), dtsDeps);
         expect(dtsDeps.dependencies.size).toEqual(2);
         expect(dtsDeps.dependencies.has(_('/node_modules/lib-1'))).toBeTruthy();
         expect(dtsDeps.dependencies.has(_('/node_modules/lib-1/sub-1'))).toBeTruthy();

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -13,6 +13,7 @@ import {loadTestFiles} from '../../../test/helpers';
 import {createDependencyInfo} from '../../src/dependencies/dependency_host';
 import {EsmDependencyHost, hasImportOrReexportStatements, isStringImportOrReexport} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
+import {createDtsDependencyHost} from '../../src/utils';
 
 runInEachFileSystem(() => {
 
@@ -159,8 +160,7 @@ runInEachFileSystem(() => {
         expect(jsDeps.missing.has(relativeFrom('./internal-typings'))).toBeTruthy();
 
         // Typings mode will pick up `internal-typings.d.ts` dependency
-        const dtsHost = new EsmDependencyHost(
-            fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
+        const dtsHost = createDtsDependencyHost(fs);
         const dtsDeps = createDependencyInfo();
         dtsHost.collectDependencies(_('/external/index.d.ts'), dtsDeps);
         expect(dtsDeps.dependencies.size).toEqual(2);

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -30,13 +30,14 @@ runInEachFileSystem(() => {
       it('should not generate a TS AST if the source does not contain any imports or re-exports',
          () => {
            spyOn(ts, 'createSourceFile');
-           host.findDependencies(_('/no/imports/or/re-exports/index.js'), createDependencyInfo());
+           host.collectDependencies(
+               _('/no/imports/or/re-exports/index.js'), createDependencyInfo());
            expect(ts.createSourceFile).not.toHaveBeenCalled();
          });
 
       it('should resolve all the external imports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/imports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
@@ -47,7 +48,7 @@ runInEachFileSystem(() => {
 
       it('should resolve all the external re-exports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/re-exports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
@@ -58,7 +59,7 @@ runInEachFileSystem(() => {
 
       it('should capture missing external imports', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/imports-missing/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
@@ -73,7 +74,7 @@ runInEachFileSystem(() => {
         // is found that does not map to an entry-point but still exists on disk, i.e. a deep
         // import. Such deep imports are captured for diagnostics purposes.
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/external/deep-import/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(0);
@@ -84,7 +85,8 @@ runInEachFileSystem(() => {
 
       it('should recurse into internal dependencies', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/internal/outer/index.js'), {dependencies, missing, deepImports});
+        host.collectDependencies(
+            _('/internal/outer/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
@@ -94,7 +96,7 @@ runInEachFileSystem(() => {
 
       it('should handle circular internal dependencies', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(
+        host.collectDependencies(
             _('/internal/circular-a/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(dependencies.has(_('/node_modules/lib-1'))).toBe(true);
@@ -113,7 +115,7 @@ runInEachFileSystem(() => {
                                        }
                                      }));
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
+        host.collectDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(4);
         expect(dependencies.has(_('/dist/components'))).toBe(true);
         expect(dependencies.has(_('/dist/shared'))).toBe(true);
@@ -125,7 +127,8 @@ runInEachFileSystem(() => {
 
       it('should handle entry-point paths with no extension', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.findDependencies(_('/external/imports/index'), {dependencies, missing, deepImports});
+        host.collectDependencies(
+            _('/external/imports/index'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);

--- a/packages/compiler-cli/ngcc/test/dependencies/umd_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/umd_dependency_host_spec.ts
@@ -10,6 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, relativeFrom} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
+import {createDependencyInfo} from '../../src/dependencies/dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {UmdDependencyHost} from '../../src/dependencies/umd_dependency_host';
 
@@ -28,13 +29,14 @@ runInEachFileSystem(() => {
     describe('getDependencies()', () => {
       it('should not generate a TS AST if the source does not contain any require calls', () => {
         spyOn(ts, 'createSourceFile');
-        host.findDependencies(_('/no/imports/or/re-exports/index.js'));
+        host.findDependencies(_('/no/imports/or/re-exports/index.js'), createDependencyInfo());
         expect(ts.createSourceFile).not.toHaveBeenCalled();
       });
 
       it('should resolve all the external imports of the source file', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/imports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);
@@ -43,8 +45,9 @@ runInEachFileSystem(() => {
       });
 
       it('should resolve all the external re-exports of the source file', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/re-exports/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/re-exports/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);
@@ -53,8 +56,9 @@ runInEachFileSystem(() => {
       });
 
       it('should capture missing external imports', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports-missing/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/imports-missing/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib_1'))).toBe(true);
@@ -67,8 +71,9 @@ runInEachFileSystem(() => {
         // This scenario verifies the behavior of the dependency analysis when an external import
         // is found that does not map to an entry-point but still exists on disk, i.e. a deep
         // import. Such deep imports are captured for diagnostics purposes.
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/deep-import/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/external/deep-import/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(0);
         expect(missing.size).toBe(0);
@@ -77,8 +82,8 @@ runInEachFileSystem(() => {
       });
 
       it('should recurse into internal dependencies', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/internal/outer/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/internal/outer/index.js'), {dependencies, missing, deepImports});
 
         expect(dependencies.size).toBe(1);
         expect(dependencies.has(_('/node_modules/lib_1/sub_1'))).toBe(true);
@@ -87,8 +92,9 @@ runInEachFileSystem(() => {
       });
 
       it('should handle circular internal dependencies', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/internal/circular_a/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(
+            _('/internal/circular_a/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(dependencies.has(_('/node_modules/lib_1'))).toBe(true);
         expect(dependencies.has(_('/node_modules/lib_1/sub_1'))).toBe(true);
@@ -105,8 +111,8 @@ runInEachFileSystem(() => {
                                          '@lib/*/test': ['lib/*/test'],
                                        }
                                      }));
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/path-alias/index.js'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/path-alias/index.js'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(4);
         expect(dependencies.has(_('/dist/components'))).toBe(true);
         expect(dependencies.has(_('/dist/shared'))).toBe(true);
@@ -117,8 +123,8 @@ runInEachFileSystem(() => {
       });
 
       it('should handle entry-point paths with no extension', () => {
-        const {dependencies, missing, deepImports} =
-            host.findDependencies(_('/external/imports/index'));
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.findDependencies(_('/external/imports/index'), {dependencies, missing, deepImports});
         expect(dependencies.size).toBe(2);
         expect(missing.size).toBe(0);
         expect(deepImports.size).toBe(0);

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -29,8 +29,10 @@ runInEachFileSystem(() => {
       fs = getFileSystem();
       _Abs = absoluteFrom;
       logger = new MockLogger();
-      resolver = new DependencyResolver(
-          fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs))});
+      const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
+      const dtsHost =
+          new EsmDependencyHost(fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
+      resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
     });
 
@@ -152,8 +154,10 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist/pkg2/node_modules'), 'pkg4'),
           ...createPackage(_Abs('/path_mapped/dist/lib/pkg3'), 'test'),
         ]);
-        resolver = new DependencyResolver(
-            fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings))});
+        const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
+        const dtsHost = new EsmDependencyHost(
+            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();
@@ -179,8 +183,10 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/node_modules'), 'test', []),
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg2'),
         ]);
-        resolver = new DependencyResolver(
-            fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings))});
+        const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
+        const dtsHost = new EsmDependencyHost(
+            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -14,7 +14,7 @@ import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {DirectoryWalkerEntryPointFinder} from '../../src/entry_point_finder/directory_walker_entry_point_finder';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
-import {PathMappings} from '../../src/utils';
+import {PathMappings, createDtsDependencyHost} from '../../src/utils';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {
@@ -30,8 +30,7 @@ runInEachFileSystem(() => {
       _Abs = absoluteFrom;
       logger = new MockLogger();
       const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
-      const dtsHost =
-          new EsmDependencyHost(fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
+      const dtsHost = createDtsDependencyHost(fs);
       resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
     });
@@ -155,8 +154,7 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist/lib/pkg3'), 'test'),
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
-        const dtsHost = new EsmDependencyHost(
-            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        const dtsHost = createDtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);
@@ -184,8 +182,7 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg2'),
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
-        const dtsHost = new EsmDependencyHost(
-            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        const dtsHost = createDtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -14,7 +14,7 @@ import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {TargetedEntryPointFinder} from '../../src/entry_point_finder/targeted_entry_point_finder';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
-import {PathMappings} from '../../src/utils';
+import {PathMappings, createDtsDependencyHost} from '../../src/utils';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {
@@ -30,8 +30,7 @@ runInEachFileSystem(() => {
       _Abs = absoluteFrom;
       logger = new MockLogger();
       const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
-      const dtsHost =
-          new EsmDependencyHost(fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
+      const dtsHost = createDtsDependencyHost(fs);
       resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
     });
@@ -187,8 +186,7 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg5'),
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
-        const dtsHost = new EsmDependencyHost(
-            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        const dtsHost = createDtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);
@@ -218,8 +216,7 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg2'),
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
-        const dtsHost = new EsmDependencyHost(
-            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        const dtsHost = createDtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -29,8 +29,10 @@ runInEachFileSystem(() => {
       fs = getFileSystem();
       _Abs = absoluteFrom;
       logger = new MockLogger();
-      resolver = new DependencyResolver(
-          fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs))});
+      const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
+      const dtsHost =
+          new EsmDependencyHost(fs, new ModuleResolver(fs, undefined, ['', '.d.ts', 'index.d.ts']));
+      resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
     });
 
@@ -184,8 +186,10 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/dist/lib/pkg3'), 'test'),
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg5'),
         ]);
-        resolver = new DependencyResolver(
-            fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings))});
+        const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
+        const dtsHost = new EsmDependencyHost(
+            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();
@@ -213,8 +217,10 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/path_mapped/node_modules'), 'test', []),
           ...createPackage(_Abs('/path_mapped/dist'), 'pkg2'),
         ]);
-        resolver = new DependencyResolver(
-            fs, logger, {esm2015: new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings))});
+        const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
+        const dtsHost = new EsmDependencyHost(
+            fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', 'index.d.ts']));
+        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();


### PR DESCRIPTION
See FW-1781 for the background

Fixes #34411