### PR TITLE
fix(core): use console to show error if ErrorHandler not present

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -2021,7 +2021,15 @@ export function loadComponentRenderer(
 export function handleError(lView: LView, error: any): void {
   const injector = lView[INJECTOR];
   const errorHandler = injector ? injector.get(ErrorHandler, null) : null;
-  errorHandler && errorHandler.handleError(error);
+  if (errorHandler !== null) {
+    errorHandler.handleError(error);
+    // tslint:disable-next-line:no-console
+  } else if (typeof console === 'object' && console !== null) {
+    // tslint:disable-next-line:no-console
+    (console.error || console.log)(error);
+  } else {
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
The errors used to be swallowed if no `Injector` or `ErrorHandler` were present. The new implementation falls back to `console` or re-throws if no `console` is present.

Using classical bootstrap we are guaranteed to have `Injector`. This can only happen if we bootstrap using `renderComponent` which is not public yet and so it it is used in tests only.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
