### PR TITLE
fix(compiler): element source span should encompass start and end tags

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -71,9 +71,14 @@ export class Element implements Node {
       public outputs: BoundEvent[], public children: Node[], public references: Reference[],
       public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan|null,
       public endSourceSpan: ParseSourceSpan|null, public i18n?: I18nMeta) {
-    // If the element is empty then the source span should include any closing tag
-    if (children.length === 0 && startSourceSpan && endSourceSpan) {
-      this.sourceSpan = new ParseSourceSpan(sourceSpan.start, endSourceSpan.end);
+    // If startSourceSpan and endSourceSpan are provided then make sure
+    // sourceSpan encompasses both the start and end tag. i.e.
+    // <h1> ... </h1>
+    // ^^^^ startSourceSpan
+    //          ^^^^^ endSourceSpan
+    // ^^^^^^^^^^^^^^ sourceSpan
+    if (startSourceSpan && endSourceSpan) {
+      this.sourceSpan = new ParseSourceSpan(startSourceSpan.start, endSourceSpan.end);
     }
   }
   visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitElement(this); }

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -118,6 +118,13 @@ describe('R3 AST source spans', () => {
       ]);
     });
 
+    it('is correct for elements with bound text', () => {
+      expectFromHtml('<div>{{x}}</div>').toEqual([
+        ['Element', '0:16', '0:5', '10:16'],
+        ['BoundText', '5:10'],
+      ]);
+    });
+
     it('is correct for elements with attributes without value', () => {
       expectFromHtml('<div a></div>').toEqual([
         ['Element', '0:13', '0:7', '7:13'],


### PR DESCRIPTION
This commit fixes a bug whereby an Element's sourceSpan refers only to
its start tag and not the entire element.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
