### PR TITLE
build: fix flakiness in integration/bazel by disabling symlinked_node…

### DIFF
--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -1,7 +1,4 @@
-workspace(
-    name = "bazel_integration_test",
-    managed_directories = {"@npm": ["node_modules"]},
-)
+workspace(name = "bazel_integration_test")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -57,6 +54,11 @@ node_repositories(
 yarn_install(
     name = "npm",
     package_json = "//:package.json",
+    # Turn off symlink_node_modules here as it causes flakiness with missing
+    # files in node_modules.
+    # TODO: track down the root cause of the flakiness; current suspect is that
+    # it is an issue with managed_directories when resources are limited
+    symlink_node_modules = False,
     yarn_lock = "//:yarn.lock",
 )
 


### PR DESCRIPTION
…_modules

The flakiness in integration/bazel-schematics is going to be a bit tricker as the WORKSPACE file is JIT generated by the architect build layer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
