### PR TITLE
fix(ivy): catch FatalDiagnosticError thrown from preanalysis phase

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -198,7 +198,8 @@ export class TraitCompiler {
     this.fileToClasses.get(sf) !.add(record.node);
   }
 
-  private scanClassForTraits(clazz: ClassDeclaration): Trait<unknown, unknown, unknown>[]|null {
+  private scanClassForTraits(clazz: ClassDeclaration):
+      PendingTrait<unknown, unknown, unknown>[]|null {
     if (!this.compileNonExportedClasses && !isExported(clazz)) {
       return null;
     }
@@ -209,9 +210,9 @@ export class TraitCompiler {
   }
 
   protected detectTraits(clazz: ClassDeclaration, decorators: Decorator[]|null):
-      Trait<unknown, unknown, unknown>[]|null {
+      PendingTrait<unknown, unknown, unknown>[]|null {
     let record: ClassRecord|null = this.recordFor(clazz);
-    let foundTraits: Trait<unknown, unknown, unknown>[] = [];
+    let foundTraits: PendingTrait<unknown, unknown, unknown>[] = [];
 
     for (const handler of this.handlers) {
       const result = handler.detect(clazz, decorators);
@@ -308,7 +309,7 @@ export class TraitCompiler {
           preanalysis = trait.handler.preanalyze(clazz, trait.detected.metadata) || null;
         } catch (err) {
           if (err instanceof FatalDiagnosticError) {
-            (trait as PendingTrait<unknown, unknown, unknown>).toErrored([err.toDiagnostic()]);
+            trait.toErrored([err.toDiagnostic()]);
             return;
           } else {
             throw err;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3578,9 +3578,7 @@ runInEachFileSystem(os => {
 
           const diags = await driveDiagnostics();
           expect(diags[0].messageText).toBe('component is missing a template');
-          expect(diags[0].file !.fileName).toContain('test.ts');
-          expect(diags[0].start).toBeDefined();
-          expect(diags[0].length).toBeDefined();
+          expect(diags[0].file !.fileName).toBe(absoluteFrom('/test.ts'));
         });
 
         it('should throw if `styleUrls` is defined incorrectly in @Component', async() => {
@@ -3597,9 +3595,7 @@ runInEachFileSystem(os => {
 
           const diags = await driveDiagnostics();
           expect(diags[0].messageText).toBe('styleUrls must be an array of strings');
-          expect(diags[0].file !.fileName).toContain('test.ts');
-          expect(diags[0].start).toBeDefined();
-          expect(diags[0].length).toBeDefined();
+          expect(diags[0].file !.fileName).toBe(absoluteFrom('/test.ts'));
         });
       });
     });


### PR DESCRIPTION
Component's decorator handler exposes `preanalyze` method to preload async resources (templates, stylesheets). The logic in preanalysis phase may throw `FatalDiagnosticError` errors that contain useful information regarding the origin of the problem. However these errors from preanalysis phase were not intercepted in TraitCompiler, resulting in just error message text be displayed. This commit updates the logic to handle FatalDiagnosticError and transform it before throwing, so that the result diagnostic errors contain the necessary info.

Resolves #34725.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No