### PR TITLE
build: fix elements test failures on IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/systemjs": "0.19.32",
     "@types/yaml": "^1.2.0",
     "@types/yargs": "^11.1.1",
-    "@webcomponents/custom-elements": "^1.0.4",
+    "@webcomponents/custom-elements": "^1.1.0",
     "angular": "npm:angular@1.7",
     "angular-1.5": "npm:angular@1.5",
     "angular-1.6": "npm:angular@1.6",

--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
     testonly = True,
     # do not sort
     srcs = [
+        "@npm//:node_modules/core-js/client/core.js",
         "@npm//:node_modules/@webcomponents/custom-elements/src/native-shim.js",
         "@npm//:node_modules/reflect-metadata/Reflect.js",
         "//packages/zone.js/dist:zone.js",
@@ -41,11 +42,6 @@ karma_web_test_suite(
     name = "test",
     bootstrap = [
         ":elements_test_bootstrap_scripts",
-    ],
-    tags = [
-        # FIXME: timed out in CI
-        "fixme-saucelabs-ivy",
-        "fixme-saucelabs-ve",
     ],
     deps = [
         ":test_lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,10 +1905,10 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/custom-elements@^1.0.4":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.1.2.tgz#041e4c20df35245f4d160b50d044b8cff192962c"
-  integrity sha512-gVhuQHLTrQ28v1qMp0WGPSCBukFL7qAlemxCf19TnuNZ0bO9KPF72bfhH6Hpuwdu9TptIMGNlqrr9PzqrzfZFQ==
+"@webcomponents/custom-elements@^1.1.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.4.0.tgz#f21f41804e1f708d1bc924c345413f8a0e9b51a3"
+  integrity sha512-t9xpI4KVH4IcVp9XqLIAxHOovNcaUDDcfjK3v7ORv7xjnbIL1Dc+735tUTgyJvugTPAaxunILJY+Rh6+5729Hw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Fixes the following issues which caused the `elements` unit tests to break on IE:
1. `core.js` wasn't included which caused an error about `Promise` and `Symbol` to be thrown.
2. We were using a version of `@webcomponents/custom-elements` which was shipping ES6 code to npm. As a result, IE was throwing a syntax error.
