### PR TITLE
fix(localize): translation file parser selection

### DIFF
--- a/packages/localize/src/tools/src/diagnostics.ts
+++ b/packages/localize/src/tools/src/diagnostics.ts
@@ -15,4 +15,15 @@ export class Diagnostics {
   get hasErrors() { return this.messages.some(m => m.type === 'error'); }
   warn(message: string) { this.messages.push({type: 'warning', message}); }
   error(message: string) { this.messages.push({type: 'error', message}); }
+  formatDiagnostics(message: string): string {
+    const errors = this.messages !.filter(d => d.type === 'error').map(d => ' - ' + d.message);
+    const warnings = this.messages !.filter(d => d.type === 'warning').map(d => ' - ' + d.message);
+    if (errors.length) {
+      message += '\nERRORS:\n' + errors.join('\n');
+    }
+    if (warnings.length) {
+      message += '\nWARNINGS:\n' + warnings.join('\n');
+    }
+    return message;
+  }
 }

--- a/packages/localize/src/tools/src/translate/main.ts
+++ b/packages/localize/src/tools/src/translate/main.ts
@@ -142,7 +142,7 @@ export function translateFiles({sourceRootPath, sourceFilePaths, translationFile
       [
         new Xliff2TranslationParser(),
         new Xliff1TranslationParser(),
-        new XtbTranslationParser(diagnostics),
+        new XtbTranslationParser(),
         new SimpleJsonTranslationParser(),
       ],
       diagnostics);

--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -15,7 +15,7 @@ import {TranslationParser} from './translation_parsers/translation_parser';
  */
 export class TranslationLoader {
   constructor(
-      private translationParsers: TranslationParser[],
+      private translationParsers: TranslationParser<any>[],
       /** @deprecated */ private diagnostics?: Diagnostics) {}
 
   /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -42,7 +42,7 @@ export class TranslationLoader {
         }
 
         const {locale: parsedLocale, translations, diagnostics} =
-            translationParser.parse(filePath, fileContents);
+            translationParser.parse(filePath, fileContents, result);
         if (diagnostics.hasErrors) {
           throw new Error(diagnostics.formatDiagnostics(
               `The translation file "${filePath}" could not be parsed.`));

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
@@ -7,6 +7,7 @@
  */
 import {ɵMessageId, ɵParsedTranslation, ɵparseTranslation} from '@angular/localize';
 import {extname} from 'path';
+import {Diagnostics} from '../../../diagnostics';
 import {ParsedTranslationBundle, TranslationParser} from './translation_parser';
 
 /**
@@ -32,6 +33,6 @@ export class SimpleJsonTranslationParser implements TranslationParser {
       const targetMessage = translations[messageId];
       parsedTranslations[messageId] = ɵparseTranslation(targetMessage);
     }
-    return {locale: parsedLocale, translations: parsedTranslations};
+    return {locale: parsedLocale, translations: parsedTranslations, diagnostics: new Diagnostics()};
   }
 }

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵMessageId, ɵParsedTranslation} from '@angular/localize/private';
+import {Diagnostics} from '../../../diagnostics';
 
 /**
 * An object that holds translations that have been parsed from a translation file.
@@ -13,6 +14,7 @@ import {ɵMessageId, ɵParsedTranslation} from '@angular/localize/private';
 export interface ParsedTranslationBundle {
   locale: string|undefined;
   translations: Record<ɵMessageId, ɵParsedTranslation>;
+  diagnostics: Diagnostics;
 }
 
 /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Element, LexerRange, Node, XmlParser} from '@angular/compiler';
+import {Element, LexerRange, Node, ParseError, ParseErrorLevel, ParseSourceSpan, XmlParser} from '@angular/compiler';
+import {Diagnostics} from '../../../diagnostics';
 import {TranslationParseError} from './translation_parse_error';
 
 export function getAttrOrThrow(element: Element, attrName: string): string {
@@ -22,6 +23,14 @@ export function getAttribute(element: Element, attrName: string): string|undefin
   return attr !== undefined ? attr.value : undefined;
 }
 
+/**
+ * Parse the "contents" of an XML element.
+ *
+ * This would be equivalent to parsing the `innerHTML` string of an HTML document.
+ *
+ * @param element The element whose inner range we want to parse.
+ * @returns a collection of XML `Node` objects that were parsed from the element's contents.
+ */
 export function parseInnerRange(element: Element): Node[] {
   const xmlParser = new XmlParser();
   const xml = xmlParser.parse(
@@ -33,6 +42,10 @@ export function parseInnerRange(element: Element): Node[] {
   return xml.rootNodes;
 }
 
+/**
+ * Compute a `LexerRange` that contains all the children of the given `element`.
+ * @param element The element whose inner range we want to compute.
+ */
 function getInnerRange(element: Element): LexerRange {
   const start = element.startSourceSpan !.end;
   const end = element.endSourceSpan !.start;
@@ -42,4 +55,94 @@ function getInnerRange(element: Element): LexerRange {
     startCol: start.col,
     endPos: end.offset,
   };
+}
+
+/**
+ * This "hint" object is used to pass information from `canParse()` to `parse()` for
+ * `TranslationParser`s that expect XML contents.
+ *
+ * This saves the `parse()` method from having to re-parse the XML.
+ */
+export interface XmlTranslationParserHint {
+  element: Element;
+  errors: ParseError[];
+}
+
+/**
+ * Can this XML be parsed for translations, given the expected `rootNodeName` and expected root node
+ * `attributes` that should appear in the file.
+ *
+ * @param filePath The path to the file being checked.
+ * @param contents The contents of the file being checked.
+ * @param rootNodeName The expected name of an XML root node that should exist.
+ * @param attributes The attributes (and their values) that should appear on the root node.
+ * @returns The `XmlTranslationParserHint` object for use by `TranslationParser.parse()` if the XML
+ * document has the expected format.
+ */
+export function canParseXml(
+    filePath: string, contents: string, rootNodeName: string,
+    attributes: Record<string, string>): XmlTranslationParserHint|false {
+  const xmlParser = new XmlParser();
+  const xml = xmlParser.parse(contents, filePath);
+
+  if (xml.rootNodes.length === 0 ||
+      xml.errors.some(error => error.level === ParseErrorLevel.ERROR)) {
+    return false;
+  }
+
+  const rootElements = xml.rootNodes.filter(isNamedElement(rootNodeName));
+  const rootElement = rootElements[0];
+  if (rootElement === undefined) {
+    return false;
+  }
+
+  for (const attrKey of Object.keys(attributes)) {
+    const attr = rootElement.attrs.find(attr => attr.name === attrKey);
+    if (attr === undefined || attr.value !== attributes[attrKey]) {
+      return false;
+    }
+  }
+
+  if (rootElements.length > 1) {
+    xml.errors.push(new ParseError(
+        xml.rootNodes[1].sourceSpan,
+        'Unexpected root node. XLIFF 1.2 files should only have a single <xliff> root node.',
+        ParseErrorLevel.WARNING));
+  }
+
+  return {element: rootElement, errors: xml.errors};
+}
+
+/**
+ * Create a predicate, which can be used by things like `Array.filter()`, that will match a named
+ * XML Element from a collection of XML Nodes.
+ *
+ * @param name The expected name of the element to match.
+ */
+export function isNamedElement(name: string): (node: Node) => node is Element {
+  function predicate(node: Node): node is Element {
+    return node instanceof Element && node.name === name;
+  }
+  return predicate;
+}
+
+/**
+ * Add an XML parser related message to the given `diagnostics` object.
+ */
+export function addParseDiagnostic(
+    diagnostics: Diagnostics, sourceSpan: ParseSourceSpan, message: string,
+    level: ParseErrorLevel): void {
+  addParseError(diagnostics, new ParseError(sourceSpan, message, level));
+}
+
+/**
+ * Copy the formatted error message from the given `parseError` object into the given `diagnostics`
+ * object.
+ */
+export function addParseError(diagnostics: Diagnostics, parseError: ParseError): void {
+  if (parseError.level === ParseErrorLevel.ERROR) {
+    diagnostics.error(parseError.toString());
+  } else {
+    diagnostics.warn(parseError.toString());
+  }
 }

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
@@ -9,6 +9,7 @@ import {Element, Node, XmlParser, visitAll} from '@angular/compiler';
 import {ɵMessageId, ɵParsedTranslation} from '@angular/localize';
 import {extname} from 'path';
 
+import {Diagnostics} from '../../../diagnostics';
 import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
@@ -55,7 +56,8 @@ class XliffFileElementVisitor extends BaseVisitor {
     if (element.name === 'file') {
       this.bundle = {
         locale: getAttribute(element, 'target-language'),
-        translations: XliffTranslationVisitor.extractTranslations(element)
+        translations: XliffTranslationVisitor.extractTranslations(element),
+        diagnostics: new Diagnostics(),
       };
     } else {
       return visitAll(this, element.children);

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
@@ -9,6 +9,7 @@ import {Element, Node, XmlParser, visitAll} from '@angular/compiler';
 import {ɵMessageId, ɵParsedTranslation} from '@angular/localize';
 import {extname} from 'path';
 
+import {Diagnostics} from '../../../diagnostics';
 import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
@@ -61,7 +62,8 @@ class Xliff2TranslationBundleVisitor extends BaseVisitor {
     } else if (element.name === 'file') {
       this.bundle = {
         locale: parsedLocale,
-        translations: Xliff2TranslationVisitor.extractTranslations(element)
+        translations: Xliff2TranslationVisitor.extractTranslations(element),
+        diagnostics: new Diagnostics(),
       };
     } else {
       return visitAll(this, element.children, {parsedLocale});

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -24,7 +24,7 @@ import {getAttrOrThrow, parseInnerRange} from './translation_utils';
  * A translation parser that can load XB files.
  */
 export class XtbTranslationParser implements TranslationParser {
-  constructor(private diagnostics: Diagnostics) {}
+  constructor(private diagnostics: Diagnostics = new Diagnostics()) {}
 
   canParse(filePath: string, contents: string): boolean {
     const extension = extname(filePath);
@@ -61,7 +61,11 @@ class XtbVisitor extends BaseVisitor {
               element.sourceSpan, '<translationbundle> elements can not be nested');
         }
         const langAttr = element.attrs.find((attr) => attr.name === 'lang');
-        bundle = {locale: langAttr && langAttr.value, translations: {}};
+        bundle = {
+          locale: langAttr && langAttr.value,
+          translations: {},
+          diagnostics: this.diagnostics
+        };
         visitAll(this, element.children, bundle);
         return bundle;
 

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Element, Node, XmlParser, visitAll} from '@angular/compiler';
+import {Element, ParseErrorLevel, visitAll} from '@angular/compiler';
 import {ɵParsedTranslation} from '@angular/localize';
 import {extname} from 'path';
 
@@ -14,87 +14,100 @@ import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
 
-import {TranslationParseError} from './translation_parse_error';
 import {ParsedTranslationBundle, TranslationParser} from './translation_parser';
-import {getAttrOrThrow, parseInnerRange} from './translation_utils';
-
+import {XmlTranslationParserHint, addParseDiagnostic, addParseError, canParseXml, getAttribute, parseInnerRange} from './translation_utils';
 
 
 /**
  * A translation parser that can load XB files.
  */
-export class XtbTranslationParser implements TranslationParser {
-  constructor(private diagnostics: Diagnostics = new Diagnostics()) {}
-
-  canParse(filePath: string, contents: string): boolean {
+export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
+  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
     const extension = extname(filePath);
-    return (extension === '.xtb' || extension === '.xmb') &&
-        contents.includes('<translationbundle');
+    if (extension !== '.xtb' && extension !== '.xmb') {
+      return false;
+    }
+    return canParseXml(filePath, contents, 'translationbundle', {});
   }
 
-  parse(filePath: string, contents: string): ParsedTranslationBundle {
-    const xmlParser = new XmlParser();
-    const xml = xmlParser.parse(contents, filePath);
-    const bundle = XtbVisitor.extractBundle(this.diagnostics, xml.rootNodes);
-    if (bundle === undefined) {
-      throw new Error(`Unable to parse "${filePath}" as XTB/XMB format.`);
+  parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):
+      ParsedTranslationBundle {
+    if (hint) {
+      return this.extractBundle(hint);
+    } else {
+      return this.extractBundleDeprecated(filePath, contents);
+    }
+  }
+
+  private extractBundle({element, errors}: XmlTranslationParserHint): ParsedTranslationBundle {
+    const langAttr = element.attrs.find((attr) => attr.name === 'lang');
+    const bundle: ParsedTranslationBundle = {
+      locale: langAttr && langAttr.value,
+      translations: {},
+      diagnostics: new Diagnostics()
+    };
+    errors.forEach(e => addParseError(bundle.diagnostics, e));
+
+    const bundleVisitor = new XtbVisitor();
+    visitAll(bundleVisitor, element.children, bundle);
+    return bundle;
+  }
+
+  private extractBundleDeprecated(filePath: string, contents: string) {
+    const hint = this.canParse(filePath, contents);
+    if (!hint) {
+      throw new Error(`Unable to parse "${filePath}" as XMB/XTB format.`);
+    }
+    const bundle = this.extractBundle(hint);
+    if (bundle.diagnostics.hasErrors) {
+      const message =
+          bundle.diagnostics.formatDiagnostics(`Failed to parse "${filePath}" as XMB/XTB format`);
+      throw new Error(message);
     }
     return bundle;
   }
 }
 
 class XtbVisitor extends BaseVisitor {
-  static extractBundle(diagnostics: Diagnostics, messageBundles: Node[]): ParsedTranslationBundle
-      |undefined {
-    const visitor = new this(diagnostics);
-    const bundles: ParsedTranslationBundle[] = visitAll(visitor, messageBundles, undefined);
-    return bundles[0];
-  }
-
-  constructor(private diagnostics: Diagnostics) { super(); }
-
-  visitElement(element: Element, bundle: ParsedTranslationBundle|undefined): any {
+  visitElement(element: Element, bundle: ParsedTranslationBundle): any {
     switch (element.name) {
-      case 'translationbundle':
-        if (bundle) {
-          throw new TranslationParseError(
-              element.sourceSpan, '<translationbundle> elements can not be nested');
-        }
-        const langAttr = element.attrs.find((attr) => attr.name === 'lang');
-        bundle = {
-          locale: langAttr && langAttr.value,
-          translations: {},
-          diagnostics: this.diagnostics
-        };
-        visitAll(this, element.children, bundle);
-        return bundle;
-
       case 'translation':
-        if (!bundle) {
-          throw new TranslationParseError(
-              element.sourceSpan, '<translation> must be inside a <translationbundle>');
+        // Error if no `id` attribute
+        const id = getAttribute(element, 'id');
+        if (id === undefined) {
+          addParseDiagnostic(
+              bundle.diagnostics, element.sourceSpan,
+              `Missing required "id" attribute on <trans-unit> element.`, ParseErrorLevel.ERROR);
+          return;
         }
-        const id = getAttrOrThrow(element, 'id');
-        if (bundle.translations.hasOwnProperty(id)) {
-          throw new TranslationParseError(
-              element.sourceSpan, `Duplicated translations for message "${id}"`);
-        } else {
-          try {
-            bundle.translations[id] = serializeTargetMessage(element);
-          } catch (error) {
-            if (typeof error === 'string') {
-              this.diagnostics.warn(
-                  `Could not parse message with id "${id}" - perhaps it has an unrecognised ICU format?\n` +
-                  error);
-            } else {
-              throw error;
-            }
+
+        // Error if there is already a translation with the same id
+        if (bundle.translations[id] !== undefined) {
+          addParseDiagnostic(
+              bundle.diagnostics, element.sourceSpan, `Duplicated translations for message "${id}"`,
+              ParseErrorLevel.ERROR);
+          return;
+        }
+
+        try {
+          bundle.translations[id] = serializeTargetMessage(element);
+        } catch (error) {
+          if (typeof error === 'string') {
+            bundle.diagnostics.warn(
+                `Could not parse message with id "${id}" - perhaps it has an unrecognised ICU format?\n` +
+                error);
+          } else if (error.span && error.msg && error.level) {
+            addParseDiagnostic(bundle.diagnostics, error.span, error.msg, error.level);
+          } else {
+            throw error;
           }
         }
         break;
 
       default:
-        throw new TranslationParseError(element.sourceSpan, 'Unexpected tag');
+        addParseDiagnostic(
+            bundle.diagnostics, element.sourceSpan, `Unexpected <${element.name}> tag.`,
+            ParseErrorLevel.ERROR);
     }
   }
 }

--- a/packages/localize/src/tools/src/translate/translator.ts
+++ b/packages/localize/src/tools/src/translate/translator.ts
@@ -19,6 +19,7 @@ import {OutputPathFn} from './output_path';
 export interface TranslationBundle {
   locale: string;
   translations: Record<ɵMessageId, ɵParsedTranslation>;
+  diagnostics?: Diagnostics;
 }
 
 /**

--- a/packages/localize/src/tools/test/diagnostics_spec.ts
+++ b/packages/localize/src/tools/test/diagnostics_spec.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Diagnostics} from '../src/diagnostics';
+
+describe('Diagnostics', () => {
+  describe('formatDiagnostics', () => {
+    it('should just return the message passed in if there are no errors nor warnings', () => {
+      const diagnostics = new Diagnostics();
+      expect(diagnostics.formatDiagnostics('This is a message')).toEqual('This is a message');
+    });
+
+    it('should return a string with all the errors listed', () => {
+      const diagnostics = new Diagnostics();
+      diagnostics.error('Error 1');
+      diagnostics.error('Error 2');
+      diagnostics.error('Error 3');
+      expect(diagnostics.formatDiagnostics('This is a message'))
+          .toEqual('This is a message\nERRORS:\n - Error 1\n - Error 2\n - Error 3');
+    });
+
+    it('should return a string with all the warnings listed', () => {
+      const diagnostics = new Diagnostics();
+      diagnostics.warn('Warning 1');
+      diagnostics.warn('Warning 2');
+      diagnostics.warn('Warning 3');
+      expect(diagnostics.formatDiagnostics('This is a message'))
+          .toEqual('This is a message\nWARNINGS:\n - Warning 1\n - Warning 2\n - Warning 3');
+    });
+
+    it('should return a string with all the errors and warnings listed', () => {
+      const diagnostics = new Diagnostics();
+      diagnostics.warn('Warning 1');
+      diagnostics.warn('Warning 2');
+      diagnostics.error('Error 1');
+      diagnostics.error('Error 2');
+      diagnostics.warn('Warning 3');
+      diagnostics.error('Error 3');
+      expect(diagnostics.formatDiagnostics('This is a message'))
+          .toEqual(
+              'This is a message\nERRORS:\n - Error 1\n - Error 2\n - Error 3\nWARNINGS:\n - Warning 1\n - Warning 2\n - Warning 3');
+    });
+  });
+});

--- a/packages/localize/src/tools/test/translate/translation_files/translation_loader_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_loader_spec.ts
@@ -58,8 +58,8 @@ describe('TranslationLoader', () => {
       const result =
           loader.loadBundles(['/src/locale/messages.en.xlf', '/src/locale/messages.fr.xlf'], []);
       expect(result).toEqual([
-        {locale: 'pl', translations},
-        {locale: 'pl', translations},
+        {locale: 'pl', translations, diagnostics: new Diagnostics()},
+        {locale: 'pl', translations, diagnostics: new Diagnostics()},
       ]);
     });
 
@@ -71,8 +71,8 @@ describe('TranslationLoader', () => {
       const result = loader.loadBundles(
           ['/src/locale/messages.en.xlf', '/src/locale/messages.fr.xlf'], ['en', 'fr']);
       expect(result).toEqual([
-        {locale: 'en', translations},
-        {locale: 'fr', translations},
+        {locale: 'en', translations, diagnostics: new Diagnostics()},
+        {locale: 'fr', translations, diagnostics: new Diagnostics()},
       ]);
     });
 
@@ -127,6 +127,6 @@ class MockTranslationParser implements TranslationParser {
 
   parse(filePath: string, fileContents: string) {
     this.log.push(`parse(${filePath}, ${fileContents})`);
-    return {locale: this._locale, translations: this._translations};
+    return {locale: this._locale, translations: this._translations, diagnostics: new Diagnostics()};
   }
 }

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
@@ -10,23 +10,27 @@ import {Xliff1TranslationParser} from '../../../../src/translate/translation_fil
 
 describe('Xliff1TranslationParser', () => {
   describe('canParse()', () => {
-    it('should return true if the file extension is `.xlf` and it contains the XLIFF namespace',
+    it('should return true only if the file contains an <xliff> element with version="1.2" attribute',
        () => {
          const parser = new Xliff1TranslationParser();
          expect(parser.canParse(
                     '/some/file.xlf',
                     '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">'))
-             .toBe(true);
+             .toBeTruthy();
          expect(parser.canParse(
                     '/some/file.json',
                     '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">'))
-             .toBe(false);
+             .toBeTruthy();
+         expect(parser.canParse('/some/file.xliff', '<xliff version="1.2">')).toBeTruthy();
+         expect(parser.canParse('/some/file.json', '<xliff version="1.2">')).toBeTruthy();
+         expect(parser.canParse('/some/file.xlf', '<xliff>')).toBe(false);
+         expect(parser.canParse('/some/file.xlf', '<xliff version="2.0">')).toBe(false);
          expect(parser.canParse('/some/file.xlf', '')).toBe(false);
          expect(parser.canParse('/some/file.json', '')).toBe(false);
        });
   });
 
-  describe('parse()', () => {
+  describe('parse() [without hint]', () => {
     it('should extract the locale from the file contents', () => {
       const XLIFF = `
       <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -435,16 +439,17 @@ describe('Xliff1TranslationParser', () => {
 
     describe('[structure errors]', () => {
       it('should throw when a trans-unit has no translation', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-<body>
-  <trans-unit id="missingtarget">
-    <source/>
-  </trans-unit>
-</body>
-</file>
-</xliff>`;
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="missingtarget">
+            <source/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
 
         expect(() => {
           const parser = new Xliff1TranslationParser();
@@ -454,17 +459,18 @@ describe('Xliff1TranslationParser', () => {
 
 
       it('should throw when a trans-unit has no id attribute', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-<body>
-  <trans-unit datatype="html">
-    <source/>
-    <target/>
-  </trans-unit>
-</body>
-</file>
-</xliff>`;
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit datatype="html">
+            <source/>
+            <target/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
 
         expect(() => {
           const parser = new Xliff1TranslationParser();
@@ -473,21 +479,22 @@ describe('Xliff1TranslationParser', () => {
       });
 
       it('should throw on duplicate trans-unit id', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-<body>
-  <trans-unit id="deadbeef">
-    <source/>
-    <target/>
-  </trans-unit>
-  <trans-unit id="deadbeef">
-    <source/>
-    <target/>
-  </trans-unit>
-</body>
-</file>
-</xliff>`;
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef">
+            <source/>
+            <target/>
+          </trans-unit>
+          <trans-unit id="deadbeef">
+            <source/>
+            <target/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
 
         expect(() => {
           const parser = new Xliff1TranslationParser();
@@ -498,17 +505,18 @@ describe('Xliff1TranslationParser', () => {
 
     describe('[message errors]', () => {
       it('should throw on unknown message tags', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-<body>
-  <trans-unit id="deadbeef" datatype="html">
-    <source/>
-    <target><b>msg should contain only ph tags</b></target>
-  </trans-unit>
-</body>
-</file>
-</xliff>`;
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef" datatype="html">
+            <source/>
+            <target><b>msg should contain only ph tags</b></target>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
 
         expect(() => {
           const parser = new Xliff1TranslationParser();
@@ -517,22 +525,649 @@ describe('Xliff1TranslationParser', () => {
       });
 
       it('should throw when a placeholder misses an id attribute', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-<body>
-  <trans-unit id="deadbeef" datatype="html">
-    <source/>
-    <target><x/></target>
-  </trans-unit>
-</body>
-</file>
-</xliff>`;
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef" datatype="html">
+            <source/>
+            <target><x/></target>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
 
         expect(() => {
           const parser = new Xliff1TranslationParser();
           parser.parse('/some/file.xlf', XLIFF);
         }).toThrowError(/required "id" attribute/gi);
+      });
+    });
+  });
+
+  describe('parse() [with hint]', () => {
+    it('should extract the locale from the file contents', () => {
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      expect(result.locale).toEqual('fr');
+    });
+
+    it('should return an undefined locale if there is no locale in the file', () => {
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" datatype="plaintext" original="ng2.template">
+          <body>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      expect(result.locale).toBeUndefined();
+    });
+
+    it('should extract basic messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="1933478729560469763" datatype="html">
+              <source>translatable attribute</source>
+              <target>etubirtta elbatalsnart</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">1</context>
+              </context-group>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('translatable attribute')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+    });
+
+    it('should extract translations with simple placeholders', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="5057824347511785081" datatype="html">
+              <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>
+              <target><x id="INTERPOLATION"/> tnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="x-b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">2</context>
+              </context-group>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
+
+    it('should extract translations with placeholders containing hyphens', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><app-my-component></app-my-component> Welcome</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="2877147807876214810" datatype="html">
+              <source><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Welcome</source>
+              <context-group purpose="location">
+                <context context-type="sourcefile">src/app/app.component.html</context>
+                <context context-type="linenumber">1</context>
+              </context-group>
+              <target><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Translate</target>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      const id =
+          ɵcomputeMsgId('{$START_TAG_APP_MY_COMPONENT}{$CLOSE_TAG_APP_MY_COMPONENT} Welcome');
+      expect(result.translations[id]).toEqual(ɵmakeParsedTranslation(['', '', ' Translate'], [
+        'START_TAG_APP_MY_COMPONENT', 'CLOSE_TAG_APP_MY_COMPONENT'
+      ]));
+    });
+
+    it('should extract translations with simple ICU expressions', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="2874455947211586270" datatype="html">
+              <source>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>test<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</source>
+              <target>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>TEST<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</target>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId(
+                 '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
+    });
+
+    it('should extract translations with duplicate source messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>foo</div>
+       * <div i18n="m|d@@i">foo</div>
+       * <div i18=""m|d@@bar>foo</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="9205907420411818817" datatype="html">
+              <source>foo</source>
+              <target>oof</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">3</context>
+              </context-group>
+              <note priority="1" from="description">d</note>
+              <note priority="1" from="meaning">m</note>
+            </trans-unit>
+            <trans-unit id="i" datatype="html">
+              <source>foo</source>
+              <target>toto</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">4</context>
+              </context-group>
+              <note priority="1" from="description">d</note>
+              <note priority="1" from="meaning">m</note>
+            </trans-unit>
+            <trans-unit id="bar" datatype="html">
+              <source>foo</source>
+              <target>tata</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">5</context>
+              </context-group>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
+
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><br><img/><img/></div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="7118057989405618448" datatype="html">
+            <ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/>
+              <source><x id="LINE_BREAK" ctype="lb"/><x id="TAG_IMG" ctype="image"/><x id="TAG_IMG_1" ctype="image"/></source>
+              <target><x id="TAG_IMG_1" ctype="image"/><x id="TAG_IMG" ctype="image"/><x id="LINE_BREAK" ctype="lb"/></target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">6</context>
+              </context-group>
+              <note priority="1" from="description">ph names</note>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
+
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="2826198357052921524" datatype="html">
+              <source>hello <x id="START_TAG_SPAN" ctype="x-span"/><x id="CLOSE_TAG_SPAN" ctype="x-span"/></source>
+              <target/>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">6</context>
+              </context-group>
+              <note priority="1" from="description">ph names</note>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
+
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} } =other {a lot}}
+       * ```
+       *
+       * Note that the message gets split into two translation units:
+       *  * The first one contains the outer message with an `ICU` placeholder
+       *  * The second one is the ICU expansion itself
+       *
+       * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then replaced
+       * by IVY at runtime with the actual values being rendered by the ICU expansion.
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="980940425376233536" datatype="html">
+              <source>Test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></source>
+              <target>Le test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">11</context>
+              </context-group>
+            </trans-unit>
+            <trans-unit id="5207293143089349404" datatype="html">
+              <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>deeply nested<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {a lot}}</source>
+              <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>profondément imbriqué<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {beaucoup}}</target>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
+          ]));
+    });
+
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="2340165783990709777" datatype="html">
+              <source>multi\nlines</source>
+              <target>multi\nlignes</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">file.ts</context>
+                <context context-type="linenumber">12</context>
+              </context-group>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
+
+    it('should extract translations with <mrk> elements', () => {
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="mrk-test">
+              <source>First sentence.</source>
+              <seg-source>
+                <invalid-tag>Should not be parsed</invalid-tag>
+              </seg-source>
+              <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>
+            </trans-unit>
+            <trans-unit id="mrk-test2">
+              <source>First sentence. Second sentence.</source>
+              <seg-source>
+                <invalid-tag>Should not be parsed</invalid-tag>
+              </seg-source>
+              <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations['mrk-test'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+
+      expect(result.translations['mrk-test2'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+    });
+
+    it('should ignore alt-trans targets', () => {
+      const XLIFF = `
+      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit datatype="html" approved="no" id="registration.submit">
+              <source>Continue</source>
+              <target state="translated" xml:lang="de">Weiter</target>
+              <context-group purpose="location">
+                <context context-type="sourcefile">src/app/auth/registration-form/registration-form.component.html</context>
+                <context context-type="linenumber">69</context>
+              </context-group>
+              <?sid 1110954287-0?>
+              <alt-trans origin="autoFuzzy" tool="Swordfish" match-quality="71" ts="63">
+                <source xml:lang="en">Content</source>
+                <target state="translated" xml:lang="de">Content</target>
+              </alt-trans>
+          </trans-unit>
+          </body>
+        </file>
+      </xliff>`;
+
+      const parser = new Xliff1TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      expect(result.translations['registration.submit'])
+          .toEqual(ɵmakeParsedTranslation(['Weiter']));
+    });
+
+    describe('[structure errors]', () => {
+      it('should provide a diagnostic error when a trans-unit has no translation', () => {
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="missingtarget">
+            <source/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff1TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Missing required <target> element ("ge="en" target-language="fr" datatype="plaintext" original="ng2.template">\n` +
+                `        <body>\n` +
+                `          [ERROR ->]<trans-unit id="missingtarget">\n` +
+                `            <source/>\n` +
+                `          </trans-unit>\n` +
+                `"): /some/file.xlf@5:10`);
+      });
+
+
+      it('should provide a diagnostic error when a trans-unit has no id attribute', () => {
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit datatype="html">
+            <source/>
+            <target/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff1TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Missing required "id" attribute on <trans-unit> element. ("ge="en" target-language="fr" datatype="plaintext" original="ng2.template">\n` +
+                `        <body>\n` +
+                `          [ERROR ->]<trans-unit datatype="html">\n` +
+                `            <source/>\n` +
+                `            <target/>\n` +
+                `"): /some/file.xlf@5:10`);
+      });
+
+      it('should provide a diagnostic error on duplicate trans-unit id', () => {
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef">
+            <source/>
+            <target/>
+          </trans-unit>
+          <trans-unit id="deadbeef">
+            <source/>
+            <target/>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff1TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Duplicated translations for message "deadbeef" ("\n` +
+                `            <target/>\n` +
+                `          </trans-unit>\n` +
+                `          [ERROR ->]<trans-unit id="deadbeef">\n` +
+                `            <source/>\n` +
+                `            <target/>\n` +
+                `"): /some/file.xlf@9:10`);
+      });
+    });
+
+    describe('[message errors]', () => {
+      it('should provide a diagnostic error on unknown message tags', () => {
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef" datatype="html">
+            <source/>
+            <target><b>msg should contain only ph tags</b></target>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff1TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Invalid element found in message. ("\n` +
+                `          <trans-unit id="deadbeef" datatype="html">\n` +
+                `            <source/>\n` +
+                `            <target>[ERROR ->]<b>msg should contain only ph tags</b></target>\n` +
+                `          </trans-unit>\n` +
+                `        </body>\n` +
+                `"): /some/file.xlf@7:20`);
+      });
+
+      it('should provide a diagnostic error when a placeholder misses an id attribute', () => {
+        const XLIFF = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+        <body>
+          <trans-unit id="deadbeef" datatype="html">
+            <source/>
+            <target><x/></target>
+          </trans-unit>
+        </body>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff1TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Missing required "id" attribute: ("\n` +
+                `          <trans-unit id="deadbeef" datatype="html">\n` +
+                `            <source/>\n` +
+                `            <target>[ERROR ->]<x/></target>\n` +
+                `          </trans-unit>\n` +
+                `        </body>\n` +
+                `"): /some/file.xlf@7:20`);
       });
     });
   });

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
@@ -10,24 +10,27 @@ import {Xliff2TranslationParser} from '../../../../src/translate/translation_fil
 
 describe('Xliff2TranslationParser', () => {
   describe('canParse()', () => {
-    it('should return true if the file extension is `.xlf` and it contains the XLIFF namespace', () => {
-      const parser = new Xliff2TranslationParser();
-      expect(
-          parser.canParse(
-              '/some/file.xlf',
-              '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">'))
-          .toBe(true);
-      expect(
-          parser.canParse(
-              '/some/file.json',
-              '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">'))
-          .toBe(false);
-      expect(parser.canParse('/some/file.xlf', '')).toBe(false);
-      expect(parser.canParse('/some/file.json', '')).toBe(false);
-    });
+    it('should return true if the file contains an <xliff> element with version="2.0" attribute',
+       () => {
+         const parser = new Xliff2TranslationParser();
+         expect(parser.canParse(
+                    '/some/file.xlf',
+                    '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
+             .toBeTruthy();
+         expect(parser.canParse(
+                    '/some/file.json',
+                    '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
+             .toBeTruthy();
+         expect(parser.canParse('/some/file.xliff', '<xliff version="2.0">')).toBeTruthy();
+         expect(parser.canParse('/some/file.json', '<xliff version="2.0">')).toBeTruthy();
+         expect(parser.canParse('/some/file.xlf', '<xliff>')).toBe(false);
+         expect(parser.canParse('/some/file.xlf', '<xliff version="1.2">')).toBe(false);
+         expect(parser.canParse('/some/file.xlf', '')).toBe(false);
+         expect(parser.canParse('/some/file.json', '')).toBe(false);
+       });
   });
 
-  describe('parse()', () => {
+  describe('parse() [without hint]', () => {
     it('should extract the locale from the file contents', () => {
       const XLIFF = `
       <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
@@ -472,6 +475,552 @@ describe('Xliff2TranslationParser', () => {
           const parser = new Xliff2TranslationParser();
           parser.parse('/some/file.xlf', XLIFF);
         }).toThrowError(/Missing required "equiv" attribute/);
+      });
+    });
+  });
+
+  describe('parse() [with hint]', () => {
+    it('should extract the locale from the file contents', () => {
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      expect(result.locale).toEqual('fr');
+    });
+
+    it('should return undefined locale if there is no locale in the file', () => {
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
+        <file original="ng.template" id="ngi18n">
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+      expect(result.locale).toBeUndefined();
+    });
+
+    it('should extract basic messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="1933478729560469763">
+            <notes>
+              <note category="location">file.ts:2</note>
+            </notes>
+            <segment>
+              <source>translatable attribute</source>
+              <target>etubirtta elbatalsnart</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('translatable attribute', '')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+    });
+
+    it('should extract translations with simple placeholders', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable element <b>>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="5057824347511785081">
+            <notes>
+              <note category="location">file.ts:3</note>
+            </notes>
+            <segment>
+              <source>translatable element <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc> <ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>
+              <target><ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele elbatalsnart <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
+
+    it('should extract translations with simple ICU expressions', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="2874455947211586270">
+            <notes>
+              <note category="location">file.ts:4</note>
+            </notes>
+            <segment>
+              <source>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">test</pc>} }</source>
+              <target>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">TEST</pc>} }</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId(
+                 '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
+    });
+
+    it('should extract translations with duplicate source messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>foo</div>
+       * <div i18n="m|d@@i">foo</div>
+       * <div i18=""m|d@@bar>foo</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="9205907420411818817">
+            <notes>
+              <note category="description">d</note>
+              <note category="meaning">m</note>
+              <note category="location">file.ts:5</note>
+            </notes>
+            <segment>
+              <source>foo</source>
+              <target>oof</target>
+            </segment>
+          </unit>
+          <unit id="i">
+            <notes>
+              <note category="description">d</note>
+              <note category="meaning">m</note>
+              <note category="location">file.ts:5</note>
+            </notes>
+            <segment>
+              <source>foo</source>
+              <target>toto</target>
+            </segment>
+          </unit>
+          <unit id="bar">
+            <notes>
+              <note category="description">d</note>
+              <note category="meaning">m</note>
+              <note category="location">file.ts:5</note>
+            </notes>
+            <segment>
+              <source>foo</source>
+              <target>tata</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
+
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><br><img/><img/></div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="7118057989405618448">
+            <notes>
+              <note category="description">ph names</note>
+              <note category="location">file.ts:7</note>
+            </notes>
+            <segment>
+              <source><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/></source>
+              <target><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/></target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
+
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="2826198357052921524">
+            <notes>
+              <note category="description">empty element</note>
+              <note category="location">file.ts:8</note>
+            </notes>
+            <segment>
+              <source>hello <pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&lt;span&gt;" dispEnd="&lt;/span&gt;"></pc></source>
+              <target></target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
+
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} } =other {a lot}}
+       * ```
+       *
+       * Note that the message gets split into two translation units:
+       *  * The first one contains the outer message with an `ICU` placeholder
+       *  * The second one is the ICU expansion itself
+       *
+       * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then replaced
+       * by IVY at runtime with the actual values being rendered by the ICU expansion.
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="980940425376233536">
+            <notes>
+              <note category="location">file.ts:10</note>
+            </notes>
+            <segment>
+              <source>Test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></source>
+              <target>Le test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></target>
+            </segment>
+          </unit>
+          <unit id="5207293143089349404">
+            <notes>
+              <note category="location">file.ts:10</note>
+            </notes>
+            <segment>
+              <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">deeply nested</pc>}}} =other {a lot}}</source>
+              <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">profondément imbriqué</pc>}}} =other {beaucoup}}</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
+          ]));
+    });
+
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="2340165783990709777">
+            <notes>
+              <note category="location">file.ts:11,12</note>
+            </notes>
+            <segment>
+              <source>multi\nlines</source>
+              <target>multi\nlignes</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
+
+    it('should extract translations with <mrk> elements', () => {
+      const XLIFF = `
+      <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="mrk-test">
+            <segment>
+              <source>First sentence.</source>
+              <target>Translated <mrk id="m1" type="comment" ref="#n1">first sentence</mrk>.</target>
+            </segment>
+          </unit>
+          <unit id="mrk-test2">
+            <segment>
+              <source>First sentence. Second sentence.</source>
+              <target>Translated <mrk id="m1" type="comment" ref="#n1"><mrk id="m2" type="comment" ref="#n1">first</mrk> sentence</mrk>.</target>
+            </segment>
+          </unit>
+        </file>
+      </xliff>`;
+      const parser = new Xliff2TranslationParser();
+      const hint = parser.canParse('/some/file.xlf', XLIFF);
+      if (!hint) {
+        return fail('expected XLIFF to be valid');
+      }
+      const result = parser.parse('/some/file.xlf', XLIFF, hint);
+
+      expect(result.translations['mrk-test'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+
+      expect(result.translations['mrk-test2'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+    });
+
+    describe('[structure errors]', () => {
+      it('should provide a diagnostic error when a trans-unit has no translation', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="missingtarget">
+            <segment>
+              <source/>
+            </segment>
+          </unit>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff2TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message).toEqual(`Missing required <target> element ("
+        <file original="ng.template" id="ngi18n">
+          <unit id="missingtarget">
+            [ERROR ->]<segment>
+              <source/>
+            </segment>
+"): /some/file.xlf@4:12`);
+      });
+
+
+      it('should provide a diagnostic error when a trans-unit has no id attribute', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit>
+            <segment>
+              <source/>
+              <target/>
+            </segment>
+          </unit>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff2TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Missing required "id" attribute on <trans-unit> element. ("ocument:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          [ERROR ->]<unit>
+            <segment>
+              <source/>
+"): /some/file.xlf@3:10`);
+      });
+
+      it('should provide a diagnostic error on duplicate trans-unit id', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="deadbeef">
+            <segment>
+              <source/>
+              <target/>
+            </segment>
+          </unit>
+          <unit id="deadbeef">
+            <segment>
+              <source/>
+              <target/>
+            </segment>
+          </unit>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff2TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(`Duplicated translations for message "deadbeef" ("
+            </segment>
+          </unit>
+          [ERROR ->]<unit id="deadbeef">
+            <segment>
+              <source/>
+"): /some/file.xlf@9:10`);
+      });
+    });
+
+    describe('[message errors]', () => {
+      it('should provide a diagnostic error on unknown message tags', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="deadbeef">
+            <segment>
+              <source/>
+              <target><b>msg should contain only ph and pc tags</b></target>
+            </segment>
+          </unit>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff2TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message).toEqual(`Invalid element found in message. ("
+            <segment>
+              <source/>
+              <target>[ERROR ->]<b>msg should contain only ph and pc tags</b></target>
+            </segment>
+          </unit>
+"): /some/file.xlf@6:22`);
+      });
+
+      it('should provide a diagnostic error when a placeholder misses an id attribute', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+        <file original="ng.template" id="ngi18n">
+          <unit id="deadbeef">
+            <segment>
+              <source/>
+              <target><ph/></target>
+            </segment>
+          </unit>
+        </file>
+        </xliff>`;
+
+        const parser = new Xliff2TranslationParser();
+        const hint = parser.canParse('/some/file.xlf', XLIFF);
+        if (!hint) {
+          return fail('expected XLIFF to be valid');
+        }
+        const result = parser.parse('/some/file.xlf', XLIFF, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(`Missing required "equiv" attribute: ("
+            <segment>
+              <source/>
+              <target>[ERROR ->]<ph/></target>
+            </segment>
+          </unit>
+"): /some/file.xlf@6:22`);
       });
     });
   });

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xtb_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xtb_translation_parser_spec.ts
@@ -13,24 +13,24 @@ describe('XtbTranslationParser', () => {
   describe('canParse()', () => {
     it('should return true if the file extension is `.xtb` or `.xmb` and it contains the `<translationbundle>` tag',
        () => {
-         const parser = new XtbTranslationParser(new Diagnostics());
-         expect(parser.canParse('/some/file.xtb', '<translationbundle>')).toBe(true);
-         expect(parser.canParse('/some/file.xmb', '<translationbundle>')).toBe(true);
-         expect(parser.canParse('/some/file.xtb', '<translationbundle lang="en">')).toBe(true);
-         expect(parser.canParse('/some/file.xmb', '<translationbundle lang="en">')).toBe(true);
+         const parser = new XtbTranslationParser();
+         expect(parser.canParse('/some/file.xtb', '<translationbundle>')).toBeTruthy();
+         expect(parser.canParse('/some/file.xmb', '<translationbundle>')).toBeTruthy();
+         expect(parser.canParse('/some/file.xtb', '<translationbundle lang="en">')).toBeTruthy();
+         expect(parser.canParse('/some/file.xmb', '<translationbundle lang="en">')).toBeTruthy();
          expect(parser.canParse('/some/file.json', '<translationbundle>')).toBe(false);
          expect(parser.canParse('/some/file.xmb', '')).toBe(false);
          expect(parser.canParse('/some/file.xtb', '')).toBe(false);
        });
   });
 
-  describe('parse()', () => {
+  describe('parse() [without hint]', () => {
     it('should extract the locale from the file contents', () => {
       const XTB = `<?xml version="1.0" encoding="UTF-8"?>
       <translationbundle lang='fr'>
         <translation id="8841459487341224498">rab</translation>
       </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
       expect(result.locale).toEqual('fr');
     });
@@ -39,17 +39,17 @@ describe('XtbTranslationParser', () => {
       const XTB = `<?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE translationbundle [<!ELEMENT translationbundle (translation)*>
       <!ATTLIST translationbundle lang CDATA #REQUIRED>
-      
+
       <!ELEMENT translation (#PCDATA|ph)*>
       <!ATTLIST translation id CDATA #REQUIRED>
-      
+
       <!ELEMENT ph EMPTY>
       <!ATTLIST ph name CDATA #REQUIRED>
       ]>
       <translationbundle>
         <translation id="8841459487341224498">rab</translation>
       </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations['8841459487341224498']).toEqual(ɵmakeParsedTranslation(['rab']));
@@ -60,7 +60,7 @@ describe('XtbTranslationParser', () => {
       <translationbundle>
         <translation id="8877975308926375834"><ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/></translation>
       </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations['8877975308926375834'])
@@ -73,7 +73,7 @@ describe('XtbTranslationParser', () => {
         <translation id="7717087045075616176">*<ph name="ICU"/>*</translation>
         <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
       </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations['7717087045075616176'])
@@ -90,7 +90,7 @@ describe('XtbTranslationParser', () => {
           <translation id="i">toto</translation>
           <translation id="bar">tata</translation>
         </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
@@ -103,7 +103,7 @@ describe('XtbTranslationParser', () => {
         <translationbundle>
           <translation id="7118057989405618448"><ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/></translation>
         </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
@@ -123,7 +123,7 @@ describe('XtbTranslationParser', () => {
         <translationbundle>
           <translation id="2826198357052921524"></translation>
         </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
@@ -150,7 +150,7 @@ describe('XtbTranslationParser', () => {
           <translation id="980940425376233536">Le test: <ph name="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></translation>
           <translation id="5207293143089349404">{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<ph name="START_PARAGRAPH"/>profondément imbriqué<ph name="CLOSE_PARAGRAPH"/>}}} =other {beaucoup}}</translation>
         </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
@@ -177,7 +177,7 @@ describe('XtbTranslationParser', () => {
         <translationbundle>
           <translation id="2340165783990709777">multi\nlignes</translation>
         </translationbundle>`;
-      const parser = new XtbTranslationParser(new Diagnostics());
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       expect(result.translations[ɵcomputeMsgId('multi\nlines')])
@@ -194,8 +194,7 @@ describe('XtbTranslationParser', () => {
         </translationbundle>`;
 
       // Parsing the file should not fail
-      const diagnostics = new Diagnostics();
-      const parser = new XtbTranslationParser(diagnostics);
+      const parser = new XtbTranslationParser();
       const result = parser.parse('/some/file.xtb', XTB);
 
       // We should be able to read the valid message
@@ -204,7 +203,7 @@ describe('XtbTranslationParser', () => {
 
       // Trying to access the invalid message should fail
       expect(result.translations['invalid']).toBeUndefined();
-      expect(diagnostics.messages).toContain({
+      expect(result.diagnostics.messages).toContain({
         type: 'warning',
         message:
             `Could not parse message with id "invalid" - perhaps it has an unrecognised ICU format?\n` +
@@ -219,9 +218,11 @@ describe('XtbTranslationParser', () => {
             '<translationbundle><translationbundle></translationbundle></translationbundle>';
 
         expect(() => {
-          const parser = new XtbTranslationParser(new Diagnostics());
+          const parser = new XtbTranslationParser();
           parser.parse('/some/file.xtb', XTB);
-        }).toThrowError(/<translationbundle> elements can not be nested/);
+        }).toThrowError(`Failed to parse "/some/file.xtb" as XMB/XTB format
+ERRORS:
+ - Unexpected <translationbundle> tag. ("<translationbundle>[ERROR ->]<translationbundle></translationbundle></translationbundle>"): /some/file.xtb@0:19`);
       });
 
       it('should throw when a translation has no id attribute', () => {
@@ -231,7 +232,7 @@ describe('XtbTranslationParser', () => {
     </translationbundle>`;
 
         expect(() => {
-          const parser = new XtbTranslationParser(new Diagnostics());
+          const parser = new XtbTranslationParser();
           parser.parse('/some/file.xtb', XTB);
         }).toThrowError(/Missing required "id" attribute/);
       });
@@ -244,7 +245,7 @@ describe('XtbTranslationParser', () => {
     </translationbundle>`;
 
         expect(() => {
-          const parser = new XtbTranslationParser(new Diagnostics());
+          const parser = new XtbTranslationParser();
           parser.parse('/some/file.xtb', XTB);
         }).toThrowError(/Duplicated translations for message "deadbeef"/);
       });
@@ -260,7 +261,7 @@ describe('XtbTranslationParser', () => {
     </translationbundle>`;
 
         expect(() => {
-          const parser = new XtbTranslationParser(new Diagnostics());
+          const parser = new XtbTranslationParser();
           parser.parse('/some/file.xtb', XTB);
         }).toThrowError(/Invalid element found in message/);
       });
@@ -272,9 +273,343 @@ describe('XtbTranslationParser', () => {
     </translationbundle>`;
 
         expect(() => {
-          const parser = new XtbTranslationParser(new Diagnostics());
+          const parser = new XtbTranslationParser();
           parser.parse('/some/file.xtb', XTB);
         }).toThrowError(/required "name" attribute/gi);
+      });
+    });
+  });
+
+  describe('parse() [with hint]', () => {
+    it('should extract the locale from the file contents', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+      <translationbundle lang='fr'>
+        <translation id="8841459487341224498">rab</translation>
+      </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+      expect(result.locale).toEqual('fr');
+    });
+
+    it('should extract basic messages', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE translationbundle [<!ELEMENT translationbundle (translation)*>
+      <!ATTLIST translationbundle lang CDATA #REQUIRED>
+
+      <!ELEMENT translation (#PCDATA|ph)*>
+      <!ATTLIST translation id CDATA #REQUIRED>
+
+      <!ELEMENT ph EMPTY>
+      <!ATTLIST ph name CDATA #REQUIRED>
+      ]>
+      <translationbundle>
+        <translation id="8841459487341224498">rab</translation>
+      </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations['8841459487341224498']).toEqual(ɵmakeParsedTranslation(['rab']));
+    });
+
+    it('should extract translations with simple placeholders', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+      <translationbundle>
+        <translation id="8877975308926375834"><ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/></translation>
+      </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations['8877975308926375834'])
+          .toEqual(ɵmakeParsedTranslation(['', 'rab', ''], ['START_PARAGRAPH', 'CLOSE_PARAGRAPH']));
+    });
+
+    it('should extract translations with simple ICU expressions', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
+      <translationbundle>
+        <translation id="7717087045075616176">*<ph name="ICU"/>*</translation>
+        <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
+      </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations['7717087045075616176'])
+          .toEqual(ɵmakeParsedTranslation(['*', '*'], ['ICU']));
+      expect(result.translations['5115002811911870583'])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =1 {{START_PARAGRAPH}rab{CLOSE_PARAGRAPH}}}'], []));
+    });
+
+    it('should extract translations with duplicate source messages', () => {
+      const XTB = `
+        <translationbundle>
+          <translation id="9205907420411818817">oof</translation>
+          <translation id="i">toto</translation>
+          <translation id="bar">tata</translation>
+        </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
+
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      const XTB = `
+        <translationbundle>
+          <translation id="7118057989405618448"><ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/></translation>
+        </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
+
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XTB = `
+        <translationbundle>
+          <translation id="2826198357052921524"></translation>
+        </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
+
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} } =other {a lot}}
+       * ```
+       *
+       * Note that the message gets split into two translation units:
+       *  * The first one contains the outer message with an `ICU` placeholder
+       *  * The second one is the ICU expansion itself
+       *
+       * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
+       replaced by IVY at runtime with the actual values being rendered by the ICU expansion.
+       */
+      const XTB = `
+        <translationbundle>
+          <translation id="980940425376233536">Le test: <ph name="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></translation>
+          <translation id="5207293143089349404">{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<ph name="START_PARAGRAPH"/>profondément imbriqué<ph name="CLOSE_PARAGRAPH"/>}}} =other {beaucoup}}</translation>
+        </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
+          ]));
+    });
+
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XTB = `
+        <translationbundle>
+          <translation id="2340165783990709777">multi\nlignes</translation>
+        </translationbundle>`;
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
+
+    it('should warn on unrecognised ICU messages', () => {
+      // See https://github.com/angular/angular/issues/14046
+
+      const XTB = `
+        <translationbundle>
+          <translation id="valid">This is a valid message</translation>
+          <translation id="invalid">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other {{REGION_COUNT_2} regions}}</translation>
+        </translationbundle>`;
+
+      // Parsing the file should not fail
+      const parser = new XtbTranslationParser();
+      const hint = parser.canParse('/some/file.xtb', XTB);
+      if (!hint) {
+        return fail('expected XTB to be valid');
+      }
+      const result = parser.parse('/some/file.xtb', XTB, hint);
+
+      // We should be able to read the valid message
+      expect(result.translations['valid'])
+          .toEqual(ɵmakeParsedTranslation(['This is a valid message']));
+
+      // Trying to access the invalid message should fail
+      expect(result.translations['invalid']).toBeUndefined();
+      expect(result.diagnostics.messages).toContain({
+        type: 'warning',
+        message:
+            `Could not parse message with id "invalid" - perhaps it has an unrecognised ICU format?\n` +
+            `Error: Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)\n` +
+            `Error: Invalid ICU message. Missing '}'.`
+      });
+    });
+
+    describe('[structure errors]', () => {
+      it('should throw when there are nested translationbundle tags', () => {
+        const XTB =
+            '<translationbundle><translationbundle></translationbundle></translationbundle>';
+
+        const parser = new XtbTranslationParser();
+        const hint = parser.canParse('/some/file.xtb', XTB);
+        if (!hint) {
+          return fail('expected XTB to be valid');
+        }
+        const result = parser.parse('/some/file.xtb', XTB, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(
+                `Unexpected <translationbundle> tag. ("<translationbundle>[ERROR ->]<translationbundle></translationbundle></translationbundle>"): /some/file.xtb@0:19`);
+      });
+
+      it('should throw when a translation has no id attribute', () => {
+        const XTB = `
+          <translationbundle>
+            <translation></translation>
+          </translationbundle>`;
+
+        const parser = new XtbTranslationParser();
+        const hint = parser.canParse('/some/file.xtb', XTB);
+        if (!hint) {
+          return fail('expected XTB to be valid');
+        }
+        const result = parser.parse('/some/file.xtb', XTB, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(`Missing required "id" attribute on <trans-unit> element. ("
+          <translationbundle>
+            [ERROR ->]<translation></translation>
+          </translationbundle>"): /some/file.xtb@2:12`);
+      });
+
+      it('should throw on duplicate translation id', () => {
+        const XTB = `
+          <translationbundle>
+            <translation id="deadbeef"></translation>
+            <translation id="deadbeef"></translation>
+          </translationbundle>`;
+
+        const parser = new XtbTranslationParser();
+        const hint = parser.canParse('/some/file.xtb', XTB);
+        if (!hint) {
+          return fail('expected XTB to be valid');
+        }
+        const result = parser.parse('/some/file.xtb', XTB, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(`Duplicated translations for message "deadbeef" ("
+          <translationbundle>
+            <translation id="deadbeef"></translation>
+            [ERROR ->]<translation id="deadbeef"></translation>
+          </translationbundle>"): /some/file.xtb@3:12`);
+      });
+    });
+
+    describe('[message errors]', () => {
+      it('should throw on unknown message tags', () => {
+        const XTB = `
+          <translationbundle>
+            <translation id="deadbeef">
+              <source/>
+            </translation>
+          </translationbundle>`;
+
+        const parser = new XtbTranslationParser();
+        const hint = parser.canParse('/some/file.xtb', XTB);
+        if (!hint) {
+          return fail('expected XTB to be valid');
+        }
+        const result = parser.parse('/some/file.xtb', XTB, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message).toEqual(`Invalid element found in message. ("
+          <translationbundle>
+            <translation id="deadbeef">
+              [ERROR ->]<source/>
+            </translation>
+          </translationbundle>"): /some/file.xtb@3:14`);
+      });
+
+      it('should throw when a placeholder misses a name attribute', () => {
+        const XTB = `
+          <translationbundle>
+            <translation id="deadbeef"><ph/></translation>
+          </translationbundle>`;
+
+        const parser = new XtbTranslationParser();
+        const hint = parser.canParse('/some/file.xtb', XTB);
+        if (!hint) {
+          return fail('expected XTB to be valid');
+        }
+        const result = parser.parse('/some/file.xtb', XTB, hint);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message)
+            .toEqual(`Missing required "name" attribute: ("
+          <translationbundle>
+            <translation id="deadbeef">[ERROR ->]<ph/></translation>
+          </translationbundle>"): /some/file.xtb@2:39`);
       });
     });
   });


### PR DESCRIPTION
These changes should fix #35525, and should be compatible with current CLI integration code (@clydin  to confirm), although the `hint` based approach with accompanied change to remove the need to pass `diagnostics` to constructors should also improve the performance and maintainability.

This should be completely backward compatible with previous versions.

FW-1888