### PR TITLE
fix(language-service): always use non-strict mode

### DIFF
--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -454,7 +454,7 @@ describe('diagnostics', () => {
       export class AppComponent {
         something: 'foo' | 'bar';
       }`);
-    mockHost.overrideOptions({
+    mockHost.setCompilerOptions({
       strict: false,  // TODO: this test fails in strict mode
     });
     const tsDiags = tsLS.getSemanticDiagnostics(APP_COMPONENT);
@@ -473,7 +473,7 @@ describe('diagnostics', () => {
       export class AppComponent {
         something: 123 | 456;
       }`);
-    mockHost.overrideOptions({
+    mockHost.setCompilerOptions({
       strict: false,  // TODO: This test fails in strict mode
     });
     const tsDiags = tsLS.getSemanticDiagnostics(APP_COMPONENT);
@@ -511,7 +511,7 @@ describe('diagnostics', () => {
       export class AppComponent {
         something = 'foo';
       }`);
-    mockHost.overrideOptions({
+    mockHost.setCompilerOptions({
       strict: false,  // TODO: This test fails in strict mode
     });
     const tsDiags = tsLS.getSemanticDiagnostics(APP_COMPONENT);
@@ -654,7 +654,7 @@ describe('diagnostics', () => {
 
   // Issue #15885
   it('should be able to remove null and undefined from a type', () => {
-    mockHost.overrideOptions({
+    mockHost.setCompilerOptions({
       strictNullChecks: true,
     });
     mockHost.override(APP_COMPONENT, `
@@ -699,7 +699,7 @@ describe('diagnostics', () => {
         onSubmit(form: NgForm) {}
       }`);
     mockHost.addScript('/other/files/app/server.ts', 'export class Server {}');
-    mockHost.overrideOptions({
+    mockHost.setCompilerOptions({
       baseUrl: '/other/files',
     });
     const tsDiags = tsLS.getSemanticDiagnostics(APP_COMPONENT);

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -154,6 +154,7 @@ export class TemplateReference {
   heroesByName: {[name: string]: Hero} = {};
   primitiveIndexType: {[name: string]: string} = {};
   anyValue: any;
+  optional?: string;
   myClick(event: any) {}
 }
 

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -135,7 +135,7 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     this.scriptNames.push(fileName);
   }
 
-  overrideOptions(options: Partial<ts.CompilerOptions>) {
+  setCompilerOptions(options: Partial<ts.CompilerOptions>) {
     this.options = {...this.options, ...options};
     this.projectVersion++;
   }


### PR DESCRIPTION
Under strict mode, the language service fails to typecheck nullable
Symbols that have already verified to be non-null.

This generates incorrect and confusing diagnostics for users.

To work around this issue in the short term, this commit makes a few changes:

1. Always use strict=false internally in the language service
2. Rename MockHost.overrideOptions() to setCompilerOptions() to conform
to the interface of ts.server.Project

PR closes https://github.com/angular/vscode-ng-language-service/issues/589

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
