### PR TITLE
fix(ivy): draft containsDirty alternative

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1641,7 +1641,8 @@ function refreshTransplantedViews(lContainer: LContainer, declaredComponentLView
       // should automatically mark a view as dirty.
       const insertionComponentIsOnPush =
           (insertedComponentLView[FLAGS] & LViewFlags.CheckAlways) === 0;
-      if (insertionComponentIsOnPush) {
+      const insertionComponentDirty = insertedComponentLView[FLAGS] & LViewFlags.Dirty;
+      if (insertionComponentIsOnPush && !insertionComponentDirty) {
         // Here we know that the template has been transplanted across components and is
         // on-push (not just moved within a component). If the insertion is marked dirty, then
         // there is no need to CD here as we will do it again later when we get to insertion

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1318,7 +1318,8 @@ describe('change detection', () => {
 
       insertComp.changeDetectorRef.markForCheck();
       fixture.detectChanges(false);
-      expect(log).toEqual(ivyEnabled ? ['Declare', 'Insert'] : ['Insert']);
+      // Only checked with insertion because insertion is dirty.
+      expect(log).toEqual(['Insert']);
       log.length = 0;
       expect(trim(fixture.nativeElement.textContent))
           .toEqual('DeclareComp(Angular) InsertComp(Hi) Hi Angular!');


### PR DESCRIPTION
[Draft/test] - Currently, if the insertion component is OnPush, we always check the transplanted view at the declaration point. We could potentially check only if the insertion is *not* dirty. This would work in most cases, but could fail in one very specific case: backwards references (insertion checked before declaration) that also get marked dirty after change detection **and** there is a change in the declaration that was not available when the insertion was checked.