### PR TITLE
feat: support custom `zoneSpec` when bootstrapping Angular application with `NgZone`

### DIFF
--- a/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
@@ -16,7 +16,7 @@
     "outDir": "../node_modules/flat_module",
     "rootDir": "",
     "target": "es5",
-    "typeRoots": ["../node_modules/@types"]
+    "typeRoots": ["../node_modules/@types"],
  },
 
  "files": ["public-api.ts"]

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -239,6 +239,12 @@ export interface BootstrapOptions {
    * the change detection will only be trigged once.
    */
   ngZoneEventCoalescing?: boolean;
+
+  /**
+   * Optionally specify an array of ZoneSpecs, and those ZoneSpecs
+   * will be forked in the NgZone instance.
+   */
+  additionalZoneSpecKeys?: string[];
 }
 
 /**
@@ -290,7 +296,8 @@ export class PlatformRef {
     // pass that as parent to the NgModuleFactory.
     const ngZoneOption = options ? options.ngZone : undefined;
     const ngZoneEventCoalescing = (options && options.ngZoneEventCoalescing) || false;
-    const ngZone = getNgZone(ngZoneOption, ngZoneEventCoalescing);
+    const ngZone =
+        getNgZone(ngZoneOption, ngZoneEventCoalescing, options && options.additionalZoneSpecKeys);
     const providers: StaticProvider[] = [{provide: NgZone, useValue: ngZone}];
     // Attention: Don't use ApplicationRef.run here,
     // as we want to be sure that all possible constructor calls are inside `ngZone.run`!
@@ -387,7 +394,8 @@ export class PlatformRef {
 }
 
 function getNgZone(
-    ngZoneOption: NgZone | 'zone.js' | 'noop' | undefined, ngZoneEventCoalescing: boolean): NgZone {
+    ngZoneOption: NgZone | 'zone.js' | 'noop' | undefined, ngZoneEventCoalescing: boolean,
+    additionalZoneSpecKeys: string[] | undefined): NgZone {
   let ngZone: NgZone;
 
   if (ngZoneOption === 'noop') {
@@ -395,7 +403,7 @@ function getNgZone(
   } else {
     ngZone = (ngZoneOption === 'zone.js' ? undefined : ngZoneOption) || new NgZone({
                enableLongStackTrace: isDevMode(),
-               shouldCoalesceEventChangeDetection: ngZoneEventCoalescing
+               shouldCoalesceEventChangeDetection: ngZoneEventCoalescing, additionalZoneSpecKeys
              });
   }
   return ngZone;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -632,9 +632,10 @@ export declare class NgZone {
     readonly onMicrotaskEmpty: EventEmitter<any>;
     readonly onStable: EventEmitter<any>;
     readonly onUnstable: EventEmitter<any>;
-    constructor({ enableLongStackTrace, shouldCoalesceEventChangeDetection }: {
+    constructor({ enableLongStackTrace, shouldCoalesceEventChangeDetection, additionalZoneSpecKeys }: {
         enableLongStackTrace?: boolean | undefined;
         shouldCoalesceEventChangeDetection?: boolean | undefined;
+        additionalZoneSpecKeys?: string[] | undefined;
     });
     run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;
     runGuarded<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


Now `ngZone` will load `wtfZoneSpec`, `TaskTrackingZoneSpec`, `LongStackTraceZoneSpec` and `angular` ZoneSpec, this PR add the ability to allow user to pass an array of custom `ZoneSpecs`, so user can easily add the custom behavior without override `NgZone`.

The reason I want to do this is I want to create some monitor zone utility in the future.