### PR TITLE
fix(ivy): do not reset view dirty state in check no changes mode

### DIFF
--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -9,10 +9,10 @@
 
 import {CommonModule} from '@angular/common';
 import {ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, Directive, DoCheck, EmbeddedViewRef, ErrorHandler, Input, NgModule, OnInit, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
-import {AfterContentChecked, AfterViewChecked} from '@angular/core/src/core';
+import {AfterViewChecked} from '@angular/core/src/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
+import {ivyEnabled} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
 describe('change detection', () => {
@@ -1247,6 +1247,105 @@ describe('change detection', () => {
       log.length = 0;
       expect(trim(fixture.nativeElement.textContent)).toEqual('InsertComp(Hello) Hello Angular!');
     });
+  });
+
+  describe('OnPush markForCheck in lifecycle hooks', () => {
+    describe('with check no changes enabled', () => createOnPushMarkForCheckTests(true));
+    describe('with check no changes disabled', () => createOnPushMarkForCheckTests(false));
+
+    function createOnPushMarkForCheckTests(checkNoChanges: boolean) {
+      const detectChanges = (f: ComponentFixture<any>) => f.detectChanges(checkNoChanges);
+
+      // 1. ngAfterViewInit and ngAfterViewChecked lifecycle hooks run after "OnPushComp" has
+      //    been refreshed. They can mark the component as dirty. Meaning that the "OnPushComp"
+      //    can be checked/refreshed in a subsequent change detection cycle.
+      // 2. ngDoCheck and ngAfterContentChecked lifecycle hooks run before "OnPushComp" is
+      //    refreshed. This means that those hooks cannot leave the component as dirty because
+      //    the dirty state is reset afterwards. Though these hooks run every change detection
+      //    cycle before "OnPushComp" is considered for refreshing. Hence marking as dirty from
+      //    within such a hook can cause the component to checked/refreshed as intended.
+      ['ngAfterViewInit', 'ngAfterViewChecked', 'ngAfterContentChecked', 'ngDoCheck'].forEach(
+          hookName => {
+            it(`should be able to mark component as dirty from within ${hookName}`, () => {
+              @Component({
+                selector: 'on-push-comp',
+                changeDetection: ChangeDetectionStrategy.OnPush,
+                template: `<p>{{text}}</p>`,
+              })
+              class OnPushComp {
+                text = 'initial';
+
+                constructor(private _cdRef: ChangeDetectorRef){}
+
+                    [hookName]() {
+                  this._cdRef.markForCheck();
+                }
+              }
+
+              @Component({template: `<on-push-comp></on-push-comp>`})
+              class TestApp {
+                @ViewChild(OnPushComp) onPushComp !: OnPushComp;
+              }
+
+              TestBed.configureTestingModule(
+                  {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
+              const fixture = TestBed.createComponent(TestApp);
+              const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
+
+              detectChanges(fixture);
+              expect(pElement.textContent).toBe('initial');
+
+              // "OnPushComp" component should be re-checked since it has been left dirty
+              // in the first change detection (through the lifecycle hook). Hence, setting
+              // a programmatic value and triggering a new change detection cycle should cause
+              // the text to be updated in the view.
+              fixture.componentInstance.onPushComp.text = 'new';
+              detectChanges(fixture);
+              expect(pElement.textContent).toBe('new');
+            });
+          });
+
+      // ngOnInit and ngAfterContentInit lifecycle hooks run once before "OnPushComp" is
+      // refreshed/checked. This means they cannot mark the component as dirty because the
+      // component dirty state will immediately reset after these hooks complete.
+      ['ngOnInit', 'ngAfterContentInit'].forEach(hookName => {
+        it(`should not be able to mark component as dirty from within ${hookName}`, () => {
+          @Component({
+            selector: 'on-push-comp',
+            changeDetection: ChangeDetectionStrategy.OnPush,
+            template: `<p>{{text}}</p>`,
+          })
+          class OnPushComp {
+            text = 'initial';
+
+            constructor(private _cdRef: ChangeDetectorRef){}
+
+                [hookName]() {
+              this._cdRef.markForCheck();
+            }
+          }
+
+          @Component({template: `<on-push-comp></on-push-comp>`})
+          class TestApp {
+            @ViewChild(OnPushComp) onPushComp !: OnPushComp;
+          }
+
+          TestBed.configureTestingModule(
+              {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
+          const fixture = TestBed.createComponent(TestApp);
+          const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
+
+          detectChanges(fixture);
+          expect(pElement.textContent).toBe('initial');
+
+          fixture.componentInstance.onPushComp.text = 'new';
+          // this is a noop since the "OnPushComp" component is not marked as dirty. The
+          // programmatically updated value will not be reflected in the rendered view.
+          detectChanges(fixture);
+          expect(pElement.textContent).toBe('initial');
+        });
+      });
+    }
   });
 
   describe('ExpressionChangedAfterItHasBeenCheckedError', () => {

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -9,7 +9,6 @@ import {CommonModule} from '@angular/common';
 import {Component, ContentChild, Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, NgModule, OnInit, Output, Pipe, QueryList, TemplateRef, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
 import {TVIEW} from '@angular/core/src/render3/interfaces/view';
 import {getLView} from '@angular/core/src/render3/state';
-import {loadLContext} from '@angular/core/src/render3/util/discovery_utils';
 import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';


### PR DESCRIPTION
In Ivy we currently also reset the dirty state of components in the check
no changes change detection cycle. This is not the case in View Engine.

This behavior in Ivy results in inconsistencies and unpredictable behavior of
components using the `OnPush` change detection strategy. One example
is that components can no longer be marked as dirty from view lifecycle hooks
because the dirty flag is reset afterwards in the check-no-changes CD cycle.

Resolves FW-1354. Fixes #34471 