### PR TITLE
ci(docs-infra): do not output build progress for e2e tests on CI

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -97,6 +97,9 @@
                 }
               ],
               "serviceWorker": true
+            },
+            "ci": {
+              "progress": false
             }
           }
         },
@@ -119,7 +122,7 @@
               "browserTarget": "site:build:archive"
             },
             "ci": {
-              "progress": false
+              "browserTarget": "site:build:ci"
             }
           }
         },


### PR DESCRIPTION
When running the e2e tests on CI, it is desirable that the build progress is not logged, because that clutters the logs and makes it difficult to get to the useful info in case of failures.

The previous config to achieve that doesn't work any more.

This commit update the `ci` configuration for e2e tests to suppress build progress logging.
