### PR TITLE
fix(language-service): resolve the real path for symlink

### DIFF
--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -19,12 +19,17 @@ class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost, Me
   });
 
   readonly directoryExists?: (directoryName: string) => boolean;
+  // Resolve a symbolic link.
+  realpath?: (path: string) => string;
 
   constructor(
       private readonly tsLSHost: ts.LanguageServiceHost,
       private readonly getProgram: () => ts.Program) {
     if (tsLSHost.directoryExists) {
       this.directoryExists = directoryName => tsLSHost.directoryExists !(directoryName);
+    }
+    if (tsLSHost.realpath) {
+      this.realpath = path => tsLSHost.realpath !(path);
     }
   }
 


### PR DESCRIPTION
when AOT resolves the module name, it will preserve the path of the symlink (because of no `host.realpath`), but the ts-server will return the real path for symlink(https://github.com/angular/vscode-ng-language-service/blob/9120631a10fc9d49b4dd16c9976cc4222b98f3ff/server/src/server_host.ts#L132).

I don't know if it needs a test case.

fixed: https://github.com/angular/vscode-ng-language-service/issues/657

https://github.com/microsoft/TypeScript/blob/6769313eee2f2403387ea935a4fef4dfddae7671/src/compiler/moduleNameResolver.ts#L951

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
