### PR TITLE
feat(language-service): provide completions for microsyntax

### DIFF
--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -78,6 +78,17 @@ export function getSelectors(info: AstResult): SelectorInfo {
   return {selectors: results, map};
 }
 
+export function getSelectorByName(directiveName: string, cssSelectors: CssSelector[]) {
+  return cssSelectors.find(s => {
+    // attributes are listed in (attribute, value) pairs
+    for (let i = 0; i < s.attrs.length; i += 2) {
+      if (s.attrs[i] === directiveName) {
+        return true;
+      }
+    }
+  });
+}
+
 export function isTypescriptVersion(low: string, high?: string) {
   const version = ts.version;
 


### PR DESCRIPTION
Provide completions for microsyntax, for example, `ngFor` completions will include `of`, `trackBy`, etc. `ngIf` completions will include `then`, `else`.
```
*ngFor="let item of items; | ;"
```
Here provide template context(`index`, `odd`, etc.) and directive input property(`of`, `trackBy`, etc.).
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
