### PR TITLE
docs(forms): update the ngForm deprecation notice

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -57,8 +57,8 @@ const resolvedPromise = (() => Promise.resolve(null))();
  *
  * ### Migrating from deprecated ngForm selector
  *
- * Support for using `ngForm` element selector has been deprecated in Angular v6 and will be removed
- * in Angular v9.
+ * Support for using `ngForm` element selector has been deprecated in Angular v6 and may be removed
+ * in Angular v9 or later.
  *
  * This has been deprecated to keep selectors consistent with other core Angular selectors,
  * as element selectors are typically written in kebab-case.


### PR DESCRIPTION
we should be documenting when an API is eligible for removal and not when it will be removed.

The actual removal depends on many factors, e.g. if we were able to automate the refactoring to
the recommended API in time or not.

