### PR TITLE
fix(ivy): repeat template guards to narrow types in event handlers

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -271,32 +271,35 @@ describe('type check blocks', () => {
       const TEMPLATE = `<div dir (dirOutput)="foo($event)"></div>`;
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain(
-          '_outputHelper(_t2["outputField"]).subscribe(($event): any => (ctx).foo($event));');
+          '_outputHelper(_t2["outputField"]).subscribe(function ($event): any { (ctx).foo($event); });');
     });
 
     it('should emit a listener function with AnimationEvent for animation events', () => {
       const TEMPLATE = `<div (@animation.done)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
-      expect(block).toContain('($event: animations.AnimationEvent): any => (ctx).foo($event);');
+      expect(block).toContain(
+          'function ($event: animations.AnimationEvent): any { (ctx).foo($event); }');
     });
 
     it('should emit addEventListener calls for unclaimed outputs', () => {
       const TEMPLATE = `<div (event)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
-      expect(block).toContain('_t1.addEventListener("event", ($event): any => (ctx).foo($event));');
+      expect(block).toContain(
+          '_t1.addEventListener("event", function ($event): any { (ctx).foo($event); });');
     });
 
     it('should allow to cast $event using $any', () => {
       const TEMPLATE = `<div (event)="foo($any($event))"></div>`;
       const block = tcb(TEMPLATE);
       expect(block).toContain(
-          '_t1.addEventListener("event", ($event): any => (ctx).foo(($event as any)));');
+          '_t1.addEventListener("event", function ($event): any { (ctx).foo(($event as any)); });');
     });
 
     it('should detect writes to template variables', () => {
       const TEMPLATE = `<ng-template let-v><div (event)="v = 3"></div></ng-template>`;
       const block = tcb(TEMPLATE);
-      expect(block).toContain('_t3.addEventListener("event", ($event): any => (_t2 = 3))');
+      expect(block).toContain(
+          '_t3.addEventListener("event", function ($event): any { (_t2 = 3); });');
     });
 
   });
@@ -410,18 +413,18 @@ describe('type check blocks', () => {
       it('should check types of directive outputs when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-            '_outputHelper(_t2["outputField"]).subscribe(($event): any => (ctx).foo($event));');
+            '_outputHelper(_t2["outputField"]).subscribe(function ($event): any { (ctx).foo($event); });');
         expect(block).toContain(
-            '_t1.addEventListener("nonDirOutput", ($event): any => (ctx).foo($event));');
+            '_t1.addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
       it('should not check types of directive outputs when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfOutputEvents: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('($event: any): any => (ctx).foo($event);');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
         // Note that DOM events are still checked, that is controlled by `checkTypeOfDomEvents`
         expect(block).toContain(
-            '_t1.addEventListener("nonDirOutput", ($event): any => (ctx).foo($event));');
+            '_t1.addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
     });
 
@@ -430,13 +433,14 @@ describe('type check blocks', () => {
 
       it('should check types of animation events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('($event: animations.AnimationEvent): any => (ctx).foo($event);');
+        expect(block).toContain(
+            'function ($event: animations.AnimationEvent): any { (ctx).foo($event); }');
       });
       it('should not check types of animation events when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfAnimationEvents: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('($event: any): any => (ctx).foo($event);');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
       });
     });
 
@@ -446,9 +450,9 @@ describe('type check blocks', () => {
       it('should check types of DOM events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-            '_outputHelper(_t2["outputField"]).subscribe(($event): any => (ctx).foo($event));');
+            '_outputHelper(_t2["outputField"]).subscribe(function ($event): any { (ctx).foo($event); });');
         expect(block).toContain(
-            '_t1.addEventListener("nonDirOutput", ($event): any => (ctx).foo($event));');
+            '_t1.addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
       it('should not check types of DOM events when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfDomEvents: false};
@@ -456,8 +460,8 @@ describe('type check blocks', () => {
         // Note that directive outputs are still checked, that is controlled by
         // `checkTypeOfOutputEvents`
         expect(block).toContain(
-            '_outputHelper(_t2["outputField"]).subscribe(($event): any => (ctx).foo($event));');
-        expect(block).toContain('($event: any): any => (ctx).foo($event);');
+            '_outputHelper(_t2["outputField"]).subscribe(function ($event): any { (ctx).foo($event); });');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
       });
     });
 


### PR DESCRIPTION
In Ivy's template type checker, event bindings are checked in a closure
to allow for accurate type inference of the `$event` parameter. Because
of the closure, any narrowing effects of template guards will no longer
be in effect when checking the event binding, as TypeScript assumes that
the guard outside of the closure may no longer be true once the closure
is invoked. For more information on TypeScript's Control Flow Analysis,
please refer to https://github.com/microsoft/TypeScript/issues/9998.

In Angular templates, it is known that an event binding can only be
executed when the view it occurs in is currently rendered, hence the
corresponding template guard is known to hold during the invocation of
an event handler closure. As such, it is desirable that any narrowing
effects from template guards are still in effect within the event
handler closure.

This commit tweaks the generated Type-Check Block (TCB) to repeat all
template guards within an event handler closure. This achieves the
narrowing effect of the guards even within the closure.

Fixes #35073