### PR TITLE
fix(compiler): do not recurse to find static symbols of same module

### DIFF
--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -313,9 +313,9 @@ export class StaticSymbolResolver {
             }
           });
         } else {
-          // handle the symbols via export * directives.
+          // Handle the symbols loaded by 'export *' directives.
           const resolvedModule = this.resolveModule(moduleExport.from, filePath);
-          if (resolvedModule) {
+          if (resolvedModule && resolvedModule !== filePath) {
             const nestedExports = this.getSymbolsOf(resolvedModule);
             nestedExports.forEach((targetSymbol) => {
               const sourceSymbol = this.getStaticSymbol(filePath, targetSymbol.name);


### PR DESCRIPTION
To the create symbols of a module, the static symbol resolver first gets
all the symbols loaded in the module by an export statement. For
`export * from './module'`-like statements, all symbols from `./module`
must be loaded. In cases where the exporting module is actually the
same module that the export statement is in, this causes an unbounded
recursive resolution of the same module.

Exports of the same module are not needed, as their symbols will be
resolved when the symbols in the module metadata's `metadata` key is
explored.

This commit resolves the unbounded recursion by loading exporting
modules only if they differ from the module currently being resolved.

Closes https://github.com/angular/vscode-ng-language-service/issues/593

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No