### PR TITLE
fix(language-service): suggest, not error, on missing context members

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -292,16 +292,12 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
     if (directive && ast.value) {
       const context = this.info.query.getTemplateContext(directive.type.reference) !;
       if (context && !context.has(ast.value)) {
-        if (ast.value === '$implicit') {
-          this.reportError(
-              `The template context of '${directive.type.reference.name}' does not define an implicit value.\n` +
-                  `If the context type is a base type, consider refining it to a more specific type.`,
-              spanOf(ast.sourceSpan));
-        } else {
-          this.reportError(
-              `The template context of '${directive.type.reference.name}' does not define a member called '${ast.value}'`,
-              spanOf(ast.sourceSpan));
-        }
+        const missingMember =
+            ast.value === '$implicit' ? 'an implicit value' : `a member called '${ast.value}'`;
+        this.reportError(
+            `The template context of '${directive.type.reference.name}' does not define ${missingMember}.\n` +
+                `If the context type is a base type, consider refining it to a more specific type.`,
+            spanOf(ast.sourceSpan), ts.DiagnosticCategory.Warning);
       }
     }
   }
@@ -353,10 +349,11 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
 
   private pop() { this.path.pop(); }
 
-  private reportError(message: string, span: Span|undefined) {
+  private reportError(
+      message: string, span: Span|undefined,
+      kind: ts.DiagnosticCategory = ts.DiagnosticCategory.Error) {
     if (span) {
-      this.diagnostics.push(
-          {span: offsetSpan(span, this.info.offset), kind: ts.DiagnosticCategory.Error, message});
+      this.diagnostics.push({span: offsetSpan(span, this.info.offset), kind, message});
     }
   }
 }

--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -294,10 +294,10 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
       if (context && !context.has(ast.value)) {
         const missingMember =
             ast.value === '$implicit' ? 'an implicit value' : `a member called '${ast.value}'`;
-        this.reportError(
+        this.reportDiagnostic(
             `The template context of '${directive.type.reference.name}' does not define ${missingMember}.\n` +
-                `If the context type is a base type, consider refining it to a more specific type.`,
-            spanOf(ast.sourceSpan), ts.DiagnosticCategory.Warning);
+                `If the context type is a base type or 'any', consider refining it to a more specific type.`,
+            spanOf(ast.sourceSpan), ts.DiagnosticCategory.Suggestion);
       }
     }
   }
@@ -349,12 +349,9 @@ class ExpressionDiagnosticsVisitor extends RecursiveTemplateAstVisitor {
 
   private pop() { this.path.pop(); }
 
-  private reportError(
-      message: string, span: Span|undefined,
-      kind: ts.DiagnosticCategory = ts.DiagnosticCategory.Error) {
-    if (span) {
-      this.diagnostics.push({span: offsetSpan(span, this.info.offset), kind, message});
-    }
+  private reportDiagnostic(
+      message: string, span: Span, kind: ts.DiagnosticCategory = ts.DiagnosticCategory.Error) {
+    this.diagnostics.push({span: offsetSpan(span, this.info.offset), kind, message});
   }
 }
 

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -258,11 +258,11 @@ describe('diagnostics', () => {
       const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
       expect(diags.length).toBe(1);
       const {messageText, start, length, category} = diags[0];
-      expect(category).toBe(ts.DiagnosticCategory.Warning);
+      expect(category).toBe(ts.DiagnosticCategory.Suggestion);
       expect(messageText)
           .toBe(
               `The template context of 'CounterDirective' does not define an implicit value.\n` +
-                  `If the context type is a base type, consider refining it to a more specific type.`, );
+                  `If the context type is a base type or 'any', consider refining it to a more specific type.`, );
 
       const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'emb');
       expect(start).toBe(span.start);
@@ -276,11 +276,11 @@ describe('diagnostics', () => {
       const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
       expect(diags.length).toBe(1);
       const {messageText, start, length, category} = diags[0];
-      expect(category).toBe(ts.DiagnosticCategory.Warning);
+      expect(category).toBe(ts.DiagnosticCategory.Suggestion);
       expect(messageText)
           .toBe(
               `The template context of 'NgForOf' does not define a member called 'even_1'.\n` +
-              `If the context type is a base type, consider refining it to a more specific type.`);
+              `If the context type is a base type or 'any', consider refining it to a more specific type.`);
 
       const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'emb');
       expect(start).toBe(span.start);

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -257,7 +257,8 @@ describe('diagnostics', () => {
           `<button type="button" ~{start-emb}*counter="let hero of heroes"~{end-emb}></button>`);
       const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
       expect(diags.length).toBe(1);
-      const {messageText, start, length} = diags[0];
+      const {messageText, start, length, category} = diags[0];
+      expect(category).toBe(ts.DiagnosticCategory.Warning);
       expect(messageText)
           .toBe(
               `The template context of 'CounterDirective' does not define an implicit value.\n` +
@@ -274,9 +275,12 @@ describe('diagnostics', () => {
           `<div ~{start-emb}*ngFor="let hero of heroes; let e = even_1"~{end-emb}></div>`);
       const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
       expect(diags.length).toBe(1);
-      const {messageText, start, length} = diags[0];
+      const {messageText, start, length, category} = diags[0];
+      expect(category).toBe(ts.DiagnosticCategory.Warning);
       expect(messageText)
-          .toBe(`The template context of 'NgForOf' does not define a member called 'even_1'`);
+          .toBe(
+              `The template context of 'NgForOf' does not define a member called 'even_1'.\n` +
+              `If the context type is a base type, consider refining it to a more specific type.`);
 
       const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'emb');
       expect(start).toBe(span.start);


### PR DESCRIPTION
The language service reports an error when a directive's template
context is missing a member that is being used in a template (e.g. if
`$implicit` is being used with a template context typed as `any`).
While this diagnostic message is valuable, typing template contexts
loosely as `any` or `object` is very widespread in community packages,
and often still compiles correctly, so reporting the diagnostic as an
error may be misleading to users.

This commit changes the diagnostic to be a warning, and adds additional
information about how the user can eliminate the warning entirely -- by
refining the template context type.

A screenshot demonstrating the change with VSCode's LSP is attached to
the PR for this commit.

<img width="1069" alt="Screen Shot 2020-01-29 at 10 17 15 AM" src="https://user-images.githubusercontent.com/20735482/73385256-b8fca180-4281-11ea-8f7d-5d705f4050d8.png">

Closes https://github.com/angular/vscode-ng-language-service/issues/572

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
