### PR TITLE
Fix nav to match new TOH titles

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -135,17 +135,17 @@
           {
             "url": "tutorial",
             "title": "Introduction",
-            "tooltip": "Introduction to the Tour of Heroes tutorial"
+            "tooltip": "Introduction to the Tour of Heroes app and tutorial"
           },
           {
             "url": "tutorial/toh-pt0",
-            "title": "The Application Shell",
+            "title": "Create a Project",
             "tooltip": "Creating the application shell"
           },
           {
             "url": "tutorial/toh-pt1",
             "title": "1. The Hero Editor",
-            "tooltip": "Part 1: Build a simple hero editor"
+            "tooltip": "Part 1: Build a simple editor"
           },
           {
             "url": "tutorial/toh-pt2",

--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -1,4 +1,4 @@
-# Create services
+# Add services
 
 The Tour of Heroes `HeroesComponent` is currently getting and displaying fake data.
 

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -1,4 +1,4 @@
-# Add in-app navigation (routing)
+# Add in-app navigation with routing
 
 There are new requirements for the Tour of Heroes app:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Previous TOH PR changed page titles, but missed TOC (left-nav) titles
https://angular.io/tutorial/toh-pt3
https://angular.io/tutorial/toh-pt4

Issue Number: N/A


## What is the new behavior?
TOC titles match, slight update of titles

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No