### PR TITLE
fix(ngcc): recognize re-exports with imported TS helpers in CommonJS and UMD

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -510,7 +510,7 @@ var c = file_a.a;
           var a_module = require('./a_module');
           var b_module = require('./b_module');
           var xtra_module = require('./xtra_module');
-          var wildcard_reexports = require('./wildcard_reexports');
+          var wildcard_reexports_emitted_helpers = require('./wildcard_reexports_emitted_helpers');
           var wildcard_reexports_imported_helpers = require('./wildcard_reexports_imported_helpers');
           `
         },
@@ -553,7 +553,7 @@ exports.xtra2 = xtra2;
 `,
         },
         {
-          name: _('/wildcard_reexports.js'),
+          name: _('/wildcard_reexports_emitted_helpers.js'),
           contents: `
 function __export(m) {
   for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -1778,7 +1778,8 @@ exports.ExternalModule = ExternalModule;
           loadTestFiles(EXPORTS_FILES);
           const bundle = makeTestBundleProgram(_('/index.js'));
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
-          const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
+          const file =
+              getSourceFileOrError(bundle.program, _('/wildcard_reexports_emitted_helpers.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBe(null);
           expect(Array.from(exportDeclarations !.entries())


### PR DESCRIPTION
~~_Builds on top of #34512 (so the first 7 commits are from there)._~~
_Rebased on master now that #34512 has been merged._

##
Previously, the `CommonJsReflectionHost` and `UmdReflectionHost` would only recognize re-exports of the form `__export(...)`. This is what re-exports look like, when the TypeScript helpers are emitted inline (i.e. when compiling with the default [TypeScript compiler options][1] that include `noEmitHelpers: false` and `importHelpers: false`).

However, when compiling with `importHelpers: true` and [tslib][2] (which is the recommended way for optimized bundles), the re-exports will look like: `tslib_1.__exportStar(..., exports)`
These types of re-exports were previously not recognized by the CommonJS/UMD `ReflectionHost`s and thus ignored.

This commit fixes this by ensuring both re-export formats are recognized.

[1]: https://www.typescriptlang.org/docs/handbook/compiler-options.html
[2]: https://www.npmjs.com/package/tslib