### PR TITLE
ci: remove typescript 3.7 patches in material-unit-tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,21 +780,6 @@ jobs:
           name: Setting up release packages.
           command: node scripts/ci/update-deps-to-dist-packages.js ${MATERIAL_REPO_TMP_DIR}/package.json dist/packages-dist/
       - run:
-          # Install TypeScript 3.7 and Tsickle 0.38.0.
-          name: Setting up TypeScript 3.7 and Tsickle 0.38.0
-          # TODO: remove this once the repo has been updated to use TypeScript 3.7 and
-          # Tsickle 0.38.0. Note that the components repository has a Yarn resolution to ensure
-          # that "dgeni-packages" uses a specific TypeScript version. This resolution causes the
-          # specified TS version to be a valid candidate for the "@angular/bazel" peer dependency.
-          # Ultimately, Yarn seems to use the TS version from the resolution for Angular Bazel.
-          # This causes a mismatch of TypeScript versions as tsickle will use the v3.7.4 version,
-          # while Angular Bazel uses any arbitrary version from the resolution (currently v3.6.4).
-          # Also note that we need to explicitly update `tsickle` because `angular/components`
-          # declared it as explicit dep, and their current version is not compatible with TS 3.7.
-          command: |
-            sed -i -E 's#(dgeni-packages/typescript": ").+"#\13.7.4"#' ${MATERIAL_REPO_TMP_DIR}/package.json
-            yarn --ignore-engines --cwd ${MATERIAL_REPO_TMP_DIR} add typescript@3.7.4 tsickle@0.38.0 --dev
-      - run:
           name: "Running Material unit tests"
           command: ./scripts/ci/run_angular_material_unit_tests.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ var_4_win: &cache_key_win_fallback v5-angular-win-node-12.0-
 
 # Cache key for the Material unit tests job. **Note** when updating the SHA in the cache keys,
 # also update the SHA for the "MATERIAL_REPO_COMMIT" environment variable.
-var_5: &material_unit_tests_cache_key v5-angular-material-71955d2e194bfc5561f25daea16e68af266d6ff9
+var_5: &material_unit_tests_cache_key v5-angular-material-97a7e2babbccd3dc58e7b3364004e45ed5bd9968
 var_6: &material_unit_tests_cache_key_fallback v5-angular-material-
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages` and

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -75,7 +75,7 @@ setPublicVar MATERIAL_REPO_TMP_DIR "/tmp/material2"
 setPublicVar MATERIAL_REPO_URL "https://github.com/angular/material2.git"
 setPublicVar MATERIAL_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI "config.yml".
-setPublicVar MATERIAL_REPO_COMMIT "71955d2e194bfc5561f25daea16e68af266d6ff9"
+setPublicVar MATERIAL_REPO_COMMIT "97a7e2babbccd3dc58e7b3364004e45ed5bd9968"
 
 # Source `$BASH_ENV` to make the variables available immediately.
 source $BASH_ENV;


### PR DESCRIPTION
* See individual commits.