### PR TITLE
docs: move ngIndia 2020 to past events on events page

### DIFF
--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -13,12 +13,6 @@
       </tr>
     </thead>
     <tbody>
-      <!-- ngIndia 2020 -->
-      <tr>
-        <th><a href="https://www.ng-ind.com/" title="ngIndia">ngIndia</a></th>
-        <td>Delhi, India</td>
-        <td>Feb 29, 2020</td>
-      </tr>
       <!-- ng-conf 2020 -->
       <tr>
         <th><a href="https://ng-conf.org/" title="ng-conf">ng-conf</a></th>
@@ -38,6 +32,12 @@
       </tr>
     </thead>
     <tbody>
+      <!-- ngIndia 2020 -->
+      <tr>
+        <th><a href="https://www.ng-ind.com/" title="ngIndia">ngIndia</a></th>
+        <td>Delhi, India</td>
+        <td>Feb 29, 2020</td>
+      </tr>
       <!-- ReactiveConf 2019 -->
       <tr>
         <th><a href="https://reactiveconf.com/" title="ReactiveConf">ReactiveConf</a></th>


### PR DESCRIPTION
ng india was an outdated event removed it from upcoming events on the events page and added to already presented events

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ngIndia is in upcoming events. Its already completed

Issue Number: N/A


## What is the new behavior?
Added ng India to already presented events

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
