### PR TITLE
build(docs-infra): add auto-link-filter for generic words

### DIFF
--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -40,6 +40,7 @@ module.exports = new Package('angular-base', [
   .factory(require('./services/auto-link-filters/filterPipes'))
   .factory(require('./services/auto-link-filters/filterAmbiguousDirectiveAliases'))
   .factory(require('./services/auto-link-filters/ignoreHttpInUrls'))
+  .factory(require('./services/auto-link-filters/ignoreGenericWords'))
 
   .factory(require('./post-processors/add-image-dimensions'))
   .factory(require('./post-processors/auto-link-code'))
@@ -129,9 +130,9 @@ module.exports = new Package('angular-base', [
   })
 
 
-  .config(function(postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases, ignoreHttpInUrls) {
+  .config(function(postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases, ignoreHttpInUrls, ignoreGenericWords) {
     addImageDimensions.basePath = path.resolve(AIO_PATH, 'src');
-    autoLinkCode.customFilters = [ignoreHttpInUrls, filterPipes, filterAmbiguousDirectiveAliases];
+    autoLinkCode.customFilters = [ignoreGenericWords, ignoreHttpInUrls, filterPipes, filterAmbiguousDirectiveAliases];
     postProcessHtml.plugins = [
       require('./post-processors/autolink-headings'),
       addImageDimensions,

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -1,0 +1,10 @@
+
+/**
+ * This service is used by the autoLinkCode post-processor to ignore generic words
+ * that could be mistaken as classes, functions, etc.
+ */
+
+module.exports = function ignoreGenericWords() {
+  const ignoredWords = new Set(['a', 'create', 'error', 'group', 'request', 'value']);
+  return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
+};

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
@@ -1,0 +1,21 @@
+const ignoreGenericWords = require('./ignoreGenericWords')();
+
+describe('ignoreGenericWords', () => {
+  it('should ignore generic words in all docs', () => {
+    const docs = [{docType: 'package', name: 'create'}, {docType: 'class', name: 'Foo'}];
+    const words = ['create', 'a', 'thing'];
+    expect(ignoreGenericWords(docs, words, 0)).toEqual([]);
+    expect(ignoreGenericWords(docs, words, 1)).toEqual([]);
+    expect(ignoreGenericWords(docs, words, 2)).toEqual(docs);
+  });
+
+  it('should ignore generic words with mixed case in all docs', () => {
+    const docs = [{docType: 'package', name: 'create'}, {docType: 'class', name: 'Foo'}];
+    const words = ['Create', 'eRrOr', 'STUFF'];
+    expect(ignoreGenericWords(docs, words, 0)).toEqual([]);
+    expect(ignoreGenericWords(docs, words, 1)).toEqual([]);
+    expect(ignoreGenericWords(docs, words, 2)).toEqual(docs);
+  });
+});
+
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34794 


## What is the new behavior?

Adds filter to prevent autolinking words like "create" 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
