### PR TITLE
docs: set default file property in stackblitz.json

### DIFF
--- a/aio/content/examples/accessibility/stackblitz.json
+++ b/aio/content/examples/accessibility/stackblitz.json
@@ -5,6 +5,5 @@
     "!**/*.js",
     "!**/*.[1,2].*"
   ],
-  "file": "src/app/app.component.ts",
   "tags": ["Accessibility"]
 }

--- a/aio/content/examples/animations/stackblitz.json
+++ b/aio/content/examples/animations/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2,3].*"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["animations"]
 }

--- a/aio/content/examples/architecture/stackblitz.json
+++ b/aio/content/examples/architecture/stackblitz.json
@@ -5,5 +5,5 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
-  "file": "src/app/app.module.ts"
+  "file": "src/app/hero-list.component.html"
 }

--- a/aio/content/examples/attribute-directives/stackblitz.json
+++ b/aio/content/examples/attribute-directives/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2,3].*"
   ],
+  "file": "src/app/highlight.directive.ts",
   "tags": ["attribute", "directive"]
 }

--- a/aio/content/examples/component-styles/stackblitz.json
+++ b/aio/content/examples/component-styles/stackblitz.json
@@ -6,5 +6,6 @@
     "!**/*.native.*",
     "!**/*.[1].*"
   ],
+  "file": "src/app/hero-app.component.ts",
   "tags": ["CSS"]
 }

--- a/aio/content/examples/dependency-injection-in-action/stackblitz.json
+++ b/aio/content/examples/dependency-injection-in-action/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/app.component.ts",
   "tags":["cookbook"]
 }

--- a/aio/content/examples/dependency-injection/stackblitz.json
+++ b/aio/content/examples/dependency-injection/stackblitz.json
@@ -6,5 +6,6 @@
     "!**/*.[0,1,2,3,4].*",
     "!**/dummy.module.ts"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["dependency", "di"]
 }

--- a/aio/content/examples/displaying-data/stackblitz.json
+++ b/aio/content/examples/displaying-data/stackblitz.json
@@ -6,5 +6,6 @@
     "!**/app-ctor.component.ts",
     "!**/*.[1,2,3].*"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["Template"]
 }

--- a/aio/content/examples/docs-style-guide/second.stackblitz.json
+++ b/aio/content/examples/docs-style-guide/second.stackblitz.json
@@ -1,8 +1,11 @@
 {
   "description": "Second authors style guide stackblitz (non-executing)",
   "files": [
-    "src/index.2.html"
+    "src/main.2.ts",
+    "src/index.2.html",
+    "src/styles.css"
   ],
   "main": "src/index.2.html",
+  "file": "src/index.html",
   "tags": ["author", "style guide"]
 }

--- a/aio/content/examples/dynamic-component-loader/stackblitz.json
+++ b/aio/content/examples/dynamic-component-loader/stackblitz.json
@@ -4,5 +4,6 @@
     "!**/*.d.ts",
     "!**/*.js"
   ],
+  "file": "src/app/app.component.ts",
   "tags":["cookbook component"]
 }

--- a/aio/content/examples/dynamic-form/stackblitz.json
+++ b/aio/content/examples/dynamic-form/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/app.component.ts",
   "tags":["cookbook"]
 }

--- a/aio/content/examples/elements/stackblitz.json
+++ b/aio/content/examples/elements/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/popup.service.ts",
   "tags":["cookbook"]
 }

--- a/aio/content/examples/form-validation/stackblitz.json
+++ b/aio/content/examples/form-validation/stackblitz.json
@@ -4,5 +4,6 @@
     "!**/*.d.ts",
     "!**/*.js",
     "!**/*.[1].*"
-  ]
+  ],
+  "file": "src/app/app.component.ts"
 }

--- a/aio/content/examples/forms-overview/stackblitz.json
+++ b/aio/content/examples/forms-overview/stackblitz.json
@@ -3,5 +3,6 @@
   "files":[
     "!**/*.d.ts",
     "!**/*.js"
-  ]
+  ],
+  "file": "src/app/app.component.ts"
 }

--- a/aio/content/examples/forms/stackblitz.json
+++ b/aio/content/examples/forms/stackblitz.json
@@ -3,5 +3,6 @@
   "files":[
     "!**/*.d.ts",
     "!**/*.js"
-  ]
+  ],
+  "file": "src/app/hero-form/hero-form.component.html"
 }

--- a/aio/content/examples/getting-started-v0/stackblitz.json
+++ b/aio/content/examples/getting-started-v0/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[0-9].*"
   ],
+  "file": "src/app/app.component.ts", 
   "tags": ["Angular", "getting started", "tutorial"]
 }

--- a/aio/content/examples/getting-started/stackblitz.json
+++ b/aio/content/examples/getting-started/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[0-9].*"
   ],
+  "file": "src/app/product-list/product-list.component.html",
   "tags": ["Angular", "getting started", "tutorial"]
 }

--- a/aio/content/examples/hierarchical-dependency-injection/stackblitz.json
+++ b/aio/content/examples/hierarchical-dependency-injection/stackblitz.json
@@ -4,5 +4,6 @@
     "!**/*.d.ts",
     "!**/*.js"
   ],
+  "file": "src/app/app.component.ts", 
   "tags": ["dependency", "injection"]
 }

--- a/aio/content/examples/http/stackblitz.json
+++ b/aio/content/examples/http/stackblitz.json
@@ -3,10 +3,10 @@
   "files":[
     "!**/*.d.ts",
     "!**/*.js",
-
     "!src/testing/*.*",
     "!src/index-specs.html",
     "!src/main-specs.ts"
   ],
+  "file": "src/app/app.component.ts", 
   "tags": ["http"]
 }

--- a/aio/content/examples/lazy-loading-ngmodules/stackblitz.json
+++ b/aio/content/examples/lazy-loading-ngmodules/stackblitz.json
@@ -5,6 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2].*"
   ],
-  "file": "src/app/app.component.ts",
+  "file": "src/app/app-routing.module.ts",
   "tags": ["lazy loading"]
 }

--- a/aio/content/examples/ngmodules/stackblitz.json
+++ b/aio/content/examples/ngmodules/stackblitz.json
@@ -5,6 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2].*"
   ],
-  "file": "src/app/app.component.ts",
+  "file": "src/app/app.module.ts",
   "tags": ["NgModules"]
 }

--- a/aio/content/examples/reactive-forms/stackblitz.json
+++ b/aio/content/examples/reactive-forms/stackblitz.json
@@ -11,5 +11,6 @@
     "!src/app/main-final.ts",
     "!src/index-final.html"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["reactive", "forms"]
 }

--- a/aio/content/examples/router/stackblitz.json
+++ b/aio/content/examples/router/stackblitz.json
@@ -7,5 +7,6 @@
     "!src/app/crisis-list/*.*",
     "!src/app/hero-list/*.*"
   ],
-  "tags": ["router"]
+  "tags": ["router"],
+  "file": "src/app/app-routing.module.ts"
 }

--- a/aio/content/examples/security/stackblitz.json
+++ b/aio/content/examples/security/stackblitz.json
@@ -4,5 +4,6 @@
     "!**/*.d.ts",
     "!**/*.js"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["security"]
 }

--- a/aio/content/examples/set-document-title/stackblitz.json
+++ b/aio/content/examples/set-document-title/stackblitz.json
@@ -5,5 +5,6 @@
 		"!**/*.js",
 		"!**/*.[1].*"
 	],
+	"file": "src/app/app.component.ts", 
 	"tags": [ "cookbook" ]
 }

--- a/aio/content/examples/structural-directives/stackblitz.json
+++ b/aio/content/examples/structural-directives/stackblitz.json
@@ -5,6 +5,7 @@
     "!**/*.js",
     "!src/app/scrap.txt"
   ],
+  "file": "src/app/app.component.ts",
   "tags": [
     "structural", "directives", "template", "ngIf",
     "ngSwitch", "ngFor"

--- a/aio/content/examples/toh-pt0/stackblitz.json
+++ b/aio/content/examples/toh-pt0/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/app.component.ts",
   "tags": ["tutorial", "tour", "heroes"]
 }

--- a/aio/content/examples/toh-pt1/stackblitz.json
+++ b/aio/content/examples/toh-pt1/stackblitz.json
@@ -6,5 +6,6 @@
     "!**/*.[1].*",
     "!**/dummy.module.ts"
   ],
+  "file": "src/app/heroes/heroes.component.html",
   "tags": ["tutorial", "tour", "heroes"]
 }

--- a/aio/content/examples/toh-pt2/stackblitz.json
+++ b/aio/content/examples/toh-pt2/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/heroes/heroes.component.html",
   "tags": ["tutorial", "tour", "heroes"]
 }

--- a/aio/content/examples/toh-pt3/stackblitz.json
+++ b/aio/content/examples/toh-pt3/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1].*"
   ],
+  "file": "src/app/heroes/heroes.component.html",
   "tags": ["tutorial", "tour", "heroes"]
 }

--- a/aio/content/examples/toh-pt4/stackblitz.json
+++ b/aio/content/examples/toh-pt4/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2].*"
   ],
+  "file": "src/app/hero.service.ts",
   "tags": ["tutorial", "tour", "heroes"]
 }

--- a/aio/content/examples/toh-pt5/stackblitz.json
+++ b/aio/content/examples/toh-pt5/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[0,1,2,3].*"
   ],
+  "file": "src/app/app-routing.module.ts",
   "tags": ["tutorial", "tour", "heroes", "router"]
 }

--- a/aio/content/examples/toh-pt6/stackblitz.json
+++ b/aio/content/examples/toh-pt6/stackblitz.json
@@ -5,5 +5,6 @@
     "!**/*.js",
     "!**/*.[1,2].*"
   ],
+  "file": "src/app/hero.service.ts",
   "tags": ["tutorial", "tour", "heroes", "http"]
 }

--- a/aio/tools/stackblitz-builder/builder.js
+++ b/aio/tools/stackblitz-builder/builder.js
@@ -116,13 +116,26 @@ class StackblitzBuilder {
     }
   }
 
-  _createBaseStackblitzHtml(config) {
-    var file = '';
-
-    // TODO: Doesn't work properly yet
+  _getPrimaryFile(config) {
     if (config.file) {
-      file = `?file=${config.file}`;
+      if (!this._existsSync(path.join(config.basePath, config.file))) {
+        throw new Error(`The specified primary file (${config.file}) does not exist in '${config.basePath}'.`);
+      }
+      return config.file;
+    } else {
+      const defaultPrimaryFiles = ['src/app/app.component.html', 'src/app/app.component.ts', 'src/app/main.ts'];
+      const primaryFile = defaultPrimaryFiles.find(fileName =>  this._existsSync(path.join(config.basePath, fileName)));
+  
+      if (!primaryFile) {
+        throw new Error(`None of the default primary files (${defaultPrimaryFiles.join(', ')}) exists in '${config.basePath}'.`);
+      }
+ 
+      return primaryFile;
     }
+  }
+
+  _createBaseStackblitzHtml(config) {
+    var file = `?file=${this._getPrimaryFile(config)}`;
     var action = `https://run.stackblitz.com/api/angular/v1${file}`;
     var html = `<!DOCTYPE html><html lang="en"><body>
     <form id="mainForm" method="post" action="${action}" target="_self"></form>


### PR DESCRIPTION
Previously, when no default file is defined in the `stackblitz.json`, stackblitz
will set it automatically. It used to be `main.ts` and nowadays it seems
to be `app.component.ts`. However, this behaviour can change in the future. To overcome
this, the stackblitz API allows specifying the file to open in the editor by passing
a query param. This PR sets the default file in the `stackblitz.json` through the
`file` property. If still no file is specified, the `builder.js` will try to default to
`app.component.html`, `app.component.ts` or `main.ts`.

Closes #22357

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22357


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


