### PR TITLE
fix(language-service): infer context type of structural directives (#35537)

### DIFF
--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -286,6 +286,42 @@ describe('diagnostics', () => {
       expect(start).toBe(span.start);
       expect(length).toBe(span.length);
     });
+
+    it('report an unknown field in $implicit context', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <div *withContext="let myVar">
+          {{ ~{start-emb}myVar.missingField ~{end-emb}}}
+        </div>
+      `);
+      const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
+      expect(diags.length).toBe(1);
+      const {messageText, start, length, category} = diags[0];
+      expect(category).toBe(ts.DiagnosticCategory.Error);
+      expect(messageText)
+          .toBe(
+              `Identifier 'missingField' is not defined. '{ implicitPerson: Person; }' does not contain such a member`, );
+      const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'emb');
+      expect(start).toBe(span.start);
+      expect(length).toBe(span.length);
+    });
+
+    it('report an unknown field in non implicit context', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <div *withContext="let myVar = nonImplicitPerson">
+          {{ ~{start-emb}myVar.missingField ~{end-emb}}}
+        </div>
+      `);
+      const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
+      expect(diags.length).toBe(1);
+      const {messageText, start, length, category} = diags[0];
+      expect(category).toBe(ts.DiagnosticCategory.Error);
+      expect(messageText)
+          .toBe(
+              `Identifier 'missingField' is not defined. 'Person' does not contain such a member`, );
+      const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'emb');
+      expect(start).toBe(span.start);
+      expect(length).toBe(span.length);
+    });
   });
 
   // #17611

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -43,6 +43,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.StringModel,
     ParsingCases.TemplateReference,
     ParsingCases.TestComponent,
+    ParsingCases.WithContextDirective,
   ]
 })
 export class AppModule {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -127,6 +127,21 @@ export class CounterDirective implements OnChanges {
   }
 }
 
+interface WithContextDirectiveContext {
+  $implicit: {implicitPerson: Person;};
+  nonImplicitPerson: Person;
+}
+
+@Directive({selector: '[withContext]'})
+export class WithContextDirective {
+  constructor(_template: TemplateRef<WithContextDirectiveContext>) {}
+
+  static ngTemplateContextGuard(dir: WithContextDirective, ctx: unknown):
+      ctx is WithContextDirectiveContext {
+    return true;
+  }
+}
+
 /**
  * This Component provides the `test-comp` selector.
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #35537, #35426

## What is the new behavior?

The type of structural directive context is now correctly inferred instead of any. There was a trick before to manually handle the context of ngFor exported values (getNgForExportedValueType function), this is not needed anymore, because my solutions handle them automatically. New unit tests were added to validate this change and also to ensure the fix is actually working.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The implementation works like in angular 8, because it relies on the already existing getTemplateContext method. So the context is inferred from the type parameter of injected TemplateRef. The ivy compiler works differently by relying on ngTemplateContextGuard static method. However, the TemplateRef solution will work with much more existing directives and as I understand, full ivy parity was not scope of language-service v9. 
