### PR TITLE
build(localize): sync up babel dependencies

### DIFF
--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -32,7 +32,7 @@
     "node": ">=8.0"
   },
   "dependencies": {
-    "@babel/core": "^7.5.5",
+    "@babel/core": "7.8.3",
     "glob": "7.1.2",
     "yargs": "13.1.0"
   },


### PR DESCRIPTION
In #34974 the top level dependency on `@babel/core` was bumped to
7.8.3. This commit ensures that the package.json that gets included
in the `@angular/localize` distributable is at the same version.
