### PR TITLE
(docs): fix syntax of code example for ES5 configuration

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -663,14 +663,14 @@ In `angular.json` add two new configuration sections under the `build` and `serv
      ...
     },
     "es5": {
-      "browserTarget": "&lt;app-name&gt;:build:es5"
+      "browserTarget": "YOUR_APP_NAME:build:es5"
     }
   }
 },
 
 </code-example>
 
-You can then run the `ng serve` command with this configuration. Make sure to replace `<app-name>` (in `"<app-name>:build:es5"`) with the actual name of the app, as it appears under `projects` in `angular.json`. For example, if your app name is `myAngularApp` the config will become `"browserTarget": "myAngularApp:build:es5"`.
+You can then run the `ng serve` command with this configuration. Make sure to replace `YOUR_APP_NAME` (in `"YOUR_APP_NAME:build:es5"`) with the actual name of the app, as it appears under `projects` in `angular.json`. For example, if your app name is `myAngularApp` the config will become `"browserTarget": "myAngularApp:build:es5"`.
 
 <code-example language="none" class="code-shell">
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
At the end of the second code example under "**Configuring serve for ES5**", Markdown correctly formats `&lt;app-name&gt;:build:es5` as `<app-name>:build:es5`, but the rendered code sample online at angular.io doesn't show `<app-name>` at all, so it ends up being `"browserTarget": ":build:es5"`, which makes the note below the code sample confusing as it says to replace `<app-name>`, which doesn't exist.

## What is the new behavior?
Code example is rendered correctly to match the hint underneath. I don't know if there's a way to render "less than" and "greater than" symbols correctly online, so I used all caps with an underscore delimiter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
