### PR TITLE
refactor(common): use console service

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -219,7 +219,7 @@ export declare class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> impleme
     set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>);
     set ngForTrackBy(fn: TrackByFunction<T>);
     get ngForTrackBy(): TrackByFunction<T>;
-    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers);
+    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers, _console: ɵConsole);
     ngDoCheck(): void;
     static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
 }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, EmbeddedViewRef, Input, isDevMode, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, NgIterable, TemplateRef, TrackByFunction, ViewContainerRef} from '@angular/core';
+import {Directive, DoCheck, EmbeddedViewRef, Input, isDevMode, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, NgIterable, TemplateRef, TrackByFunction, ViewContainerRef, ɵConsole as Console} from '@angular/core';
 
 /**
  * @publicApi
@@ -160,12 +160,9 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
   @Input()
   set ngForTrackBy(fn: TrackByFunction<T>) {
     if (isDevMode() && fn != null && typeof fn !== 'function') {
-      // TODO(vicb): use a log service once there is a public one available
-      if (<any>console && <any>console.warn) {
-        console.warn(
-            `trackBy must be a function, but received ${JSON.stringify(fn)}. ` +
-            `See https://angular.io/api/common/NgForOf#change-propagation for more information.`);
-      }
+      this._console.warn(
+          `trackBy must be a function, but received ${JSON.stringify(fn)}. ` +
+          `See https://angular.io/api/common/NgForOf#change-propagation for more information.`);
     }
     this._trackByFn = fn;
   }
@@ -182,7 +179,8 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
 
   constructor(
       private _viewContainer: ViewContainerRef,
-      private _template: TemplateRef<NgForOfContext<T, U>>, private _differs: IterableDiffers) {}
+      private _template: TemplateRef<NgForOfContext<T, U>>, private _differs: IterableDiffers,
+      private _console: Console) {}
 
   /**
    * A reference to the template that is stamped out for each item in the iterable.

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "Console"
+  },
+  {
     "name": "DefaultIterableDiffer"
   },
   {

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgForOf as NgForOfDef, NgIf as NgIfDef, NgTemplateOutlet as NgTemplateOutletDef} from '@angular/common';
-import {IterableDiffers, NgIterable, TemplateRef, ViewContainerRef} from '@angular/core';
+import {IterableDiffers, NgIterable, TemplateRef, ViewContainerRef, ɵConsole as Console} from '@angular/core';
 
 import {DirectiveType, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵNgOnChangesFeature} from '../../src/render3/index';
 
@@ -27,7 +27,7 @@ NgForOf.ɵdir = ɵɵdefineDirective({
 
 NgForOf.ɵfac = () => new NgForOfDef(
     ɵɵdirectiveInject(ViewContainerRef as any), ɵɵdirectiveInject(TemplateRef as any),
-    ɵɵdirectiveInject(IterableDiffers));
+    ɵɵdirectiveInject(IterableDiffers), ɵɵdirectiveInject(Console));
 
 NgIf.ɵdir = ɵɵdefineDirective({
   type: NgIfDef,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`NgForOf` doesn't use the `Console` service and doesn't verify warnings in tests.

Issue Number: N/A


## What is the new behavior?
`NgForOf` uses the `Console` service and verifies warnings in tests.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Adds a constructor argument of type `Console` to the `NgForOf` directive. Note that this is exported with the internal identifier `ɵConsole`.


## Other information