### PR TITLE
refactor(compiler): rename _ParseAST.optionalCharacter TemplateBinding.expression

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -286,7 +286,7 @@ export class ASTWithSource extends AST {
 export class TemplateBinding {
   constructor(
       public span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public key: string,
-      public keyIsVar: boolean, public name: string, public expression: ASTWithSource|null) {}
+      public keyIsVar: boolean, public name: string, public value: ASTWithSource|null) {}
 }
 
 export interface AstVisitor {

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -134,10 +134,9 @@ export class BindingParser {
       const binding = bindings[i];
       if (binding.keyIsVar) {
         targetVars.push(new ParsedVariable(binding.key, binding.name, sourceSpan));
-      } else if (binding.expression) {
+      } else if (binding.value) {
         this._parsePropertyAst(
-            binding.key, binding.expression, sourceSpan, undefined, targetMatchableAttrs,
-            targetProps);
+            binding.key, binding.value, sourceSpan, undefined, targetMatchableAttrs, targetProps);
       } else {
         targetMatchableAttrs.push([binding.key, '']);
         this.parseLiteralAttr(
@@ -165,8 +164,8 @@ export class BindingParser {
           this._exprParser.parseTemplateBindings(tplKey, tplValue, sourceInfo, absoluteValueOffset);
       this._reportExpressionParserErrors(bindingsResult.errors, sourceSpan);
       bindingsResult.templateBindings.forEach((binding) => {
-        if (binding.expression) {
-          this._checkPipes(binding.expression, sourceSpan);
+        if (binding.value) {
+          this._checkPipes(binding.value, sourceSpan);
         }
       });
       bindingsResult.warnings.forEach(

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -248,14 +248,16 @@ describe('parser', () => {
 
   describe('parseTemplateBindings', () => {
 
-    function keys(templateBindings: any[]) { return templateBindings.map(binding => binding.key); }
+    function keys(templateBindings: TemplateBinding[]) {
+      return templateBindings.map(binding => binding.key);
+    }
 
-    function keyValues(templateBindings: any[]) {
+    function keyValues(templateBindings: TemplateBinding[]) {
       return templateBindings.map(binding => {
         if (binding.keyIsVar) {
           return 'let ' + binding.key + (binding.name == null ? '=null' : '=' + binding.name);
         } else {
-          return binding.key + (binding.expression == null ? '' : `=${binding.expression}`);
+          return binding.key + (binding.value == null ? '' : `=${binding.value}`);
         }
       });
     }
@@ -265,14 +267,13 @@ describe('parser', () => {
           binding => source.substring(binding.span.start, binding.span.end));
     }
 
-    function exprSources(templateBindings: any[]) {
-      return templateBindings.map(
-          binding => binding.expression != null ? binding.expression.source : null);
+    function exprSources(templateBindings: TemplateBinding[]) {
+      return templateBindings.map(binding => binding.value != null ? binding.value.source : null);
     }
 
     function humanize(bindings: TemplateBinding[]): Array<[string, string | null, boolean]> {
       return bindings.map(binding => {
-        const {key, expression, name, keyIsVar} = binding;
+        const {key, value: expression, name, keyIsVar} = binding;
         const value = keyIsVar ? name : (expression ? expression.source : expression);
         return [key, value, keyIsVar];
       });
@@ -316,13 +317,13 @@ describe('parser', () => {
 
     it('should store the sources in the result', () => {
       const bindings = parseTemplateBindings('a', '1,b 2');
-      expect(bindings[0].expression !.source).toEqual('1');
-      expect(bindings[1].expression !.source).toEqual('2');
+      expect(bindings[0].value !.source).toEqual('1');
+      expect(bindings[1].value !.source).toEqual('2');
     });
 
     it('should store the passed-in location', () => {
       const bindings = parseTemplateBindings('a', '1,b 2', 'location');
-      expect(bindings[0].expression !.location).toEqual('location');
+      expect(bindings[0].value !.location).toEqual('location');
     });
 
     it('should support common usage of ngIf', () => {
@@ -415,7 +416,7 @@ describe('parser', () => {
 
     it('should parse pipes', () => {
       const bindings = parseTemplateBindings('key', 'value|pipe');
-      const ast = bindings[0].expression !.ast;
+      const ast = bindings[0].value !.ast;
       expect(ast).toBeAnInstanceOf(BindingPipe);
     });
 

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -567,8 +567,8 @@ class ExpressionVisitor extends NullTemplateVisitor {
       }
     }
 
-    if (binding.expression && inSpan(valueRelativePosition, binding.expression.ast.span)) {
-      this.processExpressionCompletions(binding.expression.ast);
+    if (binding.value && inSpan(valueRelativePosition, binding.value.ast.span)) {
+      this.processExpressionCompletions(binding.value.ast);
       return;
     }
 

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -209,10 +209,10 @@ function getSymbolInMicrosyntax(info: AstResult, path: TemplateAstPath, attribut
 
   // Find the symbol that contains the position.
   templateBindings.filter(tb => !tb.keyIsVar).forEach(tb => {
-    if (inSpan(valueRelativePosition, tb.expression?.ast.span)) {
+    if (inSpan(valueRelativePosition, tb.value?.ast.span)) {
       const dinfo = diagnosticInfoFromTemplateInfo(info);
       const scope = getExpressionScope(dinfo, path);
-      result = getExpressionSymbol(scope, tb.expression !, path.position, info.template.query);
+      result = getExpressionSymbol(scope, tb.value !, path.position, info.template.query);
     } else if (inSpan(valueRelativePosition, tb.span)) {
       const template = path.first(EmbeddedTemplateAst);
       if (template) {


### PR DESCRIPTION
This commit renames
1. _ParseAST.optionalCharacter -> consumeOptionalCharacter
2. TemplateBinding.expression -> value

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
