### PR TITLE
fix(ngcc): do not lock if the target is not compiled by Angular

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -71,7 +71,7 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
       }
     }
     // All `propertiesToConsider` that appear in this entry-point have been processed.
-    // In other word, there were no properties that need processing.
+    // In other words, there were no properties that need processing.
     return false;
   }
 

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -51,29 +51,28 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
     return entryPoints;
   }
 
-  hasProcessedTargetEntryPoint(
+  targetNeedsProcessingOrCleaning(
       propertiesToConsider: EntryPointJsonProperty[], compileAllFormats: boolean): boolean {
     const entryPoint = this.getEntryPoint(this.targetPath);
     if (entryPoint === null || !entryPoint.compiledByAngular) {
-      return true;
+      return false;
     }
 
     for (const property of propertiesToConsider) {
       if (entryPoint.packageJson[property]) {
-        // Here is a property that should be processed
+        // Here is a property that should be processed.
         if (!hasBeenProcessed(entryPoint.packageJson, property)) {
-          // `hasBeenProcessed()` may return `null`, which means that this entry-point package needs
-          // cleaning and therefore needs to be processed.
-          return false;
+          return true;
         }
         if (!compileAllFormats) {
-          // It has been processed and we only need one, so we are done.
-          return true;
+          // This property has been processed, and we only need one.
+          return false;
         }
       }
     }
-    // All formats need to be compiled and there were none that were not,
-    return true;
+    // All `propertiesToConsider` that appear in this entry-point have been processed.
+    // In other word, there were no properties that need processing.
+    return false;
   }
 
   private processNextPath(): void {

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -185,9 +185,6 @@ export function mainNgcc(
 
     const {entryPoints, invalidEntryPoints, graph} = entryPointInfo;
     logInvalidEntryPoints(logger, invalidEntryPoints);
-    if (entryPoints.length === 0 && absoluteTargetEntryPointPath !== null) {
-      markNonAngularPackageAsProcessed(fileSystem, pkgJsonUpdater, absoluteTargetEntryPointPath);
-    }
 
     const unprocessableEntryPointPaths: string[] = [];
     // The tasks are partially ordered by virtue of the entry-points being partially ordered too.

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -238,7 +238,7 @@ runInEachFileSystem(() => {
     describe('targetNeedsProcessingOrCleaning()', () => {
       it('should return false if there is no entry-point', () => {
         const targetPath = _Abs('/no_packages/node_modules/should_not_be_found');
-        fs.ensureDir(_Abs('/no_packages/node_modules/should_not_be_found'));
+        fs.ensureDir(targetPath);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, _Abs('/no_packages/node_modules'), targetPath, undefined);
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
@@ -316,8 +316,7 @@ runInEachFileSystem(() => {
             ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
           ]);
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-              undefined);
+              fs, config, logger, resolver, basePath, targetPath, undefined);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
         });
 
@@ -343,8 +342,7 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-                 undefined);
+                 fs, config, logger, resolver, basePath, targetPath, undefined);
              expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
            });
 
@@ -370,8 +368,7 @@ runInEachFileSystem(() => {
           fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-              undefined);
+              fs, config, logger, resolver, basePath, targetPath, undefined);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(false);
         });
       });
@@ -389,8 +386,7 @@ runInEachFileSystem(() => {
           ]);
 
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-              undefined);
+              fs, config, logger, resolver, basePath, targetPath, undefined);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
         });
 
@@ -416,12 +412,11 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-                 undefined);
+                 fs, config, logger, resolver, basePath, targetPath, undefined);
              expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
            });
 
-        it('should return true if the first of the properties to consider (that actually appear in the package.json) has been processed',
+        it('should return false if the first of the properties to consider (that actually appear in the package.json) has been processed',
            () => {
              const basePath = _Abs('/sub_entry_points/node_modules');
              const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
@@ -443,9 +438,9 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-                 undefined);
-             expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
+                 fs, config, logger, resolver, basePath, targetPath, undefined);
+             expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false))
+                 .toBe(false);
            });
       });
     });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -13,6 +13,7 @@ import {DtsDependencyHost} from '../../src/dependencies/dts_dependency_host';
 import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {TargetedEntryPointFinder} from '../../src/entry_point_finder/targeted_entry_point_finder';
+import {NGCC_VERSION} from '../../src/packages/build_marker';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
 import {PathMappings} from '../../src/utils';
@@ -227,32 +228,258 @@ runInEachFileSystem(() => {
         ]);
       });
 
-      function createPackage(
-          basePath: AbsoluteFsPath, packageName: string, deps: string[] = []): TestFile[] {
-        return [
-          {
-            name: _Abs(`${basePath}/${packageName}/package.json`),
-            contents: JSON.stringify({
-              typings: `./${packageName}.d.ts`,
-              fesm2015: `./fesm2015/${packageName}.js`,
-            })
-          },
-          {
-            name: _Abs(`${basePath}/${packageName}/${packageName}.metadata.json`),
-            contents: 'metadata info'
-          },
-          {
-            name: _Abs(`${basePath}/${packageName}/fesm2015/${packageName}.js`),
-            contents: deps.map((dep, i) => `import * as i${i} from '${dep}';`).join('\n'),
-          },
-        ];
-      }
-
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
         return entryPoints.map(x => [relative(basePath, x.package), relative(basePath, x.path)]);
       }
 
     });
+
+    describe('hasProcessedTargetEntryPoint()', () => {
+      it('should return true if there is no entry-point', () => {
+        const targetPath = _Abs('/no_packages/node_modules/should_not_be_found');
+        fs.ensureDir(_Abs('/no_packages/node_modules/should_not_be_found'));
+        const finder = new TargetedEntryPointFinder(
+            fs, config, logger, resolver, _Abs('/no_packages/node_modules'), targetPath, undefined);
+        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+      });
+
+      it('should return true if the target path is not a valid entry-point', () => {
+        const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
+        loadTestFiles([
+          {
+            name: _Abs('/no_valid_entry_points/node_modules/some_package/package.json'),
+            contents: '{}'
+          },
+        ]);
+        const finder = new TargetedEntryPointFinder(
+            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
+            undefined);
+        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+      });
+
+      it('should true if the target path has no typings', () => {
+        const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
+        loadTestFiles([
+          {
+            name: _Abs('/no_valid_entry_points/node_modules/some_package/package.json'),
+            contents: '{"fesm2015": "./index.js"}'
+          },
+          {
+            name:
+                _Abs('/no_valid_entry_points/node_modules/some_package/some_package.metadata.json'),
+            contents: 'metadata info'
+          },
+          {
+            name: _Abs('/no_valid_entry_points/node_modules/some_package/index.js'),
+            contents: 'export class MyClass {}'
+          },
+        ]);
+        const finder = new TargetedEntryPointFinder(
+            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
+            undefined);
+        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+      });
+
+      it('should true if the target path is not compiled by Angular - i.e has no metadata file',
+         () => {
+           const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
+           loadTestFiles([
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/package.json'),
+               contents: '{"typings": "./index.d.ts", "fesm2015": "./index.js"}'
+             },
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/index.d.ts'),
+               contents: 'export declare class MyClass {}'
+             },
+             {
+               name: _Abs('/no_valid_entry_points/node_modules/some_package/index.js'),
+               contents: 'export class MyClass {}'
+             },
+           ]);
+           const finder = new TargetedEntryPointFinder(
+               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'),
+               targetPath, undefined);
+           expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+         });
+
+      describe('[compileAllFormats: true]', () => {
+        it('should return false if none of the properties to consider have been processed', () => {
+          const basePath = _Abs('/sub_entry_points/node_modules');
+          const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+          loadTestFiles([
+            ...createPackage(fs.resolve(basePath, ''), 'common'),
+            ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+            ...createPackage(
+                fs.resolve(basePath, 'common/http'), 'testing', ['common/http', 'common/testing']),
+            ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+          ]);
+          const finder = new TargetedEntryPointFinder(
+              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+              undefined);
+          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+        });
+
+        it('should return false if at least one of the properties to consider has not been processed',
+           () => {
+             const basePath = _Abs('/sub_entry_points/node_modules');
+             const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+             loadTestFiles([
+               ...createPackage(fs.resolve(basePath, ''), 'common'),
+               ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+               ...createPackage(
+                   fs.resolve(basePath, 'common/http'), 'testing',
+                   ['common/http', 'common/testing']),
+               ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+             ]);
+
+             // Add a build marker to the package.json
+             const packageJsonPath = _Abs(`${targetPath}/package.json`);
+             const packageJson = JSON.parse(fs.readFile(packageJsonPath));
+             packageJson.__processed_by_ivy_ngcc__ = {
+               esm5: NGCC_VERSION,
+             };
+             fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
+
+             const finder = new TargetedEntryPointFinder(
+                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+                 undefined);
+             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+           });
+
+        it('should return true if all of the properties to consider have been processed', () => {
+          const basePath = _Abs('/sub_entry_points/node_modules');
+          const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+          loadTestFiles([
+            ...createPackage(fs.resolve(basePath, ''), 'common'),
+            ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+            ...createPackage(
+                fs.resolve(basePath, 'common/http'), 'testing', ['common/http', 'common/testing']),
+            ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+          ]);
+
+          // Add build markers to the package.json
+          const packageJsonPath = _Abs(`${targetPath}/package.json`);
+          const packageJson = JSON.parse(fs.readFile(packageJsonPath));
+          packageJson.__processed_by_ivy_ngcc__ = {
+            fesm2015: NGCC_VERSION,
+            esm5: NGCC_VERSION,
+            main: NGCC_VERSION,
+          };
+          fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
+
+          const finder = new TargetedEntryPointFinder(
+              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+              undefined);
+          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(true);
+        });
+      });
+
+      describe('[compileAllFormats: false]', () => {
+        it('should return false if none of the properties to consider have been processed', () => {
+          const basePath = _Abs('/sub_entry_points/node_modules');
+          const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+          loadTestFiles([
+            ...createPackage(fs.resolve(basePath, ''), 'common'),
+            ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+            ...createPackage(
+                fs.resolve(basePath, 'common/http'), 'testing', ['common/http', 'common/testing']),
+            ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+          ]);
+
+          const finder = new TargetedEntryPointFinder(
+              fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+              undefined);
+          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], false)).toEqual(false);
+        });
+
+        it('should return false if the first of the properties to consider that is in the package.json has not been processed',
+           () => {
+             const basePath = _Abs('/sub_entry_points/node_modules');
+             const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+             loadTestFiles([
+               ...createPackage(fs.resolve(basePath, ''), 'common'),
+               ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+               ...createPackage(
+                   fs.resolve(basePath, 'common/http'), 'testing',
+                   ['common/http', 'common/testing']),
+               ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+             ]);
+
+             // Add build markers to the package.json
+             const packageJsonPath = _Abs(`${targetPath}/package.json`);
+             const packageJson = JSON.parse(fs.readFile(packageJsonPath));
+             packageJson.__processed_by_ivy_ngcc__ = {
+               esm5: NGCC_VERSION,
+             };
+             fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
+
+             const finder = new TargetedEntryPointFinder(
+                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+                 undefined);
+             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], false))
+                 .toEqual(false);
+           });
+
+        it('should return true if the first of the properties to consider that is in the package.json has been processed',
+           () => {
+             const basePath = _Abs('/sub_entry_points/node_modules');
+             const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
+             loadTestFiles([
+               ...createPackage(fs.resolve(basePath, ''), 'common'),
+               ...createPackage(fs.resolve(basePath, 'common'), 'http', ['common']),
+               ...createPackage(
+                   fs.resolve(basePath, 'common/http'), 'testing',
+                   ['common/http', 'common/testing']),
+               ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
+             ]);
+
+             // Add build markers to the package.json
+             const packageJsonPath = _Abs(`${targetPath}/package.json`);
+             const packageJson = JSON.parse(fs.readFile(packageJsonPath));
+             packageJson.__processed_by_ivy_ngcc__ = {
+               fesm2015: NGCC_VERSION,
+             };
+             fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
+
+             const finder = new TargetedEntryPointFinder(
+                 fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
+                 undefined);
+             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+           });
+      });
+    });
+
+    function createPackage(
+        basePath: AbsoluteFsPath, packageName: string, deps: string[] = []): TestFile[] {
+      return [
+        {
+          name: _Abs(`${basePath}/${packageName}/package.json`),
+          contents: JSON.stringify({
+            typings: `./${packageName}.d.ts`,
+            fesm2015: `./fesm2015/${packageName}.js`,
+            esm5: `./esm5/${packageName}.js`,
+            main: `./common/${packageName}.js`,
+          })
+        },
+        {
+          name: _Abs(`${basePath}/${packageName}/${packageName}.metadata.json`),
+          contents: 'metadata info'
+        },
+        {
+          name: _Abs(`${basePath}/${packageName}/fesm2015/${packageName}.js`),
+          contents: deps.map((dep, i) => `import * as i${i} from '${dep}';`).join('\n'),
+        },
+        {
+          name: _Abs(`${basePath}/${packageName}/esm5/${packageName}.js`),
+          contents: deps.map((dep, i) => `import * as i${i} from '${dep}';`).join('\n'),
+        },
+        {
+          name: _Abs(`${basePath}/${packageName}/commonjs/${packageName}.js`),
+          contents: deps.map((dep, i) => `var i${i} = require('${dep}');`).join('\n'),
+        },
+      ];
+    }
   });
 });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -235,16 +235,16 @@ runInEachFileSystem(() => {
 
     });
 
-    describe('hasProcessedTargetEntryPoint()', () => {
-      it('should return true if there is no entry-point', () => {
+    describe('targetNeedsProcessingOrCleaning()', () => {
+      it('should return false if there is no entry-point', () => {
         const targetPath = _Abs('/no_packages/node_modules/should_not_be_found');
         fs.ensureDir(_Abs('/no_packages/node_modules/should_not_be_found'));
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, _Abs('/no_packages/node_modules'), targetPath, undefined);
-        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+        expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
-      it('should return true if the target path is not a valid entry-point', () => {
+      it('should return false if the target path is not a valid entry-point', () => {
         const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
         loadTestFiles([
           {
@@ -255,10 +255,10 @@ runInEachFileSystem(() => {
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
             undefined);
-        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+        expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
-      it('should true if the target path has no typings', () => {
+      it('should false if the target path has no typings', () => {
         const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
         loadTestFiles([
           {
@@ -278,10 +278,10 @@ runInEachFileSystem(() => {
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
             undefined);
-        expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+        expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
-      it('should true if the target path is not compiled by Angular - i.e has no metadata file',
+      it('should false if the target path is not compiled by Angular - i.e has no metadata file',
          () => {
            const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
            loadTestFiles([
@@ -301,11 +301,11 @@ runInEachFileSystem(() => {
            const finder = new TargetedEntryPointFinder(
                fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'),
                targetPath, undefined);
-           expect(finder.hasProcessedTargetEntryPoint(['fesm2015'], true)).toBe(true);
+           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
          });
 
       describe('[compileAllFormats: true]', () => {
-        it('should return false if none of the properties to consider have been processed', () => {
+        it('should return true if none of the properties to consider have been processed', () => {
           const basePath = _Abs('/sub_entry_points/node_modules');
           const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
           loadTestFiles([
@@ -318,10 +318,10 @@ runInEachFileSystem(() => {
           const finder = new TargetedEntryPointFinder(
               fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
               undefined);
-          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+          expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
         });
 
-        it('should return false if at least one of the properties to consider has not been processed',
+        it('should return true if at least one of the properties to consider has not been processed',
            () => {
              const basePath = _Abs('/sub_entry_points/node_modules');
              const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
@@ -345,10 +345,10 @@ runInEachFileSystem(() => {
              const finder = new TargetedEntryPointFinder(
                  fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
                  undefined);
-             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+             expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
            });
 
-        it('should return true if all of the properties to consider have been processed', () => {
+        it('should return false if all of the properties to consider have been processed', () => {
           const basePath = _Abs('/sub_entry_points/node_modules');
           const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
           loadTestFiles([
@@ -372,12 +372,12 @@ runInEachFileSystem(() => {
           const finder = new TargetedEntryPointFinder(
               fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
               undefined);
-          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(true);
+          expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(false);
         });
       });
 
       describe('[compileAllFormats: false]', () => {
-        it('should return false if none of the properties to consider have been processed', () => {
+        it('should return true if none of the properties to consider have been processed', () => {
           const basePath = _Abs('/sub_entry_points/node_modules');
           const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
           loadTestFiles([
@@ -391,10 +391,10 @@ runInEachFileSystem(() => {
           const finder = new TargetedEntryPointFinder(
               fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
               undefined);
-          expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], false)).toEqual(false);
+          expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
         });
 
-        it('should return false if the first of the properties to consider that is in the package.json has not been processed',
+        it('should return true if the first of the properties to consider that is in the package.json has not been processed',
            () => {
              const basePath = _Abs('/sub_entry_points/node_modules');
              const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
@@ -418,11 +418,10 @@ runInEachFileSystem(() => {
              const finder = new TargetedEntryPointFinder(
                  fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
                  undefined);
-             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], false))
-                 .toEqual(false);
+             expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
            });
 
-        it('should return true if the first of the properties to consider that is in the package.json has been processed',
+        it('should return true if the first of the properties to consider (that actually appear in the package.json) has been processed',
            () => {
              const basePath = _Abs('/sub_entry_points/node_modules');
              const targetPath = _Abs('/sub_entry_points/node_modules/common/http/testing');
@@ -446,7 +445,7 @@ runInEachFileSystem(() => {
              const finder = new TargetedEntryPointFinder(
                  fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
                  undefined);
-             expect(finder.hasProcessedTargetEntryPoint(['fesm2015', 'esm5'], true)).toEqual(false);
+             expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
            });
       });
     });

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -487,12 +487,12 @@ runInEachFileSystem(() => {
         expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toBeUndefined();
 
         // * `core` is a dependency of `test-package`, but it is also not processed, since
-        // test-package was not processed.
+        // `test-package` was not processed.
         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toBeUndefined();
       });
 
       it('should not mark a non-Angular package as processed if it is a dependency', () => {
-        // `test-package-user` is a valid Angular package that depends upon test-package.
+        // `test-package-user` is a valid Angular package that depends upon `test-package`.
         loadTestFiles([
           {
             name: _('/node_modules/test-package-user/package.json'),

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -480,19 +480,46 @@ runInEachFileSystem(() => {
         expect(loadPackage('@angular/common/testing').__processed_by_ivy_ngcc__).toBeUndefined();
       });
 
-      it('should mark a non-Angular package target as processed', () => {
+      it('should not mark a non-Angular package as processed if it is the target', () => {
         mainNgcc({basePath: '/node_modules', targetEntryPointPath: 'test-package'});
 
-        // `test-package` has no Angular but is marked as processed.
-        expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toEqual({
+        // * `test-package` has no Angular and is not marked as processed.
+        expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toBeUndefined();
+
+        // * `core` is a dependency of `test-package`, but it is also not processed, since
+        // test-package was not processed.
+        expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toBeUndefined();
+      });
+
+      it('should not mark a non-Angular package as processed if it is a dependency', () => {
+        // a package that depends upon test-package, which no metadata.json file so not compiled by
+        // Angular.
+        loadTestFiles([
+          {
+            name: _('/node_modules/test-package-user/package.json'),
+            contents:
+                '{"name": "test-package-user", "es2015": "./index.js", "typings": "./index.d.ts"}'
+          },
+          {
+            name: _('/node_modules/test-package-user/index.js'),
+            contents: 'import * as x from \'test-package\';'
+          },
+          {
+            name: _('/node_modules/test-package-user/index.d.ts'),
+            contents: 'import * as x from \'test-package\';'
+          },
+          {name: _('/node_modules/test-package-user/index.metadata.json'), contents: 'DUMMY DATA'},
+        ]);
+
+        mainNgcc({basePath: '/node_modules', targetEntryPointPath: 'test-package-user'});
+
+        expect(loadPackage('test-package-user').__processed_by_ivy_ngcc__).toEqual({
           es2015: '0.0.0-PLACEHOLDER',
-          esm2015: '0.0.0-PLACEHOLDER',
-          esm5: '0.0.0-PLACEHOLDER',
-          fesm2015: '0.0.0-PLACEHOLDER',
-          fesm5: '0.0.0-PLACEHOLDER',
-          main: '0.0.0-PLACEHOLDER',
-          module: '0.0.0-PLACEHOLDER',
+          typings: '0.0.0-PLACEHOLDER',
         });
+
+        // * `test-package` has no Angular but is marked as processed.
+        expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toBeUndefined();
 
         // * `core` is a dependency of `test-package`, but it is not processed, since test-package
         // was not processed.

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -492,8 +492,7 @@ runInEachFileSystem(() => {
       });
 
       it('should not mark a non-Angular package as processed if it is a dependency', () => {
-        // a package that depends upon test-package, which no metadata.json file so not compiled by
-        // Angular.
+        // `test-package-user` is a valid Angular package that depends upon test-package.
         loadTestFiles([
           {
             name: _('/node_modules/test-package-user/package.json'),
@@ -513,16 +512,18 @@ runInEachFileSystem(() => {
 
         mainNgcc({basePath: '/node_modules', targetEntryPointPath: 'test-package-user'});
 
+        // * `test-package-user` is processed because it is compiled by Angular
         expect(loadPackage('test-package-user').__processed_by_ivy_ngcc__).toEqual({
           es2015: '0.0.0-PLACEHOLDER',
           typings: '0.0.0-PLACEHOLDER',
         });
 
-        // * `test-package` has no Angular but is marked as processed.
+        // * `test-package` is a dependency of `test-package-user` but has not been compiled by
+        // Angular, and so is not marked as processed
         expect(loadPackage('test-package').__processed_by_ivy_ngcc__).toBeUndefined();
 
-        // * `core` is a dependency of `test-package`, but it is not processed, since test-package
-        // was not processed.
+        // * `core` is a dependency of `test-package`, but it is not processed, because
+        // `test-package` was not processed.
         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toBeUndefined();
       });
 


### PR DESCRIPTION
To support parallel CLI builds we instruct developers to pre-process
their node_modules via ngcc at the command line.

Despite doing this ngcc was still trying to set a lock when it was being
triggered by the CLI for packages that are not going to be processed,
since they are not compiled by Angular for instance.

This commit checks whether a target package needs to be compiled
at all before attempting to set the lock.

Fixes #35000
