### PR TITLE
fix(ivy): host-styling throws assert exception inside *ngFor

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -834,8 +834,18 @@ function findStylingValue(
     const containsStatics = Array.isArray(rawKey);
     // Unwrap the key if we contain static values.
     const key = containsStatics ? (rawKey as string[])[1] : rawKey;
-    let currentValue = key === null ? keyValueArrayGet(lView[index + 1], prop) :
-                                      key === prop ? lView[index + 1] : undefined;
+    let valueAtLViewIndex = lView[index + 1];
+    if (valueAtLViewIndex === NO_CHANGE) {
+      // In firstUpdatePass the styling instructions create a linked list of styling.
+      // On subsequent passes it is possible for a styling instruction try to read a binding which
+      // has not yet executed. In that case we will find `NO_CHANGE` and we should assume that
+      // we have `undefined` (or empty array in case of styling-map instruction) instead. This
+      // allows the resolution to apply the value (which may later be overwritten when the
+      // binding actually executes.)
+      valueAtLViewIndex = key === null ? EMPTY_ARRAY : undefined;
+    }
+    let currentValue = key === null ? keyValueArrayGet(valueAtLViewIndex, prop) :
+                                      key === prop ? valueAtLViewIndex : undefined;
     if (containsStatics && !isStylingValuePresent(currentValue)) {
       currentValue = keyValueArrayGet(rawKey as KeyValueArray<any>, prop);
     }

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -834,17 +834,19 @@ function findStylingValue(
     const containsStatics = Array.isArray(rawKey);
     // Unwrap the key if we contain static values.
     const key = containsStatics ? (rawKey as string[])[1] : rawKey;
+    const isStylingMap = key === null;
     let valueAtLViewIndex = lView[index + 1];
     if (valueAtLViewIndex === NO_CHANGE) {
       // In firstUpdatePass the styling instructions create a linked list of styling.
-      // On subsequent passes it is possible for a styling instruction try to read a binding which
+      // On subsequent passes it is possible for a styling instruction to try to read a binding
+      // which
       // has not yet executed. In that case we will find `NO_CHANGE` and we should assume that
       // we have `undefined` (or empty array in case of styling-map instruction) instead. This
       // allows the resolution to apply the value (which may later be overwritten when the
       // binding actually executes.)
-      valueAtLViewIndex = key === null ? EMPTY_ARRAY : undefined;
+      valueAtLViewIndex = isStylingMap ? EMPTY_ARRAY : undefined;
     }
-    let currentValue = key === null ? keyValueArrayGet(valueAtLViewIndex, prop) :
+    let currentValue = isStylingMap ? keyValueArrayGet(valueAtLViewIndex, prop) :
                                       key === prop ? valueAtLViewIndex : undefined;
     if (containsStatics && !isStylingValuePresent(currentValue)) {
       currentValue = keyValueArrayGet(rawKey as KeyValueArray<any>, prop);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3300,21 +3300,23 @@ describe('styling', () => {
 
           @Component({template: `<my-cmp *ngFor="let i of [1,2]" host-styling></my-cmp>`})
           class MyApp {
-            // On first pass of `ngFor` everything works.
-            // On second pass the styling has already created the data structures. As a result when
+            // When the first view in the list gets CD-ed, everything works.
+            // When the second view gets CD-ed, the styling has already created the data structures
+            // in the `TView`. As a result when
             // `[class.foo]` runs it already knows that `[class]` is a duplicate and hence it
             // should check with it. While the resolution is happening it reads the value of the
             // `[class]`, however `[class]` has not yet executed and therefore it does not have
-            // normalized value. The result is that the assertions fails as it expects an
+            // normalized value in its `LView`. The result is that the assertions fails as it
+            // expects an
             // `KeyValueArray`.
           }
 
           TestBed.configureTestingModule({declarations: [MyApp, MyCmp, HostStylingsDir]});
           const fixture = TestBed.createComponent(MyApp);
-          fixture.detectChanges();
           expect(() => fixture.detectChanges()).not.toThrow();
           const [cmp1, cmp2] = fixture.nativeElement.querySelectorAll('my-cmp');
-          expect(cmp1.outerHTML).toEqual(cmp2.outerHTML);
+          expectClass(cmp1).toEqual({foo: true, bar: true});
+          expectClass(cmp2).toEqual({foo: true, bar: true});
         });
   });
 });

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -48,6 +48,9 @@
     "name": "EMPTY_ARRAY"
   },
   {
+    "name": "EMPTY_ARRAY"
+  },
+  {
     "name": "EMPTY_OBJ"
   },
   {


### PR DESCRIPTION
Inside `*ngFor` the second run of the styling instructions can get into situation where it tries to read a value from a binding which has not yet executed. As a result the read is `NO_CHANGE` value and subsequent property read cause an exception as it is of wrong type.

Fix #35118

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
