### PR TITLE
feat(ngcc): support JSON formatted console logging

### DIFF
--- a/packages/compiler-cli/ngcc/src/logging/json_console_logger.ts
+++ b/packages/compiler-cli/ngcc/src/logging/json_console_logger.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {LogLevel, Logger} from './logger';
+
+/**
+ * A simple logger that outputs messages formmatted as JSON objects directly to the Console.
+ *
+ * For example:
+ *
+ * ```
+ * {"type":"info","args":["Compiling @angular/core : fesm2015 as esm2015"]}
+ * {"type":"info","args":["Compiling @angular/core : fesm5 as esm5"]}
+ * ```
+ *
+ * The log messages can be filtered based on severity via the `logLevel`
+ * constructor parameter.
+ */
+export class JsonConsoleLogger implements Logger {
+  constructor(public level: LogLevel) {}
+  debug(...args: string[]) {
+    if (this.level <= LogLevel.debug) console.debug(JSON.stringify({type: 'debug', args}));
+  }
+  info(...args: string[]) {
+    if (this.level <= LogLevel.info) console.info(JSON.stringify({type: 'info', args}));
+  }
+  warn(...args: string[]) {
+    if (this.level <= LogLevel.warn) console.warn(JSON.stringify({type: 'warn', args}));
+  }
+  error(...args: string[]) {
+    if (this.level <= LogLevel.error) console.error(JSON.stringify({type: 'error', args}));
+  }
+}

--- a/packages/compiler-cli/ngcc/test/logging/json_console_logger_spec.ts
+++ b/packages/compiler-cli/ngcc/test/logging/json_console_logger_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {JsonConsoleLogger} from '../../src/logging/json_console_logger';
+import {LogLevel} from '../../src/logging/logger';
+
+describe('JsonConsoleLogger', () => {
+  it('should pass through calls to Console', () => {
+    spyOn(console, 'debug');
+    spyOn(console, 'info');
+    spyOn(console, 'warn');
+    spyOn(console, 'error');
+    const logger = new JsonConsoleLogger(LogLevel.debug);
+
+    logger.debug('debug', 'test');
+    expect(console.debug).toHaveBeenCalledWith('{"type":"debug","args":["debug","test"]}');
+
+    logger.info('info', 'test');
+    expect(console.info).toHaveBeenCalledWith('{"type":"info","args":["info","test"]}');
+
+    logger.warn('warn', 'test');
+    expect(console.warn).toHaveBeenCalledWith('{"type":"warn","args":["warn","test"]}');
+
+    logger.error('error', 'test');
+    expect(console.error).toHaveBeenCalledWith('{"type":"error","args":["error","test"]}');
+  });
+
+  it('should filter out calls below the given log level', () => {
+    spyOn(console, 'debug');
+    spyOn(console, 'info');
+    spyOn(console, 'warn');
+    spyOn(console, 'error');
+    const logger = new JsonConsoleLogger(LogLevel.warn);
+
+    logger.debug('debug', 'test');
+    expect(console.debug).not.toHaveBeenCalled();
+
+    logger.info('info', 'test');
+    expect(console.info).not.toHaveBeenCalled();
+
+    logger.warn('warn', 'test');
+    expect(console.warn).toHaveBeenCalledWith('{"type":"warn","args":["warn","test"]}');
+
+    logger.error('error', 'test');
+    expect(console.error).toHaveBeenCalledWith('{"type":"error","args":["error","test"]}');
+  });
+
+  it('should encode newlines within args', () => {
+    spyOn(console, 'error');
+    const logger = new JsonConsoleLogger(LogLevel.debug);
+    logger.error('error\ntest');
+    expect(console.error).toHaveBeenCalledWith('{"type":"error","args":["error\\ntest"]}');
+  });
+});


### PR DESCRIPTION
This commit adds a `Logger` that will format messages as JSON
strings before writing them to the console. This should allow tools
to parse the messages if running ngcc in a separate process.

FW-1960

(I have set the target as "master-only" since this is arguably a new public API for ngcc, so I expect it to go into 9.1.0)