### PR TITLE
build(zone.js): sets rollup_bundle to use the --silent flag

### DIFF
--- a/packages/zone.js/dist/tools.bzl
+++ b/packages/zone.js/dist/tools.bzl
@@ -8,6 +8,7 @@ def zone_rollup_bundle(config_file, bundles):
             name = b[0] + "-rollup",
             config_file = config_file,
             entry_point = b[1] + ".ts",
+            silent = True,
             sourcemap = "false",
             deps = [
                 "//packages/zone.js/lib",


### PR DESCRIPTION
Using the --silent flag prevents the spammy logging messages in the
bazel execution logs.


Log lines like these are no longer present:
```
INFO: From Bundling JavaScript packages/zone.js/dist/zone-rollup.umd.js [rollup]:

bazel-out/k8-fastbuild/bin/packages/zone.js/lib/browser/rollup-legacy-main.mjs → bazel-out/k8-fastbuild/bin/packages/zone.js/dist/zone-rollup.umd.js...
created bazel-out/k8-fastbuild/bin/packages/zone.js/dist/zone-rollup.umd.js in 736ms
```
