### PR TITLE
fix(forms): ensure the field value of a FormGroup/FormArray always co…

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -36,6 +36,7 @@ ts_library(
         "@npm//reflect-metadata",
         "@npm//tsickle",
         "@npm//typescript",
+        "@npm//chokidar"
     ],
 )
 

--- a/packages/compiler-cli/tsconfig-build.json
+++ b/packages/compiler-cli/tsconfig-build.json
@@ -34,6 +34,7 @@
     "src/extract_i18n.ts",
     "src/language_services.ts",
     "../../node_modules/@types/node/index.d.ts",
+    "../../node_modules/@types/chokidar/index.d.ts",
     "../../node_modules/@types/jasmine/index.d.ts"
   ]
 }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1567,7 +1567,7 @@ export class FormGroup extends AbstractControl {
   _reduceValue() {
     return this._reduceChildren(
         {}, (acc: {[k: string]: AbstractControl}, control: AbstractControl, name: string) => {
-          if (control.enabled || this.disabled) {
+          if (control.enabled) {
             acc[name] = control.value;
           }
           return acc;

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -962,7 +962,9 @@ import {FormArray} from '@angular/forms/src/model';
         expect(g.value).toEqual({'two': 'two'});
 
         c2.disable();
-        expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        // expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        expect(g.value).toEqual({}); // c and c2 are disable so g.value is empty
+
 
         c.enable();
         expect(g.value).toEqual({'one': 'one'});

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -241,7 +241,8 @@ import {of } from 'rxjs';
         expect(c.value).toEqual('one');
         expect(c2.value).toEqual('two');
 
-        expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        // expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        expect(g.value).toEqual({}); // gi disable so its value is empty
       });
 
       it('should set parent values', () => {
@@ -355,7 +356,9 @@ import {of } from 'rxjs';
         g.patchValue({'one': 'one', 'two': 'two'});
         expect(c.value).toEqual('one');
         expect(c2.value).toEqual('two');
-        expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        // expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        expect(g.value).toEqual({}); // g disable so its value is empty
+
       });
 
       it('should set parent values', () => {
@@ -1032,7 +1035,9 @@ import {of } from 'rxjs';
         expect(g.value).toEqual({nested: {one: 'one'}});
 
         g.get('nested') !.disable();
-        expect(g.value).toEqual({nested: {one: 'one', two: 'two'}});
+        // expect(g.value).toEqual({nested: {one: 'one', two: 'two'}});
+        expect(g.value).toEqual({}); // g disable so its value is empty
+
 
         g.get('nested') !.enable();
         expect(g.value).toEqual({nested: {one: 'one', two: 'two'}});


### PR DESCRIPTION
…ntains enabled controls values

Prior to this change, the field value of a FormGroup or FormArray may contains disabled controls value.

PR close #35184

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you have a form which contains enabled controls, the value field contains the value of the enabled controls even if you add disabled controls of if you disable the form. The field value will always contain only enabled controls value.

The problem is : **Sometimes the field value doesn't contain only enabled controls value**
If you have a form disabled (either because it is disabled directly itself, or because all of its contained controls are disabled), the value field contains the value of the disabled controls until we add an enabled control or until we enable the form. When you add an enabled control or enable the form, the value field will always contain the value of the enabled controls even if you add disabled controls after.

Again, If you disable your form and you use setValue or patchValue method, the field value will contains the value you gave to theses methods, while the status of the form is disabled.
The field "value" sometimes doesn't contain only enabled controls value.
Issue Number: #35184


## What is the new behavior?
Now, the value field contains only enabled controls value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
