### PR TITLE
ci: increase AIO payload size limit

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 449438,
+        "main-es2015": 450017,
         "polyfills-es2015": 52195
       }
     }


### PR DESCRIPTION
This commit updates AIO payload size limit that is triggering a problem after merging https://github.com/angular/angular/commit/f95b8ce07e71cf0b736cec1f617349a44e41f939. That commit added some payload size, but all checks were "green" for the PR (https://github.com/angular/angular/pull/34481) after rebase that happened a couple hours before the merge, so this is an accumulated payload size increase from multiple changes. The goal of this commit is to bring the master and patch branches back to "green" state.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No