### PR TITLE
fix(ivy): support @SkipSelf while injecting special DI tokens

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 450017,
+        "main-es2015": 450763,
         "polyfills-es2015": 52195
       }
     }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 141569,
+        "main-es2015": 142106,
         "polyfills-es2015": 36657
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 147647,
+        "main-es2015": 148184,
         "polyfills-es2015": 36657
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 136777,
+        "main-es2015": 137380,
         "polyfills-es2015": 37334
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 247198,
+        "main-es2015": 247815,
         "polyfills-es2015": 36657,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 226144,
+        "main-es2015": 226689,
         "polyfills-es2015": 36657,
         "5-es2015": 779
       }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -23,7 +23,7 @@ import {DirectiveDef, FactoryFn} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
 import {AttributeMarker, TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TNode, TNodeProviderIndexes, TNodeType} from './interfaces/node';
 import {isComponentDef, isComponentHost} from './interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, INJECTOR, LView, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, INJECTOR, LView, TData, TVIEW, TView, TViewType, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {enterDI, leaveDI} from './state';
 import {isNameOnlyAttributeMarker} from './util/attrs_utils';
@@ -313,6 +313,12 @@ function getParentTNode(
   // Falling back to `T_HOST` in case we cross component boundary (thus `tNode.parent` is not
   // defined in this case), but do that only if `@Host()` is not present.
   if (parent === null && !(flags & InjectFlags.Host)) {
+    const tView = lView[TVIEW];
+    if (tView.type === TViewType.Embedded) {
+      // TODO: we should go up the chain until we find Element or ElementContainer node
+      return (tView as any).declarationTNode;
+    }
+    // TODO: check other TViewType types
     return lView[T_HOST] as TDirectiveHostNode;
   }
   return parent;

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -379,12 +379,12 @@ export function getOrCreateInjectable<T>(
       // `-1` is a special value used to identify `Injector` types.
       if (bloomHash === -1) {
         if (flags & InjectFlags.SkipSelf) {
-          const parentInjectorLocation = getParentInjectorLocation(tNode, lView);
+          const _tNode = tNode;
           tNode = getParentTNode(tNode, lView, flags);
           if (tNode === null) {
             return notFoundValueOrThrow(notFoundValue, token, flags);
           }
-          lView = getParentInjectorView(parentInjectorLocation, lView);
+          lView = getParentInjectorView(getParentInjectorLocation(_tNode, lView), lView);
         }
         return new NodeInjector(tNode, lView) as any;
       }

--- a/packages/core/src/render3/instructions/container.ts
+++ b/packages/core/src/render3/instructions/container.ts
@@ -62,6 +62,10 @@ function templateFirstCreatePass(
   const embeddedTView = tNode.tViews = createTView(
       TViewType.Embedded, -1, templateFn, decls, vars, tView.directiveRegistry, tView.pipeRegistry,
       null, tView.schemas, tViewConsts);
+
+  // TODO: temporary change to test POC
+  (embeddedTView as any).declarationTNode = tNode;
+
   const embeddedTViewNode = createTNode(tView, null, TNodeType.View, -1, null, null) as TViewNode;
   embeddedTViewNode.injectorIndex = tNode.injectorIndex;
   embeddedTView.node = embeddedTViewNode;

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -714,6 +714,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeParent"
+  },
+  {
     "name": "getTStylingRangeNext"
   },
   {
@@ -1000,6 +1003,9 @@
   },
   {
     "name": "normalizeAndApplySuffixOrSanitizer"
+  },
+  {
+    "name": "notFoundValueOrThrow"
   },
   {
     "name": "readPatchedData"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -693,6 +693,9 @@
     "name": "getParentState"
   },
   {
+    "name": "getParentTNode"
+  },
+  {
     "name": "getPipeDef"
   },
   {
@@ -712,9 +715,6 @@
   },
   {
     "name": "getTNode"
-  },
-  {
-    "name": "getTNodeParent"
   },
   {
     "name": "getTStylingRangeNext"


### PR DESCRIPTION
Currently Ivy doesn't support adding `@SkipSelf` for some of the special DI tokens (e.g. `Injector`, `ViewContainerRef`, `ElementRef`, `ChangeDetectorRef`). These changes add support for `@SkipSelf` flag and align the behavior with View Engine.

Closes #34066.
Closes #34819.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No