### PR TITLE
docs: replace non-breaking with regular spaces in `resources.json`

### DIFF
--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -426,7 +426,7 @@
             "url": "https://www.jqwidgets.com/angular/"
           },
           "amexio": {
-            "desc": "Amexio is a rich set of Angular components powered by HTML5 & CSS3 for Responsive Web Design and 80+ built-in Material Design Themes. Amexio has 3 Editions, Standard, Enterprise and Creative. Std Edition consists of basic UI Components which include Grid, Tabs, Form Inputs and so on. While Enterprise Edition consists of components like Calendar, Tree Tabs, Social Media Logins (Facebook, GitHub, Twitter and so on) and Creative Edition is focused building elegant and beautiful websites. With more than 200+ components/features. All the editions are open-sourced and free, based on Apache 2 License.",
+            "desc": "Amexio is a rich set of Angular components powered by HTML5 & CSS3 for Responsive Web Design and 80+ built-in Material Design Themes. Amexio has 3 Editions, Standard, Enterprise and Creative. Std Edition consists of basic UI Components which include Grid, Tabs, Form Inputs and so on. While Enterprise Edition consists of components like Calendar, Tree Tabs, Social Media Logins (Facebook, GitHub, Twitter and so on) and Creative Edition is focused building elegant and beautiful websites. With more than 200+ components/features. All the editions are open-sourced and free, based on Apache 2 License.",
             "rev": true,
             "title": "Amexio - Angular Extensions",
             "url": "http://www.amexio.tech/",


### PR DESCRIPTION
By using non-breaking spaces, the description of Amexio UI components was overflowing its container in the "Resources" page.

**Before:**
![amexio before](https://user-images.githubusercontent.com/8604205/72343472-9db56200-36d7-11ea-817d-9f5bc77030a9.png)

**After:**
![amexio after](https://user-images.githubusercontent.com/8604205/72343482-a27a1600-36d7-11ea-85f9-b9aff86f8685.png)
