### PR TITLE
Revert "ci: filter out bad commit from the commit message check to green up master (#35017)"

### DIFF
--- a/tools/gulp-tasks/validate-commit-message.js
+++ b/tools/gulp-tasks/validate-commit-message.js
@@ -31,7 +31,7 @@ module.exports = (gulp) => () => {
     // We need to fetch origin explicitly because it might be stale.
     // I couldn't find a reliable way to do this without fetch.
     const result = shelljs.exec(
-        `git fetch origin ${baseBranch} && git log --reverse --format=%s origin/${baseBranch}..HEAD | grep -v "#34769"`);
+        `git fetch origin ${baseBranch} && git log --reverse --format=%s origin/${baseBranch}..HEAD`);
 
     if (result.code) {
       throw new Error(`Failed to fetch commits: ${result.stderr}`);


### PR DESCRIPTION
This reverts commit 85c4f3aa8da3cb880bf4baefbb8e6327f0f60c91 due to CI failures with lint checks. Note: reverting from patch branch only, since it works as expected in master.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No