### PR TITLE
fix(platform-browser): add missing peerDependency on `@angular/animat…

### DIFF
--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -13,9 +13,15 @@
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
+    "@angular/animations": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "tslib": "^1.10.0"
+  },
+  "peerDependenciesMeta": {
+    "@angular/animations": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…ions`

`@angular/platform-browser/animations` has a dependency on `@angular/animations` however, this is not listed in `peerDependencies`

With this change we add this package as an optional peerDependency as it's only required when using the `@angular/platform-browser/animations` entrypoint.

Fixes #35888
