### PR TITLE
feat(docs-infra): add entry-point label on api endpoint docs

### DIFF
--- a/aio/tools/transforms/templates/api/package.template.html
+++ b/aio/tools/transforms/templates/api/package.template.html
@@ -23,7 +23,7 @@
 {% block header %}
 <header class="api-header">
   <h1>{$ doc.name $}</h1>
-  <label class="api-type-label {$ doc.docType $}">{$ doc.docType $}</label>
+  {% if doc.isPrimaryPackage %}<label class="api-type-label package">package</label>{% else %}<label class="api-type-label {$ entry-point $}">entry-point</label>{% endif %}
   {% if doc.packageDeprecated or (not doc.isPrimaryPackage and doc.deprecated !== undefined) %}<label class="api-status-label deprecated">deprecated</label>{% endif %}
   {% if doc.security !== undefined %}<label class="api-status-label security">security</label>{% endif %}
   {% if doc.pipeOptions.pure === 'false' %}<label class="api-status-label impure-pipe">impure</label>{% endif %}


### PR DESCRIPTION
On API docs pages for Angular packages (e.g. https://angular.io/api/common), we show all primary and secondary entry-points. Following a link to one of the secondary entry-points (e.g. https://angular.io/api/common/http), navigates the docs page for the secondary entry-point, where it is incorrectly (and misleadingly) labelled as PACKAGE and not as an entry-point.

Implemented a new ENTRY-POINT label and add support for correctly differentiating between entry-points and packages.

Fixes #34081

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Enrty points are also labeled as packages in api docs

Issue Number: #34081


## What is the new behavior?
Add new label entry-point for entry point packages

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
