### PR TITLE
fix(docs-infra): size footer links to appropriate size for seo and small css fixes

### DIFF
--- a/aio/src/styles/1-layouts/_footer.scss
+++ b/aio/src/styles/1-layouts/_footer.scss
@@ -40,7 +40,7 @@ footer {
     @include font-size(16);
     text-transform: uppercase;
     font-weight: 400;
-    margin: 0 0 16px;
+    margin: 8px 0 12px;
     color: $white;
   }
   p {
@@ -69,7 +69,7 @@ footer {
 
       li {
         list-style-type: none;
-        padding: 0px;
+        padding: 4px 0;
         text-align: left;
       }
     }

--- a/aio/src/styles/1-layouts/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/_marketing-layout.scss
@@ -97,7 +97,6 @@ section#intro {
 
   .hero-logo {
     display: flex;
-    width: 400px;
 
     @media (max-width: 780px) {
       justify-content: center;

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -6,7 +6,8 @@ aio-search-results {
     flex-direction: row;
     justify-content: space-around;
     overflow: auto;
-    padding: 68px 32px 0;
+    padding: 0px 32px;
+    border-top: 68px solid transparent;
     width: auto;
     max-height: 95vh;
     position: fixed;


### PR DESCRIPTION
Footer links did not have enough space between them, so lighouse was reporting that tap targets are not appropriately sized added the required 8px space between links

Fixes #34901

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Footer Links does not have enough space between them

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34901


## What is the new behavior?
Added required 8 px space between them

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Added other small fixes to make it work on small screens less that with 400px and search results when scrolling soes not interfere wit the top navbar items