### PR TITLE
docs-infra: include CLI options in search

### DIFF
--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
@@ -4,10 +4,14 @@ module.exports = function processCliCommands(createDocMessage) {
     $runBefore: ['rendering-docs'],
     $process(docs) {
       const navigationDoc = docs.find(doc => doc.docType === 'navigation-json');
-      const navigationNode = navigationDoc && navigationDoc.data['SideNav'].find(node => node.children && node.children.length && node.children[0].url === 'cli');
+      const navigationNode = navigationDoc &&
+          navigationDoc.data['SideNav'].find(
+              node => node.children && node.children.length && node.children[0].url === 'cli');
 
       if (!navigationNode) {
-        throw new Error(createDocMessage('Missing `cli` url - CLI Commands must include a first child node with url set at `cli`', navigationDoc));
+        throw new Error(createDocMessage(
+            'Missing `cli` url - CLI Commands must include a first child node with url set at `cli`',
+            navigationDoc));
       }
 
       docs.forEach(doc => {
@@ -18,7 +22,7 @@ module.exports = function processCliCommands(createDocMessage) {
           processOptions(doc, doc.options);
 
           // Add to navigation doc
-          navigationNode.children.push({ url: doc.path, title: `ng ${doc.name}` });
+          navigationNode.children.push({url: doc.path, title: `ng ${doc.name}`});
         }
       });
     }
@@ -31,7 +35,9 @@ function processOptions(container, options) {
 
   options.forEach(option => {
     // Ignore any hidden options
-    if (option.hidden) { return; }
+    if (option.hidden) {
+      return;
+    }
 
     option.types = option.types || [option.type];
     option.names = collectNames(option.name, option.aliases);

--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
@@ -19,7 +19,9 @@ module.exports = function processCliCommands(createDocMessage) {
           doc.names = collectNames(doc.name, doc.commandAliases);
 
           // Recursively process the options
-          processOptions(doc, doc.options);
+          const optionKeywords = new Set();
+          processOptions(doc, doc.options, optionKeywords);
+          doc.optionKeywords = Array.from(optionKeywords).join(' ');
 
           // Add to navigation doc
           navigationNode.children.push({url: doc.path, title: `ng ${doc.name}`});
@@ -29,7 +31,7 @@ module.exports = function processCliCommands(createDocMessage) {
   };
 };
 
-function processOptions(container, options) {
+function processOptions(container, options, optionKeywords) {
   container.positionalOptions = [];
   container.namedOptions = [];
 
@@ -41,6 +43,7 @@ function processOptions(container, options) {
 
     option.types = option.types || [option.type];
     option.names = collectNames(option.name, option.aliases);
+    option.names.forEach(name => optionKeywords.add(name));
 
     // Now work out what kind of option it is: positional/named
     if (option.positional !== undefined) {
@@ -54,7 +57,8 @@ function processOptions(container, options) {
       option.subcommands = getValues(option.subcommands);
       option.subcommands.forEach(subcommand => {
         subcommand.names = collectNames(subcommand.name, subcommand.aliases);
-        processOptions(subcommand, subcommand.options);
+        subcommand.names.forEach(name => optionKeywords.add(name));
+        processOptions(subcommand, subcommand.options, optionKeywords);
       });
     }
   });

--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
@@ -67,7 +67,7 @@ function processOptions(container, options, optionKeywords) {
 }
 
 function collectNames(name, aliases) {
-  return [name].concat(aliases);
+  return [name].concat(aliases || []);
 }
 
 function getValues(obj) {

--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
@@ -7,11 +7,7 @@ describe('processCliCommands processor', () => {
 
   const navigationStub = {
     docType: 'navigation-json',
-    data: {
-      SideNav: [{
-        children: [{'url': 'cli'}]
-      }]
-    }
+    data: {SideNav: [{children: [{'url': 'cli'}]}]}
   };
 
   beforeEach(() => {
@@ -21,17 +17,13 @@ describe('processCliCommands processor', () => {
     createDocMessage = injector.get('createDocMessage');
   });
 
-  it('should be available on the injector', () => {
-    expect(processor.$process).toBeDefined();
-  });
+  it('should be available on the injector', () => { expect(processor.$process).toBeDefined(); });
 
-  it('should run after the correct processor', () => {
-    expect(processor.$runAfter).toEqual(['extra-docs-added']);
-  });
+  it('should run after the correct processor',
+     () => { expect(processor.$runAfter).toEqual(['extra-docs-added']); });
 
-  it('should run before the correct processor', () => {
-    expect(processor.$runBefore).toEqual(['rendering-docs']);
-  });
+  it('should run before the correct processor',
+     () => { expect(processor.$runBefore).toEqual(['rendering-docs']); });
 
   it('should collect the names (name + aliases)', () => {
     const doc = {
@@ -51,16 +43,16 @@ describe('processCliCommands processor', () => {
         name: 'name',
         commandAliases: [],
         options: [
-          { name: 'option1' },
-          { name: 'option2', hidden: true },
-          { name: 'option3' },
-          { name: 'option4', hidden: true },
+          {name: 'option1'},
+          {name: 'option2', hidden: true},
+          {name: 'option3'},
+          {name: 'option4', hidden: true},
         ],
       };
       processor.$process([doc, navigationStub]);
       expect(doc.namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'option1' }),
-        jasmine.objectContaining({ name: 'option3' }),
+        jasmine.objectContaining({name: 'option1'}),
+        jasmine.objectContaining({name: 'option3'}),
       ]);
     });
 
@@ -70,18 +62,18 @@ describe('processCliCommands processor', () => {
         name: 'name',
         commandAliases: [],
         options: [
-          { name: 'named1' },
-          { name: 'positional1', positional: 0},
-          { name: 'named2', hidden: true },
-          { name: 'positional2', hidden: true, positional: 1},
+          {name: 'named1'},
+          {name: 'positional1', positional: 0},
+          {name: 'named2', hidden: true},
+          {name: 'positional2', hidden: true, positional: 1},
         ],
       };
       processor.$process([doc, navigationStub]);
       expect(doc.positionalOptions).toEqual([
-        jasmine.objectContaining({ name: 'positional1', positional: 0}),
+        jasmine.objectContaining({name: 'positional1', positional: 0}),
       ]);
       expect(doc.namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'named1' }),
+        jasmine.objectContaining({name: 'named1'}),
       ]);
     });
 
@@ -91,16 +83,16 @@ describe('processCliCommands processor', () => {
         name: 'name',
         commandAliases: [],
         options: [
-          { name: 'c' },
-          { name: 'a' },
-          { name: 'b' },
+          {name: 'c'},
+          {name: 'a'},
+          {name: 'b'},
         ],
       };
       processor.$process([doc, navigationStub]);
       expect(doc.namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'a' }),
-        jasmine.objectContaining({ name: 'b' }),
-        jasmine.objectContaining({ name: 'c' }),
+        jasmine.objectContaining({name: 'a'}),
+        jasmine.objectContaining({name: 'b'}),
+        jasmine.objectContaining({name: 'c'}),
       ]);
     });
   });
@@ -117,15 +109,15 @@ describe('processCliCommands processor', () => {
             subcommand1: {
               name: 'subcommand1',
               options: [
-                { name: 'subcommand1-option1' },
-                { name: 'subcommand1-option2' },
+                {name: 'subcommand1-option1'},
+                {name: 'subcommand1-option2'},
               ],
             },
             subcommand2: {
               name: 'subcommand2',
               options: [
-                { name: 'subcommand2-option1' },
-                { name: 'subcommand2-option2' },
+                {name: 'subcommand2-option1'},
+                {name: 'subcommand2-option2'},
               ],
             }
           },
@@ -133,8 +125,8 @@ describe('processCliCommands processor', () => {
       };
       processor.$process([doc, navigationStub]);
       expect(doc.options[0].subcommands).toEqual([
-        jasmine.objectContaining({ name: 'subcommand1' }),
-        jasmine.objectContaining({ name: 'subcommand2' }),
+        jasmine.objectContaining({name: 'subcommand1'}),
+        jasmine.objectContaining({name: 'subcommand2'}),
       ]);
     });
 
@@ -149,15 +141,15 @@ describe('processCliCommands processor', () => {
             subcommand1: {
               name: 'subcommand1',
               options: [
-                { name: 'subcommand1-option1' },
-                { name: 'subcommand1-option2', hidden: true },
+                {name: 'subcommand1-option1'},
+                {name: 'subcommand1-option2', hidden: true},
               ],
             },
             subcommand2: {
               name: 'subcommand2',
               options: [
-                { name: 'subcommand2-option1', hidden: true },
-                { name: 'subcommand2-option2' },
+                {name: 'subcommand2-option1', hidden: true},
+                {name: 'subcommand2-option2'},
               ],
             }
           },
@@ -165,10 +157,10 @@ describe('processCliCommands processor', () => {
       };
       processor.$process([doc, navigationStub]);
       expect(doc.options[0].subcommands[0].namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'subcommand1-option1' }),
+        jasmine.objectContaining({name: 'subcommand1-option1'}),
       ]);
       expect(doc.options[0].subcommands[1].namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'subcommand2-option2' }),
+        jasmine.objectContaining({name: 'subcommand2-option2'}),
       ]);
     });
 
@@ -183,15 +175,15 @@ describe('processCliCommands processor', () => {
             subcommand1: {
               name: 'subcommand1',
               options: [
-                { name: 'subcommand1-option1' },
-                { name: 'subcommand1-option2', positional: 0 },
+                {name: 'subcommand1-option1'},
+                {name: 'subcommand1-option2', positional: 0},
               ],
             },
             subcommand2: {
               name: 'subcommand2',
               options: [
-                { name: 'subcommand2-option1', hidden: true },
-                { name: 'subcommand2-option2', hidden: true, positional: 1 },
+                {name: 'subcommand2-option1', hidden: true},
+                {name: 'subcommand2-option2', hidden: true, positional: 1},
               ],
             }
           },
@@ -199,10 +191,10 @@ describe('processCliCommands processor', () => {
       };
       processor.$process([doc, navigationStub]);
       expect(doc.options[0].subcommands[0].positionalOptions).toEqual([
-        jasmine.objectContaining({ name: 'subcommand1-option2', positional: 0}),
+        jasmine.objectContaining({name: 'subcommand1-option2', positional: 0}),
       ]);
       expect(doc.options[0].subcommands[0].namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'subcommand1-option1' }),
+        jasmine.objectContaining({name: 'subcommand1-option1'}),
       ]);
 
       expect(doc.options[0].subcommands[1].positionalOptions).toEqual([]);
@@ -220,9 +212,9 @@ describe('processCliCommands processor', () => {
             subcommand1: {
               name: 'subcommand1',
               options: [
-                { name: 'c' },
-                { name: 'a' },
-                { name: 'b' },
+                {name: 'c'},
+                {name: 'a'},
+                {name: 'b'},
               ]
             }
           }
@@ -230,47 +222,42 @@ describe('processCliCommands processor', () => {
       };
       processor.$process([doc, navigationStub]);
       expect(doc.options[0].subcommands[0].namedOptions).toEqual([
-        jasmine.objectContaining({ name: 'a' }),
-        jasmine.objectContaining({ name: 'b' }),
-        jasmine.objectContaining({ name: 'c' }),
+        jasmine.objectContaining({name: 'a'}),
+        jasmine.objectContaining({name: 'b'}),
+        jasmine.objectContaining({name: 'c'}),
       ]);
     });
   });
 
-  it('should add the command to the CLI node in the navigation doc if there is a first child node with a `cli` url', () => {
-    const command = {
-      docType: 'cli-command',
-      name: 'command1',
-      commandAliases: ['alias1', 'alias2'],
-      options: [],
-      path: 'cli/command1',
-    };
-    const navigation = {
-      docType: 'navigation-json',
-      data: {
-        SideNav: [
-          { url: 'some/page', title: 'Some Page' },
-          {
-            title: 'CLI Commands',
-            tooltip: 'Angular CLI command reference',
-            children: [
-              {
-                'title': 'Overview',
-                'url': 'cli'
-              }
-            ]
-          },
-          { url: 'other/page', title: 'Other Page' }
-        ]
-      }
-    };
-    processor.$process([command, navigation]);
-    expect(navigation.data.SideNav[1].title).toEqual('CLI Commands');
-    expect(navigation.data.SideNav[1].children).toEqual([
-      { url: 'cli', title: 'Overview' },
-      { url: 'cli/command1', title: 'ng command1' },
-    ]);
-  });
+  it('should add the command to the CLI node in the navigation doc if there is a first child node with a `cli` url',
+     () => {
+       const command = {
+         docType: 'cli-command',
+         name: 'command1',
+         commandAliases: ['alias1', 'alias2'],
+         options: [],
+         path: 'cli/command1',
+       };
+       const navigation = {
+         docType: 'navigation-json',
+         data: {
+           SideNav: [
+             {url: 'some/page', title: 'Some Page'}, {
+               title: 'CLI Commands',
+               tooltip: 'Angular CLI command reference',
+               children: [{'title': 'Overview', 'url': 'cli'}]
+             },
+             {url: 'other/page', title: 'Other Page'}
+           ]
+         }
+       };
+       processor.$process([command, navigation]);
+       expect(navigation.data.SideNav[1].title).toEqual('CLI Commands');
+       expect(navigation.data.SideNav[1].children).toEqual([
+         {url: 'cli', title: 'Overview'},
+         {url: 'cli/command1', title: 'ng command1'},
+       ]);
+     });
 
   it('should complain if there is no child with `cli` url', () => {
     const command = {
@@ -284,21 +271,18 @@ describe('processCliCommands processor', () => {
       docType: 'navigation-json',
       data: {
         SideNav: [
-          { url: 'some/page', title: 'Some Page' },
-          {
+          {url: 'some/page', title: 'Some Page'}, {
             title: 'CLI Commands',
             tooltip: 'Angular CLI command reference',
-            children: [
-              {
-                'title': 'Overview',
-                'url': 'client'
-              }
-            ]
+            children: [{'title': 'Overview', 'url': 'client'}]
           },
-          { url: 'other/page', title: 'Other Page' }
+          {url: 'other/page', title: 'Other Page'}
         ]
       }
     };
-    expect(() => processor.$process([command, navigation])).toThrowError(createDocMessage('Missing `cli` url - CLI Commands must include a first child node with url set at `cli`', navigation));
+    expect(() => processor.$process([command, navigation]))
+        .toThrowError(createDocMessage(
+            'Missing `cli` url - CLI Commands must include a first child node with url set at `cli`',
+            navigation));
   });
 });

--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
@@ -95,6 +95,22 @@ describe('processCliCommands processor', () => {
         jasmine.objectContaining({name: 'c'}),
       ]);
     });
+
+    it('should collect potential search terms from options for indexing', () => {
+      const doc = {
+        docType: 'cli-command',
+        name: 'name',
+        commandAliases: [],
+        options: [
+          {name: 'named1'},
+          {name: 'positional1', positional: 0},
+          {name: 'named2', hidden: true},
+          {name: 'positional2', hidden: true, positional: 1},
+        ],
+      };
+      processor.$process([doc, navigationStub]);
+      expect(doc.optionKeywords).toEqual('named1  positional1');
+    });
   });
 
   describe('subcommands', () => {

--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
@@ -109,7 +109,7 @@ describe('processCliCommands processor', () => {
         ],
       };
       processor.$process([doc, navigationStub]);
-      expect(doc.optionKeywords).toEqual('named1  positional1');
+      expect(doc.optionKeywords).toEqual('named1 positional1');
     });
   });
 
@@ -301,4 +301,36 @@ describe('processCliCommands processor', () => {
             'Missing `cli` url - CLI Commands must include a first child node with url set at `cli`',
             navigation));
   });
+
+  it('should collect potential search terms from options for indexing', () => {
+    const doc = {
+      docType: 'cli-command',
+      name: 'name',
+      commandAliases: [],
+      options: [{
+        name: 'supercommand',
+        subcommands: {
+          subcommand1: {
+            name: 'subcommand1',
+            options: [
+              {name: 'subcommand1-option1'},
+              {name: 'subcommand1-option2'},
+            ],
+          },
+          subcommand2: {
+            name: 'subcommand2',
+            options: [
+              {name: 'subcommand2-option1'},
+              {name: 'subcommand2-option2'},
+            ],
+          }
+        },
+      }],
+    };
+    processor.$process([doc, navigationStub]);
+    expect(doc.optionKeywords)
+        .toEqual(
+            'supercommand subcommand1 subcommand1-option1 subcommand1-option2 subcommand2 subcommand2-option1 subcommand2-option2');
+  });
+
 });


### PR DESCRIPTION
The first commit is just a reformatting - the real changes are in the second commit.

You can test it in the preview at https://pr35801-a121ba5.ngbuilds.io/. Try searching for `deleteOutputPath`. Looks like:

<img width="727" alt="Screenshot 2020-03-02 at 18 07 44" src="https://user-images.githubusercontent.com/15655/75704267-f30df880-5cb0-11ea-93ac-2e91b3fce453.png">
