### PR TITLE
docs: remove browserstack badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CircleCI](https://circleci.com/gh/angular/angular/tree/master.svg?style=shield)](https://circleci.com/gh/angular/workflows/angular/tree/master)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=LzF3RzBVVGt6VWE2S0hHaC9uYllOZz09LS1BVjNTclBKV0x4eVRlcjA4QVY1M0N3PT0=--eb4ce8c8dc2c1c5b2b5352d473ee12a73ac20e06)](https://www.browserstack.com/automate/public-build/LzF3RzBVVGt6VWE2S0hHaC9uYllOZz09LS1BVjNTclBKV0x4eVRlcjA4QVY1M0N3PT0=--eb4ce8c8dc2c1c5b2b5352d473ee12a73ac20e06)
 [![Join the chat at https://gitter.im/angular/angular](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/angular/angular?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![npm version](https://badge.fury.io/js/%40angular%2Fcore.svg)](https://www.npmjs.com/@angular/core)
 
@@ -21,7 +20,6 @@ Angular is a development platform for building mobile and desktop web applicatio
 Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our
 guidelines for [contributing][contributing] and then check out one of our issues in the [hotlist: community-help](https://github.com/angular/angular/labels/hotlist%3A%20community-help).
 
-[browserstack]: https://www.browserstack.com/automate/public-build/LzF3RzBVVGt6VWE2S0hHaC9uYllOZz09LS1BVjNTclBKV0x4eVRlcjA4QVY1M0N3PT0=--eb4ce8c8dc2c1c5b2b5352d473ee12a73ac20e06
 [contributing]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md
 [quickstart]: https://angular.io/start
 [changelog]: https://github.com/angular/angular/blob/master/CHANGELOG.md


### PR DESCRIPTION
We don't run tests on Browserstack for this repository. Also the
badge was referring to a non-existent project.

This removes the badge since we don't need it anymore, and rather
we should generate a new one for repositories like `angular/components`
where browserstack is actually used, and where the badge can provide
useful information.

Closes #28287.