### PR TITLE
build: fix integration tests flakes using local yarn cache for bazel-…

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -38,7 +38,7 @@ function installLocalPackages() {
   local_packages+=("puppeteer@file:${pwd}/../node_modules/puppeteer")
   local_packages+=("webdriver-manager@file:${pwd}/../node_modules/webdriver-manager")
 
-  yarn add --ignore-scripts --silent "${local_packages[@]}"
+  yarn add --ignore-scripts --silent "${local_packages[@]}" --cache-folder ./.yarn_local_cache
 }
 
 function patchKarmaConf() {
@@ -58,6 +58,8 @@ function testBazel() {
   # Create project
   ng new demo --collection=@angular/bazel --routing --skip-git --skip-install --style=scss
   cd demo
+  # Use a local yarn cache folder so we don't access the global yarn cache
+  mkdir .yarn_local_cache
   patchKarmaConf
   patchProtractorConf
   installLocalPackages
@@ -79,7 +81,7 @@ function testNonBazel() {
   # disable CLI's version check (if version is 0.0.0, then no version check happens)
   yarn --cwd node_modules/@angular/cli version --new-version 0.0.0 --no-git-tag-version
   # re-add build-angular
-  yarn add --dev file:../node_modules/@angular-devkit/build-angular
+  yarn add --dev file:../node_modules/@angular-devkit/build-angular --cache-folder ./.yarn_local_cache
   ng build --progress=false
   ng test --progress=false --watch=false
   ng e2e --port 0 --configuration=production --webdriver-update=false

--- a/integration/ng_elements_schematics/test.ts
+++ b/integration/ng_elements_schematics/test.ts
@@ -53,11 +53,13 @@ rm('-rf', `demo`);
 exec('ng version');
 exec('ng new demo --skip-git --skip-install --style=css --no-interactive');
 cd('demo');
+// Use a local yarn cache folder so we don't access the global yarn cache
+exec('mkdir .yarn_local_cache');
 
 // Install Angular packages that are built locally from HEAD and npm packages
 // from root node modules that are to be kept in sync
 const packageList = Object.keys(packages).map(p => `${p}@${packages[p]}`).join(' ');
-exec(`yarn add --ignore-scripts --silent ${packageList}`);
+exec(`yarn add --ignore-scripts --silent ${packageList} --cache-folder ./.yarn_local_cache`);
 
 // Add @angular/elements
 exec(bazelMappings ? `ng add "${bazelMappings['@angular/elements']}"` : `ng add "${__dirname}/../../dist/packages-dist/elements"`);


### PR DESCRIPTION
…schematics & ng_elements_schematics demos

ng_update_migrations will still access the global yarn cache on its `ng update` call and there is no way to avoid this that I can see but if no other integration tests access the global yarn cache then that one test can have free reign over it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
