### PR TITLE
docs(animations): increase wait time for status-slider animation

### DIFF
--- a/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
@@ -89,14 +89,14 @@ describe('Animation Tests', () => {
       sleepFor(2000);
     });
 
-    it('should be inactive with an blue background', async () => {
+    it('should be inactive with a blue background', async () => {
       const toggleButton = statusSlider.getToggleButton();
       const container = statusSlider.getComponentContainer();
       let text = await container.getText();
 
       if (text === 'Active') {
         await toggleButton.click();
-        await browser.wait(async () => await container.getCssValue('backgroundColor') === inactiveColor, 2101);
+        await browser.wait(async () => await container.getCssValue('backgroundColor') === inactiveColor, 3000);
       }
 
       text = await container.getText();
@@ -106,14 +106,14 @@ describe('Animation Tests', () => {
       expect(bgColor).toBe(inactiveColor);
     });
 
-    it('should be active with a orange background', async () => {
+    it('should be active with an orange background', async () => {
       const toggleButton = statusSlider.getToggleButton();
       const container = statusSlider.getComponentContainer();
       let text = await container.getText();
 
       if (text === 'Inactive') {
         await toggleButton.click();
-        await browser.wait(async () => await container.getCssValue('backgroundColor') === activeColor, 2101);
+        await browser.wait(async () => await container.getCssValue('backgroundColor') === activeColor, 3000);
       }
 
       text = await container.getText();

--- a/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
@@ -89,14 +89,14 @@ describe('Animation Tests', () => {
       sleepFor(2000);
     });
 
-    it('should be inactive with an orange background', async () => {
+    it('should be inactive with an blue background', async () => {
       const toggleButton = statusSlider.getToggleButton();
       const container = statusSlider.getComponentContainer();
       let text = await container.getText();
 
       if (text === 'Active') {
         await toggleButton.click();
-        await browser.wait(async () => await container.getCssValue('backgroundColor') === inactiveColor, 2000);
+        await browser.wait(async () => await container.getCssValue('backgroundColor') === inactiveColor, 2101);
       }
 
       text = await container.getText();
@@ -106,14 +106,14 @@ describe('Animation Tests', () => {
       expect(bgColor).toBe(inactiveColor);
     });
 
-    it('should be active with a blue background', async () => {
+    it('should be active with a orange background', async () => {
       const toggleButton = statusSlider.getToggleButton();
       const container = statusSlider.getComponentContainer();
       let text = await container.getText();
 
       if (text === 'Inactive') {
         await toggleButton.click();
-        await browser.wait(async () => await container.getCssValue('backgroundColor') === activeColor, 2000);
+        await browser.wait(async () => await container.getCssValue('backgroundColor') === activeColor, 2101);
       }
 
       text = await container.getText();


### PR DESCRIPTION
Because the animation completes in 2000ms, and browser.wait checks
every 100ms, there can be a race condition of if the final state has
actually been reached to read the color. By moving to 2101ms, we ensure
that we check after the 2000ms of the animation has completed.


Fixes #35038