### PR TITLE
feat(compiler): add dependency info and ng-content selectors to metadata

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -715,7 +715,7 @@ export declare type ɵɵComponentDefWithMeta<T, Selector extends String, ExportA
     [key: string]: string;
 }, OutputMap extends {
     [key: string]: string;
-}, QueryFields extends string[]> = ɵComponentDef<T>;
+}, QueryFields extends string[], NgContentSelectors extends string[]> = ɵComponentDef<T>;
 
 export declare function ɵɵcomponentHostSyntheticListener(eventName: string, listenerFn: (e?: any) => any, useCapture?: boolean, eventTargetResolver?: GlobalTargetResolver): typeof ɵɵcomponentHostSyntheticListener;
 
@@ -834,7 +834,7 @@ export declare function ɵɵembeddedViewStart(viewBlockId: number, decls: number
 
 export declare function ɵɵenableBindings(): void;
 
-export declare type ɵɵFactoryDef<T> = () => T;
+export declare type ɵɵFactoryDef<T, CtorDependencies extends CtorDependency[]> = () => T;
 
 export declare function ɵɵgetCurrentView(): OpaqueViewState;
 

--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -91,6 +91,7 @@ export class DtsRenderer {
       const endOfClass = dtsClass.dtsDeclaration.getEnd();
       dtsClass.compilation.forEach(declaration => {
         const type = translateType(declaration.type, importManager);
+        markForEmitAsSingleLine(type);
         const typeStr = printer.printNode(ts.EmitHint.Unspecified, type, dtsFile);
         const newStatement = `    static ${declaration.name}: ${typeStr};\n`;
         outputText.appendRight(endOfClass - 1, newStatement);
@@ -175,4 +176,9 @@ export class DtsRenderer {
 
     return dtsMap;
   }
+}
+
+function markForEmitAsSingleLine(node: ts.Node) {
+  ts.setEmitFlags(node, ts.EmitFlags.SingleLine);
+  ts.forEachChild(node, markForEmitAsSingleLine);
 }

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -399,8 +399,21 @@ runInEachFileSystem(() => {
          expect(dtsContents)
              .toContain(`export declare class ${exportedName} extends PlatformLocation`);
          // And that ngcc's modifications to that class use the correct (exported) name
-         expect(dtsContents).toContain(`static ɵfac: ɵngcc0.ɵɵFactoryDef<${exportedName}>`);
+         expect(dtsContents).toContain(`static ɵfac: ɵngcc0.ɵɵFactoryDef<${exportedName}, never>`);
        });
+
+    it('should include constructor metadata in factory definitions', () => {
+      mainNgcc({
+        basePath: '/node_modules',
+        targetEntryPointPath: '@angular/common',
+        propertiesToConsider: ['esm2015']
+      });
+
+      const dtsContents = fs.readFile(_('/node_modules/@angular/common/common.d.ts'));
+      expect(dtsContents)
+          .toContain(
+              `static ɵfac: ɵngcc0.ɵɵFactoryDef<NgPluralCase, [{ attribute: "ngPluralCase"; }, null, null, { host: true; }]>`);
+    });
 
     it('should add generic type for ModuleWithProviders and generate exports for private modules',
        () => {
@@ -1477,7 +1490,7 @@ runInEachFileSystem(() => {
            const dtsContents = fs.readFile(_(`/node_modules/test-package/index.d.ts`));
            expect(dtsContents)
                .toContain(
-                   'static ɵcmp: ɵngcc0.ɵɵComponentDefWithMeta<DerivedCmp, "[base]", never, {}, {}, never>;');
+                   'static ɵcmp: ɵngcc0.ɵɵComponentDefWithMeta<DerivedCmp, "[base]", never, {}, {}, never, never>;');
          });
 
       it('should generate directive definitions with CopyDefinitionFeature for undecorated child directives in a long inheritance chain',

--- a/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/dts_renderer_spec.ts
@@ -130,7 +130,7 @@ runInEachFileSystem(() => {
           result.find(f => f.path === _('/node_modules/test-package/typings/file.d.ts')) !;
       expect(typingsFile.contents)
           .toContain(
-              'foo(x: number): number;\n    static ɵfac: ɵngcc0.ɵɵFactoryDef<A>;\n    static ɵdir: ɵngcc0.ɵɵDirectiveDefWithMeta');
+              'foo(x: number): number;\n    static ɵfac: ɵngcc0.ɵɵFactoryDef<A, never>;\n    static ɵdir: ɵngcc0.ɵɵDirectiveDefWithMeta');
     });
 
     it('should render imports into typings files', () => {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -313,6 +313,7 @@ export class ComponentDecoratorHandler implements
           ...metadata,
           template: {
             nodes: template.emitNodes,
+            ngContentSelectors: template.ngContentSelectors,
           },
           encapsulation,
           interpolation: template.interpolation,
@@ -770,12 +771,13 @@ export class ComponentDecoratorHandler implements
       interpolation = InterpolationConfig.fromArray(value as[string, string]);
     }
 
-    const {errors, nodes: emitNodes, styleUrls, styles} = parseTemplate(templateStr, templateUrl, {
-      preserveWhitespaces,
-      interpolationConfig: interpolation,
-      range: templateRange, escapedString,
-      enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
-    });
+    const {errors, nodes: emitNodes, styleUrls, styles, ngContentSelectors} =
+        parseTemplate(templateStr, templateUrl, {
+          preserveWhitespaces,
+          interpolationConfig: interpolation,
+          range: templateRange, escapedString,
+          enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
+        });
 
     // Unfortunately, the primary parse of the template above may not contain accurate source map
     // information. If used directly, it would result in incorrect code locations in template
@@ -804,6 +806,7 @@ export class ComponentDecoratorHandler implements
       diagNodes,
       styleUrls,
       styles,
+      ngContentSelectors,
       errors,
       template: templateStr, templateUrl,
       isInline: component.has('template'),
@@ -922,6 +925,11 @@ export interface ParsedTemplate {
    * Any inline styles extracted from the metadata.
    */
   styles: string[];
+
+  /**
+   * Any ng-content selectors extracted from the template.
+   */
+  ngContentSelectors: string[];
 
   /**
    * Whether the template was inline.

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -274,6 +274,7 @@ function extractInjectableCtorDeps(
 function getDep(dep: ts.Expression, reflector: ReflectionHost): R3DependencyMetadata {
   const meta: R3DependencyMetadata = {
     token: new WrappedNodeExpr(dep),
+    attribute: null,
     host: false,
     resolved: R3ResolvedDependencyType.Token,
     optional: false,

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -205,7 +205,7 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
     const newMembers = fields.map(decl => {
       const modifiers = [ts.createModifier(ts.SyntaxKind.StaticKeyword)];
       const typeRef = translateType(decl.type, imports);
-      emitAsSingleLine(typeRef);
+      markForEmitAsSingleLine(typeRef);
       return ts.createProperty(
           /* decorators */ undefined,
           /* modifiers */ modifiers,
@@ -226,9 +226,9 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
   }
 }
 
-function emitAsSingleLine(node: ts.Node) {
+function markForEmitAsSingleLine(node: ts.Node) {
   ts.setEmitFlags(node, ts.EmitFlags.SingleLine);
-  ts.forEachChild(node, emitAsSingleLine);
+  ts.forEachChild(node, markForEmitAsSingleLine);
 }
 
 export class ReturnTypeTransform implements DtsTransform {

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -34,6 +34,7 @@ export const Inject = callableParamDecorator();
 export const Self = callableParamDecorator();
 export const SkipSelf = callableParamDecorator();
 export const Optional = callableParamDecorator();
+export const Host = callableParamDecorator();
 
 export const ContentChild = callablePropDecorator();
 export const ContentChildren = callablePropDecorator();
@@ -68,7 +69,8 @@ export function forwardRef<T>(fn: () => T): T {
 export interface SimpleChanges { [propName: string]: any; }
 
 export type ɵɵNgModuleDefWithMeta<ModuleT, DeclarationsT, ImportsT, ExportsT> = any;
-export type ɵɵDirectiveDefWithMeta<DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT> = any;
+export type ɵɵDirectiveDefWithMeta<
+    DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT, NgContentSelectorsT> = any;
 export type ɵɵPipeDefWithMeta<PipeT, NameT> = any;
 
 export enum ViewEncapsulation {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -68,8 +68,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep, never>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service, never>;');
     });
 
     it('should compile Injectables with a generic service', () => {
@@ -86,7 +86,7 @@ runInEachFileSystem(os => {
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain('Store.ɵprov =');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Store<any>>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Store<any>, never>;');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Store<any>>;');
     });
 
@@ -117,8 +117,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Dep>;');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Dep, never>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service, never>;');
     });
 
     it('should compile Injectables with providedIn and factory without errors', () => {
@@ -143,7 +143,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service, never>;');
     });
 
     it('should compile Injectables with providedIn and factory with deps without errors', () => {
@@ -172,7 +172,7 @@ runInEachFileSystem(os => {
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDef<Service>;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<Service, never>;');
     });
 
     it('should compile @Injectable with an @Optional dependency', () => {
@@ -237,7 +237,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵdir: i0.ɵɵDirectiveDefWithMeta<TestDir, "[dir]", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestDir>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestDir, never>');
     });
 
     it('should compile abstract Directives without errors', () => {
@@ -259,7 +259,7 @@ runInEachFileSystem(os => {
       expect(dtsContents)
           .toContain(
               'static ɵdir: i0.ɵɵDirectiveDefWithMeta<TestDir, never, never, {}, {}, never>');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestDir>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestDir, never>');
     });
 
     it('should compile Components (inline template) without errors', () => {
@@ -283,8 +283,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
-              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
+              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never, never>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp, never>');
     });
 
     it('should compile Components (dynamic inline template) without errors', () => {
@@ -309,8 +309,9 @@ runInEachFileSystem(os => {
 
       expect(dtsContents)
           .toContain(
-              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
+              'static ɵcmp: i0.ɵɵComponentDefWithMeta' +
+              '<TestCmp, "test-cmp", never, {}, {}, never, never>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp, never>');
     });
 
     it('should compile Components (function call inline template) without errors', () => {
@@ -337,8 +338,8 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
-              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp>');
+              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never, never>');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestCmp, never>');
     });
 
     it('should compile Components (external template) without errors', () => {
@@ -935,7 +936,7 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain(
-              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
+              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never, never>');
       expect(dtsContents)
           .toContain(
               'static ɵmod: i0.ɵɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], never, never>');
@@ -1327,7 +1328,7 @@ runInEachFileSystem(os => {
           .toContain(
               'TestPipe.ɵfac = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents).toContain('static ɵpipe: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe, never>;');
     });
 
     it('should compile pure Pipes without errors', () => {
@@ -1352,7 +1353,7 @@ runInEachFileSystem(os => {
           .toContain(
               'TestPipe.ɵfac = function TestPipe_Factory(t) { return new (t || TestPipe)(); }');
       expect(dtsContents).toContain('static ɵpipe: i0.ɵɵPipeDefWithMeta<TestPipe, "test-pipe">;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe, never>;');
     });
 
     it('should compile Pipes with dependencies', () => {
@@ -1393,7 +1394,7 @@ runInEachFileSystem(os => {
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
           .toContain('static ɵpipe: i0.ɵɵPipeDefWithMeta<TestPipe<any>, "test-pipe">;');
-      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe<any>>;');
+      expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDef<TestPipe<any>, never>;');
     });
 
     it('should include @Pipes in @NgModule scopes', () => {
@@ -2572,6 +2573,141 @@ runInEachFileSystem(os => {
       expect(jsContents)
           .toContain(
               `FooCmp.ɵfac = function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`);
+    });
+
+    it('should include constructor dependency metadata for directives/components/pipes', () => {
+      env.write(`test.ts`, `
+        import {Attribute, Component, Directive, Pipe, Self, SkipSelf, Host, Optional} from '@angular/core';
+
+        export class MyService {}
+        export function dynamic() {};
+
+        @Directive()
+        export class WithDecorators {
+          constructor(
+            @Self() withSelf: MyService,
+            @SkipSelf() withSkipSelf: MyService,
+            @Host() withHost: MyService,
+            @Optional() withOptional: MyService,
+            @Attribute("attr") withAttribute: string,
+            @Attribute(dynamic()) withAttributeDynamic: string,
+            @Optional() @SkipSelf() @Host() withMany: MyService,
+            noDecorators: MyService) {}
+        }
+
+        @Directive()
+        export class NoCtor {}
+
+        @Directive()
+        export class EmptyCtor {
+          constructor() {}
+        }
+
+        @Directive()
+        export class WithoutDecorators {
+          constructor(noDecorators: MyService) {}
+        }
+
+        @Component({ template: 'test' })
+        export class MyCmp {
+          constructor(@Host() withHost: MyService) {}
+        }
+
+        @Pipe({ name: 'test' })
+        export class MyPipe {
+          constructor(@Host() withHost: MyService) {}
+        }
+    `);
+
+      env.driveMain();
+      const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents)
+          .toContain(
+              'static ɵfac: i0.ɵɵFactoryDef<WithDecorators, [' +
+              '{ self: true; }, { skipSelf: true; }, { host: true; }, ' +
+              '{ optional: true; }, { attribute: "attr"; }, { attribute: unknown; }, ' +
+              '{ optional: true; host: true; skipSelf: true; }, null]>');
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<NoCtor, never>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<EmptyCtor, never>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<WithoutDecorators, never>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<MyCmp, [{ host: true; }]>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<MyPipe, [{ host: true; }]>`);
+    });
+
+    it('should include constructor dependency metadata for @Injectable', () => {
+      env.write(`test.ts`, `
+        import {Injectable, Self, Host} from '@angular/core';
+
+        export class MyService {}
+
+        @Injectable()
+        export class Inj {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useExisting: MyService })
+        export class InjUseExisting {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useClass: MyService })
+        export class InjUseClass {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useClass: MyService, deps: [[new Host(), MyService]] })
+        export class InjUseClassWithDeps {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useFactory: () => new Injectable(new MyService()) })
+        export class InjUseFactory {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useFactory: (service: MyService) => new Injectable(service), deps: [[new Host(), MyService]] })
+        export class InjUseFactoryWithDeps {
+          constructor(@Self() service: MyService) {}
+        }
+
+        @Injectable({ useValue: new Injectable(new MyService()) })
+        export class InjUseValue {
+          constructor(@Self() service: MyService) {}
+        }
+    `);
+
+      env.driveMain();
+      const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<Inj, [{ self: true; }]>`);
+      expect(dtsContents)
+          .toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseExisting, [{ self: true; }]>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseClass, [{ self: true; }]>`);
+      expect(dtsContents)
+          .toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseClassWithDeps, [{ self: true; }]>`);
+      expect(dtsContents)
+          .toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseFactory, [{ self: true; }]>`);
+      expect(dtsContents)
+          .toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseFactoryWithDeps, [{ self: true; }]>`);
+      expect(dtsContents).toContain(`static ɵfac: i0.ɵɵFactoryDef<InjUseValue, [{ self: true; }]>`);
+    });
+
+    it('should include ng-content selectors in the metadata', () => {
+      env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '<ng-content></ng-content> <ng-content select=".foo"></ng-content>',
+        })
+        export class TestCmp {
+        }
+    `);
+
+      env.driveMain();
+      const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents)
+          .toContain(
+              'static ɵcmp: i0.ɵɵComponentDefWithMeta<TestCmp, "test", never, {}, {}, never, ["*", ".foo"]>');
     });
 
     it('should generate queries for components', () => {
@@ -6520,7 +6656,7 @@ export const Foo = Foo__PRE_R3__;
             export declare class NgZone {}
 
             export declare class Testability {
-              static ɵfac: i0.ɵɵFactoryDef<Testability>;
+              static ɵfac: i0.ɵɵFactoryDef<Testability, never>;
               constructor(ngZone: NgZone) {}
             }
           `);

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -296,11 +296,12 @@ function convertR3DependencyMetadata(facade: R3DependencyMetadataFacade): R3Depe
   }
   return {
     token: tokenExpr,
+    attribute: null,
     resolved: facade.resolved,
     host: facade.host,
     optional: facade.optional,
     self: facade.self,
-    skipSelf: facade.skipSelf
+    skipSelf: facade.skipSelf,
   };
 }
 

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -52,6 +52,7 @@ export interface Render3ParseResult {
   errors: ParseError[];
   styles: string[];
   styleUrls: string[];
+  ngContentSelectors: string[];
 }
 
 export function htmlAstToRender3Ast(
@@ -73,6 +74,7 @@ export function htmlAstToRender3Ast(
     errors: allErrors,
     styleUrls: transformer.styleUrls,
     styles: transformer.styles,
+    ngContentSelectors: transformer.ngContentSelectors,
   };
 }
 
@@ -80,6 +82,7 @@ class HtmlAstToIvyAst implements html.Visitor {
   errors: ParseError[] = [];
   styles: string[] = [];
   styleUrls: string[] = [];
+  ngContentSelectors: string[] = [];
   private inI18nBlock: boolean = false;
 
   constructor(private bindingParser: BindingParser) {}
@@ -189,6 +192,8 @@ class HtmlAstToIvyAst implements html.Visitor {
       const selector = preparsedElement.selectAttr;
       const attrs: t.TextAttribute[] = element.attrs.map(attr => this.visitAttribute(attr));
       parsedElement = new t.Content(selector, attrs, element.sourceSpan, element.i18n);
+
+      this.ngContentSelectors.push(selector);
     } else if (isTemplateElement) {
       // `<ng-template>`
       const attrs = this.extractAttributes(element.name, parsedProperties, i18nAttrsMeta);

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -129,6 +129,12 @@ export interface R3ComponentMetadata extends R3DirectiveMetadata {
      * Parsed nodes of the template.
      */
     nodes: t.Node[];
+
+    /**
+     * Any ng-content selectors extracted from the template. Contains `null` when an ng-content
+     * element without selector is present.
+     */
+    ngContentSelectors: string[];
   };
 
   /**

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1983,8 +1983,13 @@ export interface ParseTemplateOptions {
  * @param options options to modify how the template is parsed
  */
 export function parseTemplate(
-    template: string, templateUrl: string, options: ParseTemplateOptions = {}):
-    {errors?: ParseError[], nodes: t.Node[], styleUrls: string[], styles: string[]} {
+    template: string, templateUrl: string, options: ParseTemplateOptions = {}): {
+  errors?: ParseError[],
+  nodes: t.Node[],
+  styleUrls: string[],
+  styles: string[],
+  ngContentSelectors: string[]
+} {
   const {interpolationConfig, preserveWhitespaces, enableI18nLegacyMessageIdFormat} = options;
   const bindingParser = makeBindingParser(interpolationConfig);
   const htmlParser = new HtmlParser();
@@ -1993,7 +1998,13 @@ export function parseTemplate(
       {leadingTriviaChars: LEADING_TRIVIA_CHARS, ...options, tokenizeExpansionForms: true});
 
   if (parseResult.errors && parseResult.errors.length > 0) {
-    return {errors: parseResult.errors, nodes: [], styleUrls: [], styles: []};
+    return {
+      errors: parseResult.errors,
+      nodes: [],
+      styleUrls: [],
+      styles: [],
+      ngContentSelectors: []
+    };
   }
 
   let rootNodes: html.Node[] = parseResult.rootNodes;
@@ -2020,12 +2031,13 @@ export function parseTemplate(
     }
   }
 
-  const {nodes, errors, styleUrls, styles} = htmlAstToRender3Ast(rootNodes, bindingParser);
+  const {nodes, errors, styleUrls, styles, ngContentSelectors} =
+      htmlAstToRender3Ast(rootNodes, bindingParser);
   if (errors && errors.length > 0) {
-    return {errors, nodes: [], styleUrls: [], styles: []};
+    return {errors, nodes: [], styleUrls: [], styles: [], ngContentSelectors: []};
   }
 
-  return {nodes, styleUrls, styles};
+  return {nodes, styleUrls, styles, ngContentSelectors};
 }
 
 const elementRegistry = new DomElementSchemaRegistry();

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -90,6 +90,39 @@ export interface DirectiveType<T> extends Type<T> {
 export interface PipeType<T> extends Type<T> { ɵpipe: never; }
 
 /**
+ * An object literal of this type is used to represent the metadata of a constructor dependency.
+ * The type itself is never referred to from generated code.
+ */
+export type CtorDependency = {
+  /**
+   * If an `@Attribute` decorator is used, this represents the injected attribute's name. If the
+   * attribute name is a dynamic expression instead of a string literal, this will be the unknown
+   * type.
+   */
+  attribute?: string | unknown;
+
+  /**
+   * If `@Optional()` is used, this key is set to true.
+   */
+  optional?: true;
+
+  /**
+   * If `@Host` is used, this key is set to true.
+   */
+  host?: true;
+
+  /**
+   * If `@Self` is used, this key is set to true.
+   */
+  self?: true;
+
+  /**
+   * If `@SkipSelf` is used, this key is set to true.
+   */
+  skipSelf?: true;
+} | null;
+
+/**
  * @codeGenApi
  */
 export type ɵɵDirectiveDefWithMeta<
@@ -236,12 +269,13 @@ export interface DirectiveDef<T> {
  */
 export type ɵɵComponentDefWithMeta<
     T, Selector extends String, ExportAs extends string[], InputMap extends{[key: string]: string},
-    OutputMap extends{[key: string]: string}, QueryFields extends string[]> = ComponentDef<T>;
+    OutputMap extends{[key: string]: string}, QueryFields extends string[],
+    NgContentSelectors extends string[]> = ComponentDef<T>;
 
 /**
  * @codeGenApi
  */
-export type ɵɵFactoryDef<T> = () => T;
+export type ɵɵFactoryDef<T, CtorDependencies extends CtorDependency[]> = () => T;
 
 /**
  * Runtime link information for Components.

--- a/packages/core/test/strict_types/inheritance_spec.ts
+++ b/packages/core/test/strict_types/inheritance_spec.ts
@@ -9,7 +9,7 @@
 import {ɵɵComponentDefWithMeta, ɵɵPipeDefWithMeta as PipeDefWithMeta} from '@angular/core';
 
 declare class SuperComponent {
-  static ɵcmp: ɵɵComponentDefWithMeta<SuperComponent, '[super]', never, {}, {}, never>;
+  static ɵcmp: ɵɵComponentDefWithMeta<SuperComponent, '[super]', never, {}, {}, never, never>;
 }
 
 declare class SubComponent extends SuperComponent {
@@ -18,7 +18,7 @@ declare class SubComponent extends SuperComponent {
   // would produce type errors when the "strictFunctionTypes" option is enabled.
   onlyInSubtype: string;
 
-  static ɵcmp: ɵɵComponentDefWithMeta<SubComponent, '[sub]', never, {}, {}, never>;
+  static ɵcmp: ɵɵComponentDefWithMeta<SubComponent, '[sub]', never, {}, {}, never, never>;
 }
 
 declare class SuperPipe { static ɵpipe: PipeDefWithMeta<SuperPipe, 'super'>; }


### PR DESCRIPTION
This commit augments the `FactoryDef` declaration of Angular decorated 
classes to contain information about the parameter decorators used in 
the constructor. If no constructor is present, or none of the parameters
have any Angular decorators, then this will be represented using the 
`null` type. Otherwise, a tuple type is used where the entry at index `i`
corresponds with parameter `i`. Each tuple entry can be one of two types:

1. If the associated parameter does not have any Angular decorators,
   the tuple entry will be the `null` type.
2. Otherwise, a type literal is used that may declare at least one of 
   the following properties:
   - "attribute": if `@Attribute` is present. The injected attribute's 
   name is used as string literal type, or the `unknown` type if the
   attribute name is not a string literal. 
   - "self": if `@Self` is present, always of type `true`.
   - "skipSelf": if `@SkipSelf` is present, always of type `true`.
   - "host": if `@Host` is present, always of type `true`.
   - "optional": if `@Optional` is present, always of type `true`.
   
   A property is only present if the corresponding decorator is used.
   
   Note that the `@Inject` decorator is currently not included, as it's
   non-trivial to properly convert the token's value expression to a 
   type that is valid in a declaration file. 

Additionally, the `ComponentDefWithMeta` declaration that is created for
Angular components has been extended to include all selectors on 
`ng-content` elements within the component's template.

This additional metadata is useful for tooling such as the Angular
Language Service, as it provides the ability to offer suggestions for
directives/components defined in libraries. At the moment, such
tooling extracts the necessary information from the _metadata.json_
manifest file as generated by ngc, however this metadata representation
is being replaced by the information emitted into the declaration files.

Resolves FW-1870