### PR TITLE
docs: use an explicit product id in the getting started example 

### DIFF
--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
@@ -23,8 +23,11 @@ export class ProductDetailsComponent implements OnInit {
   // #enddocregion props-methods
   // #docregion get-product
   ngOnInit() {
-    this.route.paramMap.subscribe(params => {
-      this.product = products[+params.get('productId')];
+    // First get the product id from the current route.
+    const productIdFromRoute = this.route.snapshot.paramMap.get('productId');
+    // Find the product that correspond with the id provided in route.
+    this.product = products.find(product => {
+      return product.id === Number(productIdFromRoute);
     });
   // #docregion product-prop
   }

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
@@ -30,8 +30,11 @@ export class ProductDetailsComponent implements OnInit {
 // #docregion get-product
   ngOnInit() {
 // #enddocregion props-methods
-    this.route.paramMap.subscribe(params => {
-      this.product = products[+params.get('productId')];
+    // First get the product id from the current route.
+    const productIdFromRoute = this.route.snapshot.paramMap.get('productId');
+    // Find the product that correspond with the id provided in route.
+    this.product = products.find(product => {
+      return product.id === Number(productIdFromRoute);
     });
 // #docregion props-methods
   }

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
@@ -1,10 +1,10 @@
 <h2>Products</h2>
 
 <!-- #docregion router-link -->
-<div *ngFor="let product of products; index as productId">
+<div *ngFor="let product of products">
 
   <h3>
-    <a [title]="product.name + ' details'" [routerLink]="['/products', productId]">
+    <a [title]="product.name + ' details'" [routerLink]="['/products', product.id]">
       {{ product.name }}
     </a>
   </h3>

--- a/aio/content/examples/getting-started/src/app/products.ts
+++ b/aio/content/examples/getting-started/src/app/products.ts
@@ -1,15 +1,18 @@
 export const products = [
   {
+    id: 1,
     name: 'Phone XL',
     price: 799,
     description: 'A large phone with one of the best screens'
   },
   {
+    id: 2,
     name: 'Phone Mini',
     price: 699,
     description: 'A great phone with one of the best cameras'
   },
   {
+    id: 3,
     name: 'Phone Standard',
     price: 299,
     description: ''

--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -31,7 +31,7 @@ This section shows you how to define a route to show individual product details.
 1. Update the `*ngFor` directive to read as follows.
     This statement instructs Angular to iterate over the items in the `products` array and assigns each index in the array to the `productId` variable when iterating over the list.
 
-1. Modify the product name anchor to include a `routerLink`.
+1. Modify the product name anchor to include a `routerLink` with the `product.id` as a parameter.
 
     <code-example header="src/app/product-list/product-list.component.html" path="getting-started/src/app/product-list/product-list.component.html" region="router-link">
     </code-example>


### PR DESCRIPTION
Simplyfing the example by prodiving an id for each
product instead of relying on their index in the array.

Closes #34738

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34738


## What is the new behavior?

Instead of using the index to extract the product from the array, each product now has an id.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
