### PR TITLE
fix(language-service): infer $implicit value for ngIf template contexts

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -185,7 +185,7 @@ function refinedVariableType(
       // See @angular/common/ng_if.ts for more information.
       const ngIfBinding = ngIfDirective.inputs.find(i => i.directiveName === 'ngIf');
       if (ngIfBinding) {
-        // Check if tehre is a known type bound to the ngIf input.
+        // Check if there is a known type bound to the ngIf input.
         const bindingType = new AstType(mergedTable, query, {}).getType(ngIfBinding.value);
         if (bindingType) {
           return bindingType;

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -144,6 +144,44 @@ describe('diagnostics', () => {
     });
   });
 
+  describe('diagnostics for ngIf exported values', () => {
+    it('should infer the type of an implicit value in an NgIf context', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <div *ngIf="title; let titleProxy;">
+            'titleProxy' is a string
+          {{~{start-err}titleProxy.notAProperty~{end-err}}}
+        </div>
+      `);
+      const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
+      expect(diags.length).toBe(1);
+      const {messageText, start, length} = diags[0];
+      expect(messageText)
+          .toBe(
+              `Identifier 'notAProperty' is not defined. 'string' does not contain such a member`);
+      const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'err');
+      expect(start).toBe(span.start);
+      expect(length).toBe(span.length);
+    });
+
+    it('should infer the type of an ngIf value in an NgIf context', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <div *ngIf="title as titleProxy">
+            'titleProxy' is a string
+          {{~{start-err}titleProxy.notAProperty~{end-err}}}
+        </div>
+      `);
+      const diags = ngLS.getSemanticDiagnostics(TEST_TEMPLATE);
+      expect(diags.length).toBe(1);
+      const {messageText, start, length} = diags[0];
+      expect(messageText)
+          .toBe(
+              `Identifier 'notAProperty' is not defined. 'string' does not contain such a member`);
+      const span = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'err');
+      expect(start).toBe(span.start);
+      expect(length).toBe(span.length);
+    });
+  });
+
   describe('diagnostics for invalid indexed type property access', () => {
     it('should work with numeric index signatures (arrays)', () => {
       mockHost.override(TEST_TEMPLATE, `


### PR DESCRIPTION
Today, the language service infers the type of variables bound to the
"ngIf" template context member of an NgIf directive, but does not do the
same for the the "$implicit" context member. This commit adds support
for that.

Fixes https://github.com/angular/vscode-ng-language-service/issues/676

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
