### PR TITLE
fix(language-service): include directives in template AST paths

### DIFF
--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -139,10 +139,6 @@ export function findTemplateAstAt(ast: TemplateAst[], position: number): Templat
     visitDirective(ast: DirectiveAst, context: any): any {
       // Ignore the host properties of a directive
       const result = this.visitChildren(context, visit => { visit(ast.inputs); });
-      // We never care about the diretive itself, just its inputs.
-      if (path[path.length - 1] === ast) {
-        path.pop();
-      }
       return result;
     }
   };

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -136,7 +136,7 @@ describe('definitions', () => {
       // Get the marker for «test-comp» in the code added above.
       const marker = mockHost.getReferenceMarkerFor(fileName, 'test-comp');
 
-      const result = ngService.getDefinitionAt(fileName, marker.start);
+      const result = ngService.getDefinitionAndBoundSpan(fileName, marker.start);
       expect(result).toBeDefined();
       const {textSpan, definitions} = result !;
 
@@ -173,7 +173,7 @@ describe('definitions', () => {
       // Get the marker for «test-comp» in the code added above.
       const marker = mockHost.getReferenceMarkerFor(fileName, 'test-comp');
 
-      const result = ngService.getDefinitionAt(fileName, marker.start);
+      const result = ngService.getDefinitionAndBoundSpan(fileName, marker.start);
       expect(result).toBeDefined();
       const {textSpan, definitions} = result !;
 

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -125,40 +125,79 @@ describe('definitions', () => {
     expect(def.textSpan).toEqual(mockHost.getDefinitionMarkerFor(fileName, 'include'));
   });
 
-  it('should be able to find a reference to a component', () => {
-    const fileName = mockHost.addCode(`
+  describe('find a reference to a component', () => {
+    it('should be able to find the reference from an opening tag', () => {
+      const fileName = mockHost.addCode(`
       @Component({
-        template: '~{start-my}<«test-comp»></test-comp>~{end-my}'
+        template: '~{start-my}<«test-comp»>~{end-my}</test-comp>'
       })
       export class MyComponent { }`);
 
-    // Get the marker for «test-comp» in the code added above.
-    const marker = mockHost.getReferenceMarkerFor(fileName, 'test-comp');
+      // Get the marker for «test-comp» in the code added above.
+      const marker = mockHost.getReferenceMarkerFor(fileName, 'test-comp');
 
-    const result = ngService.getDefinitionAndBoundSpan(fileName, marker.start);
-    expect(result).toBeDefined();
-    const {textSpan, definitions} = result !;
+      const result = ngService.getDefinitionAt(fileName, marker.start);
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result !;
 
-    // Get the marker for bounded text in the code added above.
-    const boundedText = mockHost.getLocationMarkerFor(fileName, 'my');
-    expect(textSpan).toEqual(boundedText);
+      // Get the marker for bounded text in the code added above.
+      const boundedText = mockHost.getLocationMarkerFor(fileName, 'my');
+      expect(textSpan).toEqual(boundedText);
 
-    // There should be exactly 1 definition
-    expect(definitions).toBeDefined();
-    expect(definitions !.length).toBe(1);
-    const def = definitions ![0];
+      // There should be exactly 1 definition
+      expect(definitions).toBeDefined();
+      expect(definitions !.length).toBe(1);
+      const def = definitions ![0];
 
-    const refFileName = '/app/parsing-cases.ts';
-    expect(def.fileName).toBe(refFileName);
-    expect(def.name).toBe('TestComponent');
-    expect(def.kind).toBe('component');
-    const content = mockHost.readFile(refFileName) !;
-    const begin = '/*BeginTestComponent*/ ';
-    const start = content.indexOf(begin) + begin.length;
-    const end = content.indexOf(' /*EndTestComponent*/');
-    expect(def.textSpan).toEqual({
-      start,
-      length: end - start,
+      const refFileName = '/app/parsing-cases.ts';
+      expect(def.fileName).toBe(refFileName);
+      expect(def.name).toBe('TestComponent');
+      expect(def.kind).toBe('component');
+      const content = mockHost.readFile(refFileName) !;
+      const begin = '/*BeginTestComponent*/ ';
+      const start = content.indexOf(begin) + begin.length;
+      const end = content.indexOf(' /*EndTestComponent*/');
+      expect(def.textSpan).toEqual({
+        start,
+        length: end - start,
+      });
+    });
+
+    it('should be able to find the reference from a closing tag', () => {
+      const fileName = mockHost.addCode(`
+      @Component({
+        template: '~{start-my}<test-comp></«test-comp»>~{end-my}'
+      })
+      export class MyComponent { }`);
+
+      // Get the marker for «test-comp» in the code added above.
+      const marker = mockHost.getReferenceMarkerFor(fileName, 'test-comp');
+
+      const result = ngService.getDefinitionAt(fileName, marker.start);
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result !;
+
+      // Get the marker for bounded text in the code added above.
+      const boundedText = mockHost.getLocationMarkerFor(fileName, 'my');
+      expect(textSpan).toEqual(boundedText);
+
+      // There should be exactly 1 definition
+      expect(definitions).toBeDefined();
+      expect(definitions !.length).toBe(1);
+      const def = definitions ![0];
+
+      const refFileName = '/app/parsing-cases.ts';
+      expect(def.fileName).toBe(refFileName);
+      expect(def.name).toBe('TestComponent');
+      expect(def.kind).toBe('component');
+      const content = mockHost.readFile(refFileName) !;
+      const begin = '/*BeginTestComponent*/ ';
+      const start = content.indexOf(begin) + begin.length;
+      const end = content.indexOf(' /*EndTestComponent*/');
+      expect(def.textSpan).toEqual({
+        start,
+        length: end - start,
+      });
     });
   });
 


### PR DESCRIPTION
When constructing a path to a template node, the language service
currently expunges all directives ASTs. This commit includes them again,
which simplifies location of symbols where directives are, in fact, the
most specific symbol (like element selectors). This commit will also
help in the implementation of #34564, which relies on determination of
the nearest AST in a path.

One inconsistency this introduces is the location of symbols referencing
components between opening and closing tags in an element. In the past,
querying the definition for both opening and closing tags would result
in a query for the symbol encompassing the entire element.

```text
      v                 cursor
<app-c|omp></app-comp>
~~~~~~~~~~~~~~~~~~~~~~  symbol location
                 v      cursor
<app-comp></app-c|omp>
~~~~~~~~~~~~~~~~~~~~~~  symbol location
```

Now, this behavior only occurs for closing tags; for opening tags, the
queried symbol is the opening tag precisely because that's where the
component selector applies.

```text
      v                 cursor
<app-c|omp></app-comp>
~~~~~~~~~~~             symbol location
                 v      cursor
<app-comp></app-c|omp>
~~~~~~~~~~~~~~~~~~~~~~  symbol location
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
