### PR TITLE
refactor(common): delete obsolete NgClassBase and NgStyleBase

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -20,7 +20,7 @@ export {registerLocaleData} from './i18n/locale_data';
 export {Plural, NumberFormatStyle, FormStyle, Time, TranslationWidth, FormatWidth, NumberSymbol, WeekDay, getNumberOfCurrencyDigits, getCurrencySymbol, getLocaleDayPeriods, getLocaleDayNames, getLocaleMonthNames, getLocaleId, getLocaleEraNames, getLocaleWeekEndRange, getLocaleFirstDayOfWeek, getLocaleDateFormat, getLocaleDateTimeFormat, getLocaleExtraDayPeriodRules, getLocaleExtraDayPeriods, getLocalePluralCase, getLocaleTimeFormat, getLocaleNumberSymbol, getLocaleNumberFormat, getLocaleCurrencyName, getLocaleCurrencySymbol, getLocaleDirection} from './i18n/locale_data_api';
 export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule} from './common_module';
-export {NgClass, NgClassBase, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgStyleBase, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
+export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
 export {DOCUMENT} from './dom_tokens';
 export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe, KeyValuePipe, KeyValue} from './pipes/index';
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';

--- a/packages/common/src/directives/index.ts
+++ b/packages/common/src/directives/index.ts
@@ -7,18 +7,17 @@
  */
 
 import {Provider} from '@angular/core';
-import {NgClass, NgClassBase} from './ng_class';
+import {NgClass} from './ng_class';
 import {NgComponentOutlet} from './ng_component_outlet';
 import {NgForOf, NgForOfContext} from './ng_for_of';
 import {NgIf, NgIfContext} from './ng_if';
 import {NgPlural, NgPluralCase} from './ng_plural';
-import {NgStyle, NgStyleBase} from './ng_style';
+import {NgStyle} from './ng_style';
 import {NgSwitch, NgSwitchCase, NgSwitchDefault} from './ng_switch';
 import {NgTemplateOutlet} from './ng_template_outlet';
 
 export {
   NgClass,
-  NgClassBase,
   NgComponentOutlet,
   NgForOf,
   NgForOfContext,
@@ -27,7 +26,6 @@ export {
   NgPlural,
   NgPluralCase,
   NgStyle,
-  NgStyleBase,
   NgSwitch,
   NgSwitchCase,
   NgSwitchDefault,

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -48,28 +48,6 @@ export const ngClassFactoryDef__PRE_R3__ = undefined;
 export const ngClassFactoryDef__POST_R3__ = function() {};
 export const ngClassFactoryDef = ngClassFactoryDef__PRE_R3__;
 
-/**
- * Serves as the base non-VE container for NgClass.
- *
- * While this is a base class that NgClass extends from, the
- * class itself acts as a container for non-VE code to setup
- * a link to the `[class]` host binding (via the static
- * `ɵdir` property on the class).
- *
- * Note that the `ɵdir` property's code is switched
- * depending if VE is present or not (this allows for the
- * binding code to be set only for newer versions of Angular).
- *
- * @publicApi
- */
-export class NgClassBase {
-  static ɵdir: any = ngClassDirectiveDef;
-  static ɵfac: any = ngClassFactoryDef;
-
-  constructor(protected _delegate: NgClassImpl) {}
-
-  getValue() { return this._delegate.getValue(); }
-}
 
 /**
  * @ngModule CommonModule
@@ -100,8 +78,11 @@ export class NgClassBase {
  * @publicApi
  */
 @Directive({selector: '[ngClass]', providers: [NgClassImplProvider]})
-export class NgClass extends NgClassBase implements DoCheck {
-  constructor(delegate: NgClassImpl) { super(delegate); }
+export class NgClass implements DoCheck {
+  static ɵdir: never = ngClassDirectiveDef as never;
+  static ɵfac: never = ngClassFactoryDef as never;
+
+  constructor(private _delegate: NgClassImpl) {}
 
   @Input('class')
   set klass(value: string) { this._delegate.setClass(value); }
@@ -112,4 +93,6 @@ export class NgClass extends NgClassBase implements DoCheck {
   }
 
   ngDoCheck() { this._delegate.applyChanges(); }
+
+  getValue() { return this._delegate.getValue(); }
 }

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -48,28 +48,6 @@ export const ngStyleFactoryDef__POST_R3__ = function() {};
 export const ngStyleDirectiveDef = ngStyleDirectiveDef__PRE_R3__;
 export const ngStyleFactoryDef = ngStyleDirectiveDef__PRE_R3__;
 
-/**
- * Serves as the base non-VE container for NgStyle.
- *
- * While this is a base class that NgStyle extends from, the
- * class itself acts as a container for non-VE code to setup
- * a link to the `[style]` host binding (via the static
- * `ɵdir` property on the class).
- *
- * Note that the `ɵdir` property's code is switched
- * depending if VE is present or not (this allows for the
- * binding code to be set only for newer versions of Angular).
- *
- * @publicApi
- */
-export class NgStyleBase {
-  static ɵdir: any = ngStyleDirectiveDef;
-  static ɵfac: any = ngStyleFactoryDef;
-
-  constructor(protected _delegate: NgStyleImpl) {}
-
-  getValue() { return this._delegate.getValue(); }
-}
 
 /**
  * @ngModule CommonModule
@@ -108,11 +86,16 @@ export class NgStyleBase {
  * @publicApi
  */
 @Directive({selector: '[ngStyle]', providers: [NgStyleImplProvider]})
-export class NgStyle extends NgStyleBase implements DoCheck {
-  constructor(delegate: NgStyleImpl) { super(delegate); }
+export class NgStyle implements DoCheck {
+  static ɵdir: never = ngStyleDirectiveDef as never;
+  static ɵfac: never = ngStyleFactoryDef as never;
+
+  constructor(private _delegate: NgStyleImpl) {}
 
   @Input('ngStyle')
   set ngStyle(value: {[klass: string]: any}|null) { this._delegate.setNgStyle(value); }
 
   ngDoCheck() { this._delegate.applyChanges(); }
+
+  getValue() { return this._delegate.getValue(); }
 }

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -187,23 +187,16 @@ export declare class LowerCasePipe implements PipeTransform {
     transform(value: string): string;
 }
 
-export declare class NgClass extends NgClassBase implements DoCheck {
+export declare class NgClass implements DoCheck {
     klass: string;
     ngClass: string | string[] | Set<string> | {
         [klass: string]: any;
     };
-    constructor(delegate: NgClassImpl);
-    ngDoCheck(): void;
-}
-
-export declare class NgClassBase {
-    protected _delegate: NgClassImpl;
     constructor(_delegate: NgClassImpl);
     getValue(): {
         [key: string]: any;
     } | null;
-    static ɵdir: any;
-    static ɵfac: any;
+    ngDoCheck(): void;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -272,22 +265,15 @@ export declare class NgPluralCase {
     constructor(value: string, template: TemplateRef<Object>, viewContainer: ViewContainerRef, ngPlural: NgPlural);
 }
 
-export declare class NgStyle extends NgStyleBase implements DoCheck {
+export declare class NgStyle implements DoCheck {
     ngStyle: {
         [klass: string]: any;
     } | null;
-    constructor(delegate: NgStyleImpl);
-    ngDoCheck(): void;
-}
-
-export declare class NgStyleBase {
-    protected _delegate: NgStyleImpl;
     constructor(_delegate: NgStyleImpl);
     getValue(): {
         [key: string]: any;
     } | null;
-    static ɵdir: any;
-    static ɵfac: any;
+    ngDoCheck(): void;
 }
 
 export declare class NgSwitch {


### PR DESCRIPTION
These classes are no longer needed.

These classes were accidently exported as public api in the past, but fortunately since they are
useless, we don't expect anyone to depend on them, so I'm simply deleting them.