### PR TITLE
feat(compiler): type TemplateAst values as ASTWithSource

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -691,7 +691,7 @@ export class ParsedEvent {
   // Animation events have a phase
   constructor(
       public name: string, public targetOrPhase: string, public type: ParsedEventType,
-      public handler: AST, public sourceSpan: ParseSourceSpan,
+      public handler: ASTWithSource, public sourceSpan: ParseSourceSpan,
       public handlerSpan: ParseSourceSpan) {}
 }
 
@@ -715,6 +715,6 @@ export const enum BindingType {
 export class BoundElementProperty {
   constructor(
       public name: string, public type: BindingType, public securityContext: SecurityContext,
-      public value: AST, public unit: string|null, public sourceSpan: ParseSourceSpan,
+      public value: ASTWithSource, public unit: string|null, public sourceSpan: ParseSourceSpan,
       public valueSpan?: ParseSourceSpan) {}
 }

--- a/packages/compiler/src/template_parser/template_ast.ts
+++ b/packages/compiler/src/template_parser/template_ast.ts
@@ -9,7 +9,7 @@
 import {AstPath} from '../ast_path';
 import {CompileDirectiveSummary, CompileProviderMetadata, CompileTokenMetadata} from '../compile_metadata';
 import {SecurityContext} from '../core';
-import {AST, BindingType, BoundElementProperty, ParsedEvent, ParsedEventType, ParsedVariable} from '../expression_parser/ast';
+import {ASTWithSource, BindingType, BoundElementProperty, ParsedEvent, ParsedEventType, ParsedVariable} from '../expression_parser/ast';
 import {LifecycleHooks} from '../lifecycle_reflector';
 import {ParseSourceSpan} from '../parse_util';
 
@@ -44,7 +44,8 @@ export class TextAst implements TemplateAst {
  */
 export class BoundTextAst implements TemplateAst {
   constructor(
-      public value: AST, public ngContentIndex: number, public sourceSpan: ParseSourceSpan) {}
+      public value: ASTWithSource, public ngContentIndex: number,
+      public sourceSpan: ParseSourceSpan) {}
   visit(visitor: TemplateAstVisitor, context: any): any {
     return visitor.visitBoundText(this, context);
   }
@@ -88,8 +89,8 @@ export class BoundElementPropertyAst implements TemplateAst {
 
   constructor(
       public name: string, public type: PropertyBindingType,
-      public securityContext: SecurityContext, public value: AST, public unit: string|null,
-      public sourceSpan: ParseSourceSpan) {
+      public securityContext: SecurityContext, public value: ASTWithSource,
+      public unit: string|null, public sourceSpan: ParseSourceSpan) {
     this.isAnimation = this.type === PropertyBindingType.Animation;
   }
 
@@ -114,7 +115,7 @@ export class BoundEventAst implements TemplateAst {
 
   constructor(
       public name: string, public target: string|null, public phase: string|null,
-      public handler: AST, public sourceSpan: ParseSourceSpan,
+      public handler: ASTWithSource, public sourceSpan: ParseSourceSpan,
       public handlerSpan: ParseSourceSpan) {
     this.fullName = BoundEventAst.calcFullName(this.name, this.target, this.phase);
     this.isAnimation = !!this.phase;
@@ -209,7 +210,7 @@ export class EmbeddedTemplateAst implements TemplateAst {
  */
 export class BoundDirectivePropertyAst implements TemplateAst {
   constructor(
-      public directiveName: string, public templateName: string, public value: AST,
+      public directiveName: string, public templateName: string, public value: ASTWithSource,
       public sourceSpan: ParseSourceSpan) {}
   visit(visitor: TemplateAstVisitor, context: any): any {
     return visitor.visitDirectiveProperty(this, context);
@@ -350,7 +351,7 @@ export class RecursiveTemplateAstVisitor extends NullTemplateVisitor implements 
     });
   }
 
-  protected visitChildren<T extends TemplateAst>(
+  protected visitChildren(
       context: any,
       cb: (visit: (<V extends TemplateAst>(children: V[]|undefined) => void)) => void) {
     let results: any[][] = [];

--- a/packages/compiler/src/view_compiler/type_check_compiler.ts
+++ b/packages/compiler/src/view_compiler/type_check_compiler.ts
@@ -9,14 +9,12 @@
 import {AotCompilerOptions} from '../aot/compiler_options';
 import {StaticReflector} from '../aot/static_reflector';
 import {StaticSymbol} from '../aot/static_symbol';
-import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompilePipeSummary} from '../compile_metadata';
-import {BindingForm, BuiltinConverter, EventHandlerVars, LocalResolver, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins} from '../compiler_util/expression_converter';
+import {CompileDirectiveMetadata, CompilePipeSummary} from '../compile_metadata';
+import {BindingForm, EventHandlerVars, LocalResolver, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins} from '../compiler_util/expression_converter';
 import {AST, ASTWithSource, Interpolation} from '../expression_parser/ast';
-import {Identifiers} from '../identifiers';
 import * as o from '../output/output_ast';
-import {convertValueToOutputAst} from '../output/value_util';
 import {ParseSourceSpan} from '../parse_util';
-import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAst, ProviderAstType, QueryMatch, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '../template_parser/template_ast';
+import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '../template_parser/template_ast';
 import {OutputContext} from '../util';
 
 
@@ -133,7 +131,11 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
           result.push({
             guard,
             useIf,
-            expression: {context: this.component, value: input.value} as Expression
+            expression: {
+              context: this.component,
+              value: input.value,
+              sourceSpan: input.sourceSpan,
+            },
           });
         }
       }


### PR DESCRIPTION
TemplateAst values are currently typed as the base class AST, but they
are actually constructed with ASTWithSource. Type them as such, because
ASTWithSource gives more information about the consumed expression AST
to downstream customers (namely, the expression AST source).

Unblocks #35271

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
  - N/A
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
