### PR TITLE
docs: update payload size limits for angular.io application

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 461697,
+        "main-es2015": 462235,
         "polyfills-es2015": 52503
       }
     }


### PR DESCRIPTION
This commit increases payload size limits for angular.io application that triggered an error after merging another commit (https://github.com/angular/angular/commit/00f13cc074608b1e9524ee9b03c19f9c177d19c9). The goal of this commit is to bring master back to a "green" state and separate investigation is required to identify the root cause for size increase.

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No