### PR TITLE
docs(docs-infra): remove duplicated sentence

### DIFF
--- a/aio/content/start/data.md
+++ b/aio/content/start/data.md
@@ -33,7 +33,7 @@ Later, the [Forms](start/forms "Getting Started: Forms") part of
 this tutorial guides you through accessing this cart service
 from the page where the user checks out.
 
-Later, the [Forms](start/forms "Getting Started: Forms") part of this tutorial guides you through accessing this cart service from the page where the user checks out.
+
 
 </div>
 


### PR DESCRIPTION
docs(docs-infra): remove duplicated sentence

Remove the duplicate of the sentence "Later, the Forms part of this tutorial guides you through accessing this cart service from the page where the user checks out." in the  [Managing Data page](https://angular.io/start/data).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the [Managing Data page](https://angular.io/start/data) the sentence, "Later, the Forms part of this tutorial guides you through accessing this cart service from the page where the user checks out." is written twice.

Issue Number: N/A


## What is the new behavior?

In the [Managing Data page](https://angular.io/start/data) the sentence, "Later, the Forms part of this tutorial guides you through accessing this cart service from the page where the user checks out." appear only once.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
None