### PR TITLE
feat(ivy): improve `ExpressionChangedAfterChecked` error message for text interpolations

### DIFF
--- a/packages/core/src/render3/instructions/host_property.ts
+++ b/packages/core/src/render3/instructions/host_property.ts
@@ -11,7 +11,7 @@ import {TVIEW} from '../interfaces/view';
 import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
-import {elementPropertyInternal, loadComponentRenderer, storePropertyBindingMetadata} from './shared';
+import {elementPropertyInternal, loadComponentRenderer, storeBindingMetadata} from './shared';
 
 /**
  * Update a property on a host element. Only applies to native node properties, not inputs.
@@ -23,7 +23,7 @@ import {elementPropertyInternal, loadComponentRenderer, storePropertyBindingMeta
  * @param value New value to write.
  * @param sanitizer An optional function used to sanitize the value.
  * @returns This function returns itself so that it may be chained
- * (e.g. `property('name', ctx.name)('title', ctx.title)`)
+ * (e.g. `hostProperty('name', ctx.name)('title', ctx.title)`)
  *
  * @codeGenApi
  */
@@ -34,7 +34,7 @@ export function ɵɵhostProperty<T>(
   if (bindingUpdated(lView, bindingIndex, value)) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, value, sanitizer, true);
-    ngDevMode && storePropertyBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
+    ngDevMode && storeBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
   }
   return ɵɵhostProperty;
 }
@@ -70,7 +70,7 @@ export function ɵɵupdateSyntheticHostBinding<T>(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(
         lView, nodeIndex, propName, value, sanitizer, true, loadComponentRenderer);
-    ngDevMode && storePropertyBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
+    ngDevMode && storeBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
   }
   return ɵɵupdateSyntheticHostBinding;
 }

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -10,7 +10,7 @@ import {SanitizerFn} from '../interfaces/sanitization';
 import {TVIEW} from '../interfaces/view';
 import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
 
-import {elementPropertyInternal, storePropertyBindingMetadata} from './shared';
+import {elementPropertyInternal, storeBindingMetadata} from './shared';
 
 
 /**
@@ -38,7 +38,7 @@ export function ɵɵproperty<T>(
   if (bindingUpdated(lView, bindingIndex, value)) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, value, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
+    ngDevMode && storeBindingMetadata(lView[TVIEW].data, nodeIndex, propName, bindingIndex);
   }
   return ɵɵproperty;
 }

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -11,7 +11,7 @@ import {getBindingIndex, getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
-import {elementPropertyInternal, storePropertyBindingMetadata} from './shared';
+import {elementPropertyInternal, storeBindingMetadata} from './shared';
 
 
 
@@ -87,7 +87,7 @@ export function ɵɵpropertyInterpolate1(
   if (interpolatedValue !== NO_CHANGE) {
     elementPropertyInternal(lView, getSelectedIndex(), propName, interpolatedValue, sanitizer);
     ngDevMode &&
-        storePropertyBindingMetadata(
+        storeBindingMetadata(
             lView[TVIEW].data, getSelectedIndex(), propName, getBindingIndex() - 1, prefix, suffix);
   }
   return ɵɵpropertyInterpolate1;
@@ -132,7 +132,7 @@ export function ɵɵpropertyInterpolate2(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode &&
-        storePropertyBindingMetadata(
+        storeBindingMetadata(
             lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 2, prefix, i0, suffix);
   }
   return ɵɵpropertyInterpolate2;
@@ -180,7 +180,7 @@ export function ɵɵpropertyInterpolate3(
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
     ngDevMode &&
-        storePropertyBindingMetadata(
+        storeBindingMetadata(
             lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 3, prefix, i0, i1, suffix);
   }
   return ɵɵpropertyInterpolate3;
@@ -229,7 +229,7 @@ export function ɵɵpropertyInterpolate4(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
+    ngDevMode && storeBindingMetadata(
                      lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 4, prefix, i0, i1,
                      i2, suffix);
   }
@@ -283,7 +283,7 @@ export function ɵɵpropertyInterpolate5(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
+    ngDevMode && storeBindingMetadata(
                      lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 5, prefix, i0, i1,
                      i2, i3, suffix);
   }
@@ -339,7 +339,7 @@ export function ɵɵpropertyInterpolate6(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
+    ngDevMode && storeBindingMetadata(
                      lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 6, prefix, i0, i1,
                      i2, i3, i4, suffix);
   }
@@ -397,7 +397,7 @@ export function ɵɵpropertyInterpolate7(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
+    ngDevMode && storeBindingMetadata(
                      lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 7, prefix, i0, i1,
                      i2, i3, i4, i5, suffix);
   }
@@ -457,7 +457,7 @@ export function ɵɵpropertyInterpolate8(
   if (interpolatedValue !== NO_CHANGE) {
     const nodeIndex = getSelectedIndex();
     elementPropertyInternal(lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
+    ngDevMode && storeBindingMetadata(
                      lView[TVIEW].data, nodeIndex, propName, getBindingIndex() - 8, prefix, i0, i1,
                      i2, i3, i4, i5, i6, suffix);
   }
@@ -506,7 +506,7 @@ export function ɵɵpropertyInterpolateV(
       for (let i = 2; i < values.length; i += 2) {
         interpolationInBetween.push(values[i]);
       }
-      storePropertyBindingMetadata(
+      storeBindingMetadata(
           lView[TVIEW].data, nodeIndex, propName,
           getBindingIndex() - interpolationInBetween.length + 1, ...interpolationInBetween);
     }

--- a/packages/core/src/render3/instructions/text_interpolation.ts
+++ b/packages/core/src/render3/instructions/text_interpolation.ts
@@ -5,11 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {getLView, getSelectedIndex} from '../state';
+import {TVIEW} from '../interfaces/view';
+import {getBindingIndex, getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
-import {textBindingInternal} from './shared';
+import {storeBindingMetadata, textBindingInternal} from './shared';
+
 
 
 /**
@@ -62,7 +64,10 @@ export function ɵɵtextInterpolate1(
   const lView = getLView();
   const interpolated = interpolation1(lView, prefix, v0, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 1, prefix, suffix);
   }
   return ɵɵtextInterpolate1;
 }
@@ -91,7 +96,10 @@ export function ɵɵtextInterpolate2(
   const lView = getLView();
   const interpolated = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 2, prefix, i0, suffix);
   }
   return ɵɵtextInterpolate2;
 }
@@ -122,7 +130,11 @@ export function ɵɵtextInterpolate3(
   const lView = getLView();
   const interpolated = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode &&
+        storeBindingMetadata(
+            lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 3, prefix, i0, i1, suffix);
   }
   return ɵɵtextInterpolate3;
 }
@@ -153,7 +165,11 @@ export function ɵɵtextInterpolate4(
   const lView = getLView();
   const interpolated = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode &&
+        storeBindingMetadata(
+            lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 4, prefix, i0, i1, i2, suffix);
   }
   return ɵɵtextInterpolate4;
 }
@@ -184,7 +200,11 @@ export function ɵɵtextInterpolate5(
   const lView = getLView();
   const interpolated = interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 5, prefix, i0, i1, i2,
+                     i3, suffix);
   }
   return ɵɵtextInterpolate5;
 }
@@ -218,7 +238,11 @@ export function ɵɵtextInterpolate6(
   const interpolated =
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 6, prefix, i0, i1, i2,
+                     i3, i4, suffix);
   }
   return ɵɵtextInterpolate6;
 }
@@ -251,7 +275,11 @@ export function ɵɵtextInterpolate7(
   const interpolated =
       interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 7, prefix, i0, i1, i2,
+                     i3, i4, i5, suffix);
   }
   return ɵɵtextInterpolate7;
 }
@@ -284,7 +312,11 @@ export function ɵɵtextInterpolate8(
   const interpolated = interpolation8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    ngDevMode && storeBindingMetadata(
+                     lView[TVIEW].data, nodeIndex, null, getBindingIndex() - 8, prefix, i0, i1, i2,
+                     i3, i4, i5, i6, suffix);
   }
   return ɵɵtextInterpolate8;
 }
@@ -317,7 +349,17 @@ export function ɵɵtextInterpolateV(values: any[]): typeof ɵɵtextInterpolateV
   const lView = getLView();
   const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
-    textBindingInternal(lView, getSelectedIndex(), interpolated as string);
+    const nodeIndex = getSelectedIndex();
+    textBindingInternal(lView, nodeIndex, interpolated as string);
+    if (ngDevMode) {
+      const interpolationInBetween = [values[0]];  // prefix
+      for (let i = 2; i < values.length; i += 2) {
+        interpolationInBetween.push(values[i]);
+      }
+      storeBindingMetadata(
+          lView[TVIEW].data, nodeIndex, null, getBindingIndex() - interpolationInBetween.length + 1,
+          ...interpolationInBetween);
+    }
   }
   return ɵɵtextInterpolateV;
 }

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1319,21 +1319,25 @@ describe('change detection', () => {
           .toThrowError(new RegExp(message));
     });
 
-    it('should only display a value of an expression that was changed in text interpolation',
-       () => {
-         expect(() => initWithTemplate('Expressions: {{ a }} and {{ unstableStringExpression }}!'))
-             .toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-       });
+    it('should work with text interpolations', () => {
+      const message = ivyEnabled ?
+          `Previous value: 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+          `Previous value: '.*?initial'. Current value: '.*?changed'`;
+      expect(() => initWithTemplate('Expressions: {{ a }} and {{ unstableStringExpression }}!'))
+          .toThrowError(new RegExp(message));
+    });
 
-    it('should only display a value of an expression that was changed in text interpolation ' +
-           'that follows an element with property interpolation',
+    it('should work with text interpolations that follow an element with property interpolation',
        () => {
+         const message = ivyEnabled ?
+             `Previous value: ' Text interpolation: initial. '. Current value: ' Text interpolation: changed. '` :
+             `Previous value: '.*?initial'. Current value: '.*?changed'`;
          expect(() => {
            initWithTemplate(`
              <div id="Prop interpolation: {{ aVal }}"></div>
              Text interpolation: {{ unstableStringExpression }}.
            `);
-         }).toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+         }).toThrowError(new RegExp(message));
        });
 
     it('should include style prop name in case of style binding', () => {


### PR DESCRIPTION
This commit improves ExpressionChangedAfterChecked error message for text interpolations by including the content of entire expression that contains interpolation(s). In order to achieve that, metadata for text interpolations is now stored in TData array when textInterpolate instructions are being called (similar to property and propertyInterpolate instructions).

## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No