### PR TITLE
Revert "build(docs-infra): use local version of Zone.js when testing …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,7 +552,6 @@ jobs:
           root: *workspace_location
           paths:
             - ng/dist/packages-dist-ivy-aot
-            - ng/dist/zone.js-dist
 
   # We run a subset of the integration tests outside of Bazel that track
   # payload size.

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -15,7 +15,6 @@ describe('NgPackagesInstaller', () => {
   const yarnLockPath = path.resolve(absoluteProjectDir, 'yarn.lock');
   const ngRootDir = path.resolve(__dirname, '../../..');
   const packagesDir = path.join(ngRootDir, 'dist/packages-dist');
-  const zoneJsDir = path.join(ngRootDir, 'dist/zone.js-dist');
   const toolsDir = path.join(ngRootDir, 'dist/tools/@angular');
   let installer;
 
@@ -52,7 +51,7 @@ describe('NgPackagesInstaller', () => {
 
   describe('installLocalDependencies()', () => {
     const copyJsonObj = obj => JSON.parse(JSON.stringify(obj));
-    let dummyLocalPackages, dummyPackage, dummyPackageJson, expectedModifiedPackage, expectedModifiedPackageJson;
+    let dummyNgPackages, dummyPackage, dummyPackageJson, expectedModifiedPackage, expectedModifiedPackageJson;
 
     beforeEach(() => {
       spyOn(installer, '_checkLocalMarker');
@@ -61,18 +60,17 @@ describe('NgPackagesInstaller', () => {
 
       spyOn(installer, '_parseLockfile').and.returnValue({
         'rxjs@^6.3.0': {version: '6.3.3'},
-        'rxjs-dev@^6.3.0': {version: '6.4.2'}
+        'zone.js@^0.8.26': {version: '0.8.27'}
       });
 
       // These are the packages that are "found" in the dist directory
-      dummyLocalPackages = {
+      dummyNgPackages = {
         '@angular/core': {
           packageDir: `${packagesDir}/core`,
           packageJsonPath: `${packagesDir}/core/package.json`,
           config: {
             peerDependencies: {
               'rxjs': '^6.4.0',
-              'rxjs-dev': '^6.4.0',
               'some-package': '5.0.1',
               'zone.js': '~0.8.26'
             }
@@ -103,40 +101,32 @@ describe('NgPackagesInstaller', () => {
             devDependencies: { '@angular/common': '4.4.4-1ab23cd4' },
             peerDependencies: { tsickle: '^1.4.0' }
           }
-        },
-        'zone.js': {
-          packageDir: `${zoneJsDir}/zone.js`,
-          packageJsonPath: `${zoneJsDir}/zone.js/package.json`,
-          config: {
-            devDependencies: { typescript: '^2.4.2' }
-          }
-        },
+        }
       };
-      spyOn(installer, '_getDistPackages').and.callFake(() => copyJsonObj(dummyLocalPackages));
+      spyOn(installer, '_getDistPackages').and.callFake(() => copyJsonObj(dummyNgPackages));
 
       // This is the package.json in the "test" folder
       dummyPackage = {
         dependencies: {
           '@angular/core': '4.4.1',
           '@angular/common': '4.4.1',
-          rxjs: '^6.3.0',
-          'zone.js': '^0.8.26'
+          rxjs: '^6.3.0'
         },
         devDependencies: {
           '@angular/compiler-cli': '4.4.1',
-          'rxjs-dev': '^6.3.0'
+          'zone.js': '^0.8.26'
         }
       };
       dummyPackageJson = JSON.stringify(dummyPackage);
       fs.readFileSync.and.returnValue(dummyPackageJson);
 
       // This is the package.json that is temporarily written to the "test" folder
-      // Note that the Angular/Zone.js (dev)dependencies have been modified to use a "file:" path
-      // and that the peerDependencies from `dummyLocalPackages` have been updated or added as
+      // Note that the Angular (dev)dependencies have been modified to use a "file:" path
+      // And that the peerDependencies from `dummyNgPackages` have been updated or added as
       // (dev)dependencies (unless the current version in lockfile satisfies semver).
       //
-      // For example, `rxjs-dev@6.4.2` (from lockfile) satisfies `rxjs-dev@^6.4.0` (from
-      // `@angular/core`), thus `rxjs-dev: ^6.3.0` (from original `package.json`) is retained.
+      // For example, `zone.js@0.8.27` (from lockfile) satisfies `zone.js@~0.8.26` (from
+      // `@angular/core`), thus `zone.js: ^0.8.26` (from original `package.json`) is retained.
       // In contrast, `rxjs@6.3.3` (from lockfile) does not satisfy `rxjs@^6.4.0 (from
       // `@angular/core`), thus `rxjs: ^6.3.0` (from original `package.json`) is replaced with
       // `rxjs: ^6.4.0` (from `@angular/core`).
@@ -144,12 +134,11 @@ describe('NgPackagesInstaller', () => {
         dependencies: {
           '@angular/core': `file:${packagesDir}/core`,
           '@angular/common': `file:${packagesDir}/common`,
-          'rxjs': '^6.4.0',
-          'zone.js': `file:${zoneJsDir}/zone.js`,
+          'rxjs': '^6.4.0'
         },
         devDependencies: {
           '@angular/compiler-cli': `file:${toolsDir}/compiler-cli`,
-          'rxjs-dev': '^6.3.0',
+          'zone.js': '^0.8.26',
           'some-package': '5.0.1',
           typescript: '^2.4.2'
         },
@@ -193,56 +182,31 @@ describe('NgPackagesInstaller', () => {
       });
 
       it('should temporarily overwrite the package.json files of local Angular packages', () => {
-        const pkgJsonPathFor = pkgName => dummyLocalPackages[pkgName].packageJsonPath;
-        const pkgConfigFor = pkgName => copyJsonObj(dummyLocalPackages[pkgName].config);
+        const pkgJsonFor = pkgName => dummyNgPackages[`@angular/${pkgName}`].packageJsonPath;
+        const pkgConfigFor = pkgName => copyJsonObj(dummyNgPackages[`@angular/${pkgName}`].config);
         const overwriteConfigFor = (pkgName, newProps) => Object.assign(pkgConfigFor(pkgName), newProps);
         const stringifyConfig = config => JSON.stringify(config, null, 2);
 
         const allArgs = fs.writeFileSync.calls.allArgs();
-        const firstSixArgs = allArgs.slice(0, 6);
-        const lastSixArgs = allArgs.slice(-6);
+        const firstFiveArgs = allArgs.slice(0, 5);
+        const lastFiveArgs = allArgs.slice(-5);
 
-        expect(firstSixArgs).toEqual([
-          [
-            pkgJsonPathFor('@angular/core'),
-            stringifyConfig(overwriteConfigFor('@angular/core', {private: true})),
-          ],
-          [
-            pkgJsonPathFor('@angular/common'),
-            stringifyConfig(overwriteConfigFor('@angular/common', {private: true})),
-          ],
-          [
-            pkgJsonPathFor('@angular/compiler'),
-            stringifyConfig(overwriteConfigFor('@angular/compiler', {private: true})),
-          ],
-          [
-            pkgJsonPathFor('@angular/compiler-cli'),
-            stringifyConfig(overwriteConfigFor('@angular/compiler-cli', {
-              private: true,
-              dependencies: { '@angular/tsc-wrapped': `file:${toolsDir}/tsc-wrapped` },
-            })),
-          ],
-          [
-            pkgJsonPathFor('@angular/tsc-wrapped'),
-            stringifyConfig(overwriteConfigFor('@angular/tsc-wrapped', {
-              private: true,
-              devDependencies: { '@angular/common': `file:${packagesDir}/common` },
-            })),
-          ],
-          [
-            pkgJsonPathFor('zone.js'),
-            stringifyConfig(overwriteConfigFor('zone.js', {private: true})),
-          ],
+        expect(firstFiveArgs).toEqual([
+          [pkgJsonFor('core'), stringifyConfig(overwriteConfigFor('core', {private: true}))],
+          [pkgJsonFor('common'), stringifyConfig(overwriteConfigFor('common', {private: true}))],
+          [pkgJsonFor('compiler'), stringifyConfig(overwriteConfigFor('compiler', {private: true}))],
+          [pkgJsonFor('compiler-cli'), stringifyConfig(overwriteConfigFor('compiler-cli', {
+            private: true,
+            dependencies: { '@angular/tsc-wrapped': `file:${toolsDir}/tsc-wrapped` }
+          }))],
+          [pkgJsonFor('tsc-wrapped'), stringifyConfig(overwriteConfigFor('tsc-wrapped', {
+            private: true,
+            devDependencies: { '@angular/common': `file:${packagesDir}/common` }
+          }))],
         ]);
 
-        expect(lastSixArgs).toEqual([
-          '@angular/core',
-          '@angular/common',
-          '@angular/compiler',
-          '@angular/compiler-cli',
-          '@angular/tsc-wrapped',
-          'zone.js',
-        ].map(pkgName => [pkgJsonPathFor(pkgName), stringifyConfig(pkgConfigFor(pkgName))]));
+        expect(lastFiveArgs).toEqual(['core', 'common', 'compiler', 'compiler-cli', 'tsc-wrapped']
+            .map(pkgName => [pkgJsonFor(pkgName), stringifyConfig(pkgConfigFor(pkgName))]));
       });
 
       it('should load the package.json', () => {
@@ -316,7 +280,7 @@ describe('NgPackagesInstaller', () => {
 
       expect(shelljs.exec).not.toHaveBeenCalled();
       expect(warning).toContain(
-          'Automatically building the local Angular/Zone.js packages is currently not supported on Windows.');
+          'Automatically building the local Angular packages is currently not supported on Windows.');
       expect(warning).toContain('Git Bash for Windows');
       expect(warning).toContain('Windows Subsystem for Linux');
       expect(warning).toContain('Linux docker container or VM');
@@ -345,8 +309,8 @@ describe('NgPackagesInstaller', () => {
       expect(installer._buildDistPackages).not.toHaveBeenCalled();
     });
 
-    it('should include top level Angular and Zone.js packages', () => {
-      const localPackages = installer._getDistPackages();
+    it('should include top level Angular packages', () => {
+      const ngPackages = installer._getDistPackages();
       const expectedValue = jasmine.objectContaining({
         packageDir: jasmine.any(String),
         packageJsonPath: jasmine.any(String),
@@ -354,30 +318,28 @@ describe('NgPackagesInstaller', () => {
       });
 
       // For example...
-      expect(localPackages['@angular/common']).toEqual(expectedValue);
-      expect(localPackages['@angular/core']).toEqual(expectedValue);
-      expect(localPackages['@angular/router']).toEqual(expectedValue);
-      expect(localPackages['@angular/upgrade']).toEqual(expectedValue);
-      expect(localPackages['zone.js']).toEqual(expectedValue);
+      expect(ngPackages['@angular/common']).toEqual(expectedValue);
+      expect(ngPackages['@angular/core']).toEqual(expectedValue);
+      expect(ngPackages['@angular/router']).toEqual(expectedValue);
+      expect(ngPackages['@angular/upgrade']).toEqual(expectedValue);
 
-      expect(localPackages['@angular/upgrade/static']).not.toBeDefined();
+      expect(ngPackages['@angular/upgrade/static']).not.toBeDefined();
     });
 
     it('should store each package\'s directory', () => {
-      const localPackages = installer._getDistPackages();
+      const ngPackages = installer._getDistPackages();
 
       // For example...
-      expect(localPackages['@angular/core'].packageDir).toBe(path.join(packagesDir, 'core'));
-      expect(localPackages['@angular/router'].packageDir).toBe(path.join(packagesDir, 'router'));
-      expect(localPackages['zone.js'].packageDir).toBe(path.join(zoneJsDir, 'zone.js'));
+      expect(ngPackages['@angular/core'].packageDir).toBe(path.join(packagesDir, 'core'));
+      expect(ngPackages['@angular/router'].packageDir).toBe(path.join(packagesDir, 'router'));
     });
 
     it('should not include packages that have been ignored', () => {
       installer = new NgPackagesInstaller(projectDir, { ignorePackages: ['@angular/router'] });
-      const localPackages = installer._getDistPackages();
+      const ngPackages = installer._getDistPackages();
 
-      expect(localPackages['@angular/common']).toBeDefined();
-      expect(localPackages['@angular/router']).toBeUndefined();
+      expect(ngPackages['@angular/common']).toBeDefined();
+      expect(ngPackages['@angular/router']).toBeUndefined();
     });
   });
 
@@ -518,7 +480,7 @@ describe('NgPackagesInstaller', () => {
   describe('_printWarning()', () => {
     it('should mention the message passed in the warning', () => {
       installer._printWarning();
-      expect(console.warn.calls.argsFor(0)[0]).toContain('is running against the local Angular/Zone.js build');
+      expect(console.warn.calls.argsFor(0)[0]).toContain('is running against the local Angular build');
     });
 
     it('should mention the command to restore the Angular packages in any warning', () => {

--- a/scripts/build/build-ivy-npm-packages.js
+++ b/scripts/build/build-ivy-npm-packages.js
@@ -9,13 +9,8 @@
 
 'use strict';
 
-const {buildZoneJsPackage} = require('./zone-js-builder');
 const {buildTargetPackages} = require('./package-builder');
 
 
 // Build the ivy packages into `dist/packages-dist-ivy-aot/`.
 buildTargetPackages('dist/packages-dist-ivy-aot', true, 'Ivy AOT');
-
-// Build the `zone.js` npm package into `dist/zone.js-dist/`, because it might be needed by other
-// scripts/tests.
-buildZoneJsPackage();


### PR DESCRIPTION
…against local packages (#35780)"

This reverts commit 7d832ae1001b6264bb7124086089e9e69c10c9b6; breaks CI
with error `Concurrent upstream jobs persisted the same file(s) into the workspace:`
