### PR TITLE
docs: add migration guides to sidenav in updating to Version 9 section

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -772,9 +772,56 @@
           "tooltip": "Angular versioning, release, support, and deprecation policies and practices."
         },
         {
-          "url": "guide/updating-to-version-9",
           "title": "Updating to Version 9",
-          "tooltip": "Support for updating your application from version 8 to 9."
+          "tooltip": "Support for updating your application from version 8 to 9.",
+          "children": [
+            {
+              "url": "guide/updating-to-version-9",
+              "title": "Overview",
+              "tooltip": "Everything you need to know for updating your application from version 8 to 9."
+            },
+            {
+              "url": "guide/ivy-compatibility",
+              "title": "Ivy Compatibility Guide",
+              "tooltip": "Details to help you make sure your application is compatible with Ivy."
+            },
+            {
+              "title": "Optional v9 Migration Details",
+              "tooltip": "Optional migration details regarding updating to version 9.",
+              "children": [
+                {
+                  "url": "guide/migration-renderer",
+                  "title": "Renderer to Renderer2",
+                  "tooltip": "Migration from the deprecated Renderer API to the newer Renderer2 API."
+                },
+                {
+                  "url": "guide/migration-dynamic-flag",
+                  "title": "Dynamic Queries Flag",
+                  "tooltip": "Migration to remove unnecessary `static: false` flag from @ViewChild and @ContentChild queries."
+                },
+                {
+                  "url": "guide/migration-injectable",
+                  "title": "Missing @Injectable() Decorators",
+                  "tooltip": "Migration to add missing @Injectable() decorators and incomplete provider definitions."
+                },
+                {
+                  "url": "guide/migration-localize",
+                  "title": "$localize Global Import",
+                  "tooltip": "Migration to add an import statement for @angular/localize to polyfills.ts."
+                },
+                {
+                  "url": "guide/migration-module-with-providers",
+                  "title": "Missing ModuleWithProviders Generic",
+                  "tooltip": "Migration to add a generic type to any ModuleWithProviders usages that are missing the generic."
+                },
+                {
+                  "url": "guide/migration-undecorated-classes",
+                  "title": "Missing @Directive() Decorators",
+                  "tooltip": "Migration to add missing @Directive()/@Component() decorators."
+                }
+              ]
+            }
+          ]
         },
         {
           "url": "guide/deprecations",

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -786,7 +786,7 @@
               "tooltip": "Details to help you make sure your application is compatible with Ivy."
             },
             {
-              "title": "Optional v9 Migration Details",
+              "title": "Optional Migrations",
               "tooltip": "Optional migration details regarding updating to version 9.",
               "children": [
                 {

--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -177,6 +177,16 @@ button.vertical-menu-item {
   margin: 0;
   padding-left: 32px;
   text-transform: none;
+
+  &.expanded .mat-icon,
+  .level-3.expanded .mat-icon {
+    @include rotate(90deg);
+  }
+
+  &:not(.expanded) .mat-icon,
+  .level-3:not(.expanded) .mat-icon {
+    @include rotate(0deg);
+  }
 }
 
 .level-3 {
@@ -185,6 +195,16 @@ button.vertical-menu-item {
   @include font-size(14);
   margin: 0;
   padding-left: 40px;
+  text-transform: none;
+}
+
+.level-4 {
+  color: $mediumgray;
+  font-family: $main-font;
+  @include font-size(14);
+  margin: 0;
+  padding-left: 48px;
+  text-transform: none;
 }
 
 aio-nav-menu.top-menu {


### PR DESCRIPTION
All migration guides did not have a direct link to access them so added them to the side nav in the section updating to version 9 for direct access, it also helps to add right side nav to these migration guides

Fixes #33582

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No navigation in migration of renderer to renderer 2

Issue Number: :33582


## What is the new behavior?
Navigation available in the migration guide

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
