### PR TITLE
perf(ngcc): implement entry-point manifest

### DIFF
--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -79,7 +79,7 @@ if (require.main === module) {
           .option('invalidate-entry-point-manifest', {
             describe:
                 'If this is set then ngcc will not read an entry-point manifest file from disk.\n' +
-                'Instead it will walking the directory tree as normal looking for entry-points, and then write a new manifest file.',
+                'Instead it will walk the directory tree as normal looking for entry-points, and then write a new manifest file.',
             type: 'boolean',
             default: false,
           })

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -76,6 +76,13 @@ if (require.main === module) {
             describe: 'The lowest severity logging message that should be output.',
             choices: ['debug', 'info', 'warn', 'error'],
           })
+          .option('invalidate-entry-point-manifest', {
+            describe:
+                'If this is set then ngcc will not read an entry-point manifest file from disk.\n' +
+                'Instead it will walking the directory tree as normal looking for entry-points, and then write a new manifest file.',
+            type: 'boolean',
+            default: false,
+          })
           .strict()
           .help()
           .parse(args);
@@ -95,6 +102,7 @@ if (require.main === module) {
   const createNewEntryPointFormats = options['create-ivy-entry-points'];
   const logLevel = options['l'] as keyof typeof LogLevel | undefined;
   const enableI18nLegacyMessageIdFormat = options['legacy-message-ids'];
+  const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
 
   (async() => {
     try {
@@ -108,7 +116,7 @@ if (require.main === module) {
         createNewEntryPointFormats,
         logger,
         enableI18nLegacyMessageIdFormat,
-        async: options['async'],
+        async: options['async'], invalidateEntryPointManifest,
       });
 
       if (logger) {

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -70,7 +70,7 @@ export class ClusterMaster {
 
     // First, check whether all tasks have been completed.
     if (this.taskQueue.allTasksCompleted) {
-      const duration = Math.round((Date.now() - this.processingStartTime) / 1000);
+      const duration = Math.round((Date.now() - this.processingStartTime) / 100) / 10;
       this.logger.debug(`Processed tasks in ${duration}s.`);
 
       return this.finishedDeferred.resolve();

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -231,7 +231,7 @@ export function mainNgcc(
           unprocessableEntryPointPaths.map(path => `\n  - ${path}`).join(''));
     }
 
-    const duration = Math.round((Date.now() - startTime) / 1000);
+    const duration = Math.round((Date.now() - startTime) / 100) / 10;
     logger.debug(
         `Analyzed ${entryPoints.length} entry-points in ${duration}s. ` +
         `(Total tasks: ${tasks.length})`);

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -119,13 +119,11 @@ export interface SyncNgccOptions {
   enableI18nLegacyMessageIdFormat?: boolean;
 
   /**
-   * Whether to read an entry-point manifest file from disk, rather than walking the directory tree
-   * looking for entry-points.
+   * Whether to invalidate any entry-point manifest file that is on disk. Instead, walk the
+   * directory tree looking for entry-points, and then write a new entry-point manifest, if
+   * possible.
    *
-   * If `true` then any manifest that exists will be replaced with a new one created from walking
-   * the directory tree.
-   *
-   * Default: `false` (i.e. the manifest will be read)
+   * Default: `false` (i.e. the manifest will be used if available)
    */
   invalidateEntryPointManifest?: boolean;
 }

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -39,7 +39,7 @@ import {hasBeenProcessed} from './packages/build_marker';
 import {NgccConfiguration} from './packages/configuration';
 import {EntryPoint, EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat} from './packages/entry_point';
 import {makeEntryPointBundle} from './packages/entry_point_bundle';
-import {EntryPointManifest, NullEntryPointManifest} from './packages/entry_point_manifest';
+import {EntryPointManifest, InvalidatingEntryPointManifest} from './packages/entry_point_manifest';
 import {Transformer} from './packages/transformer';
 import {PathMappings} from './utils';
 import {cleanOutdatedPackages} from './writing/cleaning/package_cleaner';
@@ -167,7 +167,7 @@ export function mainNgcc({basePath, targetEntryPointPath,
   const config = new NgccConfiguration(fileSystem, dirname(absBasePath));
   const dependencyResolver = getDependencyResolver(fileSystem, logger, config, pathMappings);
   const entryPointManifest = invalidateEntryPointManifest ?
-      new NullEntryPointManifest(fileSystem, config, logger) :
+      new InvalidatingEntryPointManifest(fileSystem, config, logger) :
       new EntryPointManifest(fileSystem, config, logger);
 
   // Bail out early if the work is already done.

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {createHash} from 'crypto';
 import {satisfies} from 'semver';
 import * as vm from 'vm';
 import {AbsoluteFsPath, FileSystem, dirname, join, resolve} from '../../../src/ngtsc/file_system';
@@ -159,10 +160,12 @@ export class NgccConfiguration {
   private defaultConfig: NgccProjectConfig<VersionedPackageConfig[]>;
   private projectConfig: NgccProjectConfig<VersionedPackageConfig[]>;
   private cache = new Map<string, VersionedPackageConfig>();
+  readonly hash: string;
 
   constructor(private fs: FileSystem, baseDir: AbsoluteFsPath) {
     this.defaultConfig = this.processProjectConfig(baseDir, DEFAULT_NGCC_CONFIG);
     this.projectConfig = this.processProjectConfig(baseDir, this.loadProjectConfig(baseDir));
+    this.hash = this.computeHash();
   }
 
   /**
@@ -282,6 +285,10 @@ export class NgccConfiguration {
           packagePathAndVersion.substring(versionIndex + 1)
         ] :
         [packagePathAndVersion, undefined];
+  }
+
+  private computeHash(): string {
+    return createHash('md5').update(JSON.stringify(this.projectConfig)).digest('hex');
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -129,6 +129,18 @@ export class EntryPointManifest {
 }
 
 /**
+ * A specialized implementation of the `EntryPointManifest` that always returns `null` rather than a
+ * set of entry-points from a manifest file.
+ *
+ * This is used if you want to ignore a manifest file that is written to disc.
+ * Note that it will still write a new manifest file with the entry-points that were found by
+ * walking the directories.
+ */
+export class NullEntryPointManifest extends EntryPointManifest {
+  readEntryPointsUsingManifest(basePath: AbsoluteFsPath): EntryPoint[]|null { return null; }
+}
+
+/**
  * The JSON format of the manifest file that is written to disk.
  */
 export interface EntryPointManifestFile {

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -129,14 +129,14 @@ export class EntryPointManifest {
 }
 
 /**
- * A specialized implementation of the `EntryPointManifest` that always returns `null` rather than a
- * set of entry-points from a manifest file.
+ * A specialized implementation of the `EntryPointManifest` that can be used to invalidate the
+ * current manifest file.
  *
- * This is used if you want to ignore a manifest file that is written to disc.
- * Note that it will still write a new manifest file with the entry-points that were found by
- * walking the directories.
+ * It always returns `null` from the `readEntryPointsUsingManifest()` method, which forces a new
+ * manifest to be created, which will overwrite the current file when `writeEntryPointManifest()` is
+ * called.
  */
-export class NullEntryPointManifest extends EntryPointManifest {
+export class InvalidatingEntryPointManifest extends EntryPointManifest {
   readEntryPointsUsingManifest(basePath: AbsoluteFsPath): EntryPoint[]|null { return null; }
 }
 

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -15,8 +15,8 @@ import {NgccConfiguration} from './configuration';
 import {EntryPoint, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from './entry_point';
 
 /**
- * Manages reading and write a manifest file that contains a list of all the entry-points that were
- * found below a given basePath.
+ * Manages reading and writing a manifest file that contains a list of all the entry-points that
+ * were found below a given basePath.
  *
  * This is a super-set of the entry-points that are actually processed for a given run of ngcc,
  * since some may already be processed, or excluded if they do not have the required format.
@@ -46,13 +46,13 @@ export class EntryPointManifest {
         return null;
       }
 
-      const computedLockFileHash = this.computeLockFileHash(basePath);
-      if (computedLockFileHash === null) {
+      const manifestPath = this.getEntryPointManifestPath(basePath);
+      if (!this.fs.exists(manifestPath)) {
         return null;
       }
 
-      const manifestPath = this.getEntryPointManifestPath(basePath);
-      if (!this.fs.exists(manifestPath)) {
+      const computedLockFileHash = this.computeLockFileHash(basePath);
+      if (computedLockFileHash === null) {
         return null;
       }
 
@@ -82,7 +82,8 @@ export class EntryPointManifest {
       this.logger.debug(`Reading entry-points using the manifest entries took ${duration}s.`);
       return entryPoints;
     } catch (e) {
-      this.logger.warn(`Unable to read the entry-point manifest for ${basePath}:`, e.toString());
+      this.logger.warn(
+          `Unable to read the entry-point manifest for ${basePath}:\n`, e.stack || e.toString());
       return null;
     }
   }

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {createHash} from 'crypto';
+
+import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {Logger} from '../logging/logger';
+
+import {NGCC_VERSION} from './build_marker';
+import {NgccConfiguration} from './configuration';
+import {EntryPoint, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from './entry_point';
+
+/**
+ * Manages reading and write a manifest file that contains a list of all the entry-points that were
+ * found below a given basePath.
+ *
+ * This is a super-set of the entry-points that are actually processed for a given run of ngcc,
+ * since some may already be processed, or excluded if they do not have the required format.
+ */
+export class EntryPointManifest {
+  constructor(private fs: FileSystem, private config: NgccConfiguration, private logger: Logger) {}
+
+  /**
+   * Try to get the entry-point info from a manifest file for the given `basePath` if it exists and
+   * is not out of date.
+   *
+   * Reasons for the manifest to be out of date are:
+   *
+   * * the file does not exist
+   * * the ngcc version has changed
+   * * the package lock-file (i.e. yarn.lock or package-lock.json) has changed
+   * * the project configuration has changed
+   * * one or more entry-points in the manifest are not valid
+   *
+   * @param basePath The path that would contain the entry-points and the manifest file.
+   * @returns an array of entry-point information for all entry-points found below the given
+   * `basePath` or `null` if the manifest was out of date.
+   */
+  readEntryPointsUsingManifest(basePath: AbsoluteFsPath): EntryPoint[]|null {
+    try {
+      if (this.fs.basename(basePath) !== 'node_modules') {
+        return null;
+      }
+
+      const computedLockFileHash = this.computeLockFileHash(basePath);
+      if (computedLockFileHash === null) {
+        return null;
+      }
+
+      const manifestPath = this.getEntryPointManifestPath(basePath);
+      if (!this.fs.exists(manifestPath)) {
+        return null;
+      }
+
+      const {ngccVersion, configFileHash, lockFileHash, entryPointPaths} =
+          JSON.parse(this.fs.readFile(manifestPath)) as EntryPointManifestFile;
+      if (ngccVersion !== NGCC_VERSION || configFileHash !== this.config.hash ||
+          lockFileHash !== computedLockFileHash) {
+        return null;
+      }
+
+      this.logger.debug(
+          `Entry-point manifest found for ${basePath} so loading entry-point information directly.`);
+      const startTime = Date.now();
+
+      const entryPoints: EntryPoint[] = [];
+      for (const [packagePath, entryPointPath] of entryPointPaths) {
+        const result =
+            getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
+        if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+          throw new Error(
+              `The entry-point manifest at ${manifestPath} contained an invalid pair of package paths: [${packagePath}, ${entryPointPath}]`);
+        } else {
+          entryPoints.push(result);
+        }
+      }
+      const duration = Math.round((Date.now() - startTime) / 100) / 10;
+      this.logger.debug(`Reading entry-points using the manifest entries took ${duration}s.`);
+      return entryPoints;
+    } catch (e) {
+      this.logger.warn(`Unable to read the entry-point manifest for ${basePath}:`, e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * Write a manifest file at the given `basePath`.
+   *
+   * The manifest includes the current ngcc version and hashes of the package lock-file and current
+   * project config. These will be used to check whether the manifest file is out of date. See
+   * `readEntryPointsUsingManifest()`.
+   *
+   * @param basePath The path where the manifest file is to be written.
+   * @param entryPoints A collection of entry-points to record in the manifest.
+   */
+  writeEntryPointManifest(basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): void {
+    const lockFileHash = this.computeLockFileHash(basePath);
+    if (lockFileHash === null) {
+      return;
+    }
+    const manifest: EntryPointManifestFile = {
+      ngccVersion: NGCC_VERSION,
+      configFileHash: this.config.hash,
+      lockFileHash: lockFileHash,
+      entryPointPaths: entryPoints.map(entryPoint => [entryPoint.package, entryPoint.path]),
+    };
+    this.fs.writeFile(this.getEntryPointManifestPath(basePath), JSON.stringify(manifest));
+  }
+
+  private getEntryPointManifestPath(basePath: AbsoluteFsPath) {
+    return this.fs.resolve(basePath, '__ngcc_entry_points__.json');
+  }
+
+  private computeLockFileHash(basePath: AbsoluteFsPath): string|null {
+    const directory = this.fs.dirname(basePath);
+    for (const lockFileName of ['yarn.lock', 'package-lock.json']) {
+      const lockFilePath = this.fs.resolve(directory, lockFileName);
+      if (this.fs.exists(lockFilePath)) {
+        const lockFileContents = this.fs.readFile(lockFilePath);
+        return createHash('md5').update(lockFileContents).digest('hex');
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * The JSON format of the manifest file that is written to disk.
+ */
+export interface EntryPointManifestFile {
+  ngccVersion: string;
+  configFileHash: string;
+  lockFileHash: string;
+  entryPointPaths: Array<[AbsoluteFsPath, AbsoluteFsPath]>;
+}

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -15,7 +15,7 @@ import {Folder, MockFileSystem, TestFile, runInEachFileSystem} from '../../../sr
 import {loadStandardTestFiles, loadTestFiles} from '../../../test/helpers';
 import {getLockFilePath} from '../../src/locking/lock_file';
 import {mainNgcc} from '../../src/main';
-import {markAsProcessed} from '../../src/packages/build_marker';
+import {hasBeenProcessed, markAsProcessed} from '../../src/packages/build_marker';
 import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTIES} from '../../src/packages/entry_point';
 import {Transformer} from '../../src/packages/transformer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
@@ -980,6 +980,39 @@ runInEachFileSystem(() => {
 
            function stringifyKeys(obj: object) { return `|${Object.keys(obj).join('|')}|`; }
          });
+    });
+
+    describe('with ignoreEntryPointManifest', () => {
+      it('should not read the entry-point manifest file', () => {
+        // Ensure there is a lock-file. Otherwise the manifest will not be written
+        fs.writeFile(_('/yarn.lock'), 'DUMMY YARN LOCK FILE');
+        // Populate the manifest file
+        mainNgcc(
+            {basePath: '/node_modules', propertiesToConsider: ['esm5'], logger: new MockLogger()});
+        // Check that common/testings ES5 was processed
+        let commonTesting =
+            JSON.parse(fs.readFile(_('/node_modules/@angular/common/testing/package.json')));
+        expect(hasBeenProcessed(commonTesting, 'esm5')).toBe(true);
+        expect(hasBeenProcessed(commonTesting, 'esm2015')).toBe(false);
+        // Modify the manifest to test that is has no effect
+        const manifest = JSON.parse(fs.readFile(_('/node_modules/__ngcc_entry_points__.json')));
+        manifest.entryPointPaths = manifest.entryPointPaths.filter(
+            (paths: [string, string]) => paths[1] !== _('/node_modules/@angular/common/testing'));
+        fs.writeFile(_('/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifest));
+        // Now run ngcc again ignoring this manifest but trying to process ES2015, which are not yet
+        // processed.
+        mainNgcc({
+          basePath: '/node_modules',
+          propertiesToConsider: ['esm2015'],
+          logger: new MockLogger(),
+          invalidateEntryPointManifest: true,
+        });
+        // Check that common/testing ES2015 is now processed, despite the manifest not listing it
+        commonTesting =
+            JSON.parse(fs.readFile(_('/node_modules/@angular/common/testing/package.json')));
+        expect(hasBeenProcessed(commonTesting, 'esm5')).toBe(true);
+        expect(hasBeenProcessed(commonTesting, 'esm2015')).toBe(true);
+      });
     });
 
     describe('diagnostics', () => {

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {createHash} from 'crypto';
+
+import {FileSystem, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadTestFiles} from '../../../test/helpers';
+import {NGCC_VERSION} from '../../src/packages/build_marker';
+import {NgccConfiguration} from '../../src/packages/configuration';
+import {EntryPoint} from '../../src/packages/entry_point';
+import {EntryPointManifest, EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
+import {MockLogger} from '../helpers/mock_logger';
+
+import {createPackageJson} from './entry_point_spec';
+
+runInEachFileSystem(() => {
+  describe('EntryPointManifest', () => {
+    let fs: FileSystem;
+    let _Abs: typeof absoluteFrom;
+    let config: NgccConfiguration;
+    let logger: MockLogger;
+    let manifest: EntryPointManifest;
+
+    beforeEach(() => {
+      _Abs = absoluteFrom;
+      fs = getFileSystem();
+      fs.ensureDir(_Abs('/project/node_modules'));
+      config = new NgccConfiguration(fs, _Abs('/project'));
+      logger = new MockLogger();
+      manifest = new EntryPointManifest(fs, config, logger);
+    });
+
+    describe('readEntryPointsUsingManifest()', () => {
+      let manifestFile: EntryPointManifestFile;
+      beforeEach(() => {
+        manifestFile = {
+          ngccVersion: NGCC_VERSION,
+          lockFileHash: createHash('md5').update('LOCK FILE CONTENTS').digest('hex'),
+          configFileHash: config.hash,
+          entryPointPaths: []
+        };
+      });
+
+      it('should return null if the base path is not node_modules', () => {
+        fs.ensureDir(_Abs('/project/dist'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        fs.writeFile(
+            _Abs('/project/dist/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/dist'));
+        expect(entryPoints).toBe(null);
+      });
+
+      it('should return null if there is no package lock-file', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(
+            _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toBe(null);
+      });
+
+      it('should return null if there is no manifest file', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toBe(null);
+      });
+
+      it('should return null if the ngcc version does not match', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifestFile.ngccVersion = 'bad-version';
+        fs.writeFile(
+            _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toBe(null);
+      });
+
+      it('should return null if the config hash does not match', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifestFile.configFileHash = 'bad-hash';
+        fs.writeFile(
+            _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toBe(null);
+      });
+
+      ['yarn.lock', 'package-lock.json'].forEach(packageLockFilePath => {
+        it('should return null if the lockfile hash does not match', () => {
+          fs.ensureDir(_Abs('/project/node_modules'));
+          fs.writeFile(_Abs(`/project/${packageLockFilePath}`), 'LOCK FILE CONTENTS');
+          manifestFile.lockFileHash = 'bad-hash';
+          fs.writeFile(
+              _Abs('/project/node_modules/__ngcc_entry_points__.json'),
+              JSON.stringify(manifestFile));
+          const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+          expect(entryPoints).toBe(null);
+        });
+
+        it('should return an array of entry-points if all the checks pass', () => {
+          fs.ensureDir(_Abs('/project/node_modules'));
+          fs.writeFile(_Abs(`/project/${packageLockFilePath}`), 'LOCK FILE CONTENTS');
+          fs.writeFile(
+              _Abs('/project/node_modules/__ngcc_entry_points__.json'),
+              JSON.stringify(manifestFile));
+          const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+          expect(entryPoints).toEqual([]);
+        });
+      });
+
+      it('should read in all the entry-point info', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        loadTestFiles([
+          {
+            name: _Abs('/project/node_modules/some_package/valid_entry_point/package.json'),
+            contents: createPackageJson('valid_entry_point')
+          },
+          {
+            name: _Abs(
+                '/project/node_modules/some_package/valid_entry_point/valid_entry_point.metadata.json'),
+            contents: 'some meta data'
+          },
+        ]);
+        manifestFile.entryPointPaths.push([
+          _Abs('/project/node_modules/some_package'),
+          _Abs('/project/node_modules/some_package/valid_entry_point')
+        ]);
+        fs.writeFile(
+            _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toEqual([{
+          name: 'some_package/valid_entry_point', packageJson: jasmine.any(Object),
+              package: _Abs('/project/node_modules/some_package'),
+              path: _Abs('/project/node_modules/some_package/valid_entry_point'),
+              typings: _Abs(
+                  '/project/node_modules/some_package/valid_entry_point/valid_entry_point.d.ts'),
+              compiledByAngular: true, ignoreMissingDependencies: false,
+              generateDeepReexports: false,
+        } as any]);
+      });
+
+      it('should return null if any of the entry-points are not valid', () => {
+        fs.ensureDir(_Abs('/project/node_modules'));
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifestFile.entryPointPaths.push([
+          _Abs('/project/node_modules/some_package'),
+          _Abs('/project/node_modules/some_package/valid_entry_point')
+        ]);
+        fs.writeFile(
+            _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
+        const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
+        expect(entryPoints).toEqual(null);
+      });
+    });
+
+    describe('writeEntryPointManifest()', () => {
+      it('should do nothing if there is no package lock-file', () => {
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+        expect(fs.exists(_Abs('/project/node_modules/__ngcc_entry_points__.json'))).toBe(false);
+      });
+
+      it('should write an __ngcc_entry_points__.json file below the base path if there is a yarn.lock file',
+         () => {
+           fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+           manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+           expect(fs.exists(_Abs('/project/node_modules/__ngcc_entry_points__.json'))).toBe(true);
+         });
+
+      it('should write an __ngcc_entry_points__.json file below the base path if there is a package-lock.json file',
+         () => {
+           fs.writeFile(_Abs('/project/package-lock.json'), 'LOCK FILE CONTENTS');
+           manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+           expect(fs.exists(_Abs('/project/node_modules/__ngcc_entry_points__.json'))).toBe(true);
+         });
+
+      it('should write the ngcc version', () => {
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+        const file: EntryPointManifestFile =
+            JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json')));
+        expect(file.ngccVersion).toEqual(NGCC_VERSION);
+      });
+
+      it('should write a hash of the yarn.lock file', () => {
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+        const file: EntryPointManifestFile =
+            JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json')));
+        expect(file.lockFileHash)
+            .toEqual(createHash('md5').update('LOCK FILE CONTENTS').digest('hex'));
+      });
+
+      it('should write a hash of the package-lock.json file', () => {
+        fs.writeFile(_Abs('/project/package-lock.json'), 'LOCK FILE CONTENTS');
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+        const file: EntryPointManifestFile =
+            JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json')));
+        expect(file.lockFileHash)
+            .toEqual(createHash('md5').update('LOCK FILE CONTENTS').digest('hex'));
+      });
+
+      it('should write a hash of the project config', () => {
+        fs.writeFile(_Abs('/project/package-lock.json'), 'LOCK FILE CONTENTS');
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), []);
+        const file: EntryPointManifestFile =
+            JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json')));
+        expect(file.configFileHash).toEqual(config.hash);
+      });
+
+      it('should write the package path and entry-point path of each entry-point provided', () => {
+        fs.writeFile(_Abs('/project/package-lock.json'), 'LOCK FILE CONTENTS');
+        const entryPoint1 = {
+          package: _Abs('/project/node_modules/package-1/'),
+          path: _Abs('/project/node_modules/package-1/'),
+        } as unknown as EntryPoint;
+        const entryPoint2 = {
+          package: _Abs('/project/node_modules/package-2/'),
+          path: _Abs('/project/node_modules/package-2/entry-point'),
+        } as unknown as EntryPoint;
+        manifest.writeEntryPointManifest(_Abs('/project/node_modules'), [entryPoint1, entryPoint2]);
+        const file: EntryPointManifestFile =
+            JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json')));
+        expect(file.entryPointPaths).toEqual([
+          [
+            _Abs('/project/node_modules/package-1/'),
+            _Abs('/project/node_modules/package-1/'),
+          ],
+          [
+            _Abs('/project/node_modules/package-2/'),
+            _Abs('/project/node_modules/package-2/entry-point'),
+          ]
+        ]);
+      });
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -466,28 +466,28 @@ runInEachFileSystem(() => {
       expect(getEntryPointFormat(fs, entryPoint, 'main')).toBe('umd');
     });
   });
-
-  function createPackageJson(
-      packageName: string,
-      {excludes, typingsProp = 'typings', typingsIsArray}:
-          {excludes?: string[], typingsProp?: string, typingsIsArray?: boolean} = {}): string {
-    const packageJson: any = {
-      name: `some_package/${packageName}`,
-      [typingsProp]: typingsIsArray ? [`./${packageName}.d.ts`] : `./${packageName}.d.ts`,
-      fesm2015: `./fesm2015/${packageName}.js`,
-      esm2015: `./esm2015/${packageName}.js`,
-      es2015: `./es2015/${packageName}.js`,
-      fesm5: `./fesm5/${packageName}.js`,
-      esm5: `./esm5/${packageName}.js`,
-      main: `./bundles/${packageName}/index.js`,
-      module: './index.js',
-    };
-    if (excludes) {
-      excludes.forEach(exclude => delete packageJson[exclude]);
-    }
-    return JSON.stringify(packageJson);
-  }
 });
+
+export function createPackageJson(
+    packageName: string,
+    {excludes, typingsProp = 'typings', typingsIsArray}:
+        {excludes?: string[], typingsProp?: string, typingsIsArray?: boolean} = {}): string {
+  const packageJson: any = {
+    name: `some_package/${packageName}`,
+    [typingsProp]: typingsIsArray ? [`./${packageName}.d.ts`] : `./${packageName}.d.ts`,
+    fesm2015: `./fesm2015/${packageName}.js`,
+    esm2015: `./esm2015/${packageName}.js`,
+    es2015: `./es2015/${packageName}.js`,
+    fesm5: `./fesm5/${packageName}.js`,
+    esm5: `./esm5/${packageName}.js`,
+    main: `./bundles/${packageName}/index.js`,
+    module: './index.js',
+  };
+  if (excludes) {
+    excludes.forEach(exclude => delete packageJson[exclude]);
+  }
+  return JSON.stringify(packageJson);
+}
 
 export function loadPackageJson(fs: FileSystem, packagePath: string) {
   return JSON.parse(fs.readFile(fs.resolve(packagePath + '/package.json')));


### PR DESCRIPTION
The `DirectoryWalkerEntryPointFinder` has to traverse the
entire node_modules library everytime it executes in order to
identify the entry-points that need to be processed. This is
very time consuming (several seconds for big projects on
Windows).

This commit changes the `DirectoryWalkerEntryPointFinder` to
use the `EntryPointManifest` to store the paths to entry-points
that were found when doing this initial node_modules traversal
in a file to be reused for subsequent calls.

This dramatically speeds up ngcc processing when it has been run once already.

FW-1962