### PR TITLE
docs: remove `ivy` and mention `ve` label in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,8 @@ There are currently a few exceptions to the "use package name" rule:
 * **changelog**: used for updating the release notes in CHANGELOG.md
 * **docs-infra**: used for docs-app (angular.io) related changes within the /aio directory of the
   repo
-* **ivy**: used for changes to the [Ivy renderer](https://github.com/angular/angular/issues/21706).
 * **ngcc**: used for changes to the [Angular Compatibility Compiler](./packages/compiler-cli/ngcc/README.md)
+* **ve**: used for changes specific to ViewEngine (legacy compiler/renderer).
 * none/empty string: useful for `style`, `test` and `refactor` changes that are done across all
   packages (e.g. `style: add missing semicolons`) and for docs changes that are not related to a
   specific package (e.g. `docs: fix typo in tutorial`).

--- a/docs/TRIAGE_AND_LABELS.md
+++ b/docs/TRIAGE_AND_LABELS.md
@@ -21,6 +21,7 @@ The components have a clear piece of source code associated with it within the `
   browser-platforms are very intertwined, we will be treating them as one
 * `comp: ivy` - a subset of core representing the new Ivy renderer.
 * `comp: ngcc` - a subset of ivy representing the [Angular Compatibility Compiler](../packages/compiler-cli/ngcc/README.md)
+* `comp: ve` - a subset of `core & compiler` representing changes specific to ViewEngine (legacy compiler/renderer).
 * `comp: docs-infra` - the angular.io application and docs-related tooling
 * `comp: elements`
 * `comp: forms`


### PR DESCRIPTION
This is a follow-up to #35799.