### PR TITLE
feat(language-service): provide completion for $event variable

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -306,9 +306,10 @@ function attributeCompletionsForElement(
 function attributeValueCompletions(info: AstResult, htmlPath: HtmlAstPath): ng.CompletionEntry[] {
   // Find the corresponding Template AST path.
   const templatePath = findTemplateAstAt(info.templateAst, htmlPath.position);
+  const isEvent = templatePath.tail instanceof BoundEventAst;
   const visitor = new ExpressionVisitor(info, htmlPath.position, () => {
     const dinfo = diagnosticInfoFromTemplateInfo(info);
-    return getExpressionScope(dinfo, templatePath, false);
+    return getExpressionScope(dinfo, templatePath, isEvent);
   });
   if (templatePath.tail instanceof AttrAst ||
       templatePath.tail instanceof BoundElementPropertyAst ||

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -306,10 +306,9 @@ function attributeCompletionsForElement(
 function attributeValueCompletions(info: AstResult, htmlPath: HtmlAstPath): ng.CompletionEntry[] {
   // Find the corresponding Template AST path.
   const templatePath = findTemplateAstAt(info.templateAst, htmlPath.position);
-  const isEvent = templatePath.tail instanceof BoundEventAst;
   const visitor = new ExpressionVisitor(info, htmlPath.position, () => {
     const dinfo = diagnosticInfoFromTemplateInfo(info);
-    return getExpressionScope(dinfo, templatePath, isEvent);
+    return getExpressionScope(dinfo, templatePath);
   });
   if (templatePath.tail instanceof AttrAst ||
       templatePath.tail instanceof BoundElementPropertyAst ||
@@ -399,8 +398,7 @@ function interpolationCompletions(info: AstResult, position: number): ng.Complet
     return [];
   }
   const visitor = new ExpressionVisitor(
-      info, position,
-      () => getExpressionScope(diagnosticInfoFromTemplateInfo(info), templatePath, false));
+      info, position, () => getExpressionScope(diagnosticInfoFromTemplateInfo(info), templatePath));
   templatePath.tail.visit(visitor, null);
   return visitor.results;
 }

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -25,7 +25,7 @@ export interface DiagnosticTemplateInfo {
 
 export function getTemplateExpressionDiagnostics(info: DiagnosticTemplateInfo): Diagnostic[] {
   const visitor = new ExpressionDiagnosticsVisitor(
-      info, (path: TemplateAstPath, includeEvent: boolean) => getExpressionScope(info, path));
+      info, (path: TemplateAstPath) => getExpressionScope(info, path));
   templateVisitAll(visitor, info.templateAst);
   return visitor.diagnostics;
 }
@@ -332,11 +332,6 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
       this.diagnostics.push(
           {span: offsetSpan(span, this.info.offset), kind: ts.DiagnosticCategory.Error, message});
     }
-  }
-
-  private reportWarning(message: string, span: Span) {
-    this.diagnostics.push(
-        {span: offsetSpan(span, this.info.offset), kind: ts.DiagnosticCategory.Warning, message});
   }
 }
 

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -25,8 +25,7 @@ export interface DiagnosticTemplateInfo {
 
 export function getTemplateExpressionDiagnostics(info: DiagnosticTemplateInfo): Diagnostic[] {
   const visitor = new ExpressionDiagnosticsVisitor(
-      info, (path: TemplateAstPath, includeEvent: boolean) =>
-                getExpressionScope(info, path, includeEvent));
+      info, (path: TemplateAstPath, includeEvent: boolean) => getExpressionScope(info, path));
   templateVisitAll(visitor, info.templateAst);
   return visitor.diagnostics;
 }
@@ -194,9 +193,9 @@ function refinedVariableType(
   return query.getBuiltinType(BuiltinType.Any);
 }
 
-function getEventDeclaration(info: DiagnosticTemplateInfo, includeEvent?: boolean) {
+function getEventDeclaration(info: DiagnosticTemplateInfo, path: TemplateAstPath) {
   let result: SymbolDeclaration[] = [];
-  if (includeEvent) {
+  if (path.tail instanceof BoundEventAst) {
     // TODO: Determine the type of the event parameter based on the Observable<T> or EventEmitter<T>
     // of the event.
     result = [{name: '$event', kind: 'variable', type: info.query.getBuiltinType(BuiltinType.Any)}];
@@ -205,11 +204,11 @@ function getEventDeclaration(info: DiagnosticTemplateInfo, includeEvent?: boolea
 }
 
 export function getExpressionScope(
-    info: DiagnosticTemplateInfo, path: TemplateAstPath, includeEvent: boolean): SymbolTable {
+    info: DiagnosticTemplateInfo, path: TemplateAstPath): SymbolTable {
   let result = info.members;
   const references = getReferences(info);
   const variables = getVarDeclarations(info, path);
-  const events = getEventDeclaration(info, includeEvent);
+  const events = getEventDeclaration(info, path);
   if (references.length || variables.length || events.length) {
     const referenceTable = info.query.createSymbolTable(references);
     const variableTable = info.query.createSymbolTable(variables);

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -37,7 +37,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
       if (attribute) {
         if (inSpan(templatePosition, spanOf(attribute.valueSpan))) {
           const dinfo = diagnosticInfoFromTemplateInfo(info);
-          const scope = getExpressionScope(dinfo, path, inEvent);
+          const scope = getExpressionScope(dinfo, path);
           if (attribute.valueSpan) {
             const result = getExpressionSymbol(scope, ast, templatePosition, info.template.query);
             if (result) {
@@ -113,7 +113,7 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
             const expressionPosition = templatePosition - ast.sourceSpan.start.offset;
             if (inSpan(expressionPosition, ast.value.span)) {
               const dinfo = diagnosticInfoFromTemplateInfo(info);
-              const scope = getExpressionScope(dinfo, path, /* includeEvent */ false);
+              const scope = getExpressionScope(dinfo, path);
               const result =
                   getExpressionSymbol(scope, ast.value, templatePosition, info.template.query);
               if (result) {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -749,7 +749,6 @@ describe('completions', () => {
     it('should suggest $event in event bindings', () => {
       mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      debugger;
       const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.VARIABLE, ['$event']);
     });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -744,6 +744,16 @@ describe('completions', () => {
     const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
     expectContain(completions, CompletionKind.PROPERTY, ['title']);
   });
+
+  describe('$event completions', () => {
+    it('should suggest $event in event bindings', () => {
+      mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      debugger;
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.VARIABLE, ['$event']);
+    });
+  });
 });
 
 function expectContain(


### PR DESCRIPTION
This commit adds a completion for the `$event` variable in bound event
expressions.

This is the first in a series of PRs to support completions for
properties on `$event` variables (https://github.com/angular/vscode-ng-language-service/issues/531).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No