### PR TITLE
fix(documentation): correct prop for setting a default value to dynamic dropdowns.

### DIFF
--- a/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
+++ b/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
@@ -8,7 +8,7 @@
             [id]="question.key" [type]="question.type">
 
     <select [id]="question.key" *ngSwitchCase="'dropdown'" [formControlName]="question.key">
-      <option *ngFor="let opt of question.options" [value]="opt.key">{{opt.value}}</option>
+      <option *ngFor="let opt of question.options" [value]="opt.value">{{opt.value}}</option>
     </select>
 
   </div>


### PR DESCRIPTION
```javascript
      new DropdownQuestion({
        key: 'brave',
        label: 'Bravery Rating',
        value: 'Unproven',
        options: [
          {key: 'solid',  value: 'Solid'},
          {key: 'great',  value: 'Great'},
          {key: 'good',   value: 'Good'},
          {key: 'unproven', value: 'Unproven'}
        ],
        required: true
      }),
```

This does not cause breaking changes with the JSON output by the dynamic form.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
It seems the code snippets for docs are generated dynamically hope this is the correct place to make the fix. And not sure how to update the stack blitz example.
New to contributing.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the dropdown example at https://angular.io/guide/dynamic-form
does not use a dynamic value. 
here is the stackblitz related to the shown as live example in the guide:
https://stackblitz.com/angular/lrvnmvdmovq

## What is the new behavior?

This change allows users to specify that value similar to the text-box example in the dynamic form.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

currently opt.key is used but I believe it does not show up because the key 'brave' in the example does not exist in the given options.

## Other information
Please let me know if there is any way to improve the commit or if there are breaking changes I may have missed.
Cheers, Michael Dimmitt