### PR TITLE
feat(zone.js): add a zone config to allow user disable wrapping uncaught promise rejection

### DIFF
--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -529,6 +529,17 @@ interface ZoneGlobalConfigurations {
    * The preceding code makes all scroll event listeners passive.
    */
   __zone_symbol__PASSIVE_EVENTS?: boolean;
+
+  /**
+   * Disable wrapping uncaught promise rejection.
+   *
+   * By default, `zone.js` wraps the uncaught promise rejection in a new `Error` object
+   * which contains additional information such as a value of the rejection and a stack trace.
+   *
+   * If you set `__zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION = true;` before
+   * importing `zone.js`, `zone.js` will not wrap the uncaught promise rejection.
+   */
+  __zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION?: boolean;
 }
 
 /**

--- a/packages/zone.js/test/BUILD.bazel
+++ b/packages/zone.js/test/BUILD.bazel
@@ -33,6 +33,7 @@ ts_library(
         ],
         exclude = [
             "common/Error.spec.ts",
+            "common/promise-disable-wrap-uncaught-promise-rejection.spec.ts",
         ],
     ),
     deps = [
@@ -253,7 +254,10 @@ env_entry_point = ":browser-env-setup.ts"
 
 test_srcs = glob(
     ["browser/*.ts"],
-    exclude = ["browser/shadydom.spec.ts"],
+    exclude = [
+        "browser/shadydom.spec.ts",
+        "common/promise-disable-wrap-uncaught-promise-rejection.spec.ts",
+    ],
 ) + [
     "extra/cordova.spec.ts",
     "mocha-patch.spec.ts",
@@ -321,5 +325,26 @@ karma_test(
     test_srcs = [
         "browser/shadydom.spec.ts",
         "browser_shadydom_entry_point.ts",
+    ],
+)
+
+karma_test(
+    name = "browser_disable_wrap_uncaught_promise_rejection",
+    bootstraps = {"browser_disable_wrap_uncaught_promise_rejection": [
+        "//packages/zone.js/dist:zone-testing-bundle.js",
+    ]},
+    ci = False,
+    env_deps = [
+        "//packages/zone.js/lib",
+    ],
+    env_entry_point = ":browser_disable_wrap_uncaught_promise_rejection_setup.ts",
+    env_srcs = ["browser_disable_wrap_uncaught_promise_rejection_setup.ts"],
+    test_deps = [
+        "//packages/zone.js/lib",
+    ],
+    test_entry_point = ":browser_disable_wrap_uncaught_promise_rejection_entry_point.ts",
+    test_srcs = [
+        "common/promise-disable-wrap-uncaught-promise-rejection.spec.ts",
+        "browser_disable_wrap_uncaught_promise_rejection_entry_point.ts",
     ],
 )

--- a/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_entry_point.ts
+++ b/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_entry_point.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import './common/promise-disable-wrap-uncaught-promise-rejection.spec';

--- a/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_setup.ts
+++ b/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_setup.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+(window as any)['__zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION'] = true;

--- a/packages/zone.js/test/common/promise-disable-wrap-uncaught-promise-rejection.spec.ts
+++ b/packages/zone.js/test/common/promise-disable-wrap-uncaught-promise-rejection.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+class TestRejection {
+  prop1?: string;
+  prop2?: string;
+}
+
+describe('disable wrap uncaught promise rejection', () => {
+  it('should notify Zone.onHandleError if promise is uncaught', (done) => {
+    let promiseError: Error|null = null;
+    let zone: Zone|null = null;
+    let task: Task|null = null;
+    let error: Error|null = null;
+    Zone.current
+        .fork({
+          name: 'promise-error',
+          onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any):
+                             boolean => {
+                               promiseError = error;
+                               delegate.handleError(target, error);
+                               return false;
+                             }
+        })
+        .run(() => {
+          zone = Zone.current;
+          task = Zone.currentTask;
+          error = new Error('rejectedErrorShouldBeHandled');
+          try {
+            // throw so that the stack trace is captured
+            throw error;
+          } catch (e) {
+          }
+          Promise.reject(error);
+          expect(promiseError).toBe(null);
+        });
+    setTimeout((): any => null);
+    setTimeout(() => {
+      expect(promiseError).toBe(error);
+      expect((promiseError as any)['rejection']).toBe(error);
+      expect((promiseError as any)['zone']).toBe(zone);
+      expect((promiseError as any)['task']).toBe(task);
+      done();
+    });
+  });
+
+  it('should print original information when a non-Error object is used for rejection', (done) => {
+    let promiseError: Error|null = null;
+    let rejectObj: TestRejection;
+    Zone.current
+        .fork({
+          name: 'promise-error',
+          onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any):
+                             boolean => {
+                               promiseError = error;
+                               delegate.handleError(target, error);
+                               return false;
+                             }
+        })
+        .run(() => {
+          rejectObj = new TestRejection();
+          rejectObj.prop1 = 'value1';
+          rejectObj.prop2 = 'value2';
+          (rejectObj as any).message = 'rejectMessage';
+          Promise.reject(rejectObj);
+          expect(promiseError).toBe(null);
+        });
+    setTimeout((): any => null);
+    setTimeout(() => {
+      expect(promiseError).toEqual(rejectObj as any);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Close #27840.

By default, `zone.js` wrap uncaught promise error and wrap it to a new Error object with some
additional information includes the value of the error and the stack trace.

Consider the following example:

```
Zone.current
  .fork({
    name: 'promise-error',
    onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any): boolean => {
      console.log('caught an error', error);
      delegate.handleError(target, error);
      return false;
    }
}).run(() => {
  const originalError = new Error('testError');
  Promise.reject(originalError);
});
```

The `promise-error` zone catches a wrapped `Error` object whose `reject` property equals
to the `originalError`, and the message will be `Uncaught (in promise): testError...`.
You can disable this wrapping behavior by defining a global configuraiton
` __zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION = true;` before importing `zone.js`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28740

This PR was original submitted here https://github.com/angular/angular/pull/31443, and it was reverted as it is a breaking change, and in this new PR, I changed the logic and keep the original behavior and use a configuration to let user change the behavior.