### PR TITLE
test(language-service): differentiate feature and internal infra tests

### DIFF
--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -8,24 +8,11 @@ circular_dependency_test(
 )
 
 ts_library(
-    name = "test_lib",
+    name = "test_utils_lib",
     testonly = True,
     srcs = [
-        "completions_spec.ts",
-        "definitions_spec.ts",
-        "diagnostics_spec.ts",
-        "global_symbols_spec.ts",
-        "hover_spec.ts",
-        "html_info_spec.ts",
-        "language_service_spec.ts",
-        "reflector_host_spec.ts",
-        "template_spec.ts",
         "test_utils.ts",
-        "ts_plugin_spec.ts",
-        "typescript_host_spec.ts",
-        "utils_spec.ts",
     ],
-    data = glob(["project/**/*"]),
     deps = [
         "//packages/compiler",
         "//packages/compiler-cli/test:test_utils",
@@ -34,8 +21,48 @@ ts_library(
     ],
 )
 
+ts_library(
+    name = "features_test_lib",
+    testonly = True,
+    srcs = [
+        "completions_spec.ts",
+        "definitions_spec.ts",
+        "diagnostics_spec.ts",
+        "hover_spec.ts",
+    ],
+    data = glob(["project/**/*"]),
+    deps = [
+        ":test_utils_lib",
+        "//packages/language-service",
+        "@npm//typescript",
+    ],
+)
+
+ts_library(
+    name = "infra_test_lib",
+    testonly = True,
+    srcs = [
+        "global_symbols_spec.ts",
+        "html_info_spec.ts",
+        "language_service_spec.ts",
+        "reflector_host_spec.ts",
+        "template_spec.ts",
+        "ts_plugin_spec.ts",
+        "typescript_host_spec.ts",
+        "utils_spec.ts",
+    ],
+    data = glob(["project/**/*"]),
+    deps = [
+        ":test_utils_lib",
+        "//packages/compiler",
+        "//packages/language-service",
+        "@npm//typescript",
+    ],
+)
+
 jasmine_node_test(
-    name = "test",
+    name = "features_test",
+    coverage = True,
     data = [
         "//packages/common:npm_package",
         "//packages/core:npm_package",
@@ -46,7 +73,42 @@ jasmine_node_test(
         "no-ivy-aot",
     ],
     deps = [
-        ":test_lib",
+        ":features_test_lib",
+    ],
+)
+
+jasmine_node_test(
+    name = "infra_test",
+    coverage = True,
+    data = [
+        "//packages/common:npm_package",
+        "//packages/core:npm_package",
+        "//packages/forms:npm_package",
+    ],
+    tags = [
+        # the language service is not yet compatible with Ivy
+        "no-ivy-aot",
+    ],
+    deps = [
+        ":infra_test_lib",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    coverage = True,
+    data = [
+        "//packages/common:npm_package",
+        "//packages/core:npm_package",
+        "//packages/forms:npm_package",
+    ],
+    tags = [
+        # the language service is not yet compatible with Ivy
+        "no-ivy-aot",
+    ],
+    deps = [
+        ":features_test_lib",
+        ":infra_test_lib",
     ],
 )
 

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -62,7 +62,6 @@ ts_library(
 
 jasmine_node_test(
     name = "features_test",
-    coverage = True,
     data = [
         "//packages/common:npm_package",
         "//packages/core:npm_package",
@@ -79,7 +78,6 @@ jasmine_node_test(
 
 jasmine_node_test(
     name = "infra_test",
-    coverage = True,
     data = [
         "//packages/common:npm_package",
         "//packages/core:npm_package",
@@ -96,7 +94,6 @@ jasmine_node_test(
 
 jasmine_node_test(
     name = "test",
-    coverage = True,
     data = [
         "//packages/common:npm_package",
         "//packages/core:npm_package",


### PR DESCRIPTION
This commit differentiates language service feature and language service
infrastructure tests. This is primarily to make testing of different
components at the development level easier. This commit continues a
small effort to expand our test coverage and normalize testing
structure.

Also adds test coverage to language service tests. We have quite a bit
to go on that front :slightly_smiling_face:.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Build related changes



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

