### PR TITLE
fix(ivy): Check transplanted views at declaration even if insertion is CheckAlways

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1634,21 +1634,9 @@ function refreshTransplantedViews(lContainer: LContainer, declaredComponentLView
     // Check if we have a transplanted view by compering declaration and insertion location.
     if (insertedComponentLView !== declaredComponentLView) {
       // Yes the `LView` is transplanted.
-      // Here we would like to know if the component is `OnPush`. We don't have
-      // explicit `OnPush` flag instead we set `CheckAlways` to false (which is `OnPush`)
-      // Not to be confused with `ManualOnPush` which is used with wether a DOM event
-      // should automatically mark a view as dirty.
-      const insertionComponentIsOnPush =
-          (insertedComponentLView[FLAGS] & LViewFlags.CheckAlways) === 0;
-      if (insertionComponentIsOnPush) {
-        // Here we know that the template has been transplanted across components and is
-        // on-push (not just moved within a component). If the insertion is marked dirty, then
-        // there is no need to CD here as we will do it again later when we get to insertion
-        // point.
-        const movedTView = movedLView[TVIEW];
-        ngDevMode && assertDefined(movedTView, 'TView must be allocated');
-        refreshView(movedTView, movedLView, movedTView.template, movedLView[CONTEXT] !);
-      }
+      const movedTView = movedLView[TVIEW];
+      ngDevMode && assertDefined(movedTView, 'TView must be allocated');
+      refreshView(movedTView, movedLView, movedTView.template, movedLView[CONTEXT] !);
     }
   }
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -269,18 +269,13 @@ function trackMovedView(declarationContainer: LContainer, lView: LView) {
   ngDevMode && assertLContainer(insertedLContainer);
   const insertedComponentLView = insertedLContainer[PARENT] ![DECLARATION_COMPONENT_VIEW];
   ngDevMode && assertDefined(insertedComponentLView, 'Missing insertedComponentLView');
-  const insertedComponentIsOnPush =
-      (insertedComponentLView[FLAGS] & LViewFlags.CheckAlways) !== LViewFlags.CheckAlways;
-  if (insertedComponentIsOnPush) {
-    const declaredComponentLView = lView[DECLARATION_COMPONENT_VIEW];
-    ngDevMode && assertDefined(declaredComponentLView, 'Missing declaredComponentLView');
-    if (declaredComponentLView !== insertedComponentLView) {
-      // At this point the declaration-component is not same as insertion-component and we are in
-      // on-push mode, this means that this is a transplanted view. Mark the declared lView as
-      // having
-      // transplanted views so that those views can participate in CD.
-      declarationContainer[ACTIVE_INDEX] |= ActiveIndexFlag.HAS_TRANSPLANTED_VIEWS;
-    }
+  const declaredComponentLView = lView[DECLARATION_COMPONENT_VIEW];
+  ngDevMode && assertDefined(declaredComponentLView, 'Missing declaredComponentLView');
+  if (declaredComponentLView !== insertedComponentLView) {
+    // At this point the declaration-component is not same as insertion-component and we are in
+    // on-push mode, this means that this is a transplanted view. Mark the declared lView as
+    // having transplanted views so that those views can participate in CD.
+    declarationContainer[ACTIVE_INDEX] |= ActiveIndexFlag.HAS_TRANSPLANTED_VIEWS;
   }
   if (movedViews === null) {
     declarationContainer[MOVED_VIEWS] = [lView];


### PR DESCRIPTION
This PR fixes #35400 where a template that is declared in a CheckAlways
view is inserted into another `CheckAlways` view. With the current
implementation, we do not check the template at the point of
declaration, assuming that it will be checked at the insertion (because
it is `CheckAlways`). However, this will not happen if the insertion view
is a child of a non-dirty `OnPush` component. This change simply removes
the condition that prevented `CheckAlways` transplanted views from being
refreshed at the declaration if insertion is also `CheckAlways`.