### PR TITLE
docs: fix public api tool name

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -51,7 +51,6 @@ Angular tracks the status of the public API in *golden files*. These files are s
 If you modify any part of a public API in one of the supported public packages, you must update the golden files that track the public API surface.
 If the golden files are not updated correctly, our test suite will detect the problem and the PR will fail to pass the tests.
 In such case a test error message will provide instructions for a command to run to update the golden files.
-The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended).
 
 ```shell
 yarn bazel run //tools/public_api_guard:<modified_package>_api.accept

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -48,9 +48,9 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 
 ## Golden files
 
-Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard)` and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
+Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard) and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
 
-The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended). 
+The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended).
 
 ```shell
 yarn bazel run //tools/public_api_guard:<modified_package>_api.accept

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -47,9 +47,10 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 <a name="golden-files"></a>
 
 ## Golden files
-
-Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard) and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
-
+Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard) and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian).
+If you modify any part of a public API in one of the supported public packages, you must update the golden files that track the public API surface.
+If the golden files are not updated correctly, our test suite will detect the problem and the PR will fail to pass the tests.
+In such case a test error message will provide instructions for a command to run to update the golden files.
 The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended).
 
 ```shell

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -48,9 +48,9 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 
 ## Golden files
 
-Angular tracks the status of the public API in a *golden file*, maintained with a tool called the *TS API Guardian*.  If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
+Angular tracks the status of the public API in *golden files*. These files are stored in `tools/public_api_guard` and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
 
-The public API guard provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended).
+The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended). 
 
 ```shell
 yarn bazel run //tools/public_api_guard:<modified_package>_api.accept

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -50,7 +50,7 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard) and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian).
 If you modify any part of a public API in one of the supported public packages, you must update the golden files that track the public API surface.
 If the golden files are not updated correctly, our test suite will detect the problem and the PR will fail to pass the tests.
-In such case a test error message will provide instructions for a command to run to update the golden files.
+In such cases, a test error message will provide instructions for a command that updates the golden files.
 
 ```shell
 yarn bazel run //tools/public_api_guard:<modified_package>_api.accept

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -48,7 +48,7 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 
 ## Golden files
 
-Angular tracks the status of the public API in a *golden file*, maintained with a tool called the *public API guard*.  If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
+Angular tracks the status of the public API in a *golden file*, maintained with a tool called the *TS API Guardian*.  If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
 
 The public API guard provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended).
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -48,7 +48,7 @@ Our peer dependencies (such as TypeScript, Zone.js, or RxJS) are not considered 
 
 ## Golden files
 
-Angular tracks the status of the public API in *golden files*. These files are stored in `tools/public_api_guard` and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
+Angular tracks the status of the public API in *golden files*. These files are stored in [tools/public_api_guard/](../tools/public_api_guard)` and are maintained with a tool called [TS API Guardian](https://www.npmjs.com/package/ts-api-guardian). If you modify any part of a public API in one of the supported public packages, the PR can fail a Circle CI test with failures in `testlogs/tools/public_api_guard`, and an error message that instructs you to accept the golden file.
 
 The TS API Guardian provides a Bazel target that updates the current status of a given package. If you add to or modify the public API in any way, you must use [yarn](https://yarnpkg.com/) to execute the Bazel target in your terminal shell of choice (a recent version of `bash` is recommended). 
 

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -85,8 +85,7 @@ export function startCli() {
         if (bazelTarget) {
           console.error('\n\nIf you modify a public API, you must accept the new golden file.');
           console.error('\n\nTo do so, execute the following Bazel target:');
-          console.error(
-              `  yarn bazel run ${bazelTarget.replace(/_bin$/, "")}.accept`);
+          console.error(`  yarn bazel run ${bazelTarget.replace(/_bin$/, "")}.accept`);
           if (process.env['TEST_WORKSPACE'] === 'angular') {
             console.error('\n\nFor more information, see');
             console.error(

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -80,16 +80,20 @@ export function startCli() {
       }
 
       if (hasDiff) {
+        const bazelTarget = process.env['BAZEL_TARGET'];
         // Under bazel, give instructions how to use bazel run to accept the golden file.
-        if (!!process.env['BAZEL_TARGET']) {
+        if (bazelTarget) {
           console.error('\n\nIf you modify a public API, you must accept the new golden file.');
           console.error('\n\nTo do so, execute the following Bazel target:');
           console.error(
-              `  yarn bazel run ${process.env['BAZEL_TARGET'].replace(/_bin$/, "")}.accept`);
-          console.error('\n\nFor more information, see');
-          console.error(
-              '\n  https://github.com/angular/angular/blob/master/docs/PUBLIC_API.md#golden-files');
+              `  yarn bazel run ${bazelTarget.replace(/_bin$/, "")}.accept`);
+          if (process.env['TEST_WORKSPACE'] === 'angular') {
+            console.error('\n\nFor more information, see');
+            console.error(
+                '\n  https://github.com/angular/angular/blob/master/docs/PUBLIC_API.md#golden-files');
+          }
         }
+
         process.exit(1);
       }
     }


### PR DESCRIPTION
The tool in question is named `TS API Guardian` and not `public API guard`.