### PR TITLE
refactor(ivy): delete `ɵɵelementHostAttrs` instruction

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 142903,
+        "main-es2015": 143641,
         "polyfills-es2015": 36808
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 149037,
+        "main-es2015": 149794,
         "polyfills-es2015": 36808
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 138021,
+        "main-es2015": 138909,
         "polyfills-es2015": 37494
       }
     }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 227444,
+        "main-es2015": 228198,
         "polyfills-es2015": 36808,
         "5-es2015": 779
       }

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -154,31 +154,32 @@ export const TViewConstructor = class TView implements ITView {
 
 export const TNodeConstructor = class TNode implements ITNode {
   constructor(
-      public tView_: TView,                                                    //
-      public type: TNodeType,                                                  //
-      public index: number,                                                    //
-      public injectorIndex: number,                                            //
-      public directiveStart: number,                                           //
-      public directiveEnd: number,                                             //
-      public propertyBindings: number[]|null,                                  //
-      public flags: TNodeFlags,                                                //
-      public providerIndexes: TNodeProviderIndexes,                            //
-      public tagName: string|null,                                             //
-      public attrs: (string|AttributeMarker|(string|SelectorFlags)[])[]|null,  //
-      public localNames: (string|number)[]|null,                               //
-      public initialInputs: (string[]|null)[]|null|undefined,                  //
-      public inputs: PropertyAliases|null,                                     //
-      public outputs: PropertyAliases|null,                                    //
-      public tViews: ITView|ITView[]|null,                                     //
-      public next: ITNode|null,                                                //
-      public projectionNext: ITNode|null,                                      //
-      public child: ITNode|null,                                               //
-      public parent: TElementNode|TContainerNode|null,                         //
-      public projection: number|(ITNode|RNode[])[]|null,                       //
-      public styles: TStylingContext|null,                                     //
-      public classes: TStylingContext|null,                                    //
-      public classBindings: TStylingRange,                                     //
-      public styleBindings: TStylingRange,                                     //
+      public tView_: TView,                                                          //
+      public type: TNodeType,                                                        //
+      public index: number,                                                          //
+      public injectorIndex: number,                                                  //
+      public directiveStart: number,                                                 //
+      public directiveEnd: number,                                                   //
+      public propertyBindings: number[]|null,                                        //
+      public flags: TNodeFlags,                                                      //
+      public providerIndexes: TNodeProviderIndexes,                                  //
+      public tagName: string|null,                                                   //
+      public attrs: (string|AttributeMarker|(string|SelectorFlags)[])[]|null,        //
+      public mergedAttrs: (string|AttributeMarker|(string|SelectorFlags)[])[]|null,  //
+      public localNames: (string|number)[]|null,                                     //
+      public initialInputs: (string[]|null)[]|null|undefined,                        //
+      public inputs: PropertyAliases|null,                                           //
+      public outputs: PropertyAliases|null,                                          //
+      public tViews: ITView|ITView[]|null,                                           //
+      public next: ITNode|null,                                                      //
+      public projectionNext: ITNode|null,                                            //
+      public child: ITNode|null,                                                     //
+      public parent: TElementNode|TContainerNode|null,                               //
+      public projection: number|(ITNode|RNode[])[]|null,                             //
+      public styles: TStylingContext|null,                                           //
+      public classes: TStylingContext|null,                                          //
+      public classBindings: TStylingRange,                                           //
+      public styleBindings: TStylingRange,                                           //
       ) {}
 
   get type_(): string {

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -435,6 +435,19 @@ export interface TNode {
   attrs: TAttributes|null;
 
   /**
+   * Same as `TNode.attrs` but contains merged data across all directive host bindings.
+   *
+   * We need to keep `attrs` as unmerged so that it can be used for attribute selectors.
+   * We merge attrs here so that it can be used in a performant way for initial rendering.
+   *
+   * The `attrs` are merged in first pass in following order:
+   * - Component's `hostAttrs`
+   * - Directives' `hostAttrs`
+   * - Template `TNode.attrs` associated with the current `TNode`.
+   */
+  mergedAttrs: TAttributes|null;
+
+  /**
    * A set of local names under which a given element is exported in a template and
    * visible to queries. An entry in this array can be created for different reasons:
    * - an element itself is referenced, ex.: `<div #foo>`

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -194,14 +194,6 @@ export function decreaseElementDepthCount() {
   instructionState.lFrame.elementDepthCount--;
 }
 
-export function getCurrentDirectiveDef(): DirectiveDef<any>|ComponentDef<any>|null {
-  return instructionState.lFrame.currentDirectiveDef;
-}
-
-export function setCurrentDirectiveDef(def: DirectiveDef<any>| ComponentDef<any>| null): void {
-  instructionState.lFrame.currentDirectiveDef = def;
-}
-
 export function getBindingsEnabled(): boolean {
   return instructionState.bindingsEnabled;
 }

--- a/packages/core/src/render3/styling/class_differ.ts
+++ b/packages/core/src/render3/styling/class_differ.ts
@@ -113,7 +113,7 @@ export function removeClass(className: string, classToRemove: string): string {
  *
  * @param className A string containing classes (whitespace separated)
  * @param classToToggle A class name to remove or add to the `className`
- * @param toggle Weather the resulting `className` should contain or not the `classToToggle`
+ * @param toggle Whether the resulting `className` should contain or not the `classToToggle`
  * @returns a new class-list which does not have `classToRemove`
  */
 export function toggleClass(className: string, classToToggle: string, toggle: boolean): string {

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {assertEqual} from '../../util/assert';
 import {CharCode} from '../../util/char_code';
 import {AttributeMarker, TAttributes} from '../interfaces/node';
 import {CssSelector} from '../interfaces/projection';

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -830,6 +830,30 @@ describe('host bindings', () => {
     expect(hostElement.title).toBe('other title');
   });
 
+  it('should merge attributes on host and template', () => {
+    @Directive({selector: '[dir1]', host: {id: 'dir1'}})
+    class MyDir1 {
+    }
+    @Directive({selector: '[dir2]', host: {id: 'dir2'}})
+    class MyDir2 {
+    }
+
+    @Component({template: `<div dir1 dir2 id="tmpl"></div>`})
+    class MyComp {
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]});
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+    const div: HTMLElement = fixture.debugElement.nativeElement.firstChild;
+    expect(div.id).toEqual(
+        ivyEnabled ?
+            // In ivy the correct result is `tmpl` because template has the highest priority.
+            'tmpl' :
+            // In VE the order was simply that of execution and so dir2 would win.
+            'dir2');
+  });
+
   onlyInIvy('Host bindings do not get merged in ViewEngine')
       .it('should work correctly with inherited directives with hostBindings', () => {
         @Directive({selector: '[superDir]', host: {'[id]': 'id'}})

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -192,6 +192,9 @@
     "name": "callHooks"
   },
   {
+    "name": "classIndexOf"
+  },
+  {
     "name": "concatString"
   },
   {
@@ -279,7 +282,7 @@
     "name": "findAttrIndexInNode"
   },
   {
-    "name": "findDirectiveMatches"
+    "name": "findDirectiveDefMatches"
   },
   {
     "name": "forceStylesAsString"
@@ -408,9 +411,6 @@
     "name": "getStylingMapArray"
   },
   {
-    "name": "getTNode"
-  },
-  {
     "name": "growHostVarsSpace"
   },
   {
@@ -444,7 +444,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initNodeFlags"
+    "name": "initTNodeFlags"
   },
   {
     "name": "initializeInputAndOutputAliases"
@@ -532,6 +532,12 @@
   },
   {
     "name": "matchTemplateAttribute"
+  },
+  {
+    "name": "mergeHostAttribute"
+  },
+  {
+    "name": "mergeHostAttrs"
   },
   {
     "name": "nativeAppendChild"
@@ -639,9 +645,6 @@
     "name": "setClassName"
   },
   {
-    "name": "setCurrentDirectiveDef"
-  },
-  {
     "name": "setCurrentQueryIndex"
   },
   {
@@ -718,9 +721,6 @@
   },
   {
     "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementHostAttrs"
   },
   {
     "name": "ɵɵelementStart"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -348,9 +348,6 @@
     "name": "getStylingMapArray"
   },
   {
-    "name": "getTNode"
-  },
-  {
     "name": "growHostVarsSpace"
   },
   {
@@ -372,7 +369,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initNodeFlags"
+    "name": "initTNodeFlags"
   },
   {
     "name": "insertBloom"
@@ -519,9 +516,6 @@
     "name": "setClassName"
   },
   {
-    "name": "setCurrentDirectiveDef"
-  },
-  {
     "name": "setCurrentQueryIndex"
   },
   {
@@ -571,9 +565,6 @@
   },
   {
     "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵelementHostAttrs"
   },
   {
     "name": "ɵɵtext"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -438,6 +438,9 @@
     "name": "checkNoChangesInternal"
   },
   {
+    "name": "classIndexOf"
+  },
+  {
     "name": "cleanUpView"
   },
   {
@@ -579,7 +582,7 @@
     "name": "findAttrIndexInNode"
   },
   {
-    "name": "findDirectiveMatches"
+    "name": "findDirectiveDefMatches"
   },
   {
     "name": "findExistingListener"
@@ -867,7 +870,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initNodeFlags"
+    "name": "initTNodeFlags"
   },
   {
     "name": "initializeInputAndOutputAliases"
@@ -1039,6 +1042,12 @@
   },
   {
     "name": "matchTemplateAttribute"
+  },
+  {
+    "name": "mergeHostAttribute"
+  },
+  {
+    "name": "mergeHostAttrs"
   },
   {
     "name": "nativeAppendChild"
@@ -1218,9 +1227,6 @@
     "name": "setClassName"
   },
   {
-    "name": "setCurrentDirectiveDef"
-  },
-  {
     "name": "setCurrentQueryIndex"
   },
   {
@@ -1381,9 +1387,6 @@
   },
   {
     "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementHostAttrs"
   },
   {
     "name": "ɵɵelementStart"

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -22,7 +22,7 @@ describe('css selector matching', () => {
     const tNode = (!attrsOrTNode || Array.isArray(attrsOrTNode)) ?
         createTNode(null !, null, TNodeType.Element, 0, tagName, attrsOrTNode as TAttributes) :
         (attrsOrTNode as TNode);
-    return isNodeMatchingSelector(tNode, selector, false);
+    return isNodeMatchingSelector(tNode, selector, true);
   }
 
   describe('isNodeMatchingSimpleSelector', () => {
@@ -322,26 +322,6 @@ describe('css selector matching', () => {
         // <div class="foo">
         expect(isMatching('div', ['class', 'foo'], selector)).toBeFalsy();
       });
-
-      it('should match against a class value before and after the styling context is created',
-         () => {
-           // selector: 'div.abc'
-           const selector = ['div', SelectorFlags.CLASS, 'abc'];
-           const tNode = createTNode(null !, null, TNodeType.Element, 0, 'div', []);
-
-           // <div> (without attrs or styling context)
-           expect(isMatching('div', tNode, selector)).toBeFalsy();
-
-           // <div class="abc"> (with attrs but without styling context)
-           tNode.attrs = ['class', 'abc'];
-           tNode.classes = null;
-           expect(isMatching('div', tNode, selector)).toBeTruthy();
-
-           // <div class="abc"> (with styling context but without attrs)
-           tNode.classes = ['abc', 'abc', true];
-           tNode.attrs = null;
-           expect(isMatching('div', tNode, selector)).toBeTruthy();
-         });
     });
   });
 


### PR DESCRIPTION
This PR is part of sequence of work which is meant to be reviewed together:
- [#34683 - refactor(ivy): move hostVars/hostAttrs from instruction to DirectiveDef](https://github.com/angular/angular/pull/34683)
- [#34708 - refactor(ivy): delete `ɵɵallocHostVars` instruction](https://github.com/angular/angular/pull/34708)
- YOU ARE HERE => [#34717 - refactor(ivy): delete `ɵɵelementHostAttrs` instruction](https://github.com/angular/angular/pull/34708)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
