### PR TITLE
docs(core): describe your change...

### DIFF
--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -116,7 +116,7 @@ export interface DoCheck {
 export interface OnDestroy {
   /**
    * A callback method that performs custom clean-up, invoked immediately
-   * after a directive, pipe, or service instance is destroyed.
+   * before a directive, pipe, or service instance is destroyed.
    */
   ngOnDestroy(): void;
 }


### PR DESCRIPTION
According to https://angular.io/guide/lifecycle-hooks#ondestroy
"Put cleanup logic in ngOnDestroy(), the logic that must run before Angular destroys the directive."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
These two sections of the docs are in disagreement. I investigated and believe this is now correctly describing the behavior.


Issue Number: N/A


## What is the new behavior?
Document that ngOnDestroy runs before the directive is destroyed. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
