### PR TITLE
build: remove unneeded style code for ngClass and ngStyle

### DIFF
--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -157,11 +157,4 @@ export class NgClass implements DoCheck {
       });
     }
   }
-
-  // TODO(misko): Delete this code after angula/flex-layout stops depending on private APIs
-  // We need to export this to make angular/flex-layout happy
-  // https://github.com/angular/flex-layout/blob/ec7b57eb6adf59ecfdfff1de5ccf1ab2f6652ed3/src/lib/extended/class/class.ts#L9
-  setClass(value: string) { this.klass = value; }
-  setNgClass(value: any) { this.ngClass = value; }
-  applyChanges() { this.ngDoCheck(); }
 }

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -85,10 +85,4 @@ export class NgStyle implements DoCheck {
     changes.forEachAddedItem((record) => this._setStyle(record.key, record.currentValue));
     changes.forEachChangedItem((record) => this._setStyle(record.key, record.currentValue));
   }
-
-  // TODO(misko): Delete this code after angula/flex-layout stops depending on private APIs
-  // We need to export this to make angular/flex-layout happy
-  // https://github.com/angular/flex-layout/blob/ec7b57eb6adf59ecfdfff1de5ccf1ab2f6652ed3/src/lib/extended/class/class.ts#L9
-  setNgStyle(value: any) { this.ngStyle = value; }
-  applyChanges() { this.ngDoCheck(); }
 }

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,11 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// TODO(misko): Delete this code after angula/flex-layout stops depending on private APIs
-// We need to export this to make angular/flex-layout happy
-// https://github.com/angular/flex-layout/blob/ec7b57eb6adf59ecfdfff1de5ccf1ab2f6652ed3/src/lib/extended/class/class.ts#L9
-export {NgClass as ɵNgClassImpl, NgClass as ɵNgClassR2Impl} from './directives/ng_class';
-export {NgStyle as ɵNgStyleR2Impl} from './directives/ng_style';
-
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -195,10 +195,7 @@ export declare class NgClass implements DoCheck {
         [klass: string]: any;
     });
     constructor(_iterableDiffers: IterableDiffers, _keyValueDiffers: KeyValueDiffers, _ngEl: ElementRef, _renderer: Renderer2);
-    applyChanges(): void;
     ngDoCheck(): void;
-    setClass(value: string): void;
-    setNgClass(value: any): void;
 }
 
 export declare class NgComponentOutlet implements OnChanges, OnDestroy {
@@ -273,9 +270,7 @@ export declare class NgStyle implements DoCheck {
         [klass: string]: any;
     } | null);
     constructor(_ngEl: ElementRef, _differs: KeyValueDiffers, _renderer: Renderer2);
-    applyChanges(): void;
     ngDoCheck(): void;
-    setNgStyle(value: any): void;
 }
 
 export declare class NgSwitch {


### PR DESCRIPTION
With the release of Flex Layout v9.0.0-beta.28, some added code
after the recent styling refactor is no longer needed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
