### PR TITLE
build: cleanup and unify tsconfigs used across the repo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,11 +7,12 @@ exports_files([
     "protractor-perf.conf.js",
     "karma-js.conf.js",
     "browser-providers.conf.js",
+    "tsconfig-defaults.json",
 ])
 
 alias(
     name = "tsconfig.json",
-    actual = "//packages:tsconfig-build.json",
+    actual = "//packages:tsconfig-browser",
 )
 
 filegroup(

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -24,15 +24,21 @@ ts_config(
 )
 
 ts_config(
+    name = "tsconfig-node",
+    src = "tsconfig-node.json",
+    deps = ["//:tsconfig-defaults.json"],
+)
+
+ts_config(
     name = "tsconfig-test",
     src = "tsconfig-test.json",
-    deps = [":tsconfig-build.json"],
+    deps = [":tsconfig-browser"],
 )
 
 ts_config(
     name = "tsconfig-build-no-strict",
     src = "tsconfig-build-no-strict.json",
-    deps = [":tsconfig-build.json"],
+    deps = [":tsconfig-browser"],
 )
 
 exports_files([

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -18,6 +18,12 @@ ts_library(
 )
 
 ts_config(
+    name = "tsconfig-browser",
+    src = "tsconfig-build.json",
+    deps = ["//:tsconfig-defaults.json"],
+)
+
+ts_config(
     name = "tsconfig-test",
     src = "tsconfig-test.json",
     deps = [":tsconfig-build.json"],

--- a/packages/bazel/src/ng_package/BUILD.bazel
+++ b/packages/bazel/src/ng_package/BUILD.bazel
@@ -1,22 +1,17 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-
-# BEGIN-DEV-ONLY
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:defaults.bzl", "nodejs_binary", "ts_library")
 
 ts_library(
     name = "lib",
     srcs = glob(["*.ts"]),
-    node_modules = "@npm//typescript:typescript__typings",
-    tsconfig = ":tsconfig.json",
+    tsconfig = "//:tsconfig-defaults.json",
     deps = [
         "@npm//@types/node",
         "@npm//@types/shelljs",
     ],
 )
 
-# END-DEV-ONLY
 nodejs_binary(
     name = "packager",
     data = [

--- a/packages/bazel/src/ng_package/tsconfig.json
+++ b/packages/bazel/src/ng_package/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "compilerOptions": {
-    "noImplicitAny": true,
-    "lib": ["es2015"],
-    "types": []
-  }
+  "extends": "../../../../tsconfig-defaults.json",
 }

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -6,7 +6,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_config")
 ts_config(
     name = "tsconfig",
     src = "tsconfig-build.json",
-    deps = ["//packages:tsconfig-build.json"],
+    deps = ["//packages:tsconfig-node"],
 )
 
 ts_library(

--- a/packages/compiler-cli/tsconfig-build.json
+++ b/packages/compiler-cli/tsconfig-build.json
@@ -1,39 +1,22 @@
 {
-  "extends": "../tsconfig-build.json",
-
+  "extends": "../tsconfig-node.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "stripInternal": false,
-    "target": "es2015",
-    "lib": [
-      "es2015",
-      "es2017.object",
-    ],
-    "baseUrl": ".",
-    "rootDir": ".",
-    "paths": {
-      "@angular/compiler": ["../../dist/packages/compiler"]
-    },
-    "strict": true,
-    "types": [
-      "node"
-    ],
-    "outDir": "../../dist/packages/compiler-cli"
+    // "baseUrl": ".",
+    // "rootDir": ".",
+    // "paths": {
+    //   "@angular/compiler": [
+    //     "../../dist/packages/compiler"
+    //   ]
+    // },
+    //    "outDir": "../../dist/packages/compiler-cli"
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   },
-
-  "exclude": [
-    "integrationtest"
-  ],
-
   "files": [
     "index.ts",
     "src/main.ts",
     "src/extract_i18n.ts",
     "src/language_services.ts",
-    "../../node_modules/@types/node/index.d.ts",
-    "../../node_modules/@types/jasmine/index.d.ts"
   ]
 }

--- a/packages/localize/schematics/ng-add/BUILD.bazel
+++ b/packages/localize/schematics/ng-add/BUILD.bazel
@@ -6,7 +6,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_config")
 ts_config(
     name = "tsconfig",
     src = "tsconfig-build.json",
-    deps = ["//packages:tsconfig-build.json"],
+    deps = ["//:tsconfig-defaults.json"],
 )
 
 ts_library(

--- a/packages/localize/schematics/ng-add/tsconfig-build.json
+++ b/packages/localize/schematics/ng-add/tsconfig-build.json
@@ -1,20 +1,16 @@
 {
-  "extends": "../../../tsconfig-build.json",
+  "extends": "../../../../tsconfig-defaults.json",
   "compilerOptions": {
     "module": "commonjs",
     "stripInternal": false,
-    "target": "es2015",
     "lib": [
       "es2015",
-      "es2017.object",
+      //      "es2017.object",
     ],
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true,
   },
-  "exclude": [
-    "index_spec.ts",
-  ],
   "files": [
     "index.ts",
   ]

--- a/packages/localize/src/tools/BUILD.bazel
+++ b/packages/localize/src/tools/BUILD.bazel
@@ -6,7 +6,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_config")
 ts_config(
     name = "tsconfig",
     src = "tsconfig-build.json",
-    deps = ["//packages:tsconfig-build.json"],
+    deps = ["//:tsconfig-defaults.json"],
 )
 
 ts_library(

--- a/packages/localize/src/tools/tsconfig-build.json
+++ b/packages/localize/src/tools/tsconfig-build.json
@@ -1,18 +1,16 @@
 {
-  "extends": "../../../tsconfig-build.json",
-
+  "extends": "../../../../tsconfig-defaults.json",
   "compilerOptions": {
     "module": "commonjs",
-    "stripInternal": false,
-    "target": "es2015",
     "lib": [
       "es2015",
-      "es2017.object"
+      //      "es2017.object"
     ],
     "paths": {
-      "@angular/*": ["./packages/*"]
+      "@angular/*": [
+        "./packages/*"
+      ]
     },
-    "strict": true,
     "types": [
       "node"
     ]

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -1,34 +1,14 @@
 /**
- * Root tsconfig file for use building all Angular packages. Note there is no rootDir
- * and therefore any tsconfig in the package directory will need to define its own
- * rootDir.
+ * tsconfig file for use building all Angular libraries that run in the browser
  */
 {
+  "extends": "../tsconfig-defaults.json",
   "compilerOptions": {
-    "declaration": true,
-    "stripInternal": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strict": true,
-    "strictPropertyInitialization": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "module": "es2015",
-    "target": "es2015",
-    "lib": ["es2015", "dom"],
-    "skipLibCheck": true,
-    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
-    "types": [],
     "experimentalDecorators": true,
-    // This is needed due to https://github.com/Microsoft/TypeScript/issues/17516.
-    // As tsickle will lower decorators before TS, this is not a problem for our build.
     "emitDecoratorMetadata": true,
-    "sourceMap": true,
-    "inlineSources": true,
-    "importHelpers": true
-  },
-  "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true,
-    "devmodeTargetOverride": "es5"
+    "lib": [
+      "ES2015",
+      "dom"
+    ]
   }
 }

--- a/packages/tsconfig-node.json
+++ b/packages/tsconfig-node.json
@@ -1,0 +1,15 @@
+/**
+ * tsconfig file for use building all Angular libraries that run in the browser
+ */
+{
+  "extends": "../tsconfig-defaults.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "ES2017"
+    ],
+    "types": [
+      "node",
+    ]
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -10,25 +10,42 @@
     "module": "commonjs",
     "strict": true,
     "moduleResolution": "node",
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
     "outDir": "../dist/all/@angular",
-    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "selenium-webdriver": ["./node_modules/@types/selenium-webdriver/index.d.ts"],
-      "rxjs/*": ["./node_modules/rxjs/*"],
-      "@angular/*": ["./packages/*"],
-      "zone.js/*": ["./packages/zone.js/*"],
-      "e2e_util/*": ["./modules/e2e_util/*"]
+      "selenium-webdriver": [
+        "./node_modules/@types/selenium-webdriver/index.d.ts"
+      ],
+      "rxjs/*": [
+        "./node_modules/rxjs/*"
+      ],
+      "@angular/*": [
+        "./packages/*"
+      ],
+      "zone.js/*": [
+        "./packages/zone.js/*"
+      ],
+      "e2e_util/*": [
+        "./modules/e2e_util/*"
+      ]
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.core", "es2017.object"],
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.core",
+      "es2017.object"
+    ],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "target": "es5",
-    "types": ["angular"]
+    "types": [
+      "angular"
+    ]
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true

--- a/tsconfig-defaults.json
+++ b/tsconfig-defaults.json
@@ -13,14 +13,19 @@
     "module": "es2015",
     "target": "es2015",
     "lib": [
-      // DO NOT ADD other libs unless we absolutely positively want them to be available to all compilation units
-      // this includes, node.js programs, webworker programs, etc.
+      // DO NOT ADD other libs unless we absolutely positively want them to be available to all compilation units.
+      // This includes browser, node.js, webworker programs, etc.
       // In order to define custom `lib`, create a custom tsconfig that extends from this one and configure `lib` there.
       "es2015",
     ],
     "skipLibCheck": true,
-    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
-    "types": [],
+    "types": [
+      // DO NOT ADD any types in here unless we absolutely positively want them to be available to all compilation units.
+      // This includes browser, node.js, webworker programs, etc.
+      // We explicitly set types to [] so that we disable auto-discovery feature of tsc that would otherwise find
+      // @types/node and other types in our mono-repos node_modules and that would then result in tsc emitting
+      // a ///<reference in the .d.ts output
+    ],
     "sourceMap": true,
     "inlineSources": true,
     "importHelpers": true

--- a/tsconfig-defaults.json
+++ b/tsconfig-defaults.json
@@ -1,0 +1,32 @@
+/**
+ * Root tsconfig file for use building all Angular packages. Note there is no rootDir
+ * and therefore any tsconfig in the package directory will need to define its own
+ * rootDir.
+ */
+{
+  "compilerOptions": {
+    "declaration": true,
+    "stripInternal": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "module": "es2015",
+    "target": "es2015",
+    "lib": [
+      // DO NOT ADD other libs unless we absolutely positively want them to be available to all compilation units
+      // this includes, node.js programs, webworker programs, etc.
+      // In order to define custom `lib`, create a custom tsconfig that extends from this one and configure `lib` there.
+      "es2015",
+    ],
+    "skipLibCheck": true,
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": [],
+    "sourceMap": true,
+    "inlineSources": true,
+    "importHelpers": true
+  },
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true,
+    "devmodeTargetOverride": "es5"
+  }
+}


### PR DESCRIPTION
The tsconfig-defaults.json is the main tsconfig from which all the other tsconfig will extend.

This allows us to have just a single place where we set common flags, like "strict", etc.
