### PR TITLE
refactor(language-service): cleanup of low-hanging TODOs

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -220,8 +220,7 @@ export function getExpressionScope(
 
 class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
   private path: TemplateAstPath;
-  // TODO(issue/24571): remove '!'.
-  private directiveSummary !: CompileDirectiveSummary;
+  private directiveSummary: CompileDirectiveSummary|undefined;
 
   diagnostics: Diagnostic[] = [];
 

--- a/packages/language-service/src/expression_type.ts
+++ b/packages/language-service/src/expression_type.ts
@@ -19,8 +19,7 @@ export class TypeDiagnostic {
 
 // AstType calculatetype of the ast given AST element.
 export class AstType implements AstVisitor {
-  // TODO(issue/24571): remove '!'.
-  public diagnostics !: TypeDiagnostic[];
+  public diagnostics: TypeDiagnostic[] = [];
 
   constructor(
       private scope: SymbolTable, private query: SymbolQuery,
@@ -338,8 +337,7 @@ export class AstType implements AstVisitor {
     return this.resolvePropertyRead(this.query.getNonNullableType(this.getType(ast.receiver)), ast);
   }
 
-  // TODO(issue/24571): remove '!'.
-  private _anyType !: Symbol;
+  private _anyType: Symbol|undefined;
   private get anyType(): Symbol {
     let result = this._anyType;
     if (!result) {
@@ -348,8 +346,7 @@ export class AstType implements AstVisitor {
     return result;
   }
 
-  // TODO(issue/24571): remove '!'.
-  private _undefinedType !: Symbol;
+  private _undefinedType: Symbol|undefined;
   private get undefinedType(): Symbol {
     let result = this._undefinedType;
     if (!result) {

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -98,8 +98,6 @@ export function locateSymbol(info: AstResult, position: number): SymbolInfo|unde
             }
 
             // See if this attribute matches the selector of any directive on the element.
-            // TODO(ayazhafiz): Consider caching selector matches (at the expense of potentially
-            // very high memory usage).
             const attributeSelector = `[${ast.name}=${ast.value}]`;
             const parsedAttribute = CssSelector.parse(attributeSelector);
             if (!parsedAttribute.length) return;

--- a/packages/language-service/test/mocks.ts
+++ b/packages/language-service/test/mocks.ts
@@ -107,11 +107,11 @@ const summaryResolver = new AotSummaryResolver(
     staticSymbolCache);
 
 export class DiagnosticContext {
-  _analyzedModules: NgAnalyzedModules|undefined;
-  _staticSymbolResolver: StaticSymbolResolver|undefined;
-  _reflector: StaticReflector|undefined;
-  _errors: {e: any, path?: string}[] = [];
-  _resolver: CompileMetadataResolver|undefined;
+  private _analyzedModules: NgAnalyzedModules|undefined;
+  private _staticSymbolResolver: StaticSymbolResolver|undefined;
+  private _reflector: StaticReflector|undefined;
+  private _errors: {e: any, path?: string}[] = [];
+  private _resolver: CompileMetadataResolver|undefined;
 
   constructor(
       public service: ts.LanguageService, public program: ts.Program,

--- a/packages/language-service/test/mocks.ts
+++ b/packages/language-service/test/mocks.ts
@@ -107,14 +107,11 @@ const summaryResolver = new AotSummaryResolver(
     staticSymbolCache);
 
 export class DiagnosticContext {
-  // tslint:disable
-  // TODO(issue/24571): remove '!'.
-  _analyzedModules !: NgAnalyzedModules;
+  _analyzedModules: NgAnalyzedModules|undefined;
   _staticSymbolResolver: StaticSymbolResolver|undefined;
   _reflector: StaticReflector|undefined;
   _errors: {e: any, path?: string}[] = [];
   _resolver: CompileMetadataResolver|undefined;
-  // tslint:enable
 
   constructor(
       public service: ts.LanguageService, public program: ts.Program,


### PR DESCRIPTION
Cleans up some simple TODOs. Also removes
`typescript_symbols#getTypeWrapper`, which I thought I had but failed to
remove in #34571.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No