### PR TITLE
fix(localize): re-enable filename in code-frame error messages

### DIFF
--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -9,7 +9,7 @@ import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
 import {Diagnostics} from '../../diagnostics';
-import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromTemplateLiteral} from './source_file_utils';
+import {TranslatePluginOptions, buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromTemplateLiteral} from './source_file_utils';
 
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
@@ -32,7 +32,7 @@ export function makeEs2015TranslatePlugin(
             // If we get a BabelParseError here then something went wrong with Babel itself
             // since there must be something wrong with the structure of the AST generated
             // by Babel parsing a TaggedTemplateExpression.
-            throw path.hub.file.buildCodeFrameError(e.node, e.message);
+            throw buildCodeFrameError(path, e);
           }
         }
       }

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -9,7 +9,7 @@ import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
 import {Diagnostics} from '../../diagnostics';
-import {TranslatePluginOptions, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from './source_file_utils';
+import {TranslatePluginOptions, buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from './source_file_utils';
 
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
@@ -29,7 +29,7 @@ export function makeEs5TranslatePlugin(
           }
         } catch (e) {
           if (isBabelParseError(e)) {
-            diagnostics.error(callPath.hub.file.buildCodeFrameError(e.node, e.message).message);
+            diagnostics.error(buildCodeFrameError(callPath, e));
           }
         }
       }

--- a/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
@@ -328,3 +328,9 @@ export class BabelParseError extends Error {
 export function isBabelParseError(e: any): e is BabelParseError {
   return e.type === 'BabelParseError';
 }
+
+export function buildCodeFrameError(path: NodePath, e: BabelParseError): string {
+  const filename = path.hub.file.opts.filename || '(unknown file)';
+  const message = path.hub.file.buildCodeFrameError(e.node, e.message).message;
+  return `${filename}: ${message}`;
+}

--- a/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
@@ -140,7 +140,7 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.hasErrors).toBe(true);
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
-           message: '`$localize` called without any arguments.\n' +
+           message: '/app/dist/test.js: `$localize` called without any arguments.\n' +
                '> 1 | $localize()\n' +
                '    | ^^^^^^^^^^^',
          });
@@ -156,7 +156,7 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.hasErrors).toBe(true);
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
-           message: 'Unexpected argument to `$localize` (expected an array).\n' +
+           message: '/app/dist/test.js: Unexpected argument to `$localize` (expected an array).\n' +
                '> 1 | $localize(...x)\n' +
                '    |           ^^^^',
          });
@@ -172,7 +172,8 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.hasErrors).toBe(true);
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
-           message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           message:
+               '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                '> 1 | $localize(null, [])\n' +
                '    |           ^^^^',
          });
@@ -189,7 +190,7 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
            message:
-               'Unexpected `raw` argument to the "makeTemplateObject()" function (expected an expression).\n' +
+               '/app/dist/test.js: Unexpected `raw` argument to the "makeTemplateObject()" function (expected an expression).\n' +
                '> 1 | $localize(__makeTemplateObject([], ...[]))\n' +
                '    |                                    ^^^^^',
          });
@@ -206,7 +207,7 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
            message:
-               'Unexpected `cooked` argument to the "makeTemplateObject()" function (expected an expression).\n' +
+               '/app/dist/test.js: Unexpected `cooked` argument to the "makeTemplateObject()" function (expected an expression).\n' +
                '> 1 | $localize(__makeTemplateObject(...[], []))\n' +
                '    |                                ^^^^^',
          });
@@ -222,7 +223,8 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.hasErrors).toBe(true);
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
-           message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           message:
+               '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                '> 1 | $localize(__makeTemplateObject(["a", 12, "b"], ["a", "12", "b"]))\n' +
                '    |                                ^^^^^^^^^^^^^^',
          });
@@ -238,7 +240,8 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.hasErrors).toBe(true);
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
-           message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           message:
+               '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                '> 1 | $localize(__makeTemplateObject(["a", "12", "b"], ["a", 12, "b"]))\n' +
                '    |                                                  ^^^^^^^^^^^^^^',
          });
@@ -255,7 +258,7 @@ describe('makeEs5Plugin', () => {
          expect(diagnostics.messages[0]).toEqual({
            type: 'error',
            message:
-               'Invalid substitutions for `$localize` (expected all substitution arguments to be expressions).\n' +
+               '/app/dist/test.js: Invalid substitutions for `$localize` (expected all substitution arguments to be expressions).\n' +
                '> 1 | $localize(__makeTemplateObject(["a", "b"], ["a", "b"]), ...[])\n' +
                '    |                                                         ^^^^^',
          });


### PR DESCRIPTION
These were removed in 4c3a543f7fd42ec3c6490fcb39d523bc7368f776 due to a breaking change in an update to `babel-core`.
See https://github.com/babel/babel/commit/dcf7d89b8e9b6b364aae17652f94a4f0d3fe0950.

This commit adds back in the filename to these messages.

Resolves https://github.com/angular/angular/pull/34974/files#r371034476
