### PR TITLE
fix(forms): disabled input acceptance member not applied properly

### DIFF
--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -144,7 +144,7 @@ export class NgModel extends NgControl implements OnChanges,
   // This static member tells the compiler that values of type "string" can also be assigned
   // to the input in a template.
   /** @nodoc */
-  static ngAcceptInputType_disabled: boolean|string;
+  static ngAcceptInputType_isDisabled: boolean|string;
 
   /** @internal */
   _registered = false;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -415,7 +415,7 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_isDisabled: boolean | string;
 }
 
 export declare class NgModelGroup extends AbstractFormGroupDirective implements OnInit, OnDestroy {


### PR DESCRIPTION
With 5cecd97493025cd940c9ade4ea9f1836d5b05cc8 we intended to expand the input type of the `disabled` input
of the `NgModel` directive. Read more about the reason for this in the actual commit
message.

Currently though, the acceptance coercion member does not have any effect. This
is because the acceptance member needs to refer to the actual input property name,
and not to the public input name. `disabled` corresponds to the `isDisabled` property