### PR TITLE
fix(localize): support minified ES5 `$localize` calls

### DIFF
--- a/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
@@ -89,6 +89,25 @@ export function unwrapMessagePartsFromLocalizeCall(call: NodePath<t.CallExpressi
         throw new BabelParseError(
             cooked.node, 'Unexpected "makeTemplateObject()" function (expected an expression).');
       }
+    } else if (right.isSequenceExpression()) {
+      const expressions = right.get('expressions');
+      if (expressions.length > 2) {
+        // This is a minified sequence expression, where the first two expressions in the sequence
+        // are assignments of the cooked and raw arrays respectively.
+        const first = expressions[0];
+        const second = expressions[1];
+        if (first.isAssignmentExpression() && second.isAssignmentExpression()) {
+          cooked = first.get('right');
+          if (!cooked.isExpression()) {
+            throw new BabelParseError(
+                first.node, 'Unexpected cooked value, expected an expression.');
+          }
+          raw = second.get('right');
+          if (!raw.isExpression()) {
+            throw new BabelParseError(second.node, 'Unexpected raw value, expected an expression.');
+          }
+        }
+      }
     }
   }
 

--- a/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
@@ -94,8 +94,7 @@ export function unwrapMessagePartsFromLocalizeCall(call: NodePath<t.CallExpressi
       if (expressions.length > 2) {
         // This is a minified sequence expression, where the first two expressions in the sequence
         // are assignments of the cooked and raw arrays respectively.
-        const first = expressions[0];
-        const second = expressions[1];
+        const [first, second] = expressions;
         if (first.isAssignmentExpression() && second.isAssignmentExpression()) {
           cooked = first.get('right');
           if (!cooked.isExpression()) {

--- a/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
@@ -103,6 +103,22 @@ describe('makeEs5Plugin', () => {
       expect(output.code).toEqual('"try" + (40 + 2) + "me";');
     });
 
+    it('should handle minified code', () => {
+      const diagnostics = new Diagnostics();
+      const input = `$localize(
+        cachedObj||
+        (
+          cookedParts=['try', 'me'],
+          rawParts=['try', 'me'],
+          Object.defineProperty?
+            Object.defineProperty(cookedParts,"raw",{value:rawParts}):
+            cookedParts.raw=rawParts,
+          cachedObj=cookedParts
+        ),40 + 2)`;
+      const output = transformSync(input, {plugins: [makeEs5TranslatePlugin(diagnostics, {})]}) !;
+      expect(output.code).toEqual('"try" + (40 + 2) + "me";');
+    });
+
     it('should handle lazy-load helper calls', () => {
       const diagnostics = new Diagnostics();
       const input = `


### PR DESCRIPTION
Some minification tooling modifies `$localize` calls
to contain a comma sequence of items, where the
cooked and raw values are assigned to variables.

This change improves our ability to recognize these
structures.

Fixes #35376
