### PR TITLE
docs: remove service from region where it was added before it was cre…

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.1.ts
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.1.ts
@@ -5,9 +5,9 @@ import { Observable } from 'rxjs';
 class DummyHeroesComponent {
 
   heroes: Observable<Hero[]>;
-
+  // #docregion ctor
   constructor(private heroService: HeroService) {}
-
+  // #enddocregion ctor
   // #docregion getHeroes
   getHeroes(): void {
     // #docregion get-heroes

--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.ts
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.ts
@@ -5,8 +5,8 @@ import { Component, OnInit } from '@angular/core';
 import { Hero } from '../hero';
 // #docregion hero-service-import
 import { HeroService } from '../hero.service';
-import { MessageService } from '../message.service';
 // #enddocregion hero-service-import
+import { MessageService } from '../message.service';
 
 @Component({
   selector: 'app-heroes',

--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -122,7 +122,7 @@ Replace the definition of the `heroes` property with a simple declaration.
 
 Add a private `heroService` parameter of type `HeroService` to the constructor.
 
-<code-example path="toh-pt4/src/app/heroes/heroes.component.ts" header="src/app/heroes/heroes.component.ts" region="ctor">
+<code-example path="toh-pt4/src/app/heroes/heroes.component.1.ts" header="src/app/heroes/heroes.component.ts" region="ctor">
 </code-example>
 
 The parameter simultaneously defines a private `heroService` property and identifies it as a `HeroService` injection site.


### PR DESCRIPTION
…ated

The message service in toh4  was created at a later point in the tutorial, it is added in a section create message service but was impoted much before it removed those imports

Fixes #35259

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
import message service before it was created 
Issue Number: #35259


## What is the new behavior?
Removed import of message service before it was created.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
