### PR TITLE
fix(docs-infra): remove entry components from aio codebase

### DIFF
--- a/aio/src/app/custom-elements/announcement-bar/announcement-bar.module.ts
+++ b/aio/src/app/custom-elements/announcement-bar/announcement-bar.module.ts
@@ -8,7 +8,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule, SharedModule, HttpClientModule ],
   declarations: [ AnnouncementBarComponent ],
-  entryComponents: [ AnnouncementBarComponent ],
 })
 export class AnnouncementBarModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = AnnouncementBarComponent;

--- a/aio/src/app/custom-elements/api/api-list.module.ts
+++ b/aio/src/app/custom-elements/api/api-list.module.ts
@@ -9,7 +9,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule, SharedModule, HttpClientModule ],
   declarations: [ ApiListComponent ],
-  entryComponents: [ ApiListComponent ],
   providers: [ ApiService ]
 })
 export class ApiListModule implements WithCustomElementComponent {

--- a/aio/src/app/custom-elements/code/code-example.module.ts
+++ b/aio/src/app/custom-elements/code/code-example.module.ts
@@ -8,7 +8,6 @@ import { WithCustomElementComponent } from '../element-registry';
   imports: [ CommonModule, CodeModule ],
   declarations: [ CodeExampleComponent ],
   exports: [ CodeExampleComponent ],
-  entryComponents: [ CodeExampleComponent ]
 })
 export class CodeExampleModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = CodeExampleComponent;

--- a/aio/src/app/custom-elements/code/code-tabs.module.ts
+++ b/aio/src/app/custom-elements/code/code-tabs.module.ts
@@ -10,7 +10,6 @@ import { WithCustomElementComponent } from '../element-registry';
   imports: [ CommonModule, MatCardModule, MatTabsModule, CodeModule ],
   declarations: [ CodeTabsComponent ],
   exports: [ CodeTabsComponent ],
-  entryComponents: [ CodeTabsComponent ]
 })
 export class CodeTabsModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = CodeTabsComponent;

--- a/aio/src/app/custom-elements/code/code.module.ts
+++ b/aio/src/app/custom-elements/code/code.module.ts
@@ -8,7 +8,6 @@ import { CopierService } from 'app/shared/copier.service';
 @NgModule({
   imports: [ CommonModule, MatSnackBarModule ],
   declarations: [ CodeComponent ],
-  entryComponents: [ CodeComponent ],
   exports: [ CodeComponent ],
   providers: [ PrettyPrinter, CopierService ]
 })

--- a/aio/src/app/custom-elements/contributor/contributor-list.module.ts
+++ b/aio/src/app/custom-elements/contributor/contributor-list.module.ts
@@ -9,7 +9,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule, MatIconModule ],
   declarations: [ ContributorListComponent, ContributorComponent ],
-  entryComponents: [ ContributorListComponent ],
   providers: [ ContributorService ]
 })
 export class ContributorListModule implements WithCustomElementComponent {

--- a/aio/src/app/custom-elements/live-example/live-example.module.ts
+++ b/aio/src/app/custom-elements/live-example/live-example.module.ts
@@ -6,7 +6,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule ],
   declarations: [ LiveExampleComponent, EmbeddedStackblitzComponent ],
-  entryComponents: [ LiveExampleComponent ]
 })
 export class LiveExampleModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = LiveExampleComponent;

--- a/aio/src/app/custom-elements/resource/resource-list.module.ts
+++ b/aio/src/app/custom-elements/resource/resource-list.module.ts
@@ -7,7 +7,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule ],
   declarations: [ ResourceListComponent ],
-  entryComponents: [ ResourceListComponent ],
   providers: [ ResourceService ]
 })
 export class ResourceListModule implements WithCustomElementComponent {

--- a/aio/src/app/custom-elements/search/file-not-found-search.module.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.module.ts
@@ -7,7 +7,6 @@ import { WithCustomElementComponent } from '../element-registry';
 @NgModule({
   imports: [ CommonModule, SharedModule ],
   declarations: [ FileNotFoundSearchComponent ],
-  entryComponents: [ FileNotFoundSearchComponent ]
 })
 export class FileNotFoundSearchModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = FileNotFoundSearchComponent;

--- a/aio/src/app/custom-elements/toc/toc.module.ts
+++ b/aio/src/app/custom-elements/toc/toc.module.ts
@@ -7,7 +7,6 @@ import { TocComponent } from './toc.component';
 @NgModule({
   imports: [ CommonModule, MatIconModule ],
   declarations: [ TocComponent ],
-  entryComponents: [ TocComponent ],
 })
 export class TocModule implements WithCustomElementComponent {
   customElementComponent: Type<any> = TocComponent;


### PR DESCRIPTION
Angular version 9 no longer need entry components in the code so clean up remaining entry components in the aio codebase

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Extra code of entry components
Issue Number: N/A


## What is the new behavior?
Removed extra code of entry components

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
