### PR TITLE
docs: fix non-working example in the `Observables` section

### DIFF
--- a/aio/content/examples/observables/src/geolocation.ts
+++ b/aio/content/examples/observables/src/geolocation.ts
@@ -5,28 +5,39 @@ import { Observable } from 'rxjs';
 // Create an Observable that will start listening to geolocation updates
 // when a consumer subscribes.
 const locations = new Observable((observer) => {
-  // Get the next and error callbacks. These will be passed in when
-  // the consumer subscribes.
-  const {next, error} = observer;
-  let watchId;
+  let watchId: number;
 
   // Simple geolocation API check provides values to publish
   if ('geolocation' in navigator) {
-    watchId = navigator.geolocation.watchPosition(next, error);
+    watchId = navigator.geolocation.watchPosition((position: Position) => {
+      observer.next(position);
+    }, (error: PositionError) => {
+      observer.error(error);
+    });
   } else {
-    error('Geolocation not available');
+    observer.error('Geolocation not available');
   }
 
   // When the consumer unsubscribes, clean up data ready for next subscription.
-  return {unsubscribe() { navigator.geolocation.clearWatch(watchId); }};
+  return {
+    unsubscribe() {
+      navigator.geolocation.clearWatch(watchId);
+    }
+  };
 });
 
 // Call subscribe() to start listening for updates.
 const locationsSubscription = locations.subscribe({
-  next(position) { console.log('Current Position: ', position); },
-  error(msg) { console.log('Error Getting Location: ', msg); }
+  next(position) {
+    console.log('Current Position: ', position);
+  },
+  error(msg) {
+    console.log('Error Getting Location: ', msg);
+  }
 });
 
 // Stop listening for location after 10 seconds
-setTimeout(() => { locationsSubscription.unsubscribe(); }, 10000);
+setTimeout(() => {
+  locationsSubscription.unsubscribe();
+}, 10000);
 // #enddocregion


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, this example doesn't work because of:
```js
const { next, error } = observer;
```

Since they will be invoked with the global context.


## What is the new behavior?
In the new behavior, those methods are invoked correctly with the `Subscriber` context.
I was thinking of something like:
```js
const next = observer.next.bind(observer);
const error = ...;
```
But I think that this will be complicated for readers.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
