### PR TITLE
feat(bazel): enable ivy template type-checking in g3

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -306,9 +306,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": is_ivy_enabled(ctx),
         "fullTemplateTypeCheck": ctx.attr.type_check,
-        # TODO(alxhub/arick): template type-checking in g3 is currently disabled because of
-        # preexisting failures. Reenable once g3 is fixed: FW-1753
-        "ivyTemplateTypeCheck": _is_bazel(),
         # In Google3 we still want to use the symbol factory re-exports in order to
         # not break existing apps inside Google. Unlike Bazel, Google3 does not only
         # enforce strict dependencies of source files, but also for generated files


### PR DESCRIPTION
Template type-checking within the Ivy compiler has been disabled internally
in g3 until compatibility with the whole codebase could be verified. As that
verification is now complete and template type-checking is known to be
compatible with g3, this commit enables it.

Caretaker: this will require a g3 patch to go in with the sync cl. The patch is: cl/297178029

