### PR TITLE
fix(ngcc): use logger.debug() for "Compiling" message

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -267,7 +267,7 @@ export function mainNgcc(
           fileSystem, entryPoint, formatPath, isCore, format, processDts, pathMappings, true,
           enableI18nLegacyMessageIdFormat);
 
-      logger.info(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
+      logger.debug(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
 
       const result = transformer.transform(bundle);
       if (result.success) {


### PR DESCRIPTION
Change the only logger.info() statement in createCompileFn() to use logger.debug() instead of logger.info(). When building under maven, messages at the info level are flagged as errors in the build output. The "Compiling" message is of the same importance as the "Skipping" message and should be consistent.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Changes the log level for an ngcc message

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When building under maven, messages at the info level are flagged as errors in the build output. 

Issue Number: N/A


## What is the new behavior?
Change the only logger.info() statement in createCompileFn() to use logger.debug() instead of logger.info(). The "Compiling" message is of the same importance as the "Skipping" message and should be consistent. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
