### PR TITLE
fix(core): Hide `debugger` statement in asserts behind a flag

### DIFF
--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -55,8 +55,6 @@ export function throwErrorIfNoChangesMode(
   }
   // TODO: include debug context, see `viewDebugError` function in
   // `packages/core/src/view/errors.ts` for reference.
-  // tslint:disable-next-line
-  debugger;  // Left intentionally for better debugger experience.
   throw new Error(msg);
 }
 

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -93,8 +93,20 @@ export function assertDefined<T>(actual: T, msg: string) {
 export function throwError(msg: string): never;
 export function throwError(msg: string, actual: any, expected: any, comparison: string): never;
 export function throwError(msg: string, actual?: any, expected?: any, comparison?: string): never {
-  // tslint:disable-next-line
-  debugger;  // Left intentionally for better debugger experience.
+  if (ngDevMode && (Error as any).stopInDebuggerOnAssertFailure) {
+    // In Angular asserts are consider fatal. During normal application execution they should not
+    // happen. When doing development and the dev-tools console is open it is often useful to stop
+    // the debugger at this line, so that one can examine the conditions under which these error
+    // occur. For this reason if `Error.stopInDebuggerOnAssertFailure = true` then the debugger will
+    // stop here. In default case the `Error.stopInDebuggerOnAssertFailure` is not set and so there
+    // is no observable behavior to the developer.
+    //
+    // Notice that the `debugger` statement is only present in `ngDevMode` and is removed in
+    // production.
+    //
+    // tslint:disable-next-line
+    debugger;  // Left intentionally for better debugger experience in tests.
+  }
   throw new Error(
       `ASSERTION ERROR: ${msg}` +
       (comparison == null ? '' : ` [Expected=> ${expected} ${comparison} ${actual} <=Actual]`));

--- a/tools/testing/init_browser_spec.ts
+++ b/tools/testing/init_browser_spec.ts
@@ -14,6 +14,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 TestBed.initTestEnvironment(
     [BrowserDynamicTestingModule, NoopAnimationsModule], platformBrowserDynamicTesting());
 
+(Error as any).stopInDebuggerOnAssertFailure = true;
 (window as any).isNode = false;
 (window as any).isBrowser = true;
 (window as any).global = window;

--- a/tools/testing/init_node_spec.ts
+++ b/tools/testing/init_node_spec.ts
@@ -20,6 +20,7 @@ import 'reflect-metadata/Reflect';
 require('@bazel/jasmine').boot();
 import 'zone.js/lib/jasmine/jasmine';
 
+(Error as any).stopInDebuggerOnAssertFailure = true;
 (global as any).isNode = true;
 (global as any).isBrowser = false;
 


### PR DESCRIPTION
fix(core): Hide `debugger` statement in asserts behind a flag

Hide the debugger statement behind a flag so that it will only trigger if one sets `Error.stopInDebuggerOnAssertFailure = true;`. This is useful so that Angular teams development experience is better without effecting our users.
    
    Fix #35470
    Fix FW-1925

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
