### PR TITLE
feat(language-service): support multiple symbol definitions

### DIFF
--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -39,25 +39,27 @@ export function getDefinitionAndBoundSpan(
     return;
   }
 
-  let textSpan: ts.TextSpan;
+  let textSpan = ngSpanToTsTextSpan(symbols[0].span);
   const definitions: ts.DefinitionInfo[] = [];
   for (const symbolInfo of symbols) {
-    const {symbol, span} = symbolInfo;
-    textSpan = ngSpanToTsTextSpan(span);
-    const {container, definition: locations} = symbol;
+    const {symbol} = symbolInfo;
+
+    // symbol.definition is really the locations of the symbol. There could be
+    // more than one. No meaningful info could be provided without any location.
+    const {kind, name, container, definition: locations} = symbol;
     if (!locations || !locations.length) {
-      // symbol.definition is really the locations of the symbol. There could be
-      // more than one. No meaningful info could be provided without any location.
-      return {textSpan};
+      continue;
     }
-    const containerKind = container ? container.kind : ts.ScriptElementKind.unknown;
+
+    const containerKind =
+        container ? container.kind as ts.ScriptElementKind : ts.ScriptElementKind.unknown;
     const containerName = container ? container.name : '';
     definitions.push(...locations.map((location) => {
       return {
-        kind: symbol.kind as ts.ScriptElementKind,
-        name: symbol.name,
-        containerKind: containerKind as ts.ScriptElementKind,
-        containerName: containerName,
+        kind: kind as ts.ScriptElementKind,
+        name,
+        containerKind,
+        containerName,
         textSpan: ngSpanToTsTextSpan(location.span),
         fileName: location.fileName,
       };
@@ -65,8 +67,7 @@ export function getDefinitionAndBoundSpan(
   }
 
   return {
-    definitions,
-    textSpan: textSpan !,
+      definitions, textSpan,
   };
 }
 

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -39,7 +39,7 @@ export function getDefinitionAndBoundSpan(
     return;
   }
 
-  let textSpan = ngSpanToTsTextSpan(symbols[0].span);
+  const textSpan = ngSpanToTsTextSpan(symbols[0].span);
   const definitions: ts.DefinitionInfo[] = [];
   for (const symbolInfo of symbols) {
     const {symbol} = symbolInfo;

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -148,8 +148,9 @@ export function getExpressionSymbol(
     },
     visitPropertyWrite(ast) {
       const receiverType = getType(ast.receiver);
+      const {start} = ast.span;
       symbol = receiverType && receiverType.members().get(ast.name);
-      span = ast.span;
+      span = {start, end: start + ast.name.length};
     },
     visitQuote(ast) {},
     visitSafeMethodCall(ast) {

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -150,6 +150,11 @@ export function getExpressionSymbol(
       const receiverType = getType(ast.receiver);
       const {start} = ast.span;
       symbol = receiverType && receiverType.members().get(ast.name);
+      // A PropertyWrite span includes both the LHS (name) and the RHS (value) of the write. In this
+      // visit, only the name is relevant.
+      //   prop=$event
+      //   ^^^^        name
+      //        ^^^^^^ value; visited separately as a nested AST
       span = {start, end: start + ast.name.length};
     },
     visitQuote(ast) {},

--- a/packages/language-service/src/hover.ts
+++ b/packages/language-service/src/hover.ts
@@ -10,7 +10,7 @@ import {CompileSummaryKind, StaticSymbol} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {AstResult} from './common';
-import {locateSymbol} from './locate_symbol';
+import {locateSymbols} from './locate_symbol';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
 import {findTightestNode} from './utils';
@@ -32,10 +32,11 @@ const SYMBOL_INTERFACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.inter
  */
 export function getHover(info: AstResult, position: number, host: Readonly<TypeScriptServiceHost>):
     ts.QuickInfo|undefined {
-  const symbolInfo = locateSymbol(info, position);
+  const symbolInfo = locateSymbols(info, position)[0];
   if (!symbolInfo) {
     return;
   }
+
   const {symbol, span, compileTypeSummary} = symbolInfo;
   const textSpan = {start: span.start, length: span.end - span.start};
 

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -53,8 +53,8 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
   const templatePosition = path.position;
   const position = templatePosition + info.template.span.start;
   let compileTypeSummary: CompileTypeSummary|undefined = undefined;
-  let symbol: Symbol|undefined = undefined;
-  let span: Span|undefined = undefined;
+  let symbol: Symbol|undefined;
+  let span: Span|undefined;
   const attributeValueSymbol = (ast: AST): boolean => {
     const attribute = findAttribute(info, position);
     if (attribute) {

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -70,7 +70,7 @@ describe('definitions', () => {
       expect(def.kind).toBe('property');
 
       const fileContent = mockHost.readFile(def.fileName);
-      expect(fileContent !.substr(def.textSpan.start, def.textSpan.length))
+      expect(fileContent !.substring(def.textSpan.start, def.textSpan.start + def.textSpan.length))
           .toEqual(`title = 'Some title';`);
     }
   });
@@ -315,14 +315,14 @@ describe('definitions', () => {
     expect(def1.name).toBe('model');
     expect(def1.kind).toBe('property');
     let content = mockHost.readFile(refFileName) !;
-    expect(content.substr(def1.textSpan.start, def1.textSpan.length))
+    expect(content.substring(def1.textSpan.start, def1.textSpan.start + def1.textSpan.length))
         .toEqual(`@Input() model: string = 'model';`);
 
     expect(def2.fileName).toBe(refFileName);
     expect(def2.name).toBe('modelChange');
     expect(def2.kind).toBe('event');
     content = mockHost.readFile(refFileName) !;
-    expect(content.substr(def2.textSpan.start, def2.textSpan.length))
+    expect(content.substring(def2.textSpan.start, def2.textSpan.start + def2.textSpan.length))
         .toEqual(`@Output() modelChange: EventEmitter<string> = new EventEmitter();`);
   });
 

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -64,13 +64,14 @@ describe('definitions', () => {
 
     expect(textSpan).toEqual(marker);
     expect(definitions).toBeDefined();
-    expect(definitions !.length).toBe(1);
-    const def = definitions ![0];
+    expect(definitions !.length).toBe(2);
 
-    expect(def.fileName).toBe(fileName);
-    expect(def.name).toBe('name');
-    expect(def.kind).toBe('property');
-    expect(def.textSpan).toEqual(mockHost.getDefinitionMarkerFor(fileName, 'name'));
+    for (const def of definitions !) {
+      expect(def.fileName).toBe(fileName);
+      expect(def.name).toBe('name');
+      expect(def.kind).toBe('property');
+      expect(def.textSpan).toEqual(mockHost.getDefinitionMarkerFor(fileName, 'name'));
+    }
   });
 
   it('should be able to find a method from a call', () => {
@@ -304,18 +305,24 @@ describe('definitions', () => {
     const boundedText = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'my');
     expect(textSpan).toEqual(boundedText);
 
-    // There should be exactly 1 definition
     expect(definitions).toBeDefined();
-    expect(definitions !.length).toBe(1);
-    const def = definitions ![0];
+    expect(definitions !.length).toBe(2);
+    const [def1, def2] = definitions !;
 
     const refFileName = '/app/parsing-cases.ts';
-    expect(def.fileName).toBe(refFileName);
-    expect(def.name).toBe('model');
-    expect(def.kind).toBe('property');
-    const content = mockHost.readFile(refFileName) !;
-    expect(content.substring(def.textSpan.start, def.textSpan.start + def.textSpan.length))
+    expect(def1.fileName).toBe(refFileName);
+    expect(def1.name).toBe('model');
+    expect(def1.kind).toBe('property');
+    let content = mockHost.readFile(refFileName) !;
+    expect(content.substring(def1.textSpan.start, def1.textSpan.start + def1.textSpan.length))
         .toEqual(`@Input() model: string = 'model';`);
+
+    expect(def2.fileName).toBe(refFileName);
+    expect(def2.name).toBe('modelChange');
+    expect(def2.kind).toBe('event');
+    content = mockHost.readFile(refFileName) !;
+    expect(content.substring(def2.textSpan.start, def2.textSpan.start + def2.textSpan.length))
+        .toEqual(`@Output() modelChange: EventEmitter<string> = new EventEmitter();`);
   });
 
   it('should be able to find a template from a url', () => {


### PR DESCRIPTION
In Angular, symbol can have multiple definitions (e.g. a two-way
binding). This commit adds support for for multiple definitions for a
queried location in a template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
