### PR TITLE
docs: change docs for get request return object type checking

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -140,7 +140,7 @@ This particular `HttpClient.get()` call returns an `Observable<Hero[]>`; that is
 ### `HttpClient.get()` returns response data
 
 `HttpClient.get()` returns the body of the response as an untyped JSON object by default.
-Applying the optional type specifier, `<Hero[]>` , gives you a typed result object.
+Applying the optional type specifier, `<Hero[]>` , adds TypeScript capabilities, which reduce errors during compile time.
 
 The server's data API determines the shape of the JSON data.
 The _Tour of Heroes_ data API returns the hero data as an array.


### PR DESCRIPTION
earlier in the docs it was told that adding typescript's type checking makes JSON response typed so changed docs to say that it adds all typescript capabilities during compile time

Fixes #34746

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
earlier in the docs it was told that adding typescript's type checking makes JSON response typed

Issue Number: #34746 


## What is the new behavior?
changed docs to say that it adds all typescript capabilities during compile time

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
