### PR TITLE
refactor(core): misc refactoring to support upcoming changes to improve synthetic host bindings

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -800,7 +800,8 @@ function readCreateOpCodes(
           const attrValue = createOpCodes[++i] as string;
           // This code is used for ICU expressions only, since we don't support
           // directives/components in ICUs, we don't need to worry about inputs here
-          elementAttributeInternal(elementNodeIndex, attrName, attrValue, tView, lView);
+          elementAttributeInternal(
+              getTNode(tView, elementNodeIndex), lView, attrName, attrValue, null, null);
           break;
         default:
           throw new Error(`Unable to determine the type of mutate operation for "${opCode}"`);
@@ -877,7 +878,9 @@ function readUpdateOpCodes(
               case I18nUpdateOpCode.Attr:
                 const propName = updateOpCodes[++j] as string;
                 const sanitizeFn = updateOpCodes[++j] as SanitizerFn | null;
-                elementPropertyInternal(tView, lView, nodeIndex, propName, value, sanitizeFn);
+                elementPropertyInternal(
+                    tView, getTNode(tView, nodeIndex), lView, propName, value, lView[RENDERER],
+                    sanitizeFn, false);
                 break;
               case I18nUpdateOpCode.Text:
                 textBindingInternal(lView, nodeIndex, value);
@@ -1042,7 +1045,7 @@ function i18nAttributesFirstPass(lView: LView, tView: TView, index: number, valu
           // Set attributes for Elements only, for other types (like ElementContainer),
           // only set inputs below
           if (tNode.type === TNodeType.Element) {
-            elementAttributeInternal(previousElementIndex, attrName, value, tView, lView);
+            elementAttributeInternal(tNode, lView, attrName, value, null, null);
           }
           // Check if that attribute is a directive input
           const dataValue = tNode.inputs !== null && tNode.inputs[attrName];

--- a/packages/core/src/render3/instructions/attribute.ts
+++ b/packages/core/src/render3/instructions/attribute.ts
@@ -7,7 +7,7 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
+import {getLView, getSelectedIndex, getSelectedTNode, getTView, nextBindingIndex} from '../state';
 import {elementAttributeInternal, storePropertyBindingMetadata} from './shared';
 
 
@@ -31,10 +31,10 @@ export function ɵɵattribute(
   const lView = getLView();
   const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementAttributeInternal(nodeIndex, name, value, tView, lView, sanitizer, namespace);
-    ngDevMode && storePropertyBindingMetadata(tView.data, nodeIndex, 'attr.' + name, bindingIndex);
+    const tNode = getSelectedTNode();
+    elementAttributeInternal(tNode, lView, name, value, sanitizer || null, namespace || null);
+    ngDevMode && storePropertyBindingMetadata(tView.data, tNode, 'attr.' + name, bindingIndex);
   }
   return ɵɵattribute;
 }

--- a/packages/core/src/render3/instructions/attribute.ts
+++ b/packages/core/src/render3/instructions/attribute.ts
@@ -33,7 +33,7 @@ export function ɵɵattribute(
   if (bindingUpdated(lView, bindingIndex, value)) {
     const tView = getTView();
     const tNode = getSelectedTNode();
-    elementAttributeInternal(tNode, lView, name, value, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, name, value, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(tView.data, tNode, 'attr.' + name, bindingIndex);
   }
   return ɵɵattribute;

--- a/packages/core/src/render3/instructions/attribute_interpolation.ts
+++ b/packages/core/src/render3/instructions/attribute_interpolation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {SanitizerFn} from '../interfaces/sanitization';
-import {getBindingIndex, getLView, getSelectedIndex, getTView} from '../state';
+import {getBindingIndex, getLView, getSelectedTNode, getTView} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
 import {elementAttributeInternal, storePropertyBindingMetadata} from './shared';
@@ -43,13 +43,12 @@ export function ɵɵattributeInterpolate1(
   const lView = getLView();
   const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode &&
         storePropertyBindingMetadata(
-            tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 1, prefix, suffix);
+            getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 1, prefix, suffix);
   }
   return ɵɵattributeInterpolate1;
 }
@@ -86,13 +85,12 @@ export function ɵɵattributeInterpolate2(
   const lView = getLView();
   const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode &&
         storePropertyBindingMetadata(
-            tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 2, prefix, i0, suffix);
+            getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 2, prefix, i0, suffix);
   }
   return ɵɵattributeInterpolate2;
 }
@@ -132,12 +130,11 @@ export function ɵɵattributeInterpolate3(
   const lView = getLView();
   const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 3, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 3, prefix, i0,
                      i1, suffix);
   }
   return ɵɵattributeInterpolate3;
@@ -181,12 +178,11 @@ export function ɵɵattributeInterpolate4(
   const lView = getLView();
   const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 4, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 4, prefix, i0,
                      i1, i2, suffix);
   }
   return ɵɵattributeInterpolate4;
@@ -233,12 +229,11 @@ export function ɵɵattributeInterpolate5(
   const interpolatedValue =
       interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 5, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 5, prefix, i0,
                      i1, i2, i3, suffix);
   }
   return ɵɵattributeInterpolate5;
@@ -287,12 +282,11 @@ export function ɵɵattributeInterpolate6(
   const interpolatedValue =
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 6, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 6, prefix, i0,
                      i1, i2, i3, i4, suffix);
   }
   return ɵɵattributeInterpolate6;
@@ -343,12 +337,11 @@ export function ɵɵattributeInterpolate7(
   const interpolatedValue =
       interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 7, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 7, prefix, i0,
                      i1, i2, i3, i4, i5, suffix);
   }
   return ɵɵattributeInterpolate7;
@@ -401,12 +394,11 @@ export function ɵɵattributeInterpolate8(
   const interpolatedValue = interpolation8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
-    const tView = getTView();
+    const tNode = getSelectedTNode();
     elementAttributeInternal(
-        nodeIndex, attrName, interpolatedValue, tView, lView, sanitizer, namespace);
+        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, 'attr.' + attrName, getBindingIndex() - 8, prefix, i0,
+                     getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 8, prefix, i0,
                      i1, i2, i3, i4, i5, i6, suffix);
   }
   return ɵɵattributeInterpolate8;
@@ -444,16 +436,16 @@ export function ɵɵattributeInterpolateV(
   const lView = getLView();
   const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
-    const tView = getTView();
-    const nodeIndex = getSelectedIndex();
-    elementAttributeInternal(nodeIndex, attrName, interpolated, tView, lView, sanitizer, namespace);
+    const tNode = getSelectedTNode();
+    elementAttributeInternal(
+        tNode, lView, attrName, interpolated, sanitizer || null, namespace || null);
     if (ngDevMode) {
       const interpolationInBetween = [values[0]];  // prefix
       for (let i = 2; i < values.length; i += 2) {
         interpolationInBetween.push(values[i]);
       }
       storePropertyBindingMetadata(
-          tView.data, nodeIndex, 'attr.' + attrName,
+          getTView().data, tNode, 'attr.' + attrName,
           getBindingIndex() - interpolationInBetween.length + 1, ...interpolationInBetween);
     }
   }

--- a/packages/core/src/render3/instructions/attribute_interpolation.ts
+++ b/packages/core/src/render3/instructions/attribute_interpolation.ts
@@ -44,8 +44,7 @@ export function ɵɵattributeInterpolate1(
   const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode &&
         storePropertyBindingMetadata(
             getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 1, prefix, suffix);
@@ -86,8 +85,7 @@ export function ɵɵattributeInterpolate2(
   const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode &&
         storePropertyBindingMetadata(
             getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 2, prefix, i0, suffix);
@@ -131,8 +129,7 @@ export function ɵɵattributeInterpolate3(
   const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 3, prefix, i0,
                      i1, suffix);
@@ -179,8 +176,7 @@ export function ɵɵattributeInterpolate4(
   const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 4, prefix, i0,
                      i1, i2, suffix);
@@ -230,8 +226,7 @@ export function ɵɵattributeInterpolate5(
       interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 5, prefix, i0,
                      i1, i2, i3, suffix);
@@ -283,8 +278,7 @@ export function ɵɵattributeInterpolate6(
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 6, prefix, i0,
                      i1, i2, i3, i4, suffix);
@@ -338,8 +332,7 @@ export function ɵɵattributeInterpolate7(
       interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 7, prefix, i0,
                      i1, i2, i3, i4, i5, suffix);
@@ -395,8 +388,7 @@ export function ɵɵattributeInterpolate8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolatedValue, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolatedValue, sanitizer, namespace);
     ngDevMode && storePropertyBindingMetadata(
                      getTView().data, tNode, 'attr.' + attrName, getBindingIndex() - 8, prefix, i0,
                      i1, i2, i3, i4, i5, i6, suffix);
@@ -437,8 +429,7 @@ export function ɵɵattributeInterpolateV(
   const interpolated = interpolationV(lView, values);
   if (interpolated !== NO_CHANGE) {
     const tNode = getSelectedTNode();
-    elementAttributeInternal(
-        tNode, lView, attrName, interpolated, sanitizer || null, namespace || null);
+    elementAttributeInternal(tNode, lView, attrName, interpolated, sanitizer, namespace);
     if (ngDevMode) {
       const interpolationInBetween = [values[0]];  // prefix
       for (let i = 2; i < values.length; i += 2) {

--- a/packages/core/src/render3/instructions/host_property.ts
+++ b/packages/core/src/render3/instructions/host_property.ts
@@ -34,8 +34,7 @@ export function ɵɵhostProperty<T>(
   if (bindingUpdated(lView, bindingIndex, value)) {
     const tView = getTView();
     const tNode = getSelectedTNode();
-    elementPropertyInternal(
-        tView, tNode, lView, propName, value, lView[RENDERER], sanitizer || null, true);
+    elementPropertyInternal(tView, tNode, lView, propName, value, lView[RENDERER], sanitizer, true);
     ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵhostProperty;
@@ -72,8 +71,7 @@ export function ɵɵupdateSyntheticHostBinding<T>(
     const tView = getTView();
     const tNode = getSelectedTNode();
     const renderer = loadComponentRenderer(tNode, lView);
-    elementPropertyInternal(
-        tView, tNode, lView, propName, value, renderer, sanitizer || null, true);
+    elementPropertyInternal(tView, tNode, lView, propName, value, renderer, sanitizer, true);
     ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵupdateSyntheticHostBinding;

--- a/packages/core/src/render3/instructions/host_property.ts
+++ b/packages/core/src/render3/instructions/host_property.ts
@@ -7,8 +7,10 @@
  */
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
+import {RENDERER} from '../interfaces/view';
+import {getLView, getSelectedTNode, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
+
 import {elementPropertyInternal, loadComponentRenderer, storePropertyBindingMetadata} from './shared';
 
 /**
@@ -30,10 +32,11 @@ export function ɵɵhostProperty<T>(
   const lView = getLView();
   const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, value, sanitizer, true);
-    ngDevMode && storePropertyBindingMetadata(tView.data, nodeIndex, propName, bindingIndex);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, value, lView[RENDERER], sanitizer || null, true);
+    ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵhostProperty;
 }
@@ -66,11 +69,12 @@ export function ɵɵupdateSyntheticHostBinding<T>(
   const lView = getLView();
   const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
+    const tNode = getSelectedTNode();
+    const renderer = loadComponentRenderer(tNode, lView);
     elementPropertyInternal(
-        tView, lView, nodeIndex, propName, value, sanitizer, true, loadComponentRenderer);
-    ngDevMode && storePropertyBindingMetadata(tView.data, nodeIndex, propName, bindingIndex);
+        tView, tNode, lView, propName, value, renderer, sanitizer || null, true);
+    ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵupdateSyntheticHostBinding;
 }

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -42,7 +42,8 @@ export function ɵɵlistener(
   const tView = getTView();
   const tNode = getPreviousOrParentTNode();
   listenerInternal(
-      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, useCapture, eventTargetResolver);
+      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, useCapture,
+      eventTargetResolver || null);
   return ɵɵlistener;
 }
 
@@ -75,7 +76,8 @@ export function ɵɵcomponentHostSyntheticListener(
   const renderer = loadComponentRenderer(tNode, lView);
   const tView = getTView();
   listenerInternal(
-      tView, lView, renderer, tNode, eventName, listenerFn, useCapture, eventTargetResolver);
+      tView, lView, renderer, tNode, eventName, listenerFn, useCapture,
+      eventTargetResolver || null);
   return ɵɵcomponentHostSyntheticListener;
 }
 
@@ -114,7 +116,7 @@ function findExistingListener(
 function listenerInternal(
     tView: TView, lView: LView, renderer: Renderer3, tNode: TNode, eventName: string,
     listenerFn: (e?: any) => any, useCapture = false,
-    eventTargetResolver?: GlobalTargetResolver): void {
+    eventTargetResolver: GlobalTargetResolver | null): void {
   const isTNodeDirectiveHost = isDirectiveHost(tNode);
   const firstCreatePass = tView.firstCreatePass;
   const tCleanup: false|any[] = firstCreatePass && (tView.cleanup || (tView.cleanup = []));
@@ -132,10 +134,10 @@ function listenerInternal(
   // add native event listener - applicable to elements only
   if (tNode.type === TNodeType.Element) {
     const native = getNativeByTNode(tNode, lView) as RElement;
-    const resolved = eventTargetResolver ? eventTargetResolver(native) : EMPTY_OBJ as any;
+    const resolved = eventTargetResolver !== null ? eventTargetResolver(native) : EMPTY_OBJ as any;
     const target = resolved.target || native;
     const lCleanupIndex = lCleanup.length;
-    const idxOrTargetGetter = eventTargetResolver ?
+    const idxOrTargetGetter = eventTargetResolver !== null ?
         (_lView: LView) => eventTargetResolver(unwrapRNode(_lView[tNode.index])).target :
         tNode.index;
 
@@ -159,7 +161,7 @@ function listenerInternal(
       // Also, we don't have to search for existing listeners is there are no directives
       // matching on a given node as we can't register multiple event handlers for the same event in
       // a template (this would mean having duplicate attributes).
-      if (!eventTargetResolver && isTNodeDirectiveHost) {
+      if (eventTargetResolver === null && isTNodeDirectiveHost) {
         existingListener = findExistingListener(tView, lView, eventName, tNode.index);
       }
       if (existingListener !== null) {

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -42,8 +42,7 @@ export function ɵɵlistener(
   const tView = getTView();
   const tNode = getPreviousOrParentTNode();
   listenerInternal(
-      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, useCapture,
-      eventTargetResolver || null);
+      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, useCapture, eventTargetResolver);
   return ɵɵlistener;
 }
 
@@ -76,8 +75,7 @@ export function ɵɵcomponentHostSyntheticListener(
   const renderer = loadComponentRenderer(tNode, lView);
   const tView = getTView();
   listenerInternal(
-      tView, lView, renderer, tNode, eventName, listenerFn, useCapture,
-      eventTargetResolver || null);
+      tView, lView, renderer, tNode, eventName, listenerFn, useCapture, eventTargetResolver);
   return ɵɵcomponentHostSyntheticListener;
 }
 
@@ -116,7 +114,7 @@ function findExistingListener(
 function listenerInternal(
     tView: TView, lView: LView, renderer: Renderer3, tNode: TNode, eventName: string,
     listenerFn: (e?: any) => any, useCapture = false,
-    eventTargetResolver: GlobalTargetResolver | null): void {
+    eventTargetResolver?: GlobalTargetResolver): void {
   const isTNodeDirectiveHost = isDirectiveHost(tNode);
   const firstCreatePass = tView.firstCreatePass;
   const tCleanup: false|any[] = firstCreatePass && (tView.cleanup || (tView.cleanup = []));
@@ -134,10 +132,10 @@ function listenerInternal(
   // add native event listener - applicable to elements only
   if (tNode.type === TNodeType.Element) {
     const native = getNativeByTNode(tNode, lView) as RElement;
-    const resolved = eventTargetResolver !== null ? eventTargetResolver(native) : EMPTY_OBJ as any;
+    const resolved = eventTargetResolver ? eventTargetResolver(native) : EMPTY_OBJ as any;
     const target = resolved.target || native;
     const lCleanupIndex = lCleanup.length;
-    const idxOrTargetGetter = eventTargetResolver !== null ?
+    const idxOrTargetGetter = eventTargetResolver ?
         (_lView: LView) => eventTargetResolver(unwrapRNode(_lView[tNode.index])).target :
         tNode.index;
 
@@ -161,7 +159,7 @@ function listenerInternal(
       // Also, we don't have to search for existing listeners is there are no directives
       // matching on a given node as we can't register multiple event handlers for the same event in
       // a template (this would mean having duplicate attributes).
-      if (eventTargetResolver === null && isTNodeDirectiveHost) {
+      if (!eventTargetResolver && isTNodeDirectiveHost) {
         existingListener = findExistingListener(tView, lView, eventName, tNode.index);
       }
       if (existingListener !== null) {

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -8,8 +8,9 @@
 import {bindingUpdated} from '../bindings';
 import {TNode} from '../interfaces/node';
 import {SanitizerFn} from '../interfaces/sanitization';
-import {LView, TView} from '../interfaces/view';
-import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
+import {LView, RENDERER, TView} from '../interfaces/view';
+import {getLView, getSelectedTNode, getTView, nextBindingIndex} from '../state';
+
 import {elementPropertyInternal, setInputsForProperty, storePropertyBindingMetadata} from './shared';
 
 
@@ -36,10 +37,11 @@ export function ɵɵproperty<T>(
   const lView = getLView();
   const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, value)) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, value, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(tView.data, nodeIndex, propName, bindingIndex);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, value, lView[RENDERER], sanitizer || null, false);
+    ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵproperty;
 }

--- a/packages/core/src/render3/instructions/property.ts
+++ b/packages/core/src/render3/instructions/property.ts
@@ -40,7 +40,7 @@ export function ɵɵproperty<T>(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, value, lView[RENDERER], sanitizer || null, false);
+        tView, tNode, lView, propName, value, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(tView.data, tNode, propName, bindingIndex);
   }
   return ɵɵproperty;

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -87,8 +87,7 @@ export function ɵɵpropertyInterpolate1(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(
                      tView.data, tNode, propName, getBindingIndex() - 1, prefix, suffix);
   }
@@ -134,8 +133,7 @@ export function ɵɵpropertyInterpolate2(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(
                      tView.data, tNode, propName, getBindingIndex() - 2, prefix, i0, suffix);
   }
@@ -184,8 +182,7 @@ export function ɵɵpropertyInterpolate3(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(
                      tView.data, tNode, propName, getBindingIndex() - 3, prefix, i0, i1, suffix);
   }
@@ -236,8 +233,7 @@ export function ɵɵpropertyInterpolate4(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode &&
         storePropertyBindingMetadata(
             tView.data, tNode, propName, getBindingIndex() - 4, prefix, i0, i1, i2, suffix);
@@ -293,8 +289,7 @@ export function ɵɵpropertyInterpolate5(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode &&
         storePropertyBindingMetadata(
             tView.data, tNode, propName, getBindingIndex() - 5, prefix, i0, i1, i2, i3, suffix);
@@ -352,8 +347,7 @@ export function ɵɵpropertyInterpolate6(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode &&
         storePropertyBindingMetadata(
             tView.data, tNode, propName, getBindingIndex() - 6, prefix, i0, i1, i2, i3, i4, suffix);
@@ -413,8 +407,7 @@ export function ɵɵpropertyInterpolate7(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(
                      tView.data, tNode, propName, getBindingIndex() - 7, prefix, i0, i1, i2, i3, i4,
                      i5, suffix);
@@ -476,8 +469,7 @@ export function ɵɵpropertyInterpolate8(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     ngDevMode && storePropertyBindingMetadata(
                      tView.data, tNode, propName, getBindingIndex() - 8, prefix, i0, i1, i2, i3, i4,
                      i5, i6, suffix);
@@ -523,8 +515,7 @@ export function ɵɵpropertyInterpolateV(
     const tView = getTView();
     const tNode = getSelectedTNode();
     elementPropertyInternal(
-        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
-        false);
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer, false);
     if (ngDevMode) {
       const interpolationInBetween = [values[0]];  // prefix
       for (let i = 2; i < values.length; i += 2) {

--- a/packages/core/src/render3/instructions/property_interpolation.ts
+++ b/packages/core/src/render3/instructions/property_interpolation.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {SanitizerFn} from '../interfaces/sanitization';
-import {getBindingIndex, getLView, getSelectedIndex, getTView} from '../state';
+import {RENDERER} from '../interfaces/view';
+import {getBindingIndex, getLView, getSelectedTNode, getTView} from '../state';
 import {NO_CHANGE} from '../tokens';
+
 import {interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV} from './interpolation';
 import {elementPropertyInternal, storePropertyBindingMetadata} from './shared';
 
@@ -82,11 +84,13 @@ export function ɵɵpropertyInterpolate1(
   const lView = getLView();
   const interpolatedValue = interpolation1(lView, prefix, v0, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, propName, getBindingIndex() - 1, prefix, suffix);
+                     tView.data, tNode, propName, getBindingIndex() - 1, prefix, suffix);
   }
   return ɵɵpropertyInterpolate1;
 }
@@ -127,11 +131,13 @@ export function ɵɵpropertyInterpolate2(
   const lView = getLView();
   const interpolatedValue = interpolation2(lView, prefix, v0, i0, v1, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, propName, getBindingIndex() - 2, prefix, i0, suffix);
+                     tView.data, tNode, propName, getBindingIndex() - 2, prefix, i0, suffix);
   }
   return ɵɵpropertyInterpolate2;
 }
@@ -175,12 +181,13 @@ export function ɵɵpropertyInterpolate3(
   const lView = getLView();
   const interpolatedValue = interpolation3(lView, prefix, v0, i0, v1, i1, v2, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode &&
-        storePropertyBindingMetadata(
-            tView.data, nodeIndex, propName, getBindingIndex() - 3, prefix, i0, i1, suffix);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
+    ngDevMode && storePropertyBindingMetadata(
+                     tView.data, tNode, propName, getBindingIndex() - 3, prefix, i0, i1, suffix);
   }
   return ɵɵpropertyInterpolate3;
 }
@@ -226,12 +233,14 @@ export function ɵɵpropertyInterpolate4(
   const lView = getLView();
   const interpolatedValue = interpolation4(lView, prefix, v0, i0, v1, i1, v2, i2, v3, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode &&
         storePropertyBindingMetadata(
-            tView.data, nodeIndex, propName, getBindingIndex() - 4, prefix, i0, i1, i2, suffix);
+            tView.data, tNode, propName, getBindingIndex() - 4, prefix, i0, i1, i2, suffix);
   }
   return ɵɵpropertyInterpolate4;
 }
@@ -281,12 +290,14 @@ export function ɵɵpropertyInterpolate5(
   const interpolatedValue =
       interpolation5(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode &&
         storePropertyBindingMetadata(
-            tView.data, nodeIndex, propName, getBindingIndex() - 5, prefix, i0, i1, i2, i3, suffix);
+            tView.data, tNode, propName, getBindingIndex() - 5, prefix, i0, i1, i2, i3, suffix);
   }
   return ɵɵpropertyInterpolate5;
 }
@@ -338,12 +349,14 @@ export function ɵɵpropertyInterpolate6(
   const interpolatedValue =
       interpolation6(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
-    ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, propName, getBindingIndex() - 6, prefix, i0, i1, i2, i3,
-                     i4, suffix);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
+    ngDevMode &&
+        storePropertyBindingMetadata(
+            tView.data, tNode, propName, getBindingIndex() - 6, prefix, i0, i1, i2, i3, i4, suffix);
   }
   return ɵɵpropertyInterpolate6;
 }
@@ -397,12 +410,14 @@ export function ɵɵpropertyInterpolate7(
   const interpolatedValue =
       interpolation7(lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, propName, getBindingIndex() - 7, prefix, i0, i1, i2, i3,
-                     i4, i5, suffix);
+                     tView.data, tNode, propName, getBindingIndex() - 7, prefix, i0, i1, i2, i3, i4,
+                     i5, suffix);
   }
   return ɵɵpropertyInterpolate7;
 }
@@ -458,12 +473,14 @@ export function ɵɵpropertyInterpolate8(
   const interpolatedValue = interpolation8(
       lView, prefix, v0, i0, v1, i1, v2, i2, v3, i3, v4, i4, v5, i5, v6, i6, v7, suffix);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     ngDevMode && storePropertyBindingMetadata(
-                     tView.data, nodeIndex, propName, getBindingIndex() - 8, prefix, i0, i1, i2, i3,
-                     i4, i5, i6, suffix);
+                     tView.data, tNode, propName, getBindingIndex() - 8, prefix, i0, i1, i2, i3, i4,
+                     i5, i6, suffix);
   }
   return ɵɵpropertyInterpolate8;
 }
@@ -503,16 +520,18 @@ export function ɵɵpropertyInterpolateV(
   const lView = getLView();
   const interpolatedValue = interpolationV(lView, values);
   if (interpolatedValue !== NO_CHANGE) {
-    const nodeIndex = getSelectedIndex();
     const tView = getTView();
-    elementPropertyInternal(tView, lView, nodeIndex, propName, interpolatedValue, sanitizer);
+    const tNode = getSelectedTNode();
+    elementPropertyInternal(
+        tView, tNode, lView, propName, interpolatedValue, lView[RENDERER], sanitizer || null,
+        false);
     if (ngDevMode) {
       const interpolationInBetween = [values[0]];  // prefix
       for (let i = 2; i < values.length; i += 2) {
         interpolationInBetween.push(values[i]);
       }
       storePropertyBindingMetadata(
-          tView.data, nodeIndex, propName, getBindingIndex() - interpolationInBetween.length + 1,
+          tView.data, tNode, propName, getBindingIndex() - interpolationInBetween.length + 1,
           ...interpolationInBetween);
     }
   }

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -941,17 +941,15 @@ function mapPropName(name: string): string {
 }
 
 export function elementPropertyInternal<T>(
-    tView: TView, lView: LView, index: number, propName: string, value: T,
-    sanitizer?: SanitizerFn | null, nativeOnly?: boolean,
-    loadRendererFn?: ((tNode: TNode, lView: LView) => Renderer3) | null): void {
+    tView: TView, tNode: TNode, lView: LView, propName: string, value: T, renderer: Renderer3,
+    sanitizer: SanitizerFn | null, nativeOnly: boolean): void {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
-  const element = getNativeByIndex(index, lView) as RElement | RComment;
-  const tNode = getTNode(tView, index);
+  const element = getNativeByTNode(tNode, lView) as RElement | RComment;
   let inputData = tNode.inputs;
   let dataValue: PropertyAliasValue|undefined;
   if (!nativeOnly && inputData != null && (dataValue = inputData[propName])) {
     setInputsForProperty(tView, lView, dataValue, propName, value);
-    if (isComponentHost(tNode)) markDirtyIfOnPush(lView, index + HEADER_OFFSET);
+    if (isComponentHost(tNode)) markDirtyIfOnPush(lView, tNode.index);
     if (ngDevMode) {
       setNgReflectProperties(lView, element, tNode.type, dataValue, value);
     }
@@ -968,10 +966,9 @@ export function elementPropertyInternal<T>(
       ngDevMode.rendererSetProperty++;
     }
 
-    const renderer = loadRendererFn ? loadRendererFn(tNode, lView) : lView[RENDERER];
     // It is assumed that the sanitizer is only added when the compiler determines that the
     // property is risky, so sanitization can be done without further checks.
-    value = sanitizer != null ? (sanitizer(value, tNode.tagName || '', propName) as any) : value;
+    value = sanitizer !== null ? (sanitizer(value, tNode.tagName || '', propName) as any) : value;
     if (isProceduralRenderer(renderer)) {
       renderer.setProperty(element as RElement, propName, value);
     } else if (!isAnimationProp(propName)) {
@@ -1438,11 +1435,11 @@ function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: Compon
 }
 
 export function elementAttributeInternal(
-    index: number, name: string, value: any, tView: TView, lView: LView,
-    sanitizer?: SanitizerFn | null, namespace?: string) {
+    tNode: TNode, lView: LView, name: string, value: any, sanitizer: SanitizerFn | null,
+    namespace: string | null) {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
   ngDevMode && validateAgainstEventAttributes(name);
-  const element = getNativeByIndex(index, lView) as RElement;
+  const element = getNativeByTNode(tNode, lView) as RElement;
   const renderer = lView[RENDERER];
   if (value == null) {
     ngDevMode && ngDevMode.rendererRemoveAttribute++;
@@ -1450,9 +1447,8 @@ export function elementAttributeInternal(
                                      element.removeAttribute(name);
   } else {
     ngDevMode && ngDevMode.rendererSetAttribute++;
-    const tNode = getTNode(tView, index);
     const strValue =
-        sanitizer == null ? renderStringify(value) : sanitizer(value, tNode.tagName || '', name);
+        sanitizer === null ? renderStringify(value) : sanitizer(value, tNode.tagName || '', name);
 
 
     if (isProceduralRenderer(renderer)) {
@@ -1892,19 +1888,18 @@ function executeViewQueryFn<T>(
  * interpolated properties.
  *
  * @param tData `TData` where meta-data will be saved;
- * @param nodeIndex index of a `TNode` that is a target of the binding;
+ * @param tNode `TNode` that is a target of the binding;
  * @param propertyName bound property name;
  * @param bindingIndex binding index in `LView`
  * @param interpolationParts static interpolation parts (for property interpolations)
  */
 export function storePropertyBindingMetadata(
-    tData: TData, nodeIndex: number, propertyName: string, bindingIndex: number,
+    tData: TData, tNode: TNode, propertyName: string, bindingIndex: number,
     ...interpolationParts: string[]) {
   // Binding meta-data are stored only the first time a given property instruction is processed.
   // Since we don't have a concept of the "first update pass" we need to check for presence of the
   // binding meta-data to decide if one should be stored (or if was stored already).
   if (tData[bindingIndex] === null) {
-    const tNode = tData[nodeIndex + HEADER_OFFSET] as TNode;
     if (tNode.inputs == null || !tNode.inputs[propertyName]) {
       const propBindingIdxs = tNode.propertyBindings || (tNode.propertyBindings = []);
       propBindingIdxs.push(bindingIndex);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -942,7 +942,7 @@ function mapPropName(name: string): string {
 
 export function elementPropertyInternal<T>(
     tView: TView, tNode: TNode, lView: LView, propName: string, value: T, renderer: Renderer3,
-    sanitizer: SanitizerFn | null, nativeOnly: boolean): void {
+    sanitizer?: SanitizerFn | null, nativeOnly?: boolean): void {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
   const element = getNativeByTNode(tNode, lView) as RElement | RComment;
   let inputData = tNode.inputs;
@@ -968,7 +968,7 @@ export function elementPropertyInternal<T>(
 
     // It is assumed that the sanitizer is only added when the compiler determines that the
     // property is risky, so sanitization can be done without further checks.
-    value = sanitizer !== null ? (sanitizer(value, tNode.tagName || '', propName) as any) : value;
+    value = sanitizer != null ? (sanitizer(value, tNode.tagName || '', propName) as any) : value;
     if (isProceduralRenderer(renderer)) {
       renderer.setProperty(element as RElement, propName, value);
     } else if (!isAnimationProp(propName)) {
@@ -1435,8 +1435,8 @@ function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: Compon
 }
 
 export function elementAttributeInternal(
-    tNode: TNode, lView: LView, name: string, value: any, sanitizer: SanitizerFn | null,
-    namespace: string | null) {
+    tNode: TNode, lView: LView, name: string, value: any, sanitizer?: SanitizerFn | null,
+    namespace?: string | null) {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
   ngDevMode && validateAgainstEventAttributes(name);
   const element = getNativeByTNode(tNode, lView) as RElement;
@@ -1448,7 +1448,7 @@ export function elementAttributeInternal(
   } else {
     ngDevMode && ngDevMode.rendererSetAttribute++;
     const strValue =
-        sanitizer === null ? renderStringify(value) : sanitizer(value, tNode.tagName || '', name);
+        sanitizer == null ? renderStringify(value) : sanitizer(value, tNode.tagName || '', name);
 
 
     if (isProceduralRenderer(renderer)) {

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -942,7 +942,7 @@ function mapPropName(name: string): string {
 
 export function elementPropertyInternal<T>(
     tView: TView, tNode: TNode, lView: LView, propName: string, value: T, renderer: Renderer3,
-    sanitizer?: SanitizerFn | null, nativeOnly?: boolean): void {
+    sanitizer: SanitizerFn | null | undefined, nativeOnly: boolean): void {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
   const element = getNativeByTNode(tNode, lView) as RElement | RComment;
   let inputData = tNode.inputs;
@@ -1435,8 +1435,8 @@ function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: Compon
 }
 
 export function elementAttributeInternal(
-    tNode: TNode, lView: LView, name: string, value: any, sanitizer?: SanitizerFn | null,
-    namespace?: string | null) {
+    tNode: TNode, lView: LView, name: string, value: any, sanitizer: SanitizerFn | null | undefined,
+    namespace: string | null | undefined) {
   ngDevMode && assertNotSame(value, NO_CHANGE as any, 'Incoming value should never be NO_CHANGE.');
   ngDevMode && validateAgainstEventAttributes(name);
   const element = getNativeByTNode(tNode, lView) as RElement;

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -8,7 +8,6 @@
 
 import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 import {assertDefined, assertEqual} from '../util/assert';
-
 import {assertLViewOrUndefined} from './assert';
 import {TNode} from './interfaces/node';
 import {CONTEXT, DECLARATION_VIEW, LView, OpaqueViewState, TVIEW, TView} from './interfaces/view';

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -538,7 +538,8 @@ export function setSelectedIndex(index: number) {
  * Gets the `tNode` that represents currently selected element.
  */
 export function getSelectedTNode() {
-  return getTNode(instructionState.lFrame.tView, instructionState.lFrame.selectedIndex);
+  const lFrame = instructionState.lFrame;
+  return getTNode(lFrame.tView, lFrame.selectedIndex);
 }
 
 /**

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -8,10 +8,12 @@
 
 import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 import {assertDefined, assertEqual} from '../util/assert';
+
 import {assertLViewOrUndefined} from './assert';
 import {TNode} from './interfaces/node';
 import {CONTEXT, DECLARATION_VIEW, LView, OpaqueViewState, TVIEW, TView} from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
+import {getTNode} from './util/view_utils';
 
 
 /**
@@ -532,6 +534,12 @@ export function setSelectedIndex(index: number) {
   instructionState.lFrame.selectedIndex = index;
 }
 
+/**
+ * Gets the `tNode` that represents currently selected element.
+ */
+export function getSelectedTNode() {
+  return getTNode(instructionState.lFrame.tView, instructionState.lFrame.selectedIndex);
+}
 
 /**
  * Sets the namespace used to create elements to `'http://www.w3.org/2000/svg'` in global state.

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -192,6 +192,9 @@
     "name": "newArray"
   },
   {
+    "name": "noSideEffects"
+  },
+  {
     "name": "providerToFactory"
   },
   {
@@ -223,8 +226,5 @@
   },
   {
     "name": "ɵɵinject"
-  },
-  {
-    "name": "noSideEffects"
   }
 ]

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -708,6 +708,9 @@
     "name": "getSelectedIndex"
   },
   {
+    "name": "getSelectedTNode"
+  },
+  {
     "name": "getSymbolIterator"
   },
   {


### PR DESCRIPTION
This commit performs a few updates to internal functions that would be required in upcoming changes to support synthetic host bindings in Directives.

* the `elementPropertyInternal` function was refactored to accept renderer as an argument (prior to that, there was a function that loads the renderer in some specific way for animation bindings)
* `elementPropertyInternal`, `elementAttributeInternal` and `listenerInternal` functions were updated to have a fixed set of arguments (for better performance)
* `elementPropertyInternal` and `elementAttributeInternal` functions were updated to take `tNode` as an argument instead of passing node index (that was used to retrieve `tNode` internally), in some cases we already have `tNode` available or we can retrieve it from the state

The refactoring was triggered by the need to pass different renderers to the `elementPropertyInternal` to support synthetic host bindings in Directives (see this comment for additional context: https://github.com/angular/angular/pull/35568/files#r388034584).


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No