### PR TITLE
fix(ivy): Ensure ngProjectAs marker name appears at even attribute index

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1536,7 +1536,7 @@ describe('compiler compliance', () => {
             decls: 1,
             vars: 1,
             consts: [
-                ["ngProjectAs", ".someclass", ${AttributeMarker.Template}, "ngIf", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]],
+                ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"], ${AttributeMarker.Template}, "ngIf"],
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]]
             ],
             template: function MyApp_Template(rf, ctx) {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -599,14 +599,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       attributes.push(...getAttributeNameLiterals(attr.name), o.literal(attr.value));
     });
 
-    // Keep ngProjectAs next to the other name, value pairs so we can verify that we match
-    // ngProjectAs marker in the attribute name slot.
-    if (ngProjectAsAttr) {
-      attributes.push(...getNgProjectAsLiteral(ngProjectAsAttr));
-    }
     // add attributes for directive and projection matching purposes
     attributes.push(...this.prepareNonRenderAttrs(
-        allOtherInputs, element.outputs, stylingBuilder, [], i18nAttrs));
+        allOtherInputs, element.outputs, stylingBuilder, [], i18nAttrs, ngProjectAsAttr));
     parameters.push(this.addAttrsToConsts(attributes));
 
     // local refs (ex.: <div #foo #bar="baz">)
@@ -876,13 +871,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       }
       attrsExprs.push(asLiteral(attr.name), asLiteral(attr.value));
     });
-    // Keep ngProjectAs next to the other name, value pairs so we can verify that we match
-    // ngProjectAs marker in the attribute name slot.
-    if (ngProjectAsAttr) {
-      attrsExprs.push(...getNgProjectAsLiteral(ngProjectAsAttr));
-    }
     attrsExprs.push(...this.prepareNonRenderAttrs(
-        template.inputs, template.outputs, undefined, template.templateAttrs, undefined));
+        template.inputs, template.outputs, undefined, template.templateAttrs, undefined,
+        ngProjectAsAttr));
     parameters.push(this.addAttrsToConsts(attrsExprs));
 
     // local refs (ex.: <ng-template #foo>)
@@ -1263,9 +1254,16 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private prepareNonRenderAttrs(
       inputs: t.BoundAttribute[], outputs: t.BoundEvent[], styles?: StylingBuilder,
       templateAttrs: (t.BoundAttribute|t.TextAttribute)[] = [],
-      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = []): o.Expression[] {
+      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = [],
+      ngProjectAsAttr?: t.TextAttribute): o.Expression[] {
     const alreadySeen = new Set<string>();
     const attrExprs: o.Expression[] = [];
+
+    // Keep ngProjectAs next to the other name, value pairs so we can verify that we match
+    // ngProjectAs marker in the attribute name slot.
+    if (ngProjectAsAttr) {
+      attrExprs.push(...getNgProjectAsLiteral(ngProjectAsAttr));
+    }
 
     function addAttrExpr(key: string | number, value?: o.Expression): void {
       if (typeof key === 'string') {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -599,9 +599,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       attributes.push(...getAttributeNameLiterals(attr.name), o.literal(attr.value));
     });
 
+    // Keep ngProjectAs next to the other name, value pairs so we can verify that we match
+    // ngProjectAs marker in the attribute name slot.
+    if (ngProjectAsAttr) {
+      attributes.push(...getNgProjectAsLiteral(ngProjectAsAttr));
+    }
     // add attributes for directive and projection matching purposes
     attributes.push(...this.prepareNonRenderAttrs(
-        allOtherInputs, element.outputs, stylingBuilder, [], i18nAttrs, ngProjectAsAttr));
+        allOtherInputs, element.outputs, stylingBuilder, [], i18nAttrs));
     parameters.push(this.addAttrsToConsts(attributes));
 
     // local refs (ex.: <div #foo #bar="baz">)
@@ -871,9 +876,13 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       }
       attrsExprs.push(asLiteral(attr.name), asLiteral(attr.value));
     });
+    // Keep ngProjectAs next to the other name, value pairs so we can verify that we match
+    // ngProjectAs marker in the attribute name slot.
+    if (ngProjectAsAttr) {
+      attrsExprs.push(...getNgProjectAsLiteral(ngProjectAsAttr));
+    }
     attrsExprs.push(...this.prepareNonRenderAttrs(
-        template.inputs, template.outputs, undefined, template.templateAttrs, undefined,
-        ngProjectAsAttr));
+        template.inputs, template.outputs, undefined, template.templateAttrs, undefined));
     parameters.push(this.addAttrsToConsts(attrsExprs));
 
     // local refs (ex.: <ng-template #foo>)
@@ -1240,11 +1249,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
    *
    * ```
    * attrs = [prop, value, prop2, value2,
+   *   PROJECT_AS, selector,
    *   CLASSES, class1, class2,
    *   STYLES, style1, value1, style2, value2,
    *   BINDINGS, name1, name2, name3,
    *   TEMPLATE, name4, name5, name6,
-   *   PROJECT_AS, selector,
    *   I18N, name7, name8, ...]
    * ```
    *
@@ -1254,8 +1263,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private prepareNonRenderAttrs(
       inputs: t.BoundAttribute[], outputs: t.BoundEvent[], styles?: StylingBuilder,
       templateAttrs: (t.BoundAttribute|t.TextAttribute)[] = [],
-      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = [],
-      ngProjectAsAttr?: t.TextAttribute): o.Expression[] {
+      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = []): o.Expression[] {
     const alreadySeen = new Set<string>();
     const attrExprs: o.Expression[] = [];
 
@@ -1309,10 +1317,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     if (templateAttrs.length) {
       attrExprs.push(o.literal(core.AttributeMarker.Template));
       templateAttrs.forEach(attr => addAttrExpr(attr.name));
-    }
-
-    if (ngProjectAsAttr) {
-      attrExprs.push(...getNgProjectAsLiteral(ngProjectAsAttr));
     }
 
     if (i18nAttrs.length) {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -496,24 +496,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const slot = this.allocateDataSlot();
     const projectionSlotIdx = this._ngContentSelectorsOffset + this._ngContentReservedSlots.length;
     const parameters: o.Expression[] = [o.literal(slot)];
-    const attributes: o.Expression[] = [];
-    let ngProjectAsAttr: t.TextAttribute|undefined;
 
     this._ngContentReservedSlots.push(ngContent.selector);
 
-    ngContent.attributes.forEach((attribute) => {
-      const {name, value} = attribute;
-      if (name === NG_PROJECT_AS_ATTR_NAME) {
-        ngProjectAsAttr = attribute;
-      }
-      if (name.toLowerCase() !== NG_CONTENT_SELECT_ATTR) {
-        attributes.push(o.literal(name), o.literal(value));
-      }
-    });
-
-    if (ngProjectAsAttr) {
-      attributes.push(...getNgProjectAsLiteral(ngProjectAsAttr));
-    }
+    const nonContentSelectAttributes =
+        ngContent.attributes.filter(attr => attr.name.toLowerCase() !== NG_CONTENT_SELECT_ATTR);
+    const attributes = this.getAttributeExpressions(nonContentSelectAttributes, [], []);
 
     if (attributes.length > 0) {
       parameters.push(o.literal(projectionSlotIdx), o.literalArr(attributes));
@@ -1237,7 +1225,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private getAttributeExpressions(
       renderAttributes: t.TextAttribute[], inputs: t.BoundAttribute[], outputs: t.BoundEvent[],
       styles?: StylingBuilder, templateAttrs: (t.BoundAttribute|t.TextAttribute)[] = [],
-      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = [], ): o.Expression[] {
+      i18nAttrs: (t.BoundAttribute|t.TextAttribute)[] = []): o.Expression[] {
     const alreadySeen = new Set<string>();
     const attrExprs: o.Expression[] = [];
     let ngProjectAsAttr: t.TextAttribute|undefined;

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -966,6 +966,8 @@ describe('projection', () => {
       template: `
         <ng-content select="[card-title]"></ng-content>
         ---
+        <ng-content select="[card-subtitle]"></ng-content>
+        ---
         <ng-content select="[card-content]"></ng-content>
         ---
         <ng-content select="[card-footer]"></ng-content>
@@ -979,6 +981,7 @@ describe('projection', () => {
       template: `
         <card>
          <h1 [color]="'red'" [margin]="10" ngProjectAs="[card-title]">Title</h1>
+         <h2  xlink:href="google.com" ngProjectAs="[card-subtitle]">Subtitle</h2>
          <div style="font-color: blue;" ngProjectAs="[card-content]">content</div>
          <div [color]="'blue'" ngProjectAs="[card-footer]">footer</div>
         </card>
@@ -992,7 +995,8 @@ describe('projection', () => {
     fixture.detectChanges();
 
     // Compare the text output, because Ivy and ViewEngine produce slightly different HTML.
-    expect(fixture.nativeElement.textContent).toContain('Title --- content --- footer');
+    expect(fixture.nativeElement.textContent)
+        .toContain('Title --- Subtitle --- content --- footer');
   });
 
   it('should support ngProjectAs on elements (including <ng-content>)', () => {

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -955,6 +955,46 @@ describe('projection', () => {
     expect(fixture.nativeElement).toHaveText('hello');
   });
 
+  it('should support ngProjectAs with a various number of other bindings and attributes', () => {
+    @Directive({selector: '[color],[margin]'})
+    class ElDecorator {
+      @Input() color?: string;
+      @Input() margin?: number;
+    }
+    @Component({
+      selector: 'card',
+      template: `
+        <ng-content select="[card-title]"></ng-content>
+        ---
+        <ng-content select="[card-content]"></ng-content>
+        ---
+        <ng-content select="[card-footer]"></ng-content>
+      `
+    })
+    class Card {
+    }
+
+    @Component({
+      selector: 'card-with-title',
+      template: `
+        <card>
+         <h1 [color]="'red'" [margin]="10" ngProjectAs="[card-title]">Title</h1>
+         <div style="font-color: blue;" ngProjectAs="[card-content]">content</div>
+         <div [color]="'blue'" ngProjectAs="[card-footer]">footer</div>
+        </card>
+      `
+    })
+    class CardWithTitle {
+    }
+
+    TestBed.configureTestingModule({declarations: [Card, CardWithTitle, ElDecorator]});
+    const fixture = TestBed.createComponent(CardWithTitle);
+    fixture.detectChanges();
+
+    // Compare the text output, because Ivy and ViewEngine produce slightly different HTML.
+    expect(fixture.nativeElement.textContent).toContain('Title --- content --- footer');
+  });
+
   it('should support ngProjectAs on elements (including <ng-content>)', () => {
     @Component({
       selector: 'card',


### PR DESCRIPTION
The `getProjectAsAttrValue` in `node_selector_matcher` finds the
`ProjectAs` marker and then additionally checks that the marker appears in
an even index of the node attributes because "attribute names are stored
at even indexes". This is true for "regular" attribute bindings but
classes, styles, bindings, templates, and i18n do not necessarily follow
this rule because there can be an uneven number of them, causing the
next "special" attribute "name" to appear at an odd index. To address
this issue, ensure `ngProjectAs` is placed right after "regular"
attributes.
