### PR TITLE
docs: fix strictTemplates for angular 9+

### DIFF
--- a/aio/content/guide/typescript-configuration.md
+++ b/aio/content/guide/typescript-configuration.md
@@ -53,7 +53,7 @@ The initial `tsconfig.json` for an Angular app typically looks like the followin
     ]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
+    "strictTemplates": true,
     "strictInjectionParameters": true
   }
 }
@@ -61,7 +61,6 @@ The initial `tsconfig.json` for an Angular app typically looks like the followin
 
 
 {@a noImplicitAny}
-
 
 ### *noImplicitAny* and *suppressImplicitAnyIndexErrors*
 
@@ -95,6 +94,7 @@ You can suppress them with the following additional flag:
 For more information about how the TypeScript configuration affects compilation, see [Angular Compiler Options](guide/angular-compiler-options) and [Template Type Checking](guide/template-typecheck).
 
 </div>
+
 
 {@a typings}
 
@@ -145,7 +145,6 @@ For instance, to install typings for `jasmine` you run `npm install @types/jasmi
 
 
 {@a target}
-
 
 ### *target*
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

doc shows previous tsconfig setting, and should show `strictTemplates`


## What is the new behavior?

doc will show tsconfig setting `strictTemplates`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

cc @IgorMinar 