### PR TITLE
fix(language-service): correctly parse expressions in an attribute

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -436,12 +436,11 @@ class ExpressionVisitor extends NullTemplateVisitor {
     if (ast.name.startsWith('*')) {
       this.microSyntaxInAttributeValue(ast, binding);
     } else {
-      // If the position is in the expression or after the key or there is no key,
-      // return the expression completions
-      const span = new ParseSpan(0, ast.value.length);
-      const offset = ast.sourceSpan.start.offset;
-      const receiver = new ImplicitReceiver(span, span.toAbsolute(offset));
-      const expressionAst = new PropertyRead(span, span.toAbsolute(offset), receiver, '');
+      // If the position is in the expression or after the key or there is no key, return the
+      // expression completions.
+      // The expression must be reparsed to get a valid AST rather than only template bindings.
+      const expressionAst = this.info.expressionParser.parseBinding(
+          ast.value, ast.sourceSpan.toString(), ast.sourceSpan.start.offset);
       this.addAttributeValuesToCompletions(expressionAst);
     }
   }

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -537,10 +537,8 @@ class ExpressionVisitor extends NullTemplateVisitor {
     const KW_OF = ' of ';
     const ofLocation = attr.value.indexOf(KW_OF);
     if (ofLocation > 0 && valueRelativePosition >= ofLocation + KW_OF.length) {
-      const span = new ParseSpan(0, attr.value.length);
-      const offset = attr.sourceSpan.start.offset;
-      const receiver = new ImplicitReceiver(span, span.toAbsolute(offset));
-      const expressionAst = new PropertyRead(span, span.toAbsolute(offset), receiver, '');
+      const expressionAst = this.info.expressionParser.parseBinding(
+          attr.value, attr.sourceSpan.toString(), attr.sourceSpan.start.offset);
       this.addAttributeValuesToCompletions(expressionAst);
     }
   }

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -419,11 +419,9 @@ class ExpressionVisitor extends NullTemplateVisitor {
   }
 
   visitAttr(ast: AttrAst) {
-    // The attribute value is a template expression but the expression AST
-    // was not produced when the TemplateAst was produced so do that here.
+    // First, verify the attribute consists of some binding we can give completions for.
     const {templateBindings} = this.info.expressionParser.parseTemplateBindings(
         ast.name, ast.value, ast.sourceSpan.toString(), ast.sourceSpan.start.offset);
-
     // Find where the cursor is relative to the start of the attribute value.
     const valueRelativePosition = this.position - ast.sourceSpan.start.offset;
     // Find the template binding that contains the position

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -358,6 +358,12 @@ describe('completions', () => {
       expectContain(completions, CompletionKind.PROPERTY, ['test']);
     });
 
+    it('should be able to complete property read', () => {
+      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'data-binding-property-read');
+      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['key']);
+    });
+
     it('should be able to complete an event', () => {
       const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'event-binding-model');
       const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
@@ -455,6 +461,13 @@ describe('completions', () => {
 
     it('should reference the component', () => {
       const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'test-comp-after-test');
+      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['name', 'testEvent']);
+    });
+
+    it('should get reference property completions in a data binding', () => {
+      const marker =
+          mockHost.getLocationMarkerFor(PARSING_CASES, 'event-binding-ref-property-read');
       const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
       expectContain(completions, CompletionKind.PROPERTY, ['name', 'testEvent']);
     });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -308,6 +308,13 @@ describe('completions', () => {
       expectContain(completions, CompletionKind.VARIABLE, ['x']);
     });
 
+    it('should include expression completions', () => {
+      mockHost.override(TEST_TEMPLATE, `<div *ngFor="let x of hero.~{expr-property-read}"></div>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'expr-property-read');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['name']);
+    });
+
     it('should include variable in the let scope in interpolation', () => {
       mockHost.override(TEST_TEMPLATE, `
         <div *ngFor="let h of heroes">
@@ -359,9 +366,10 @@ describe('completions', () => {
     });
 
     it('should be able to complete property read', () => {
-      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'data-binding-property-read');
-      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
-      expectContain(completions, CompletionKind.PROPERTY, ['key']);
+      mockHost.override(TEST_TEMPLATE, `<h1 [model]="hero.~{property-read}"></h1>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'property-read');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['id', 'name']);
     });
 
     it('should be able to complete an event', () => {
@@ -466,9 +474,12 @@ describe('completions', () => {
     });
 
     it('should get reference property completions in a data binding', () => {
-      const marker =
-          mockHost.getLocationMarkerFor(PARSING_CASES, 'event-binding-ref-property-read');
-      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
+      mockHost.override(TEST_TEMPLATE, `
+        <test-comp #test></test-comp>
+        <div (click)="test.~{property-read}"></div>
+      `);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'property-read');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.PROPERTY, ['name', 'testEvent']);
     });
 

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -53,13 +53,10 @@ export class AttributeBinding {
 }
 
 @Component({
-  template: `
-    <h1 [model]="~{property-binding-model}test"></h1>
-    <h1 [model]="obj.~{data-binding-property-read}"></h1>`,
+  template: '<h1 [model]="~{property-binding-model}test"></h1>',
 })
 export class PropertyBinding {
   test: string = 'test';
-  obj = {key: 'value'};
 }
 
 @Component({
@@ -129,8 +126,6 @@ export class AsyncForUsingComponent {
         {{test1.~{test-comp-after-test}name}}
         {{div.~{test-comp-after-div}.innerText}}
       </test-comp>
-
-      <div (click)="test1.~{event-binding-ref-property-read}"></div>
     </div>
     <test-comp #test2></test-comp>`,
 })

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -53,10 +53,13 @@ export class AttributeBinding {
 }
 
 @Component({
-  template: '<h1 [model]="~{property-binding-model}test"></h1>',
+  template: `
+    <h1 [model]="~{property-binding-model}test"></h1>
+    <h1 [model]="obj.~{data-binding-property-read}"></h1>`,
 })
 export class PropertyBinding {
   test: string = 'test';
+  obj = {key: 'value'};
 }
 
 @Component({
@@ -126,6 +129,8 @@ export class AsyncForUsingComponent {
         {{test1.~{test-comp-after-test}name}}
         {{div.~{test-comp-after-div}.innerText}}
       </test-comp>
+
+      <div (click)="test1.~{event-binding-ref-property-read}"></div>
     </div>
     <test-comp #test2></test-comp>`,
 })


### PR DESCRIPTION
Currently, the language service provides completions in a template node
attribute by first checking if the attribute contains template bindings
to provide completions for, and then providing completions for the
expression in the attribute.

In the latter case, the expression AST was being constructed
"synthetically" inside the language service, in particular declaring the
expression to be a `PropertyRead` with an implicit receiver.
Unfortunately, this AST can be incorrect if the expression is actually a
property read on a component property receiver (e.g. when reading
`key` in the expression `obj.key`, `obj` is the receiver).

The fix is pretty simple - rather than a synthetic construction of the
AST, ask the expression parser to parse the expression in the attribute.

Fixes https://github.com/angular/vscode-ng-language-service/issues/523

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No