### PR TITLE
fix(docs-infra): lighthouse reporting links to cross-origin destination are unsafe

### DIFF
--- a/aio/src/app/custom-elements/resource/resource-list.component.html
+++ b/aio/src/app/custom-elements/resource/resource-list.component.html
@@ -14,7 +14,7 @@
 
         <div *ngFor="let resource of subCategory.resources">
           <div class="c-resource" *ngIf="resource.rev">
-            <a class="l-flex--column resource-row-link" target="_blank" [href]="resource.url">
+            <a class="l-flex--column resource-row-link" rel="noopener" target="_blank" [href]="resource.url">
               <div>
                 <h4>{{resource.title}}</h4>
                 <p class="resource-description">{{resource.desc || 'No Description'}}</p>


### PR DESCRIPTION
…ons are unsafe

Light house was reporting in best practices that our cross origin links are a unsafe so aded rel=noopener according to light houe suggestion link to the article https://web.dev/external-anchors-use-rel-noopener/\?utm_source\=lighthouse\&utm_medium\=lr

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The croossorigin liks were termed as unsafe

Issue Number: N/A


## What is the new behavior?
Added the required tags for making it safe

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
