### PR TITLE
fix(docs-infra): fix resources page tabs text which is not visible on…

### DIFF
--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -11,6 +11,18 @@
 
 .resources-container {
   position: relative;
+  .group-buttons{
+    @media (max-width: 480px) {
+      .button, a.button.mat-button{
+        font-size:1.2rem;
+        padding:0;
+      }
+
+      a.filter-button{
+        margin: 0;
+      }
+    }
+  }
 }
 
 .grid-fixed:after, .grid-fixed:before {

--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -11,14 +11,13 @@
 
 .resources-container {
   position: relative;
-  .group-buttons{
+
+  .group-buttons {
+
     @media (max-width: 480px) {
-      .button, a.button.mat-button {
+      .button {
         font-size: 1.2rem;
         padding: 0;
-      }
-
-      a.filter-button {
         margin: 0;
       }
     }

--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -65,11 +65,11 @@
 
 @media handheld and (max-width: 900px), screen and (max-width: 900px) {
   /* line 6, ../scss/_responsive.scss */
-  .grid-fixed{
+  .grid-fixed {
     margin: 0 auto;
     *zoom: 1;
   }
-  .grid-fixed:after, .grid-fixed:before, {
+  .grid-fixed:after, .grid-fixed:before {
     content: '.';
     clear: both;
     display: block;
@@ -181,7 +181,7 @@ aio-resource-list {
     flex-direction: column;
   }
 
-  .align-items-center{
+  .align-items-center {
     align-items: center;
   }
 
@@ -231,7 +231,7 @@ aio-resource-list {
     transform: translateY(-2px);
   }
 
-  @media(max-width: 900px) {
+  @media (max-width: 900px) {
     .c-resource-nav {
       display: none;
     }

--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -13,12 +13,12 @@
   position: relative;
   .group-buttons{
     @media (max-width: 480px) {
-      .button, a.button.mat-button{
-        font-size:1.2rem;
-        padding:0;
+      .button, a.button.mat-button {
+        font-size: 1.2rem;
+        padding: 0;
       }
 
-      a.filter-button{
+      a.filter-button {
         margin: 0;
       }
     }


### PR DESCRIPTION
… small screens

on small mobile screens the top tab bar contains text which was not visible on small screens changed text size, margin and padding so that the text could be contained in these screens (320px to 480px)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On small screents tab text on resources page was not visible
![Angular - EXPLORE ANGULAR RESOURCES (1)](https://user-images.githubusercontent.com/39260684/76161716-ee878b00-615b-11ea-966d-be243e2825cd.png)


Issue Number: N/A


## What is the new behavior?
On small screents tab text on resources page is not visible
![Angular - EXPLORE ANGULAR RESOURCES](https://user-images.githubusercontent.com/39260684/76161713-e891aa00-615b-11ea-832f-465e27db0789.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
