### PR TITLE
Fix/35119 strict emit type

### DIFF
--- a/modules/playground/src/order_management/index.ts
+++ b/modules/playground/src/order_management/index.ts
@@ -139,7 +139,7 @@ export class OrderListComponent {
 })
 export class OrderItemComponent {
   @Input() item: OrderItem;
-  @Output() delete = new EventEmitter();
+  @Output() delete = new EventEmitter<OrderItem>();
 
   onDelete(): void { this.delete.emit(this.item); }
 }

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -83,7 +83,7 @@ export class EventEmitter<T extends any> extends Subject<T> {
    * Emits an event containing a given value.
    * @param value The value to emit.
    */
-  emit(value?: T) { super.next(value); }
+  emit(value: T) { super.next(value); }
 
   /**
    * Registers handlers for events emitted by this instance.

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -61,7 +61,7 @@ import {Subject, Subscription} from 'rxjs';
  * @see [Observables in Angular](guide/observables-in-angular)
  * @publicApi
  */
-export class EventEmitter<T extends any> extends Subject<T> {
+export class EventEmitter<T extends any = void> extends Subject<T> {
   /**
    * @internal
    */

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -1984,7 +1984,7 @@ describe('di', () => {
       @Directive({selector: '[dir]'})
       class MyDir {
         @Input() binding !: string;
-        @Output() output = new EventEmitter();
+        @Output() output = new EventEmitter<any>();
         constructor(
             @Attribute('exist') public exist: string,
             @Attribute('binding') public bindingAttr: string,

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -344,7 +344,7 @@ describe('directives', () => {
   describe('outputs', () => {
     @Directive({selector: '[out]'})
     class TestDir {
-      @Output() out = new EventEmitter();
+      @Output() out = new EventEmitter<void>();
     }
 
     it('should allow outputs of directive on ng-template', () => {

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -221,7 +221,7 @@ describe('directives', () => {
     it('should match directives with attribute selectors on outputs', () => {
       @Directive({selector: '[out]'})
       class TestDir {
-        @Output() out = new EventEmitter();
+        @Output() out = new EventEmitter<any>();
       }
 
       TestBed.configureTestingModule({declarations: [TestComponent, TestDir]});

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -207,7 +207,7 @@ describe('event listeners', () => {
       @Directive({selector: '[foo]'})
       class FooDirective {
         @Input('foo') model: any;
-        @Output('fooChange') update = new EventEmitter();
+        @Output('fooChange') update = new EventEmitter<any>();
 
         updateValue(value: any) { this.update.emit(value); }
       }

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -188,7 +188,7 @@ describe('property bindings', () => {
     })
     class OtherDir {
       @Input() id: number|undefined;
-      @Output('click') clickStream = new EventEmitter();
+      @Output('click') clickStream = new EventEmitter<any>();
     }
 
     @Directive({
@@ -398,7 +398,7 @@ describe('property bindings', () => {
     class MyDir {
       @Input() role: string|undefined;
       @Input('dir') direction: string|undefined;
-      @Output('change') changeStream = new EventEmitter();
+      @Output('change') changeStream = new EventEmitter<any>();
     }
 
     @Directive({selector: '[myDirB]'})

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -107,7 +107,7 @@ import {EventEmitter} from '../src/event_emitter';
 
     it('delivers events asynchronously when forced to async mode',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-         const e = new EventEmitter(true);
+         const e = new EventEmitter<number>(true);
          const log: any[] /** TODO #9100 */ = [];
          e.subscribe((x: any) => {
            log.push(x);

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -2466,7 +2466,7 @@ class IdDir {
 
 @Directive({selector: '[customEvent]'})
 class EventDir {
-  @Output() customEvent = new EventEmitter();
+  @Output() customEvent = new EventEmitter<any>();
   doSomething() {}
 }
 
@@ -2533,7 +2533,7 @@ class ToolbarComponent {
 
 @Directive({selector: '[two-way]', inputs: ['control'], outputs: ['controlChange']})
 class DirectiveWithTwoWayBinding {
-  controlChange = new EventEmitter();
+  controlChange = new EventEmitter<any>();
   control: any = null;
 
   triggerChange(value: any) { this.controlChange.emit(value); }
@@ -2722,7 +2722,7 @@ class DirectiveWithPropDecorators {
 
   // TODO(issue/24571): remove '!'.
   @Input('elProp') dirProp !: string;
-  @Output('elEvent') event = new EventEmitter();
+  @Output('elEvent') event = new EventEmitter<any>();
 
   // TODO(issue/24571): remove '!'.
   @HostBinding('attr.my-attr') myAttr !: string;

--- a/packages/elements/test/slots_spec.ts
+++ b/packages/elements/test/slots_spec.ts
@@ -134,7 +134,7 @@ class NamedSlotsComponent {
 })
 class SlotEventsComponent {
   @Input() slotEvents: Event[] = [];
-  @Output() slotEventsChange = new EventEmitter();
+  @Output() slotEventsChange = new EventEmitter<Event>();
   constructor() {}
   onSlotChange(event: Event) {
     this.slotEvents.push(event);

--- a/packages/examples/upgrade/static/ts/full/module.ts
+++ b/packages/examples/upgrade/static/ts/full/module.ts
@@ -40,8 +40,8 @@ export class TextFormatter {
 })
 export class Ng2HeroesComponent {
   @Input() heroes !: Hero[];
-  @Output() addHero = new EventEmitter();
-  @Output() removeHero = new EventEmitter();
+  @Output() addHero = new EventEmitter<void>();
+  @Output() removeHero = new EventEmitter<Hero>();
 }
 // #enddocregion
 

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -116,7 +116,7 @@ export class NgForm extends ControlContainer implements Form,
    * @description
    * Event emitter for the "ngSubmit" event
    */
-  ngSubmit = new EventEmitter();
+  ngSubmit = new EventEmitter<unknown>();
 
   /**
    * @description

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -200,7 +200,7 @@ export class NgModel extends NgControl implements OnChanges,
    * Event emitter for producing the `ngModelChange` event after
    * the view model updates.
    */
-  @Output('ngModelChange') update = new EventEmitter();
+  @Output('ngModelChange') update = new EventEmitter<any>();
 
   constructor(@Optional() @Host() parent: ControlContainer,
               @Optional() @Self() @Inject(NG_VALIDATORS) validators: Array<Validator|ValidatorFn>,

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -78,7 +78,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
    * @description
    * Emits an event when the form submission has been triggered.
    */
-  @Output() ngSubmit = new EventEmitter();
+  @Output() ngSubmit = new EventEmitter<unknown>();
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: any[],
@@ -210,7 +210,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
    * @param value The new value for the directive's control.
    */
   updateModel(dir: FormControlName, value: any): void {
-    const ctrl  = <FormControl>this.form.get(dir.path);
+    const ctrl = <FormControl>this.form.get(dir.path);
     ctrl.setValue(value);
   }
 

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -32,7 +32,7 @@ import {FormArray} from '@angular/forms/src/model';
   }
 
   function asyncValidatorReturningObservable(c: AbstractControl) {
-    const e = new EventEmitter();
+    const e = new EventEmitter<any>();
     Promise.resolve(null).then(() => { e.emit({'async': true}); });
     return e;
   }

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -36,7 +36,7 @@ import {of } from 'rxjs';
   }
 
   function asyncValidatorReturningObservable(c: AbstractControl) {
-    const e = new EventEmitter();
+    const e = new EventEmitter<any>();
     Promise.resolve(null).then(() => { e.emit({'async': true}); });
     return e;
   }

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1365,7 +1365,7 @@ class WrappedValue implements ControlValueAccessor {
 
 @Component({selector: 'my-input', template: ''})
 export class MyInput implements ControlValueAccessor {
-  @Output('input') onInput = new EventEmitter();
+  @Output('input') onInput = new EventEmitter<any>();
   // TODO(issue/24571): remove '!'.
   value !: string;
 

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -390,10 +390,10 @@ withEachNg1Version(() => {
              oneWayB = '?';
              twoWayA = '?';
              twoWayB = '?';
-             eventA = new EventEmitter();
-             eventB = new EventEmitter();
-             twoWayAEmitter = new EventEmitter();
-             twoWayBEmitter = new EventEmitter();
+             eventA = new EventEmitter<string>();
+             eventB = new EventEmitter<string>();
+             twoWayAEmitter = new EventEmitter<string>();
+             twoWayBEmitter = new EventEmitter<string>();
              ngOnChanges(changes: SimpleChanges) {
                const assert = (prop: string, value: any) => {
                  if ((this as any)[prop] != value) {
@@ -490,7 +490,7 @@ withEachNg1Version(() => {
            class Ng2Component implements OnChanges {
              ngOnChangesCount = 0;
              @Input() model = '?';
-             @Output() modelChange = new EventEmitter();
+             @Output() modelChange = new EventEmitter<string>();
 
              ngOnChanges(changes: SimpleChanges) {
                switch (this.ngOnChangesCount++) {

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -53,10 +53,10 @@ withEachNg1Version(() => {
            oneWayB = '?';
            twoWayA = '?';
            twoWayB = '?';
-           eventA = new EventEmitter();
-           eventB = new EventEmitter();
-           twoWayAEmitter = new EventEmitter();
-           twoWayBEmitter = new EventEmitter();
+           eventA = new EventEmitter<string>();
+           eventB = new EventEmitter<string>();
+           twoWayAEmitter = new EventEmitter<string>();
+           twoWayBEmitter = new EventEmitter<string>();
 
            ngOnChanges(changes: SimpleChanges) {
              const assert = (prop: string, value: any) => {
@@ -198,7 +198,7 @@ withEachNg1Version(() => {
          class Ng2Component implements OnChanges {
            ngOnChangesCount = 0;
            @Input() model = '?';
-           @Output() modelChange = new EventEmitter();
+           @Output() modelChange = new EventEmitter<string>();
 
            ngOnChanges(changes: SimpleChanges) {
              switch (this.ngOnChangesCount++) {

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -4029,7 +4029,7 @@ withEachNg1Version(() => {
          class Ng2ComponentB {
            @Input('ng2BInput1') ng2BInputA: any;
            @Input() ng2BInputC: any;
-           @Output() ng2BOutputC = new EventEmitter();
+           @Output() ng2BOutputC = new EventEmitter<any>();
 
            constructor() { ng2ComponentBInstance = this; }
          }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -328,7 +328,7 @@ export declare class ErrorHandler {
     handleError(error: any): void;
 }
 
-export declare class EventEmitter<T extends any> extends Subject<T> {
+export declare class EventEmitter<T extends any = void> extends Subject<T> {
     constructor(isAsync?: boolean);
     emit(value: T): void;
     subscribe(generatorOrNext?: any, error?: any, complete?: any): Subscription;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -330,7 +330,7 @@ export declare class ErrorHandler {
 
 export declare class EventEmitter<T extends any> extends Subject<T> {
     constructor(isAsync?: boolean);
-    emit(value?: T): void;
+    emit(value: T): void;
     subscribe(generatorOrNext?: any, error?: any, complete?: any): Subscription;
 }
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -241,7 +241,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     set isDisabled(isDisabled: boolean);
     /** @deprecated */ model: any;
     get path(): string[];
-    /** @deprecated */ update: EventEmitter<any>;
+    /** @deprecated */ update: EventEmitter<void>;
     get validator(): ValidatorFn | null;
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
@@ -257,7 +257,7 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
     /** @deprecated */ model: any;
     name: string | number | null;
     get path(): string[];
-    /** @deprecated */ update: EventEmitter<any>;
+    /** @deprecated */ update: EventEmitter<void>;
     get validator(): ValidatorFn | null;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
@@ -301,7 +301,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     directives: FormControlName[];
     form: FormGroup;
     get formDirective(): Form;
-    ngSubmit: EventEmitter<any>;
+    ngSubmit: EventEmitter<unknown>;
     get path(): string[];
     readonly submitted: boolean;
     constructor(_validators: any[], _asyncValidators: any[]);
@@ -372,7 +372,7 @@ export declare class NgForm extends ControlContainer implements Form, AfterViewI
     };
     form: FormGroup;
     get formDirective(): Form;
-    ngSubmit: EventEmitter<any>;
+    ngSubmit: EventEmitter<unknown>;
     options: {
         updateOn?: FormHooks;
     };
@@ -408,7 +408,7 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
         updateOn?: FormHooks;
     };
     get path(): string[];
-    update: EventEmitter<any>;
+    update: EventEmitter<void>;
     get validator(): ValidatorFn | null;
     viewModel: any;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?

Change the type of EventEmitter to make it "more" type safe.

Issue Number: #35119

This error is not caught and will cause bugs at runtime:
```ts
const em = new EventEmitter<number>;
em.next(); // <- No value provided will feed `undefined` where `number` is expected
```


## What is the new behavior?

This error is caught by TypeScript
```ts
const em = new EventEmitter<number>;
em.next(); // <- Expected 1 argument to `next()` but 0 arguments provided
```

However, this valid behavior is still permitted:
```ts
const em = new EventEmitter();
em.next(); // <- This is OK because we did not specify what em is supposed to emit
```

In this PR, the default template type of `EventEmitter` is set to `EventEmitter<void>`. This is a strongly opinionated choice which favors safety. It might break code which expected the previous typing.

It's also perfectly valid to keep the previous default of `EventEmitter<any>`.

I find that using `<void>` is the safest alternative. It's more straightforward: `emit()` takes as argument exactly the type you specified in the template brackets, including no argument if you specified nothing. `<any>` is dangerous because the template argument may have been omitted by mistake and the user is unaware that the EventEmitter's data is not type checked.

The previous design was loose by default and let you opt-in strictness: defaults to `any`, allows more specific type to be provided. (noob friendly, but gets in the way of advanced users)
The new design is strict by default and lets you opt-out of strictness: defaults to `void`, but allows `any` to be specified. (ninja-friendly, but gets in the way of noobs).

What to chose depends on who is the primary audience of angular. Either way it's a breaking change.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

It's no longer possible to have an event emitter type which sometimes accepts arguments and sometimes not. It's either one but not both:

```ts
const em = new EventEmitter<void>();
em.next(); // OK
em.next(something); // Not OK

const em2 = new EventEmitter<any>();
em2.next(); // Not OK
em2.next(something); // OK
```

In the second example above, `em2.next();` should be replaced with `em2.next(undefined);`


Note that if you want to stick to the same API as RxJS, then wait on this PR to know what they chose to do: https://github.com/ReactiveX/rxjs/pull/5307

## Other information
