### PR TITLE
Revert "docs: add comment markers for internal goog.define replacement

### DIFF
--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -8,9 +8,6 @@
 
 import {global} from './global';
 
-// Do not remove: needed for closure to be able to properly tree-shake ngDevMode.
-// goog.define
-
 declare global {
   /**
    * Values of ngDevMode

--- a/packages/core/src/util/ng_i18n_closure_mode.ts
+++ b/packages/core/src/util/ng_i18n_closure_mode.ts
@@ -8,9 +8,6 @@
 
 import {global} from './global';
 
-// Do not remove: needed for closure to be able to properly tree-shake ngI18nClosureMode.
-// goog.define
-
 declare global {
   const ngI18nClosureMode: boolean;
 }


### PR DESCRIPTION
This reverts commit 32b6c2285e9b3cdcc860e6e87092b54865e12694 as this is
no longer used.
