### PR TITLE
Remove side effects to improve Ivy tree shaking in Closure

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -60,7 +60,7 @@
       "uncompressed": {
         "bundle": "TODO(i): temporarily increase the payload size limit from 105779 - this is due to a closure issue related to ESM reexports that still needs to be investigated",
         "bundle": "TODO(i): we should define ngDevMode to false in Closure, but --define only works in the global scope.",
-        "bundle": 175498
+        "bundle": 170618
       }
     }
   }

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -2542,7 +2542,7 @@ describe('compiler compliance', () => {
             type: LifecycleComp,
             selectors: [["lifecycle-comp"]],
             inputs: {nameMin: ["name", "nameMin"]},
-            features: [$r3$.ɵɵNgOnChangesFeature()],
+            features: [$r3$.ɵɵNgOnChangesFeature],
             decls: 0,
             vars: 0,
             template:  function LifecycleComp_Template(rf, ctx) {},
@@ -2662,7 +2662,7 @@ describe('compiler compliance', () => {
               ForOfDirective.ɵdir = $r3$.ɵɵdefineDirective({
                 type: ForOfDirective,
                 selectors: [["", "forOf", ""]],
-                features: [$r3$.ɵɵNgOnChangesFeature()],
+                features: [$r3$.ɵɵNgOnChangesFeature],
                 inputs: {forOf: "forOf"}
               });
             `;
@@ -2742,7 +2742,7 @@ describe('compiler compliance', () => {
           ForOfDirective.ɵdir = $r3$.ɵɵdefineDirective({
             type: ForOfDirective,
             selectors: [["", "forOf", ""]],
-            features: [$r3$.ɵɵNgOnChangesFeature()],
+            features: [$r3$.ɵɵNgOnChangesFeature],
             inputs: {forOf: "forOf"}
           });
         `;
@@ -3767,7 +3767,7 @@ describe('compiler compliance', () => {
       // ...
       BaseClass.ɵdir = $r3$.ɵɵdefineDirective({
         type: BaseClass,
-        features: [$r3$.ɵɵNgOnChangesFeature()]
+        features: [$r3$.ɵɵNgOnChangesFeature]
       });
       // ...
       `;

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -87,7 +87,7 @@ function baseDirectiveFields(
  */
 function addFeatures(
     definitionMap: DefinitionMap, meta: R3DirectiveMetadata | R3ComponentMetadata) {
-  // e.g. `features: [NgOnChangesFeature()]`
+  // e.g. `features: [NgOnChangesFeature]`
   const features: o.Expression[] = [];
 
   const providers = meta.providers;
@@ -107,7 +107,7 @@ function addFeatures(
     features.push(o.importExpr(R3.CopyDefinitionFeature));
   }
   if (meta.lifecycle.usesOnChanges) {
-    features.push(o.importExpr(R3.NgOnChangesFeature).callFn(EMPTY_ARRAY));
+    features.push(o.importExpr(R3.NgOnChangesFeature));
   }
   if (features.length) {
     definitionMap.set('features', o.literalArr(features));

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -289,56 +289,56 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
    */
   schemas?: SchemaMetadata[] | null;
 }): never {
-  // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
-  // See the `initNgDevMode` docstring for more information.
-  (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
+  return noSideEffects(() => {
+    // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
+    // See the `initNgDevMode` docstring for more information.
+    (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
 
-  const type = componentDefinition.type;
-  const typePrototype = type.prototype;
-  const declaredInputs: {[key: string]: string} = {} as any;
-  const def: Mutable<ComponentDef<any>, keyof ComponentDef<any>> = {
-    type: type,
-    providersResolver: null,
-    decls: componentDefinition.decls,
-    vars: componentDefinition.vars,
-    factory: null,
-    template: componentDefinition.template || null !,
-    consts: componentDefinition.consts || null,
-    ngContentSelectors: componentDefinition.ngContentSelectors,
-    hostBindings: componentDefinition.hostBindings || null,
-    hostVars: componentDefinition.hostVars || 0,
-    hostAttrs: componentDefinition.hostAttrs || null,
-    contentQueries: componentDefinition.contentQueries || null,
-    declaredInputs: declaredInputs,
-    inputs: null !,   // assigned in noSideEffects
-    outputs: null !,  // assigned in noSideEffects
-    exportAs: componentDefinition.exportAs || null,
-    onChanges: null,
-    onInit: typePrototype.ngOnInit || null,
-    doCheck: typePrototype.ngDoCheck || null,
-    afterContentInit: typePrototype.ngAfterContentInit || null,
-    afterContentChecked: typePrototype.ngAfterContentChecked || null,
-    afterViewInit: typePrototype.ngAfterViewInit || null,
-    afterViewChecked: typePrototype.ngAfterViewChecked || null,
-    onDestroy: typePrototype.ngOnDestroy || null,
-    onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
-    directiveDefs: null !,  // assigned in noSideEffects
-    pipeDefs: null !,       // assigned in noSideEffects
-    selectors: componentDefinition.selectors || EMPTY_ARRAY,
-    viewQuery: componentDefinition.viewQuery || null,
-    features: componentDefinition.features as DirectiveDefFeature[] || null,
-    data: componentDefinition.data || {},
-    // TODO(misko): convert ViewEncapsulation into const enum so that it can be used directly in the
-    // next line. Also `None` should be 0 not 2.
-    encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,
-    id: 'c',
-    styles: componentDefinition.styles || EMPTY_ARRAY,
-    _: null as never,
-    setInput: null,
-    schemas: componentDefinition.schemas || null,
-    tView: null,
-  };
-  def._ = noSideEffects(() => {
+    const type = componentDefinition.type;
+    const typePrototype = type.prototype;
+    const declaredInputs: {[key: string]: string} = {} as any;
+    const def: Mutable<ComponentDef<any>, keyof ComponentDef<any>> = {
+      type: type,
+      providersResolver: null,
+      decls: componentDefinition.decls,
+      vars: componentDefinition.vars,
+      factory: null,
+      template: componentDefinition.template || null !,
+      consts: componentDefinition.consts || null,
+      ngContentSelectors: componentDefinition.ngContentSelectors,
+      hostBindings: componentDefinition.hostBindings || null,
+      hostVars: componentDefinition.hostVars || 0,
+      hostAttrs: componentDefinition.hostAttrs || null,
+      contentQueries: componentDefinition.contentQueries || null,
+      declaredInputs: declaredInputs,
+      inputs: null !,   // assigned in noSideEffects
+      outputs: null !,  // assigned in noSideEffects
+      exportAs: componentDefinition.exportAs || null,
+      onChanges: null,
+      onInit: typePrototype.ngOnInit || null,
+      doCheck: typePrototype.ngDoCheck || null,
+      afterContentInit: typePrototype.ngAfterContentInit || null,
+      afterContentChecked: typePrototype.ngAfterContentChecked || null,
+      afterViewInit: typePrototype.ngAfterViewInit || null,
+      afterViewChecked: typePrototype.ngAfterViewChecked || null,
+      onDestroy: typePrototype.ngOnDestroy || null,
+      onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
+      directiveDefs: null !,  // assigned in noSideEffects
+      pipeDefs: null !,       // assigned in noSideEffects
+      selectors: componentDefinition.selectors || EMPTY_ARRAY,
+      viewQuery: componentDefinition.viewQuery || null,
+      features: componentDefinition.features as DirectiveDefFeature[] || null,
+      data: componentDefinition.data || {},
+      // TODO(misko): convert ViewEncapsulation into const enum so that it can be used directly in
+      // the next line. Also `None` should be 0 not 2.
+      encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,
+      id: 'c',
+      styles: componentDefinition.styles || EMPTY_ARRAY,
+      _: null as never,
+      setInput: null,
+      schemas: componentDefinition.schemas || null,
+      tView: null,
+    };
     const directiveTypes = componentDefinition.directives !;
     const feature = componentDefinition.features;
     const pipeTypes = componentDefinition.pipes !;
@@ -353,9 +353,9 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
     def.pipeDefs = pipeTypes ?
         () => (typeof pipeTypes === 'function' ? pipeTypes() : pipeTypes).map(extractPipeDef) :
         null;
-  }) as never;
 
-  return def as never;
+    return def as never;
+  });
 }
 
 /**

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -35,25 +35,25 @@ type OnChangesExpando = OnChanges & {
  * static ɵcmp = defineComponent({
  *   ...
  *   inputs: {name: 'publicName'},
- *   features: [NgOnChangesFeature()]
+ *   features: [NgOnChangesFeature]
  * });
  * ```
  *
  * @codeGenApi
  */
-export function ɵɵNgOnChangesFeature<T>(): DirectiveDefFeature {
-  // This option ensures that the ngOnChanges lifecycle hook will be inherited
-  // from superclasses (in InheritDefinitionFeature).
-  (NgOnChangesFeatureImpl as DirectiveDefFeature).ngInherit = true;
-  return NgOnChangesFeatureImpl;
-}
 
-function NgOnChangesFeatureImpl<T>(definition: DirectiveDef<T>): void {
+export function ɵɵNgOnChangesFeature<T>(definition: DirectiveDef<T>): void {
   if (definition.type.prototype.ngOnChanges) {
     definition.setInput = ngOnChangesSetInput;
     (definition as{onChanges: Function}).onChanges = wrapOnChanges();
   }
 }
+
+// This option ensures that the ngOnChanges lifecycle hook will be inherited
+// from superclasses (in InheritDefinitionFeature).
+/** @nocollapse */
+// tslint:disable-next-line:no-toplevel-property-access
+(ɵɵNgOnChangesFeature as DirectiveDefFeature).ngInherit = true;
 
 function wrapOnChanges() {
   return function wrapOnChangesHook_inPreviousChangesStorage(this: OnChanges) {

--- a/packages/core/src/util/closure.ts
+++ b/packages/core/src/util/closure.ts
@@ -15,6 +15,6 @@
  * to something which is retained otherwise the call to `noSideEffects` will be removed by closure
  * compiler.
  */
-export function noSideEffects(fn: () => void): string {
-  return '' + {toString: fn};
+export function noSideEffects<T>(fn: () => T): T {
+  return {toString: fn}.toString() as unknown as T;
 }

--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -8,6 +8,10 @@
 
 import {Type} from '../interface/type';
 
+import {noSideEffects} from './closure';
+
+
+
 /**
  * An interface implemented by all Angular type decorators, which allows them to be used as
  * decorators as well as Angular syntax.
@@ -44,39 +48,41 @@ export function makeDecorator<T>(
     additionalProcessing?: (type: Type<T>) => void,
     typeFn?: (type: Type<T>, ...args: any[]) => void):
     {new (...args: any[]): any; (...args: any[]): any; (...args: any[]): (cls: any) => any;} {
-  const metaCtor = makeMetadataCtor(props);
+  return noSideEffects(() => {
+    const metaCtor = makeMetadataCtor(props);
 
-  function DecoratorFactory(
-      this: unknown | typeof DecoratorFactory, ...args: any[]): (cls: Type<T>) => any {
-    if (this instanceof DecoratorFactory) {
-      metaCtor.call(this, ...args);
-      return this as typeof DecoratorFactory;
+    function DecoratorFactory(
+        this: unknown | typeof DecoratorFactory, ...args: any[]): (cls: Type<T>) => any {
+      if (this instanceof DecoratorFactory) {
+        metaCtor.call(this, ...args);
+        return this as typeof DecoratorFactory;
+      }
+
+      const annotationInstance = new (DecoratorFactory as any)(...args);
+      return function TypeDecorator(cls: Type<T>) {
+        if (typeFn) typeFn(cls, ...args);
+        // Use of Object.defineProperty is important since it creates non-enumerable property which
+        // prevents the property is copied during subclassing.
+        const annotations = cls.hasOwnProperty(ANNOTATIONS) ?
+            (cls as any)[ANNOTATIONS] :
+            Object.defineProperty(cls, ANNOTATIONS, {value: []})[ANNOTATIONS];
+        annotations.push(annotationInstance);
+
+
+        if (additionalProcessing) additionalProcessing(cls);
+
+        return cls;
+      };
     }
 
-    const annotationInstance = new (DecoratorFactory as any)(...args);
-    return function TypeDecorator(cls: Type<T>) {
-      if (typeFn) typeFn(cls, ...args);
-      // Use of Object.defineProperty is important since it creates non-enumerable property which
-      // prevents the property is copied during subclassing.
-      const annotations = cls.hasOwnProperty(ANNOTATIONS) ?
-          (cls as any)[ANNOTATIONS] :
-          Object.defineProperty(cls, ANNOTATIONS, {value: []})[ANNOTATIONS];
-      annotations.push(annotationInstance);
+    if (parentClass) {
+      DecoratorFactory.prototype = Object.create(parentClass.prototype);
+    }
 
-
-      if (additionalProcessing) additionalProcessing(cls);
-
-      return cls;
-    };
-  }
-
-  if (parentClass) {
-    DecoratorFactory.prototype = Object.create(parentClass.prototype);
-  }
-
-  DecoratorFactory.prototype.ngMetadataName = name;
-  (DecoratorFactory as any).annotationCls = DecoratorFactory;
-  return DecoratorFactory as any;
+    DecoratorFactory.prototype.ngMetadataName = name;
+    (DecoratorFactory as any).annotationCls = DecoratorFactory;
+    return DecoratorFactory as any;
+  });
 }
 
 function makeMetadataCtor(props?: (...args: any[]) => any): any {
@@ -92,77 +98,82 @@ function makeMetadataCtor(props?: (...args: any[]) => any): any {
 
 export function makeParamDecorator(
     name: string, props?: (...args: any[]) => any, parentClass?: any): any {
-  const metaCtor = makeMetadataCtor(props);
-  function ParamDecoratorFactory(
-      this: unknown | typeof ParamDecoratorFactory, ...args: any[]): any {
-    if (this instanceof ParamDecoratorFactory) {
-      metaCtor.apply(this, args);
-      return this;
-    }
-    const annotationInstance = new (<any>ParamDecoratorFactory)(...args);
-
-    (<any>ParamDecorator).annotation = annotationInstance;
-    return ParamDecorator;
-
-    function ParamDecorator(cls: any, unusedKey: any, index: number): any {
-      // Use of Object.defineProperty is important since it creates non-enumerable property which
-      // prevents the property is copied during subclassing.
-      const parameters = cls.hasOwnProperty(PARAMETERS) ?
-          (cls as any)[PARAMETERS] :
-          Object.defineProperty(cls, PARAMETERS, {value: []})[PARAMETERS];
-
-      // there might be gaps if some in between parameters do not have annotations.
-      // we pad with nulls.
-      while (parameters.length <= index) {
-        parameters.push(null);
+  return noSideEffects(() => {
+    const metaCtor = makeMetadataCtor(props);
+    function ParamDecoratorFactory(
+        this: unknown | typeof ParamDecoratorFactory, ...args: any[]): any {
+      if (this instanceof ParamDecoratorFactory) {
+        metaCtor.apply(this, args);
+        return this;
       }
+      const annotationInstance = new (<any>ParamDecoratorFactory)(...args);
 
-      (parameters[index] = parameters[index] || []).push(annotationInstance);
-      return cls;
+      (<any>ParamDecorator).annotation = annotationInstance;
+      return ParamDecorator;
+
+      function ParamDecorator(cls: any, unusedKey: any, index: number): any {
+        // Use of Object.defineProperty is important since it creates non-enumerable property which
+        // prevents the property is copied during subclassing.
+        const parameters = cls.hasOwnProperty(PARAMETERS) ?
+            (cls as any)[PARAMETERS] :
+            Object.defineProperty(cls, PARAMETERS, {value: []})[PARAMETERS];
+
+        // there might be gaps if some in between parameters do not have annotations.
+        // we pad with nulls.
+        while (parameters.length <= index) {
+          parameters.push(null);
+        }
+
+        (parameters[index] = parameters[index] || []).push(annotationInstance);
+        return cls;
+      }
     }
-  }
-  if (parentClass) {
-    ParamDecoratorFactory.prototype = Object.create(parentClass.prototype);
-  }
-  ParamDecoratorFactory.prototype.ngMetadataName = name;
-  (<any>ParamDecoratorFactory).annotationCls = ParamDecoratorFactory;
-  return ParamDecoratorFactory;
+    if (parentClass) {
+      ParamDecoratorFactory.prototype = Object.create(parentClass.prototype);
+    }
+    ParamDecoratorFactory.prototype.ngMetadataName = name;
+    (<any>ParamDecoratorFactory).annotationCls = ParamDecoratorFactory;
+    return ParamDecoratorFactory;
+  });
 }
 
 export function makePropDecorator(
     name: string, props?: (...args: any[]) => any, parentClass?: any,
     additionalProcessing?: (target: any, name: string, ...args: any[]) => void): any {
-  const metaCtor = makeMetadataCtor(props);
+  return noSideEffects(() => {
+    const metaCtor = makeMetadataCtor(props);
 
-  function PropDecoratorFactory(this: unknown | typeof PropDecoratorFactory, ...args: any[]): any {
-    if (this instanceof PropDecoratorFactory) {
-      metaCtor.apply(this, args);
-      return this;
+    function PropDecoratorFactory(
+        this: unknown | typeof PropDecoratorFactory, ...args: any[]): any {
+      if (this instanceof PropDecoratorFactory) {
+        metaCtor.apply(this, args);
+        return this;
+      }
+
+      const decoratorInstance = new (<any>PropDecoratorFactory)(...args);
+
+      function PropDecorator(target: any, name: string) {
+        const constructor = target.constructor;
+        // Use of Object.defineProperty is important since it creates non-enumerable property which
+        // prevents the property is copied during subclassing.
+        const meta = constructor.hasOwnProperty(PROP_METADATA) ?
+            (constructor as any)[PROP_METADATA] :
+            Object.defineProperty(constructor, PROP_METADATA, {value: {}})[PROP_METADATA];
+        meta[name] = meta.hasOwnProperty(name) && meta[name] || [];
+        meta[name].unshift(decoratorInstance);
+
+        if (additionalProcessing) additionalProcessing(target, name, ...args);
+      }
+
+      return PropDecorator;
     }
 
-    const decoratorInstance = new (<any>PropDecoratorFactory)(...args);
-
-    function PropDecorator(target: any, name: string) {
-      const constructor = target.constructor;
-      // Use of Object.defineProperty is important since it creates non-enumerable property which
-      // prevents the property is copied during subclassing.
-      const meta = constructor.hasOwnProperty(PROP_METADATA) ?
-          (constructor as any)[PROP_METADATA] :
-          Object.defineProperty(constructor, PROP_METADATA, {value: {}})[PROP_METADATA];
-      meta[name] = meta.hasOwnProperty(name) && meta[name] || [];
-      meta[name].unshift(decoratorInstance);
-
-      if (additionalProcessing) additionalProcessing(target, name, ...args);
+    if (parentClass) {
+      PropDecoratorFactory.prototype = Object.create(parentClass.prototype);
     }
 
-    return PropDecorator;
-  }
-
-  if (parentClass) {
-    PropDecoratorFactory.prototype = Object.create(parentClass.prototype);
-  }
-
-  PropDecoratorFactory.prototype.ngMetadataName = name;
-  (<any>PropDecoratorFactory).annotationCls = PropDecoratorFactory;
-  return PropDecoratorFactory;
+    PropDecoratorFactory.prototype.ngMetadataName = name;
+    (<any>PropDecoratorFactory).annotationCls = PropDecoratorFactory;
+    return PropDecoratorFactory;
+  });
 }

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -168,6 +168,9 @@
     "name": "attachPatchData"
   },
   {
+    "name": "autoRegisterModuleById"
+  },
+  {
     "name": "baseResolveDirective"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -223,5 +223,8 @@
   },
   {
     "name": "ɵɵinject"
+  },
+  {
+    "name": "noSideEffects"
   }
 ]

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -41,7 +41,7 @@ NgIf.ɵfac = () =>
 NgTemplateOutlet.ɵdir = ɵɵdefineDirective({
   type: NgTemplateOutletDef,
   selectors: [['', 'ngTemplateOutlet', '']],
-  features: [ɵɵNgOnChangesFeature()],
+  features: [ɵɵNgOnChangesFeature],
   inputs:
       {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}
 });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -915,7 +915,7 @@ export declare function ɵɵnextContext<T = any>(level?: number): T;
 
 export declare type ɵɵNgModuleDefWithMeta<T, Declarations, Imports, Exports> = NgModuleDef<T>;
 
-export declare function ɵɵNgOnChangesFeature<T>(): DirectiveDefFeature;
+export declare function ɵɵNgOnChangesFeature<T>(definition: DirectiveDef<T>): void;
 
 export declare function ɵɵpipe(index: number, pipeName: string): any;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
N/A - No easy way to verify that Closure tree shakes the relevant functions.
- [X] Docs have been added / updated (for bug fixes / features)
No docs to update.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closure does not tree shake unused components built with Ivy.

Issue Number: http://b/149874196, http://b/149874638.

## What is the new behavior?

Closure will now tree shake unused components built with Ivy.

## Does this PR introduce a breaking change?

- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is effectively identical to https://github.com/angular/angular/pull/35769, just targeting patch branch. I cherry-picked all the commits onto a new branch based on `9.0.x`.