### PR TITLE
feat(zone.js): patch jasmine.createSpyObj to make properties enumerable to be true

### DIFF
--- a/packages/zone.js/test/jasmine-patch.spec.ts
+++ b/packages/zone.js/test/jasmine-patch.spec.ts
@@ -77,4 +77,14 @@ ifEnvSupports(supportJasmineSpec, () => {
       expect(log).toEqual(['resolved']);
     });
   });
+
+  describe('jasmine.createSpyObj', () => {
+    it('createSpyObj with properties should be able to be retrieved from the spy', () => {
+      const spy = jasmine.createSpyObj('obj', ['someFunction'], {prop1: 'foo'});
+      expect(spy.prop1).toEqual('foo');
+      const desc: any = Object.getOwnPropertyDescriptor(spy, 'prop1');
+      expect(desc.enumerable).toBe(true);
+      expect(desc.configurable).toBe(true);
+    });
+  });
 })();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33657 


Close #33657

in jasmine 3.5, there is a new feature, user can pass a properties object to `jasmine.createSpyObj`

```
const spy = jasmine.createSpyObj('spy', ['method1'], {prop1: 'foo'});
expect(spy.prop1).toEqual('foo');
```

This case will not work for Angular TestBed, for example,

```
describe('AppComponent', () => {
  beforeEach(() => {

    //Note the third parameter
    // @ts-ignore
    const someServiceSpy = jasmine.createSpyObj('SomeService', ['someFunction'], ['aProperty']);

    TestBed.configureTestingModule({
      declarations: [
        AppComponent
      ],
      providers: [
        {provide: SomeService, useValue: someServiceSpy},
      ]
    }).compileComponents();

  });

  it('should create the app', () => {
    //spyObj will have someFunction, but will not have aProperty
    let spyObj = TestBed.get(SomeService);
  });
```

Because `jasmine.createSpyObj` will create the `aProperty` with `enumerable=false`,
and `TestBed.configureTestingModule` will try to copy all the properties from spyObj to
the injected service instance. And because `enumerable` is false, so the property (here is aProperty)
will not be copied.

This PR will monkey patch the `jasmine.createSpyObj` and make sure the new property's
`enumerable=true`.