### PR TITLE
build: create dev-infra-private npm package

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -928,6 +928,7 @@ groups:
           '.github/**',
           '.vscode/**',
           '.yarn/**',
+          'dev-infra/**',
           'docs/BAZEL.md',
           'docs/CARETAKER.md',
           'docs/COMMITTER.md',

--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "cli",
+    srcs = [
+        "cli.ts",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+pkg_npm(
+    name = "npm_package",
+    srcs = [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cli",
+    ],
+)

--- a/dev-infra/cli.ts
+++ b/dev-infra/cli.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const args = process.argv.slice(2);
+
+// TODO(josephperrott): Set up proper cli flag/command handling
+switch(args[0]) {
+  default:
+    console.info('No commands were matched');
+}

--- a/dev-infra/package.json
+++ b/dev-infra/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@angular/dev-infra-private",
+  "version": "0.0.0",
+  "description": "INTERNAL USE ONLY - Angular internal DevInfra tooling/scripts - INTERNAL USE ONLY",
+  "license": "MIT",
+  "bin": {
+    "ng-dev": "./cli.js"
+  }
+}

--- a/scripts/build/build-packages-dist.js
+++ b/scripts/build/build-packages-dist.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const {buildZoneJsPackage} = require('./zone-js-builder');
+const {buildDevInfraPackage} = require('./dev-infra-builder');
 const {buildTargetPackages} = require('./package-builder');
 
 
@@ -19,3 +20,6 @@ buildTargetPackages('dist/packages-dist', false, 'Production');
 // Build the `zone.js` npm package into `dist/zone.js-dist/`, because it might be needed by other
 // scripts/tests.
 buildZoneJsPackage();
+
+// Build the `angular-dev-infra` npm package into `dist/packages-dist/@angular/dev-infra-private`
+buildDevInfraPackage();

--- a/scripts/build/dev-infra-builder.js
+++ b/scripts/build/dev-infra-builder.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+'use strict';
+
+const {chmod, cp, mkdir, rm} = require('shelljs');
+const {baseDir, bazelBin, bazelCmd, exec, scriptPath} = require('./package-builder');
+
+/**
+ * Build the `@angular/dev-infra-private` npm package and copies it to `dist/packages-dist`.
+ */
+function buildDevInfraPackage() {
+  console.info('##############################');
+  console.info(`${scriptPath}:`);
+  console.info('  Building @angular/dev-infra-private npm package');
+  console.info('##############################');
+  exec(`${bazelCmd} build //dev-infra:npm_package`);
+
+  const buildOutputDir = `${bazelBin}/dev-infra/npm_package`;
+  const distTargetDir = `${baseDir}/dist/packages-dist/dev-infra-private`;
+
+  console.info(`# Copy artifacts to ${distTargetDir}`);
+  mkdir('-p', distTargetDir);
+  rm('-rf', distTargetDir);
+  cp('-R', buildOutputDir, distTargetDir);
+  chmod('-R', 'u+w', distTargetDir);
+
+  console.info('');
+}
+
+module.exports = {
+  buildDevInfraPackage
+};


### PR DESCRIPTION
Creates the scaffolding for an @angular/dev-infra-private package
which will not be published to npm but will be pushed to
https://github.com/angular/dev-infra-private-builds repo for each
commit to master.

The contents of this npm package will then be depended on via
package.json dependency for angular/angular angular/angular-cli and
angular/components.
