### PR TITLE
build: add missing @babel/generator bazel dep to fix //packages/localize/src/tools/test:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@angular-devkit/schematics": "9.0.0-rc.8",
     "@angular/bazel": "file:./tools/npm/@angular_bazel",
     "@babel/core": "^7.6.4",
+    "@babel/generator": "^7.6.4",
     "@bazel/jasmine": "1.1.0",
     "@bazel/karma": "1.1.0",
     "@bazel/protractor": "1.1.0",

--- a/packages/localize/src/tools/test/BUILD.bazel
+++ b/packages/localize/src/tools/test/BUILD.bazel
@@ -11,6 +11,8 @@ ts_library(
         "//packages/compiler",
         "//packages/localize",
         "//packages/localize/src/tools",
+        "@npm//@babel/core",
+        "@npm//@babel/generator",
         "@npm//@babel/template",
         "@npm//@babel/types",
         "@npm//@types/babel__core",


### PR DESCRIPTION
Based on https://github.com/angular/angular/pull/34974 with the addition of the @babel/core dep & the package.json change.

* Also add @babel/generator to root package.json. This doesn't change the yarn.lock since yarn is already hoisting that version the top anyway but it will prevent yarn from not-hoisting in the future.
