### PR TITLE
build: set dev-infra package to be private

### DIFF
--- a/dev-infra/package.json
+++ b/dev-infra/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "INTERNAL USE ONLY - Angular internal DevInfra tooling/scripts - INTERNAL USE ONLY",
   "license": "MIT",
+  "private": true,
   "bin": {
     "ng-dev": "./cli.js"
   }


### PR DESCRIPTION
Setting the dev-infra package to private will prevent us
from accidentally publishing the package to npm.
