### PR TITLE
test(docs-infra): add proxy to fake images in tests

### DIFF
--- a/aio/karma.conf.js
+++ b/aio/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function (config) {
       {'reporter:jasmine-seed': ['type', JasmineSeedReporter]},
     ],
     proxies: {
-      '/link/to/image': 'src/assets/images/logos/angular/angular.png'
+      '/dummy/image': 'src/assets/images/logos/angular/angular.png',
     },
     client: {
       clearContext: false,  // leave Jasmine Spec Runner output visible in browser

--- a/aio/karma.conf.js
+++ b/aio/karma.conf.js
@@ -14,6 +14,9 @@ module.exports = function (config) {
       require('@angular-devkit/build-angular/plugins/karma'),
       {'reporter:jasmine-seed': ['type', JasmineSeedReporter]},
     ],
+    proxies: {
+      '/link/to/image': 'src/assets/images/logos/angular/angular.png'
+    },
     client: {
       clearContext: false,  // leave Jasmine Spec Runner output visible in browser
       jasmine: {

--- a/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
+++ b/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
@@ -88,7 +88,7 @@ describe('AnnouncementBarComponent', () => {
   describe('rendering', () => {
     beforeEach(() => {
       component.announcement = {
-        imageUrl: 'link/to/image',
+        imageUrl: 'dummy/image',
         linkUrl: 'link/to/website',
         message: 'this is an <b>important</b> message',
         endDate: '2018-03-01',
@@ -102,7 +102,7 @@ describe('AnnouncementBarComponent', () => {
     });
 
     it('should display an image', () => {
-      expect(element.querySelector('img')!.src).toContain('link/to/image');
+      expect(element.querySelector('img')!.src).toContain('dummy/image');
     });
 
     it('should display a link', () => {


### PR DESCRIPTION
Previously, when running the unit tests for aio on Windows, many 404s
are logged for images, resulting in progress logs being spread over
multiple lines. This commit fixes this by adding a `proxy` to point
the fake image to a real image within the `src` folder.

Closes #29775

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29775


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**Before:**

![image](https://user-images.githubusercontent.com/59734/75511045-dde84f80-59ba-11ea-9f99-4f52fd990c06.png)

**After:**

![image](https://user-images.githubusercontent.com/59734/75511059-f22c4c80-59ba-11ea-8e4d-25ad01e24f36.png)

