### PR TITLE
refactor(docs-infra): simplify Firebase redirect config

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -59,8 +59,7 @@
       {"type": 301, "source": "/**/api/common/NgModel", "destination": "/api/forms/NgModel"},
 
       // `@angular/http` package was removed, and new `HttpClient` APIs are available under `@angular/common/http` package
-      {"type": 301, "source": "/api/http/:rest*", "destination": "/guide/deprecations#http"},
-      {"type": 301, "source": "/api/http", "destination": "/guide/deprecations#http"},
+      {"type": 301, "source": "/api/http/**", "destination": "/guide/deprecations#http"},
 
       // Animations moves, renames and removals
       {"type": 301, "source": "/api/animate/:rest*", "destination": "/api/animations/:rest*"},


### PR DESCRIPTION
This simplifies the Firebase redirect config, removing a redundant pattern (`/api/http`) which is covered by the previous pattern and dropping an unused named captured segment (`:rest*`).

This change does not affect the redirection behavior for the deployed apps, but allows the Firebase hosting emulator to work correctly.
(See [here][1] for more info.)

NOTE:
Although we are not currently using the Firebase emulator for development/testing, we might want to use it in the future.

[1]: https://github.com/firebase/superstatic/issues/231#issuecomment-573034515
