### PR TITLE
feat(router): add skipNavigation option to routerLink

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -124,6 +124,8 @@ export class RouterLink {
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange !: boolean;
   // TODO(issue/24571): remove '!'.
+  @Input() disableNavigation !: boolean;
+  // TODO(issue/24571): remove '!'.
   @Input() replaceUrl !: boolean;
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
@@ -160,6 +162,10 @@ export class RouterLink {
 
   @HostListener('click')
   onClick(): boolean {
+    if (attrBoolValue(this.disableNavigation)) {
+      return true;
+    }
+
     const extras = {
       skipLocationChange: attrBoolValue(this.skipLocationChange),
       replaceUrl: attrBoolValue(this.replaceUrl),
@@ -206,6 +212,8 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange !: boolean;
   // TODO(issue/24571): remove '!'.
+  @Input() disableNavigation !: boolean;
+  // TODO(issue/24571): remove '!'.
   @Input() replaceUrl !: boolean;
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
@@ -249,6 +257,10 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey', '$event.shiftKey'])
   onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean {
+    if (attrBoolValue(this.disableNavigation)) {
+      return false;
+    }
+
     if (button !== 0 || ctrlKey || metaKey || shiftKey) {
       return true;
     }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1758,6 +1758,37 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/team/22');
        })));
 
+    it('should support skipping navigation for anchor router links',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = TestBed.createComponent(RootCmp);
+         advance(fixture);
+
+         router.resetConfig([{path: 'team/:id', component: NoNavCmp}]);
+
+         router.navigateByUrl('/team/22');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22');
+         expect(fixture.nativeElement).toHaveText('team 22');
+
+         const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+
+         teamCmp.routerLink = ['/team/0'];
+         advance(fixture);
+         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         anchor.click();
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22');
+         expect(location.path()).toEqual('/team/22');
+
+         teamCmp.routerLink = ['/team/1'];
+         advance(fixture);
+         const button = fixture.debugElement.query(By.css('button')).nativeElement;
+         button.click();
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22');
+         expect(location.path()).toEqual('/team/22');
+       })));
+
     it('should support string router links', fakeAsync(inject([Router], (router: Router) => {
          const fixture = createRoot(router, RootCmp);
 
@@ -5002,6 +5033,28 @@ class TeamCmp {
 }
 
 @Component({
+  selector: 'no-nav-cmp',
+  template: `team {{id | async}}` +
+      `<router-outlet></router-outlet>` +
+      `<a [routerLink]="routerLink" disableNavigation></a>` +
+      `<button [routerLink]="routerLink" disableNavigation></button>`
+})
+class NoNavCmp {
+  id: Observable<string>;
+  recordedParams: Params[] = [];
+  snapshotParams: Params[] = [];
+  routerLink = ['.'];
+
+  constructor(public route: ActivatedRoute) {
+    this.id = route.params.pipe(map((p: any) => p['id']));
+    route.params.forEach(p => {
+      this.recordedParams.push(p);
+      this.snapshotParams.push(route.snapshot.params);
+    });
+  }
+}
+
+@Component({
   selector: 'two-outlets-cmp',
   template: `[ <router-outlet></router-outlet>, aux: <router-outlet name="aux"></router-outlet> ]`
 })
@@ -5147,6 +5200,7 @@ class LazyComponent {
     SimpleCmp,
     TwoOutletsCmp,
     TeamCmp,
+    NoNavCmp,
     UserCmp,
     StringLinkCmp,
     DummyLinkCmp,
@@ -5177,6 +5231,7 @@ class LazyComponent {
     SimpleCmp,
     TwoOutletsCmp,
     TeamCmp,
+    NoNavCmp,
     UserCmp,
     StringLinkCmp,
     DummyLinkCmp,
@@ -5208,6 +5263,7 @@ class LazyComponent {
     BlankCmp,
     SimpleCmp,
     TeamCmp,
+    NoNavCmp,
     TwoOutletsCmp,
     UserCmp,
     StringLinkCmp,

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -372,6 +372,7 @@ export declare class RouterEvent {
 }
 
 export declare class RouterLink {
+    disableNavigation: boolean;
     fragment: string;
     preserveFragment: boolean;
     /** @deprecated */ set preserveQueryParams(value: boolean);
@@ -405,6 +406,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 }
 
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
+    disableNavigation: boolean;
     fragment: string;
     href: string;
     preserveFragment: boolean;


### PR DESCRIPTION
The RouterLink directive now has a 'skipNavigation' boolean which disables navigating.

Closes #31154
Closes #13980

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: 31154


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I could not find documentation for the 'skipLocationChange' boolean, so I did not add any documentation for the 'skipNavigation' boolean either.
