### PR TITLE
ci(docs-infra): ignore node version in `aio_monitoring_stable` CI job

### DIFF
--- a/aio/scripts/test-production.sh
+++ b/aio/scripts/test-production.sh
@@ -12,8 +12,9 @@ set +x -eu -o pipefail
   cd "$aioDir"
 
   # Install dependencies.
+  # (Since this script may run on different branches (e.g. stable), ignore the engines check.)
   echo -e "\nInstalling dependencies in '$aioDir'...\n-----"
-  yarn install --frozen-lockfile --non-interactive
+  yarn install --frozen-lockfile --ignore-engines --non-interactive
   yarn update-webdriver
 
   # Run checks for target URL.


### PR DESCRIPTION
In #34955, we switched to Node.js v12 on master and 9.0.x. This causes the `aio_monitoring_job` CI job (which checks out files from the stable branch; currently 8.2.x) to start failing yarn's engines check (since the 8.2.x branch expects Node.js version <11).
Example failure: https://circleci.com/gh/angular/angular/602499

Since the job is expected to run with files from both the stable and the master branches (and since the version of Node.js is not important here), this commit uses the `--ignore-engines` option to prevent failures due to Node.js version mismatch.

NOTE:
Typically, the stable and master branch are on the same Node.js version, because related PRs land on both master and the patch branch. One exception is during RC periods, when the stable branch is different than the patch branch. These periods are usually short, but in the case of 9.0.0 the period has lasted several months causing the CI environments between master and the stable branch to get significantly out-of-sync.