### PR TITLE
docs(animations): Rephrase NoopAnimationsModule documentation string

### DIFF
--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -23,7 +23,7 @@ export class BrowserAnimationsModule {
 }
 
 /**
- * A null player that must be imported to allow disabling of animations.
+ * A null player that must be imported to disable animations.
  * @publicApi
  */
 @NgModule({


### PR DESCRIPTION
The phrasing "allow disabling of animations" is confusing and suggests that some further action needs to be taken in order to *actually* disable animations. However, importing this module has the effect of *actually* disabling animations. This change rephrases the phrasing of NoopAnimationsModule's documentation string in order to be more clear.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
