### PR TITLE
build: avoid running duplicate tests in language service

### DIFF
--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -61,7 +61,7 @@ ts_library(
 )
 
 jasmine_node_test(
-    name = "features_test",
+    name = "test",
     data = [
         "//packages/common:npm_package",
         "//packages/core:npm_package",
@@ -88,23 +88,6 @@ jasmine_node_test(
         "no-ivy-aot",
     ],
     deps = [
-        ":infra_test_lib",
-    ],
-)
-
-jasmine_node_test(
-    name = "test",
-    data = [
-        "//packages/common:npm_package",
-        "//packages/core:npm_package",
-        "//packages/forms:npm_package",
-    ],
-    tags = [
-        # the language service is not yet compatible with Ivy
-        "no-ivy-aot",
-    ],
-    deps = [
-        ":features_test_lib",
         ":infra_test_lib",
     ],
 )


### PR DESCRIPTION
The test libs should only be included in one jasmine_node_test
otherwise `bazel test //packages/language-service/...` would
end up running `feature_test` and `infra_test` twice.

This change was unintentionally introduced in https://github.com/angular/angular/pull/35688.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
