### PR TITLE
ci(docs-infra): ignore node version in `aio_monitoring_stable` CI job (for real)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,6 +623,8 @@ jobs:
             git checkout --force origin/$CI_STABLE_BRANCH -- aio/ .yarn/ .yarnrc
         # Overwrite yarn again to use the version from the checked out branch.
       - overwrite_yarn
+        # Since we check out `aio/package.json` from the stable branch, ignore yarn's engines check.
+      - run: yarn config set ignore-engines true
       - run:
           name: Run tests against https://angular.io/
           command: ./aio/scripts/test-production.sh https://angular.io/ $CI_AIO_MIN_PWA_SCORE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,7 +623,8 @@ jobs:
             git checkout --force origin/$CI_STABLE_BRANCH -- aio/ .yarn/ .yarnrc
         # Overwrite yarn again to use the version from the checked out branch.
       - overwrite_yarn
-        # Since we check out `aio/package.json` from the stable branch, ignore yarn's engines check.
+        # Ignore yarn's engines check, because we checked out `aio/package.json` from the stable
+        # branch and there could be a node version skew, which is acceptable in this monitoring job.
       - run: yarn config set ignore-engines true
       - run:
           name: Run tests against https://angular.io/

--- a/aio/scripts/test-production.sh
+++ b/aio/scripts/test-production.sh
@@ -12,9 +12,8 @@ set +x -eu -o pipefail
   cd "$aioDir"
 
   # Install dependencies.
-  # (Since this script may run on different branches (e.g. stable), ignore the engines check.)
   echo -e "\nInstalling dependencies in '$aioDir'...\n-----"
-  yarn install --frozen-lockfile --ignore-engines --non-interactive
+  yarn install --frozen-lockfile --non-interactive
   yarn update-webdriver
 
   # Run checks for target URL.


### PR DESCRIPTION
In #35004, we started ignoring yarn's engines check for `yarn install` in AIO's `test-production.sh` script to fix a failure in the `aio_monitoring_stable` CI job. (See #35004 for details.)

It turns out that the version of yarn used on the stable branch (1.17.3) `--ignore-engines` is needed on all yarn commands (including `yarn run`). Thus, #35004 is not enough to fix the failures.
New example failure: https://circleci.com/gh/angular/angular/604341

This commit turns of the engines check for the whole `aio_monitoring_stable` CI job to fix the failure and make the job more robust.