### PR TITLE
fix(ngcc): correctly detect emitted TS helpers in ES5

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -11,7 +11,7 @@ import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
-import {FactoryMap, isDefined, stripExtension} from '../utils';
+import {FactoryMap, getTsHelperFnFromIdentifier, isDefined, stripExtension} from '../utils';
 
 import {ExportDeclaration, ExportStatement, ReexportStatement, RequireCall, findNamespaceOfIdentifier, findRequireCallReference, isExportStatement, isReexportStatement, isRequireCall} from './commonjs_umd_utils';
 import {Esm5ReflectionHost} from './esm5_host';
@@ -189,7 +189,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     }
 
     const viaModule = !importInfo.from.startsWith('.') ? importInfo.from : null;
-    return {node: importedFile, known: null, viaModule};
+    return {node: importedFile, known: getTsHelperFnFromIdentifier(id), viaModule};
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -47,7 +47,8 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
   }
 
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
-    return this.getCommonJsImportedDeclaration(id) || super.getDeclarationOfIdentifier(id);
+    return (!id.getSourceFile().isDeclarationFile && this.getCommonJsImportedDeclaration(id)) ||
+        super.getDeclarationOfIdentifier(id);
   }
 
   getExportsOfModule(module: ts.Node): Map<string, Declaration>|null {

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -274,8 +274,8 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
       |null {
     const superDeclaration = super.getDeclarationOfSymbol(symbol, originalId);
 
-    if ((superDeclaration !== null) && (superDeclaration.node !== null) &&
-        (superDeclaration.known === null)) {
+    if (superDeclaration !== null && superDeclaration.node !== null &&
+        superDeclaration.known === null) {
       superDeclaration.known = getTsHelperFnFromDeclaration(superDeclaration.node);
     }
 

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,8 +8,8 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, Parameter, TsHelperFn, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
-import {getNameText, hasNameIdentifier, stripDollarSuffix} from '../utils';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, Parameter, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {getNameText, getTsHelperFnFromDeclaration, hasNameIdentifier} from '../utils';
 
 import {Esm2015ReflectionHost, ParamInfo, getPropertyValueFromSymbol, isAssignment, isAssignmentStatement} from './esm2015_host';
 import {NgccClassSymbol} from './ngcc_host';
@@ -118,6 +118,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
     // Return the statement before the IIFE return statement
     return iifeBody.statements[returnStatementIndex - 1];
   }
+
   /**
    * In ES5, the implementation of a class is a function expression that is hidden inside an IIFE,
    * whose value is assigned to a variable (which represents the class to the rest of the program).
@@ -245,23 +246,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    */
   getDefinitionOfFunction(node: ts.Node): FunctionDefinition|null {
     if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
-        !ts.isFunctionExpression(node) && !ts.isVariableDeclaration(node)) {
-      return null;
-    }
-
-    const tsHelperFn = getTsHelperFn(node);
-    if (tsHelperFn !== null) {
-      return {
-        node,
-        body: null,
-        helper: tsHelperFn,
-        parameters: [],
-      };
-    }
-
-    // If the node was not identified to be a TypeScript helper, a variable declaration at this
-    // point cannot be resolved as a function.
-    if (ts.isVariableDeclaration(node)) {
+        !ts.isFunctionExpression(node)) {
       return null;
     }
 
@@ -276,11 +261,26 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
       return !lookingForParamInitializers;
     });
 
-    return {node, body: statements || null, helper: null, parameters};
+    return {node, body: statements || null, parameters};
   }
 
 
   ///////////// Protected Helpers /////////////
+  /**
+   * Resolve a `ts.Symbol` to its declaration and detect whether it corresponds with a known
+   * TypeScript helper function.
+   */
+  protected getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
+      |null {
+    const superDeclaration = super.getDeclarationOfSymbol(symbol, originalId);
+
+    if ((superDeclaration !== null) && (superDeclaration.node !== null) &&
+        (superDeclaration.known === null)) {
+      superDeclaration.known = getTsHelperFnFromDeclaration(superDeclaration.node);
+    }
+
+    return superDeclaration;
+  }
 
   /**
    * Get the inner function declaration of an ES5-style class.
@@ -643,28 +643,6 @@ function getReturnStatement(declaration: ts.Expression | undefined): ts.ReturnSt
 
 function reflectArrayElement(element: ts.Expression) {
   return ts.isObjectLiteralExpression(element) ? reflectObjectLiteral(element) : null;
-}
-
-/**
- * Inspects a function declaration to determine if it corresponds with a TypeScript helper function,
- * returning its kind if so or null if the declaration does not seem to correspond with such a
- * helper.
- */
-function getTsHelperFn(node: ts.NamedDeclaration): TsHelperFn|null {
-  const name = node.name !== undefined && ts.isIdentifier(node.name) ?
-      stripDollarSuffix(node.name.text) :
-      null;
-
-  switch (name) {
-    case '__assign':
-      return TsHelperFn.Assign;
-    case '__spread':
-      return TsHelperFn.Spread;
-    case '__spreadArrays':
-      return TsHelperFn.SpreadArrays;
-    default:
-      return null;
-  }
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/host/umd_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/umd_host.ts
@@ -12,7 +12,7 @@ import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
-import {FactoryMap, stripExtension} from '../utils';
+import {FactoryMap, getTsHelperFnFromIdentifier, stripExtension} from '../utils';
 import {ExportDeclaration, ExportStatement, ReexportStatement, findNamespaceOfIdentifier, findRequireCallReference, isExportStatement, isReexportStatement, isRequireCall} from './commonjs_umd_utils';
 import {Esm5ReflectionHost, stripParentheses} from './esm5_host';
 
@@ -215,7 +215,7 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
 
     // We need to add the `viaModule` because  the `getExportsOfModule()` call
     // did not know that we were importing the declaration.
-    return {node: importedFile, known: null, viaModule: importInfo.from};
+    return {node: importedFile, known: getTsHelperFnFromIdentifier(id), viaModule: importInfo.from};
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -7,6 +7,7 @@
  */
 import * as ts from 'typescript';
 import {AbsoluteFsPath, FileSystem, absoluteFrom} from '../../src/ngtsc/file_system';
+import {KnownDeclaration} from '../../src/ngtsc/reflection';
 
 /**
  * A list (`Array`) of partially ordered `T` items.
@@ -130,6 +131,40 @@ export function resolveFileWithPostfixes(
     }
   }
   return null;
+}
+
+/**
+ * Determine whether a function declaration corresponds with a TypeScript helper function, returning
+ * its kind if so or null if the declaration does not seem to correspond with such a helper.
+ */
+export function getTsHelperFnFromDeclaration(decl: ts.Declaration): KnownDeclaration|null {
+  if (!ts.isFunctionDeclaration(decl) && !ts.isVariableDeclaration(decl)) {
+    return null;
+  }
+
+  if ((decl.name === undefined) || !ts.isIdentifier(decl.name)) {
+    return null;
+  }
+
+  return getTsHelperFnFromIdentifier(decl.name);
+}
+
+/**
+ * Determine whether an identifier corresponds with a TypeScript helper function (based on its
+ * name), returning its kind if so or null if the identifier does not seem to correspond with such a
+ * helper.
+ */
+export function getTsHelperFnFromIdentifier(id: ts.Identifier): KnownDeclaration|null {
+  switch (stripDollarSuffix(id.text)) {
+    case '__assign':
+      return KnownDeclaration.TsHelperAssign;
+    case '__spread':
+      return KnownDeclaration.TsHelperSpread;
+    case '__spreadArrays':
+      return KnownDeclaration.TsHelperSpreadArrays;
+    default:
+      return null;
+  }
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -142,7 +142,7 @@ export function getTsHelperFnFromDeclaration(decl: ts.Declaration): KnownDeclara
     return null;
   }
 
-  if ((decl.name === undefined) || !ts.isIdentifier(decl.name)) {
+  if (decl.name === undefined || !ts.isIdentifier(decl.name)) {
     return null;
   }
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1665,7 +1665,7 @@ exports.ExternalModule = ExternalModule;
                 };
 
         const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
-          if ((decl.initializer !== undefined) && ts.isCallExpression(decl.initializer)) {
+          if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
             const expr = decl.initializer.expression;
             if (ts.isIdentifier(expr)) return expr;
             if (ts.isPropertyAccessExpression(expr)) return expr.name;

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, CtorParameter, InlineDeclaration, KnownDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
@@ -1777,6 +1777,206 @@ exports.ExternalModule = ExternalModule;
              expect(decl.viaModule).toEqual('sub_module');
              expect(decl.node).toBe(expectedDeclaration);
            });
+
+        it('should recognize TypeScript helpers (as function declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              function __assign(t, ...sources) { /* ... */ }
+              function __spread(...args) { /* ... */ }
+              function __spreadArrays(...args) { /* ... */ }
+
+              var a = __assign({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier =
+                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getDeclaration(
+                      bundle.program, file.name, helperName, ts.isFunctionDeclaration),
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
+
+        it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              function __assign$1(t, ...sources) { /* ... */ }
+              function __spread$2(...args) { /* ... */ }
+              function __spreadArrays$3(...args) { /* ... */ }
+
+              var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier =
+                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getDeclaration(
+                      bundle.program, file.name, helperName, ts.isFunctionDeclaration),
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
+
+        it('should recognize TypeScript helpers (as variable declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
+              var __spread = (this && this.__spread) || function (...args) { /* ... */ }
+              var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+
+              var a = __assign({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier =
+                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getDeclaration(
+                      bundle.program, file.name, helperName, ts.isVariableDeclaration),
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
+
+        it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              var __assign$1 = (this && this.__assign$1) || function (t, ...sources) { /* ... */ }
+              var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
+              var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
+
+              var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier =
+                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getDeclaration(
+                      bundle.program, file.name, helperName, ts.isVariableDeclaration),
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
+
+        it('should recognize imported TypeScript helpers', () => {
+          const files: TestFile[] = [
+            {
+              name: _('/test.js'),
+              contents: `
+                var tslib_1 = require('tslib');
+
+                var a = tslib_1.__assign({foo: 'bar'}, {baz: 'qux'});
+                var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
+                var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              `,
+            },
+            {
+              name: _('/node_modules/tslib/index.d.ts'),
+              contents: `
+                export declare function __assign(t: any, ...sources: any[]): any;
+                export declare function __spread(...args: any[][]): any[];
+                export declare function __spreadArrays(...args: any[][]): any[];
+              `,
+            },
+          ];
+          loadTestFiles(files);
+
+          const [testFile, tslibFile] = files;
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node = getDeclaration(
+                    bundle.program, testFile.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier = ((node.initializer as ts.CallExpression)
+                                              .expression as ts.PropertyAccessExpression)
+                                             .name;
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getSourceFileOrError(bundle.program, tslibFile.name),
+                  viaModule: 'tslib',
+                });
+              };
+
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
       });
 
       describe('getExportsOfModule()', () => {
@@ -1875,6 +2075,31 @@ exports.ExternalModule = ExternalModule;
           expect(decl).not.toBeUndefined();
           expect(decl.node).toBeNull();
           expect(decl.expression).toBeDefined();
+        });
+
+        it('should recognize declarations of known TypeScript helpers', () => {
+          const tslib = {
+            name: _('/tslib.d.ts'),
+            contents: `
+              export declare function __assign(t: any, ...sources: any[]): any;
+              export declare function __spread(...args: any[][]): any[];
+              export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __unknownHelper(...args: any[]): any;
+            `,
+          };
+          loadTestFiles([tslib]);
+          const bundle = makeTestBundleProgram(tslib.name);
+          const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const sf = getSourceFileOrError(bundle.program, tslib.name);
+          const exportDeclarations = host.getExportsOfModule(sf) !;
+
+          expect([...exportDeclarations].map(([exportName, {known}]) => [exportName, known]))
+              .toEqual([
+                ['__assign', KnownDeclaration.TsHelperAssign],
+                ['__spread', KnownDeclaration.TsHelperSpread],
+                ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+                ['__unknownHelper', null],
+              ]);
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1647,6 +1647,32 @@ exports.ExternalModule = ExternalModule;
       });
 
       describe('getDeclarationOfIdentifier', () => {
+        // Helpers
+        const createTestForTsHelper =
+            (program: ts.Program, host: CommonJsReflectionHost, srcFile: TestFile,
+             getHelperDeclaration: (name: string) => ts.Declaration) =>
+                (varName: string, helperName: string, knownAs: KnownDeclaration,
+                 viaModule: string | null = null) => {
+                  const node =
+                      getDeclaration(program, srcFile.name, varName, ts.isVariableDeclaration);
+                  const helperIdentifier = getIdentifierFromCallExpression(node);
+                  const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                  expect(helperDeclaration).toEqual({
+                    known: knownAs,
+                    node: getHelperDeclaration(helperName), viaModule,
+                  });
+                };
+
+        const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
+          if ((decl.initializer !== undefined) && ts.isCallExpression(decl.initializer)) {
+            const expr = decl.initializer.expression;
+            if (ts.isIdentifier(expr)) return expr;
+            if (ts.isPropertyAccessExpression(expr)) return expr.name;
+          }
+          throw new Error(`Unable to extract identifier from declaration '${decl.getText()}'.`);
+        };
+
         it('should return the declaration of a locally defined identifier', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
           const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
@@ -1795,21 +1821,10 @@ exports.ExternalModule = ExternalModule;
           const bundle = makeTestBundleProgram(file.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
-          const testForHelper =
-              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-                const node =
-                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-                const helperIdentifier =
-                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-                expect(helperDeclaration).toEqual({
-                  known: knownAs,
-                  node: getDeclaration(
-                      bundle.program, file.name, helperName, ts.isFunctionDeclaration),
-                  viaModule: null,
-                });
-              };
+          const testForHelper = createTestForTsHelper(
+              bundle.program, host, file,
+              helperName =>
+                  getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration));
 
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
@@ -1833,21 +1848,10 @@ exports.ExternalModule = ExternalModule;
           const bundle = makeTestBundleProgram(file.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
-          const testForHelper =
-              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-                const node =
-                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-                const helperIdentifier =
-                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-                expect(helperDeclaration).toEqual({
-                  known: knownAs,
-                  node: getDeclaration(
-                      bundle.program, file.name, helperName, ts.isFunctionDeclaration),
-                  viaModule: null,
-                });
-              };
+          const testForHelper = createTestForTsHelper(
+              bundle.program, host, file,
+              helperName =>
+                  getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration));
 
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
@@ -1871,21 +1875,10 @@ exports.ExternalModule = ExternalModule;
           const bundle = makeTestBundleProgram(file.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
-          const testForHelper =
-              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-                const node =
-                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-                const helperIdentifier =
-                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-                expect(helperDeclaration).toEqual({
-                  known: knownAs,
-                  node: getDeclaration(
-                      bundle.program, file.name, helperName, ts.isVariableDeclaration),
-                  viaModule: null,
-                });
-              };
+          const testForHelper = createTestForTsHelper(
+              bundle.program, host, file,
+              helperName =>
+                  getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration));
 
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
@@ -1909,21 +1902,10 @@ exports.ExternalModule = ExternalModule;
           const bundle = makeTestBundleProgram(file.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
 
-          const testForHelper =
-              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-                const node =
-                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-                const helperIdentifier =
-                    (node.initializer as ts.CallExpression).expression as ts.Identifier;
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-                expect(helperDeclaration).toEqual({
-                  known: knownAs,
-                  node: getDeclaration(
-                      bundle.program, file.name, helperName, ts.isVariableDeclaration),
-                  viaModule: null,
-                });
-              };
+          const testForHelper = createTestForTsHelper(
+              bundle.program, host, file,
+              helperName =>
+                  getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration));
 
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
@@ -1956,26 +1938,14 @@ exports.ExternalModule = ExternalModule;
           const [testFile, tslibFile] = files;
           const bundle = makeTestBundleProgram(testFile.name);
           const host = new CommonJsReflectionHost(new MockLogger(), false, bundle);
+          const tslibSourceFile = getSourceFileOrError(bundle.program, tslibFile.name);
 
           const testForHelper =
-              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-                const node = getDeclaration(
-                    bundle.program, testFile.name, varName, ts.isVariableDeclaration);
-                const helperIdentifier = ((node.initializer as ts.CallExpression)
-                                              .expression as ts.PropertyAccessExpression)
-                                             .name;
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+              createTestForTsHelper(bundle.program, host, testFile, () => tslibSourceFile);
 
-                expect(helperDeclaration).toEqual({
-                  known: knownAs,
-                  node: getSourceFileOrError(bundle.program, tslibFile.name),
-                  viaModule: 'tslib',
-                });
-              };
-
-          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, Decorator, Import, TsHelperFn, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, CtorParameter, Decorator, KnownDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
@@ -1676,224 +1676,6 @@ runInEachFileSystem(() => {
            expect(quxDef.parameters[0].name).toEqual('x');
            expect(quxDef.parameters[0].initializer).toBe(null);
          });
-
-      it('should recognize TypeScript __spread helper function declaration', () => {
-        const file: TestFile = {
-          name: _('/declaration.d.ts'),
-          contents: `export declare function __spread(...args: any[][]): any[];`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node =
-            getDeclaration(bundle.program, file.name, '__spread', isNamedFunctionDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.Spread);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __spread helper function implementation', () => {
-        const file: TestFile = {
-          name: _('/implementation.js'),
-          contents: `
-              var __spread = (this && this.__spread) || function () {
-                for (var ar = [], i = 0; i < arguments.length; i++) ar = ar.concat(__read(arguments[i]));
-                return ar;
-              };`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node =
-            getDeclaration(bundle.program, file.name, '__spread', ts.isVariableDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.Spread);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __spread helper function implementation when suffixed',
-         () => {
-           const file: TestFile = {
-             name: _('/implementation.js'),
-             contents: `
-              var __spread$2 = (this && this.__spread$2) || function () {
-                for (var ar = [], i = 0; i < arguments.length; i++) ar = ar.concat(__read(arguments[i]));
-                return ar;
-              };`,
-           };
-           loadTestFiles([file]);
-           const bundle = makeTestBundleProgram(file.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-           const node =
-               getDeclaration(bundle.program, file.name, '__spread$2', ts.isVariableDeclaration) !;
-
-           const definition = host.getDefinitionOfFunction(node) !;
-           expect(definition.node).toBe(node);
-           expect(definition.body).toBeNull();
-           expect(definition.helper).toBe(TsHelperFn.Spread);
-           expect(definition.parameters.length).toEqual(0);
-         });
-
-      it('should recognize TypeScript __spreadArrays helper function declaration', () => {
-        const file: TestFile = {
-          name: _('/declaration.d.ts'),
-          contents: `export declare function __spreadArrays(...args: any[][]): any[];`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node = getDeclaration(
-            bundle.program, file.name, '__spreadArrays', isNamedFunctionDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.SpreadArrays);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __spreadArrays helper function implementation', () => {
-        const file: TestFile = {
-          name: _('/implementation.js'),
-          contents: `
-                var __spreadArrays = (this && this.__spreadArrays) || function () {
-                  for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
-                  for (var r = Array(s), k = 0, i = 0; i < il; i++)
-                      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
-                          r[k] = a[j];
-                  return r;
-                };`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node =
-            getDeclaration(bundle.program, file.name, '__spreadArrays', ts.isVariableDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.SpreadArrays);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __spreadArrays helper function implementation when suffixed',
-         () => {
-           const file: TestFile = {
-             name: _('/implementation.js'),
-             contents: `
-                var __spreadArrays$2 = (this && this.__spreadArrays$2) || function () {
-                  for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
-                  for (var r = Array(s), k = 0, i = 0; i < il; i++)
-                      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
-                          r[k] = a[j];
-                  return r;
-                };`,
-           };
-           loadTestFiles([file]);
-           const bundle = makeTestBundleProgram(file.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-           const node = getDeclaration(
-               bundle.program, file.name, '__spreadArrays$2', ts.isVariableDeclaration) !;
-
-           const definition = host.getDefinitionOfFunction(node) !;
-           expect(definition.node).toBe(node);
-           expect(definition.body).toBeNull();
-           expect(definition.helper).toBe(TsHelperFn.SpreadArrays);
-           expect(definition.parameters.length).toEqual(0);
-         });
-
-      it('should recognize TypeScript __assign helper function declaration', () => {
-        const file: TestFile = {
-          name: _('/declaration.d.ts'),
-          contents: `export declare function __assign(...args: object[]): object;`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node =
-            getDeclaration(bundle.program, file.name, '__assign', isNamedFunctionDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.Assign);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __assign helper function implementation', () => {
-        const file: TestFile = {
-          name: _('/implementation.js'),
-          contents: `
-            var __assign = (this && this.__assign) || function () {
-                __assign = Object.assign || function(t) {
-                    for (var s, i = 1, n = arguments.length; i < n; i++) {
-                        s = arguments[i];
-                        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                            t[p] = s[p];
-                    }
-                    return t;
-                };
-                return __assign.apply(this, arguments);
-            };`,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-        const node =
-            getDeclaration(bundle.program, file.name, '__assign', ts.isVariableDeclaration) !;
-
-        const definition = host.getDefinitionOfFunction(node) !;
-        expect(definition.node).toBe(node);
-        expect(definition.body).toBeNull();
-        expect(definition.helper).toBe(TsHelperFn.Assign);
-        expect(definition.parameters.length).toEqual(0);
-      });
-
-      it('should recognize TypeScript __assign helper function implementation when suffixed',
-         () => {
-           const file: TestFile = {
-             name: _('/implementation.js'),
-             contents: `
-              var __assign$2 = (this && this.__assign$2) || function () {
-                  __assign$2 = Object.assign || function(t) {
-                      for (var s, i = 1, n = arguments.length; i < n; i++) {
-                          s = arguments[i];
-                          for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                              t[p] = s[p];
-                      }
-                      return t;
-                  };
-                  return __assign$2.apply(this, arguments);
-              };`,
-           };
-           loadTestFiles([file]);
-           const bundle = makeTestBundleProgram(file.name);
-           const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
-
-           const node =
-               getDeclaration(bundle.program, file.name, '__assign$2', ts.isVariableDeclaration) !;
-
-           const definition = host.getDefinitionOfFunction(node) !;
-           expect(definition.node).toBe(node);
-           expect(definition.body).toBeNull();
-           expect(definition.helper).toBe(TsHelperFn.Assign);
-           expect(definition.parameters.length).toEqual(0);
-         });
     });
 
     describe('getImportOfIdentifier()', () => {
@@ -2076,6 +1858,241 @@ runInEachFileSystem(() => {
            const actualDeclaration = host.getDeclarationOfIdentifier(identifier) !;
            expect(actualDeclaration.node !.getText()).toBe(expectedDeclaration.getText());
          });
+
+      it('should recognize TypeScript helpers (as function declarations)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            function __assign(t, ...sources) { /* ... */ }
+            function __spread(...args) { /* ... */ }
+            function __spreadArrays(...args) { /* ... */ }
+
+            var a = __assign({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              (node.initializer as ts.CallExpression).expression as ts.Identifier;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration),
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            function __assign$1(t, ...sources) { /* ... */ }
+            function __spread$2(...args) { /* ... */ }
+            function __spreadArrays$3(...args) { /* ... */ }
+
+            var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              (node.initializer as ts.CallExpression).expression as ts.Identifier;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration),
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize TypeScript helpers (as variable declarations)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
+            var __spread = (this && this.__spread) || function (...args) { /* ... */ }
+            var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+
+            var a = __assign({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              (node.initializer as ts.CallExpression).expression as ts.Identifier;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration),
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            var __assign$1 = (this && this.__assign$1) || function (t, ...sources) { /* ... */ }
+            var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
+            var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
+
+            var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              (node.initializer as ts.CallExpression).expression as ts.Identifier;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration),
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize imported TypeScript helpers (named imports)', () => {
+        const files: TestFile[] = [
+          {
+            name: _('/test.js'),
+            contents: `
+              import {__assign, __spread, __spreadArrays} from 'tslib';
+
+              var a = __assign({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          },
+          {
+            name: _('/node_modules/tslib/index.d.ts'),
+            contents: `
+              export declare function __assign(t: any, ...sources: any[]): any;
+              export declare function __spread(...args: any[][]): any[];
+              export declare function __spreadArrays(...args: any[][]): any[];
+            `,
+          },
+        ];
+        loadTestFiles(files);
+
+        const [testFile, tslibFile] = files;
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node =
+              getDeclaration(bundle.program, testFile.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              (node.initializer as ts.CallExpression).expression as ts.Identifier;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(
+                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration),
+            viaModule: 'tslib',
+          });
+        };
+
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize imported TypeScript helpers (star import)', () => {
+        const files: TestFile[] = [
+          {
+            name: _('/test.js'),
+            contents: `
+              import * as tslib_1 from 'tslib';
+
+              var a = tslib_1.__assign({foo: 'bar'}, {baz: 'qux'});
+              var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
+              var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          },
+          {
+            name: _('/node_modules/tslib/index.d.ts'),
+            contents: `
+              export declare function __assign(t: any, ...sources: any[]): any;
+              export declare function __spread(...args: any[][]): any[];
+              export declare function __spreadArrays(...args: any[][]): any[];
+            `,
+          },
+        ];
+        loadTestFiles(files);
+
+        const [testFile, tslibFile] = files;
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node =
+              getDeclaration(bundle.program, testFile.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier =
+              ((node.initializer as ts.CallExpression).expression as ts.PropertyAccessExpression)
+                  .name;
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            node: getDeclaration(
+                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration),
+            viaModule: 'tslib',
+          });
+        };
+
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+      });
     });
 
     describe('getExportsOfModule()', () => {
@@ -2117,6 +2134,31 @@ runInEachFileSystem(() => {
             null
           ],
         ]);
+      });
+
+      it('should recognize declarations of known TypeScript helpers', () => {
+        const tslib = {
+          name: _('/tslib.d.ts'),
+          contents: `
+            export declare function __assign(t: any, ...sources: any[]): any;
+            export declare function __spread(...args: any[][]): any[];
+            export declare function __spreadArrays(...args: any[][]): any[];
+            export declare function __unknownHelper(...args: any[]): any;
+          `,
+        };
+        loadTestFiles([tslib]);
+        const bundle = makeTestBundleProgram(tslib.name);
+        const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
+        const sf = getSourceFileOrError(bundle.program, tslib.name);
+        const exportDeclarations = host.getExportsOfModule(sf) !;
+
+        expect([...exportDeclarations].map(([exportName, {known}]) => [exportName, known]))
+            .toEqual([
+              ['__assign', KnownDeclaration.TsHelperAssign],
+              ['__spread', KnownDeclaration.TsHelperSpread],
+              ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+              ['__unknownHelper', null],
+            ]);
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1732,7 +1732,7 @@ runInEachFileSystem(() => {
               };
 
       const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
-        if ((decl.initializer !== undefined) && ts.isCallExpression(decl.initializer)) {
+        if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
           const expr = decl.initializer.expression;
           if (ts.isIdentifier(expr)) return expr;
           if (ts.isPropertyAccessExpression(expr)) return expr.name;

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1714,6 +1714,32 @@ runInEachFileSystem(() => {
     });
 
     describe('getDeclarationOfIdentifier()', () => {
+      // Helpers
+      const createTestForTsHelper =
+          (program: ts.Program, host: Esm5ReflectionHost, srcFile: TestFile,
+           getHelperDeclaration: (name: string) => ts.Declaration) =>
+              (varName: string, helperName: string, knownAs: KnownDeclaration,
+               viaModule: string | null = null) => {
+                const node =
+                    getDeclaration(program, srcFile.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier = getIdentifierFromCallExpression(node);
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  node: getHelperDeclaration(helperName), viaModule,
+                });
+              };
+
+      const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
+        if ((decl.initializer !== undefined) && ts.isCallExpression(decl.initializer)) {
+          const expr = decl.initializer.expression;
+          if (ts.isIdentifier(expr)) return expr;
+          if (ts.isPropertyAccessExpression(expr)) return expr.name;
+        }
+        throw new Error(`Unable to extract identifier from declaration '${decl.getText()}'.`);
+      };
+
       it('should return the declaration of a locally defined identifier', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
@@ -1876,18 +1902,10 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(file.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              (node.initializer as ts.CallExpression).expression as ts.Identifier;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration),
-            viaModule: null,
-          });
-        };
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, file,
+            helperName =>
+                getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration));
 
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
@@ -1911,18 +1929,10 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(file.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              (node.initializer as ts.CallExpression).expression as ts.Identifier;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration),
-            viaModule: null,
-          });
-        };
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, file,
+            helperName =>
+                getDeclaration(bundle.program, file.name, helperName, ts.isFunctionDeclaration));
 
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
@@ -1946,18 +1956,10 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(file.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              (node.initializer as ts.CallExpression).expression as ts.Identifier;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration),
-            viaModule: null,
-          });
-        };
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, file,
+            helperName =>
+                getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration));
 
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
@@ -1981,18 +1983,10 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(file.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              (node.initializer as ts.CallExpression).expression as ts.Identifier;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
-
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration),
-            viaModule: null,
-          });
-        };
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, file,
+            helperName =>
+                getDeclaration(bundle.program, file.name, helperName, ts.isVariableDeclaration));
 
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
@@ -2026,24 +2020,14 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(testFile.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node =
-              getDeclaration(bundle.program, testFile.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              (node.initializer as ts.CallExpression).expression as ts.Identifier;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, testFile,
+            helperName => getDeclaration(
+                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration));
 
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(
-                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration),
-            viaModule: 'tslib',
-          });
-        };
-
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
       });
 
       it('should recognize imported TypeScript helpers (star import)', () => {
@@ -2073,25 +2057,14 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(testFile.name);
         const host = new Esm5ReflectionHost(new MockLogger(), false, bundle);
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node =
-              getDeclaration(bundle.program, testFile.name, varName, ts.isVariableDeclaration);
-          const helperIdentifier =
-              ((node.initializer as ts.CallExpression).expression as ts.PropertyAccessExpression)
-                  .name;
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+        const testForHelper = createTestForTsHelper(
+            bundle.program, host, testFile,
+            helperName => getDeclaration(
+                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration));
 
-          expect(helperDeclaration).toEqual({
-            known: knownAs,
-            node: getDeclaration(
-                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration),
-            viaModule: 'tslib',
-          });
-        };
-
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1831,7 +1831,7 @@ runInEachFileSystem(() => {
               .find(decl => (decl.name !== undefined) && (decl.name.text === name)) !;
 
       const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
-        if ((decl.initializer !== undefined) && ts.isCallExpression(decl.initializer)) {
+        if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
           const expr = decl.initializer.expression;
           if (ts.isIdentifier(expr)) return expr;
           if (ts.isPropertyAccessExpression(expr)) return expr.name;

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1864,10 +1864,6 @@ runInEachFileSystem(() => {
               `,
              },
              {
-               name: _('/node_modules/packages.json'),
-               contents: '{ "typings: "index.d.ts" }',
-             },
-             {
                name: _('/node_modules/sub_module/index.d.ts'),
                contents: `export class SubModule {}`,
              }
@@ -1876,7 +1872,7 @@ runInEachFileSystem(() => {
            const bundle = makeTestBundleProgram(FILES[0].name);
            const host = new UmdReflectionHost(new MockLogger(), false, bundle);
            const expectedDeclaration =
-               getDeclaration(bundle.program, FILES[2].name, 'SubModule', isNamedClassDeclaration);
+               getDeclaration(bundle.program, FILES[1].name, 'SubModule', isNamedClassDeclaration);
            const x = getDeclaration(bundle.program, FILES[0].name, 'x', isNamedVariableDeclaration);
            if (x.initializer === undefined || !ts.isIdentifier(x.initializer)) {
              return fail('Expected constant `x` to have an identifer as an initializer.');

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FactoryMap, isRelativePath, stripExtension} from '../src/utils';
+import * as ts from 'typescript';
+import {KnownDeclaration} from '../../src/ngtsc/reflection';
+import {FactoryMap, getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, isRelativePath, stripExtension} from '../src/utils';
 
 describe('FactoryMap', () => {
   it('should return an existing value', () => {
@@ -47,6 +49,121 @@ describe('FactoryMap', () => {
 
     expect(factoryMap.get('k3')).toBe('v3');
     expect(factoryFnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTsHelperFnFromDeclaration()', () => {
+  const createFunctionDeclaration = (fnName?: string) => ts.createFunctionDeclaration(
+      undefined, undefined, undefined, fnName, undefined, [], undefined, undefined);
+  const createVariableDeclaration = (varName: string) =>
+      ts.createVariableDeclaration(varName, undefined, undefined);
+
+  it('should recongize the `__assign` helper as function declaration', () => {
+    const decl1 = createFunctionDeclaration('__assign');
+    const decl2 = createFunctionDeclaration('__assign$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperAssign);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperAssign);
+  });
+
+  it('should recongize the `__assign` helper as variable declaration', () => {
+    const decl1 = createVariableDeclaration('__assign');
+    const decl2 = createVariableDeclaration('__assign$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperAssign);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperAssign);
+  });
+
+  it('should recongize the `__spread` helper as function declaration', () => {
+    const decl1 = createFunctionDeclaration('__spread');
+    const decl2 = createFunctionDeclaration('__spread$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpread);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpread);
+  });
+
+  it('should recongize the `__spread` helper as variable declaration', () => {
+    const decl1 = createVariableDeclaration('__spread');
+    const decl2 = createVariableDeclaration('__spread$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpread);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpread);
+  });
+
+  it('should recongize the `__spreadArrays` helper as function declaration', () => {
+    const decl1 = createFunctionDeclaration('__spreadArrays');
+    const decl2 = createFunctionDeclaration('__spreadArrays$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+  });
+
+  it('should recongize the `__spreadArrays` helper as variable declaration', () => {
+    const decl1 = createVariableDeclaration('__spreadArrays');
+    const decl2 = createVariableDeclaration('__spreadArrays$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+  });
+
+  it('should return null for unrecognized helpers', () => {
+    const decl1 = createFunctionDeclaration('__foo');
+    const decl2 = createVariableDeclaration('spread');
+    const decl3 = createFunctionDeclaration('spread$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(null);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(null);
+    expect(getTsHelperFnFromDeclaration(decl3)).toBe(null);
+  });
+
+  it('should return null for unnamed declarations', () => {
+    const unnamledDecl = createFunctionDeclaration(undefined);
+
+    expect(getTsHelperFnFromDeclaration(unnamledDecl)).toBe(null);
+  });
+
+  it('should return null for non-function/variable declarations', () => {
+    const classDecl =
+        ts.createClassDeclaration(undefined, undefined, '__assign', undefined, undefined, []);
+
+    expect(classDecl.name !.text).toBe('__assign');
+    expect(getTsHelperFnFromDeclaration(classDecl)).toBe(null);
+  });
+});
+
+describe('getTsHelperFnFromIdentifier()', () => {
+  it('should recongize the `__assign` helper', () => {
+    const id1 = ts.createIdentifier('__assign');
+    const id2 = ts.createIdentifier('__assign$42');
+
+    expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperAssign);
+    expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperAssign);
+  });
+
+  it('should recongize the `__spread` helper', () => {
+    const id1 = ts.createIdentifier('__spread');
+    const id2 = ts.createIdentifier('__spread$42');
+
+    expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpread);
+    expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpread);
+  });
+
+  it('should recongize the `__spreadArrays` helper', () => {
+    const id1 = ts.createIdentifier('__spreadArrays');
+    const id2 = ts.createIdentifier('__spreadArrays$42');
+
+    expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+    expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+  });
+
+  it('should return null for unrecognized helpers', () => {
+    const id1 = ts.createIdentifier('__foo');
+    const id2 = ts.createIdentifier('spread');
+    const id3 = ts.createIdentifier('spread$42');
+
+    expect(getTsHelperFnFromIdentifier(id1)).toBe(null);
+    expect(getTsHelperFnFromIdentifier(id2)).toBe(null);
+    expect(getTsHelperFnFromIdentifier(id3)).toBe(null);
   });
 });
 

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -58,7 +58,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
   const createVariableDeclaration = (varName: string) =>
       ts.createVariableDeclaration(varName, undefined, undefined);
 
-  it('should recongize the `__assign` helper as function declaration', () => {
+  it('should recognize the `__assign` helper as function declaration', () => {
     const decl1 = createFunctionDeclaration('__assign');
     const decl2 = createFunctionDeclaration('__assign$42');
 
@@ -66,7 +66,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperAssign);
   });
 
-  it('should recongize the `__assign` helper as variable declaration', () => {
+  it('should recognize the `__assign` helper as variable declaration', () => {
     const decl1 = createVariableDeclaration('__assign');
     const decl2 = createVariableDeclaration('__assign$42');
 
@@ -74,7 +74,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperAssign);
   });
 
-  it('should recongize the `__spread` helper as function declaration', () => {
+  it('should recognize the `__spread` helper as function declaration', () => {
     const decl1 = createFunctionDeclaration('__spread');
     const decl2 = createFunctionDeclaration('__spread$42');
 
@@ -82,7 +82,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpread);
   });
 
-  it('should recongize the `__spread` helper as variable declaration', () => {
+  it('should recognize the `__spread` helper as variable declaration', () => {
     const decl1 = createVariableDeclaration('__spread');
     const decl2 = createVariableDeclaration('__spread$42');
 
@@ -90,7 +90,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpread);
   });
 
-  it('should recongize the `__spreadArrays` helper as function declaration', () => {
+  it('should recognize the `__spreadArrays` helper as function declaration', () => {
     const decl1 = createFunctionDeclaration('__spreadArrays');
     const decl2 = createFunctionDeclaration('__spreadArrays$42');
 
@@ -98,7 +98,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
   });
 
-  it('should recongize the `__spreadArrays` helper as variable declaration', () => {
+  it('should recognize the `__spreadArrays` helper as variable declaration', () => {
     const decl1 = createVariableDeclaration('__spreadArrays');
     const decl2 = createVariableDeclaration('__spreadArrays$42');
 
@@ -132,7 +132,7 @@ describe('getTsHelperFnFromDeclaration()', () => {
 });
 
 describe('getTsHelperFnFromIdentifier()', () => {
-  it('should recongize the `__assign` helper', () => {
+  it('should recognize the `__assign` helper', () => {
     const id1 = ts.createIdentifier('__assign');
     const id2 = ts.createIdentifier('__assign$42');
 
@@ -140,7 +140,7 @@ describe('getTsHelperFnFromIdentifier()', () => {
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperAssign);
   });
 
-  it('should recongize the `__spread` helper', () => {
+  it('should recognize the `__spread` helper', () => {
     const id1 = ts.createIdentifier('__spread');
     const id2 = ts.createIdentifier('__spread$42');
 
@@ -148,7 +148,7 @@ describe('getTsHelperFnFromIdentifier()', () => {
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpread);
   });
 
-  it('should recongize the `__spreadArrays` helper', () => {
+  it('should recognize the `__spreadArrays` helper', () => {
     const id1 = ts.createIdentifier('__spreadArrays');
     const id2 = ts.createIdentifier('__spreadArrays$42');
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/index.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/index.ts
@@ -8,4 +8,4 @@
 
 export {DynamicValue} from './src/dynamic';
 export {ForeignFunctionResolver, PartialEvaluator} from './src/interface';
-export {BuiltinFn, EnumValue, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './src/result';
+export {EnumValue, KnownFn, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './src/result';

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
@@ -9,9 +9,9 @@
 import * as ts from 'typescript';
 
 import {DynamicValue} from './dynamic';
-import {BuiltinFn, ResolvedValue, ResolvedValueArray} from './result';
+import {KnownFn, ResolvedValue, ResolvedValueArray} from './result';
 
-export class ArraySliceBuiltinFn extends BuiltinFn {
+export class ArraySliceBuiltinFn extends KnownFn {
   constructor(private lhs: ResolvedValueArray) { super(); }
 
   evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
@@ -23,7 +23,7 @@ export class ArraySliceBuiltinFn extends BuiltinFn {
   }
 }
 
-export class ArrayConcatBuiltinFn extends BuiltinFn {
+export class ArrayConcatBuiltinFn extends KnownFn {
   constructor(private lhs: ResolvedValueArray) { super(); }
 
   evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
@@ -41,7 +41,7 @@ export class ArrayConcatBuiltinFn extends BuiltinFn {
   }
 }
 
-export class ObjectAssignBuiltinFn extends BuiltinFn {
+export class ObjectAssignBuiltinFn extends KnownFn {
   evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
     if (args.length === 0) {
       return DynamicValue.fromUnsupportedSyntax(node);

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -18,7 +18,7 @@ import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
 import {ForeignFunctionResolver} from './interface';
 import {resolveKnownDeclaration} from './known_declaration';
-import {BuiltinFn, EnumValue, ResolvedModule, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './result';
+import {EnumValue, KnownFn, ResolvedModule, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './result';
 import {evaluateTsHelperInline} from './ts_helpers';
 
 
@@ -404,7 +404,7 @@ export class StaticInterpreter {
     }
 
     // If the call refers to a builtin function, attempt to evaluate the function.
-    if (lhs instanceof BuiltinFn) {
+    if (lhs instanceof KnownFn) {
       return lhs.evaluate(node, this.evaluateFunctionArguments(node, context));
     }
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -19,7 +19,6 @@ import {DynamicValue} from './dynamic';
 import {ForeignFunctionResolver} from './interface';
 import {resolveKnownDeclaration} from './known_declaration';
 import {EnumValue, KnownFn, ResolvedModule, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './result';
-import {evaluateTsHelperInline} from './ts_helpers';
 
 
 
@@ -333,6 +332,10 @@ export class StaticInterpreter {
     }
 
     return new ResolvedModule(declarations, decl => {
+      if (decl.known !== null) {
+        return resolveKnownDeclaration(decl.known);
+      }
+
       const declContext = {
           ...context, ...joinModuleContext(context, node, decl),
       };
@@ -415,12 +418,6 @@ export class StaticInterpreter {
     const fn = this.host.getDefinitionOfFunction(lhs.node);
     if (fn === null) {
       return DynamicValue.fromInvalidExpressionType(node.expression, lhs);
-    }
-
-    // If the function corresponds with a tslib helper function, evaluate it with custom logic.
-    if (fn.helper !== null) {
-      const args = this.evaluateFunctionArguments(node, context);
-      return evaluateTsHelperInline(fn.helper, node, args);
     }
 
     if (!isFunctionOrMethodReference(lhs)) {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
@@ -10,19 +10,31 @@ import {KnownDeclaration} from '../../reflection/src/host';
 
 import {ObjectAssignBuiltinFn} from './builtin';
 import {ResolvedValue} from './result';
+import {AssignHelperFn, SpreadHelperFn} from './ts_helpers';
 
-/** Resolved value for the JavaScript global `Object` declaration .*/
+/** Resolved value for the JavaScript global `Object` declaration. */
 export const jsGlobalObjectValue = new Map([['assign', new ObjectAssignBuiltinFn()]]);
+
+/** Resolved value for the `__assign()` TypeScript helper declaration. */
+const assignTsHelperFn = new AssignHelperFn();
+
+/** Resolved value for the `__spread()` and `__spreadArrays()` TypeScript helper declarations. */
+const spreadTsHelperFn = new SpreadHelperFn();
 
 /**
  * Resolves the specified known declaration to a resolved value. For example,
  * the known JavaScript global `Object` will resolve to a `Map` that provides the
- * `assign` method with a builtin function. This enables evaluation of `Object.assign`.
+ * `assign` method with a built-in function. This enables evaluation of `Object.assign`.
  */
 export function resolveKnownDeclaration(decl: KnownDeclaration): ResolvedValue {
   switch (decl) {
     case KnownDeclaration.JsGlobalObject:
       return jsGlobalObjectValue;
+    case KnownDeclaration.TsHelperAssign:
+      return assignTsHelperFn;
+    case KnownDeclaration.TsHelperSpread:
+    case KnownDeclaration.TsHelperSpreadArrays:
+      return spreadTsHelperFn;
     default:
       throw new Error(`Cannot resolve known declaration. Received: ${KnownDeclaration[decl]}.`);
   }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
@@ -22,7 +22,7 @@ import {DynamicValue} from './dynamic';
  * available statically.
  */
 export type ResolvedValue = number | boolean | string | null | undefined | Reference | EnumValue |
-    ResolvedValueArray | ResolvedValueMap | ResolvedModule | BuiltinFn | DynamicValue<unknown>;
+    ResolvedValueArray | ResolvedValueMap | ResolvedModule | KnownFn | DynamicValue<unknown>;
 
 /**
  * An array of `ResolvedValue`s.
@@ -76,8 +76,10 @@ export class EnumValue {
 }
 
 /**
- * An implementation of a builtin function, such as `Array.prototype.slice`.
+ * An implementation of a known function that can be statically evaluated.
+ * It could be a built-in function or method (such as `Array.prototype.slice`) or a TypeScript
+ * helper (such as `__spread`).
  */
-export abstract class BuiltinFn {
+export abstract class KnownFn {
   abstract evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue;
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -16,8 +16,8 @@ import {ResolvedValue, ResolvedValueArray} from './result';
 
 
 /**
- * Instance of the `Object.assign` builtin function. Used for evaluating
- * the "__assign" TypeScript helper.
+ * Instance of the known `Object.assign` built-in function. Used for evaluating
+ * the `__assign` TypeScript helper.
  */
 const objectAssignBuiltinFn = new ObjectAssignBuiltinFn();
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -8,44 +8,30 @@
 
 import * as ts from 'typescript';
 
-import {TsHelperFn} from '../../reflection';
-
 import {ObjectAssignBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
-import {ResolvedValue, ResolvedValueArray} from './result';
+import {KnownFn, ResolvedValueArray} from './result';
 
 
-/**
- * Instance of the known `Object.assign` built-in function. Used for evaluating
- * the `__assign` TypeScript helper.
- */
-const objectAssignBuiltinFn = new ObjectAssignBuiltinFn();
+// Use the same implementation we use for `Object.assign()`. Semantically these functions are the
+// same, so they can also share the same evaluation code.
+export class AssignHelperFn extends ObjectAssignBuiltinFn {}
 
-export function evaluateTsHelperInline(
-    helper: TsHelperFn, node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
-  switch (helper) {
-    case TsHelperFn.Assign:
-      // Use the same implementation we use for `Object.assign`. Semantically these
-      // functions are the same, so they can also share the same evaluation code.
-      return objectAssignBuiltinFn.evaluate(node, args);
-    case TsHelperFn.Spread:
-    case TsHelperFn.SpreadArrays:
-      return evaluateTsSpreadHelper(node, args);
-    default:
-      throw new Error(`Cannot evaluate TypeScript helper function: ${TsHelperFn[helper]}`);
-  }
-}
+// Used for both `__spread()` and `__spreadArrays()` TypeScript helper functions.
+export class SpreadHelperFn extends KnownFn {
+  evaluate(node: ts.Node, args: ResolvedValueArray): ResolvedValueArray {
+    const result: ResolvedValueArray = [];
 
-function evaluateTsSpreadHelper(node: ts.Node, args: ResolvedValueArray): ResolvedValueArray {
-  const result: ResolvedValueArray = [];
-  for (const arg of args) {
-    if (arg instanceof DynamicValue) {
-      result.push(DynamicValue.fromDynamicInput(node, arg));
-    } else if (Array.isArray(arg)) {
-      result.push(...arg);
-    } else {
-      result.push(arg);
+    for (const arg of args) {
+      if (arg instanceof DynamicValue) {
+        result.push(DynamicValue.fromDynamicInput(node, arg));
+      } else if (Array.isArray(arg)) {
+        result.push(...arg);
+      } else {
+        result.push(arg);
+      }
     }
+
+    return result;
   }
-  return result;
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -317,43 +317,34 @@ export interface FunctionDefinition {
   body: ts.Statement[]|null;
 
   /**
-   * The type of tslib helper function, if the function is determined to represent a tslib helper
-   * function. Otherwise, this will be null.
-   */
-  helper: TsHelperFn|null;
-
-  /**
    * Metadata regarding the function's parameters, including possible default value expressions.
    */
   parameters: Parameter[];
 }
 
 /**
- * Possible functions from TypeScript's helper library.
- */
-export enum TsHelperFn {
-  /**
-   * Indicates the `__assign` function.
-   */
-  Assign,
-  /**
-   * Indicates the `__spread` function.
-   */
-  Spread,
-  /**
-   * Indicates the `__spreadArrays` function.
-   */
-  SpreadArrays,
-}
-
-/**
- * Possible declarations which are known.
+ * Possible declarations of known values, such as built-in objects/functions or TypeScript helpers.
  */
 export enum KnownDeclaration {
   /**
    * Indicates the JavaScript global `Object` class.
    */
   JsGlobalObject,
+
+  /**
+   * Indicates the `__assign` TypeScript helper function.
+   */
+  TsHelperAssign,
+
+  /**
+   * Indicates the `__spread` TypeScript helper function.
+   */
+  TsHelperSpread,
+
+  /**
+   * Indicates the `__spreadArrays` TypeScript helper function.
+   */
+  TsHelperSpreadArrays,
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -164,7 +164,6 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {
       node,
       body: node.body !== undefined ? Array.from(node.body.statements) : null,
-      helper: null,
       parameters: node.parameters.map(param => {
         const name = parameterName(param.name);
         const initializer = param.initializer || null;
@@ -266,10 +265,8 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
   /**
    * Resolve a `ts.Symbol` to its declaration, keeping track of the `viaModule` along the way.
-   *
-   * @internal
    */
-  private getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
+  protected getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
       |null {
     // If the symbol points to a ShorthandPropertyAssignment, resolve it.
     let valueDeclaration: ts.Declaration|undefined = undefined;


### PR DESCRIPTION
In ES5 code, TypeScript requires certain helpers (such as `__spreadArrays()`) to be able to support ES2015+ features. These helpers can be either imported from `tslib` (by setting the `importHelpers` TS compiler option to `true`) or emitted inline (by setting the `importHelpers` and `noEmitHelpers` TS compiler options to `false`, which is the default value for both).

Ngtsc's `StaticInterpreter` (which is also used during ngcc processing) is able to statically evaluate some of these helpers (currently `__assing()`, `__spread()` and `__spreadArrays()`), as long as `ReflectionHost#getDefinitionOfFunction()` correctly detects the declaration of the helper. For this to happen, the left-hand size of the corresponding call expression (i.e. `__spread(...)` or `tslib.__spread(...)`) must be evaluated as a function declaration for `getDefinitionOfFunction()` to be called with.

In the case of imported helpers, the `tslib.__someHelper` expression was resolved to a function declaration of the form `export declare function __someHelper(...args: any[][]): any[];`, which allows `getDefinitionOfFunction()` to correctly map it to a TS helper.

In contrast, in the case of emitted helpers (and regardless of the module format: `CommonJS`, `ESNext`, `UMD`, etc.)), the `__someHelper` identifier was resolved to a variable declaration of the form `var __someHelper = (this && this.__someHelper) || function () { ... }`, which upon further evaluation was categorized as a `DynamicValue` (prohibiting further evaluation by the `getDefinitionOfFunction()`).

As a result of the above, emitted TypeScript helpers were not evaluated in ES5 code.

---
This commit changes the detection of TS helpers to leverage the existing `KnownFn` feature (previously only used for built-in functions). `Esm5ReflectionHost`'s is changed to always return `KnownDeclaration`s for TS helpers, both imported (`getExportsOfModule()`) as well as emitted (`getDeclarationOfIdentifier()`).

The `KnownDeclaration`s are then mapped to `KnownFn`s in `StaticInterpreter`, allowing it to statically evaluate call expressions involving any kind of TS helpers.

Jira issue: [FW-1689][1]

---
_I tested it on `ngcc-validation` and it does fix the `mobx-angular@3` failure (without breaking anything else 😛):_
- _angular/ngcc-validation#838_
- _[CI run][2]_

[1]: https://angular-team.atlassian.net/browse/FW-1689
[2]: https://circleci.com/workflow-run/0cf476fd-319e-4821-93f9-2f3716761c22

[FW-1689]: https://angular-team.atlassian.net/browse/FW-1689