### PR TITLE
build(docs-infra): add words to ignore in snippets

### DIFF
--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -5,6 +5,6 @@
  */
 
 module.exports = function ignoreGenericWords() {
-  const ignoredWords = new Set(['a', 'create', 'error', 'group', 'request', 'value']);
+  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'target', 'value']);
   return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Adds the words "classes" and "targets" to the list of common words to NOT link in code snippets.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
These words link to unrelated API elements.
See examples in https://next.angular.io/guide/template-syntax

Issue Number: N/A


## What is the new behavior?
Words in snippets should not be links.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
 