### PR TITLE
fix(language-service): get the right 'ElementAst' in the nested HTML tag

### DIFF
--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -116,8 +116,8 @@ function locateSymbol(ast: TemplateAst, path: TemplateAstPath, info: AstResult):
         },
         visitElementProperty(ast) { attributeValueSymbol(); },
         visitAttr(ast) {
-          const element = path.head;
-          if (!element || !(element instanceof ElementAst)) return;
+          const element = path.first(ElementAst);
+          if (!element) return;
           // Create a mapping of all directives applied to the element from their selectors.
           const matcher = new SelectorMatcher<DirectiveAst>();
           for (const dir of element.directives) {

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -99,7 +99,8 @@ describe('hover', () => {
   });
 
   it('should be able to find a reference to a directive', () => {
-    const content = mockHost.override(TEST_TEMPLATE, `<div string-model~{cursor}></div>`);
+    const content =
+        mockHost.override(TEST_TEMPLATE, `<div><div string-model~{cursor}></div></div>`);
     const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
     const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
     expect(quickInfo).toBeDefined();


### PR DESCRIPTION
For example, `<div><p string-model~{cursor}></p></div>`, when provide the hover info for `string-model`, the `path.head` is root tag `div`. Use the parent of `path.tail` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
