### PR TITLE
docs: Add documentation about the CLI failing

### DIFF
--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -322,6 +322,13 @@ ngOnInit() {
 
 For more information with a working example, see the [routing tutorial section on preloading](guide/router-tutorial-toh#preloading-background-loading-of-feature-areas).
 
+## Troubleshooting lazy-loading modules
+
+A common error when lazy-loading modules is importing common modules in multiple places within an application.  You can test for this condition by first generating the module using the Angular CLI and including the `--route route-name` parameter, where `route-name` is the name of your module. Next, generate the module without the `--route` parameter. If the Angular CLI generates an error when you use the `--route` parameter, but runs correctly without it, you may have imported the same module in multiple places.
+
+Remember, many common Angular modules should be imported at the base of your application.
+
+For more information on Angular Modules, see [NgModules](guide/ngmodules).
 
 ## More on NgModules and routing
 


### PR DESCRIPTION
docs(Lazy-loading feature module): Improve documentation for CLI lazy module generation errors 

The CLI seems to trow very non-descriptive errors when it can't generate lazy modules specifically over normal non-lazy loaded modules. I think having documentation about common modules, multiple imports in sub-trees is going to save a lot of time. I think the problem is not well documented, and if people can't get lazy loading to work, it may persuade more people to not choose Angular.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Just better documentation on common problem not well documented in CLI nor common Angular core modules.

Issue Number: N/A


## What is the new behavior?
Better documentation


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Thank you Angular. I know its a small change, but I'm willing to work on anything you find.
