### PR TITLE
fix: should also allow subclass Promise without Symbol.species

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -384,7 +384,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         null): Promise<TResult1|TResult2> {
       let C = (this.constructor as any)[Symbol.species];
       if (!C || typeof C !== 'function') {
-        C = ZoneAwarePromise;
+        C = this.constructor || ZoneAwarePromise;
       }
       const chainPromise: Promise<TResult1|TResult2> = new (C as typeof ZoneAwarePromise)(noop);
       const zone = Zone.current;

--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -103,7 +103,14 @@ describe(
         }).toThrowError('Must be an instanceof Promise.');
       });
 
-      it('should allow subclassing with Promise.specices', () => {
+      it('should allow subclassing without Symbol.species', () => {
+        class MyPromise extends Promise<any> {
+          constructor(fn: any) { super(fn); }
+        }
+        expect(new MyPromise(() => {}).then(() => null) instanceof MyPromise).toBe(true);
+      });
+
+      it('should allow subclassing with Symbol.species', () => {
         class MyPromise extends Promise<any> {
           constructor(fn: any) { super(fn); }
 
@@ -112,7 +119,7 @@ describe(
         expect(new MyPromise(() => {}).then(() => null) instanceof MyPromise).toBe(true);
       });
 
-      it('Promise.specices should return ZoneAwarePromise', () => {
+      it('Symbol.species should return ZoneAwarePromise', () => {
         const empty = function() {};
         const promise = Promise.resolve(1);
         const FakePromise = ((promise.constructor = {} as any) as any)[Symbol.species] = function(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34162

This is a regression issue introduced by #34162, before that PR, we call `this.constructor` in `Promise.then()` to create a new Promise.
In the #34162 PR, ZoneAwarePromise support to subclass Promise by Symbol.species.
But we still need to support subclass without Symbol.species implemented.

## What is the new behavior?
If the subclass doesn't have Symbol.species, we should use `this.constructor` instead of hardcoded `ZoneAwarePromise`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
