### PR TITLE
feat(language-service): provide hover for microsyntax in structural directive

### DIFF
--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -29,6 +29,8 @@ export function locateSymbols(info: AstResult, position: number): SymbolInfo[] {
   const templatePosition = position - info.template.span.start;
   // TODO: update `findTemplateAstAt` to use absolute positions.
   const path = findTemplateAstAt(info.templateAst, templatePosition);
+  const attribute = findAttribute(info, position);
+
   if (!path.tail) return [];
 
   const narrowest = spanOf(path.tail);
@@ -36,6 +38,11 @@ export function locateSymbols(info: AstResult, position: number): SymbolInfo[] {
   for (let node: TemplateAst|undefined = path.tail;
        node && isNarrower(spanOf(node.sourceSpan), narrowest); node = path.parentOf(node)) {
     toVisit.push(node);
+  }
+
+  // For the structural directive, only care about the last template AST.
+  if (attribute?.name.startsWith('*')) {
+    toVisit.splice(0, toVisit.length - 1);
   }
 
   return toVisit.map(ast => locateSymbol(ast, path, info))

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -311,7 +311,7 @@ describe('definitions', () => {
 
       expect(definitions).toBeDefined();
       // The two definitions are setter and getter of 'ngForTrackBy'.
-      expect(definitions !.length).toBe(4);
+      expect(definitions !.length).toBe(2);
 
       const refFileName = '/node_modules/@angular/common/common.d.ts';
       definitions !.forEach(def => {
@@ -335,7 +335,7 @@ describe('definitions', () => {
       expect(textSpan).toEqual(marker);
 
       expect(definitions).toBeDefined();
-      expect(definitions !.length).toBe(2);
+      expect(definitions !.length).toBe(1);
 
       const refFileName = '/app/parsing-cases.ts';
       const def = definitions ![0];

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -141,14 +141,37 @@ describe('hover', () => {
     expect(toText(displayParts)).toBe('(property) TestComponent.name: string');
   });
 
-  it('should be able to find a structural directive', () => {
-    mockHost.override(TEST_TEMPLATE, `<div «*ᐱngIfᐱ="true"»></div>`);
-    const marker = mockHost.getDefinitionMarkerFor(TEST_TEMPLATE, 'ngIf');
-    const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
-    expect(quickInfo).toBeTruthy();
-    const {textSpan, displayParts} = quickInfo !;
-    expect(textSpan).toEqual(marker);
-    expect(toText(displayParts)).toBe('(property) NgIf<T>.ngIf: T');
+  describe('over structural directive', () => {
+    it('should be able to find the directive', () => {
+      mockHost.override(TEST_TEMPLATE, `<div «*ᐱngForᐱ="let item of heroes"»></div>`);
+      const marker = mockHost.getDefinitionMarkerFor(TEST_TEMPLATE, 'ngFor');
+      const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+      expect(quickInfo).toBeTruthy();
+      const {textSpan, displayParts} = quickInfo !;
+      expect(textSpan).toEqual(marker);
+      expect(toText(displayParts)).toBe('(directive) NgForOf: typeof NgForOf');
+    });
+
+    it('should be able to find the directive property', () => {
+      mockHost.override(
+          TEST_TEMPLATE, `<div *ngFor="let item of heroes; «ᐱtrackByᐱ: test»;"></div>`);
+      const marker = mockHost.getDefinitionMarkerFor(TEST_TEMPLATE, 'trackBy');
+      const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+      expect(quickInfo).toBeTruthy();
+      const {textSpan, displayParts} = quickInfo !;
+      expect(textSpan).toEqual(marker);
+      expect(toText(displayParts)).toBe('(method) NgForOf<T, U>.ngForTrackBy: TrackByFunction<T>');
+    });
+
+    it('should be able to find the property value', () => {
+      mockHost.override(TEST_TEMPLATE, `<div *ngFor="let item of «heroes»; trackBy: test;"></div>`);
+      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'heroes');
+      const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+      expect(quickInfo).toBeTruthy();
+      const {textSpan, displayParts} = quickInfo !;
+      expect(textSpan).toEqual(marker);
+      expect(toText(displayParts)).toBe('(property) TemplateReference.heroes: Hero[]');
+    });
   });
 
   it('should be able to find a reference to a two-way binding', () => {


### PR DESCRIPTION
In #34564, I only support hover over the directive name. And have a problem, when hovering over `*ngFor="exp"`, it will show `ngForOf` property of `NgForOf` class, this pr will show `(directive) CommonModule.NgForOf: class`. This PR also supports the microsyntax(e.g. `trackBy `, `of`).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
