### PR TITLE
fix(docs-infra): fix parameters with @Optional() decorator do not match declared, optional type

### DIFF
--- a/aio/content/examples/dependency-injection-in-action/src/app/hero-contact.component.ts
+++ b/aio/content/examples/dependency-injection-in-action/src/app/hero-contact.component.ts
@@ -23,7 +23,7 @@ export class HeroContactComponent {
 
       @Host()     // limit search for logger; hides the application-wide logger
       @Optional() // ok if the logger doesn't exist
-      private loggerService: LoggerService
+      private loggerService?: LoggerService
   // #enddocregion ctor-params
   ) {
     if (loggerService) {

--- a/aio/content/examples/dependency-injection-in-action/src/app/parent-finder.component.ts
+++ b/aio/content/examples/dependency-injection-in-action/src/app/parent-finder.component.ts
@@ -52,7 +52,7 @@ const templateC = `
 export class CarolComponent {
   name = 'Carol';
   // #docregion carol-ctor
-  constructor( @Optional() public parent: Parent ) { }
+  constructor( @Optional() public parent?: Parent ) { }
   // #enddocregion carol-ctor
 }
 // #enddocregion carol-class
@@ -64,7 +64,7 @@ export class CarolComponent {
 })
 export class ChrisComponent {
   name = 'Chris';
-  constructor( @Optional() public parent: Parent ) { }
+  constructor( @Optional() public parent?: Parent ) { }
 }
 
 //////  Craig ///////////
@@ -81,7 +81,7 @@ export class ChrisComponent {
   </div>`
 })
 export class CraigComponent {
-  constructor( @Optional() public alex: Base ) { }
+  constructor( @Optional() public alex?: Base ) { }
 }
 // #enddocregion craig
 
@@ -105,7 +105,7 @@ const templateB = `
 export class BarryComponent implements Parent {
   name = 'Barry';
 // #docregion barry-ctor
-  constructor( @SkipSelf() @Optional() public parent: Parent ) { }
+  constructor( @SkipSelf() @Optional() public parent?: Parent ) { }
 // #enddocregion barry-ctor
 }
 // #enddocregion barry
@@ -117,7 +117,7 @@ export class BarryComponent implements Parent {
 })
 export class BobComponent implements Parent {
   name = 'Bob';
-  constructor( @SkipSelf() @Optional() public parent: Parent ) { }
+  constructor( @SkipSelf() @Optional() public parent?: Parent ) { }
 }
 
 @Component({
@@ -129,7 +129,7 @@ export class BobComponent implements Parent {
 })
 export class BethComponent implements Parent {
   name = 'Beth';
-  constructor( @SkipSelf() @Optional() public parent: Parent ) { }
+  constructor( @SkipSelf() @Optional() public parent?: Parent ) { }
 }
 
 ///////// A - Grandparent //////
@@ -200,7 +200,7 @@ export class AliceComponent implements Parent
   </div>`
 })
 export class CathyComponent {
-  constructor( @Optional() public alex: AlexComponent ) { }
+  constructor( @Optional() public alex?: AlexComponent ) { }
 }
 // #enddocregion cathy
 

--- a/aio/content/examples/dependency-injection/src/app/providers.component.ts
+++ b/aio/content/examples/dependency-injection/src/app/providers.component.ts
@@ -247,7 +247,7 @@ let some_message = 'Hello from the injected logger';
 export class Provider10Component implements OnInit {
   log: string;
   // #docregion provider-10-ctor
-  constructor(@Optional() private logger: Logger) {
+  constructor(@Optional() private logger?: Logger) {
     if (this.logger) {
       this.logger.log(some_message);
     }

--- a/aio/content/examples/ngmodules/src/app/greeting/greeting.module.ts
+++ b/aio/content/examples/ngmodules/src/app/greeting/greeting.module.ts
@@ -14,7 +14,7 @@ import { UserServiceConfig } from './user.service';
 })
 export class GreetingModule {
   // #docregion ctor
-  constructor (@Optional() @SkipSelf() parentModule: GreetingModule) {
+  constructor (@Optional() @SkipSelf() parentModule?: GreetingModule) {
     if (parentModule) {
       throw new Error(
         'GreetingModule is already loaded. Import it in the AppModule only');

--- a/aio/content/examples/ngmodules/src/app/greeting/user.service.ts
+++ b/aio/content/examples/ngmodules/src/app/greeting/user.service.ts
@@ -15,7 +15,7 @@ export class UserService {
   private _userName = 'Sherlock Holmes';
 
   // #docregion ctor
-  constructor(@Optional() config: UserServiceConfig) {
+  constructor(@Optional() config?: UserServiceConfig) {
     if (config) { this._userName = config.userName; }
   }
   // #enddocregion ctor

--- a/aio/content/examples/providers-viewproviders/src/app/child/child.component.ts
+++ b/aio/content/examples/providers-viewproviders/src/app/child/child.component.ts
@@ -24,7 +24,7 @@ export class ChildComponent {
   // inspector is in the content.
 
 
-  // constructor( public flower: FlowerService, @Optional() @Host()  public animal: AnimalService) { }
+  // constructor( public flower: FlowerService, @Optional() @Host()  public animal?: AnimalService) { }
 
 // Comment out the above constructor and alternately
 // uncomment the two following constructors to see the
@@ -32,11 +32,11 @@ export class ChildComponent {
 
 // constructor(
 //     @Host() public animal : AnimalService,
-//     @Host() @Optional() public flower : FlowerService) { }
+//     @Host() @Optional() public flower ?: FlowerService) { }
 
 // constructor(
 //     @SkipSelf() @Host() public animal : AnimalService,
-//     @SkipSelf() @Host() @Optional() public flower : FlowerService) { }
+//     @SkipSelf() @Host() @Optional() public flower ?: FlowerService) { }
 
 // #docregion provide-animal-service
 }

--- a/aio/content/examples/resolution-modifiers/src/app/host/host.component.ts
+++ b/aio/content/examples/resolution-modifiers/src/app/host/host.component.ts
@@ -11,7 +11,7 @@ import { FlowerService } from '../flower.service';
 })
 export class HostComponent {
   // use @Host() in the constructor when injecting the service
-  constructor(@Host() @Optional() public flower: FlowerService) { }
+  constructor(@Host() @Optional() public flower?: FlowerService) { }
 
 }
 // #enddocregion host-component

--- a/aio/content/examples/resolution-modifiers/src/app/optional/optional.component.ts
+++ b/aio/content/examples/resolution-modifiers/src/app/optional/optional.component.ts
@@ -9,7 +9,7 @@ import { OptionalService } from '../optional.service';
 
 // #docregion optional-component
 export class OptionalComponent {
-  constructor(@Optional() public optional: OptionalService) {}
+  constructor(@Optional() public optional?: OptionalService) {}
 }
 // #enddocregion optional-component
 

--- a/aio/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.ts
+++ b/aio/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.ts
@@ -8,7 +8,7 @@ import { LeafService } from '../leaf.service';
   styleUrls: ['./self-no-data.component.css']
 })
 export class SelfNoDataComponent {
-  constructor(@Self() @Optional() public leaf: LeafService) { }
+  constructor(@Self() @Optional() public leaf?: LeafService) { }
 }
 
 // #enddocregion self-no-data-component

--- a/aio/content/examples/styleguide/src/04-12/app/core/core.module.ts
+++ b/aio/content/examples/styleguide/src/04-12/app/core/core.module.ts
@@ -15,7 +15,7 @@ import { throwIfAlreadyLoaded } from './module-import-guard';
   providers: [LoggerService]
 })
 export class CoreModule {
-  constructor( @Optional() @SkipSelf() parentModule: CoreModule) {
+  constructor( @Optional() @SkipSelf() parentModule?: CoreModule) {
     throwIfAlreadyLoaded(parentModule, 'CoreModule');
   }
 }

--- a/aio/content/examples/testing/src/app/demo/demo.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.ts
@@ -248,7 +248,7 @@ export class TestViewProvidersComponent {
 export class ExternalTemplateComponent implements OnInit {
   serviceValue: string;
 
-  constructor(@Optional() private service: ValueService) {  }
+  constructor(@Optional() private service?: ValueService) {  }
 
   ngOnInit() {
     if (this.service) { this.serviceValue = this.service.getValue(); }

--- a/aio/content/examples/universal/src/app/hero.service.ts
+++ b/aio/content/examples/universal/src/app/hero.service.ts
@@ -21,7 +21,7 @@ export class HeroService {
   constructor(
     private http: HttpClient,
     private messageService: MessageService,
-    @Optional() @Inject(APP_BASE_HREF) origin: string) {
+    @Optional() @Inject(APP_BASE_HREF) origin?: string) {
       this.heroesUrl = `${origin}${this.heroesUrl}`;
     }
   // #enddocregion ctor

--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -320,7 +320,7 @@ Use `@SkipSelf()` with `@Optional()` to prevent an error if the value is `null`.
 
 ``` ts
 class Person {
-  constructor(@Optional() @SkipSelf() parent: Person) {}
+  constructor(@Optional() @SkipSelf() parent?: Person) {}
 }
 ```
 

--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -214,7 +214,7 @@ import {REQUEST} from '@nguniversal/express-engine/tokens';
 @Injectable()
 export class UniversalInterceptor implements HttpInterceptor {
 
-  constructor(@Optional() @Inject(REQUEST) protected request: Request) {}
+  constructor(@Optional() @Inject(REQUEST) protected request?: Request) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler) {
     let serverReq: HttpRequest<any> = req;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Documentation content changes

## What is the current behavior?
Parameters with `@Optional()` decorator do not match declared, optional type

## What is the new behavior?
Parameters with `@Optional()` decorator do match declared, optional type

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Angular should keep typescript compatibility, which is broken in this case.