### PR TITLE
docs: added description about optional 'novalidate' attribute.

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -79,6 +79,15 @@ const resolvedPromise = (() => Promise.resolve(null))();
  *
  * {@example forms/ts/simpleForm/simple_form_example.ts region='Component'}
  *
+ * Since version 4, Angular automatically adds the `novalidate` attribute on any `<form>` whenever
+ * the `FormModule` or the `ReactiveFormModule` is imported. Therefore you can omit it in your code.
+ * If you want to use explicitly native validation with Angular forms, you can add the
+ * `ngNativeValidate` attribute to the form.
+ *
+ * ```html
+ * <form ngNativeValidate></form>
+ * ```
+ *
  * ### Setting the update options
  *
  * The following example shows you how to change the "updateOn" option from its default using

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -81,7 +81,7 @@ const resolvedPromise = (() => Promise.resolve(null))();
  *
  * Since version 4, Angular automatically adds the `novalidate` attribute on any `<form>` whenever
  * the `FormModule` or the `ReactiveFormModule` is imported. Therefore you can omit it in your code.
- * If you want to use explicitly native validation with Angular forms, you can add the
+ * If you want to use explicitly the native validation with Angular forms, you can add the
  * `ngNativeValidate` attribute to the form.
  *
  * ```html


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The [NgForm](https://angular.io/api/forms/NgForm#description) directive docs still have a code example using the `novalidate` attribute.
As many blogs and article online still use it in their examples, it would bring more clarity to explicitly  describe that `novalidate` is now added automatically by Angular, instead of simply removing it from the code sample. 

Issue Number: N/A


## What is the new behavior?
A description is added to inform that `novalidate` attribute can now be omitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
