### PR TITLE
fix(core): unable to NgModuleRef.injector in module constructor

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -78,17 +78,18 @@ interface Record<T> {
 export function createInjector(
     defType: /* InjectorType<any> */ any, parent: Injector | null = null,
     additionalProviders: StaticProvider[] | null = null, name?: string): Injector {
-  const injector = createInjectorWithoutInjectorTypes(defType, parent, additionalProviders, name);
-  injector.resolveInjectorDefTypes();
+  const injector =
+      createInjectorWithoutInjectorInstances(defType, parent, additionalProviders, name);
+  injector._resolveInjectorDefTypes();
   return injector;
 }
 
 /**
  * Creates a new injector without eagerly resolving its injector types. Can be used in places
  * where resolving the injector types immediately can lead to an infinite loop. The injector types
- * should be resolved at a later point by calling `resolveInjectorDefTypes`.
+ * should be resolved at a later point by calling `_resolveInjectorDefTypes`.
  */
-export function createInjectorWithoutInjectorTypes(
+export function createInjectorWithoutInjectorInstances(
     defType: /* InjectorType<any> */ any, parent: Injector | null = null,
     additionalProviders: StaticProvider[] | null = null, name?: string): R3Injector {
   return new R3Injector(defType, additionalProviders, parent || getNullInjector(), name);
@@ -234,7 +235,7 @@ export class R3Injector {
   }
 
   /** @internal */
-  resolveInjectorDefTypes() { this.injectorDefTypes.forEach(defType => this.get(defType)); }
+  _resolveInjectorDefTypes() { this.injectorDefTypes.forEach(defType => this.get(defType)); }
 
   toString() {
     const tokens = <string[]>[], records = this.records;

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -78,8 +78,20 @@ interface Record<T> {
 export function createInjector(
     defType: /* InjectorType<any> */ any, parent: Injector | null = null,
     additionalProviders: StaticProvider[] | null = null, name?: string): Injector {
-  parent = parent || getNullInjector();
-  return new R3Injector(defType, additionalProviders, parent, name);
+  const injector = createInjectorWithoutInjectorTypes(defType, parent, additionalProviders, name);
+  injector.resolveInjectorDefTypes();
+  return injector;
+}
+
+/**
+ * Creates a new injector without eagerly resolving its injector types. Can be used in places
+ * where resolving the injector types immediately can lead to an infinite loop. The injector types
+ * should be resolved at a later point by calling `resolveInjectorDefTypes`.
+ */
+export function createInjectorWithoutInjectorTypes(
+    defType: /* InjectorType<any> */ any, parent: Injector | null = null,
+    additionalProviders: StaticProvider[] | null = null, name?: string): R3Injector {
+  return new R3Injector(defType, additionalProviders, parent || getNullInjector(), name);
 }
 
 export class R3Injector {
@@ -135,9 +147,6 @@ export class R3Injector {
     // any injectable scoped to APP_ROOT_SCOPE.
     const record = this.records.get(INJECTOR_SCOPE);
     this.scope = record != null ? record.value : null;
-
-    // Eagerly instantiate the InjectorType classes themselves.
-    this.injectorDefTypes.forEach(defType => this.get(defType));
 
     // Source name, used for debugging
     this.source = source || (typeof def === 'object' ? null : stringify(def));
@@ -223,6 +232,9 @@ export class R3Injector {
       setCurrentInjector(previousInjector);
     }
   }
+
+  /** @internal */
+  resolveInjectorDefTypes() { this.injectorDefTypes.forEach(defType => this.get(defType)); }
 
   toString() {
     const tokens = <string[]>[], records = this.records;

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -9,7 +9,7 @@
 import {Injector} from '../di/injector';
 import {INJECTOR} from '../di/injector_compatibility';
 import {InjectFlags} from '../di/interface/injector';
-import {R3Injector, createInjector} from '../di/r3_injector';
+import {R3Injector, createInjectorWithoutInjectorTypes} from '../di/r3_injector';
 import {Type} from '../interface/type';
 import {ComponentFactoryResolver as viewEngine_ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {InternalNgModuleRef, NgModuleFactory as viewEngine_NgModuleFactory, NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
@@ -52,13 +52,18 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
     const ngLocaleIdDef = getNgLocaleIdDef(ngModuleType);
     ngLocaleIdDef && setLocaleId(ngLocaleIdDef);
     this._bootstrapComponents = maybeUnwrapFn(ngModuleDef !.bootstrap);
-    this._r3Injector = createInjector(
+    this._r3Injector = createInjectorWithoutInjectorTypes(
         ngModuleType, _parent,
         [
           {provide: viewEngine_NgModuleRef, useValue: this},
           {provide: viewEngine_ComponentFactoryResolver, useValue: this.componentFactoryResolver}
         ],
         stringify(ngModuleType)) as R3Injector;
+
+    // We need to resolve the injector types separately from the injector creation, because
+    // the module might be trying to use this ref in its contructor for DI which will cause a
+    // circular error that will eventually error out, because the injector isn't created yet.
+    this._r3Injector.resolveInjectorDefTypes();
     this.instance = this.get(ngModuleType);
   }
 

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -9,7 +9,7 @@
 import {Injector} from '../di/injector';
 import {INJECTOR} from '../di/injector_compatibility';
 import {InjectFlags} from '../di/interface/injector';
-import {R3Injector, createInjectorWithoutInjectorTypes} from '../di/r3_injector';
+import {R3Injector, createInjectorWithoutInjectorInstances} from '../di/r3_injector';
 import {Type} from '../interface/type';
 import {ComponentFactoryResolver as viewEngine_ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {InternalNgModuleRef, NgModuleFactory as viewEngine_NgModuleFactory, NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
@@ -52,7 +52,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
     const ngLocaleIdDef = getNgLocaleIdDef(ngModuleType);
     ngLocaleIdDef && setLocaleId(ngLocaleIdDef);
     this._bootstrapComponents = maybeUnwrapFn(ngModuleDef !.bootstrap);
-    this._r3Injector = createInjectorWithoutInjectorTypes(
+    this._r3Injector = createInjectorWithoutInjectorInstances(
         ngModuleType, _parent,
         [
           {provide: viewEngine_NgModuleRef, useValue: this},
@@ -63,7 +63,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
     // We need to resolve the injector types separately from the injector creation, because
     // the module might be trying to use this ref in its contructor for DI which will cause a
     // circular error that will eventually error out, because the injector isn't created yet.
-    this._r3Injector.resolveInjectorDefTypes();
+    this._r3Injector._resolveInjectorDefTypes();
     this.instance = this.get(ngModuleType);
   }
 

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {CUSTOM_ELEMENTS_SCHEMA, Component, ComponentFactory, Injectable, NO_ERRORS_SCHEMA, NgModule, NgModuleRef, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineInjector as defineInjector, ɵɵdefineNgModule as defineNgModule, ɵɵelement as element} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, Component, Injectable, InjectionToken, NO_ERRORS_SCHEMA, NgModule, NgModuleRef, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineInjector as defineInjector, ɵɵdefineNgModule as defineNgModule, ɵɵelement as element} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {modifiedInIvy, onlyInIvy} from '@angular/private/testing';
@@ -475,9 +475,28 @@ describe('NgModule', () => {
 
   });
 
-  it('should be able to use ComponentFactoryResolver from the NgModuleRef inside the module constructor',
+  it('should be able to use DI through the NgModuleRef inside the module constructor', () => {
+    const token = new InjectionToken<string>('token');
+    let value: string|undefined;
+
+    @NgModule({
+      imports: [CommonModule],
+      providers: [{provide: token, useValue: 'foo'}],
+    })
+    class TestModule {
+      constructor(ngRef: NgModuleRef<TestModule>) { value = ngRef.injector.get(token); }
+    }
+
+    TestBed.configureTestingModule({imports: [TestModule], declarations: [TestCmp]});
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+
+    expect(value).toBe('foo');
+  });
+
+  it('should be able to create a component throught the ComponentFactoryResolver of an NgModuleRef in a module constructor',
      () => {
-       let factory: ComponentFactory<TestCmp>;
+       let componentInstance: TestCmp|undefined;
 
        @NgModule({
          declarations: [TestCmp],
@@ -486,13 +505,14 @@ describe('NgModule', () => {
        })
        class MyModule {
          constructor(ngModuleRef: NgModuleRef<any>) {
-           factory = ngModuleRef.componentFactoryResolver.resolveComponentFactory(TestCmp);
+           const factory = ngModuleRef.componentFactoryResolver.resolveComponentFactory(TestCmp);
+           componentInstance = factory.create(ngModuleRef.injector).instance;
          }
        }
 
        TestBed.configureTestingModule({imports: [MyModule]});
        TestBed.createComponent(TestCmp);
-       expect(factory !.componentType).toBe(TestCmp);
+       expect(componentInstance).toBeAnInstanceOf(TestCmp);
      });
 
 });

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -494,7 +494,7 @@ describe('NgModule', () => {
     expect(value).toBe('foo');
   });
 
-  it('should be able to create a component throught the ComponentFactoryResolver of an NgModuleRef in a module constructor',
+  it('should be able to create a component through the ComponentFactoryResolver of an NgModuleRef in a module constructor',
      () => {
        let componentInstance: TestCmp|undefined;
 

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -108,7 +108,7 @@
     "name": "createInjector"
   },
   {
-    "name": "createInjectorWithoutInjectorTypes"
+    "name": "createInjectorWithoutInjectorInstances"
   },
   {
     "name": "deepForEach"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -108,6 +108,9 @@
     "name": "createInjector"
   },
   {
+    "name": "createInjectorWithoutInjectorTypes"
+  },
+  {
     "name": "deepForEach"
   },
   {


### PR DESCRIPTION
This is a follow up to #35637 which resolved a similar issue for `ComponentFactoryResolver`, but not the root cause. When a `NgModuleRef` is created, it instantiates an `Injector` internally which in turn resolves all of injector types. This can result in a circular call that results in an error, because the module is one of the injector types being resolved.

These changes work around the issue by allowing the constructor to run before resolving the injector types.

Fixes #35677.
Fixes #35639.