### PR TITLE
test(language-service): Remove test cases from parsing-cases.ts

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -372,9 +372,10 @@ describe('completions', () => {
 
   describe('data binding', () => {
     it('should be able to complete property value', () => {
-      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'property-binding-model');
-      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
-      expectContain(completions, CompletionKind.PROPERTY, ['test']);
+      mockHost.override(TEST_TEMPLATE, `<h1 [model]="~{cursor}"></h1>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['title']);
     });
 
     it('should be able to complete property read', () => {
@@ -385,9 +386,10 @@ describe('completions', () => {
     });
 
     it('should be able to complete an event', () => {
-      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'event-binding-model');
-      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
-      expectContain(completions, CompletionKind.METHOD, ['modelChanged']);
+      mockHost.override(TEST_TEMPLATE, `<h1 (model)="~{cursor}"></h1>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.METHOD, ['myClick']);
     });
 
     it('should be able to complete a the LHS of a two-way binding', () => {
@@ -398,9 +400,10 @@ describe('completions', () => {
     });
 
     it('should be able to complete a the RHS of a two-way binding', () => {
-      const marker = mockHost.getLocationMarkerFor(PARSING_CASES, 'two-way-binding-model');
-      const completions = ngLS.getCompletionsAt(PARSING_CASES, marker.start);
-      expectContain(completions, CompletionKind.PROPERTY, ['test']);
+      mockHost.override(TEST_TEMPLATE, `<h1 [(model)]="~{cursor}"></h1>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      const completions = ngLS.getCompletionsAt(TEST_TEMPLATE, marker.start);
+      expectContain(completions, CompletionKind.PROPERTY, ['title']);
     });
 
     it('should suggest property binding for input', () => {

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -30,21 +30,17 @@ import * as ParsingCases from './parsing-cases';
     NgForCases.UnknownTrackBy,
     NgIfCases.ShowIf,
     ParsingCases.AsyncForUsingComponent,
-    ParsingCases.AttributeBinding,
     ParsingCases.CaseIncompleteOpen,
     ParsingCases.CaseMissingClosing,
     ParsingCases.CaseUnknown,
     ParsingCases.EmptyInterpolation,
-    ParsingCases.EventBinding,
     ParsingCases.NoValueAttribute,
     ParsingCases.NumberModel,
     ParsingCases.Pipes,
-    ParsingCases.PropertyBinding,
     ParsingCases.References,
     ParsingCases.StringModel,
     ParsingCases.TemplateReference,
     ParsingCases.TestComponent,
-    ParsingCases.TwoWayBinding,
   ]
 })
 export class AppModule {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -44,39 +44,6 @@ export class Pipes {
 export class NoValueAttribute {
 }
 
-
-@Component({
-  template: '<h1 model="~{attribute-binding-model}test"></h1>',
-})
-export class AttributeBinding {
-  test: string = 'test';
-}
-
-@Component({
-  template: '<h1 [model]="~{property-binding-model}test"></h1>',
-})
-export class PropertyBinding {
-  test: string = 'test';
-}
-
-@Component({
-  template: '<h1 (model)="~{event-binding-model}modelChanged()"></h1>',
-})
-export class EventBinding {
-  test: string = 'test';
-
-  modelChanged() {}
-}
-
-@Component({
-  template: `
-    <h1 [(model)]="~{two-way-binding-model}test"></h1>
-    <input ~{two-way-binding-input}></input>`,
-})
-export class TwoWayBinding {
-  test: string = 'test';
-}
-
 @Directive({
   selector: '[string-model]',
 })

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -94,7 +94,7 @@ describe('TypeScriptServiceHost', () => {
     const tsLS = ts.createLanguageService(tsLSHost);
     const ngLSHost = new TypeScriptServiceHost(tsLSHost, tsLS);
     const templates = ngLSHost.getTemplates('/app/parsing-cases.ts');
-    expect(templates.length).toBe(13);
+    expect(templates.length).toBe(9);
   });
 
   it('should be able to find external template', () => {


### PR DESCRIPTION
This commit removes some test scenarios from `parsing-cases.ts` and
colocate them with the test code instead. This makes the tests easier to
read and understand.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
