### PR TITLE
perf(core): adding micro benchmark for host bindings

### DIFF
--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -216,3 +216,16 @@ ng_benchmark(
     name = "duplicate_map_based_style_and_class_bindings",
     bundle = ":duplicate_map_based_style_and_class_bindings_lib",
 )
+
+ng_rollup_bundle(
+    name = "host_binding_lib",
+    entry_point = ":host_binding/index.ts",
+    deps = [
+        ":perf_lib",
+    ],
+)
+
+ng_benchmark(
+    name = "host_binding",
+    bundle = ":host_binding",
+)

--- a/packages/core/test/render3/perf/host_binding/index.ts
+++ b/packages/core/test/render3/perf/host_binding/index.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ɵɵdefineDirective, ɵɵelement, ɵɵhostProperty, ɵɵlistener} from '../../../../src/render3/index';
+import {DirectiveDefList, RenderFlags} from '../../../../src/render3/interfaces/definition';
+import {TAttributes} from '../../../../src/render3/interfaces/node';
+import {createBenchmark} from '../micro_bench';
+import {setupTestHarness} from '../setup';
+
+`
+  @Directive({
+    selector: '[hostBindingDir]'
+  })
+  export class HostBindingDir {
+    exp = 'string-exp';
+
+    @HostBinding('data-a')
+    a: string = 'exp';
+
+    @HostBinding('data-b')
+    b: string = 'exp';
+
+    @HostListener('click')
+    onClick(event: any): void {}
+
+    @HostListener('mousemove')
+    onMousemove(event: any): void {}
+  }
+`;
+class HostBindingDir {
+  static ɵfac() { return new HostBindingDir(); }
+  static ɵdir = ɵɵdefineDirective({
+    type: HostBindingDir,
+    selectors: [['', 'hostBindingDir', '']],
+    hostVars: 2,
+    hostBindings: function(rf: RenderFlags, ctx: any) {
+      if (rf & 1) {
+        ɵɵlistener('click', function() { return ctx.onClick(); });
+        ɵɵlistener('mousemove', function() { return ctx.onMousemove(); });
+      }
+      if (rf & 2) {
+        ɵɵhostProperty('data-a', ctx.exp);
+        ɵɵhostProperty('data-b', ctx.exp);
+      }
+    }
+  });
+
+  exp = 'string-exp';
+  onClick() {}
+  onMousemove() {}
+}
+
+`
+  <div hostBindingDir></div>
+`;
+function componentTemplateFn(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'div', 0);
+  }
+}
+
+const context: any = {};
+const consts: TAttributes[] = [['hostBindingDir', '']];
+const directives: DirectiveDefList = [HostBindingDir.ɵdir];
+const harness = setupTestHarness(componentTemplateFn, 1, 0, 1000, context, consts, directives);
+
+// Benchmark host bindings execution in *creation* mode
+const createModeBenchmark = createBenchmark('host bindings');
+const createModeProfile = createModeBenchmark('`create` mode');
+
+console.profile(createModeBenchmark.name + ':' + createModeProfile.name);
+while (createModeProfile()) {
+  harness.createEmbeddedLView();
+}
+console.profileEnd();
+
+createModeBenchmark.report();
+
+// Benchmark host bindings execution in *update* mode
+const updateModeBenchmark = createBenchmark('host bindings');
+const updateModeProfile = updateModeBenchmark('`update` mode');
+
+console.profile(updateModeBenchmark.name + ':' + updateModeProfile.name);
+while (updateModeProfile()) {
+  harness.detectChanges();
+}
+console.profileEnd();
+
+updateModeBenchmark.report();

--- a/packages/core/test/render3/perf/host_binding/index.ts
+++ b/packages/core/test/render3/perf/host_binding/index.ts
@@ -21,14 +21,8 @@ import {setupTestHarness} from '../setup';
     @HostBinding('data-a')
     a: string = 'exp';
 
-    @HostBinding('data-b')
-    b: string = 'exp';
-
     @HostListener('click')
     onClick(event: any): void {}
-
-    @HostListener('mousemove')
-    onMousemove(event: any): void {}
   }
 `;
 class HostBindingDir {
@@ -40,18 +34,15 @@ class HostBindingDir {
     hostBindings: function(rf: RenderFlags, ctx: any) {
       if (rf & 1) {
         ɵɵlistener('click', function() { return ctx.onClick(); });
-        ɵɵlistener('mousemove', function() { return ctx.onMousemove(); });
       }
       if (rf & 2) {
         ɵɵhostProperty('data-a', ctx.exp);
-        ɵɵhostProperty('data-b', ctx.exp);
       }
     }
   });
 
   exp = 'string-exp';
   onClick() {}
-  onMousemove() {}
 }
 
 `


### PR DESCRIPTION
This commit adds micro benchmark for host bindings, so that we can assess the impact of changes related to host bindings (for example PR #35568).

## PR Type
What kind of change does this PR introduce?

- [x] Other: adding new perf benchmark

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No