### PR TITLE
fix(ivy): more accurate detection of pipes in host bindings

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2250,29 +2250,67 @@ runInEachFileSystem(os => {
           }
         })
         class FooCmp {}
-    `);
+      `);
       const errors = env.driveDiagnostics();
       expect(trim(errors[0].messageText as string))
           .toContain('Cannot have a pipe in an action expression');
     });
 
-    it('should throw in case pipes are used in host bindings', () => {
+    it('should throw in case pipes are used in host bindings (defined as `value | pipe`)', () => {
       env.write(`test.ts`, `
-        import {Component} from '@angular/core';
+            import {Component} from '@angular/core';
 
-        @Component({
-          selector: 'test',
-          template: '...',
-          host: {
-            '[id]': 'id | myPipe'
-          }
-        })
-        class FooCmp {}
-    `);
+            @Component({
+              selector: 'test',
+              template: '...',
+              host: {
+                '[id]': 'id | myPipe'
+              }
+            })
+            class FooCmp {}
+         `);
       const errors = env.driveDiagnostics();
       expect(trim(errors[0].messageText as string))
           .toContain('Host binding expression cannot contain pipes');
     });
+
+    it('should throw in case pipes are used in host bindings (defined as `!(value | pipe)`)',
+       () => {
+         env.write(`test.ts`, `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test',
+              template: '...',
+              host: {
+                '[id]': '!(id | myPipe)'
+              }
+            })
+            class FooCmp {}
+         `);
+         const errors = env.driveDiagnostics();
+         expect(trim(errors[0].messageText as string))
+             .toContain('Host binding expression cannot contain pipes');
+       });
+
+    it('should throw in case pipes are used in host bindings (defined as `(value | pipe) === X`)',
+       () => {
+         env.write(`test.ts`, `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test',
+              template: '...',
+              host: {
+                '[id]': '(id | myPipe) === true'
+              }
+            })
+            class FooCmp {}
+         `);
+         const errors = env.driveDiagnostics();
+         expect(trim(errors[0].messageText as string))
+             .toContain('Host binding expression cannot contain pipes');
+       });
 
     it('should generate host bindings for directives', () => {
       env.write(`test.ts`, `

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -12,7 +12,7 @@ import {ConstantPool} from '../../constant_pool';
 import * as core from '../../core';
 import {AST, AstMemoryEfficientTransformer, BindingPipe, BindingType, FunctionCall, ImplicitReceiver, Interpolation, LiteralArray, LiteralMap, LiteralPrimitive, ParsedEventType, PropertyRead} from '../../expression_parser/ast';
 import {Lexer} from '../../expression_parser/lexer';
-import {Parser} from '../../expression_parser/parser';
+import {IvyParser} from '../../expression_parser/parser';
 import * as i18n from '../../i18n/i18n_ast';
 import * as html from '../../ml_parser/ast';
 import {HtmlParser} from '../../ml_parser/html_parser';
@@ -2004,7 +2004,8 @@ const elementRegistry = new DomElementSchemaRegistry();
  */
 export function makeBindingParser(
     interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): BindingParser {
-  return new BindingParser(new Parser(new Lexer()), interpolationConfig, elementRegistry, null, []);
+  return new BindingParser(
+      new IvyParser(new Lexer()), interpolationConfig, elementRegistry, null, []);
 }
 
 export function resolveSanitizationFn(context: core.SecurityContext, isAttribute?: boolean) {


### PR DESCRIPTION
Pipes in host binding expressions are not supported in View Engine and Ivy, but in some more complex cases (like `(value | pipe) === true`) compiler was not reporting errors. This commit extends Ivy logic to detect pipes in host binding expressions and throw in cases bindings are present. View Engine behavior remains the same.

This PR resolves FW-1787.
PR is related to #34378.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No