### PR TITLE
ci: ensure saucelabs browsers can load karma test page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,27 @@ commands:
             git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
             git config --global gc.auto 0 || true
 
+  init_saucelabs_environment:
+    description: Sets up a domain that resolves to the local host.
+    steps:
+      - run:
+          name: Preparing environment for running tests on Saucelabs.
+          command: |
+            # For SauceLabs jobs, we set up a domain which resolves to the machine which launched
+            # the tunnel. We do this because devices are sometimes not able to properly resolve
+            # `localhost` or `127.0.0.1` through the SauceLabs tunnel. Using a domain that does not
+            # resolve to anything on SauceLabs VMs ensures that such requests are always resolved
+            # through the tunnel, and resolve to the actual tunnel host machine (i.e. the CircleCI VM).
+            # More context can be found in: https://github.com/angular/angular/pull/35171.
+            setPublicVar SAUCE_LOCALHOST_ALIAS_DOMAIN "angular-ci.local"
+            setSecretVar SAUCE_ACCESS_KEY $(echo $SAUCE_ACCESS_KEY | rev)
+      - run:
+          # Sets up a local domain in the machine's host file that resolves to the local
+          # host. This domain is helpful in Saucelabs tests where devices are not able to
+          # properly resolve `localhost` or `127.0.0.1` through the sauce-connect tunnel.
+          name: Setting up alias domain for local host.
+          command: echo "127.0.0.1 $SAUCE_LOCALHOST_ALIAS_DOMAIN" | sudo tee -a /etc/hosts
+
   # Normally this would be an individual job instead of a command.
   # But startup and setup time for each invidual windows job are high enough to discourage
   # many small jobs, so instead we use a command for setup unless the gain becomes significant.
@@ -313,9 +334,7 @@ jobs:
     steps:
       - custom_attach_workspace
       - init_environment
-      - run:
-          name: Preparing environment for running tests on Saucelabs.
-          command: setSecretVar SAUCE_ACCESS_KEY $(echo $SAUCE_ACCESS_KEY | rev)
+      - init_saucelabs_environment
       - run:
           name: Run Bazel tests on Saucelabs
           # See /tools/saucelabs/README.md for more info
@@ -337,9 +356,7 @@ jobs:
     steps:
       - custom_attach_workspace
       - init_environment
-      - run:
-          name: Preparing environment for running tests on Saucelabs.
-          command: setSecretVar SAUCE_ACCESS_KEY $(echo $SAUCE_ACCESS_KEY | rev)
+      - init_saucelabs_environment
       - run:
           name: Run Bazel tests on Saucelabs
           # See /tools/saucelabs/README.md for more info
@@ -659,11 +676,7 @@ jobs:
     steps:
       - custom_attach_workspace
       - init_environment
-      - run:
-          name: Preparing environment for running tests on Saucelabs.
-          command: |
-            setPublicVar KARMA_JS_BROWSERS $(node -e 'console.log(require("./browser-providers.conf").sauceAliases.CI_REQUIRED.join(","))')
-            setSecretVar SAUCE_ACCESS_KEY $(echo $SAUCE_ACCESS_KEY | rev)
+      - init_saucelabs_environment
       - run:
           name: Starting Saucelabs tunnel service
           command: ./tools/saucelabs/sauce-service.sh run
@@ -675,7 +688,11 @@ jobs:
           # Waiting on ready ensures that we don't run tests too early without Saucelabs not being ready.
           name: Waiting for Saucelabs tunnel to connect
           command: ./tools/saucelabs/sauce-service.sh ready-wait
-      - run: yarn karma start ./karma-js.conf.js --single-run --browsers=${KARMA_JS_BROWSERS}
+      - run:
+          name: Running tests on Saucelabs.
+          command: |
+            browsers=$(node -e 'console.log(require("./browser-providers.conf").sauceAliases.CI_REQUIRED.join(","))')
+            yarn karma start ./karma-js.conf.js --single-run --browsers=${browsers}
       - run:
           name: Stop Saucelabs tunnel service
           command: ./tools/saucelabs/sauce-service.sh stop

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -65,6 +65,7 @@ setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-framework-${CIRCLE_BUILD_NUM}-${CI
 # acquire CircleCI instances for too long if sauceconnect failed, we need a connect timeout.
 setPublicVar SAUCE_READY_FILE_TIMEOUT 120
 
+
 ####################################################################################################
 # Define environment variables for the `angular/components` repo unit tests job.
 ####################################################################################################

--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -30,10 +30,7 @@ var CIconfiguration = {
   'Android4.4': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Android5': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Android6': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  // Temporary disabled due to SauceLab timeout.
-  // https://angular-team.atlassian.net/browse/FW-1821
-  // 'Android7': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'Android7': {unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
+  'Android7': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Safari7': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari8': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari9': {unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -167,6 +167,16 @@ module.exports = function(config) {
     conf.browserStack.tunnelIdentifier = tunnelIdentifier;
   }
 
+  // For SauceLabs jobs, we set up a domain which resolves to the machine which launched
+  // the tunnel. We do this because devices are sometimes not able to properly resolve
+  // `localhost` or `127.0.0.1` through the SauceLabs tunnel. Using a domain that does not
+  // resolve to anything on SauceLabs VMs ensures that such requests are always resolved through
+  // the tunnel, and resolve to the actual tunnel host machine (commonly the CircleCI VMs).
+  // More context can be found in: https://github.com/angular/angular/pull/35171.
+  if (process.env.SAUCE_LOCALHOST_ALIAS_DOMAIN) {
+    conf.hostname = process.env.SAUCE_LOCALHOST_ALIAS_DOMAIN;
+  }
+
   if (process.env.KARMA_WEB_TEST_MODE) {
     // KARMA_WEB_TEST_MODE is used to setup karma to run in
     // SauceLabs or Browserstack

--- a/tools/saucelabs/karma-saucelabs.js
+++ b/tools/saucelabs/karma-saucelabs.js
@@ -21,22 +21,18 @@ try {
   // KARMA_WEB_TEST_MODE is set which informs /karma-js.conf.js that it should
   // run the test with the karma saucelabs launcher
   process.env['KARMA_WEB_TEST_MODE'] = 'SL_REQUIRED';
+  // Saucelabs parameters read from a temporary file that is created by the `sauce-service`. This
+  // will be `null` if the test runs locally without the `sauce-service` being started.
+  const saucelabsParams = readLocalSauceConnectParams();
   // Setup required SAUCE_* env if they are not already set
   if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY'] ||
       !process.env['SAUCE_TUNNEL_IDENTIFIER']) {
-    try {
-      // The following path comes from /tools/saucelabs/sauce-service.sh.
-      // We setup the required saucelabs environment variables here for the karma test
-      // from a json file under /tmp/angular/sauce-service  so that we don't break the
-      // test cache with a changing SAUCE_TUNNEL_IDENTIFIER provided through --test_env
-      const scParams = require('/tmp/angular/sauce-service/sauce-connect-params.json');
-      process.env['SAUCE_USERNAME'] = scParams.SAUCE_USERNAME;
-      process.env['SAUCE_ACCESS_KEY'] = scParams.SAUCE_ACCESS_KEY;
-      process.env['SAUCE_TUNNEL_IDENTIFIER'] = scParams.SAUCE_TUNNEL_IDENTIFIER;
-    } catch (e) {
-      console.error(e.stack || e);
-      console.error(
-          `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // We print a helpful error message below if the required Saucelabs parameters have not
+    // been specified in test environment, and the `sauce-service` params file has not been
+    // created either.
+    if (saucelabsParams === null) {
+      console.error(`
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Make sure that you have run "yarn bazel run //tools/saucelabs:sauce_service_setup"
 !!! (or "./tools/saucelabs/sauce-service.sh setup") before the test target. Alternately
 !!! you can provide the required SAUCE_* environment variables (SAUCE_USERNAME, SAUCE_ACCESS_KEY &
@@ -45,6 +41,16 @@ try {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
       process.exit(1);
     }
+    process.env['SAUCE_USERNAME'] = saucelabsParams.SAUCE_USERNAME;
+    process.env['SAUCE_ACCESS_KEY'] = saucelabsParams.SAUCE_ACCESS_KEY;
+    process.env['SAUCE_TUNNEL_IDENTIFIER'] = saucelabsParams.SAUCE_TUNNEL_IDENTIFIER;
+    process.env['SAUCE_LOCALHOST_ALIAS_DOMAIN'] = saucelabsParams.SAUCE_LOCALHOST_ALIAS_DOMAIN;
+  }
+
+  // Pass through the optional `SAUCE_LOCALHOST_ALIAS_DOMAIN` environment variable. The
+  // variable is usually specified on CI, but is not required for testing with Saucelabs.
+  if (!process.env['SAUCE_LOCALHOST_ALIAS_DOMAIN'] && saucelabsParams !== null) {
+    process.env['SAUCE_LOCALHOST_ALIAS_DOMAIN'] = saucelabsParams.SAUCE_LOCALHOST_ALIAS_DOMAIN;
   }
 
   const scStart = `${sauceService} start-ready-wait`;
@@ -59,4 +65,16 @@ try {
 } catch (e) {
   console.error(e.stack || e);
   process.exit(1);
+}
+
+function readLocalSauceConnectParams() {
+  try {
+    // The following path comes from /tools/saucelabs/sauce-service.sh.
+    // We setup the required saucelabs environment variables here for the karma test
+    // from a json file under /tmp/angular/sauce-service  so that we don't break the
+    // test cache with a changing SAUCE_TUNNEL_IDENTIFIER provided through --test_env
+    return require('/tmp/angular/sauce-service/sauce-connect-params.json');
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
[Based on the Saucelabs docs](https://support.saucelabs.com/hc/en-us/articles/225106887-Safari-and-Internet-Explorer-Won-t-Load-Website-When-Using-Sauce-Connect-on-Localhost), Saucelabs runs a process that usually takes up all requests to `localhost` / `127.0.0.1` and forwards them through the tunnel. It looks like this process somehow stopped working for Saucelabs Android devices. I tried updating to Android 9 and 10, but the same issue surfaced.

In the past, we had similar issues and the issue magically got resolved after we opened up a support ticket. They mentioned that they had issues (no real details), and that everything should work again.

In general though, I think we could improve the stability of our tests by not relying on this Saucelabs process. Even though this issue doesn't surface too often, we had it a couple of times now, and identifying the issue / temporarily disabling tests slows down the overall productivity. Not mentioning the fact that all PRs are red..

I personally think it would be worth doing such a change, so that we don't need to worry about it in the future, don't need to spend resources investigating, and that we aren't dependent on the Saucelabs support to fix/investigate it. The impact of such outage seems to cause unnecessary slow-down for the caretaker, dev-infra (in terms of investigating) and the PR submitters (who need to rebase etc.). We can make this more stable long-term by adding an alias for `localhost` to the CircleCI hosts, and using that from within the Saucelabs browsers. These requests will always go through the tunnel (might be even faster that way). Similar solutions seem to be recommended by SauceLabs if specifically needed ports aren't forwarded by the Saucelabs VM process, so the solution seems somewhat proven.