### PR TITLE
fix(core): handle `<ng-template>` with local refs in i18n blocks

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -701,7 +701,8 @@ function i18nEndFirstPass(tView: TView, lView: LView) {
     }
     // Check if an element has any local refs and skip them
     const tNode = getTNode(tView, index);
-    if (tNode && (tNode.type === TNodeType.Element || tNode.type === TNodeType.ElementContainer) &&
+    if (tNode && (tNode.type === TNodeType.Container || tNode.type === TNodeType.Element ||
+                  tNode.type === TNodeType.ElementContainer) &&
         tNode.localNames !== null) {
       // Divide by 2 to get the number of local refs,
       // since they are stored as an array that also includes directive indexes,

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -299,19 +299,28 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       [computeMsgId(
           '{$START_TAG_NG_CONTAINER} One {$CLOSE_TAG_NG_CONTAINER}' +
           '{$START_TAG_DIV} Two {$CLOSE_TAG_DIV}' +
-          '{$START_TAG_SPAN} Three {$CLOSE_TAG_SPAN}')]:
+          '{$START_TAG_SPAN} Three {$CLOSE_TAG_SPAN}' +
+          '{$START_TAG_NG_TEMPLATE} Four {$CLOSE_TAG_NG_TEMPLATE}' +
+          '{$START_TAG_NG_CONTAINER_1}{$CLOSE_TAG_NG_CONTAINER}')]:
+
           '{$START_TAG_NG_CONTAINER} Une {$CLOSE_TAG_NG_CONTAINER}' +
           '{$START_TAG_DIV} Deux {$CLOSE_TAG_DIV}' +
-          '{$START_TAG_SPAN} Trois {$CLOSE_TAG_SPAN}'
+          '{$START_TAG_SPAN} Trois {$CLOSE_TAG_SPAN}' +
+          '{$START_TAG_NG_TEMPLATE} Quatre {$CLOSE_TAG_NG_TEMPLATE}' +
+          '{$START_TAG_NG_CONTAINER_1}{$CLOSE_TAG_NG_CONTAINER}'
+
     });
     const fixture = initWithTemplate(AppComp, `
       <div i18n>
         <ng-container #localRefA> One </ng-container>
         <div #localRefB> Two </div>
         <span #localRefC> Three </span>
+
+        <ng-template #localRefD> Four </ng-template>
+        <ng-container *ngTemplateOutlet="localRefD"></ng-container>
       </div>
     `);
-    expect(fixture.nativeElement.textContent).toBe(' Une  Deux  Trois ');
+    expect(fixture.nativeElement.textContent).toBe(' Une  Deux  Trois  Quatre ');
   });
 
   it('should handle local refs correctly in case an element is removed in translation', () => {


### PR DESCRIPTION
This commit extends the range of tNode types that may have local refs to include `TNodeType.Container` to account for `<ng-template>`s. Original changes in https://github.com/angular/angular/pull/33415 didn't include that type and as a result, an error is thrown at runtime in case an i18n block contains an `<ng-template>` with local refs.

This PR closes #35746.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No