### PR TITLE
docs(common): switch HTTP guide examples to `TestBed.inject()`

### DIFF
--- a/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
+++ b/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
@@ -28,9 +28,9 @@ describe('HeroesService', () => {
 
     // Inject the http, test controller, and service-under-test
     // as they will be referenced by each test.
-    httpClient = TestBed.get(HttpClient);
-    httpTestingController = TestBed.get(HttpTestingController);
-    heroService = TestBed.get(HeroesService);
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    heroService = TestBed.inject(HeroesService);
   });
 
   afterEach(() => {
@@ -44,7 +44,7 @@ describe('HeroesService', () => {
     let expectedHeroes: Hero[];
 
     beforeEach(() => {
-      heroService = TestBed.get(HeroesService);
+      heroService = TestBed.inject(HeroesService);
       expectedHeroes = [
         { id: 1, name: 'A' },
         { id: 2, name: 'B' },

--- a/aio/content/examples/http/src/testing/http-client.spec.ts
+++ b/aio/content/examples/http/src/testing/http-client.spec.ts
@@ -27,8 +27,8 @@ describe('HttpClient testing', () => {
     });
 
     // Inject the http service and test controller for each test
-    httpClient = TestBed.get(HttpClient);
-    httpTestingController = TestBed.get(HttpTestingController);
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
   // #enddocregion setup
   // #docregion afterEach


### PR DESCRIPTION
`TestBed.get()` has been [deprecated in v9][1], in favor of `TestBed.inject()`. In ##32382, the HTTP guide wording has been updated to mention `TestBed.inject()` instead of `TestBed.get()`, but the associated code snippets (extracted from the `http` example) were not.

This commit updates the HTTP guide examples to also use `TestBed.inject()`.

[1]: https://v9.angular.io/guide/deprecations#testing

Fixes #35609
