### PR TITLE
fix(localize): improve placeholder mismatch error message

### DIFF
--- a/packages/localize/src/utils/src/translations.ts
+++ b/packages/localize/src/utils/src/translations.ts
@@ -68,7 +68,8 @@ export function translate(
         return message.substitutions[placeholder];
       } else {
         throw new Error(
-            `No placeholder found with name ${placeholder} in message ${describeMessage(message)}.`);
+            `There is a placeholder name mismatch with the translation provided for the message ${describeMessage(message)}.\n` +
+            `The translation contains a placeholder with name ${placeholder}, which does not exist in the message.`);
       }
     })
   ];

--- a/packages/localize/src/utils/test/translations_spec.ts
+++ b/packages/localize/src/utils/test/translations_spec.ts
@@ -88,9 +88,12 @@ describe('utils', () => {
 
     it('should throw an error if the translation contains placeholders that are not in the message',
        () => {
-         expect(() => doTranslate({'abc': 'a{$PH}bc'}, parts `abc`))
+         expect(
+             () => doTranslate(
+                 {'abc{$INTERPOLATION}def': 'a{$PH}bc'}, parts `abc${1 + 2}:INTERPOLATION:def`))
              .toThrowError(
-                 'No placeholder found with name PH in message "2674653928643152084" ("abc").');
+                 `There is a placeholder name mismatch with the translation provided for the message "8986527425650846693" ("abc{$INTERPOLATION}def").\n` +
+                 `The translation contains a placeholder with name PH, which does not exist in the message.`);
        });
 
     it('(with identity translations) should render template literals as-is', () => {


### PR DESCRIPTION
The original error message was confusing since often it is the
translation that is at fault not the message.

cc @ocombe 