### PR TITLE
refactor(language-service): rename expression completions method

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -432,14 +432,14 @@ class ExpressionVisitor extends NullTemplateVisitor {
   get results(): ng.CompletionEntry[] { return Array.from(this.completions.values()); }
 
   visitDirectiveProperty(ast: BoundDirectivePropertyAst): void {
-    this.addAttributeValuesToCompletions(ast.value);
+    this.processExpressionCompletions(ast.value);
   }
 
   visitElementProperty(ast: BoundElementPropertyAst): void {
-    this.addAttributeValuesToCompletions(ast.value);
+    this.processExpressionCompletions(ast.value);
   }
 
-  visitEvent(ast: BoundEventAst): void { this.addAttributeValuesToCompletions(ast.handler); }
+  visitEvent(ast: BoundEventAst): void { this.processExpressionCompletions(ast.handler); }
 
   visitElement(ast: ElementAst): void {
     // no-op for now
@@ -466,7 +466,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
       // The expression must be reparsed to get a valid AST rather than only template bindings.
       const expressionAst = this.info.expressionParser.parseBinding(
           ast.value, ast.sourceSpan.toString(), ast.sourceSpan.start.offset);
-      this.addAttributeValuesToCompletions(expressionAst);
+      this.processExpressionCompletions(expressionAst);
     }
   }
 
@@ -490,7 +490,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
     }
   }
 
-  private addAttributeValuesToCompletions(value: AST) {
+  private processExpressionCompletions(value: AST) {
     const symbols = getExpressionCompletions(
         this.getExpressionScope(), value, this.position, this.info.template.query);
     if (symbols) {
@@ -566,7 +566,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
     }
 
     if (binding.expression && inSpan(valueRelativePosition, binding.expression.ast.span)) {
-      this.addAttributeValuesToCompletions(binding.expression.ast);
+      this.processExpressionCompletions(binding.expression.ast);
       return;
     }
 
@@ -578,7 +578,7 @@ class ExpressionVisitor extends NullTemplateVisitor {
     if (ofLocation > 0 && valueRelativePosition >= ofLocation + KW_OF.length) {
       const expressionAst = this.info.expressionParser.parseBinding(
           attr.value, attr.sourceSpan.toString(), attr.sourceSpan.start.offset);
-      this.addAttributeValuesToCompletions(expressionAst);
+      this.processExpressionCompletions(expressionAst);
     }
   }
 }


### PR DESCRIPTION
This commit renames `addAttributeValuesToCompletions`, which generates
expression completions and is not exclusive to processing attributes, to
`processExpressionCompletions`. Also removes the expression completion
logic in `visitBoundText` for a call to `processExpressionCompletions`.

The conditional branch in `visitBoundText` is also removed. This branch
was added in one of the first commits to the language service
(519a32445407136b9d6b969cd0be6aa42ca73055) and appears to be
unnecessary, as the expression AST is constructed from the template
position anyway.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No