### PR TITLE
feat(language-service): Show documentation on hover

### DIFF
--- a/packages/language-service/src/expression_type.ts
+++ b/packages/language-service/src/expression_type.ts
@@ -219,6 +219,7 @@ export class AstType implements AstVisitor {
       nullable: false,
       public: true,
       definition: undefined,
+      documentation: [],
       members(): SymbolTable{return _this.scope;},
       signatures(): Signature[]{return [];},
       selectSignature(types): Signature | undefined{return undefined;},

--- a/packages/language-service/src/global_symbols.ts
+++ b/packages/language-service/src/global_symbols.ts
@@ -43,6 +43,10 @@ export const createGlobalSymbolTable: (query: ng.SymbolQuery) => ng.SymbolTable 
           callable: true,
           definition: undefined,
           nullable: false,
+          documentation: [{
+            kind: 'text',
+            text: 'function to cast an expression to the `any` type',
+          }],
           members: () => EMPTY_SYMBOL_TABLE,
           signatures: () => [],
           selectSignature(args: ng.Symbol[]) {

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -214,6 +214,8 @@ class OverrideKindSymbol implements Symbol {
 
   get definition(): Definition { return this.sym.definition; }
 
+  get documentation(): ts.SymbolDisplayPart[] { return this.sym.documentation; }
+
   members() { return this.sym.members(); }
 
   signatures() { return this.sym.signatures(); }

--- a/packages/language-service/src/symbols.ts
+++ b/packages/language-service/src/symbols.ts
@@ -7,6 +7,8 @@
  */
 
 import {StaticSymbol} from '@angular/compiler';
+import * as ts from 'typescript';
+
 
 /**
  * The range of a span of text in a source file.
@@ -94,6 +96,11 @@ export interface Symbol {
    * `true` if the symbol is a type that is nullable (can be null or undefined).
    */
   readonly nullable: boolean;
+
+  /**
+   * Documentation comment on the Symbol, if any.
+   */
+  readonly documentation: ts.SymbolDisplayPart[];
 
   /**
    * A table of the members of the symbol; that is, the members that can appear

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -262,6 +262,14 @@ class TypeWrapper implements Symbol {
     return this.context.checker.getNonNullableType(this.tsType) != this.tsType;
   }
 
+  get documentation(): ts.SymbolDisplayPart[] {
+    const symbol = this.tsType.getSymbol();
+    if (!symbol) {
+      return [];
+    }
+    return symbol.getDocumentationComment(this.context.checker);
+  }
+
   get definition(): Definition|undefined {
     const symbol = this.tsType.getSymbol();
     return symbol ? definitionFromTsSymbol(symbol) : undefined;
@@ -347,6 +355,10 @@ class SymbolWrapper implements Symbol {
 
   get definition(): Definition { return definitionFromTsSymbol(this.symbol); }
 
+  get documentation(): ts.SymbolDisplayPart[] {
+    return this.symbol.getDocumentationComment(this.context.checker);
+  }
+
   members(): SymbolTable {
     if (!this._members) {
       if ((this.symbol.flags & (ts.SymbolFlags.Class | ts.SymbolFlags.Interface)) != 0) {
@@ -397,8 +409,9 @@ class DeclaredSymbol implements Symbol {
 
   get callable(): boolean { return this.declaration.type.callable; }
 
-
   get definition(): Definition { return this.declaration.definition; }
+
+  get documentation(): ts.SymbolDisplayPart[] { return this.declaration.type.documentation; }
 
   members(): SymbolTable { return this.declaration.type.members(); }
 
@@ -594,6 +607,14 @@ class PipeSymbol implements Symbol {
   get definition(): Definition|undefined {
     const symbol = this.tsType.getSymbol();
     return symbol ? definitionFromTsSymbol(symbol) : undefined;
+  }
+
+  get documentation(): ts.SymbolDisplayPart[] {
+    const symbol = this.tsType.getSymbol();
+    if (!symbol) {
+      return [];
+    }
+    return symbol.getDocumentationComment(this.context.checker);
   }
 
   members(): SymbolTable { return EmptyTable.instance; }

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -205,6 +205,24 @@ describe('hover', () => {
     });
     expect(toText(displayParts)).toBe('(method) $any: $any');
   });
+
+  it('should provide documentation for a property', () => {
+    mockHost.override(TEST_TEMPLATE, `<div>{{~{cursor}title}}</div>`);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+    const quickInfo = ngLS.getHoverAt(TEST_TEMPLATE, marker.start);
+    expect(quickInfo).toBeDefined();
+    const documentation = toText(quickInfo !.documentation);
+    expect(documentation).toBe('This is the title of the `TemplateReference` Component.');
+  });
+
+  it('should provide documentation for a selector', () => {
+    mockHost.override(TEST_TEMPLATE, `<~{cursor}test-comp></test-comp>`);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+    const quickInfo = ngLS.getHoverAt(TEST_TEMPLATE, marker.start);
+    expect(quickInfo).toBeDefined();
+    const documentation = toText(quickInfo !.documentation);
+    expect(documentation).toBe('This Component provides the `test-comp` selector.');
+  });
 });
 
 function toText(displayParts?: ts.SymbolDisplayPart[]): string {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -132,6 +132,9 @@ export class AsyncForUsingComponent {
 export class References {
 }
 
+/**
+ * This Component provides the `test-comp` selector.
+ */
 /*BeginTestComponent*/ @Component({
   selector: 'test-comp',
   template: '<div>Testing: {{name}}</div>',
@@ -145,6 +148,9 @@ export class TestComponent {
   templateUrl: 'test.ng',
 })
 export class TemplateReference {
+  /**
+   * This is the title of the `TemplateReference` Component.
+   */
   title = 'Some title';
   hero: Hero = {id: 1, name: 'Windstorm'};
   heroes: Hero[] = [this.hero];


### PR DESCRIPTION
This commit adds dpcumentation to the hover tooltip.

Hover over property:
<img width="712" alt="Screen Shot 2019-12-19 at 6 28 44 PM" src="https://user-images.githubusercontent.com/2941178/71225777-8a58d780-228e-11ea-8609-94355e3dfc3b.png">

Hover over selector:
<img width="712" alt="Screen Shot 2019-12-19 at 6 28 52 PM" src="https://user-images.githubusercontent.com/2941178/71225782-8dec5e80-228e-11ea-9915-b88b718cb4de.png">

PR closes https://github.com/angular/vscode-ng-language-service/issues/321

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
