### PR TITLE
fix(router): removed unused ApplicationRef dependency

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -51,9 +51,9 @@ export const ROUTER_PROVIDERS: Provider[] = [
     provide: Router,
     useFactory: setupRouter,
     deps: [
-      ApplicationRef, UrlSerializer, ChildrenOutletContexts, Location, Injector,
-      NgModuleFactoryLoader, Compiler, ROUTES, ROUTER_CONFIGURATION,
-      [UrlHandlingStrategy, new Optional()], [RouteReuseStrategy, new Optional()]
+      UrlSerializer, ChildrenOutletContexts, Location, Injector, NgModuleFactoryLoader, Compiler,
+      ROUTES, ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()],
+      [RouteReuseStrategy, new Optional()]
     ]
   },
   ChildrenOutletContexts,
@@ -429,9 +429,9 @@ export interface ExtraOptions {
 }
 
 export function setupRouter(
-    ref: ApplicationRef, urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts,
-    location: Location, injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler,
-    config: Route[][], opts: ExtraOptions = {}, urlHandlingStrategy?: UrlHandlingStrategy,
+    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
+    injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler, config: Route[][],
+    opts: ExtraOptions = {}, urlHandlingStrategy?: UrlHandlingStrategy,
     routeReuseStrategy?: RouteReuseStrategy) {
   const router = new Router(
       null, urlSerializer, contexts, location, injector, loader, compiler, flatten(config));


### PR DESCRIPTION
As a part of the process of setting up Router providers, we use `ApplicationRef` as a dependency while providing `Router` token. The thing is that `ApplicationRef` is actually unused (all referenced were removed in https://github.com/angular/angular/commit/5a849829c42330d7e88e83e916e6e36380c97a97), but it's still listed as dependency. This is causing problems in case `Router` is used as a dependency for factory functions provided as `APP_INITIALIZERS` multi-token (causing cyclic dependency). This commit removes unused `ApplicationRef` dependency in `Router`, so it can be used without causing cyclic dependency issue.

This PR resolves #35225.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No