### PR TITLE
perf(language-service): cache variable and event symbols found in path

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -242,7 +242,7 @@ function getEventDeclaration(
     })();
 
     cache.set(event, eventDeclaration);
-  };
+  }
 
   return cache.get(event);
 }


### PR DESCRIPTION
When computing the diagnostics for a template, the language service
traverses through all paths in the template and computes diagnostics at
each location an Angular expression is found. The context of the
expression to be diagnosed is generated partially by examining the
variables, references, and events introduced by template nodes in a
current path. Today, this context is re-computed everytime an expression
is evaluated. This often results in a wasteful re-computation of data
for template nodes whose scope contribution is already known. For
example, in the template

```html
<main #mysection>
  {{ title }}
  {{ subtitle }}
</main>
```

The expression scope is computed twice, once for each interpolation. But
because the template is static, the contribution of the element "main"
to the expression scope should only need to be computed once.

To reduce unnecessary work in computing the expression scope, cache
references, variables, and events found in template path nodes.

Note that calculation of expression scope is likely to be one of the
hottest paths in the language service aside actual parsing of the
template. I have not benchmarked this change, but I expect at least a
minor performance improvement.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
