### PR TITLE
fix(ngcc): improve lockfile error message

### DIFF
--- a/packages/compiler-cli/ngcc/src/execution/lock_file.ts
+++ b/packages/compiler-cli/ngcc/src/execution/lock_file.ts
@@ -75,6 +75,8 @@ export class LockFile {
 
       throw new Error(
           `ngcc is already running at process with id ${pid}.\n` +
+          `If you are running multiple builds (e.g. webpack) in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
+          `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
           `(If you are sure no ngcc process is running then you should delete the lockfile at ${this.lockFilePath}.)`);
     }
   }

--- a/packages/compiler-cli/ngcc/src/execution/lock_file.ts
+++ b/packages/compiler-cli/ngcc/src/execution/lock_file.ts
@@ -75,7 +75,7 @@ export class LockFile {
 
       throw new Error(
           `ngcc is already running at process with id ${pid}.\n` +
-          `If you are running multiple builds (e.g. webpack) in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
+          `If you are running multiple builds in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
           `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
           `(If you are sure no ngcc process is running then you should delete the lockfile at ${this.lockFilePath}.)`);
     }

--- a/packages/compiler-cli/ngcc/test/execution/lock_file_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/lock_file_spec.ts
@@ -183,7 +183,7 @@ runInEachFileSystem(() => {
         expect(() => lockFile.create())
             .toThrowError(
                 `ngcc is already running at process with id 188.\n` +
-                `If you are running multiple builds (e.g. webpack) in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
+                `If you are running multiple builds in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
                 `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
                 `(If you are sure no ngcc process is running then you should delete the lockfile at ${lockFile.lockFilePath}.)`);
       });

--- a/packages/compiler-cli/ngcc/test/execution/lock_file_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/lock_file_spec.ts
@@ -183,6 +183,8 @@ runInEachFileSystem(() => {
         expect(() => lockFile.create())
             .toThrowError(
                 `ngcc is already running at process with id 188.\n` +
+                `If you are running multiple builds (e.g. webpack) in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
+                `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
                 `(If you are sure no ngcc process is running then you should delete the lockfile at ${lockFile.lockFilePath}.)`);
       });
     });


### PR DESCRIPTION
The message now gives concrete advice to developers who
experience the error due to running multiple simultaneous builds
via webpack.

Fixes #35000
