### PR TITLE
fix: work around 'noImplicityAny' incompatibility due to ts3.7 update

### DIFF
--- a/integration/typings_test_ts36/package.json
+++ b/integration/typings_test_ts36/package.json
@@ -19,7 +19,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
-    "@types/jasmine": "2.5.41",
+    "@types/jasmine": "file:../../node_modules/@types/jasmine",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "3.6.4",
     "zone.js": "file:../../dist/zone.js-dist/zone.js"

--- a/integration/typings_test_ts36/tsconfig.json
+++ b/integration/typings_test_ts36/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",
@@ -15,7 +16,6 @@
       "es2015.promise"
     ],
     "types": [],
-    "strictNullChecks": true
   },
   "files": [
     "include-all.ts",

--- a/integration/typings_test_ts36/tsconfig.json
+++ b/integration/typings_test_ts36/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "skipLibCheck": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",

--- a/integration/typings_test_ts36/yarn.lock
+++ b/integration/typings_test_ts36/yarn.lock
@@ -61,10 +61,8 @@
 "@angular/upgrade@file:../../dist/packages-dist/upgrade":
   version "9.0.0-rc.1"
 
-"@types/jasmine@2.5.41":
-  version "2.5.41"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.41.tgz#d5e86161a0af80d52062b310a33ed65b051a0713"
-  integrity sha1-1ehhYaCvgNUgYrMQoz7WWwUaBxM=
+"@types/jasmine@file:../../node_modules/@types/jasmine":
+  version "2.8.8"
 
 abbrev@1:
   version "1.1.1"

--- a/integration/typings_test_ts37/package.json
+++ b/integration/typings_test_ts37/package.json
@@ -19,7 +19,7 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
-    "@types/jasmine": "2.5.41",
+    "@types/jasmine": "file:../../node_modules/@types/jasmine",
     "rxjs": "file:../../node_modules/rxjs",
     "typescript": "3.7.4",
     "zone.js": "file:../../dist/zone.js-dist/zone.js"

--- a/integration/typings_test_ts37/tsconfig.json
+++ b/integration/typings_test_ts37/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",
@@ -15,7 +16,6 @@
       "es2015.promise"
     ],
     "types": [],
-    "strictNullChecks": true
   },
   "files": [
     "include-all.ts",

--- a/integration/typings_test_ts37/tsconfig.json
+++ b/integration/typings_test_ts37/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "skipLibCheck": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",

--- a/integration/typings_test_ts37/yarn.lock
+++ b/integration/typings_test_ts37/yarn.lock
@@ -61,10 +61,8 @@
 "@angular/upgrade@file:../../dist/packages-dist/upgrade":
   version "9.0.0-rc.1"
 
-"@types/jasmine@2.5.41":
-  version "2.5.41"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.41.tgz#d5e86161a0af80d52062b310a33ed65b051a0713"
-  integrity sha1-1ehhYaCvgNUgYrMQoz7WWwUaBxM=
+"@types/jasmine@file:../../node_modules/@types/jasmine":
+  version "2.8.8"
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -36,6 +36,10 @@ export class EmitterVisitorContext {
 
   constructor(private _indent: number) { this._lines = [new _EmittedLine(_indent)]; }
 
+  /**
+   * @internal strip this from published d.ts files due to
+   * https://github.com/microsoft/TypeScript/issues/36216
+   */
   private get _currentLine(): _EmittedLine { return this._lines[this._lines.length - 1]; }
 
   println(from?: {sourceSpan: ParseSourceSpan | null}|null, lastPart: string = ''): void {
@@ -169,6 +173,10 @@ export class EmitterVisitorContext {
     return null;
   }
 
+  /**
+   * @internal strip this from published d.ts files due to
+   * https://github.com/microsoft/TypeScript/issues/36216
+   */
   private get sourceLines(): _EmittedLine[] {
     if (this._lines.length && this._lines[this._lines.length - 1].parts.length === 0) {
       return this._lines.slice(0, -1);

--- a/packages/compiler/src/output/source_map.ts
+++ b/packages/compiler/src/output/source_map.ts
@@ -74,6 +74,10 @@ export class SourceMapGenerator {
     return this;
   }
 
+  /**
+  * @internal strip this from published d.ts files due to
+  * https://github.com/microsoft/TypeScript/issues/36216
+  */
   private get currentLine(): Segment[]|null { return this.lines.slice(-1)[0]; }
 
   toJSON(): SourceMap|null {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -351,6 +351,10 @@ export class TestBedRender3 implements TestBed {
     return fixture;
   }
 
+  /**
+   * @internal strip this from published d.ts files due to
+   * https://github.com/microsoft/TypeScript/issues/36216
+   */
   private get compiler(): R3TestBedCompiler {
     if (this._compiler === null) {
       throw new Error(`Need to call TestBed.initTestEnvironment() first`);
@@ -358,6 +362,10 @@ export class TestBedRender3 implements TestBed {
     return this._compiler;
   }
 
+  /**
+   * @internal strip this from published d.ts files due to
+   * https://github.com/microsoft/TypeScript/issues/36216
+   */
   private get testModuleRef(): NgModuleRef<any> {
     if (this._testModuleRef === null) {
       this._testModuleRef = this.compiler.finalize();


### PR DESCRIPTION
Typescript 3.7 now emits d.ts files for getters differently than prior versions,
and there seems to be a bug in how it strips private types without replacing them
with explicit 'any' type. This then leads to compilation failures in projects compiled
against our packages that don't have skipLibCheck turned on but do have strict or
noImplicitAny check on.

I'm working around this by marking the affected getters as @Internal and
adding a test to prevent future regressions.

Typescript bug report: https://github.com/microsoft/TypeScript/issues/36216