### PR TITLE
fix(language-service): provide completions for the structural directive that only injects the 'ViewContainerRef'

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -15,7 +15,7 @@ import {getExpressionCompletions} from './expressions';
 import {attributeNames, elementNames, eventNames, propertyNames} from './html_info';
 import {InlineTemplate} from './template';
 import * as ng from './types';
-import {diagnosticInfoFromTemplateInfo, findTemplateAstAt, getPathToNodeAtPosition, getSelectors, hasTemplateReference, inSpan, spanOf} from './utils';
+import {diagnosticInfoFromTemplateInfo, findTemplateAstAt, getPathToNodeAtPosition, getSelectors, inSpan, isStructuralDirective, spanOf} from './utils';
 
 const HIDDEN_HTML_ELEMENTS: ReadonlySet<string> =
     new Set(['html', 'script', 'noscript', 'base', 'body', 'title', 'head', 'link']);
@@ -629,11 +629,11 @@ function angularAttributes(info: AstResult, elementName: string): AngularAttribu
       continue;
     }
     const summary = selectorMap.get(selector) !;
-    const isTemplateRef = hasTemplateReference(summary.type);
+    const hasTemplateRef = isStructuralDirective(summary.type);
     // attributes are listed in (attribute, value) pairs
     for (let i = 0; i < selector.attrs.length; i += 2) {
       const attr = selector.attrs[i];
-      if (isTemplateRef) {
+      if (hasTemplateRef) {
         templateRefs.add(attr);
       } else {
         others.add(attr);

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -56,9 +56,11 @@ export function isNarrower(spanA: Span, spanB: Span): boolean {
   return spanA.start >= spanB.start && spanA.end <= spanB.end;
 }
 
-export function hasTemplateReference(type: CompileTypeMetadata): boolean {
+export function isStructuralDirective(type: CompileTypeMetadata): boolean {
   for (const diDep of type.diDeps) {
-    if (diDep.token && identifierName(diDep.token.identifier) === Identifiers.TemplateRef.name) {
+    const diDepName = identifierName(diDep.token?.identifier);
+    if (diDepName === Identifiers.TemplateRef.name ||
+        diDepName === Identifiers.ViewContainerRef.name) {
       return true;
     }
   }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -129,6 +129,7 @@ describe('completions', () => {
       'ngSwitchCase',
       'ngSwitchDefault',
       'ngPluralCase',
+      'ngTemplateOutlet',
     ]);
   });
 


### PR DESCRIPTION
The completions list don't include the 'ngTemplateOutlet'. The directive is a structural directive when it has injected the 'TemplateRef' or 'ViewContainerRef'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
