### PR TITLE
ci(docs-infra): use the correct version of yarn in `aio_monitoring_stable`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -621,14 +621,10 @@ jobs:
       - init_environment
       - run: setPublicVar_CI_STABLE_BRANCH
       - run:
-          name: Check out `aio/` and `third_party/github.com/yarnpkg/` from the stable branch
+          name: Check out `aio/` and yarn from the stable branch
           command: |
-            localYarnDir=third_party/github.com/yarnpkg/
-            # Remove the directory to ensure there will be only one version available (the one
-            # checked out from the stable branch below).
-            rm -rf $localYarnDir
             git fetch origin $CI_STABLE_BRANCH
-            git checkout --force origin/$CI_STABLE_BRANCH -- aio/ $localYarnDir
+            git checkout --force origin/$CI_STABLE_BRANCH -- aio/ .yarn/ .yarnrc
         # Overwrite yarn again to use the version from the checked out branch.
       - overwrite_yarn
       - run:


### PR DESCRIPTION
The `aio_monitoring_stable` CI job needs to check out (and execute commands on) some files from the stable branch. Therefore, it needs to use a version of `yarn` that is compatible with the `engines` version specified in `aio/package.json`.

In #34902 (and subsequently #34952 for the 8.2.x branch), the way to access our vendored version of yarn changed. This commit ensures that we checkout the necessary files from the stable branch to use an appropriate yarn version.

