### PR TITLE
style: Remove `ivy` scope, and add `ve` scope

### DIFF
--- a/tools/validate-commit-message/commit-message.json
+++ b/tools/validate-commit-message/commit-message.json
@@ -16,6 +16,7 @@
     "animations",
     "bazel",
     "benchpress",
+    "changelog",
     "common",
     "compiler",
     "compiler-cli",
@@ -24,10 +25,10 @@
     "elements",
     "forms",
     "http",
-    "ivy",
     "language-service",
     "localize",
     "ngcc",
+    "packaging",
     "platform-browser",
     "platform-browser-dynamic",
     "platform-server",
@@ -36,8 +37,7 @@
     "router",
     "service-worker",
     "upgrade",
-    "packaging",
-    "changelog",
+    "ve",
     "zone.js"
   ]
 }


### PR DESCRIPTION
Since ivy is now default having `ivy` scope does not make sense. We are creating `ve` scope for cases where we are specifically fixing view-engine.

NOTE: Also sorted scopes alphabetically.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
