### PR TITLE
fix(router): allow UrlMatcher to return null

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -64,7 +64,7 @@ export type UrlMatchResult = {
  * @publicApi
  */
 export type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) =>
-    UrlMatchResult;
+    UrlMatchResult | null;
 
 /**
  *

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -500,7 +500,7 @@ export declare abstract class UrlHandlingStrategy {
     abstract shouldProcessUrl(url: UrlTree): boolean;
 }
 
-export declare type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult;
+export declare type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult | null;
 
 export declare type UrlMatchResult = {
     consumed: UrlSegment[];


### PR DESCRIPTION
The matcher is allowed to return null per
https://angular.io/api/router/UrlMatcher#usage-notes

Fixes #29824

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Incorrect type error:

```
error TS2322: Type '(url: UrlSegment[]) => UrlMatchResult | null' is not assignable to type 'UrlMatcher'.
  Type 'UrlMatchResult | null' is not assignable to type 'UrlMatchResult'.
    Type 'null' is not assignable to type 'UrlMatchResult'.
```

Issue Number: 29824


## What is the new behavior?

No type error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No