### PR TITLE
build: add --stamp flag to the release config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,7 @@ test --incompatible_strict_action_env
 # This command assumes node on the path and is a workaround for
 # https://github.com/bazelbuild/bazel/issues/4802
 build:release --workspace_status_command="node ./tools/bazel_stamp_vars.js"
+build:release --stamp
 
 ###############################
 # Output                      #


### PR DESCRIPTION
In a recent upgrade of rules_nodejs an update was made the
stamping logic in npm_package.  Triggering stamping for npm_package
now require the --stamp flag.
