### PR TITLE
feat: add zone configuration to typescript interface

### DIFF
--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -25,9 +25,17 @@ genrule(
     cmd = "cp $< $@",
 )
 
+genrule(
+    name = "zone_configurations_d_ts",
+    srcs = ["//packages/zone.js/lib:zone.configurations.api.ts"],
+    outs = ["zone.configurations.api.ts"],
+    cmd = "cp $< $@",
+)
+
 filegroup(
     name = "zone_d_ts",
     srcs = [
+        ":zone_configurations_d_ts",
         ":zone_extensions_d_ts",
         ":zone_js_d_ts",
     ],

--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -1,0 +1,737 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Interface of zone.js configurations.
+ *
+ * You can define the following configurations on the window/global object before
+ * importing `dist/zone.js` to change zone.js default behaviors.
+ */
+interface ZoneGlobalConfigurations {
+  /**
+   * Disable the monkey patch of the `Node.js` `EventEmitter` API.
+   *
+   * By default, the `zone.js` monkey patches the `Node.js` `EventEmitter` APIs to make async
+   * callbacks of those APIs in the same zone when scheduled.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const EventEmitter = require('events');
+   * class MyEmitter extends EventEmitter {}
+   * const myEmitter = new MyEmitter();
+   *
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   myEmitter.on('event', () => {
+   *     console.log('an event occurs in the zone', Zone.current.name);
+   *     // the callback runs in the zone when it is scheduled,
+   *     // so the output is 'an event occurs in the zone myZone'.
+   *   });
+   * });
+   * myEmitter.emit('event');
+   * ```
+   *
+   * If you set `__Zone_disable_EventEmtter = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `EventEmitter` API and the above code
+   * outputs 'an event occurred <root>'.
+   */
+  __Zone_disable_EventEmitter?: boolean;
+
+  /**
+   * Disable the monkey patch of the `Node.js` `fs` API.
+   *
+   * By default, the `zone.js` monkey patches `Node.js` `fs` APIs to make async callbacks of those
+   * APIs in the same zone when scheduled.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const fs = require('fs');
+   *
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   fs.stat('/tmp/world', (err, stats) => {
+   *     console.log('fs.stats() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of the `fs.stat()` runs in the same zone
+   *     // when it is called, so the output is 'fs.stats() callback is invoked in the zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_fs = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `fs` API and the above code
+   * outputs 'get stats occurred <root>'.
+   */
+  __Zone_disable_fs?: boolean;
+
+  /**
+   * Disable the monkey patch of the `Node.js` `timer` API.
+   *
+   * By default, the `zone.js` monkey patches the `Node.js` `timer` APIs to make async callbacks of
+   * those APIs in the same zone when scheduled.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   setTimeout(() => {
+   *     console.log('setTimeout() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of `setTimeout()` runs in the same zone
+   *     // when it is scheduled, so the output is 'setTimeout() callback is invoked in the zone
+   *     // myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_timers = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `timer` APIs and the above code
+   * outputs 'timeout <root>'.
+   */
+  __Zone_disable_node_timers?: boolean;
+
+  /**
+   * Disable the monkey patch of the `Node.js` `process.nextTick()` API.
+   *
+   * By default, `zone.js` monkey patches the `Node.js` `process.nextTick()` API to make the
+   * callback in the same zone when calling `process.nextTick()`.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   process.nextTick(() => {
+   *     console.log('process.nextTick() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of `process.nextTick()` runs in the same zone
+   *     // when it is scheduled, so the output is 'process.nextTick() callback is invoked in the
+   *     // zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_nextTick = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `process.nextTick()` API and the above code
+   * outputs 'nextTick <root>'.
+   */
+  __Zone_disable_nextTick?: boolean;
+
+  /**
+   * Disable the monkey patch of the `Node.js` `crypto` API.
+   *
+   * By default, `zone.js` monkey patches the `Node.js` `crypto` APIs to make async callbacks of
+   * those APIs in the same zone when called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const crypto = require('crypto');
+   *
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   crypto.randomBytes(() => {
+   *     console.log('crypto.randomBytes() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of `crypto.randomBytes()` runs in the same zone
+   *     // when it is called, so the output is 'crypto.randomBytes() callback is invoked in the
+   *     // zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_crypto = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `crypto` API and the above code
+   * outputs 'crypto <root>'.
+   */
+  __Zone_disable_crypto?: boolean;
+
+  /**
+   * Disable the monkey patch of the `Object.defineProperty()` API.
+   *
+   * NOTE: this configuration is only available in the legacy bundle (dist/zone.js), this
+   * module is not available in the evergreen bundle (zone-evergreen.js).
+   *
+   * In the legacy browser, by default, `zone.js` monkey patches `Object.defineProperty()`
+   * `Object.create()` to try to ensure all property's configurable to be true. This patch is only
+   * needed in some old mobile browsers.
+   *
+   * If you set `__Zone_disable_defineProperty = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `Object.defineProperty()` API and does not
+   * modify desc.configurable to true.
+   *
+   */
+  __Zone_disable_defineProperty?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `registerElement()` API.
+   *
+   * NOTE: This configuration is only available in the legacy bundle (dist/zone.js), this
+   * module is not available in the evergreen bundle (zone-evergreen.js).
+   *
+   * In the legacy bundle, by default, `zone.js` monkey patches `registerElement()` API to make
+   * async callbacks of the API in the same zone when `registerElement()` is called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const proto = Object.create(HTMLElement.prototype);
+   * proto.createdCallback = function() {
+   *   console.log('createdCallback is invoked in the zone', Zone.current.name);
+   * };
+   * proto.attachedCallback = function() {
+   *   console.log('attachedCallback is invoked in the zone', Zone.current.name);
+   * };
+   * proto.detachedCallback = function() {
+   *   console.log('detachedCallback is invoked in the zone', Zone.current.name);
+   * };
+   * proto.attributeChangedCallback = function() {
+   *   console.log('attributeChangedCallback is invoked in the zone', Zone.current.name);
+   * };
+   *
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   document.registerElement('x-elem', {prototype: proto});
+   * });
+   * ```
+   *
+   * When those callbacks are invoked, those callbacks will be in the zone when
+   * `registerElement()` is called.
+   *
+   * If you set `__Zone_disable_registerElement = true` before importing zone.js,
+   * `zone.js` does not monkey patch `registerElement()` API and the above code
+   * outputs '<root>'.
+   */
+  __Zone_disable_registerElement?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser legacy `EventTarget` API.
+   *
+   * NOTE: This configuration is only available in the legacy bundle (dist/zone.js), this module
+   * is not available in the evergreen bundle (zone-evergreen.js).
+   *
+   * In some old browsers, the `EventTarget` is not available, so `zone.js` can not directly monkey
+   * patch the `EventTarget`, instead zone.js patches all known Html Elements' prototypes(such as
+   * HtmlDivElement). So the callback of the `addEventListener()` will be in the same zone when
+   * the `addEventListener()` is called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   div.addEventListener('click', () => {
+   *     console.log('div click event listener is invoked in the zone', Zone.current.name);
+   *     // the output is 'div click event listener is invoked in the zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_EventTargetLegacy = true` before importing zone.js
+   * in some old browsers (`EventTarget` not available).
+   * `zone.js` does not monkey patch all Html Elements APIs and the above code
+   * outputs 'clicked <root>'.
+   */
+  __Zone_disable_EventTargetLegacy?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `timer` APIs.
+   *
+   * By default, `zone.js` monkey patches browser timer
+   * APIs(`setTimeout()`/`setInterval()`/`setImmediate()`) to make async callbacks of those APIs in
+   * the same zone when scheduled.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   setTimeout(() => {
+   *     console.log('setTimeout() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of `setTimeout()` runs in the same zone
+   *     // when it is scheduled, so the output is 'setTimeout() callback is invoked in the zone
+   *     // myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_timers = true` before importing zone.js,
+   * `zone.js` does not monkey patch `timer` API and the above code
+   * outputs 'timeout <root>'.
+   *
+   */
+  __Zone_disable_timers?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `requestAnimationFrame()` API.
+   *
+   * By default, zone.js monkey patches the browser `requestAnimationFrame()` API
+   * to make the async callback of the `requestAnimationFrame()` in the same zone when scheduled.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   requestAnimationFrame(() => {
+   *     console.log('requestAnimationFrame() callback is invoked in the zone', Zone.current.name);
+   *     // since the callback of `requestAnimationFrame()` will be in the same zone
+   *     // when it is scheduled, so the output will be 'requestAnimationFrame() callback is invoked
+   *     // in the zone myZone'
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_requestAnimationframe = true` before importing zone.js,
+   * `zone.js` does not monkey patch the `requestAnimationFrame()` API and the above code
+   * outputs 'raf <root>'.
+   */
+  __Zone_disable_requestAnimationFrame?: boolean;
+
+  /**
+   *
+   * Disable the monkey patch of the browser blocking APIs(`alert()`/`prompt()`/`confirm()`).
+   */
+  __Zone_disable_blocking?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `EventTarget` APIs.
+   *
+   * By default, `zone.js` monkey patches EventTarget APIs. So the callbacks of the
+   * `addEventListener()` runs in the same zone when the `addEventListener()` is called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   div.addEventListener('click', () => {
+   *     console.log('div event listener is invoked in the zone', Zone.current.name);
+   *     // the output is 'div event listener is invoked in the zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_EventTarget = true` before importing zone.js,
+   * `zone.js` does not monkey patch EventTarget API and the above code
+   * outputs 'clicked <root>'.
+   *
+   */
+  __Zone_disable_EventTarget?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser onProperty APIs(such as onclick).
+   *
+   * By default, zone.js monkey patches onXXX properties(such as onclick). So the callbacks of onXXX
+   * properties runs in the same zone when the onXXX properties is set.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   div.onclick = () => {
+   *     console.log('div click event listener is invoked in the zone', Zone.current.name);
+   *     // the output will be 'div click event listener is invoked in the zone myZone'
+   *   }
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_on_property = true` before importing zone.js,
+   * `zone.js` does not monkey patch onXXX properties and the above code
+   * outputs 'clicked <root>'.
+   *
+   */
+  __Zone_disable_on_property?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `customElements` APIs.
+   *
+   * By default, zone.js monkey patches `customElements` APIs to make callbacks of the custom
+   * Element run in the same zone when the element is defined.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * class TestCustomElement extends HTMLElement {
+   *   constructor() { super(); }
+   *   connectedCallback() {}
+   *   disconnectedCallback() {}
+   *   attributeChangedCallback(attrName, oldVal, newVal) {}
+   *   adoptedCallback() {}
+   * }
+   *
+   * const zone = Zone.fork({name: 'myZone'});
+   * zone.run(() => {
+   *   customElements.define('x-elem', TestCustomElement);
+   * });
+   * ```
+   *
+   * All those callbacks defined in TestCustomElement runs in the zone when
+   * the `customElements.define()` is called.
+   *
+   * If you set `__Zone_disable_customElements = true` before importing zone.js,
+   * `zone.js` does not monkey patch `customElements` APIs and the above code
+   * runs inside <root> zone.
+   */
+  __Zone_disable_customElements?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `XMLHttpRequest` APIs.
+   *
+   * By default, zone.js monkey patches `XMLHttpRequest` APIs to make XMLHttpRequest act
+   * as macroTask.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({
+   *   name: 'myZone',
+   *   onScheduleTask: (delegate, curr, target, task) => {
+   *     console.log('task is scheduled', task.type, task.source, task.zone.name);
+   *     return delegate.scheduleTask(target, task);
+   *   }
+   * })
+   * const xhr = new XMLHttpRequest();
+   * zone.run(() => {
+   *   xhr.onload = function() {};
+   *   xhr.open('get', '/', true);
+   *   xhr.send();
+   * });
+   * ```
+   *
+   * In this example, the instance of the `XMLHttpRequest` runs in the zone and acts as macroTask,
+   * so the output is 'task is scheduled macroTask, XMLHttpRequest.send, zone'.
+   *
+   * If you set __Zone_disable_XHR = true before importing zone.js,
+   * `zone.js` does not monkey patch `XMLHttpRequest` APIs and the above onScheduleTask callback
+   * will not be called.
+   *
+   */
+  __Zone_disable_XHR?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser geolocation APIs.
+   *
+   * By default, Zone.js monkey patches geolcation APIs to make callbacks run in the same zone
+   * when those APIs are called.
+   *
+   * Consider the following examples:
+   *
+   * ```
+   * const zone = Zone.current.fork({
+   *   name: 'myZone'
+   * });
+   *
+   * zone.run(() => {
+   *   navigator.geolocation.getCurrentPosition(pos => {
+   *     console.log('navigator.getCurrentPosition() callback is invoked in the zone',
+   *     Zone.current.name);
+   *     // output is 'navigator.getCurrentPosition() callback is invoked in the zone myZone'.
+   *   }
+   * });
+   * ```
+   *
+   * If set you `__Zone_disable_geolocation = true` before importing zone.js,
+   * `zone.js` does not monkey patch geolocation APIs and the above code
+   * outputs 'getCurrentPosition <root>'.
+   *
+   */
+  __Zone_disable_geolocation?: boolean;
+
+  /**
+   * Disable the monkey patch of the browser `canvas` APIs.
+   *
+   * By default, Zone.js monkey patches `canvas` APIs to make callbacks run in the same zone when
+   * those APIs are called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * const zone = Zone.current.fork({
+   *   name: 'myZone'
+   * });
+   *
+   * zone.run(() => {
+   *   canvas.toBlob(blog => {
+   *     console.log('canvas.toBlob() callback is invoked in the zone', Zone.current.name);
+   *     // output is 'canvas.toBlob() callback is invoked in the zone myZone'.
+   *   }
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_canvas = true` before importing zone.js,
+   * `zone.js` does not monkey patch `canvas` APIs and the above code
+   * outputs 'canvas.toBlob <root>'.
+   */
+  __Zone_disable_canvas?: boolean;
+
+  /**
+   * Disable the `Promise` monkey patch.
+   *
+   * By default, zone.js monkey patckes `Promise` APIs to make the `then()/catch()` callbacks in the
+   * same zone when those callbacks are called.
+   *
+   * Consider the following examples:
+   *
+   * ```
+   * const zone = Zone.current.fork({name: 'myZone'});
+   *
+   * const p = Promise.resolve(1);
+   *
+   * zone.run(() => {
+   *   p.then(() => {
+   *     console.log('then() callback is invoked in the zone', Zone.current.name);
+   *     // output is 'then() callback is invoked in the zone myZone'.
+   *   });
+   * });
+   * ```
+   *
+   * If you set `__Zone_disable_ZoneAwarePromise = true` before importing zone.js,
+   * `zone.js` does not monkey patch `Promise` APIs and the above code
+   * outputs 'promise then callback <root>'.
+   */
+  __Zone_disable_ZoneAwarePromise?: boolean;
+
+  /**
+   * Define event names that users don't want monkey patched by the `zone.js`.
+   *
+   * By default, zone.js monkey patches `EventTarget.addEventListener()`, so the event listener
+   * callback runs in the zone when `addEventListener()` is called.
+   *
+   * But sometimes, users don't want all the event names use this patched version because it
+   * has performance impact. For example, in some cases, users want `scroll` or `mousemove` event
+   * listeners run with native `addEventListener()` for better performance.
+   *
+   * Users can achieve this goal by defining `__zone_symbol__UNPATCHED_EVENTS = ['scroll',
+   * 'mousemove'];` before imporing `zone.js`.
+   */
+  __zone_symbol__UNPATCHED_EVENTS?: boolean;
+
+  /**
+   * Define the event names of the passive listeners.
+   *
+   * Now Angular doesn't support to add event listeners as passive very easily. User needs to use
+   * `elem.addEventListener('scroll', listener, {passive: true});` or implements their own
+   * EventManagerPlugin to do that. Angular may finally support new template syntax to support
+   * passive event, for now, this configuration allows the user to define the
+   * passive event names in zone.js configurations.
+   *
+   * User can define a global varibale like this.
+   *
+   * ```
+   * __zone_symbol__PASSIVE_EVENTS = ['scroll'];
+   * ```
+   *
+   * to let all `scroll` event listeners passive.
+   */
+  __zone_symbol__PASSIVE_EVENTS?: boolean;
+}
+
+/**
+ * Interface of zone.js test configurations.
+ *
+ * You can define the following  configurations on the `window` or `global` object before
+ * importing `dist/zone-testing.js` to change zone.js default behaviors in the test runner.
+ */
+interface ZoneTestConfigurations {
+  /**
+   * Disable the jasmine integration.
+   *
+   * In the zone-testing.js bundle, by default, zone monkey patches jasmine APIs
+   * to make jasmine APIs run in specified zone.
+   *
+   * 1. Make the `describe()`/`xdescribe()`/`fdescribe()` run in the syncTestZone.
+   * 2. Make the `it()`/`xit()`/`fit()`/`beforeEach()`/`afterEach()`/`beforeAll()`/`afterAll()` run
+   * in the ProxyZone.
+   *
+   * With this patch, `async()`/`fakeAsync()` can work with the jasmine runner.
+   *
+   * If you set `__Zone_disable_jasmine = true` before importing `dist/zone-testing.js`,
+   * `zone.js` does not monkey patch the jasmine APIs and the `async()`/`fakeAsync()` can not
+   * work with the jasmine runner any longer.
+   */
+  __Zone_disable_jasmine?: boolean;
+
+  /**
+   * Disable the mocha integration.
+   *
+   * In the `zone-testing.js` bundle, by default, zone monkey patches the mocha APIs
+   * to make mocha APIs run in the specified zone.
+   *
+   * 1. Make the `describe()`/`xdescribe()`/`fdescribe()` run in the syncTestZone.
+   * 2. Make the `it()`/`xit()`/`fit()`/`beforeEach()`/`afterEach()`/`beforeAll()`/`afterAll()` run
+   * in the ProxyZone.
+   *
+   * With this patch, `async()`/`fakeAsync()` can work with the mocha runner.
+   *
+   * If you set `__Zone_disable_mocha = true` before importing zone-testing.js,
+   * `zone.js` does not monkey patch the mocha APIs and the `async()/`fakeAsync()` can not
+   * work with the mocha runner any longer.
+   */
+  __Zone_disable_mocha?: boolean;
+
+  /**
+   * Disable the jest integration.
+   *
+   * In the zone-testing.js bundle, by default, zone monkey patches jest APIs
+   * to make jest APIs run in the specified zone.
+   *
+   * 1. Make the `describe()`/`xdescribe()`/`fdescribe()` run in the syncTestZone.
+   * 2. Make the `it()`/`xit()`/`fit()`/`beforeEach()`/`afterEach()`/`before()`/`after()` run
+   * in the ProxyZone.
+   *
+   * With this patch, `async()`/`fakeAsync()` can work with the jest runner.
+   *
+   * If you set `__Zone_disable_jest = true` before importing zone-testing.js,
+   * `zone.js` does not monkey patch the jest APIs and `async()`/`fakeAsync()` can not
+   * work with the jest runner any longer.
+   */
+  __Zone_disable_jest?: boolean;
+
+  /**
+   * Disable monkey patch the jasmine clock APIs.
+   *
+   * By default, zone-testing.js monkey patches the `jasmine.clock()` API,
+   * so the `jasmine.clock()` can work with the `fakeAsync()/tick()` API.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * describe('jasmine.clock integration', () => {
+   *   beforeEach(() => {
+   *     jasmine.clock().install();
+   *   });
+   *   afterEach(() => {
+   *     jasmine.clock().uninstall();
+   *   });
+   *   it('fakeAsync test', fakeAsync(() => {
+   *     setTimeout(spy, 100);
+   *     expect(spy).not.toHaveBeenCalled();
+   *     jasmine.clock().tick(100);
+   *     expect(spy).toHaveBeenCalled();
+   *   }));
+   * });
+   * ```
+   *
+   * So in the `fakeAsync()`, `jasmine.clock().tick()` works just like `tick()`.
+   *
+   * If you set `__zone_symbol__fakeAsyncDisablePatchingClock = true` before importing
+   * zone-testing.js,`zone.js` does not monkey patch the `jasmine.clock()` APIs and the
+   * `jasmine.clock()` can not work with `fakeAsync()` any longer.
+   */
+  __zone_symbol__fakeAsyncDisablePatchingClock?: boolean;
+
+  /**
+   * Enable auto running into `fakeAsync()` when installing the `jasmine.clock()`.
+   *
+   * By default, zone-testing.js does not automatically run into `fakeAsync()`
+   * if the `jasmine.clock().install()` is called.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * describe('jasmine.clock integration', () => {
+   *   beforeEach(() => {
+   *     jasmine.clock().install();
+   *   });
+   *   afterEach(() => {
+   *     jasmine.clock().uninstall();
+   *   });
+   *   it('fakeAsync test', fakeAsync(() => {
+   *     setTimeout(spy, 100);
+   *     expect(spy).not.toHaveBeenCalled();
+   *     jasmine.clock().tick(100);
+   *     expect(spy).toHaveBeenCalled();
+   *   }));
+   * });
+   * ```
+   *
+   * So we still need to run `fakeAsync()` to make a test case in the `FakeAsyncTestZone`.
+   *
+   * If you set `__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched = true` before importing
+   * zone-testing.js, `zone.js` can run test case automatically into the `FakeAsyncTestZone` without
+   * calling the `fakeAsync()`.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * describe('jasmine.clock integration', () => {
+   *   beforeEach(() => {
+   *     jasmine.clock().install();
+   *   });
+   *   afterEach(() => {
+   *     jasmine.clock().uninstall();
+   *   });
+   *   it('fakeAsync test', () => { // here we don't need to call fakeAsync
+   *     setTimeout(spy, 100);
+   *     expect(spy).not.toHaveBeenCalled();
+   *     jasmine.clock().tick(100);
+   *     expect(spy).toHaveBeenCalled();
+   *   });
+   * });
+   * ```
+   *
+   */
+  __zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched?: boolean;
+
+  /**
+   * Enable waiting for the unresolved promise in the `async()` test.
+   *
+   * In the `async()` test, `AsyncTestZone` waits for all the async tasks to be finished. But if
+   * some promises never resolved, by default, `AsyncTestZone` does not wait and report unexpected
+   * result.
+   *
+   * Consider the following example:
+   *
+   * ```
+   * describe('wait never resolved promise', () => {
+   *   it('async with never resolved promise test', async(() => {
+   *     const p = new Promise(() => {});
+   *     p.then(() => {
+   *       // do some expection.
+   *     });
+   *   }))
+   * });
+   * ```
+   *
+   * By default, this case passes, because the callback of `p.then()` does not
+   * be called, and the `async()` does not wait there, because p is an unresolved
+   * promise, so there is no pending async task.
+   *
+   * If you set `__zone_symbol__supportWaitUnResolvedChainedPromise = true`, the above case
+   * timeouts, becasue `async()` will wait for the unresolved promise.
+   */
+  __zone_symbol__supportWaitUnResolvedChainedPromise?: boolean;
+}
+
+/**
+ * The interface of the zone runtime configurations.
+ *
+ * Those configurations can be defined on the `Zone` object after
+ * importing zone.js to change behaviors. The differences between
+ * the `ZoneRuntimeConfigurations` and the `ZoneGlobalConfigurations` are
+ *
+ * 1. the `ZoneGlobalConfigurations` need to be defined on the global/window object before
+ * importing `dist/zone.js`, the value of the configuration can not be changed at runtime.
+ *
+ * 2. the `ZoneRuntimeConfigurations` need to be defined on Zone object after importing
+ * `dist/zone.js`, the value of the configuration canbe changed at runtime.
+ *
+ */
+interface ZoneRuntimeConfigurations {
+  /**
+   * Ignore outputing error to console when uncaught Promise error occurs.
+   *
+   * By default, if uncaught Promise error occurs, zone.js outputs the
+   * error to the console by calling `console.error()`.
+   *
+   * If you set `__zone_symbol__ignoreConsoleErrorUncaughtError = true`, `zone.js` does not output
+   * uncaught error to `console.error()`.
+   */
+  __zone_symbol__ignoreConsoleErrorUncaughtError?: boolean;
+}

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -42,6 +42,10 @@ describe('Zone.js npm_package', () => {
 
       it('should have an zone.api.extensions.ts file',
          () => { expect(shx.cat('zone.api.extensions.ts')).toContain('EventTarget'); });
+
+      it('should have an zone.configurations.api.ts file', () => {
+        expect(shx.cat('zone.configurations.api.ts')).toContain('ZoneGlobalConfigurations');
+      });
     });
 
     describe('closure', () => {
@@ -140,6 +144,7 @@ describe('Zone.js npm_package', () => {
           'zone.js',
           'zone.js.d.ts',
           'zone.api.extensions.ts',
+          'zone.configurations.api.ts',
           'zone.min.js',
         ].sort();
         expect(list.length).toBe(expected.length);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


Add all zone.js configuration to interface, so we can define those flags in `polyfills.ts` like this.

```
const config = window as ZoneGlobalConfiguration;
config.__Zone_disable_requestAnimationFrame = true;

```