### PR TITLE
refactor(router): Allow routerLinkWithHref directive to be extended

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -126,12 +126,12 @@ export class RouterLink {
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl !: boolean;
   @Input() state?: {[k: string]: any};
-  private commands: any[] = [];
+  protected commands: any[] = [];
   // TODO(issue/24571): remove '!'.
-  private preserve !: boolean;
+  protected preserve !: boolean;
 
   constructor(
-      private router: Router, private route: ActivatedRoute,
+      protected router: Router, protected route: ActivatedRoute,
       @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
     if (tabIndex == null) {
       renderer.setAttribute(el.nativeElement, 'tabindex', '0');
@@ -208,18 +208,18 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl !: boolean;
   @Input() state?: {[k: string]: any};
-  private commands: any[] = [];
-  private subscription: Subscription;
+  protected commands: any[] = [];
+  protected subscription: Subscription;
   // TODO(issue/24571): remove '!'.
-  private preserve !: boolean;
+  protected preserve !: boolean;
 
   // the url displayed on the anchor element.
   // TODO(issue/24571): remove '!'.
   @HostBinding() href !: string;
 
   constructor(
-      private router: Router, private route: ActivatedRoute,
-      private locationStrategy: LocationStrategy) {
+      protected router: Router, protected route: ActivatedRoute,
+      protected locationStrategy: LocationStrategy) {
     this.subscription = router.events.subscribe((s: Event) => {
       if (s instanceof NavigationEnd) {
         this.updateTargetUrlAndHref();
@@ -266,7 +266,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     return false;
   }
 
-  private updateTargetUrlAndHref(): void {
+  protected updateTargetUrlAndHref(): void {
     this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
This will allow anybody that wants to extend the routerLink directive to override or modify any of the properties. 

Issue Number: N/A


## What is the new behavior?
Right now I'm trying to create a new feature that detects if the routerLink contains an external URL and router takes another path because of that. I can't continue because all the important methods are private to prevent the extended class to override them.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
