### PR TITLE
refactor(bazel): remove explicit deps param to ts_compile_actions

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -578,7 +578,6 @@ def ng_module_impl(ctx, ts_compile_actions):
     providers = ts_compile_actions(
         ctx,
         is_library = True,
-        deps = ctx.attr.deps,
         compile_action = _prodmode_compile_action,
         devmode_compile_action = _devmode_compile_action,
         tsc_wrapped_tsconfig = _ngc_tsconfig,


### PR DESCRIPTION
This was already the default. I'm working on a change in the underlying TS rules where this parameter will be replaced, so ng_module needs to change first
