### PR TITLE
feat(language-service): specific suggestions for template context diags

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -269,10 +269,12 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
       if (context && !context.has(ast.value)) {
         if (ast.value === '$implicit') {
           this.reportError(
-              'The template context does not have an implicit value', spanOf(ast.sourceSpan));
+              `The template context of '${directive.type.reference.name}' does not define an implicit value.\n` +
+                  `If the context type is a base type, consider refining it to a more specific type.`,
+              spanOf(ast.sourceSpan));
         } else {
           this.reportError(
-              `The template context does not define a member called '${ast.value}'`,
+              `The template context of '${directive.type.reference.name}' does not define a member called '${ast.value}'`,
               spanOf(ast.sourceSpan));
         }
       }

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -33,6 +33,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.CaseIncompleteOpen,
     ParsingCases.CaseMissingClosing,
     ParsingCases.CaseUnknown,
+    ParsingCases.CounterDirective,
     ParsingCases.EmptyInterpolation,
     ParsingCases.NoValueAttribute,
     ParsingCases.NumberModel,

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, EventEmitter, Input, Output} from '@angular/core';
+import {Component, Directive, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {Hero} from './app.component';
 
@@ -97,6 +97,24 @@ export class AsyncForUsingComponent {
     <test-comp #test2></test-comp>`,
 })
 export class References {
+}
+
+class CounterDirectiveContext<T> {
+  constructor(public $implicit: T) {}
+}
+
+@Directive({selector: '[counterOf]'})
+export class CounterDirective implements OnChanges {
+  // Object does not have an "$implicit" property.
+  constructor(private container: ViewContainerRef, private template: TemplateRef<Object>) {}
+
+  @Input('counterOf') counter: number = 0;
+  ngOnChanges(_changes: SimpleChanges) {
+    this.container.clear();
+    for (let i = 0; i < this.counter; ++i) {
+      this.container.createEmbeddedView(this.template, new CounterDirectiveContext<number>(i + 1));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This commit elaborates diagnostics produced for invalid template
contexts by including the name of the embedded template type using the
template context, and in the common case that the implicity property is
being referenced (e.g. in a `for .. of ..` expression), suggesting to
refine the type of the context. This suggestion is provided because
users will sometimes use a base class as the type of the context in the
embedded view, and a more specific context later on (e.g. in an
`ngOnChanges` method).

Closes https://github.com/angular/vscode-ng-language-service/issues/251

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No