### PR TITLE
build: enable network for docker on remote executors

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -23,6 +23,10 @@ platform(
             value: "SYS_ADMIN"
         }
         properties: {
+            name: "dockerNetwork"
+            value: "standard"
+        }
+        properties: {
             name: "Pool"
             value: "default"
         }


### PR DESCRIPTION
This is being done as a pre-factor for running integration tests
with bazel on RBE.
