### PR TITLE
docs(core): improve event emitter typing

### DIFF
--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -37,15 +37,15 @@ import {Subject, Subscription} from 'rxjs';
  *  </div>`})
  * export class Zippy {
  *   visible: boolean = true;
- *   @Output() open: EventEmitter<any> = new EventEmitter();
- *   @Output() close: EventEmitter<any> = new EventEmitter();
+ *   @Output() open: EventEmitter<boolean> = new EventEmitter();
+ *   @Output() close: EventEmitter<boolean> = new EventEmitter();
  *
  *   toggle() {
  *     this.visible = !this.visible;
  *     if (this.visible) {
- *       this.open.emit(null);
+ *       this.open.emit(true);
  *     } else {
- *       this.close.emit(null);
+ *       this.close.emit(false);
  *     }
  *   }
  * }


### PR DESCRIPTION
Currently the docs give the impression that you have to pass null in the emit for an emitter that only tries to notify its parent component. I believe correct typing would be `EventEmitter<void>` to make sure people do not get in the habit of using `any` type with event emitters.

Or am I wrong and is this the right way to handle these use-cases?

In this case, we do actually want to demonstrate passing a value to a parent component, which is why I suggest to change it to a typed value like a boolean.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
