### PR TITLE
fix(ngcc): correctly detect outer aliased class identifiers in ES5

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -634,7 +634,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     if (!this.preprocessedSourceFiles.has(sourceFile)) {
       this.preprocessedSourceFiles.add(sourceFile);
 
-      for (const statement of sourceFile.statements) {
+      for (const statement of this.getModuleStatements(sourceFile)) {
         this.preprocessStatement(statement);
       }
     }
@@ -660,7 +660,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     const declaration = declarations[0];
     const initializer = declaration.initializer;
     if (!ts.isIdentifier(declaration.name) || !initializer || !isAssignment(initializer) ||
-        !ts.isIdentifier(initializer.left) || !ts.isClassExpression(initializer.right)) {
+        !ts.isIdentifier(initializer.left) || !this.isClass(declaration)) {
       return;
     }
 

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -291,16 +291,14 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    *
    * Given the outer variable declaration, we want to get to the inner function declaration.
    *
-   * @param node a node that could be the variable expression outside an ES5 class IIFE.
+   * @param decl a declaration node that could be the variable expression outside an ES5 class IIFE.
    * @param checker the TS program TypeChecker
    * @returns the inner function declaration or `undefined` if it is not a "class".
    */
-  protected getInnerFunctionDeclarationFromClassDeclaration(node: ts.Node): ts.FunctionDeclaration
+  protected getInnerFunctionDeclarationFromClassDeclaration(decl: ts.Declaration): ts.FunctionDeclaration
       |undefined {
-    if (!ts.isVariableDeclaration(node)) return undefined;
-
     // Extract the IIFE body (if any).
-    const iifeBody = getIifeBody(node);
+    const iifeBody = getIifeBody(decl);
     if (!iifeBody) return undefined;
 
     // Extract the function declaration from inside the IIFE.

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -91,6 +91,19 @@ export const DEFAULT_NGCC_CONFIG: NgccProjectConfig = {
     //   },
     // },
 
+    // The package does not contain any `.metadata.json` files in the root directory but only inside
+    // `dist/`. Without this config, ngcc does not realize this is a ViewEngine-built Angular
+    // package that needs to be compiled to Ivy.
+    'angular2-highcharts': {
+      entryPoints: {
+        '.': {
+          override: {
+            main: './index.js',
+          },
+        },
+      },
+    },
+
     // The `dist/` directory has a duplicate `package.json` pointing to the same files, which (under
     // certain configurations) can causes ngcc to try to process the files twice and fail.
     // Ignore the `dist/` entry-point.

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -929,10 +929,10 @@ runInEachFileSystem(() => {
           name: _('/src/index.js'),
           contents: `
         (function (global, factory) {
-          typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./functions'), require('./methods'), require('./aliased_class')) :
-          typeof define === 'function' && define.amd ? define('index', ['exports', './functions', './methods', './aliased_class'], factory) :
-          (factory(global.index,global.functions,global.methods,global.aliased_class));
-        }(this, (function (exports,functions,methods,aliased_class) { 'use strict';
+          typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./functions'), require('./methods'), require('./outer_aliased_class'), require('./inner_aliased_class')) :
+          typeof define === 'function' && define.amd ? define('index', ['exports', './functions', './methods', './outer_aliased_class', './inner_aliased_class'], factory) :
+          (factory(global.index,global.functions,global.methods,global.outer_aliased_class,global.inner_aliased_class));
+        }(this, (function (exports,functions,methods,outer_aliased_class,inner_aliased_class) { 'use strict';
         }))));
         `,
         },
@@ -1025,12 +1025,30 @@ runInEachFileSystem(() => {
     `
         },
         {
-          name: _('/src/aliased_class.js'),
+          name: _('/src/outer_aliased_class.js'),
           contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
-      typeof define === 'function' && define.amd ? define('aliased_class', ['exports'], factory) :
-      (factory(global.aliased_class));
+      typeof define === 'function' && define.amd ? define('outer_aliased_class', ['exports'], factory) :
+      (factory(global.outer_aliased_class));
+    }(this, (function (exports,module) { 'use strict';
+      var AliasedModule = AliasedModule_1 = (function() {
+        function AliasedModule() {}
+        return AliasedModule;
+      }());
+      AliasedModule.forRoot = function() { return { ngModule: AliasedModule_1 }; };
+      exports.AliasedModule = AliasedModule;
+      var AliasedModule_1;
+    })));
+    `
+        },
+        {
+          name: _('/src/inner_aliased_class.js'),
+          contents: `
+    (function (global, factory) {
+      typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+      typeof define === 'function' && define.amd ? define('inner_aliased_class', ['exports'], factory) :
+      (factory(global.inner_aliased_class));
     }(this, (function (exports,module) { 'use strict';
       var AliasedModule = (function() {
         function AliasedModule() {}
@@ -1829,6 +1847,41 @@ runInEachFileSystem(() => {
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
         expect(actualDeclaration !.viaModule).toBe(null);
+      });
+
+      it('should return the correct declaration for an outer alias identifier', () => {
+        const PROGRAM_FILE: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            (function (global, factory) {
+              typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+              typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
+              (factory(global.test));
+            }(this, (function (exports,module) { 'use strict';
+              var AliasedClass = AliasedClass_1 = (function () {
+                function InnerClass() {
+                }
+                return InnerClass;
+              }());
+              var AliasedClass_1;
+            })));
+          `,
+        };
+
+        loadTestFiles([PROGRAM_FILE]);
+        const bundle = makeTestBundleProgram(PROGRAM_FILE.name);
+        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+
+        const expectedDeclaration = getDeclaration(
+            bundle.program, PROGRAM_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
+        // Grab the `AliasedClass_1` identifier (which is an alias for `AliasedClass`).
+        const aliasIdentifier =
+            (expectedDeclaration.initializer as ts.BinaryExpression).left as ts.Identifier;
+        const actualDeclaration = host.getDeclarationOfIdentifier(aliasIdentifier);
+
+        expect(aliasIdentifier.getText()).toBe('AliasedClass_1');
+        expect(actualDeclaration).not.toBe(null);
+        expect(actualDeclaration !.node).toBe(expectedDeclaration);
       });
 
       it('should return the source-file of an import namespace', () => {
@@ -2642,17 +2695,30 @@ runInEachFileSystem(() => {
            ]);
          });
 
+      it('should resolve aliased module references to their original declaration (outer alias)',
+         () => {
+           loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/outer_aliased_class.js'));
+           const fn = host.getModuleWithProvidersFunctions(file);
+           expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
+             ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],
+           ]);
+         });
+
       // https://github.com/angular/angular/issues/29078
-      it('should resolve aliased module references to their original declaration', () => {
-        loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
-        const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
-        const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
-        const fn = host.getModuleWithProvidersFunctions(file);
-        expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
-          ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],
-        ]);
-      });
+      it('should resolve aliased module references to their original declaration (inner alias)',
+         () => {
+           loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
+           const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
+           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const file = getSourceFileOrError(bundle.program, _('/src/inner_aliased_class.js'));
+           const fn = host.getModuleWithProvidersFunctions(file);
+           expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
+             ['function() { return { ngModule: AliasedModule_1 }; }', 'AliasedModule'],
+           ]);
+         });
     });
   });
 });


### PR DESCRIPTION
In ES5 and ES2015, class identifiers may have aliases. Previously, the `NgccReflectionHost`s recognized the following formats:
- ES5:
    ```js
    var MyClass = (function () {
      function InnerClass() {}
      InnerClass_1 = InnerClass;
      ...
    }());
    ```
- ES2015:
    ```js
    let MyClass = MyClass_1 = class MyClass { ... };
    ```

In addition to the above, this commit adds support for recognizing an alias outside the IIFE in ES5 classes (which was previously not supported):
```js
var MyClass = MyClass_1 = (function () { ... }());
```

Jira issue: [FW-1869](https://angular-team.atlassian.net/browse/FW-1869)

Fixes #35399.
