### PR TITLE
test(language-service): recognize inputs/ouputs declared in decorator

### DIFF
--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -646,7 +646,7 @@ describe('diagnostics', () => {
     expect(ngDiags).toEqual([]);
   });
 
-  // Issue #34874
+  // Issue https://github.com/angular/angular/issues/34874
   it('should recognize inputs and outputs listed inside directive decorators', () => {
     mockHost.override(
         TEST_TEMPLATE, `<div hint-model [hint]="title" (hintChange)="myClick($event)"></div>`);

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -646,6 +646,14 @@ describe('diagnostics', () => {
     expect(ngDiags).toEqual([]);
   });
 
+  // Issue #34874
+  it('should recognize inputs and outputs listed inside directive decorators', () => {
+    mockHost.override(
+        TEST_TEMPLATE, `<div hint-model [hint]="title" (hintChange)="myClick($event)"></div>`);
+    const ngDiags = ngLS.getDiagnostics(TEST_TEMPLATE);
+    expect(ngDiags).toEqual([]);
+  });
+
   it('should be able to resolve modules using baseUrl', () => {
     mockHost.override(APP_COMPONENT, `
       import { Component } from '@angular/core';

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -650,7 +650,7 @@ describe('diagnostics', () => {
   it('should recognize inputs and outputs listed inside directive decorators', () => {
     mockHost.override(
         TEST_TEMPLATE, `<div hint-model [hint]="title" (hintChange)="myClick($event)"></div>`);
-    const ngDiags = ngLS.getDiagnostics(TEST_TEMPLATE);
+    const ngDiags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
     expect(ngDiags).toEqual([]);
   });
 

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -34,6 +34,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.CaseMissingClosing,
     ParsingCases.CaseUnknown,
     ParsingCases.EmptyInterpolation,
+    ParsingCases.HintModel,
     ParsingCases.NoValueAttribute,
     ParsingCases.NumberModel,
     ParsingCases.Pipes,

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -60,6 +60,16 @@ export class NumberModel {
   @Output('outputAlias') modelChange: EventEmitter<number> = new EventEmitter();
 }
 
+@Directive({
+  selector: '[hint-model]',
+  inputs: ['hint'],
+  outputs: ['hintChange'],
+})
+export class HintModel {
+  hint: string = 'hint';
+  hintChange: EventEmitter<string> = new EventEmitter();
+}
+
 interface Person {
   name: string;
   age: number;


### PR DESCRIPTION
This commit adds a regression test to check that the language service
recognizes inputs and outputs declared in a directive decorator.

See #34874.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No