### PR TITLE
fix(common): add `HttpParamsOptions` to the public api

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1579,6 +1579,14 @@ export declare class HttpParams {
     toString(): string;
 }
 
+export declare interface HttpParamsOptions {
+    encoder?: HttpParameterCodec;
+    fromObject?: {
+        [param: string]: string | ReadonlyArray<string>;
+    };
+    fromString?: string;
+}
+
 export declare interface HttpProgressEvent {
     loaded: number;
     total?: number;

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -12,7 +12,7 @@ export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInterceptingHandler as ɵHttpInterceptingHandler} from './src/module';
-export {HttpParameterCodec, HttpParams, HttpUrlEncodingCodec} from './src/params';
+export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {HttpXhrBackend, XhrFactory} from './src/xhr';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [x] Documentation content changes
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `HttpParamsOptions` is not documented or included in the public API even though it is a constructor argument of `HttpParams` which is in the public API.

Issue Number: #20276


## What is the new behavior?
`HttpParamsOptions` will be included in the public API and documented.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
