### PR TITLE
ci: prevent benchmark_tests from executing on RBE

### DIFF
--- a/modules/benchmarks/benchmark_test.bzl
+++ b/modules/benchmarks/benchmark_test.bzl
@@ -17,7 +17,13 @@ def benchmark_test(name, server, tags = [], **kwargs):
         on_prepare = "//modules/benchmarks:start-server.js",
         server = server,
         # Benchmark targets should not run on CI by default.
-        tags = tags + ["manual"],
-        test_suite_tags = ["manual"],
+        tags = tags + [
+            "manual",
+            "no-remote-exec",
+        ],
+        test_suite_tags = [
+            "manual",
+            "no-remote-exec",
+        ],
         **kwargs
     )


### PR DESCRIPTION
Since we don't do anything with the results of the benchmark_test
executions on CI, we should not run them.  Additionally, since
benchmarks are meant to test in a consistent environment, we should
execute the benchmark tests locally rather than on RBE executors.
