### PR TITLE
fix(common): remove trailing whitespace for CurrencyPipe

### DIFF
--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -161,7 +161,12 @@ export function formatCurrency(
   return res
       .replace(CURRENCY_CHAR, currency)
       // if we have 2 time the currency character, the second one is ignored
-      .replace(CURRENCY_CHAR, '');
+      .replace(CURRENCY_CHAR, '')
+      // If there is a spacing between currency character and the value and
+      // the currency character is supressed by passing an empty string, the
+      // spacing character would remain as part of the string. Then we
+      // should remove it.
+      .trim();
 }
 
 /**

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -11,6 +11,7 @@ import localeEsUS from '@angular/common/locales/es-US';
 import localeFr from '@angular/common/locales/fr';
 import localeAr from '@angular/common/locales/ar';
 import localeDeAt from '@angular/common/locales/de-AT';
+import localeDa from '@angular/common/locales/da';
 import {ɵunregisterLocaleData, ɵregisterLocaleData} from '@angular/core';
 import {CurrencyPipe, DecimalPipe, PercentPipe} from '@angular/common';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
@@ -23,6 +24,7 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
       ɵregisterLocaleData(localeFr);
       ɵregisterLocaleData(localeAr);
       ɵregisterLocaleData(localeDeAt);
+      ɵregisterLocaleData(localeDa);
     });
 
     afterAll(() => ɵunregisterLocaleData());
@@ -95,6 +97,7 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
           expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual('EUR12.0');
           expect(pipe.transform(5.1234, 'USD', 'code', '.0-3')).toEqual('USD5.123');
           expect(pipe.transform(5.1234, 'USD', 'code')).toEqual('USD5.12');
+          expect(pipe.transform(5.1234, 'USD', '')).toEqual('5.12');
           expect(pipe.transform(5.1234, 'USD', 'symbol')).toEqual('$5.12');
           expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
           expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow')).toEqual('$5.12');
@@ -104,6 +107,8 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
           expect(pipe.transform(5, 'USD', 'symbol', '', 'fr')).toEqual('5,00 $US');
           expect(pipe.transform(123456789, 'EUR', 'symbol', '', 'de-at'))
               .toEqual('€ 123.456.789,00');
+          expect(pipe.transform(5.1234, 'EUR', '', '', 'de-at')).toEqual('5,12');
+          expect(pipe.transform(5.1234, 'DKK', '', '', 'da')).toEqual('5,12');
         });
 
         it('should support any currency code name', () => {


### PR DESCRIPTION
Trimming any surrounding whitespace characters in
formatNumberToLocaleString if currency symbol is
supressed.

Closes #34641

PR Checklist
------------

Please check if your PR fulfills the following requirements:

-   [x]  The commit message follows our guidelines: <https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit>
-   [x]  Tests for the changes have been added (for bug fixes / features)
-   [ ]  Docs have been added / updated (for bug fixes / features)

PR Type
-------

What kind of change does this PR introduce?

-   [x]  Bugfix
-   [ ]  Feature
-   [ ]  Code style update (formatting, local variables)
-   [ ]  Refactoring (no functional changes, no api changes)
-   [ ]  Build related changes
-   [ ]  CI related changes
-   [ ]  Documentation content changes
-   [ ]  angular.io application / infrastructure changes
-   [ ]  Other... Please describe:

What is the current behavior?
-----------------------------

Issue Number: [#34641](https://github.com/angular/angular/issues/34641)

What is the new behavior?
-------------------------

The exessive whitespace is trimmed.

Does this PR introduce a breaking change?
-----------------------------------------

-   [ ]  Yes
-   [x]  No