### PR TITLE
fix(ngcc): capture path-mapped entry-points that start with same string

### DIFF
--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -189,8 +189,8 @@ runInEachFileSystem(() => {
             fs, config, logger, resolver, basePath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
-          ['../dist/pkg2', '../dist/pkg2'],
           ['test', 'test'],
+          ['../dist/pkg2', '../dist/pkg2'],
         ]);
       });
 

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -236,12 +236,16 @@ runInEachFileSystem(() => {
              baseUrl: '/path_mapped/dist',
              paths: {
                'lib1': ['my-lib/my-lib', 'my-lib'],
-               'lib2': ['my-lib-other/my-lib-other', 'my-lib-other']
+               'lib2': ['my-lib/a', 'my-lib/a'],
+               'lib3': ['my-lib/b', 'my-lib/b'],
+               'lib4': ['my-lib-other/my-lib-other', 'my-lib-other']
              }
            };
            loadTestFiles([
-             ...createPackage(_Abs('/path_mapped/node_modules'), 'test', ['lib2']),
+             ...createPackage(_Abs('/path_mapped/node_modules'), 'test', ['lib2', 'lib4']),
              ...createPackage(_Abs('/path_mapped/dist/my-lib'), 'my-lib'),
+             ...createPackage(_Abs('/path_mapped/dist/my-lib'), 'a'),
+             ...createPackage(_Abs('/path_mapped/dist/my-lib'), 'b'),
              ...createPackage(_Abs('/path_mapped/dist/my-lib-other'), 'my-lib-other'),
            ]);
            const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
@@ -251,6 +255,7 @@ runInEachFileSystem(() => {
                fs, config, logger, resolver, basePath, targetPath, pathMappings);
            const {entryPoints} = finder.findEntryPoints();
            expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
+             ['../dist/my-lib/a', '../dist/my-lib/a'],
              ['../dist/my-lib-other/my-lib-other', '../dist/my-lib-other/my-lib-other'],
              ['test', 'test'],
            ]);


### PR DESCRIPTION
Previously if there were two path-mapped libraries that are in
different directories but the path of one started with same string
as the path of the other, we would incorrectly return the shorter
path - e.g. `dist/my-lib` and `dist/my-lib-second`. This was because
the list of `basePaths` was searched in ascending alphabetic order and
we were using `startsWith()` to match the path.

Now the `basePaths` are searched in reverse alphabetic order so the
longer path will be matched correctly.

// FW-1873

Fixes #35536
