### PR TITLE
perf(ngcc): spawn workers eagerly

### DIFF
--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -61,7 +61,7 @@ export interface Task extends JsonObject {
 
   /**
    * The list of all format properties (including `task.formatProperty`) that should be marked as
-   * processed once the taksk has been completed, because they point to the format-path that will be
+   * processed once the task has been completed, because they point to the format-path that will be
    * processed as part of the task.
    */
   formatPropertiesToMarkAsProcessed: EntryPointJsonProperty[];
@@ -75,9 +75,6 @@ export type TaskCompletedCallback = (task: Task, outcome: TaskProcessingOutcome)
 
 /** Represents the outcome of processing a `Task`. */
 export const enum TaskProcessingOutcome {
-  /** The target format property was already processed - didn't have to do anything. */
-  AlreadyProcessed,
-
   /** Successfully processed the target format property. */
   Processed,
 }

--- a/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
@@ -58,15 +58,8 @@ describe('ClusterWorker', () => {
         new ClusterWorker(mockLogger, createCompileFnSpy);
         const onTaskCompleted: TaskCompletedCallback = createCompileFnSpy.calls.argsFor(0)[0];
 
-        onTaskCompleted(null as any, TaskProcessingOutcome.AlreadyProcessed);
-        expect(processSendSpy).toHaveBeenCalledTimes(1);
-        expect(processSendSpy).toHaveBeenCalledWith({
-          type: 'task-completed',
-          outcome: TaskProcessingOutcome.AlreadyProcessed,
-        });
-
         onTaskCompleted(null as any, TaskProcessingOutcome.Processed);
-        expect(processSendSpy).toHaveBeenCalledTimes(2);
+        expect(processSendSpy).toHaveBeenCalledTimes(1);
         expect(processSendSpy).toHaveBeenCalledWith({
           type: 'task-completed',
           outcome: TaskProcessingOutcome.Processed,


### PR DESCRIPTION
With this change we spawn workers eagerly based on the amount of work that needs to be done and changed the behaviour in `analyzeEntryPoints`, to only create tasks for non-processed formats.

Before this change we spawned the maximum of workers possible. However, in some cases there are less tasks than the max number of workers which resulted in created unnecessary workers

Reference: #35717

