### PR TITLE
ci(docs-infra): do not deploy Firebase Realtime Database rules

### DIFF
--- a/aio/database.rules.json
+++ b/aio/database.rules.json
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    ".read": "auth != null",
-    ".write": "auth != null"
-  }
-}

--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -1,7 +1,4 @@
 {
-  "database": {
-    "rules": "database.rules.json"
-  },
   "hosting": {
     "public": "dist",
     "cleanUrls": true,


### PR DESCRIPTION
Currently, the angular.io projects do not use Firebase's Realtime Database and therefore we only need to configure and deploy changes for `hosting`.

This commit removes the unused Realtime Database related configs and files.
