### PR TITLE
fix(ngcc): handle missing sources and out of range mappings when flattening source-maps

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -111,7 +111,7 @@ export class DtsRenderer {
     this.dtsFormatter.addImports(
         outputText, importManager.getAllImports(dtsFile.fileName), dtsFile);
 
-    return renderSourceAndMap(this.fs, dtsFile, outputText);
+    return renderSourceAndMap(this.logger, this.fs, dtsFile, outputText);
   }
 
   private getTypingsFilesToRender(

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -114,7 +114,7 @@ export class Renderer {
     }
 
     if (compiledFile || switchMarkerAnalysis || isEntryPoint) {
-      return renderSourceAndMap(this.fs, sourceFile, outputText);
+      return renderSourceAndMap(this.logger, this.fs, sourceFile, outputText);
     } else {
       return [];
     }

--- a/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
+++ b/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
@@ -49,11 +49,9 @@ export class SourceFile {
     const sources: SourceFile[] = [];
     const names: string[] = [];
 
-    // Ensure a mapping line array for each line in the generated source.
-    const mappings: SourceMapMappings = this.lineLengths.map(() => []);
+    const mappings: SourceMapMappings = [];
 
     for (const mapping of this.flattenedMappings) {
-      const mappingLine = mappings[mapping.generatedSegment.line];
       const sourceIndex = findIndexOrAdd(sources, mapping.originalSource);
       const mappingArray: SourceMapSegment = [
         mapping.generatedSegment.column,
@@ -65,7 +63,14 @@ export class SourceFile {
         const nameIndex = findIndexOrAdd(names, mapping.name);
         mappingArray.push(nameIndex);
       }
-      mappingLine.push(mappingArray);
+
+      // Ensure a mapping line array for this mapping.
+      const line = mapping.generatedSegment.line;
+      while (line >= mappings.length) {
+        mappings.push([]);
+      }
+      // Add this mapping to the line
+      mappings[line].push(mappingArray);
     }
 
     const sourcePathDir = dirname(this.sourcePath);

--- a/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
+++ b/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
@@ -290,11 +290,16 @@ export function parseMappings(
     const generatedLineMappings = rawMappings[generatedLine];
     for (const rawMapping of generatedLineMappings) {
       if (rawMapping.length >= 4) {
+        const originalSource = sources[rawMapping[1] !];
+        if (originalSource === null) {
+          // the original source is missing so ignore this mapping
+          continue;
+        }
         const generatedColumn = rawMapping[0];
         const name = rawMapping.length === 5 ? rawMap.names[rawMapping[4]] : undefined;
         const mapping: Mapping = {
           generatedSegment: {line: generatedLine, column: generatedColumn},
-          originalSource: sources[rawMapping[1] !] !,
+          originalSource,
           originalSegment: {line: rawMapping[2] !, column: rawMapping[3] !}, name
         };
         mappings.push(mapping);

--- a/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
+++ b/packages/compiler-cli/ngcc/src/sourcemaps/source_file.ts
@@ -296,7 +296,7 @@ export function parseMappings(
     for (const rawMapping of generatedLineMappings) {
       if (rawMapping.length >= 4) {
         const originalSource = sources[rawMapping[1] !];
-        if (originalSource === null) {
+        if (originalSource === null || originalSource === undefined) {
           // the original source is missing so ignore this mapping
           continue;
         }

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -174,7 +174,6 @@ runInEachFileSystem(() => {
           [5, 0, 1, 20], [7, 0, 1, 22], [12, 0, 1, 27], [14, 0, 1, 28], [15, 0, 1, 29],
           [9, 0, 2, 13], [10, 0, 2, 14]
         ],
-        [],
       ];
 
       JS_CONTENT_MAP = fromObject({
@@ -196,15 +195,12 @@ runInEachFileSystem(() => {
         'file': 'file.js',
         'sources': ['file.js'],
         'names': [],
-        'mappings': encode([
-          [], [], [], [], [], [], [], [], [], [], [], [], [[0, 0, 0, 0]],
-          [], [], [], [], [], [], [], [], []
-        ]),
+        'mappings': encode([[], [], [], [], [], [], [], [], [], [], [], [], [[0, 0, 0, 0]]]),
         'sourcesContent': [JS_CONTENT.contents],
       });
 
       const MERGED_OUTPUT_PROGRAM_MAPPINGS: SourceMapMappings =
-          [[], [], [], [], [], [], [], [], [], [], [], [], ...JS_CONTENT_MAPPINGS, []];
+          [[], [], [], [], [], [], [], [], [], [], [], [], ...JS_CONTENT_MAPPINGS];
 
       MERGED_OUTPUT_PROGRAM_MAP = fromObject({
         'version': 3,

--- a/packages/compiler-cli/ngcc/test/sourcemaps/source_file_spec.ts
+++ b/packages/compiler-cli/ngcc/test/sourcemaps/source_file_spec.ts
@@ -229,6 +229,32 @@ runInEachFileSystem(() => {
             [[1, 0, 0, 0], [2, 0, 0, 2], [3, 0, 0, 3], [3, 0, 0, 6], [4, 0, 0, 1], [5, 0, 0, 7]]
           ]));
         });
+
+        it('should handle mappings that map from lines outside of the actual content lines', () => {
+          const bSource = new SourceFile(_('/foo/src/b.js'), 'abcdef', null, false, []);
+          const aToBSourceMap: RawSourceMap = {
+            mappings: encode([
+              [[0, 0, 0, 0], [2, 0, 0, 3], [4, 0, 0, 2], [5, 0, 0, 5]],
+              [
+                [0, 0, 0, 0],  // Extra mapping from a non-existent line
+              ]
+            ]),
+            names: [],
+            sources: ['b.js'],
+            version: 3
+          };
+          const aSource =
+              new SourceFile(_('/foo/src/a.js'), 'abdecf', aToBSourceMap, false, [bSource]);
+
+          const aTocSourceMap = aSource.renderFlattenedSourceMap();
+          expect(aTocSourceMap.version).toEqual(3);
+          expect(aTocSourceMap.file).toEqual('a.js');
+          expect(aTocSourceMap.names).toEqual([]);
+          expect(aTocSourceMap.sourceRoot).toBeUndefined();
+          expect(aTocSourceMap.sources).toEqual(['b.js']);
+          expect(aTocSourceMap.sourcesContent).toEqual(['abcdef']);
+          expect(aTocSourceMap.mappings).toEqual(aToBSourceMap.mappings);
+        });
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/sourcemaps/source_file_spec.ts
+++ b/packages/compiler-cli/ngcc/test/sourcemaps/source_file_spec.ts
@@ -174,6 +174,28 @@ runInEachFileSystem(() => {
             },
           ]);
         });
+
+        it('should ignore mappings to missing source files', () => {
+          const bSourceMap: RawSourceMap = {
+            mappings: encode([[[1, 0, 0, 0], [4, 0, 0, 3], [4, 0, 0, 6], [5, 0, 0, 7]]]),
+            names: [],
+            sources: ['c.js'],
+            version: 3
+          };
+          const bSource = new SourceFile(_('/foo/src/b.js'), 'abcdef', bSourceMap, false, [null]);
+          const aSourceMap: RawSourceMap = {
+            mappings: encode([[[0, 0, 0, 0], [2, 0, 0, 3], [4, 0, 0, 2], [5, 0, 0, 5]]]),
+            names: [],
+            sources: ['b.js'],
+            version: 3
+          };
+          const aSource =
+              new SourceFile(_('/foo/src/a.js'), 'abdecf', aSourceMap, false, [bSource]);
+
+          // These flattened mappings are just the mappings from a to b.
+          // (The mappings to c are dropped since there is no source file to map to.)
+          expect(aSource.flattenedMappings).toEqual(parseMappings(aSourceMap, [bSource]));
+        });
       });
 
       describe('renderFlattenedSourceMap()', () => {


### PR DESCRIPTION
This PR has two commits that fix issues with source-maps that are badly formatted.

---

If a package has a source-map but it does not provide the actual content of the sources, then the source-map flattening was crashing.

Now we ignore such mappings that have no source since we are not able to compute the merged mapping if there is no source file.

---

Previously when rendering flattened source-maps, it was assumed that no mapping would come from a line that is outside the lines of the actual source content. It turns out this is not a valid assumption.

Now the code that renders flattened source-maps will handle such mappings, with the additional benefit that the rendered source-map will only contain mapping lines up to the last mapping, rather than a mapping line for every content line.

---

Fixes #35709
