### PR TITLE
docs: update payload size limits for angular.io application (patch-only version)

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 461697,
+        "main-es2015": 462247,
         "polyfills-es2015": 52503
       }
     }


### PR DESCRIPTION
This commit increases payload size limits for angular.io application that triggered an error after merging another commit (https://github.com/angular/angular/commit/b6dfb4da2d56bf02cc725db3280f1b0baee5f778). The goal of this commit is to bring patch branch back to a "green" state and separate investigation is required to identify the root cause for size increase.

This PR is a patch-only version of a [similar PR](https://github.com/angular/angular/commit/92c411f86dc638334718c44bf1e112bcaa49c75c) submitted earlier for master branch.

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No