### PR TITLE
feat(language-service): completions for output $event properties

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -316,6 +316,7 @@ function attributeValueCompletions(info: AstResult, htmlPath: HtmlAstPath): ng.C
     templatePath.tail.visit(visitor, null);
     return visitor.results;
   }
+
   // In order to provide accurate attribute value completion, we need to know
   // what the LHS is, and construct the proper AST if it is missing.
   const htmlAttr = htmlPath.tail as Attribute;

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -316,7 +316,6 @@ function attributeValueCompletions(info: AstResult, htmlPath: HtmlAstPath): ng.C
     templatePath.tail.visit(visitor, null);
     return visitor.results;
   }
-
   // In order to provide accurate attribute value completion, we need to know
   // what the LHS is, and construct the proper AST if it is missing.
   const htmlAttr = htmlPath.tail as Attribute;

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -10,11 +10,9 @@ import {AST, AstPath, Attribute, BoundDirectivePropertyAst, BoundElementProperty
 import * as ts from 'typescript';
 
 import {AstType, ExpressionDiagnosticsContext, TypeDiagnostic} from './expression_type';
-// TODO: This introduces a circular dependency between locate_symbol and expression_diagnostics.
-import {findOutputBinding} from './locate_symbol';
 import {BuiltinType, Definition, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './symbols';
 import {Diagnostic} from './types';
-import {getPathToNodeAtPosition} from './utils';
+import {findOutputBinding, getPathToNodeAtPosition} from './utils';
 
 export interface DiagnosticTemplateInfo {
   fileName?: string;

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {AstType, ExpressionDiagnosticsContext, TypeDiagnostic} from './expression_type';
 // TODO: This introduces a circular dependency between locate_symbol and expression_diagnostics.
 import {findOutputBinding} from './locate_symbol';
-import {BuiltinType, DeclarationKind, Definition, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './symbols';
+import {BuiltinType, Definition, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './symbols';
 import {Diagnostic} from './types';
 import {getPathToNodeAtPosition} from './utils';
 
@@ -197,17 +197,17 @@ function refinedVariableType(
 
 function getEventDeclaration(
     info: DiagnosticTemplateInfo, path: TemplateAstPath): SymbolDeclaration|undefined {
-  const genericEvent = {
-    name: '$event',
-    kind: 'variable' as DeclarationKind,
-    type: info.query.getBuiltinType(BuiltinType.Any),
-  };
-
   const event = path.tail;
   if (!(event instanceof BoundEventAst)) {
     // No event available in this context.
     return;
   }
+
+  const genericEvent: SymbolDeclaration = {
+    name: '$event',
+    kind: 'variable',
+    type: info.query.getBuiltinType(BuiltinType.Any),
+  };
 
   const outputSymbol = findOutputBinding(event, path, info.query);
   if (!outputSymbol) {
@@ -218,7 +218,7 @@ function getEventDeclaration(
 
   // The raw event type is wrapped in a generic, like EventEmitter<T> or Observable<T>.
   const ta = outputSymbol.typeArguments();
-  if (!ta || ta.length != 1) return genericEvent;
+  if (!ta || ta.length !== 1) return genericEvent;
   const eventType = ta[0];
 
   return {...genericEvent, type: eventType};

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -70,7 +70,7 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
         const result = getSymbolInAttributeValue(info, path, attribute);
         if (result) {
           symbol = result.symbol;
-          span = offsetSpan(result.span, attribute.valueSpan !.start.offset);
+          span = offsetSpan(result.span, attribute.valueSpan!.start.offset);
         }
         return true;
       }
@@ -109,12 +109,14 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
         visitVariable(ast) {},
         visitEvent(ast) {
           if (!attributeValueSymbol()) {
-            symbol = findOutputBinding(info, path, ast);
+            symbol = findOutputBinding(ast, path, info.template.query);
             symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
             span = spanOf(ast);
           }
         },
-        visitElementProperty(ast) { attributeValueSymbol(); },
+        visitElementProperty(ast) {
+          attributeValueSymbol();
+        },
         visitAttr(ast) {
           const element = path.head;
           if (!element || !(element instanceof ElementAst)) return;
@@ -182,7 +184,8 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
     const {start, end} = offsetSpan(span, info.template.span.start);
     return {
       symbol,
-      span: tss.createTextSpanFromBounds(start, end), staticSymbol,
+      span: tss.createTextSpanFromBounds(start, end),
+      staticSymbol,
     };
   }
 }
@@ -205,7 +208,7 @@ function getSymbolInAttributeValue(info: AstResult, path: TemplateAstPath, attri
     if (inSpan(valueRelativePosition, tb.expression?.ast.span)) {
       const dinfo = diagnosticInfoFromTemplateInfo(info);
       const scope = getExpressionScope(dinfo, path);
-      result = getExpressionSymbol(scope, tb.expression !, path.position, info.template.query);
+      result = getExpressionSymbol(scope, tb.expression!, path.position, info.template.query);
     } else if (inSpan(valueRelativePosition, tb.span)) {
       const template = path.first(EmbeddedTemplateAst);
       if (template) {
@@ -260,7 +263,9 @@ function findParentOfBinding(
     }
 
     visitDirective(ast: DirectiveAst) {
-      const result = this.visitChildren(ast, visit => { visit(ast.inputs); });
+      const result = this.visitChildren(ast, visit => {
+        visit(ast.inputs);
+      });
       return result;
     }
 
@@ -292,33 +297,63 @@ function findInputBinding(info: AstResult, name: string, directiveAst: Directive
  */
 class OverrideKindSymbol implements Symbol {
   public readonly kind: DirectiveKind;
-  constructor(private sym: Symbol, kindOverride: DirectiveKind) { this.kind = kindOverride; }
+  constructor(private sym: Symbol, kindOverride: DirectiveKind) {
+    this.kind = kindOverride;
+  }
 
-  get name(): string { return this.sym.name; }
+  get name(): string {
+    return this.sym.name;
+  }
 
-  get language(): string { return this.sym.language; }
+  get language(): string {
+    return this.sym.language;
+  }
 
-  get type(): Symbol|undefined { return this.sym.type; }
+  get type(): Symbol|undefined {
+    return this.sym.type;
+  }
 
-  get container(): Symbol|undefined { return this.sym.container; }
+  get container(): Symbol|undefined {
+    return this.sym.container;
+  }
 
-  get public(): boolean { return this.sym.public; }
+  get public(): boolean {
+    return this.sym.public;
+  }
 
-  get callable(): boolean { return this.sym.callable; }
+  get callable(): boolean {
+    return this.sym.callable;
+  }
 
-  get nullable(): boolean { return this.sym.nullable; }
+  get nullable(): boolean {
+    return this.sym.nullable;
+  }
 
-  get definition(): Definition { return this.sym.definition; }
+  get definition(): Definition {
+    return this.sym.definition;
+  }
 
-  get documentation(): ts.SymbolDisplayPart[] { return this.sym.documentation; }
+  get documentation(): ts.SymbolDisplayPart[] {
+    return this.sym.documentation;
+  }
 
-  members() { return this.sym.members(); }
+  members() {
+    return this.sym.members();
+  }
 
-  signatures() { return this.sym.signatures(); }
+  signatures() {
+    return this.sym.signatures();
+  }
 
-  selectSignature(types: Symbol[]) { return this.sym.selectSignature(types); }
+  selectSignature(types: Symbol[]) {
+    return this.sym.selectSignature(types);
+  }
 
-  indexed(argument: Symbol) { return this.sym.indexed(argument); }
+  indexed(argument: Symbol) {
+    return this.sym.indexed(argument);
+  }
 
-  typeArguments(): Symbol[]|undefined { return this.sym.typeArguments(); }
+  typeArguments(): Symbol[]|undefined {
+    return this.sym.typeArguments();
+  }
 }

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -112,6 +112,7 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
             symbol = findOutputBinding(info, path, ast);
             symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
             span = spanOf(ast);
+<<<<<<< HEAD
           }
         },
         visitElementProperty(ast) { attributeValueSymbol(); },
@@ -124,6 +125,26 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
             if (!dir.directive.selector) continue;
             matcher.addSelectables(CssSelector.parse(dir.directive.selector), dir);
           }
+=======
+    }
+    , visitVariable(ast){}, visitEvent(ast) {
+      if (!attributeValueSymbol(ast.handler)) {
+        symbol = findOutputBinding(info, path, ast);
+        symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
+        span = spanOf(ast);
+      }
+    }
+    , visitElementProperty(ast) { attributeValueSymbol(ast.value); }
+    , visitAttr(ast) {
+      const element = path.head;
+      if (!element || !(element instanceof ElementAst)) return;
+      // Create a mapping of all directives applied to the element from their selectors.
+      const matcher = new SelectorMatcher<DirectiveAst>();
+      for (const dir of element.directives) {
+        if (!dir.directive.selector) continue;
+        matcher.addSelectables(CssSelector.parse(dir.directive.selector), dir);
+      }
+>>>>>>> feat(language-service): completions for output $event properties in
 
           // See if this attribute matches the selector of any directive on the element.
           const attributeSelector = `[${ast.name}=${ast.value}]`;

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -70,7 +70,7 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
         const result = getSymbolInAttributeValue(info, path, attribute);
         if (result) {
           symbol = result.symbol;
-          span = offsetSpan(result.span, attribute.valueSpan!.start.offset);
+          span = offsetSpan(result.span, attribute.valueSpan !.start.offset);
         }
         return true;
       }
@@ -114,9 +114,7 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
             span = spanOf(ast);
           }
         },
-        visitElementProperty(ast) {
-          attributeValueSymbol();
-        },
+        visitElementProperty(ast) { attributeValueSymbol(); },
         visitAttr(ast) {
           const element = path.head;
           if (!element || !(element instanceof ElementAst)) return;
@@ -184,8 +182,7 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
     const {start, end} = offsetSpan(span, info.template.span.start);
     return {
       symbol,
-      span: tss.createTextSpanFromBounds(start, end),
-      staticSymbol,
+      span: tss.createTextSpanFromBounds(start, end), staticSymbol,
     };
   }
 }
@@ -208,7 +205,7 @@ function getSymbolInAttributeValue(info: AstResult, path: TemplateAstPath, attri
     if (inSpan(valueRelativePosition, tb.expression?.ast.span)) {
       const dinfo = diagnosticInfoFromTemplateInfo(info);
       const scope = getExpressionScope(dinfo, path);
-      result = getExpressionSymbol(scope, tb.expression!, path.position, info.template.query);
+      result = getExpressionSymbol(scope, tb.expression !, path.position, info.template.query);
     } else if (inSpan(valueRelativePosition, tb.span)) {
       const template = path.first(EmbeddedTemplateAst);
       if (template) {
@@ -263,9 +260,7 @@ function findParentOfBinding(
     }
 
     visitDirective(ast: DirectiveAst) {
-      const result = this.visitChildren(ast, visit => {
-        visit(ast.inputs);
-      });
+      const result = this.visitChildren(ast, visit => { visit(ast.inputs); });
       return result;
     }
 
@@ -297,63 +292,33 @@ function findInputBinding(info: AstResult, name: string, directiveAst: Directive
  */
 class OverrideKindSymbol implements Symbol {
   public readonly kind: DirectiveKind;
-  constructor(private sym: Symbol, kindOverride: DirectiveKind) {
-    this.kind = kindOverride;
-  }
+  constructor(private sym: Symbol, kindOverride: DirectiveKind) { this.kind = kindOverride; }
 
-  get name(): string {
-    return this.sym.name;
-  }
+  get name(): string { return this.sym.name; }
 
-  get language(): string {
-    return this.sym.language;
-  }
+  get language(): string { return this.sym.language; }
 
-  get type(): Symbol|undefined {
-    return this.sym.type;
-  }
+  get type(): Symbol|undefined { return this.sym.type; }
 
-  get container(): Symbol|undefined {
-    return this.sym.container;
-  }
+  get container(): Symbol|undefined { return this.sym.container; }
 
-  get public(): boolean {
-    return this.sym.public;
-  }
+  get public(): boolean { return this.sym.public; }
 
-  get callable(): boolean {
-    return this.sym.callable;
-  }
+  get callable(): boolean { return this.sym.callable; }
 
-  get nullable(): boolean {
-    return this.sym.nullable;
-  }
+  get nullable(): boolean { return this.sym.nullable; }
 
-  get definition(): Definition {
-    return this.sym.definition;
-  }
+  get definition(): Definition { return this.sym.definition; }
 
-  get documentation(): ts.SymbolDisplayPart[] {
-    return this.sym.documentation;
-  }
+  get documentation(): ts.SymbolDisplayPart[] { return this.sym.documentation; }
 
-  members() {
-    return this.sym.members();
-  }
+  members() { return this.sym.members(); }
 
-  signatures() {
-    return this.sym.signatures();
-  }
+  signatures() { return this.sym.signatures(); }
 
-  selectSignature(types: Symbol[]) {
-    return this.sym.selectSignature(types);
-  }
+  selectSignature(types: Symbol[]) { return this.sym.selectSignature(types); }
 
-  indexed(argument: Symbol) {
-    return this.sym.indexed(argument);
-  }
+  indexed(argument: Symbol) { return this.sym.indexed(argument); }
 
-  typeArguments(): Symbol[]|undefined {
-    return this.sym.typeArguments();
-  }
+  typeArguments(): Symbol[]|undefined { return this.sym.typeArguments(); }
 }

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -112,7 +112,6 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
             symbol = findOutputBinding(info, path, ast);
             symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
             span = spanOf(ast);
-<<<<<<< HEAD
           }
         },
         visitElementProperty(ast) { attributeValueSymbol(); },
@@ -125,26 +124,6 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
             if (!dir.directive.selector) continue;
             matcher.addSelectables(CssSelector.parse(dir.directive.selector), dir);
           }
-=======
-    }
-    , visitVariable(ast){}, visitEvent(ast) {
-      if (!attributeValueSymbol(ast.handler)) {
-        symbol = findOutputBinding(info, path, ast);
-        symbol = symbol && new OverrideKindSymbol(symbol, DirectiveKind.EVENT);
-        span = spanOf(ast);
-      }
-    }
-    , visitElementProperty(ast) { attributeValueSymbol(ast.value); }
-    , visitAttr(ast) {
-      const element = path.head;
-      if (!element || !(element instanceof ElementAst)) return;
-      // Create a mapping of all directives applied to the element from their selectors.
-      const matcher = new SelectorMatcher<DirectiveAst>();
-      for (const dir of element.directives) {
-        if (!dir.directive.selector) continue;
-        matcher.addSelectables(CssSelector.parse(dir.directive.selector), dir);
-      }
->>>>>>> feat(language-service): completions for output $event properties in
 
           // See if this attribute matches the selector of any directive on the element.
           const attributeSelector = `[${ast.name}=${ast.value}]`;

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {AstResult, SelectorInfo} from './common';
 import {DiagnosticTemplateInfo} from './expression_diagnostics';
-import {Span, Symbol} from './types';
+import {Span, Symbol, SymbolQuery} from './types';
 
 export interface SpanHolder {
   sourceSpan: ParseSourceSpan;
@@ -268,14 +268,14 @@ export function invertMap(obj: {[name: string]: string}): {[name: string]: strin
  * @param path narrowing
  */
 export function findOutputBinding(
-    info: AstResult, path: TemplateAstPath, binding: BoundEventAst): Symbol|undefined {
+    binding: BoundEventAst, path: TemplateAstPath, query: SymbolQuery): Symbol|undefined {
   const element = path.first(ElementAst);
   if (element) {
     for (const directive of element.directives) {
       const invertedOutputs = invertMap(directive.directive.outputs);
       const fieldName = invertedOutputs[binding.name];
       if (fieldName) {
-        const classSymbol = info.template.query.getTypeSymbol(directive.directive.type.reference);
+        const classSymbol = query.getTypeSymbol(directive.directive.type.reference);
         if (classSymbol) {
           return classSymbol.members().get(fieldName);
         }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -763,30 +763,11 @@ describe('completions', () => {
     });
 
     it('should suggest $event completions in output bindings', () => {
-      mockHost.override(APP_COMPONENT, `
-        import {Component, Directive, EventEmitter, NgModule, Output} from '@angular/core';
-
-        @Directive({
-          selector: '[string-model]',
-        })
-        export class StringModel {
-          @Output('modelBinding') modelChange: EventEmitter<string> = new EventEmitter();
-        }
-
-        @Component({
-          template: '<div string-model (modelBinding)="$event.~{cursor}"></div>',
-        })
-        export class AppComponent {}
-
-        @NgModule({
-          declarations: [StringModel, AppComponent],
-        })
-        export class TestModule {}
-      `);
-      const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'cursor');
-      debugger;
-      const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);
-      expectContain(completions, CompletionKind.METHOD, ['subscribe']);
+      mockHost.override(TEST_TEMPLATE, `<div string-model (modelChange)="$event.~{cursor}"></div>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      // Expect string properties
+      expectContain(completions, CompletionKind.METHOD, ['charAt', 'substring']);
     });
   });
 });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -758,9 +758,35 @@ describe('completions', () => {
     it('should suggest $event in event bindings', () => {
       mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      debugger;
       const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.VARIABLE, ['$event']);
+    });
+
+    it('should suggest $event completions in output bindings', () => {
+      mockHost.override(APP_COMPONENT, `
+        import {Component, Directive, EventEmitter, NgModule, Output} from '@angular/core';
+
+        @Directive({
+          selector: '[string-model]',
+        })
+        export class StringModel {
+          @Output('modelBinding') modelChange: EventEmitter<string> = new EventEmitter();
+        }
+
+        @Component({
+          template: '<div string-model (modelBinding)="$event.~{cursor}"></div>',
+        })
+        export class AppComponent {}
+
+        @NgModule({
+          declarations: [StringModel, AppComponent],
+        })
+        export class TestModule {}
+      `);
+      const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'cursor');
+      debugger;
+      const completions = ngLS.getCompletionsAt(APP_COMPONENT, marker.start);
+      expectContain(completions, CompletionKind.METHOD, ['subscribe']);
     });
   });
 });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -758,14 +758,14 @@ describe('completions', () => {
     it('should suggest $event in event bindings', () => {
       mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.VARIABLE, ['$event']);
     });
 
     it('should suggest $event completions in output bindings', () => {
       mockHost.override(TEST_TEMPLATE, `<div string-model (modelChange)="$event.~{cursor}"></div>`);
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
       // Expect string properties
       expectContain(completions, CompletionKind.METHOD, ['charAt', 'substring']);
     });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -753,6 +753,16 @@ describe('completions', () => {
       expectContain(completions, CompletionKind.VARIABLE, ['$event']);
     });
   });
+
+  describe('$event completions', () => {
+    it('should suggest $event in event bindings', () => {
+      mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      debugger;
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.VARIABLE, ['$event']);
+    });
+  });
 });
 
 function expectContain(

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -311,16 +311,14 @@ describe('diagnostics', () => {
 
   describe('with $event', () => {
     it('should accept an event', () => {
-      const fileName = '/app/test.ng';
-      mockHost.override(fileName, '<div (click)="myClick($event)">Click me!</div>');
-      const diagnostics = ngLS.getSemanticDiagnostics(fileName);
+      mockHost.override(TEST_TEMPLATE, '<div (click)="myClick($event)">Click me!</div>');
+      const diagnostics = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
       expect(diagnostics).toEqual([]);
     });
 
     it('should reject it when not in an event binding', () => {
-      const fileName = '/app/test.ng';
-      const content = mockHost.override(fileName, '<div [tabIndex]="$event"></div>');
-      const diagnostics = ngLS.getSemanticDiagnostics(fileName) !;
+      const content = mockHost.override(TEST_TEMPLATE, '<div [tabIndex]="$event"></div>');
+      const diagnostics = ngLS.getSemanticDiagnostics(TEST_TEMPLATE) !;
       expect(diagnostics.length).toBe(1);
       const {messageText, start, length} = diagnostics[0];
       expect(messageText)
@@ -329,6 +327,17 @@ describe('diagnostics', () => {
       const keyword = '$event';
       expect(start).toBe(content.lastIndexOf(keyword));
       expect(length).toBe(keyword.length);
+    });
+
+    it('should reject invalid properties on an event type', () => {
+      const content = mockHost.override(
+          TEST_TEMPLATE, '<div string-model (modelChange)="$event.notSubstring()"></div>');
+      const diagnostics = ngLS.getSemanticDiagnostics(TEST_TEMPLATE) !;
+      expect(diagnostics.length).toBe(1);
+      const {messageText, start, length} = diagnostics[0];
+      expect(messageText).toBe(`Unknown method 'notSubstring'`);
+      expect(start).toBe(content.indexOf('$event'));
+      expect(length).toBe('$event.notSubstring()'.length);
     });
   });
 


### PR DESCRIPTION
This commit adds support for completions of properties on `$event`
variables in bound outputs.

This is the second major PR to support completions for `$event`
variables (angular/vscode-ng-language-service#531).
The final completion support that must be provided is for `$event`
variables in bindings targeting DOM events, like `(click)`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No