### PR TITLE
refactor(core): remove duplicate InjectableType declaration

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -86,12 +86,6 @@ export const Injectable: InjectableDecorator = makeDecorator(
     'Injectable', undefined, undefined, undefined,
     (type: Type<any>, meta: Injectable) => SWITCH_COMPILE_INJECTABLE(type as any, meta));
 
-/**
- * Type representing injectable service.
- *
- * @publicApi
- */
-export interface InjectableType<T> extends Type<T> { ɵprov: ɵɵInjectableDef<T>; }
 
 /**
  * Supports @Injectable() in JIT mode for Render2.

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -8,8 +8,7 @@
 
 import {DebugElement__PRE_R3__, DebugEventListener, DebugNode__PRE_R3__, getDebugNode, indexDebugNode, removeDebugNodeFromIndex} from '../debug/debug_node';
 import {Injector} from '../di';
-import {InjectableType} from '../di/injectable';
-import {getInjectableDef, ɵɵInjectableDef} from '../di/interface/defs';
+import {InjectableType, getInjectableDef, ɵɵInjectableDef} from '../di/interface/defs';
 import {ErrorHandler} from '../error_handler';
 import {Type} from '../interface/type';
 import {ComponentFactory} from '../linker/component_factory';


### PR DESCRIPTION
This duplication causes a compilation error with TypeScript 3.7