### PR TITLE
style(common): remove unnecessary private annotation

### DIFF
--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -223,7 +223,6 @@ function _stripIndexHtml(url: string): string {
 /**
  * Tries to decode the URI component without throwing an exception.
  *
- * @private
  * @param str value potential URI component to check.
  * @returns the decoded URI if it can be decoded or else `undefined`.
  */


### PR DESCRIPTION
The `@private` annotation on a function upsets tsc, and appears
unnecessary for non-exported functions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Code style update (formatting, local variables)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No