### PR TITLE
docs(ivy): minor changes to version 9 guide

### DIFF
--- a/aio/content/guide/ivy-compatibility-examples.md
+++ b/aio/content/guide/ivy-compatibility-examples.md
@@ -31,7 +31,7 @@ With Ivy, that `<div>` does not match because it is not a direct child of `<comp
 
 By default, `@ContentChildren` queries have the `descendants` flag set to `false`. 
 
-Previously, "descendants" referred to "descendant directives". 
+In the previous rendering engine, "descendants" referred to "descendant directives". 
 An element could be a match as long as there were no other directives between the element and the requesting directive.
 This made sense for directives with nesting like tabs, where nested tab directives might not be desirable to match.
 However, this caused surprising behavior for users because adding an unrelated directive like `ngClass` to a wrapper element could invalidate query results.
@@ -81,6 +81,21 @@ Because the previous behavior was inconsistent and surprising to users, we did n
 Instead, we simplified the mental model so that "descendants" refers to DOM nesting only. 
 Any DOM element between the requesting component and a potential match will invalidate that match.
 Type predicates and string predicates also have identical matching behavior.
+
+Ivy behavior for directive/string predicates:
+```
+<tab-list>
+  <div>
+    <tab> One </tab>     <!-- not a match (nested in element) -->
+  </div>
+  <tab>                  <!-- match (top level) -->
+    <tab> A </tab>       <!-- not a match (nested in tab) -->
+  </tab>  
+  <div [ngClass]="classes">
+    <tab> Two </tab>     <!-- not a match (nested in div) -->
+  </div>
+</tab-list>
+```
 
 
 ### Example of error
@@ -165,16 +180,16 @@ Adding the proper decorator explicitly provides this information.
 In JIT mode, the framework will throw the following error:
 
 ```
-ERROR: This constructor is not compatible with Angular Dependency Injection because dependency at index 'X' is invalid. 
+ERROR: This constructor is not compatible with Angular Dependency Injection because its dependency at index X of the parameter list is invalid. 
 This can happen if the dependency type is a primitive like a string or if an ancestor of this class is missing an Angular decorator.
 
-Please check that 1) the type for dependency X is correct and 2) the correct Angular decorators are defined for this class and its ancestors.
+Please check that 1) the type for the parameter at index X is correct and 2) the correct Angular decorators are defined for this class and its ancestors.
 ```
 
 In AOT mode, you'll see something like:
 
 ```
-X  inherits its constructor from Y, but the latter does not have an Angular decorator of its own. 
+X inherits its constructor from Y, but the latter does not have an Angular decorator of its own. 
 Dependency injection will not be able to resolve the parameters of Y's constructor. Either add a 
 @Directive decorator to Y, or add an explicit constructor to X.
 ```

--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -2,7 +2,7 @@
 
 The Angular team has worked hard to ensure Ivy is as backwards-compatible with the previous rendering engine ("View Engine") as possible.
 However, in rare cases, minor changes were necessary to ensure that the Angular's behavior was predictable and consistent, correcting issues in the View Engine implementation.
-In order to smooth the transition, we have provided automated migrations wherever possible so your application and library code is migrated automatically by the CLI.
+In order to smooth the transition, we have provided [automated migrations](guide/updating-to-version-9#migrations) wherever possible so your application and library code is migrated automatically by the CLI.
 That said, some applications will likely need to apply some manual updates.
 
 {@a debugging}

--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -2,31 +2,11 @@
 
 This guide contains everything you need to know about updating to the next Angular version.
 
-<div class="alert is-helpful">
-
-For step-by-step instructions on how to update to the latest Angular release, use the interactive update guide at [update.angular.io](https://update.angular.io).
-
-</div>
-
 ## Updating CLI Apps
 
-If your application uses the CLI, you can update to version 9 automatically with the help of the `ng update` script:
+For step-by-step instructions on how to update to the latest Angular release (and leverage our automated migration tools to do so), use the interactive update guide at [update.angular.io](https://update.angular.io).
 
-```sh
-ng update @angular/core@8 @angular/cli@8
-git add .
-git commit --all -m "build: update Angular packages to latest 8.x version"
-ng update @angular/cli @angular/core --next
-```
-
-<div class="alert is-important">
-In order to improve the updating experience, we strongly suggest that you update to the latest 8.x version of `@angular/core` and `@angular/cli`.
-
-Additionally, during the RC period, the `--next` command line flag is required. This flag will no longer be necessary once version 9 final is released.
-</div>
-
-The script runs a series of small migrations that will transform the code of your application to be compatible with version 9.
-If you're curious about the specific migrations being run, see the [automated migrations section](#migrations) for details on what code is changing and why.
+If you're curious about the specific migrations being run by the CLI, see the [automated migrations section](#migrations) for details on what code is changing and why.
 
 ## Changes and Deprecations in Version 9
 
@@ -39,7 +19,7 @@ If you're curious about the specific migrations being run, see the [automated mi
 {@a breaking-changes}
 ### New Breaking Changes
 
-- Angular now compiles with Ivy by default. See [Ivy compatibility section](#ivy).
+- Angular now compiles with Ivy by default. See the [Ivy compatibility section](#ivy).
 
 - CLI apps compile in [AOT mode](/guide/aot-compiler) by default (which includes template type-checking).
 Users who only built with JIT before may see new type errors.


### PR DESCRIPTION
The main change here was to remove the updating instructions for
version 9 and instead point to update.angular.io. This ensures
we only have one "source of truth" for update instructions.

This commit also includes updates to error message text to
keep them up-to-date with live error messages (and thus keep
them searchable).
