### PR TITLE
feat(service-worker): change default SW strategy behavior

### DIFF
--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -7,7 +7,7 @@
  */
 
 import {isPlatformBrowser} from '@angular/common';
-import {APP_INITIALIZER, ApplicationRef, InjectionToken, Injector, ModuleWithProviders, NgModule, PLATFORM_ID} from '@angular/core';
+import {APP_INITIALIZER, ApplicationRef, InjectionToken, Injector, ModuleWithProviders, NgModule, NgZone, PLATFORM_ID} from '@angular/core';
 import {Observable, merge, of } from 'rxjs';
 import {delay, filter, take} from 'rxjs/operators';
 
@@ -108,11 +108,14 @@ export function ngswAppInitializer(
           readyToRegister$ = of (null);
           break;
         case 'registerWithDelay':
-          readyToRegister$ = delayWithTimeout(+args[0] || 0);
+          readyToRegister$ =
+              injector.get<NgZone>(NgZone).runOutsideAngular(() => delayWithTimeout(+args[0] || 0));
           break;
         case 'registerWhenStable':
-          readyToRegister$ = !args[0] ? whenStable(injector) :
-                                        merge(whenStable(injector), delayWithTimeout(+args[0]));
+          readyToRegister$ = !args[0] ?
+              whenStable(injector) :
+              injector.get<NgZone>(NgZone).runOutsideAngular(
+                  () => merge(whenStable(injector), delayWithTimeout(+args[0])));
           break;
         default:
           // Unknown strategy.

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -108,14 +108,11 @@ export function ngswAppInitializer(
           readyToRegister$ = of (null);
           break;
         case 'registerWithDelay':
-          readyToRegister$ =
-              injector.get<NgZone>(NgZone).runOutsideAngular(() => delayWithTimeout(+args[0] || 0));
+          readyToRegister$ = delayWithTimeout(+args[0] || 0);
           break;
         case 'registerWhenStable':
-          readyToRegister$ = !args[0] ?
-              whenStable(injector) :
-              injector.get<NgZone>(NgZone).runOutsideAngular(
-                  () => merge(whenStable(injector), delayWithTimeout(+args[0])));
+          readyToRegister$ = !args[0] ? whenStable(injector) :
+                                        merge(whenStable(injector), delayWithTimeout(+args[0]));
           break;
         default:
           // Unknown strategy.
@@ -125,10 +122,15 @@ export function ngswAppInitializer(
     }
 
     // Don't return anything to avoid blocking the application until the SW is registered.
+    // Also, run outside the Angular zone to avoid preventing the app from stabilizing (especially
+    // given that some registration strategies wait for the app to stabilize).
     // Catch and log the error if SW registration fails to avoid uncaught rejection warning.
-    readyToRegister$.pipe(take(1)).subscribe(
-        () => navigator.serviceWorker.register(script, {scope: options.scope})
-                  .catch(err => console.error('Service worker registration failed with:', err)));
+    const ngZone = injector.get(NgZone);
+    ngZone.runOutsideAngular(
+        () => readyToRegister$.pipe(take(1)).subscribe(
+            () =>
+                navigator.serviceWorker.register(script, {scope: options.scope})
+                    .catch(err => console.error('Service worker registration failed with:', err))));
   };
   return initializer;
 }

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -100,7 +100,9 @@ export function ngswAppInitializer(
     if (typeof options.registrationStrategy === 'function') {
       readyToRegister$ = options.registrationStrategy();
     } else {
-      const [strategy, ...args] = (options.registrationStrategy || 'registerWhenStable:30000').split(':');
+      const [strategy, ...args] =
+          (options.registrationStrategy || 'registerWhenStable:30000').split(':');
+
       switch (strategy) {
         case 'registerImmediately':
           readyToRegister$ = of (null);

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -100,7 +100,7 @@ export function ngswAppInitializer(
     if (typeof options.registrationStrategy === 'function') {
       readyToRegister$ = options.registrationStrategy();
     } else {
-      const [strategy, ...args] = (options.registrationStrategy || 'registerWhenStable').split(':');
+      const [strategy, ...args] = (options.registrationStrategy || 'registerWhenStable:30000').split(':');
       switch (strategy) {
         case 'registerImmediately':
           readyToRegister$ = of (null);

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -141,7 +141,7 @@ describe('ServiceWorkerModule', () => {
               ],
             });
 
-            // Dummy `get()` call to initialize the test "app".
+            // Dummy `inject()` call to initialize the test "app".
             TestBed.inject(ApplicationRef);
 
             return isStableSub;
@@ -156,19 +156,89 @@ describe('ServiceWorkerModule', () => {
            tick();
            expect(swRegisterSpy).not.toHaveBeenCalled();
 
+           tick(60000);
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
            isStableSub.next(true);
 
            tick();
            expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
          }));
 
-      it('registers the SW when the app stabilizes with `registerWhenStable`', fakeAsync(() => {
+      it('registers the SW when the app stabilizes with `registerWhenStable:<timeout>`',
+         fakeAsync(() => {
+           const isStableSub = configTestBedWithMockedStability('registerWhenStable:1000');
+
+           isStableSub.next(false);
+           isStableSub.next(false);
+
+           tick();
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(500);
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           isStableSub.next(true);
+
+           tick();
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
+      it('registers the SW after `timeout` if the app does not stabilize with `registerWhenStable:<timeout>`',
+         fakeAsync(() => {
+           configTestBedWithMockedStability('registerWhenStable:1000');
+
+           tick(999);
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(1);
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
+      it('registers the SW asap (asynchronously) before the app stabilizes with `registerWhenStable:0`',
+         fakeAsync(() => {
+           const isStableSub = configTestBedWithMockedStability('registerWhenStable:0');
+
+           // Create a microtask.
+           Promise.resolve();
+
+           flushMicrotasks();
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(0);
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
+      it('registers the SW only when the app stabilizes with `registerWhenStable:`',
+         fakeAsync(() => {
+           const isStableSub = configTestBedWithMockedStability('registerWhenStable:');
+
+           isStableSub.next(false);
+           isStableSub.next(false);
+
+           tick();
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(60000);
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           isStableSub.next(true);
+
+           tick();
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
+      it('registers the SW only when the app stabilizes with `registerWhenStable`',
+         fakeAsync(() => {
            const isStableSub = configTestBedWithMockedStability('registerWhenStable');
 
            isStableSub.next(false);
            isStableSub.next(false);
 
            tick();
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(60000);
            expect(swRegisterSpy).not.toHaveBeenCalled();
 
            isStableSub.next(true);

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -147,7 +147,7 @@ describe('ServiceWorkerModule', () => {
             return isStableSub;
           };
 
-      it('defaults to registering the SW when the app stabilizes', fakeAsync(() => {
+      it('defaults to registering the SW when the app stabilizes (under 30s)', fakeAsync(() => {
            const isStableSub = configTestBedWithMockedStability();
 
            isStableSub.next(false);
@@ -156,12 +156,23 @@ describe('ServiceWorkerModule', () => {
            tick();
            expect(swRegisterSpy).not.toHaveBeenCalled();
 
-           tick(60000);
+           tick(20000);
            expect(swRegisterSpy).not.toHaveBeenCalled();
 
            isStableSub.next(true);
 
            tick();
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
+      it('defaults to registering the SW after 30s if the app does not stabilize sooner',
+         fakeAsync(() => {
+           const isStableSub = configTestBedWithMockedStability();
+
+           tick(29999);
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           tick(1);
            expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
          }));
 
@@ -244,22 +255,6 @@ describe('ServiceWorkerModule', () => {
            isStableSub.next(true);
 
            tick();
-           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-         }));
-
-      it('registers the SW when the app does not stabilize after `<timeout>` with `registerWhenStable:<timeout>`',
-         fakeAsync(() => {
-           const isStableSub = configTestBedWithMockedStability('registerWhenStable:30000');
-
-           isStableSub.next(false);
-           isStableSub.next(false);
-
-           tick();
-           expect(swRegisterSpy).not.toHaveBeenCalled();
-
-           // App did not stabalize, kick in the timeout to make sure that the
-           // SW registers.
-           tick(30000);
            expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
          }));
 

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -247,6 +247,22 @@ describe('ServiceWorkerModule', () => {
            expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
          }));
 
+      it('registers the SW when the app does not stabilize after `<timeout>` with `registerWhenStable:<timeout>`',
+         fakeAsync(() => {
+           const isStableSub = configTestBedWithMockedStability('registerWhenStable:30000');
+
+           isStableSub.next(false);
+           isStableSub.next(false);
+
+           tick();
+           expect(swRegisterSpy).not.toHaveBeenCalled();
+
+           // App did not stabalize, kick in the timeout to make sure that the
+           // SW registers.
+           tick(30000);
+           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+         }));
+
       it('registers the SW immediatelly (synchronously) with `registerImmediately`', () => {
         configTestBedWithMockedStability('registerImmediately');
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});


### PR DESCRIPTION
Previously, there was a chance that the SW will never register
when there is a long-running task or recurring timeout. This commit
fixes this, by first trying to wait for the app to stabilize, however,
if that does not happen, then the SW will register after 30 seconds.

Closes #34464

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34464


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
