### PR TITLE
[POC] feat(language-service): type event variables targeting DOM events

### DIFF
--- a/packages/language-service/src/ty.ts
+++ b/packages/language-service/src/ty.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * This module provides methods for extracting TypeScript type data in cases where a pass through
+ * tsc is unavoidable. In such cases, a trivial program is constructed and evaluated during the
+ * language service runtime.
+ */
+
+import * as ts from 'typescript';
+
+class TyHost {
+  private static compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2015,
+    script: true,
+  };
+  private static sourceFileCache = new Map<string, ts.SourceFile|undefined>();
+
+  static createProgram(targetFile: string, content: string): ts.Program {
+    const options = TyHost.compilerOptions;
+    const compilerHost = ts.createCompilerHost(options);
+    const originalGetSourceFile = compilerHost.getSourceFile;
+    compilerHost.getSourceFile = (fileName) => {
+      if (fileName === targetFile) {
+        return ts.createSourceFile(fileName, content, ts.ScriptTarget.ES2015, true);
+      }
+
+      // Creating TS library source files is expensive. Programs are created with the same compiler
+      // options, so we can cache common source files after they are generated once.
+      if (!TyHost.sourceFileCache.has(fileName)) {
+        const sf = originalGetSourceFile.call(compilerHost, fileName, ts.ScriptTarget.ES2015);
+        TyHost.sourceFileCache.set(fileName, sf);
+      }
+      return TyHost.sourceFileCache.get(fileName);
+    };
+
+    return ts.createProgram([targetFile], options, compilerHost);
+  }
+}
+
+/**
+ * A context a TypeScript symbol is discovered in.
+ */
+export interface TypeContext {
+  node: ts.Node;
+  program: ts.Program;
+  checker: ts.TypeChecker;
+}
+
+/**
+ * Returns the TypeScript event type corresponding to a DOM event name. If no DOM event of the
+ * specified name exists, the generic `Event` type is returned.
+ * @param eventName DOM event name
+ * @return TS event type corresponding to the DOM event. If calls through tsc fail, the return type
+ * is undefined.
+ */
+export function getDOMEventType(eventName: string): {type: ts.Type, context: TypeContext}|
+    undefined {
+  const fileName = 'event.ts';
+  const ev = 'ev';
+  const content = `
+    type EventKind<K> = K extends keyof HTMLElementEventMap ? HTMLElementEventMap[K] : Event;
+    let ${ev}: EventKind<'${eventName}'>;
+  `;
+
+  const program = TyHost.createProgram(fileName, content);
+  const ast = program.getSourceFile(fileName);
+
+  const vstmt = ast ?.getChildAt(0).getChildren().find(ts.isVariableStatement);
+  const evDecl = vstmt ?.declarationList.declarations.find(decl => decl.name.getText() === ev);
+
+  if (!evDecl) return;
+
+  const checker = program.getTypeChecker();
+  const type = checker.getTypeAtLocation(evDecl);
+
+  return {
+    type,
+    context: {
+      node: evDecl,
+      program,
+      checker,
+    },
+  };
+}

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {BuiltinType, DeclarationKind, Definition, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './symbols';
+import {TypeContext, getDOMEventType} from './ty';
 
 // In TypeScript 2.1 these flags moved
 // These helpers work for both 2.0 and 2.1.
@@ -24,12 +25,6 @@ const isReferenceType = (ts as any).ObjectFlags ?
          !!(type.flags & (ts as any).TypeFlags.Object &&
             (type as any).objectFlags & (ts as any).ObjectFlags.Reference)) :
     ((type: ts.Type) => !!(type.flags & (ts as any).TypeFlags.Reference));
-
-interface TypeContext {
-  node: ts.Node;
-  program: ts.Program;
-  checker: ts.TypeChecker;
-}
 
 export function getSymbolQuery(
     program: ts.Program, checker: ts.TypeChecker, source: ts.SourceFile,
@@ -78,6 +73,17 @@ export function getPipesTable(
     source: ts.SourceFile, program: ts.Program, checker: ts.TypeChecker,
     pipes: CompilePipeSummary[]): SymbolTable {
   return new PipesTable(pipes, {program, checker, node: source});
+}
+
+/**
+ * Returns the TypeScript event symbol corresponding to a DOM event name. If no DOM event of the
+ * specified name exists, the generic `Event` type is returned.
+ * @param eventName DOM event name
+ * @return Symbol of TS type corresponding to the DOM event.
+ */
+export function getDOMEventSymbol(eventName: string): Symbol|undefined {
+  const event = getDOMEventType(eventName);
+  return event && new TypeWrapper(event.type, event.context);
 }
 
 class TypeScriptSymbolQuery implements SymbolQuery {

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
         "template_spec.ts",
         "test_utils.ts",
         "ts_plugin_spec.ts",
+        "ty_spec.ts",
         "typescript_host_spec.ts",
         "utils_spec.ts",
     ],

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -752,15 +752,6 @@ describe('completions', () => {
       const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
       expectContain(completions, CompletionKind.VARIABLE, ['$event']);
     });
-  });
-
-  describe('$event completions', () => {
-    it('should suggest $event in event bindings', () => {
-      mockHost.override(TEST_TEMPLATE, `<div (click)="myClick(~{cursor});"></div>`);
-      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
-      expectContain(completions, CompletionKind.VARIABLE, ['$event']);
-    });
 
     it('should suggest $event completions in output bindings', () => {
       mockHost.override(TEST_TEMPLATE, `<div string-model (modelChange)="$event.~{cursor}"></div>`);
@@ -768,6 +759,14 @@ describe('completions', () => {
       const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
       // Expect string properties
       expectContain(completions, CompletionKind.METHOD, ['charAt', 'substring']);
+    });
+
+    it('should suggest $event completions in bindings targeting DOM events', () => {
+      mockHost.override(TEST_TEMPLATE, `<div (click)="$event.~{cursor}"></div>`);
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+      const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
+      // Expect 'MouseEvent' properties
+      expectContain(completions, CompletionKind.PROPERTY, ['altKey', 'screenX']);
     });
   });
 });

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -333,7 +333,7 @@ describe('diagnostics', () => {
       expect(length).toBe(keyword.length);
     });
 
-    it('should reject invalid properties on an event type', () => {
+    it('should reject invalid properties on an output event type', () => {
       const content = mockHost.override(
           TEST_TEMPLATE, '<div string-model (modelChange)="$event.notSubstring()"></div>');
       const diagnostics = ngLS.getSemanticDiagnostics(TEST_TEMPLATE) !;
@@ -342,6 +342,16 @@ describe('diagnostics', () => {
       expect(messageText).toBe(`Unknown method 'notSubstring'`);
       expect(start).toBe(content.indexOf('$event'));
       expect(length).toBe('$event.notSubstring()'.length);
+    });
+
+    it('should reject invalid properties on a DOM event type', () => {
+      const content = mockHost.override(TEST_TEMPLATE, '<div (click)="$event.notAMethod()"></div>');
+      const diagnostics = ngLS.getSemanticDiagnostics(TEST_TEMPLATE) !;
+      expect(diagnostics.length).toBe(1);
+      const {messageText, start, length} = diagnostics[0];
+      expect(messageText).toBe(`Unknown method 'notAMethod'`);
+      expect(start).toBe(content.indexOf('$event'));
+      expect(length).toBe('$event.notAMethod()'.length);
     });
   });
 

--- a/packages/language-service/test/ty_spec.ts
+++ b/packages/language-service/test/ty_spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getDOMEventType} from '../src/ty';
+
+describe('getDOMEventType', () => {
+  it('should work with known DOM event types', () => {
+    const cases = [
+      {
+        eventName: 'blur',
+        typeName: 'FocusEvent',
+      },
+      {
+        eventName: 'click',
+        typeName: 'MouseEvent',
+      },
+      {
+        eventName: 'keyup',
+        typeName: 'KeyboardEvent',
+      }
+    ];
+
+    for (const {eventName, typeName} of cases) {
+      const event = getDOMEventType(eventName);
+      expect(event?.type.symbol.name).toBe(typeName);
+    }
+  });
+
+  it('should type unknown DOM events as Event types', () => {
+    const event = getDOMEventType('not-an-event');
+    expect(event?.type.symbol.name).toBe('Event');
+  });
+});


### PR DESCRIPTION
The language service is able to type `$event` variables belonging to
outputs, but is currently unable to type events that belong to DOM
events. This commit adds support for typing DOM events by looking up the
TypeScript type of a DOM event in the `HTMLElementEventMap`. A new
module has been added to the Language Service to enable the creation of
a TypeScript program needed for this change.

Note that construction of TypeScript programs is not inexpensive.

Closes https://github.com/angular/vscode-ng-language-service/issues/531.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No