### PR TITLE
docs(ivy): add docs for styling priority order

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -5,7 +5,8 @@
     "packageManager": "yarn",
     "warnings": {
       "typescriptMismatch": false
-    }
+    },
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/aio/content/examples/attribute-binding/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/attribute-binding/e2e/src/app.e2e-spec.ts
@@ -25,11 +25,12 @@ describe('Attribute binding example', function () {
   });
 
   it('should display a blue div with a red border', function () {
-    expect(element.all(by.css('div')).get(4).getCssValue('border')).toEqual('2px solid rgb(212, 30, 46)');
+    expect(element.all(by.css('div')).get(3).getCssValue('border')).toEqual('2px solid rgb(212, 30, 46)');
   });
 
-  it('should display a div with replaced classes', function () {
-    expect(element.all(by.css('div')).get(5).getAttribute('class')).toEqual('new-class');
+  it('should display a div with many classes', function () {
+    expect(element.all(by.css('div')).get(3).getAttribute('class')).toContain('special');
+    expect(element.all(by.css('div')).get(3).getAttribute('class')).toContain('clearance');
   });
 
   it('should display four buttons', function() {

--- a/aio/content/examples/attribute-binding/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/attribute-binding/e2e/src/app.e2e-spec.ts
@@ -25,24 +25,12 @@ describe('Attribute binding example', function () {
   });
 
   it('should display a blue div with a red border', function () {
-    expect(element.all(by.css('div')).get(3).getCssValue('border')).toEqual('2px solid rgb(212, 30, 46)');
+    expect(element.all(by.css('div')).get(1).getCssValue('border')).toEqual('2px solid rgb(212, 30, 46)');
   });
 
   it('should display a div with many classes', function () {
-    expect(element.all(by.css('div')).get(3).getAttribute('class')).toContain('special');
-    expect(element.all(by.css('div')).get(3).getAttribute('class')).toContain('clearance');
-  });
-
-  it('should display four buttons', function() {
-    let redButton = element.all(by.css('button')).get(1);
-    let saveButton = element.all(by.css('button')).get(2);
-    let bigButton = element.all(by.css('button')).get(3);
-    let smallButton = element.all(by.css('button')).get(4);
-
-    expect(redButton.getCssValue('color')).toEqual('rgba(255, 0, 0, 1)');
-    expect(saveButton.getCssValue('background-color')).toEqual('rgba(0, 255, 255, 1)');
-    expect(bigButton.getText()).toBe('Big');
-    expect(smallButton.getText()).toBe('Small');
+    expect(element.all(by.css('div')).get(1).getAttribute('class')).toContain('special');
+    expect(element.all(by.css('div')).get(1).getAttribute('class')).toContain('clearance');
   });
 
 });

--- a/aio/content/examples/attribute-binding/src/app/app.component.html
+++ b/aio/content/examples/attribute-binding/src/app/app.component.html
@@ -27,50 +27,7 @@
 
 <hr />
 
-<h2>Class binding</h2>
-
-<!-- #docregion add-class -->
-<h3>Bind to a specific class</h3>
-
-<div class="item clearance" [class.special]="isSpecial">This class binding is special.</div>
-<!-- #enddocregion add-class -->
-
-<!-- #docregion bind-syntax -->
-
-<h3>Using the bind- syntax:</h3>
-
-<div bind-class.special="isSpecial">This class binding is special too.</div>
-<!-- #enddocregion bind-syntax -->
-
-<!-- #docregion direct-class-binding -->
-<h3>Bind to multiple classes</h3>
-
-<div [class]="classExpr">Add multiple classes</div>
-<!-- #enddocregion direct-class-binding -->
-
-<hr />
-
-<h2>Style binding</h2>
-
-<!-- #docregion style-binding-->
-<button [style.color]="isSpecial ? 'red': 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan': 'grey'" >Save</button>
-<!-- #enddocregion style-binding -->
-
-<!-- #docregion style-binding-condition-->
-<button [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
-<!-- #enddocregion style-binding-condition-->
-
-<!-- #docregion direct-style-binding -->
-<h3>Bind to multiple styles</h3>
-
-<div style="color: blue" [style]="styleExpr">Add multiple styles</div>
-<!-- #enddocregion direct-style-binding -->
-
-<hr />
-
-<h2>Priority Order</h2>
+<h2>Styling precedence</h2>
 
 <!-- #docregion basic-specificity -->
 <h3>Basic specificity</h3>

--- a/aio/content/examples/attribute-binding/src/app/app.component.html
+++ b/aio/content/examples/attribute-binding/src/app/app.component.html
@@ -45,7 +45,7 @@
 <!-- #docregion direct-class-binding -->
 <h3>Bind to multiple classes</h3>
 
-<div [class]="someClasses">Add multiple classes</div>
+<div [class]="classExpr">Add multiple classes</div>
 <!-- #enddocregion direct-class-binding -->
 
 <hr />
@@ -67,3 +67,44 @@
 
 <div style="color: blue" [style]="styleExpr">Add multiple styles</div>
 <!-- #enddocregion direct-style-binding -->
+
+<hr />
+
+<h2>Priority Order</h2>
+
+<!-- #docregion basic-specificity -->
+<h3>Basic specificity</h3>
+
+<!-- The `class.special` binding will override any value for the `special` class in `classExpr`.  -->
+<div [class.special]="isSpecial" [class]="classExpr">Some text.</div>
+
+<!-- The `style.color` binding will override any value for the `color` property in `styleExpr`.  -->
+<div [style.color]="color" [style]="styleExpr">Some text.</div>
+<!-- #enddocregion basic-specificity -->
+
+<!-- #docregion source-specificity -->
+<h3>Source specificity</h3>
+
+<!-- The `class.special` template binding will override any host binding to the `special` class set by `dirWithClassBinding` or `comp-with-host-binding`.-->
+<comp-with-host-binding [class.special]="isSpecial" dirWithClassBinding>Some text.</comp-with-host-binding>
+
+<!-- The `style.color` template binding will override any host binding to the `color` property set by `dirWithStyleBinding` or `comp-with-host-binding`. -->
+<comp-with-host-binding [style.color]="color" dirWithStyleBinding>Some text.</comp-with-host-binding>
+<!-- #enddocregion source-specificity -->
+
+<!-- #docregion dynamic-priority -->
+<h3>Dynamic vs static</h3>
+
+<!-- If `classExpr` has a value for the `special` class, this value will override the `class="special"` below -->
+<div class="special" [class]="classExpr">Some text.</div>
+
+<!-- If `styleExpr` has a value for the `color` property, this value will override the `style="color: blue"` below -->
+<div style="color: blue" [style]="styleExpr">Some text.</div>
+
+<!-- #enddocregion dynamic-priority -->
+
+<!-- #docregion style-delegation -->
+<comp-with-host-binding dirWithHostBinding></comp-with-host-binding>
+<!-- #enddocregion style-delegation -->
+
+

--- a/aio/content/examples/attribute-binding/src/app/app.component.html
+++ b/aio/content/examples/attribute-binding/src/app/app.component.html
@@ -29,26 +29,24 @@
 
 <h2>Class binding</h2>
 
-<!-- #docregion is-special -->
-<h3>toggle the "special" class on/off with a property:</h3>
-<div [class.special]="isSpecial">The class binding is special.</div>
-
-<h3>binding to class.special overrides the class attribute:</h3>
-<div class="special" [class.special]="!isSpecial">This one is not so special.</div>
-
-<h3>Using the bind- syntax:</h3>
-<div bind-class.special="isSpecial">This class binding is special too.</div>
-<!-- #enddocregion is-special -->
-
 <!-- #docregion add-class -->
-<h3>Add a class:</h3>
-<div class="item clearance special" [class.item-clearance]="itemClearance">Add another class</div>
+<h3>Bind to a specific class</h3>
+
+<div class="item clearance" [class.special]="isSpecial">This class binding is special.</div>
 <!-- #enddocregion add-class -->
 
-<!-- #docregion class-override -->
-<h3>Overwrite all existing classes with a new class:</h3>
-<div class="item clearance special" [attr.class]="resetClasses">Reset all classes at once</div>
-<!-- #enddocregion class-override -->
+<!-- #docregion bind-syntax -->
+
+<h3>Using the bind- syntax:</h3>
+
+<div bind-class.special="isSpecial">This class binding is special too.</div>
+<!-- #enddocregion bind-syntax -->
+
+<!-- #docregion direct-class-binding -->
+<h3>Bind to multiple classes</h3>
+
+<div [class]="someClasses">Add multiple classes</div>
+<!-- #enddocregion direct-class-binding -->
 
 <hr />
 

--- a/aio/content/examples/attribute-binding/src/app/app.component.html
+++ b/aio/content/examples/attribute-binding/src/app/app.component.html
@@ -61,3 +61,9 @@
 <button [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
 <button [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
 <!-- #enddocregion style-binding-condition-->
+
+<!-- #docregion direct-style-binding -->
+<h3>Bind to multiple styles</h3>
+
+<div style="color: blue" [style]="styleExpr">Add multiple styles</div>
+<!-- #enddocregion direct-style-binding -->

--- a/aio/content/examples/attribute-binding/src/app/app.component.ts
+++ b/aio/content/examples/attribute-binding/src/app/app.component.ts
@@ -9,8 +9,7 @@ export class AppComponent {
   actionName = 'Go for it';
   isSpecial = true;
   canSave = true;
-  someClasses = 'foo bar';
-  classExpr = 'special foo';
+  classExpr = 'special clearance';
   styleExpr = 'color: red';
   color = 'blue';
 }

--- a/aio/content/examples/attribute-binding/src/app/app.component.ts
+++ b/aio/content/examples/attribute-binding/src/app/app.component.ts
@@ -8,8 +8,9 @@ import { Component } from '@angular/core';
 export class AppComponent {
   actionName = 'Go for it';
   isSpecial = true;
-  itemClearance = true;
-  resetClasses = 'new-class';
   canSave = true;
-
+  someClasses = 'foo bar';
+  classExpr = 'special foo';
+  styleExpr = 'color: red';
+  color = 'blue';
 }

--- a/aio/content/examples/attribute-binding/src/app/app.module.ts
+++ b/aio/content/examples/attribute-binding/src/app/app.module.ts
@@ -3,11 +3,13 @@ import { NgModule } from '@angular/core';
 
 
 import { AppComponent } from './app.component';
+import { CompWithHostBindingComponent } from './comp-with-host-binding.component';
 
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    CompWithHostBindingComponent
   ],
   imports: [
     BrowserModule

--- a/aio/content/examples/attribute-binding/src/app/comp-with-host-binding.component.ts
+++ b/aio/content/examples/attribute-binding/src/app/comp-with-host-binding.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'comp-with-host-binding',
+  template: 'I am a component!',
+  host: {
+    '[class.special]': 'isSpecial',
+    '[style.color]': 'color',
+    '[style.width]': 'width'
+  }
+})
+export class CompWithHostBindingComponent {
+  isSpecial = false;
+  color = 'green';
+  width = '200px';
+}

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -895,7 +895,7 @@ Instead, you'd use property binding and write it like this:
 Add and remove CSS class names from an element's `class` attribute with
 a **class binding**.
 
-Here's how to set the attribute without binding in plain HTML:
+Here's how to set the attribute without a binding in plain HTML:
 
 ```html
 <!-- standard class attribute setting -->
@@ -903,27 +903,33 @@ Here's how to set the attribute without binding in plain HTML:
 ```
 
 Class binding syntax resembles property binding, but instead of an element property between brackets, start with the prefix `class`,
-optionally followed by a dot (`.`) and the name of a CSS class: `[class.class-name]`.
-
-You can replace that with a binding to a string of the desired class names; this is an all-or-nothing, replacement binding.
-
-
- <code-example path="attribute-binding/src/app/app.component.html" region="class-override" header="src/app/app.component.html"></code-example>
-
-You can also add a class to an element without overwriting the classes already on the element:
-
- <code-example path="attribute-binding/src/app/app.component.html" region="add-class" header="src/app/app.component.html"></code-example>
-
-Finally, you can bind to a specific class name.
+optionally followed by a dot (`.`) and the name of a CSS class: `[class.class-name]`. 
 Angular adds the class when the template expression evaluates to truthy.
 It removes the class when the expression is falsy.
+ 
+Binding to a specific class is additive, so it won't overwrite other class bindings or static classes unless the class names are duplicated.
 
-<code-example path="attribute-binding/src/app/app.component.html" region="is-special" header="src/app/app.component.html"></code-example>
+In the example below, the final class list for the `<div>` will be `"item clearance special"` if `isSpecial` is truthy, and only `"item clearance"` if it is falsy.
 
-While this technique is suitable for toggling a single class name,
-consider the [`NgClass`](guide/template-syntax#ngClass) directive when
-managing multiple class names at the same time.
+<code-example path="attribute-binding/src/app/app.component.html" region="add-class" header="src/app/app.component.html"></code-example> 
 
+You can also use the alternative class binding syntax that replaces square brackets with the `bind-` keyword:
+
+<code-example path="attribute-binding/src/app/app.component.html" region="bind-syntax" header="src/app/app.component.html"></code-example> 
+
+If there are multiple classes you'd like to toggle, you can bind to the `[class]` property directly.
+Binding to `[class]` is additive, so it shouldn't overwrite other class bindings or static classes unless the class names are duplicated*.
+
+<code-example path="attribute-binding/src/app/app.component.html" region="direct-class-binding" header="src/app/app.component.html"></code-example>
+
+The expression attached to the `[class]` binding is most often a string list of class names like `"clearance special"`. 
+
+You can also format the expression as an object with class names as the keys and truthy/falsy expressions as the values, like `{clearance: true, special: false}`. 
+In this case, Angular will add a class only if its associated value is truthy.
+It's important to note that with object format, the identity of the object must change for the class list to be updated.
+Updating the property without changing object identity will have no effect.
+
+*This is true for Angular version 9 and later. For Angular version 8, see <a href="http://v8.angular.io/guide/template-syntax#class-binding">v8.angular.io</a>
 
 <hr/>
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -892,70 +892,105 @@ Instead, you'd use property binding and write it like this:
 
 ### Class binding
 
-Add and remove CSS class names from an element's `class` attribute with
-a **class binding**.
-
-Here's how to set the attribute without a binding in plain HTML:
+Here's how to set the `class` attribute without a binding in plain HTML:
 
 ```html
 <!-- standard class attribute setting -->
-<div class="item clearance special">Item clearance special</div>
+<div class="foo bar">Some text</div>
 ```
 
-Class binding syntax resembles property binding, but instead of an element property between brackets, start with the prefix `class`,
-optionally followed by a dot (`.`) and the name of a CSS class: `[class.class-name]`. 
-Angular adds the class when the template expression evaluates to truthy.
-It removes the class when the expression is falsy.
- 
-Binding to a specific class is additive, so it won't overwrite other class bindings or static classes unless the class names are duplicated.
+You can also add and remove CSS class names from an element's `class` attribute with a **class binding**.
 
-In the example below, the final class list for the `<div>` will be `"item clearance special"` if `isSpecial` is truthy, and only `"item clearance"` if it is falsy.
+To create a single class binding, start with the prefix `class` followed by a dot (`.`) and the name of the CSS class (for example, `[class.foo]="hasFoo"`). 
+Angular adds the class when the bound expression is truthy, and it removes the class when the expression is falsy (with the exception of `undefined`, see [styling delegation](#styling-delegation)).
 
-<code-example path="attribute-binding/src/app/app.component.html" region="add-class" header="src/app/app.component.html"></code-example> 
+To create a binding to multiple classes, use a generic `[class]` binding without the dot (for example, `[class]="classExpr"`).
+The expression can be a space-delimited string of class names, or you can format it as an object with class names as the keys and truthy/falsy expressions as the values. 
+With object format, Angular will add a class only if its associated value is truthy. 
 
-You can also use the alternative class binding syntax that replaces square brackets with the `bind-` keyword:
-
-<code-example path="attribute-binding/src/app/app.component.html" region="bind-syntax" header="src/app/app.component.html"></code-example> 
-
-If there are multiple classes you'd like to toggle, you can bind to the `[class]` property directly.
-Binding to `[class]` is additive, so it shouldn't overwrite other class bindings or static classes unless the class names are duplicated*.
-
-<code-example path="attribute-binding/src/app/app.component.html" region="direct-class-binding" header="src/app/app.component.html"></code-example>
-
-The expression attached to the `[class]` binding is most often a string list of class names like `"clearance special"`. 
-
-You can also format the expression as an object with class names as the keys and truthy/falsy expressions as the values, like `{clearance: true, special: false}`. 
-In this case, Angular will add a class only if its associated value is truthy.
-It's important to note that with object format, the identity of the object must change for the class list to be updated.
+It's important to note that with any object-like expression (`object`, `Array`, `Map`, `Set`, etc), the identity of the object must change for the class list to be updated.
 Updating the property without changing object identity will have no effect.
 
-If there are multiple bindings to the same class name, conflicts are resolved using [styling priority order](#styling-priority).
+If there are multiple bindings to the same class name, conflicts are resolved using [styling precedence](#styling-precedence).
 
-*This is true for Angular version 9 and later. For Angular version 8, see <a href="http://v8.angular.io/guide/template-syntax#class-binding">v8.angular.io</a>
+<style>
+  td, th {vertical-align: top}
+</style>
+
+<table width="100%">
+  <col width="15%">
+  </col>
+  <col width="20%">
+  </col>
+  <col width="35%">
+  </col>
+  <col width="30%">
+  </col>
+  <tr>
+    <th>
+      Binding Type
+    </th>
+    <th>
+      Syntax
+    </th>
+    <th>
+      Input Type
+    </th>
+    <th>
+      Example Input Values
+    </th>
+  </tr>
+  <tr>
+    <td>Single class binding</td>
+    <td><code>[class.foo]="hasFoo"</code></td>
+    <td><code>boolean | undefined | null</code></td>
+    <td><code>true</code>, <code>false</code></td>
+  </tr>
+  <tr>
+    <td rowspan=5>Multi-class binding</td>
+    <td rowspan=5><code>[class]="classExpr"</code></td>
+    <td><code>string</code></td>
+    <td><code>"my-class-1 my-class-2 my-class-3"</code></td>
+  </tr>
+  <tr>
+    <td><code>{[key: string]: boolean | undefined | null}</code></td>
+    <td><code>{foo: true, bar: false}</code></td>
+  </tr>
+  <tr>
+    <td><code>Map</code><<code>string, boolean | undefined | null</code>></code></td>
+    <td><code>new Map([['foo', true]])</code></td>
+  </tr>
+  <tr>
+    <td><code>Array</code><<code>string</code>></td>
+    <td><code>['foo', 'bar']</code></td>
+  </tr>
+  <tr>
+    <td><code>Set</code><<code>string</code>> </code></td>
+    <td><code>new Set(['foo', 'bar'])</code></td>
+  </tr>
+</table>
+
+
+The [NgClass](#ngclass) directive can be used as an alternative to direct `[class]` bindings. 
+However, using the above class binding syntax without `NgClass` is preferred because due to improvements in class binding in Angular, `NgClass` no longer provides significant value, and might eventually be removed in the future.
+
 
 <hr/>
 
 ### Style binding
 
-Here's how to set the style attribute without a binding in plain HTML:
+Here's how to set the `style` attribute without a binding in plain HTML:
 
 ```html
 <!-- standard style attribute setting -->
-<div style="color: blue">Item clearance special</div>
+<div style="color: blue">Some text</div>
 ```
 
-You can set styles dynamically with a **style binding**.
+You can also set styles dynamically with a **style binding**.
 
-Style binding syntax resembles property binding.
-Instead of an element property between brackets, start with the prefix `style`,
-followed by a dot (`.`) and the name of a CSS style property: `[style.style-property]`.
-
-<code-example path="attribute-binding/src/app/app.component.html" region="style-binding" header="src/app/app.component.html"></code-example>
-
-Some style binding styles have a unit extension.
-The following example conditionally sets the font size in  “em” and “%” units.
-
-<code-example path="attribute-binding/src/app/app.component.html" region="style-binding-condition" header="src/app/app.component.html"></code-example>
+To create a single style binding, start with the prefix `style` followed by a dot (`.`) and the name of the CSS style property (for example, `[style.width]="width"`). 
+The property will be set to the value of the bound expression, which is normally a string.
+Optionally, you can add a unit extension like `em` or `%`, which requires a number type.
 
 <div class="alert is-helpful">
 
@@ -965,23 +1000,147 @@ Note that a _style property_ name can be written in either
 
 </div>
 
-If there are multiple styles you'd like to toggle, you can bind to the `[style]` property directly.
-Binding to `[style]` is additive, so it shouldn't overwrite other style bindings or static styles unless the same style property is duplicated.
-
-<code-example path="attribute-binding/src/app/app.component.html" region="direct-style-binding" header="src/app/app.component.html"></code-example>
-
+If there are multiple styles you'd like to toggle, you can bind to the `[style]` property directly without the dot (for example, `[style]="styleExpr"`).
 The expression attached to the `[style]` binding is most often a string list of styles like `"width: 100px; height: 100px;"`. 
 
 You can also format the expression as an object with style names as the keys and style values as the values, like `{width: '100px', height: '100px'}`. 
 It's important to note that with object format, the identity of the object must change for the styles to be updated.
 Updating the property without changing object identity will have no effect.
 
-If there are multiple bindings to the same style property, conflicts are resolved using [styling priority order](#styling-priority).
+If there are multiple bindings to the same style property, conflicts are resolved using [styling precedence rules](#styling-precedence).
 
-*This is true for Angular version 9 and later. For Angular version 8, see <a href="http://v8.angular.io/guide/template-syntax#style-binding">v8.angular.io</a>
+<style>
+  td, th {vertical-align: top}
+</style>
+
+<table width="100%">
+  <col width="15%">
+  </col>
+  <col width="20%">
+  </col>
+  <col width="35%">
+  </col>
+  <col width="30%">
+  </col>
+  <tr>
+    <th>
+      Binding Type
+    </th>
+    <th>
+      Syntax
+    </th>
+    <th>
+      Input Type
+    </th>
+    <th>
+      Example Input Values
+    </th>
+  </tr>
+  <tr>
+    <td>Single style binding</td>
+    <td><code>[style.width]="width"</code></td>
+    <td><code>string | undefined | null</code></td>
+    <td><code>"100px"</code></td>
+  </tr>
+  <tr>
+  <tr>
+    <td>Single style binding with units</td>
+    <td><code>[style.width.px]="width"</code></td>
+    <td><code>number | undefined | null</code></td>
+    <td><code>100</code></td>
+  </tr>
+    <tr>
+    <td rowspan=5>Multi-style binding</td>
+    <td rowspan=5><code>[style]="styleExpr"</code></td>
+    <td><code>string</code></td>
+    <td><code>"width: 100px; height: 100px"</code></td>
+  </tr>
+  <tr>
+    <td><code>{[key: string]: string | undefined | null}</code></td>
+    <td><code>{width: '100px', height: '100px'}</code></td>
+  </tr>
+  <tr>
+      <td><code>Map</code><<code>string, string | undefined | null</code>></code></td>
+      <td><code>new Map([['width', '100px']])</code></td>
+   </tr>
+  <tr>
+    <td><code>Array</code><<code>string</code>></td>
+    <td><code>['width', '100px']</code></td>
+  </tr>
+  <tr>
+    <td><code>Set</code><<code>string</code>> </code></td>
+    <td><code>new Set(['width', '100px'])</code></td>
+  </tr>
+</table>
+
+The [NgStyle](#ngstyle) directive can be used as an alternative to direct `[style]` bindings. 
+However, using the above style binding syntax without `NgStyle` is preferred because due to improvements in style binding in Angular, `NgStyle` no longer provides significant value, and might eventually be removed in the future.
 
 
 <hr/>
+
+{@a styling-precedence}
+### Styling Precedence
+
+A single HTML element can have its CSS class list and style values bound to a multiple sources (for example, host bindings from multiple directives).
+
+When there are multiple bindings to the same class name or style property, Angular uses a set of precedence rules to resolve conflicts and determine which classes or styles are ultimately applied to the element.
+
+<div class="alert is-helpful">
+<h4>Styling precedence (highest to lowest)</h4>
+
+1. Template bindings
+    1. Property binding (for example, `<div [class.foo]="hasFoo">` or `<div [style.color]="color">`)
+    1. Map binding (for example, `<div [class]="classExpr">` or `<div [style]="styleExpr">`)
+    1. Static value (for example, `<div class="foo">` or `<div style="color: blue">`) 
+1. Directive host bindings
+    1. Property binding (for example, `host: {'[class.foo]': 'hasFoo'}` or `host: {'[style.color]': 'color'}`)
+    1. Map binding (for example, `host: {'[class]': 'classExpr'}` or `host: {'[style]': 'styleExpr'}`)
+    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)    
+1. Component host bindings
+    1. Property binding (for example, `host: {'[class.foo]': 'hasFoo'}` or `host: {'[style.color]': 'color'}`)
+    1. Map binding (for example, `host: {'[class]': 'classExpr'}` or `host: {'[style]': 'styleExpr'}`)
+    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)    
+
+</div>
+
+The more specific a class or style binding is, the higher its precedence.
+
+A binding to a specific class (for example, `[class.foo]`) will take precedence over a generic `[class]` binding, and a binding to a specific style (for example, `[style.bar]`) will take precedence over a generic `[style]` binding.
+
+<code-example path="attribute-binding/src/app/app.component.html" region="basic-specificity" header="src/app/app.component.html"></code-example>
+
+Specificity rules also apply when it comes to bindings that originate from different sources. 
+It's possible for an element to have bindings in the template where it's declared, from host bindings on matched directives, and from host bindings on matched components.
+
+Template bindings are the most specific because they apply to the element directly and exclusively, so they have the highest precedence.
+
+Directive host bindings are considered less specific because directives can be used in multiple locations, so they have a lower precedence than template bindings.
+
+Directives often augment component behavior, so host bindings from components have the lowest precedence. 
+
+<code-example path="attribute-binding/src/app/app.component.html" region="source-specificity" header="src/app/app.component.html"></code-example>
+
+In addition, bindings take precedence over static attributes. 
+
+In the following case, `class` and `[class]` have similar specificity, but the `[class]` binding will take precedence because it is dynamic.
+
+<code-example path="attribute-binding/src/app/app.component.html" region="dynamic-priority" header="src/app/app.component.html"></code-example>
+
+{@a styling-delegation}
+### Delegating to styles with lower precedence
+
+It is possible for higher precedence styles to "delegate" to lower precedence styles using `undefined` values.
+Whereas setting a style property to `null` ensures the style is removed, setting it to `undefined` will cause Angular to fall back to the next-highest precedence binding to that style.
+
+For example, consider the following template: 
+
+<code-example path="attribute-binding/src/app/app.component.html" region="style-delegation" header="src/app/app.component.html"></code-example>
+
+Imagine that the `dirWithHostBinding` directive and the `comp-with-host-binding` component both have a `[style.width]` host binding.
+In that case, if `dirWithHostBinding` sets its binding to `undefined`, the `width` property will fall back to the value of the `comp-with-host-binding` host binding.
+However, if `dirWithHostBinding` sets its binding to `null`, the `width` property will be removed entirely.
+
 
 {@a event-binding}
 
@@ -2187,63 +2346,3 @@ Add the following code to your `svg.component.svg` file:
 
 Here you can see the use of a `click()` event binding and the property binding syntax
 (`[attr.fill]="fillColor"`).
-
-## Appendix
-
-{@a styling-priority}
-### Styling Priority Order
-
-When there are multiple bindings to the same class name or style property, Angular uses priority order to resolve conflicts and determine which classes or styles are ultimately applied to the element.
-
-The more specific a style is, the higher its priority. 
-A general `[class]` binding will have lower priority than a binding to a specific class (e.g. `[class.foo]`), and a general `[style]` binding will have lower priority than a binding to a specific style (e.g. `[style.bar]`).
-
-<code-example path="attribute-binding/src/app/app.component.html" region="basic-specificity" header="src/app/app.component.html"></code-example>
-
-Specificity rules also apply when it comes to bindings that come from different sources. 
-It's possible for a node to have bindings on the template itself, from host bindings on matched directives, and from host bindings on matched components.
-
-Template bindings are the most specific because they apply to only one node at a time, so they have the highest priority.
-
-Directive host bindings are considered less specific because directives can be used in multiple locations, so they have a lower priority than template bindings.
-
-Directives often augment component behavior, so host bindings from components have the lowest priority. 
-
-<code-example path="attribute-binding/src/app/app.component.html" region="source-specificity" header="src/app/app.component.html"></code-example>
-
-Dynamic styles also take precedence over static styles. 
-
-In the following case, `class` and `[class]` have similar specificity, but the `[class]` binding will have higher priority because it is dynamic.
-
-<code-example path="attribute-binding/src/app/app.component.html" region="dynamic-priority" header="src/app/app.component.html"></code-example>
-
-Below is a full priority list, ranked from highest (top) to lowest (bottom):
-
-* Template bindings
-  * Property binding (e.g. `<div [class.foo]="hasFoo">`)
-  * Map binding (e.g. `<div [class]="classExpr">`)
-  * Static value (e.g. `<div class="foo">`)
-  
-* Directive host bindings
-  * Property binding (e.g. `host: {'[class.foo]': 'hasFoo'}`)
-  * Map binding (e.g. `host: {'[class]': 'classExpr'}`)
-  * Static value (e.g. `host: {'class': 'foo'}`)
-  
-* Component host bindings
-  * Property binding (e.g. `host: {'[class.foo]': 'hasFoo'}`)
-  * Map binding (e.g. `host: {'[class]': 'classExpr'}`)
-  * Static value (e.g. `host: {'class': 'foo'}`)
-
-{@a styling-delegation}
-### Delegating to lower priority styles
-
-It is possible for higher priority styles to "delegate" to lower priority styles using `undefined` values.
-Whereas setting a style property to `null` will ensure the style is removed, setting it to `undefined` will cause Angular to fall back to the next-highest priority binding to that style.
-
-For example, let's say there is the following template: 
-
-<code-example path="attribute-binding/src/app/app.component.html" region="style-delegation" header="src/app/app.component.html"></code-example>
-
-And let's say `dirWithHostBinding` and `comp-with-host-binding` both have a `[style.width]` host binding.
-In that case, if `dirWithHostBinding` sets its binding to `undefined`, the `width` property will fall back to the value of the `comp-with-host-binding` host binding.
-However, if `dirWithHostBinding` sets its binding to `null`, the `width` property will be removed entirely.

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -935,7 +935,14 @@ Updating the property without changing object identity will have no effect.
 
 ### Style binding
 
-You can set inline styles with a **style binding**.
+Here's how to set the style attribute without a binding in plain HTML:
+
+```html
+<!-- standard style attribute setting -->
+<div style="color: blue">Item clearance special</div>
+```
+
+You can set styles dynamically with a **style binding**.
 
 Style binding syntax resembles property binding.
 Instead of an element property between brackets, start with the prefix `style`,
@@ -948,9 +955,6 @@ The following example conditionally sets the font size in  “em” and “%” 
 
 <code-example path="attribute-binding/src/app/app.component.html" region="style-binding-condition" header="src/app/app.component.html"></code-example>
 
-This technique is suitable for setting a single style, but consider
-the [`NgStyle`](guide/template-syntax#ngStyle) directive when setting several inline styles at the same time.
-
 <div class="alert is-helpful">
 
 Note that a _style property_ name can be written in either
@@ -958,6 +962,20 @@ Note that a _style property_ name can be written in either
 [camelCase](guide/glossary#camelcase), such as `fontSize`.
 
 </div>
+
+If there are multiple styles you'd like to toggle, you can bind to the `[style]` property directly.
+Binding to `[style]` is additive, so it shouldn't overwrite other style bindings or static styles unless the same style property is duplicated.
+
+<code-example path="attribute-binding/src/app/app.component.html" region="direct-style-binding" header="src/app/app.component.html"></code-example>
+
+The expression attached to the `[style]` binding is most often a string list of styles like `"width: 100px; height: 100px;"`. 
+
+You can also format the expression as an object with style names as the keys and style values as the values, like `{width: '100px', height: '100px'}`. 
+It's important to note that with object format, the identity of the object must change for the styles to be updated.
+Updating the property without changing object identity will have no effect.
+
+*This is true for Angular version 9 and later. For Angular version 8, see <a href="http://v8.angular.io/guide/template-syntax#style-binding">v8.angular.io</a>
+
 
 <hr/>
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -947,8 +947,8 @@ If there are multiple bindings to the same class name, conflicts are resolved us
     <td><code>true</code>, <code>false</code></td>
   </tr>
   <tr>
-    <td rowspan=5>Multi-class binding</td>
-    <td rowspan=5><code>[class]="classExpr"</code></td>
+    <td rowspan=3>Multi-class binding</td>
+    <td rowspan=3><code>[class]="classExpr"</code></td>
     <td><code>string</code></td>
     <td><code>"my-class-1 my-class-2 my-class-3"</code></td>
   </tr>
@@ -957,16 +957,8 @@ If there are multiple bindings to the same class name, conflicts are resolved us
     <td><code>{foo: true, bar: false}</code></td>
   </tr>
   <tr>
-    <td><code>Map</code><<code>string, boolean | undefined | null</code>></code></td>
-    <td><code>new Map([['foo', true]])</code></td>
-  </tr>
-  <tr>
     <td><code>Array</code><<code>string</code>></td>
     <td><code>['foo', 'bar']</code></td>
-  </tr>
-  <tr>
-    <td><code>Set</code><<code>string</code>> </code></td>
-    <td><code>new Set(['foo', 'bar'])</code></td>
   </tr>
 </table>
 
@@ -1050,8 +1042,8 @@ If there are multiple bindings to the same style property, conflicts are resolve
     <td><code>100</code></td>
   </tr>
     <tr>
-    <td rowspan=5>Multi-style binding</td>
-    <td rowspan=5><code>[style]="styleExpr"</code></td>
+    <td rowspan=3>Multi-style binding</td>
+    <td rowspan=3><code>[style]="styleExpr"</code></td>
     <td><code>string</code></td>
     <td><code>"width: 100px; height: 100px"</code></td>
   </tr>
@@ -1060,16 +1052,8 @@ If there are multiple bindings to the same style property, conflicts are resolve
     <td><code>{width: '100px', height: '100px'}</code></td>
   </tr>
   <tr>
-      <td><code>Map</code><<code>string, string | undefined | null</code>></code></td>
-      <td><code>new Map([['width', '100px']])</code></td>
-   </tr>
-  <tr>
     <td><code>Array</code><<code>string</code>></td>
     <td><code>['width', '100px']</code></td>
-  </tr>
-  <tr>
-    <td><code>Set</code><<code>string</code>> </code></td>
-    <td><code>new Set(['width', '100px'])</code></td>
   </tr>
 </table>
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1004,7 +1004,7 @@ If there are multiple styles you'd like to toggle, you can bind to the `[style]`
 The expression attached to the `[style]` binding is most often a string list of styles like `"width: 100px; height: 100px;"`. 
 
 You can also format the expression as an object with style names as the keys and style values as the values, like `{width: '100px', height: '100px'}`. 
-It's important to note that with object format, the identity of the object must change for the styles to be updated.
+It's important to note that with any object-like expression (`object`, `Array`, `Map`, `Set`, etc), the identity of the object must change for the class list to be updated.
 Updating the property without changing object identity will have no effect.
 
 If there are multiple bindings to the same style property, conflicts are resolved using [styling precedence rules](#styling-precedence).


### PR DESCRIPTION
More docs!

You can preview cleanup [here](https://pr35066-4e7880b.ngbuilds.io/guide/template-syntax#class-binding) and the new section on priority order [here](https://pr35066-4e7880b.ngbuilds.io/guide/template-syntax#styling-priority).