### PR TITLE
build: allow auto-discover all typings files in npm package by ts-api-guardian

### DIFF
--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -74,3 +74,63 @@ def ts_api_guardian_test(
         templated_args = args + ["--out", golden, actual],
         **kwargs
     )
+
+def ts_api_guardian_test_npm_package(
+        name,
+        goldenDir,
+        actualDir,
+        data = [],
+        strip_export_pattern = ["^__", "^ɵ[^ɵ]"],
+        allow_module_identifiers = COMMON_MODULE_IDENTIFIERS,
+        use_angular_tag_rules = True,
+        **kwargs):
+    """Runs ts_api_guardian
+    """
+    data += [
+        # Locally we need to add the TS build target
+        # But it will replaced to @npm//ts-api-guardian when publishing
+        "@angular//tools/ts-api-guardian:lib",
+        "@angular//tools/ts-api-guardian:bin",
+        # The below are required during runtime
+        "@npm//chalk",
+        "@npm//diff",
+        "@npm//minimist",
+        "@npm//typescript",
+    ]
+
+    args = [
+        # Needed so that node doesn't walk back to the source directory.
+        # From there, the relative imports would point to .ts files.
+        "--node_options=--preserve-symlinks",
+        # We automatically discover the enpoints for our NPM package.
+        "--autoDiscoverEntrypoints",
+    ]
+
+    for i in strip_export_pattern:
+        # The below replacement is needed because under Windows '^' needs to be escaped twice
+        args += ["--stripExportPattern", i.replace("^", "^^^^")]
+
+    for i in allow_module_identifiers:
+        args += ["--allowModuleIdentifiers", i]
+
+    if use_angular_tag_rules:
+        args += ["--useAngularTagRules"]
+
+    nodejs_test(
+        name = name,
+        data = data,
+        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        templated_args = args + ["--verifyDir", goldenDir, "--rootDir", actualDir],
+        tags = ["api_guard"],
+        **kwargs
+    )
+
+    nodejs_binary(
+        name = name + ".accept",
+        testonly = True,
+        data = data,
+        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        templated_args = args + ["--outDir", goldenDir, "--rootDir", actualDir],
+        tags = ["api_guard"],
+        **kwargs
+    )

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -156,11 +156,11 @@ export function parseArguments(input: string[]):
   if (argv['autoDiscoverEntrypoints']) {
     if (!argv['rootDir']) {
       errors.push(`rootDir must be provided with autoDiscoverEntrypoints enabled.`);
-      modes = ['help']
+      modes = ['help'];
     }
     if (!argv['outDir'] && !argv['verifyDir']) {
       errors.push(`outDir or verifyDir must be used with autoDiscoverEntrypoints.`);
-      modes = ['help']
+      modes = ['help'];
     }
   } else {
     if (!argv._.length) {
@@ -219,7 +219,7 @@ function resolveBazelFilePath(fileName: string): string {
   if (process.env['BAZEL_TARGET']) {
     try {
       return path.relative(process.cwd(), require.resolve(fileName));
-    } catch(err) {
+    } catch (err) {
       return path.relative(process.cwd(), fileName);
     }
   }

--- a/tools/ts-api-guardian/lib/main.ts
+++ b/tools/ts-api-guardian/lib/main.ts
@@ -60,7 +60,8 @@ function isDirectory(dirPath: string) {
 }
 
 /**
- * Gets an interable of paths to the typings files for each of the recursively discovered package.json
+ * Gets an interable of paths to the typings files for each of the recursively discovered
+ * package.json
  * files from the directory provided.
  */
 export function* discoverAllEntrypoints(dirPath: string) {
@@ -77,7 +78,7 @@ export function* discoverAllEntrypoints(dirPath: string) {
         }
       }
     }
-  }
+  };
   findPackageJsonsInDir(dirPath);
 
   // Get all typings file locations from package.json files

--- a/tools/ts-api-guardian/lib/main.ts
+++ b/tools/ts-api-guardian/lib/main.ts
@@ -16,6 +16,10 @@ export {SerializationOptions, publicApi} from './serializer';
 export function generateGoldenFile(
     entrypoint: string, outFile: string, options: SerializationOptions = {}): void {
   const output = publicApi(entrypoint, options);
+
+  if (process.env['BUILD_WORKSPACE_DIRECTORY']) {
+    outFile = path.join(process.env['BUILD_WORKSPACE_DIRECTORY'], outFile);
+  }
   ensureDirectory(path.dirname(outFile));
   fs.writeFileSync(outFile, output);
 }
@@ -23,7 +27,7 @@ export function generateGoldenFile(
 export function verifyAgainstGoldenFile(
     entrypoint: string, goldenFile: string, options: SerializationOptions = {}): string {
   const actual = publicApi(entrypoint, options);
-  const expected = fs.readFileSync(goldenFile).toString();
+  const expected = fs.existsSync(goldenFile) ? fs.readFileSync(goldenFile).toString() : '';
 
   if (actual === expected) {
     return '';
@@ -41,5 +45,47 @@ function ensureDirectory(dir: string) {
   if (!fs.existsSync(dir)) {
     ensureDirectory(path.dirname(dir));
     fs.mkdirSync(dir);
+  }
+}
+
+/**
+ * Determine if the provided path is a directory.
+ */
+function isDirectory(dirPath: string) {
+  try {
+    fs.lstatSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets an interable of paths to the typings files for each of the recursively discovered package.json
+ * files from the directory provided.
+ */
+export function* discoverAllEntrypoints(dirPath: string) {
+  // Determine all of the package.json files
+  const packageJsons: string[] = [];
+  const findPackageJsonsInDir = (nextPath: string) => {
+    for (const file of fs.readdirSync(nextPath)) {
+      const fullPath = path.join(nextPath, file);
+      if (isDirectory(fullPath)) {
+        findPackageJsonsInDir(fullPath);
+      } else {
+        if (file === 'package.json') {
+          packageJsons.push(fullPath);
+        }
+      }
+    }
+  }
+  findPackageJsonsInDir(dirPath);
+
+  // Get all typings file locations from package.json files
+  for (const packageJson of packageJsons) {
+    const packageJsonObj = JSON.parse(fs.readFileSync(packageJson, {encoding: 'utf8'}));
+    const typings = packageJsonObj.typings;
+    if (typings) {
+      yield path.join(path.dirname(packageJson), typings);
+    }
   }
 }

--- a/tools/ts-api-guardian/test/cli_unit_test.ts
+++ b/tools/ts-api-guardian/test/cli_unit_test.ts
@@ -63,17 +63,20 @@ describe('cli: parseArguments', () => {
     chai.assert.deepEqual(errors, []);
   });
 
-  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --baseDir', () => {
-    const {mode, errors} =
-        parseArguments(['--autoDiscoverEntrypoints']);
-    chai.assert.equal(mode, 'help');
-    chai.assert.deepEqual(errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
-  });
+  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --baseDir',
+     () => {
+       const {mode, errors} = parseArguments(['--autoDiscoverEntrypoints']);
+       chai.assert.equal(mode, 'help');
+       chai.assert.deepEqual(
+           errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+     });
 
-  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --outDir/verifyDir', () => {
-    const {mode, errors} =
-        parseArguments(['--autoDiscoverEntrypoints', '--outDir', 'something']);
-    chai.assert.equal(mode, 'help');
-    chai.assert.deepEqual(errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
-  });
+  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --outDir/verifyDir',
+     () => {
+       const {mode, errors} =
+           parseArguments(['--autoDiscoverEntrypoints', '--outDir', 'something']);
+       chai.assert.equal(mode, 'help');
+       chai.assert.deepEqual(
+           errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+     });
 });

--- a/tools/ts-api-guardian/test/cli_unit_test.ts
+++ b/tools/ts-api-guardian/test/cli_unit_test.ts
@@ -62,4 +62,18 @@ describe('cli: parseArguments', () => {
     chai.assert.equal(mode, 'verify');
     chai.assert.deepEqual(errors, []);
   });
+
+  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --baseDir', () => {
+    const {mode, errors} =
+        parseArguments(['--autoDiscoverEntrypoints']);
+    chai.assert.equal(mode, 'help');
+    chai.assert.deepEqual(errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+  });
+
+  it('should show usage with error when supplied with --autoDiscoverEntrypoints without --outDir/verifyDir', () => {
+    const {mode, errors} =
+        parseArguments(['--autoDiscoverEntrypoints', '--outDir', 'something']);
+    chai.assert.equal(mode, 'help');
+    chai.assert.deepEqual(errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+  });
 });

--- a/tools/ts-api-guardian/test/cli_unit_test.ts
+++ b/tools/ts-api-guardian/test/cli_unit_test.ts
@@ -65,18 +65,19 @@ describe('cli: parseArguments', () => {
 
   it('should show usage with error when supplied with --autoDiscoverEntrypoints without --baseDir',
      () => {
-       const {mode, errors} = parseArguments(['--autoDiscoverEntrypoints']);
+       const {mode, errors} =
+           parseArguments(['--autoDiscoverEntrypoints', '--outDir', 'something']);
        chai.assert.equal(mode, 'help');
        chai.assert.deepEqual(
-           errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+           errors, ['--rootDir must be provided with --autoDiscoverEntrypoints.']);
      });
 
   it('should show usage with error when supplied with --autoDiscoverEntrypoints without --outDir/verifyDir',
      () => {
        const {mode, errors} =
-           parseArguments(['--autoDiscoverEntrypoints', '--outDir', 'something']);
+           parseArguments(['--autoDiscoverEntrypoints', '--rootDir', 'something']);
        chai.assert.equal(mode, 'help');
        chai.assert.deepEqual(
-           errors, ['rootDir must be provided with autoDiscoverEntrypoints enabled.']);
+           errors, ['--outDir or --verifyDir must be used with --autoDiscoverEntrypoints.']);
      });
 });


### PR DESCRIPTION
Adds a new feature to ts-api-guardian allowing for automatically discovering all
entry point d.ts files from all package.json files in a provided directory.
