### PR TITLE
fix(compiler-cli): add `sass` as a valid css preprocessor extension

### DIFF
--- a/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
@@ -13,7 +13,7 @@ import {ExtendedTsCompilerHost} from '../../core/api';
 import {AbsoluteFsPath, PathSegment, join} from '../../file_system';
 import {getRootDirs} from '../../util/src/typescript';
 
-const CSS_PREPROCESSOR_EXT = /(\.scss|\.less|\.styl)$/;
+const CSS_PREPROCESSOR_EXT = /(\.scss|\.sass|\.less|\.styl)$/;
 
 /**
  * `ResourceLoader` which delegates to a `CompilerHost` resource loading method.

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -20,7 +20,7 @@ import {DTS, GENERATED_FILES, isInRootDir, relativeToRootDirs} from './util';
 
 const NODE_MODULES_PACKAGE_NAME = /node_modules\/((\w|-|\.)+|(@(\w|-|\.)+\/(\w|-|\.)+))/;
 const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
-const CSS_PREPROCESSOR_EXT = /(\.scss|\.less|\.styl)$/;
+const CSS_PREPROCESSOR_EXT = /(\.scss|\.sass|\.less|\.styl)$/;
 
 let wrapHostForTest: ((host: ts.CompilerHost) => ts.CompilerHost)|null = null;
 


### PR DESCRIPTION
`.sass` is a valid preprocessor extension which is used for Sass indented syntax

https://sass-lang.com/documentation/syntax
