### PR TITLE
fix(core): better handing of ICUs outside of i18n blocks

### DIFF
--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -270,9 +270,9 @@ export function getPreviousOrParentTNode(): TNode {
   return instructionState.lFrame.previousOrParentTNode;
 }
 
-export function setPreviousOrParentTNode(tNode: TNode, _isParent: boolean) {
+export function setPreviousOrParentTNode(tNode: TNode, isParent: boolean) {
   instructionState.lFrame.previousOrParentTNode = tNode;
-  instructionState.lFrame.isParent = _isParent;
+  instructionState.lFrame.isParent = isParent;
 }
 
 export function getIsParent(): boolean {

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -194,6 +194,7 @@ describe('Runtime i18n', () => {
       let nbConsts = 3;
       let index = 1;
       const firstTextNode = 3;
+      const rootTemplate = 2;
       let opCodes = getOpCodes(() => { ɵɵi18nStart(index, MSG_DIV); }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -202,7 +203,7 @@ describe('Runtime i18n', () => {
           '',
           nbConsts,
           index << I18nMutateOpCode.SHIFT_PARENT | I18nMutateOpCode.AppendChild,
-          2 << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select,
+          ~rootTemplate << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select,
           index << I18nMutateOpCode.SHIFT_PARENT | I18nMutateOpCode.AppendChild,
           '!',
           nbConsts + 1,
@@ -234,7 +235,7 @@ describe('Runtime i18n', () => {
           'before',
           nbConsts,
           spanElement << I18nMutateOpCode.SHIFT_PARENT | I18nMutateOpCode.AppendChild,
-          bElementSubTemplate << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select,
+          ~bElementSubTemplate << I18nMutateOpCode.SHIFT_REF | I18nMutateOpCode.Select,
           spanElement << I18nMutateOpCode.SHIFT_PARENT | I18nMutateOpCode.AppendChild,
           'after',
           nbConsts + 1,


### PR DESCRIPTION
Currently the logic that handles ICUs located outside of i18n blocks may throw exceptions at runtime. The problem is caused by the fact that we store incorrect TNode index for previous TNode (index that includes HEADER_OFFSET) and do not store a flag whether this TNode is a parent or a sibling node. As a result, the logic that assembles the final output uses incorrect TNodes and in some cases throws exceptions (when incompatible structure is extracted from tView.data due to the incorrect index). This commit adjusts the index and captures whether TNode is a parent to make sure underlying logic manipulates correct TNode.

This PR closes https://github.com/angular/angular/issues/35299.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No