### PR TITLE
fix(common): remove extra & in http params

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -224,9 +224,15 @@ export class HttpParams {
     return this.keys()
         .map(key => {
           const eKey = this.encoder.encodeKey(key);
+          // `a: ['1']` produces `'a=1'`
+          // `b: []` produces `''`
+          // `c: ['1', '2']` produces `'c=1&c=2'`
           return this.map !.get(key) !.map(value => eKey + '=' + this.encoder.encodeValue(value))
               .join('&');
         })
+        // filter out empty values because `b: []` produces `''`
+        // which results in `a=1&&c=1&c=2` instead of `a=1&c=1&c=2` if we don't
+        .filter(param => param !== '')
         .join('&');
   }
 

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -76,5 +76,20 @@ import {HttpParams} from '@angular/common/http/src/params';
         expect(body.keys()).toEqual(['a', 'b', 'c', 'd']);
       });
     });
+
+    describe('toString', () => {
+      it('should stringify string params', () => {
+        const body = new HttpParams({fromObject: {a: '', b: '2', c: '3'}});
+        expect(body.toString()).toBe('a=&b=2&c=3');
+      });
+      it('should stringify array params', () => {
+        const body = new HttpParams({fromObject: {a: '', b: ['21', '22'], c: '3'}});
+        expect(body.toString()).toBe('a=&b=21&b=22&c=3');
+      });
+      it('should stringify empty array params', () => {
+        const body = new HttpParams({fromObject: {a: '', b: [], c: '3'}});
+        expect(body.toString()).toBe('a=&c=3');
+      });
+    });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

HTTP params like
```typescript
{a: '', b: [], c: '3'}
```
result in a request with `a=&&c=3` (note the extra `&` introduced by `b` and its empty array)

Issue Number: couldn't find one

## What is the new behavior?

There are two ways to fix this:
- be coherent and generate `a=&b=&c=3`. This would be the best but it is a breaking change as ome people may rely on the current behavior of not having the array parameter sent if it is empty.
- be compatible and just remove the extra & in the URL `a=&c=3`

After discussing with @petebacondarwin we went for the simple and compatible fix.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No, although some developers may have some unit tests that need to be fixed if they are checking the generated requests of their services.
