### PR TITLE
fix(bazel): devserver shows blank page in Windows

### DIFF
--- a/packages/bazel/src/builders/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/builders/files/src/BUILD.bazel.template
@@ -116,7 +116,7 @@ filegroup(
 
 ts_devserver(
     name = "devserver",
-    additional_root_paths = ["src/_"],
+    additional_root_paths = ["project/src/_"],
     port = 4200,
     entry_module = "project/src/main.dev",
     serving_path = "/bundle.min.js",


### PR DESCRIPTION
`additional_root_paths`  should contain the workspace name see: https://github.com/bazelbuild/rules_nodejs/blob/d4200191c5fb84f395311840d8f90d3715e9f751/packages/typescript/src/internal/devserver/ts_devserver.bzl#L137-L140

Fixes #35144
