### PR TITLE
build(compiler-cli): update to chokidar 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "canonical-path": "1.0.0",
     "chai": "^4.1.2",
     "chalk": "^2.3.1",
-    "chokidar": "^2.1.1",
+    "chokidar": "^3.0.0",
     "convert-source-map": "^1.5.1",
     "core-js": "^2.4.1",
     "dependency-graph": "^0.7.2",

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -14,7 +14,7 @@
     "reflect-metadata": "^0.1.2",
     "minimist": "^1.2.0",
     "canonical-path": "1.0.0",
-    "chokidar": "^2.1.1",
+    "chokidar": "^3.0.0",
     "convert-source-map": "^1.5.1",
     "dependency-graph": "^0.7.2",
     "magic-string": "^0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,26 +3454,7 @@ chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.1.tgz#adc39ad55a2adf26548bd2afa048f611091f9184"
-  integrity sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==
-  dependencies:
-    anymatch "^2.0.0"
-    async-each "^1.0.1"
-    braces "^2.3.2"
-    glob-parent "^3.1.0"
-    inherits "^2.0.3"
-    is-binary-path "^1.0.0"
-    is-glob "^4.0.0"
-    normalize-path "^3.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.2.1"
-    upath "^1.1.0"
-  optionalDependencies:
-    fsevents "^1.2.7"
-
-chokidar@^3.0.2:
+chokidar@^3.0.0, chokidar@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
   integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
@@ -14881,11 +14862,6 @@ unzipper@^0.10.5:
     listenercount "~1.0.1"
     readable-stream "~2.3.6"
     setimmediate "~1.0.4"
-
-upath@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
-  integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
 upath@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
Update from chokidar 2.x to 3.x in ngc/ngtsc, to eliminate any possibility
of a security issue with a downstream dependency of the package.

FW-1809 #resolve