### PR TITLE
fix(animations): not waiting for child component leave animations to finish on destroy in ivy

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -336,6 +336,12 @@ export class AnimationTransitionNamespace {
   triggerLeaveAnimation(
       element: any, context: any, destroyAfterComplete?: boolean,
       defaultToFallback?: boolean): boolean {
+    const existingRemovalFlag = element[REMOVAL_FLAG];
+    // If there's a removal flag it means that we've triggered the leave animation already.
+    if (existingRemovalFlag && existingRemovalFlag !== NULL_REMOVAL_STATE) {
+      return true;
+    }
+
     const triggerStates = this._engine.statesByElement.get(element);
     if (triggerStates) {
       const players: TransitionAnimationPlayer[] = [];

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -176,6 +176,25 @@ const DEFAULT_NAMESPACE_ID = 'id';
         expect(engine.statesByElement.has(child)).toBe(false, 'Expected child data to be cleared.');
       });
 
+      it('should not mark the same element as removed multiple times', () => {
+        const engine = makeEngine();
+        const trig = trigger('myTrigger', [
+          transition(':leave', [style({height: '0px'}), animate(1000, style({height: '100px'}))])
+        ]);
+
+        registerTrigger(element, engine, trig);
+        setProperty(element, engine, 'myTrigger', 'value');
+        engine.flush();
+
+        spyOn(engine, 'markElementAsRemoved').and.callThrough();
+
+        engine.removeNode(DEFAULT_NAMESPACE_ID, element, true, true);
+        engine.removeNode(DEFAULT_NAMESPACE_ID, element, true, true);
+        engine.flush();
+
+        expect(engine.markElementAsRemoved).toHaveBeenCalledTimes(1);
+      });
+
     });
 
     describe('event listeners', () => {


### PR DESCRIPTION
Fixes the animations engine not waiting for `:leave` animations to finish when a child component host is destroyed with Ivy. The issue seems to come from the fact that when removing a host element we end up calling `removeNode` on the namespace twice which in turn calls `triggerLeaveAnimation`. The first time everything is correct and the animation triggers, but the second time we don't check whether the animation was started and we remove the element immediately. These changes add some code to check that the leave animation hasn't been started already.

Fixes #33597.
