### PR TITLE
build: adding a script to compare commits in master and stable branches

### DIFF
--- a/scripts/compare-master-to-patch.js
+++ b/scripts/compare-master-to-patch.js
@@ -23,7 +23,7 @@ const semver = require('semver');
 // present only in one branch. Ignoring them reduced the "noise" in the final output.
 const ignorePatterns = [
   'release:',
-  'docs:',
+  'docs: release notes',
   // These commits are created to update cli command docs sources with the most recent sha (stored
   // in `aio/package.json`). Separate commits are generated for master and patch branches and since
   // it's purely an infrastructure-related change, we ignore these commits while comparing master

--- a/scripts/compare-master-to-patch.js
+++ b/scripts/compare-master-to-patch.js
@@ -32,6 +32,8 @@ const ignorePatterns = [
 ];
 
 // Limit the log history to start from v9.0.0 release date.
+// Note: this is needed only for 9.0.x branch to avoid RC history.
+// Remove it once `9.1.x` branch is created.
 const after = '--after="2020-02-05"';
 
 // Helper methods
@@ -88,7 +90,7 @@ function diff(mapA, mapB) {
   const result = [];
   mapA.forEach((value, key) => {
     if (!mapB.has(key)) {
-      result.push(`[${value[1]}] ${value[0]}`);
+      result.push(`[${value[1]}+] ${value[0]}`);
     }
   });
   return result;

--- a/scripts/compare-master-to-stable.js
+++ b/scripts/compare-master-to-stable.js
@@ -24,7 +24,11 @@ const semver = require('semver');
 const ignorePatterns = [
   'release:',
   'docs:',
-  'build(docs-infra): upgrade cli command docs',
+  // These commits are created to update cli command docs sources with the most recent sha (stored
+  // in `aio/package.json`). Separate commits are generated for master and patch branches and since
+  // it's purely an infrastructure-related change, we ignore these commits while comparing master
+  // and patch diffs to look for delta.
+  'build(docs-infra): upgrade cli command docs sources',
 ];
 
 // Helper methods
@@ -72,6 +76,11 @@ function collectCommitsAsMap(rawGitCommits) {
   return commitsMap;
 }
 
+/**
+ * Returns a list of items present in `mapA`, but *not* present in `mapB`.
+ * This function is needed to compare 2 sets of commits and return the list of unique commits in the
+ * first set.
+ */
 function diff(mapA, mapB) {
   const result = [];
   mapA.forEach((value, key) => {

--- a/scripts/compare-master-to-stable.js
+++ b/scripts/compare-master-to-stable.js
@@ -97,15 +97,17 @@ function getLatestTag(tags) {
 
 // Main program
 
+execGitCommand('git fetch upstream');
+
 const tags = getAsArray('git tag');
 const latestTag = getLatestTag(tags);
 
 const branch = getBranchByTag(latestTag);
 
 const masterCommits =
-    getAsArray(`git log --cherry-pick --oneline --right-only ${branch}...upstream/master`);
+    getAsArray(`git log --cherry-pick --oneline --right-only upstream/${branch}...upstream/master`);
 const patchCommits =
-    getAsArray(`git log --cherry-pick --oneline --left-only ${branch}...upstream/master`);
+    getAsArray(`git log --cherry-pick --oneline --left-only upstream/${branch}...upstream/master`);
 
 const masterMap = toMap(masterCommits);
 const patchMap = toMap(patchCommits);

--- a/scripts/compare-master-to-stable.js
+++ b/scripts/compare-master-to-stable.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+'use strict';
+
+/**
+ * This script compares commits in master and patch branches to find the delta between them. This is
+ * useful for release reviews, to make sure all the necessary commits were included into the patch
+ * branch and there is no discrepancy.
+ *
+ * For RC period, the following ranges are compared: `9.0.0-rc.0...master` and `9.0.0-rc.0...9.0.x`.
+ * For regular patch versions, we compare  `9.1.0...master` and `9.1.0...9.1.x`
+ */
+
+const shell = require('shelljs');
+const semver = require('semver');
+
+// Ignore commits that have specific patterns in commit message, it's ok for these commits to be
+// present only in one branch. Ignoring them reduced the "noise" in the final output.
+const ignorePatterns = [
+  'release:',
+  'docs:',
+  'build(docs-infra): upgrade cli command docs',
+];
+
+// Helper methods
+
+function execGitCommand(gitCommand) {
+  const output = shell.exec(gitCommand, {silent: true});
+  if (output.code !== 0) {
+    console.error(`Error: git command "${gitCommand}" failed: \n\n ${output.stderr}`);
+    process.exit(1);
+  }
+  return output;
+}
+
+function getAsArray(gitCommand) {
+  return execGitCommand(gitCommand).split('\n');
+}
+
+function maybeExtractReleaseVersion(commit) {
+  const versionRegex = /release: cut the (.*?) release|docs: release notes for the (.*?) release/;
+  const matches = commit.match(versionRegex);
+  return matches ? matches[1] || matches[2] : null;
+}
+
+function toMap(input) {
+  let version = 'initial';
+  const data = [];
+  input.reverse().forEach((item) => {
+    const skip = ignorePatterns.some(pattern => item.indexOf(pattern) > -1);
+    // Keep track of the current version while going though the list of commits, so that we can use
+    // this information in the output (i.e. display a version when a commit was introduced).
+    version = maybeExtractReleaseVersion(item) || version;
+    if (!skip) {
+      // Extract original commit description from commit message, so that we can find matching
+      // commit in other commit range. For example, for the following commit message:
+      //
+      //   15d3e741e9 feat: update the locale files (#33556)
+      //
+      // we extract only "feat: update the locale files" part and use it as a key, since commit SHA
+      // and PR number may be different for the same commit in master and patch branches.
+      const key = item.slice(11).replace(/\(\#\d+\)/g, '').trim();
+      data.push([key, [item, version]]);
+    }
+  });
+  return new Map(data);
+}
+
+function diff(mapA, mapB) {
+  const result = [];
+  mapA.forEach((value, key) => {
+    if (!mapB.has(key)) {
+      result.push(`[${value[1]}] ${value[0]}`);
+    }
+  });
+  return result;
+}
+
+function calcRangeForVersion(raw) {
+  const isRC = raw.indexOf('rc') > -1;
+  const version = semver(raw);
+  const from = isRC ?                                //
+      raw.replace(/(\d+)$/, '0') :                   // e.g. 9.0.0-rc.15 -> 9.0.0-rc.0
+      `${version.major}.${version.minor}.0`;         // e.g. 9.1.5 -> 9.1.0
+  const to = `${version.major}.${version.minor}.x`;  // e.g. 9.0.x
+  return [from, to];
+}
+
+function getLatestTag(tags) {
+  return tags.filter(semver.valid).map(semver.clean).sort(semver.rcompare)[0];
+}
+
+// Main program
+
+const tags = getAsArray('git tag');
+const latestTag = getLatestTag(tags);
+
+const [from, to] = calcRangeForVersion(latestTag);
+
+const masterCommits = getAsArray(`git log --oneline ${from}...master`);
+const patchCommits = getAsArray(`git log --oneline ${from}...${to}`);
+
+const masterMap = toMap(masterCommits);
+const patchMap = toMap(patchCommits);
+
+console.log(`
+Comparing commits in ranges: (${from}...master) and (${from}...${to}).
+
+***** Only in MASTER *****
+${diff(masterMap, patchMap).join('\n') || 'No extra commits'}
+
+***** Only in PATCH (${to}) *****
+${diff(patchMap, masterMap).join('\n') || 'No extra commits'}
+`);

--- a/scripts/compare-master-to-stable.js
+++ b/scripts/compare-master-to-stable.js
@@ -31,6 +31,9 @@ const ignorePatterns = [
   'build(docs-infra): upgrade cli command docs sources',
 ];
 
+// Limit the log history to start from v9.0.0 release date.
+const after = '--after="2020-02-05"';
+
 // Helper methods
 
 function execGitCommand(gitCommand) {
@@ -119,9 +122,9 @@ function main() {
 
   // Extract master-only and patch-only commits using `git log` command.
   const masterCommits = execGitCommand(
-      `git log --cherry-pick --oneline --right-only upstream/${branch}...upstream/master`);
+      `git log --cherry-pick --oneline --right-only ${after} upstream/${branch}...upstream/master`);
   const patchCommits = execGitCommand(
-      `git log --cherry-pick --oneline --left-only upstream/${branch}...upstream/master`);
+      `git log --cherry-pick --oneline --left-only ${after} upstream/${branch}...upstream/master`);
 
   // Post-process commits and convert raw data into a Map, so that we can diff it easier.
   const masterCommitsMap = collectCommitsAsMap(masterCommits);

--- a/scripts/compare-master-to-stable.js
+++ b/scripts/compare-master-to-stable.js
@@ -127,6 +127,7 @@ function main() {
   const masterCommitsMap = collectCommitsAsMap(masterCommits);
   const patchCommitsMap = collectCommitsAsMap(patchCommits);
 
+  // tslint:disable-next-line:no-console
   console.log(`
 Comparing branches "${branch}" and master.
 


### PR DESCRIPTION
Adding a script that compares commits in master and patch branches and finds a delta between them. This is useful for release reviews, to make sure all the necessary commits are included into the patch branch and there is no discrepancy.

This script was inspired by the [compare-master-to-stable.js](https://github.com/angular/angular.js/blob/master/scripts/compare-master-to-stable.js) one that was used in AngularJS.


## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: a tool to compare commits in master and stable branches


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No