### PR TITLE
docs: fix routing code to use `navigate`

### DIFF
--- a/aio/content/examples/router/src/app/auth/login/login.component.1.ts
+++ b/aio/content/examples/router/src/app/auth/login/login.component.1.ts
@@ -25,9 +25,9 @@ export class LoginComponent {
     this.authService.login().subscribe(() => {
       this.setMessage();
       if (this.authService.isLoggedIn) {
-        // Get the redirect URL from our auth service
-        // If no redirect has been set, use the default
-        const redirectUrl = this.authService.redirectUrl || '/admin';
+        // Usually you would use the redirect URL from the auth service.
+        // However to keep the example simple, we will always redirect to `/admin`.
+        const redirectUrl = '/admin';
 
         // Redirect the user
         this.router.navigate([redirectUrl]);

--- a/aio/content/examples/router/src/app/auth/login/login.component.1.ts
+++ b/aio/content/examples/router/src/app/auth/login/login.component.1.ts
@@ -1,6 +1,6 @@
 // #docregion
-import { Component }   from '@angular/core';
-import { Router }      from '@angular/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { AuthService } from '../auth.service';
 
 @Component({
@@ -27,10 +27,10 @@ export class LoginComponent {
       if (this.authService.isLoggedIn) {
         // Get the redirect URL from our auth service
         // If no redirect has been set, use the default
-        let redirect = this.authService.redirectUrl ? this.router.parseUrl(this.authService.redirectUrl) : '/admin';
+        const redirectUrl = this.authService.redirectUrl || '/admin';
 
         // Redirect the user
-        this.router.navigateByUrl(redirect);
+        this.router.navigate([redirectUrl]);
       }
     });
   }

--- a/aio/content/examples/router/src/app/auth/login/login.component.ts
+++ b/aio/content/examples/router/src/app/auth/login/login.component.ts
@@ -25,15 +25,9 @@ export class LoginComponent {
     this.authService.login().subscribe(() => {
       this.setMessage();
       if (this.authService.isLoggedIn) {
-        // Get the redirect URL from our auth service
-        // If no redirect has been set, use the default
-        let redirectUrl = this.authService.redirectUrl || '/admin';
-
-        // If the redirectUrl contains an aux outlet name /admin(popup:compose)
-        // Then get rid of that and just take the first part of the Url.
-        if (redirectUrl.indexOf('(') !== -1) {
-          redirectUrl = redirectUrl.split('(')[0];
-        }
+        // Usually you would use the redirect URL from the auth service.
+        // However to keep the example simple, we will always redirect to `/admin`.
+        const redirectUrl = '/admin';
 
         // #docregion preserve
         // Set our navigation extras object

--- a/aio/content/examples/router/src/app/auth/login/login.component.ts
+++ b/aio/content/examples/router/src/app/auth/login/login.component.ts
@@ -1,8 +1,7 @@
 // #docregion
-import { Component }        from '@angular/core';
-import { Router,
-         NavigationExtras } from '@angular/router';
-import { AuthService }      from '../auth.service';
+import { Component } from '@angular/core';
+import { NavigationExtras, Router } from '@angular/router';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
@@ -28,7 +27,13 @@ export class LoginComponent {
       if (this.authService.isLoggedIn) {
         // Get the redirect URL from our auth service
         // If no redirect has been set, use the default
-        let redirect = this.authService.redirectUrl ? this.router.parseUrl(this.authService.redirectUrl) : '/admin';
+        let redirectUrl = this.authService.redirectUrl || '/admin';
+
+        // If the redirectUrl contains an aux outlet name /admin(popup:compose)
+        // Then get rid of that and just take the first part of the Url.
+        if (redirectUrl.indexOf('(') !== -1) {
+          redirectUrl = redirectUrl.split('(')[0];
+        }
 
         // #docregion preserve
         // Set our navigation extras object
@@ -39,7 +44,7 @@ export class LoginComponent {
         };
 
         // Redirect the user
-        this.router.navigateByUrl(redirect, navigationExtras);
+        this.router.navigate([redirectUrl], navigationExtras);
         // #enddocregion preserve
       }
     });

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -3302,11 +3302,11 @@ Although it doesn't actually log in, it has what you need for this discussion.
 It has an `isLoggedIn` flag to tell you whether the user is authenticated.
 Its `login` method simulates an API call to an external service by returning an
 observable that resolves successfully after a short pause.
-The `redirectUrl` property will store the attempted URL so you could navigate to it after authenticating.
+The `redirectUrl` property stores the URL that the user wanted to access so you can navigate to it after authentication.
 
 <div class="alert is-helpful">
 
-To keep the stackblitz example simple, we will always redirect an un-authenticated user to `/admin`. 
+To keep things simple, this example redirects unauthenticated users to `/admin`. 
 
 </div>
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -3302,7 +3302,13 @@ Although it doesn't actually log in, it has what you need for this discussion.
 It has an `isLoggedIn` flag to tell you whether the user is authenticated.
 Its `login` method simulates an API call to an external service by returning an
 observable that resolves successfully after a short pause.
-The `redirectUrl` property will store the attempted URL so you can navigate to it after authenticating.
+The `redirectUrl` property will store the attempted URL so you could navigate to it after authenticating.
+
+<div class="alert is-helpful">
+
+To keep the stackblitz example simple, we will always redirect an un-authenticated user to `/admin`. 
+
+</div>
 
 Revise the `AuthGuard` to call it.
 


### PR DESCRIPTION
Previously, the example in the `router` guide was not
preserving the query params after logging in.

This commit fixes this by using `navigate` instead of
using `navigateByUrl`, which ignores any properties in
the `NavigationExtras` that would change the provided URL.

Fixes #34917

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34917


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


