### PR TITLE
fix(ngcc): allow deep-import warnings to be ignored

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -150,7 +150,7 @@ export function mainNgcc(
   const fileSystem = getFileSystem();
   const absBasePath = absoluteFrom(basePath);
   const config = new NgccConfiguration(fileSystem, dirname(absBasePath));
-  const dependencyResolver = getDependencyResolver(fileSystem, logger, pathMappings);
+  const dependencyResolver = getDependencyResolver(fileSystem, logger, config, pathMappings);
 
   // Bail out early if the work is already done.
   const supportedPropertiesToConsider = ensureSupportedProperties(propertiesToConsider);
@@ -355,7 +355,7 @@ function getExecutor(
 }
 
 function getDependencyResolver(
-    fileSystem: FileSystem, logger: Logger,
+    fileSystem: FileSystem, logger: Logger, config: NgccConfiguration,
     pathMappings: PathMappings | undefined): DependencyResolver {
   const moduleResolver = new ModuleResolver(fileSystem, pathMappings);
   const esmDependencyHost = new EsmDependencyHost(fileSystem, moduleResolver);
@@ -363,7 +363,7 @@ function getDependencyResolver(
   const commonJsDependencyHost = new CommonJsDependencyHost(fileSystem, moduleResolver);
   const dtsDependencyHost = new DtsDependencyHost(fileSystem, pathMappings);
   return new DependencyResolver(
-      fileSystem, logger, {
+      fileSystem, logger, config, {
         esm5: esmDependencyHost,
         esm2015: esmDependencyHost,
         umd: umdDependencyHost,

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -13,7 +13,12 @@ import {PackageJsonFormatPropertiesMap} from './entry_point';
 /**
  * The format of a project level configuration file.
  */
-export interface NgccProjectConfig<T = NgccPackageConfig> { packages: {[packagePath: string]: T}; }
+export interface NgccProjectConfig<T = NgccPackageConfig> {
+  /**
+   * The packages that are configured by this project config.
+   */
+  packages: {[packagePath: string]: T};
+}
 
 /**
  * The format of a package level configuration file.
@@ -27,6 +32,11 @@ export interface NgccPackageConfig {
    * will be absolute.
    */
   entryPoints: {[entryPointPath: string]: NgccEntryPointConfig;};
+  /**
+   * A collection of regexes that match deep imports to ignore, for this package, rather than
+   * displaying a warning.
+   */
+  ignorableDeepImportMatchers?: RegExp[];
 }
 
 /**
@@ -201,7 +211,8 @@ export class NgccConfiguration {
         const absPackagePath = resolve(baseDir, 'node_modules', packagePath);
         const entryPoints = this.processEntryPoints(absPackagePath, packageConfig);
         processedConfig.packages[absPackagePath] = processedConfig.packages[absPackagePath] || [];
-        processedConfig.packages[absPackagePath].push({versionRange, entryPoints});
+        processedConfig.packages[absPackagePath].push(
+            {...packageConfig, versionRange, entryPoints});
       }
     }
     return processedConfig;

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -32,8 +32,8 @@ runInEachFileSystem(() => {
       logger = new MockLogger();
       const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
       const dtsHost = new DtsDependencyHost(fs);
-      resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
+      resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
     });
 
     describe('findEntryPoints()', () => {
@@ -156,7 +156,7 @@ runInEachFileSystem(() => {
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
-        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+        resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();
@@ -184,7 +184,7 @@ runInEachFileSystem(() => {
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
-        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+        resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, basePath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -33,8 +33,8 @@ runInEachFileSystem(() => {
       logger = new MockLogger();
       const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
       const dtsHost = new DtsDependencyHost(fs);
-      resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
       config = new NgccConfiguration(fs, _Abs('/'));
+      resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
     });
 
     describe('findEntryPoints()', () => {
@@ -189,7 +189,7 @@ runInEachFileSystem(() => {
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
-        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+        resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();
@@ -217,7 +217,7 @@ runInEachFileSystem(() => {
            ]);
            const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
            const dtsHost = new DtsDependencyHost(fs, pathMappings);
-           resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+           resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
            const finder = new TargetedEntryPointFinder(
                fs, config, logger, resolver, basePath, targetPath, pathMappings);
            const {entryPoints} = finder.findEntryPoints();
@@ -250,7 +250,7 @@ runInEachFileSystem(() => {
            ]);
            const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
            const dtsHost = new DtsDependencyHost(fs, pathMappings);
-           resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+           resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
            const finder = new TargetedEntryPointFinder(
                fs, config, logger, resolver, basePath, targetPath, pathMappings);
            const {entryPoints} = finder.findEntryPoints();
@@ -277,7 +277,7 @@ runInEachFileSystem(() => {
         ]);
         const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs, pathMappings));
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
-        resolver = new DependencyResolver(fs, logger, {esm2015: srcHost}, dtsHost);
+        resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, basePath, targetPath, pathMappings);
         const {entryPoints} = finder.findEntryPoints();


### PR DESCRIPTION
This commit adds a new ngcc configuration, `ignorableDeepImportMatchers`
for packages. This is a list of regular expressions matching deep imports
that can be safely ignored from that package. Deep imports that are not
ignored cause a warning to be logged.

// FW-1892

Fixes #35615
