### PR TITLE
doc: fix logging upon search in example tutorial

### DIFF
--- a/aio/content/examples/toh-pt6/src/app/hero.service.ts
+++ b/aio/content/examples/toh-pt6/src/app/hero.service.ts
@@ -86,7 +86,9 @@ export class HeroService {
       return of([]);
     }
     return this.http.get<Hero[]>(`${this.heroesUrl}/?name=${term}`).pipe(
-      tap(_ => this.log(`found heroes matching "${term}"`)),
+      tap(x => x.length ?
+         this.log(`found heroes matching "${term}"`) :
+         this.log(`no heroes matching "${term}"`)),
       catchError(this.handleError<Hero[]>('searchHeroes', []))
     );
   }


### PR DESCRIPTION
When no errors are thrown but empty array is returned we should log different message.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In Tutorial documentation example "Tour of Heroes App" there is functionality to search for heroes by name (parts of a name). 
In case there is a hero matching the term, a log message saying 'found heroes matching {term}' is logged on the screen. 
In case there are no heroes matching the term, the same message is logged and displayed which _**is incorrect.**_

Issue Number: N/A


## What is the new behavior?

In Tutorial documentation example "Tour of Heroes App" there is functionality to search for heroes by name (parts of a name). 
In case there is a hero matching the term, a log message saying 'found heroes matching {term}' is logged on the screen. 
In case there are no heroes matching the term,  **_a log message saying 'no heroes matching {term}' is logged on the screen._**

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
@mgechev As we discussed, here is the PR. Could you please review? Thanks in advance.