### PR TITLE
perf(ivy): remove unused argument in hostBindings function

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -432,7 +432,7 @@ describe('compiler compliance', () => {
         const $_c2$ = function (a0, a1) { return { collapsedWidth: a0, expandedWidth: a1 }; };
         …
         hostVars: 14,
-        hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function MyComponent_HostBindings(rf, ctx) {
           if (rf & 2) {
             $r3$.ɵɵupdateSyntheticHostBinding("@expansionHeight",
                 $r3$.ɵɵpureFunction2(5, $_c1$, ctx.getExpandedState(),
@@ -3498,7 +3498,7 @@ describe('compiler compliance', () => {
       BaseClass.ɵdir = $r3$.ɵɵdefineDirective({
         type: BaseClass,
         hostVars: 1,
-        hostBindings: function BaseClass_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function BaseClass_HostBindings(rf, ctx) {
           if (rf & 2) {
             $r3$.ɵɵattribute("tabindex", ctx.tabindex);
           }
@@ -3538,7 +3538,7 @@ describe('compiler compliance', () => {
       // ...
       BaseClass.ɵdir = $r3$.ɵɵdefineDirective({
         type: BaseClass,
-        hostBindings: function BaseClass_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function BaseClass_HostBindings(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵlistener("mousedown", function BaseClass_mousedown_HostBindingHandler($event) {
               return ctx.handleMousedown($event);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -672,7 +672,7 @@ describe('compiler compliance: bindings', () => {
         type: HostBindingDir,
         selectors: [["", "hostBindingDir", ""]],
           hostVars: 1,
-          hostBindings: function HostBindingDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostBindingDir_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵhostProperty("id", ctx.dirId);
             }
@@ -716,7 +716,7 @@ describe('compiler compliance: bindings', () => {
           type: HostBindingComp,
           selectors: [["host-binding-comp"]],
           hostVars: 3,
-          hostBindings: function HostBindingComp_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostBindingComp_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵhostProperty("id", $r3$.ɵɵpureFunction1(1, $ff$, ctx.id));
             }
@@ -761,7 +761,7 @@ describe('compiler compliance: bindings', () => {
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
           hostVars: 1,
-          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostAttributeDir_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵattribute("required", ctx.required);
             }
@@ -857,7 +857,7 @@ describe('compiler compliance: bindings', () => {
           selectors: [["", "hostAttributeDir", ""]],
           hostAttrs: ["title", "hello there from directive", ${AttributeMarker.Classes}, "one", "two", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 4,
-          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostAttributeDir_HostBindings(rf, ctx) {
             …
           }
     `;
@@ -891,7 +891,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
             if (rf & 2) {
               $r3$.ɵɵhostProperty("title", ctx.myTitle)("tabindex", 1)("id", ctx.myId);
@@ -927,7 +927,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
             if (rf & 2) {
               $r3$.ɵɵhostProperty("tabindex", 1)("title", ctx.myTitle)("id", ctx.myId);
@@ -959,7 +959,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
             if (rf & 2) {
               $r3$.ɵɵhostProperty("title", "my title")("id", "my-id");
@@ -995,7 +995,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
         …
-        hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function MyDirective_HostBindings(rf, ctx) {
           …
           if (rf & 2) {
             $r3$.ɵɵupdateSyntheticHostBinding("@expand", ctx.expandedState)("@fadeOut", true)("@shrink", ctx.isSmall);
@@ -1030,7 +1030,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
             if (rf & 2) {
               $r3$.ɵɵattribute("title", ctx.myTitle)("tabindex", 1)("id", ctx.myId);
@@ -1066,7 +1066,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
             if (rf & 2) {
               $r3$.ɵɵattribute("tabindex", 1)("title", ctx.myTitle)("id", ctx.myId);
@@ -1098,7 +1098,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
             …
-            hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+            hostBindings: function MyDirective_HostBindings(rf, ctx) {
               …
               if (rf & 2) {
                 $r3$.ɵɵhostProperty("tabindex", 1);
@@ -1136,7 +1136,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDirective_HostBindings(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵlistener("mousedown", function MyDirective_mousedown_HostBindingHandler($event) { return ctx.mousedown(); })("mouseup", function MyDirective_mouseup_HostBindingHandler($event) { return ctx.mouseup(); })("click", function MyDirective_click_HostBindingHandler($event) { return ctx.click(); });
             }
@@ -1169,7 +1169,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
           …
-          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵcomponentHostSyntheticListener("@animation.done", function MyComponent_animation_animation_done_HostBindingHandler($event) { return ctx.done(); })("@animation.start", function MyComponent_animation_animation_start_HostBindingHandler($event) { return ctx.start(); });
             }
@@ -1207,7 +1207,7 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       const template = `
         …
-        hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function MyComponent_HostBindings(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵcomponentHostSyntheticListener("@animation.done", function MyComponent_animation_animation_done_HostBindingHandler($event) { return ctx.done(); })("@animation.start", function MyComponent_animation_animation_start_HostBindingHandler($event) { return ctx.start(); });
             $r3$.ɵɵlistener("mousedown", function MyComponent_mousedown_HostBindingHandler($event) { return ctx.mousedown(); })("mouseup", function MyComponent_mouseup_HostBindingHandler($event) { return ctx.mouseup(); })("click", function MyComponent_click_HostBindingHandler($event) { return ctx.click(); });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -334,7 +334,7 @@ describe('compiler compliance: styling', () => {
         MyAnimDir.ɵdir = $r3$.ɵɵdefineDirective({
           …
           hostVars: 1,
-          hostBindings: function MyAnimDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyAnimDir_HostBindings(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵcomponentHostSyntheticListener("@myAnim.start", function MyAnimDir_animation_myAnim_start_HostBindingHandler($event) { return ctx.onStart(); })("@myAnim.done", function MyAnimDir_animation_myAnim_done_HostBindingHandler($event) { return ctx.onDone(); });
             } if (rf & 2) {
@@ -1007,7 +1007,7 @@ describe('compiler compliance: styling', () => {
       const template = `
           hostAttrs: [${AttributeMarker.Classes}, "foo", "baz", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 8,
-          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵstyleMap(ctx.myStyle, $r3$.ɵɵdefaultStyleSanitizer);
               $r3$.ɵɵclassMap(ctx.myClass);
@@ -1062,7 +1062,7 @@ describe('compiler compliance: styling', () => {
 
       const template = `
           hostVars: 12,
-          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵstyleMap(ctx.myStyle, $r3$.ɵɵdefaultStyleSanitizer);
               $r3$.ɵɵclassMap(ctx.myClasses);
@@ -1131,7 +1131,7 @@ describe('compiler compliance: styling', () => {
 
          const hostBindings = `
             hostVars: 8,
-            hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+            hostBindings: function MyComponent_HostBindings(rf, ctx) {
               if (rf & 2) {
                 $r3$.ɵɵstyleMap(ctx.myStyleExp, $r3$.ɵɵdefaultStyleSanitizer);
                 $r3$.ɵɵclassMap(ctx.myClassExp);
@@ -1195,14 +1195,14 @@ describe('compiler compliance: styling', () => {
          const template = `
           …
           hostVars: 2,
-          hostBindings: function ClassDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function ClassDirective_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵclassMap(ctx.myClassMap);
             }
           }
           …
           hostVars: 4,
-          hostBindings: function WidthDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function WidthDirective_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵstyleProp("width", ctx.myWidth);
               $r3$.ɵɵclassProp("foo", ctx.myFooClass);
@@ -1210,7 +1210,7 @@ describe('compiler compliance: styling', () => {
           }
           …
           hostVars: 4,
-          hostBindings: function HeightDirective_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HeightDirective_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵstyleProp("height", ctx.myHeight);
               $r3$.ɵɵclassProp("bar", ctx.myBarClass);
@@ -1804,7 +1804,7 @@ describe('compiler compliance: styling', () => {
          …
          MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
-          hostBindings: function MyComponent_HostBindings(rf, $ctx$, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, $ctx$) {
             …
             if (rf & 2) {
               $r3$.ɵɵstyleProp("color", $ctx$.color)("transition", $ctx$.transition)("border", $ctx$.border);
@@ -1861,7 +1861,7 @@ describe('compiler compliance: styling', () => {
     const template = `
       hostAttrs: ["title", "foo title", ${AttributeMarker.Classes}, "foo", "baz", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
       hostVars: 6,
-      hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function MyComponent_HostBindings(rf, ctx) {
         if (rf & 2) {
           $r3$.ɵɵhostProperty("id", ctx.id)("title", ctx.title);
           $r3$.ɵɵstyleMap(ctx.myStyle, $r3$.ɵɵdefaultStyleSanitizer);
@@ -1900,7 +1900,7 @@ describe('compiler compliance: styling', () => {
 
     const template = `
     hostVars: 6,
-    hostBindings: function WidthDirective_HostBindings(rf, ctx, elIndex) {
+    hostBindings: function WidthDirective_HostBindings(rf, ctx) {
         if (rf & 2) {
           $r3$.ɵɵhostProperty("id", ctx.id)("title", ctx.title);
           $r3$.ɵɵstyleProp("width", ctx.myWidth);
@@ -2062,7 +2062,7 @@ describe('compiler compliance: styling', () => {
 
       const template = `
           hostVars: 10,
-          hostBindings: function MyDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyDir_HostBindings(rf, ctx) {
             if (rf & 2) {
               $r3$.ɵɵhostProperty("title", ctx.title);
               $r3$.ɵɵupdateSyntheticHostBinding("@anim",

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2210,7 +2210,7 @@ runInEachFileSystem(os => {
       env.driveMain();
       const jsContents = env.getContents('test.js');
       const hostBindingsFn = `
-      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx) {
         if (rf & 1) {
           i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick(); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, false, i0.ɵɵresolveDocument)("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onWindowScroll(); }, false, i0.ɵɵresolveWindow);
         }
@@ -2341,7 +2341,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       const hostBindingsFn = `
       hostVars: 4,
-      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx) {
         if (rf & 1) {
           i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, false, i0.ɵɵresolveBody)("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
         }
@@ -2419,7 +2419,7 @@ runInEachFileSystem(os => {
       env.driveMain();
       const jsContents = env.getContents('test.js');
       const hostBindingsFn = `
-      hostBindings: function Dir_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function Dir_HostBindings(rf, ctx) {
         if (rf & 1) {
           i0.ɵɵlistener("change", function Dir_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg); });
         }
@@ -4263,7 +4263,7 @@ runInEachFileSystem(os => {
            const jsContents = env.getContents('test.js');
            const hostBindingsFn = `
         hostVars: 6,
-        hostBindings: function UnsafeAttrsDirective_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function UnsafeAttrsDirective_HostBindings(rf, ctx) {
           if (rf & 2) {
             i0.ɵɵattribute("href", ctx.attrHref, i0.ɵɵsanitizeUrlOrResourceUrl)("src", ctx.attrSrc, i0.ɵɵsanitizeUrlOrResourceUrl)("action", ctx.attrAction, i0.ɵɵsanitizeUrl)("profile", ctx.attrProfile, i0.ɵɵsanitizeResourceUrl)("innerHTML", ctx.attrInnerHTML, i0.ɵɵsanitizeHtml)("title", ctx.attrSafeTitle);
           }
@@ -4311,7 +4311,7 @@ runInEachFileSystem(os => {
            const jsContents = env.getContents('test.js');
            const hostBindingsFn = `
         hostVars: 6,
-        hostBindings: function UnsafePropsDirective_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function UnsafePropsDirective_HostBindings(rf, ctx) {
           if (rf & 2) {
             i0.ɵɵhostProperty("href", ctx.propHref, i0.ɵɵsanitizeUrlOrResourceUrl)("src", ctx.propSrc, i0.ɵɵsanitizeUrlOrResourceUrl)("action", ctx.propAction, i0.ɵɵsanitizeUrl)("profile", ctx.propProfile, i0.ɵɵsanitizeResourceUrl)("innerHTML", ctx.propInnerHTML, i0.ɵɵsanitizeHtml)("title", ctx.propSafeTitle);
           }
@@ -4344,7 +4344,7 @@ runInEachFileSystem(os => {
            const jsContents = env.getContents('test.js');
            const hostBindingsFn = `
         hostVars: 6,
-        hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
+        hostBindings: function FooCmp_HostBindings(rf, ctx) {
           if (rf & 2) {
             i0.ɵɵhostProperty("src", ctx.srcProp)("href", ctx.hrefProp)("title", ctx.titleProp);
             i0.ɵɵattribute("src", ctx.srcAttr)("href", ctx.hrefAttr)("title", ctx.titleAttr);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -63,7 +63,7 @@ function baseDirectiveFields(
         'viewQuery', createViewQueriesFunction(meta.viewQueries, constantPool, meta.name));
   }
 
-  // e.g. `hostBindings: (rf, ctx, elIndex) => { ... }
+  // e.g. `hostBindings: (rf, ctx) => { ... }
   definitionMap.set(
       'hostBindings', createHostBindingsFunction(
                           meta.host, meta.typeSourceSpan, bindingParser, constantPool,
@@ -530,9 +530,8 @@ function createHostBindingsFunction(
     hostBindingsMetadata: R3HostMetadata, typeSourceSpan: ParseSourceSpan,
     bindingParser: BindingParser, constantPool: ConstantPool, selector: string, name: string,
     definitionMap: DefinitionMap): o.Expression|null {
-  const elVarExp = o.variable('elIndex');
   const bindingContext = o.variable(CONTEXT_NAME);
-  const styleBuilder = new StylingBuilder(elVarExp, bindingContext);
+  const styleBuilder = new StylingBuilder(bindingContext);
 
   const {styleAttr, classAttr} = hostBindingsMetadata.specialAttributes;
   if (styleAttr !== undefined) {
@@ -698,11 +697,8 @@ function createHostBindingsFunction(
       statements.push(renderFlagCheckIfStmt(core.RenderFlags.Update, updateStatements));
     }
     return o.fn(
-        [
-          new o.FnParam(RENDER_FLAGS, o.NUMBER_TYPE), new o.FnParam(CONTEXT_NAME, null),
-          new o.FnParam(elVarExp.name !, o.NUMBER_TYPE)
-        ],
-        statements, o.INFERRED_TYPE, null, hostBindingsFnName);
+        [new o.FnParam(RENDER_FLAGS, o.NUMBER_TYPE), new o.FnParam(CONTEXT_NAME, null)], statements,
+        o.INFERRED_TYPE, null, hostBindingsFnName);
   }
 
   return null;

--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -167,7 +167,7 @@ export class StylingBuilder {
   private _initialStyleValues: string[] = [];
   private _initialClassValues: string[] = [];
 
-  constructor(private _elementIndexExpr: o.Expression, private _directiveExpr: o.Expression|null) {}
+  constructor(private _directiveExpr: o.Expression|null) {}
 
   /**
    * Registers a given input to the styling builder to be later used when producing AOT code.

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -520,7 +520,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
   visitElement(element: t.Element) {
     const elementIndex = this.allocateDataSlot();
-    const stylingBuilder = new StylingBuilder(o.literal(elementIndex), null);
+    const stylingBuilder = new StylingBuilder(null);
 
     let isNonBindableMode: boolean = false;
     const isI18nRootElement: boolean =

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -245,7 +245,7 @@ export function createRootComponent<T>(
     addHostBindingsToExpandoInstructions(rootTView, componentDef);
     growHostVarsSpace(rootTView, rootLView, componentDef.hostVars);
 
-    invokeHostBindingsInCreationMode(componentDef, component, rootTNode);
+    invokeHostBindingsInCreationMode(componentDef, component);
   }
   return component;
 }

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -172,9 +172,9 @@ function inheritHostBindings(
     definition: WritableDef, superHostBindings: HostBindingsFunction<any>) {
   const prevHostBindings = definition.hostBindings;
   if (prevHostBindings) {
-    definition.hostBindings = (rf: RenderFlags, ctx: any, elementIndex: number) => {
-      superHostBindings(rf, ctx, elementIndex);
-      prevHostBindings(rf, ctx, elementIndex);
+    definition.hostBindings = (rf: RenderFlags, ctx: any) => {
+      superHostBindings(rf, ctx);
+      prevHostBindings(rf, ctx);
     };
   } else {
     definition.hostBindings = superHostBindings;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -100,7 +100,7 @@ export function setHostBindingsByExecutingExpandoInstructions(tView: TView, lVie
           if (instruction !== null) {
             setBindingRootForHostBindings(bindingRootIndex);
             const hostCtx = lView[currentDirectiveIndex];
-            instruction(RenderFlags.Update, hostCtx, currentElementIndex);
+            instruction(RenderFlags.Update, hostCtx);
           }
           // TODO(misko): PERF Relying on incrementing the `currentDirectiveIndex` here is
           // sub-optimal. The implications are that if we have a lot of directives but none of them
@@ -1266,7 +1266,7 @@ function invokeDirectivesHostBindings(tView: TView, lView: LView, tNode: TNode) 
       const def = tView.data[i] as DirectiveDef<any>;
       const directive = lView[i];
       if (def.hostBindings !== null || def.hostVars !== 0 || def.hostAttrs !== null) {
-        invokeHostBindingsInCreationMode(def, directive, tNode);
+        invokeHostBindingsInCreationMode(def, directive);
       } else if (firstCreatePass) {
         expando.push(null);
       }
@@ -1281,13 +1281,10 @@ function invokeDirectivesHostBindings(tView: TView, lView: LView, tNode: TNode) 
  *
  * @param def `DirectiveDef` which may contain the `hostBindings` function.
  * @param directive Instance of directive.
- * @param tNode Associated `TNode`.
  */
-export function invokeHostBindingsInCreationMode(
-    def: DirectiveDef<any>, directive: any, tNode: TNode) {
+export function invokeHostBindingsInCreationMode(def: DirectiveDef<any>, directive: any) {
   if (def.hostBindings !== null) {
-    const elementIndex = tNode.index - HEADER_OFFSET;
-    def.hostBindings !(RenderFlags.Create, directive, elementIndex);
+    def.hostBindings !(RenderFlags.Create, directive);
   }
 }
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -443,8 +443,7 @@ export type DirectiveTypeList =
     (DirectiveType<any>| ComponentType<any>|
      Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
-export type HostBindingsFunction<T> =
-    <U extends T>(rf: RenderFlags, ctx: U, elementIndex: number) => void;
+export type HostBindingsFunction<T> = <U extends T>(rf: RenderFlags, ctx: U) => void;
 
 /**
  * Type used for PipeDefs on component definition.

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -233,7 +233,7 @@ ivyEnabled && describe('render3 jit', () => {
     const cmpDef = (Cmp as any).ɵcmp as ComponentDef<Cmp>;
 
     expect(cmpDef.hostBindings).toBeDefined();
-    expect(cmpDef.hostBindings !.length).toBe(3);
+    expect(cmpDef.hostBindings !.length).toBe(2);
   });
 
   it('should compile @Pipes without errors', () => {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -77,8 +77,7 @@ describe('event listeners', () => {
           ɵɵtext(0, 'Some text');
         }
       },
-      hostBindings: function HostListenerDir_HostBindings(
-          rf: RenderFlags, ctx: any, elIndex: number) {
+      hostBindings: function HostListenerDir_HostBindings(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           ɵɵlistener('custom', function() {
             return ctx.onDocumentCustomEvent();
@@ -102,8 +101,7 @@ describe('event listeners', () => {
     static ɵdir = ɵɵdefineDirective({
       type: GlobalHostListenerDir,
       selectors: [['', 'hostListenerDir', '']],
-      hostBindings: function HostListenerDir_HostBindings(
-          rf: RenderFlags, ctx: any, elIndex: number) {
+      hostBindings: function HostListenerDir_HostBindings(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           ɵɵlistener('custom', function() {
             return ctx.onDocumentCustomEvent();
@@ -537,8 +535,7 @@ describe('event listeners', () => {
             ɵɵtext(0, 'Some text');
           }
         },
-        hostBindings: function HostListenerDir_HostBindings(
-            rf: RenderFlags, ctx: any, elIndex: number) {
+        hostBindings: function HostListenerDir_HostBindings(rf: RenderFlags, ctx: any) {
           if (rf & RenderFlags.Create) {
             ɵɵlistener('click', function() { return ctx.onClick(); });
           }
@@ -581,8 +578,7 @@ describe('event listeners', () => {
       static ɵdir = ɵɵdefineDirective({
         type: HostListenerDir,
         selectors: [['', 'hostListenerDir', '']],
-        hostBindings: function HostListenerDir_HostBindings(
-            rf: RenderFlags, ctx: any, elIndex: number) {
+        hostBindings: function HostListenerDir_HostBindings(rf: RenderFlags, ctx: any) {
           if (rf & RenderFlags.Create) {
             ɵɵlistener('click', function() { return ctx.onClick(); });
           }


### PR DESCRIPTION
We had some logic for generating and passing in the `elIndex` parameter into the `hostBindings` function, but it wasn't actually being used for anything. The only place left that had a reference to it was the `StylingBuilder` and it only stored it without referencing it again.
