### PR TITLE
ci: increase AIO payload size limit

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 450017,
+        "main-es2015": 450541,
         "polyfills-es2015": 52195
       }
     }


### PR DESCRIPTION
This commit updates AIO payload size limit that is triggering a problem after merging https://github.com/angular/angular/commit/0bc35a71e2eaa0c57ef821245755c352305dd3fc. That commit added some payload size, but all checks were "green" for the original PR (#34574), so it looks like it's an accumulated payload size increase from multiple changes. The goal of this commit is to bring the master branch back to "green" state.

Note: for some reasons patch branch is not affected (which might indicate that there is a discrepancy between branches), but I think we should update both master and patch to keep limits consistent.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No