### PR TITLE
feat(compiler): Add sourceSpan and keySpan to TemplateBinding

### DIFF
--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -310,9 +310,7 @@ describe('definitions', () => {
     });
 
     it('should be able to find the directive property', () => {
-      mockHost.override(
-          TEST_TEMPLATE,
-          `<div *ngFor="let item of heroes; ~{start-my}«trackBy»: test~{end-my};"></div>`);
+      mockHost.override(TEST_TEMPLATE, `<div *ngFor="let item of heroes; «trackBy»: test;"></div>`);
 
       // Get the marker for trackBy in the code added above.
       const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'trackBy');
@@ -322,8 +320,7 @@ describe('definitions', () => {
       const {textSpan, definitions} = result !;
 
       // Get the marker for bounded text in the code added above
-      const boundedText = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'my');
-      expect(textSpan).toEqual(boundedText);
+      expect(textSpan).toEqual(marker);
 
       expect(definitions).toBeDefined();
       // The two definitions are setter and getter of 'ngForTrackBy'.

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -118,9 +118,8 @@ describe('hover', () => {
     });
 
     it('should work for structural directive inputs', () => {
-      mockHost.override(
-          TEST_TEMPLATE, `<div *ngFor="let item of heroes; «ᐱtrackByᐱ: test»;"></div>`);
-      const marker = mockHost.getDefinitionMarkerFor(TEST_TEMPLATE, 'trackBy');
+      mockHost.override(TEST_TEMPLATE, `<div *ngFor="let item of heroes; «trackBy»: test;"></div>`);
+      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'trackBy');
       const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
       expect(quickInfo).toBeTruthy();
       const {textSpan, displayParts} = quickInfo !;


### PR DESCRIPTION
This commit adds fine-grained text spans to TemplateBinding for microsyntax expressions.

1. Source span
   By convention, source span refers to the entire span of the binding,
   including its key and value.
2. Key span
   Span of the binding key, without any whitespace or keywords like `let`
3. Value span
   The value span is captured by the value expression AST.

These spans are primarily needed by the language service to provide precise autocomplete
suggestions and quick hover info at particular position.

The tests for microsyntax expressions are totally overhauled for better coverage, conciseness, and organization.

This is part of a series of PRs to fix source span mapping in microsyntax expression.
For more info, please see the design doc https://docs.google.com/document/d/1mEVF2pSSMSnOloqOPQTYNiAJO0XQxA1H0BZyESASOrE/edit?usp=sharing

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
