### PR TITLE
fix(language-service): provide hover for interpolation in attribute value

### DIFF
--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -39,6 +39,16 @@ describe('hover', () => {
     expect(toText(displayParts)).toBe('(property) MyComponent.name: string');
   });
 
+  it('should be able to find an interpolated value in an attribute', () => {
+    mockHost.override(TEST_TEMPLATE, `<div string-model model="{{«title»}}"></div>`);
+    const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'title');
+    const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+    expect(quickInfo).toBeTruthy();
+    const {textSpan, displayParts} = quickInfo !;
+    expect(textSpan).toEqual(marker);
+    expect(toText(displayParts)).toBe('(property) TemplateReference.title: string');
+  });
+
   it('should be able to find a field in a attribute reference', () => {
     const fileName = mockHost.addCode(`
       @Component({


### PR DESCRIPTION
I think the bug is introduced in my PR #34847. For example, 'model="{{title}}"', the attribute value cannot be parsed by 'parseTemplateBindings'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
