### PR TITLE
fix(bazel): spawn prod server using port 4200

### DIFF
--- a/packages/bazel/src/builders/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/builders/files/src/BUILD.bazel.template
@@ -102,6 +102,10 @@ pkg_web(
 history_server(
     name = "prodserver",
     data = [":prodapp"],
+    args = [
+        "--port",
+        "4200",
+    ],
     templated_args = ["src/prodapp"],
 )
 


### PR DESCRIPTION
Currently the prod server uses a default port of 8080, with this change we align the port with the devserver.

Reference TOOL-989