### PR TITLE
fix(ngcc): don't crash if symbol has no declarations

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -271,7 +271,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     let valueDeclaration: ts.Declaration|undefined = undefined;
     if (symbol.valueDeclaration !== undefined) {
       valueDeclaration = symbol.valueDeclaration;
-    } else if (symbol.declarations.length > 0) {
+    } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       valueDeclaration = symbol.declarations[0];
     }
     if (valueDeclaration !== undefined && ts.isShorthandPropertyAssignment(valueDeclaration)) {


### PR DESCRIPTION
In some cases TypeScript is unable to identify a valid
symbol for an export. In this case it returns an "unknown"
symbol, which does not reference any declarations.

This fix ensures that ngcc does not crash if such a symbol
is encountered by checking whether `symbol.declarations`
exists before accessing it.

The commit does not contain a unit test as it was not possible
to recreate a scenario that had such an "unknown" symbol in
the unit test environment. The fix has been manually checked
against that original issue; and also this check is equivalent to
similar checks elsewhere in the code, e.g.

https://github.com/angular/angular/blob/8d0de89e/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts#L309

Fixes #34560
