### PR TITLE
fix(docs-infra): in 404 page some text is not visible

### DIFF
--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -106,7 +106,7 @@ aio-search-results {
         }
       }
 
-      .not-found {
+      .no-results {
         color: $darkgray;
       }
 


### PR DESCRIPTION
In pr #34978 colors were not properly set, if we type wrong url in the browser and we are directed to the 404 page there some text is set to white color which as not visible set it to dark gray for visibility

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

White text not visible
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![Angular - PAGE NOT FOUND](https://user-images.githubusercontent.com/39260684/75956350-b70bab00-5edd-11ea-80de-bea87758366d.png)



Issue Number: N/A


## What is the new behavior?

Text is visible
![Desktop screenshot](https://user-images.githubusercontent.com/39260684/75956362-bf63e600-5edd-11ea-97cd-7e3df2088e3c.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
