### PR TITLE
fix(ivy): ensure multi providers in ModuleWithProviders are not duplicated

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -394,15 +394,8 @@ export class R3TestBedCompiler {
 
     const injectorDef: any = (moduleType as any)[NG_INJ_DEF];
     if (this.providerOverridesByToken.size > 0) {
-      // Extract the list of providers from ModuleWithProviders, so we can define the final list of
-      // providers that might have overrides.
-      // Note: second `flatten` operation is needed to convert an array of providers
-      // (e.g. `[[], []]`) into one flat list, also eliminating empty arrays.
-      const providersFromModules = flatten(flatten(
-          injectorDef.imports, (imported: NgModuleType<any>| ModuleWithProviders<any>) =>
-                                   isModuleWithProviders(imported) ? imported.providers : []));
       const providers = [
-        ...providersFromModules, ...injectorDef.providers,
+        ...injectorDef.providers,
         ...(this.providerOverridesByModule.get(moduleType as InjectorType<any>) || [])
       ];
       if (this.hasProviderOverrides(providers)) {


### PR DESCRIPTION
The current logic pulls multiproviders up to the parent module's provider list. This results in the multi provider being defined both in the imported ModuleWithProviders and the parent and getting an extra item in the multi provided array of values.