### PR TITLE
fix(ngcc): do not attempt compilation when analysis fails

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -17,8 +17,7 @@ import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, Inj
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
 import {ClassDeclaration} from '../../../src/ngtsc/reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../src/ngtsc/scope';
-import {resolveTrait} from '../../../src/ngtsc/transform';
-import {CompileResult, DecoratorHandler, TraitState} from '../../../src/ngtsc/transform';
+import {CompileResult, DecoratorHandler, TraitState, resolveTrait} from '../../../src/ngtsc/transform';
 import {NgccClassSymbol, NgccReflectionHost} from '../host/ngcc_host';
 import {Migration} from '../migrations/migration';
 import {MissingInjectableMigration} from '../migrations/missing_injectable_migration';

--- a/packages/compiler-cli/ngcc/src/analysis/types.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/types.ts
@@ -9,7 +9,7 @@ import {ConstantPool} from '@angular/compiler';
 import * as ts from 'typescript';
 import {Reexport} from '../../../src/ngtsc/imports';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
-import {CompileResult, DecoratorHandler, DetectResult} from '../../../src/ngtsc/transform';
+import {CompileResult, Trait} from '../../../src/ngtsc/transform';
 
 export interface AnalyzedFile {
   sourceFile: ts.SourceFile;
@@ -20,8 +20,8 @@ export interface AnalyzedClass {
   name: string;
   decorators: Decorator[]|null;
   declaration: ClassDeclaration;
-  diagnostics?: ts.Diagnostic[];
-  matches: MatchingHandler<unknown, unknown, unknown>[];
+  traits: Trait<unknown, unknown, unknown>[];
+  metaDiagnostics?: ts.Diagnostic[];
 }
 
 export interface CompiledClass extends AnalyzedClass {
@@ -41,10 +41,3 @@ export interface CompiledFile {
 
 export type DecorationAnalyses = Map<ts.SourceFile, CompiledFile>;
 export const DecorationAnalyses = Map;
-
-export interface MatchingHandler<D, A, R> {
-  handler: DecoratorHandler<D, A, R>;
-  detected: DetectResult<D>;
-  analysis: Readonly<A>;
-  resolution: Readonly<R>;
-}

--- a/packages/compiler-cli/ngcc/src/analysis/util.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/util.ts
@@ -7,61 +7,54 @@
  */
 import * as ts from 'typescript';
 
-import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
 import {AbsoluteFsPath, absoluteFromSourceFile, relative} from '../../../src/ngtsc/file_system';
 import {DependencyTracker} from '../../../src/ngtsc/incremental/api';
 import {Decorator} from '../../../src/ngtsc/reflection';
-import {DecoratorHandler, HandlerFlags, HandlerPrecedence} from '../../../src/ngtsc/transform';
+import {DecoratorHandler, HandlerFlags, HandlerPrecedence, PendingTrait, Trait, analyzeTrait} from '../../../src/ngtsc/transform';
 import {NgccClassSymbol} from '../host/ngcc_host';
 
-import {AnalyzedClass, MatchingHandler} from './types';
+import {AnalyzedClass} from './types';
 
 export function isWithinPackage(packagePath: AbsoluteFsPath, sourceFile: ts.SourceFile): boolean {
   return !relative(packagePath, absoluteFromSourceFile(sourceFile)).startsWith('..');
 }
-
-const NOT_YET_KNOWN: Readonly<unknown> = null as unknown as Readonly<unknown>;
 
 export function analyzeDecorators(
     classSymbol: NgccClassSymbol, decorators: Decorator[] | null,
     handlers: DecoratorHandler<unknown, unknown, unknown>[], flags?: HandlerFlags): AnalyzedClass|
     null {
   const declaration = classSymbol.declaration.valueDeclaration;
-  const matchingHandlers: MatchingHandler<unknown, unknown, unknown>[] = [];
+  const pending: PendingTrait<unknown, unknown, unknown>[] = [];
   for (const handler of handlers) {
     const detected = handler.detect(declaration, decorators);
     if (detected !== undefined) {
-      matchingHandlers.push({
-        handler,
-        detected,
-        analysis: NOT_YET_KNOWN,
-        resolution: NOT_YET_KNOWN,
-      });
+      const trait = Trait.pending(handler, detected);
+      pending.push(trait);
     }
   }
 
-  if (matchingHandlers.length === 0) {
+  if (pending.length === 0) {
     return null;
   }
 
-  const detections: MatchingHandler<unknown, unknown, unknown>[] = [];
+  const traits: PendingTrait<unknown, unknown, unknown>[] = [];
   let hasWeakHandler: boolean = false;
   let hasNonWeakHandler: boolean = false;
   let hasPrimaryHandler: boolean = false;
 
-  for (const match of matchingHandlers) {
-    const {handler} = match;
+  for (const trait of pending) {
+    const {handler} = trait;
     if (hasNonWeakHandler && handler.precedence === HandlerPrecedence.WEAK) {
       continue;
     } else if (hasWeakHandler && handler.precedence !== HandlerPrecedence.WEAK) {
       // Clear all the WEAK handlers from the list of matches.
-      detections.length = 0;
+      traits.length = 0;
     }
     if (hasPrimaryHandler && handler.precedence === HandlerPrecedence.PRIMARY) {
       throw new Error(`TODO.Diagnostic: Class has multiple incompatible Angular decorators.`);
     }
 
-    detections.push(match);
+    traits.push(trait);
     if (handler.precedence === HandlerPrecedence.WEAK) {
       hasWeakHandler = true;
     } else if (handler.precedence === HandlerPrecedence.SHARED) {
@@ -72,36 +65,15 @@ export function analyzeDecorators(
     }
   }
 
-  const matches: MatchingHandler<unknown, unknown, unknown>[] = [];
-  const allDiagnostics: ts.Diagnostic[] = [];
-  for (const match of detections) {
-    try {
-      const {analysis, diagnostics} =
-          match.handler.analyze(declaration, match.detected.metadata, flags);
-      if (diagnostics !== undefined) {
-        allDiagnostics.push(...diagnostics);
-      }
-      if (analysis !== undefined) {
-        match.analysis = analysis;
-        if (match.handler.register !== undefined) {
-          match.handler.register(declaration, analysis);
-        }
-      }
-      matches.push(match);
-    } catch (e) {
-      if (isFatalDiagnosticError(e)) {
-        allDiagnostics.push(e.toDiagnostic());
-      } else {
-        throw e;
-      }
-    }
+  for (const trait of traits) {
+    analyzeTrait(declaration, trait, flags);
   }
+
   return {
     name: classSymbol.name,
     declaration,
     decorators,
-    matches,
-    diagnostics: allDiagnostics.length > 0 ? allDiagnostics : undefined,
+    traits,
   };
 }
 

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -44,6 +44,7 @@ runInEachFileSystem(() => {
         const handler = jasmine.createSpyObj<DecoratorHandlerWithResolve>('TestDecoratorHandler', [
           'detect',
           'analyze',
+          'register',
           'resolve',
           'compile',
         ]);
@@ -388,6 +389,10 @@ runInEachFileSystem(() => {
           analyzer.analyzeProgram();
           expect(diagnosticLogs.length).toEqual(1);
           expect(diagnosticLogs[0]).toEqual(jasmine.objectContaining({code: -999999}));
+          expect(testHandler.analyze).toHaveBeenCalled();
+          expect(testHandler.register).not.toHaveBeenCalled();
+          expect(testHandler.resolve).not.toHaveBeenCalled();
+          expect(testHandler.compile).not.toHaveBeenCalled();
         });
 
         it('should report resolve diagnostics to the `diagnosticHandler` callback', () => {
@@ -406,6 +411,10 @@ runInEachFileSystem(() => {
           analyzer.analyzeProgram();
           expect(diagnosticLogs.length).toEqual(1);
           expect(diagnosticLogs[0]).toEqual(jasmine.objectContaining({code: -999998}));
+          expect(testHandler.analyze).toHaveBeenCalled();
+          expect(testHandler.register).toHaveBeenCalled();
+          expect(testHandler.resolve).toHaveBeenCalled();
+          expect(testHandler.compile).not.toHaveBeenCalled();
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -372,25 +372,41 @@ runInEachFileSystem(() => {
           expect(diagnosticLogs[1]).toEqual(jasmine.objectContaining({code: -996666}));
         });
 
-        it('should report analyze and resolve diagnostics to the `diagnosticHandler` callback',
-           () => {
-             const analyzer = setUpAnalyzer(
-                 [
-                   {
-                     name: _('/node_modules/test-package/index.js'),
-                     contents: `
+        it('should report analyze diagnostics to the `diagnosticHandler` callback', () => {
+          const analyzer = setUpAnalyzer(
+              [
+                {
+                  name: _('/node_modules/test-package/index.js'),
+                  contents: `
                   import {Component, Directive, Injectable} from '@angular/core';
                   export class MyComponent {}
                   MyComponent.decorators = [{type: Component}];
                 `,
-                   },
-                 ],
-                 {analyzeError: true, resolveError: true});
-             analyzer.analyzeProgram();
-             expect(diagnosticLogs.length).toEqual(2);
-             expect(diagnosticLogs[0]).toEqual(jasmine.objectContaining({code: -999999}));
-             expect(diagnosticLogs[1]).toEqual(jasmine.objectContaining({code: -999998}));
-           });
+                },
+              ],
+              {analyzeError: true, resolveError: true});
+          analyzer.analyzeProgram();
+          expect(diagnosticLogs.length).toEqual(1);
+          expect(diagnosticLogs[0]).toEqual(jasmine.objectContaining({code: -999999}));
+        });
+
+        it('should report resolve diagnostics to the `diagnosticHandler` callback', () => {
+          const analyzer = setUpAnalyzer(
+              [
+                {
+                  name: _('/node_modules/test-package/index.js'),
+                  contents: `
+                  import {Component, Directive, Injectable} from '@angular/core';
+                  export class MyComponent {}
+                  MyComponent.decorators = [{type: Component}];
+                `,
+                },
+              ],
+              {analyzeError: false, resolveError: true});
+          analyzer.analyzeProgram();
+          expect(diagnosticLogs.length).toEqual(1);
+          expect(diagnosticLogs[0]).toEqual(jasmine.objectContaining({code: -999998}));
+        });
       });
 
       describe('declaration files', () => {

--- a/packages/compiler-cli/src/ngtsc/transform/index.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './src/api';
-export {ClassRecord, TraitCompiler} from './src/compilation';
+export {analyzeTrait, ClassRecord, resolveTrait, TraitCompiler} from './src/compilation';
 export {declarationTransformFactory, DtsTransformRegistry, IvyDeclarationDtsTransform, ReturnTypeTransform} from './src/declaration';
+export {AnalyzedTrait, ErroredTrait, PendingTrait, ResolvedTrait, SkippedTrait, Trait, TraitState} from './src/trait';
 export {ivyTransformFactory} from './src/transform';


### PR DESCRIPTION
In #34288, ngtsc was refactored to separate the result of the analysis
and resolve phase for more granular incremental rebuilds. In this model,
any errors in one phase transition the trait into an error state, which
prevents it from being ran through subsequent phases. The ngcc compiler
on the other hand did not adopt this strict error model, which would
cause incomplete metadata—due to errors in earlier phases—to be offered
for compilation that could result in a hard crash.

This commit changes ngcc so that it starts using ngtsc's `Trait` concept
to track transitions between the analysis, resolve and compile phase
much more explicitly. This approach makes it illegal to attempt the
compile phase when either analysis or resolve has produced errors,
avoiding the crash.

Fixes #34500
Resolves FW-1788