### PR TITLE
fix(service-worker): treat 503 as offline

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -684,7 +684,7 @@ export class Driver implements Debuggable, UpdateSource {
   /**
    * Retrieve a copy of the latest manifest from the server.
    * Return `null` if `ignoreOfflineError` is true (default: false) and the server or client are
-   * offline (detected as response status 504).
+   * offline (detected as response status 503 (service unavailable) or 504 (gateway timeout)).
    */
   private async fetchLatestManifest(ignoreOfflineError?: false): Promise<Manifest>;
   private async fetchLatestManifest(ignoreOfflineError: true): Promise<Manifest|null>;
@@ -695,7 +695,7 @@ export class Driver implements Debuggable, UpdateSource {
       if (res.status === 404) {
         await this.deleteAllCaches();
         await this.scope.registration.unregister();
-      } else if (res.status === 504 && ignoreOfflineError) {
+      } else if ((res.status === 503 || res.status === 504) && ignoreOfflineError) {
         return null;
       }
       throw new Error(`Manifest fetch failed! (status: ${res.status})`);


### PR DESCRIPTION
Prior to this commit the service worker only treated 504 errors as "effectively offline".
This commit changes the behaviour to treat both 503 (Service Unavailable) and 504 as "offline".

Fixes #35571

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #35571


## What is the new behavior?

503 errors will be treated as "offline" and the cached content will be served.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
