### PR TITLE
fix(zone.js): tickOptions processNewMacroTasksSynchronously option should by default true

### DIFF
--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -136,11 +136,12 @@
       }
     }
 
-    tick(millis: number = 0, doTick?: (elapsed: number) => void, tickOptions: {
+    tick(millis: number = 0, doTick?: (elapsed: number) => void, tickOptions?: {
       processNewMacroTasksSynchronously: boolean
-    } = {processNewMacroTasksSynchronously: true}): void {
+    }): void {
       let finalTime = this._currentTime + millis;
       let lastCurrentTime = 0;
+      tickOptions = Object.assign({processNewMacroTasksSynchronously: true}, tickOptions);
       // we need to copy the schedulerQueue so nested timeout
       // will not be wrongly called in the current tick
       // https://github.com/angular/angular/issues/33799

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -145,6 +145,20 @@ describe('FakeAsyncTestZoneSpec', () => {
          });
        }));
 
+    it('should default to processNewMacroTasksSynchronously if providing other flags', () => {
+      function nestedTimer(callback: () => any): void {
+        setTimeout(() => setTimeout(() => callback()));
+      }
+      fakeAsyncTestZone.run(() => {
+        const callback = jasmine.createSpy('callback');
+        nestedTimer(callback);
+        expect(callback).not.toHaveBeenCalled();
+        testZoneSpec.tick(0, null, {});
+        expect(callback).toHaveBeenCalled();
+      });
+    });
+
+
     it('should not queue new macro task on tick with processNewMacroTasksSynchronously=false',
        () => {
          function nestedTimer(callback: () => any): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

with the new `tickOptions` in `tick()`, if we don't pass this `tickOptions`, by default we will have 
`processNewMacroTasksSynchronously` to be true, but if we pass a empty object `{}` as tickOptions, the `processNewMacroTasksSynchronously` will be treated as false.

## What is the new behavior?
 if we pass a empty object `{}` as tickOptions, the `processNewMacroTasksSynchronously` will be treated as true.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


related to https://github.com/angular/angular/pull/35697 PR, thanks @gkalpak find this issue.