### PR TITLE
feat(forms): add a method to set a FormControl's updateOn property

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -883,6 +883,10 @@ export abstract class AbstractControl {
     }
   }
 
+  setUpdateMethod(event: FormHooks): void {
+    this._updateOn = event; 
+  }
+
   /**
    * Check to see if parent has been marked artificially dirty.
    *

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -580,6 +580,29 @@ import {FormArray} from '@angular/forms/src/model';
       });
     });
 
+    describe('setUpdateMethod', () => {
+      let c: FormControl;
+      beforeEach(() => {
+        c = new FormControl('a value');
+      });
+
+      it('should initialize updateOn property to change', () => {
+        expect(c.updateOn).toBe('change');
+      });
+      
+      it('should set updateOn property to blur', () => {
+        c.setUpdateMethod('blur');
+        expect(c.updateOn).toBe('blur');
+      });
+      
+      it('should set updateOn property to change', () => {
+        c.setUpdateMethod('blur');
+        c.setUpdateMethod('change');
+        expect(c.updateOn).toBe('change');
+      });
+
+    });
+
     describe('reset()', () => {
       let c: FormControl;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the only way to set a FormControl's updateOn property is in the constructor.
Issue Number: #35005


## What is the new behavior?
Now, with the setUpdateMethod it's possible to dynamically change the updateOn property.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
