### PR TITLE
build(core/labs):  Set up `@angular/core/labs` package for experimentation

### DIFF
--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -622,8 +622,17 @@ export function setup(options: {
       // If running under bazel then we get the compiled version of the files from the bazel package
       // output.
       const bundles = new Set([
-        'bundles', 'esm2015', 'esm5', 'testing', 'testing.d.ts', 'testing.metadata.json', 'browser',
-        'browser.d.ts'
+        'bundles',
+        'esm2015',
+        'esm5',
+        'testing',
+        'testing.d.ts',
+        'testing.metadata.json',
+        'browser',
+        'browser.d.ts',
+        'labs',
+        'labs.d.ts',
+        'labs.metadata.json',
       ]);
       const skipDirs = (name: string) => bundles.has(name);
       if (options.compileAngular) {

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -27,6 +27,8 @@ ng_package(
     name = "npm_package",
     srcs = glob(["**/*.externs.js"]) + [
         "package.json",
+        "//packages/core/labs:package.json",
+        "//packages/core/labs:README.md",
         "//packages/core/testing:package.json",
     ],
     entry_point = ":index.ts",
@@ -51,6 +53,7 @@ ng_package(
     ],
     deps = [
         ":core",
+        "//packages/core/labs",
         "//packages/core/testing",
     ],
 )

--- a/packages/labs/BUILD.bazel
+++ b/packages/labs/BUILD.bazel
@@ -1,0 +1,49 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "karma_web_test_suite", "ng_module", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "package.json",
+    "README.md",
+])
+
+ng_module(
+    name = "labs",
+    srcs = glob(
+        ["*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    module_name = "@angular/labs",
+    deps = [
+        "//packages/core",
+        "@npm//@types/node",
+    ],
+)
+
+ts_library(
+    name = "unit_spec_lib",
+    testonly = True,
+    srcs = glob(
+        ["*.unit.spec.ts"],
+    ),
+    deps = [
+        ":labs",
+        "//packages:types",
+        "//packages/core",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit",
+    bootstrap = ["//tools/testing:node_es5"],
+    deps = [
+        ":unit_spec_lib",
+    ],
+)
+
+karma_web_test_suite(
+    name = "unit_web",
+    deps = [
+        ":unit_spec_lib",
+    ],
+)

--- a/packages/labs/README.md
+++ b/packages/labs/README.md
@@ -1,0 +1,29 @@
+# Labs
+
+Labs are a place where Angular team can test out new ideas for Angular APIs, get community feedback in a way which allows us to quickly iterate, experiment and throw away ideas. As such this is meant to solicit feedback and is not meant for production use.
+
+## DISCLAIMER
+
+The `@angular/labs` contains code which is **NOT** production ready! 
+Its intent is to try out new ideas, and make it available on experimental basis to get feedback without being committed to anything.
+
+Specifically:
+- It does **NOT** follow any version scheme.
+- We make no guarantees about any APIs being stable between any two versions.
+  - specifically we can at any time delete API, change API names, API semantics, API arguments and or return types which will most likely result in your experimental app being broken. 
+
+Use at your own risk, and give us feedback. 
+
+## How to use
+
+To use `@angular/core/labs` you have to agree to the above disclaimer in the code before the APIs can be used.
+
+```
+import {iWantToUseExperimentalAPIs} from `@angular/labs/core`
+
+iWantToUseExperimentalAPIs({
+  iUnderstand: ['not ready for production', 'unstable API']
+})
+```
+The above code will need to execute before any other APIs are enabled and can be used in your experiments. 
+The act of agreeing will create a disclaimer banner in your console, reminding you that this is not meant for production.

--- a/packages/labs/TEST.md
+++ b/packages/labs/TEST.md
@@ -1,0 +1,29 @@
+# Tests
+
+`@angular/labs` is a place to try new things. One thing which we are trying is to place the test code together with the production code. There are several advantages.
+- Most IDEs do not know that `foo.ts` and `foo.spec.ts` are related and so it makes it hard to navigate between the two files. By placing the files next to each other the navigation becomes easier.
+- It is easier to tell at a first glance if a particular code has tests and what kinds of tests (unit vs integration vs e2e)
+
+
+## Naming Strategy
+
+For any given file `path/file.ts` the following should be true.
+- When building production code all `**/*.spec.ts` files are excluded from production. The spec files are further subdivided as:
+  - `**/*.unit.spec.ts` (==> `yarn bazel packages/labs:unit` and `:unit_web`)
+    - Unit tests have a strict bazel dependency only on the `packages/labs` package and as a result have a fast build time. 
+  - `**/*.acceptance.spec.ts` (==> `yarn bazel packages/labs:acceptance` and `:acceptance_web`)
+    - Acceptance tests have a broader dependency on other packages such as `package/compiler` and `package/platform-browser` for end to end tests. These tests are necessarily slower to build and execute. 
+
+
+## Running test
+
+- `yarn bazel test packages/labs/SUB_PKG:all` will execute all tests.
+- `yarn bazel test packages/labs/SUB_PKG:unit` will execute all unit tests in node.
+- `yarn bazel test packages/labs/SUB_PKG:unit_web` will execute all unit tests in browser.
+- `yarn bazel test packages/labs/SUB_PKG:acceptance` will execute all acceptance tests in node.
+- `yarn bazel test packages/labs/SUB_PKG:acceptance_web` will execute all acceptance tests in browser.
+
+### Debugging
+
+- In node: `yarn bazel test packages/labs/SUB_PKG:unit --config=debug` and than attach your debugger.
+- In browser: `yarn bazel run packages/labs/SUB_PKG:unit_web` and than open your browser http://localhost:9876/debug.html to strat debugging.

--- a/packages/labs/core/BUILD.bazel
+++ b/packages/labs/core/BUILD.bazel
@@ -1,0 +1,88 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "karma_web_test_suite", "ng_module", "ts_library")
+load("//tools/circular_dependency_test:index.bzl", "circular_dependency_test")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "package.json",
+    "README.md",
+])
+
+ng_module(
+    name = "labs",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/core/labs",
+    deps = [
+        "//packages/core",
+        "@npm//@types/node",
+    ],
+)
+
+circular_dependency_test(
+    name = "circular_deps_test",
+    entry_point = "angular/packages/core/labs/index.js",
+    deps = [":labs"],
+)
+
+ts_library(
+    name = "unit_spec_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.unit.spec.ts"],
+    ),
+    deps = [
+        ":labs",
+        "//packages:types",
+        "//packages/core",
+    ],
+)
+
+ts_library(
+    name = "acceptance_spec_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.acceptance.spec.ts"],
+    ),
+    deps = [
+        ":labs",
+        "//packages:types",
+        "//packages/compiler",
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/platform-browser",
+        "//packages/platform-browser-dynamic",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit",
+    bootstrap = ["//tools/testing:node_es5"],
+    deps = [
+        ":unit_spec_lib",
+    ],
+)
+
+karma_web_test_suite(
+    name = "unit_web",
+    deps = [
+        ":unit_spec_lib",
+    ],
+)
+
+jasmine_node_test(
+    name = "acceptance",
+    bootstrap = ["//tools/testing:node_es5"],
+    deps = [
+        ":acceptance_spec_lib",
+    ],
+)
+
+karma_web_test_suite(
+    name = "acceptance_web",
+    deps = [
+        ":acceptance_spec_lib",
+    ],
+)

--- a/packages/labs/core/index.ts
+++ b/packages/labs/core/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const CORE = 'empty placeholder';

--- a/packages/labs/core/package.json
+++ b/packages/labs/core/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@angular/core/labs",
+  "typings": "./labs.d.ts",
+  "main": "../bundles/core-labs.umd.js",
+  "module": "../fesm5/labs.js",
+  "es2015": "../fesm2015/labs.js",
+  "esm5": "../esm5/labs/labs.js",
+  "esm2015": "../esm2015/labs/labs.js",
+  "fesm5": "../fesm5/labs.js",
+  "fesm2015": "../fesm2015/labs.js"
+}

--- a/packages/labs/index.ts
+++ b/packages/labs/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// NOTE: Please list exported API which are made public individually here.
+export {iWantToUseExperimentalAPIs} from './labs_disclaimer';

--- a/packages/labs/labs_disclaimer.acceptance.spec.ts
+++ b/packages/labs/labs_disclaimer.acceptance.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {iWantToUseExperimentalAPIs} from '@angular/labs';
+
+describe('acceptance test support', () => {
+  beforeEach(() => {
+    // reset acceptance
+    expect(() => iWantToUseExperimentalAPIs(null as any)).toThrow();
+  });
+  it('should demonstrate that acceptance test works', () => {
+    @Component({template: `agreement: {{accepted ? 'accepted': 'rejected'}}`})
+    class MyComponent {
+      constructor() {
+        iWantToUseExperimentalAPIs({iUnderstand: ['not ready for production', 'unstable API']});
+      }
+      get accepted() { return (global as any).__ng_core_labs_agreement__; }
+    }
+    TestBed.configureTestingModule({declarations: [MyComponent]});
+    const fixture = TestBed.createComponent(MyComponent);
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).innerHTML).toEqual('agreement: accepted');
+  });
+
+});

--- a/packages/labs/labs_disclaimer.ts
+++ b/packages/labs/labs_disclaimer.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertEqual} from '../core/src/util/assert';
+import {global} from '../core/src/util/global';
+
+/**
+ * Global property name where the agreement is stored.
+ */
+interface GlobalDeclaimer {
+  __ng_core_labs_agreement__?: boolean;
+}
+
+/**
+ * Mandatory agreement about unstable APIs.
+ *
+ * The purpose of this function is to communicate the importance of the fact that developer is about
+ * to use unstable APIs. As such Angular team makes no guarantee about the API stability.
+ *
+ * The agreement is important so that the developer is made fully aware of what they are about to
+ * do. Without invoking this function the rest of the APIs will throw an error which prevents their
+ * use. Agreeing here also prints a large warning in the console pointing out the experimental
+ * nature of the API.
+ *
+ * ```
+ * import {iWantToUseExperimentalAPIs} from `@angular/core/labs`
+ *
+ * iWantToUseExperimentalAPIs({
+ *   iUnderstand: ['not ready for production', 'unstable API']
+ * })
+ * ```
+ *
+ * @param agreement Correctly formated input stating the agreement must be present. See above.
+ *
+ * @publicApi
+ */
+export function iWantToUseExperimentalAPIs(
+    agreement: {iUnderstand: ['not ready for production', 'unstable API']}) {
+  (global as GlobalDeclaimer).__ng_core_labs_agreement__ = false;
+  if (agreement && agreement.iUnderstand &&
+      agreement.iUnderstand[0] === 'not ready for production' &&
+      agreement.iUnderstand[1] === 'unstable API') {
+    (global as GlobalDeclaimer).__ng_core_labs_agreement__ = true;
+    // tslint:disable-next-line:no-console
+    console.warn(
+        '%cYou are using experimental APIs! Not production ready! No guarantee of API stability! Use caution!',
+        'background: red; color: yellow; font-size: x-large');
+  } else {
+    throw new Error('Sorry you must agree to experimental APIs before you can use them!');
+  }
+}
+
+
+/**
+ * Invoked by all unstable API to verify that the user has agreed to experimental API.
+ *
+ * Throws error if `iWantToUseExperimentalAPIs` was not invoked.
+ */
+export function assertExperimentalAgreement() {
+  assertEqual(
+      (global as GlobalDeclaimer).__ng_core_labs_agreement__, true,
+      'Use my agree to use experimental APIs. See `iWantToUseExperimentalAPIs`');
+}

--- a/packages/labs/labs_disclaimer.unit.spec.ts
+++ b/packages/labs/labs_disclaimer.unit.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertExperimentalAgreement, iWantToUseExperimentalAPIs} from './labs_disclaimer';
+
+describe('disclaimer', () => {
+  it('should reset disclaimer', () => {
+    expect(() => iWantToUseExperimentalAPIs(null as any)).toThrowError();
+    expect(() => assertExperimentalAgreement()).toThrowError();
+  });
+
+  it('should allow API after agreement', () => {
+    expect(
+        () =>
+            iWantToUseExperimentalAPIs({iUnderstand: ['not ready for production', 'unstable API']}))
+        .not.toThrowError();
+    expect(() => assertExperimentalAgreement()).not.toThrowError();
+  });
+});

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@angular/labs",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "Angular - the labs framework",
+  "main": "./bundles/labs.umd.js",
+  "module": "./fesm5/labs.js",
+  "es2015": "./fesm2015/labs.js",
+  "esm5": "./esm5/labs.js",
+  "esm2015": "./esm2015/labs.js",
+  "fesm5": "./fesm5/labs.js",
+  "fesm2015": "./fesm2015/labs.js",
+  "typings": "./labs.d.ts",
+  "author": "angular",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
+  },
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
+}

--- a/tools/validate-commit-message/validate-commit-message.js
+++ b/tools/validate-commit-message/validate-commit-message.js
@@ -20,6 +20,7 @@ const config = require('./commit-message.json');
 const FIXUP_PREFIX_RE = /^fixup! /i;
 const SQUASH_PREFIX_RE = /^squash! /i;
 const REVERT_PREFIX_RE = /^revert:? /i;
+const LABS_INFIX_RE = /^(\w+\(\w+)\/labs(\): )/i;
 
 module.exports = (commitHeader, disallowSquash, nonFixupCommitHeaders) => {
   if (REVERT_PREFIX_RE.test(commitHeader)) {
@@ -87,7 +88,9 @@ function error(errorMessage, commitHeader) {
 function parseCommitHeader(header) {
   const isFixup = FIXUP_PREFIX_RE.test(header);
   const isSquash = SQUASH_PREFIX_RE.test(header);
-  header = header.replace(FIXUP_PREFIX_RE, '').replace(SQUASH_PREFIX_RE, '');
+  header = header.replace(FIXUP_PREFIX_RE, '')
+               .replace(SQUASH_PREFIX_RE, '')
+               .replace(LABS_INFIX_RE, function(match, before, after) { return before + after; });
 
   const match = /^(\w+)(?:\(([^)]+)\))?\: (.+)$/.exec(header) || [];
 

--- a/tools/validate-commit-message/validate-commit-message.spec.js
+++ b/tools/validate-commit-message/validate-commit-message.spec.js
@@ -36,6 +36,7 @@ describe('validate-commit-message.js', () => {
 
     it('should be valid', () => {
       expect(validateMessage('fix(core): something')).toBe(VALID);
+      expect(validateMessage('fix(core/labs): something')).toBe(VALID);
       expect(validateMessage('feat(common): something')).toBe(VALID);
       expect(validateMessage('docs(compiler): something')).toBe(VALID);
       expect(validateMessage('style(http): something')).toBe(VALID);


### PR DESCRIPTION


This change creates a new sub-package `@angular/core/labs` the purpose of which is to allow us to have experimental API in a way where the community can try them out without us being committed to supporting them long term.

Before the developer can use any of the APIs in the `@angular/core/labs` package they have to agree to the conditions which are clearly spelled out in both the way of agreeing as well as a warning in the console.

```
import {iWantToUseExperimentalAPIs} from `@angular/core/labs`

iWantToUseExperimentalAPIs({
  iUnderstand: ['not ready for production', 'unstable API']
})
```

The purpose of the above code is to make it very clear that the developer is about to use experimental APIs which should not be used in production.

Additionally this change sets up testing harness for `@angular/core/labs` where the specs are next to the actual code to simplify the directory structure.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
