### PR TITLE
docs: add note that sting based lazy loading is opt-in

### DIFF
--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -101,7 +101,19 @@ Instead, it adds the declared route, `customers` to the `routes` array declared 
 Notice that the lazy-loading syntax uses `loadChildren` followed by a function that uses the browser's built-in `import('...')` syntax for dynamic imports.
 The import path is the relative path to the module.
 
-#### Add another feature module
+<div class="callout is-helpful">
+<header>String based lazy loading</header>
+
+You can also make your modules lazy loaded by string based lazy loading(loadChildren: './path/to/module#Module')  without using the `import('...')` syntax but you have to include the lazy-loaded routes in your tsconfig file to make the lazy-loaded files a part of the compilation.
+
+It is an opt-in this behaviour. As by default the CLI will generate projects which stricter file inclusions intended to be used with the `import()` lazy syntax.
+
+Note: It is a deprecated syntax and will be removed in version 11 for details please refer [guide](guide/deprecations#loadChildren).
+
+</div>
+
+
+### Add another feature module
 
 Use the same command to create a second lazy-loaded feature module with routing, along with its stub component.
 

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -102,13 +102,11 @@ Notice that the lazy-loading syntax uses `loadChildren` followed by a function t
 The import path is the relative path to the module.
 
 <div class="callout is-helpful">
-<header>String based lazy loading</header>
+<header>String-based lazy loading</header>
 
-You can also make your modules lazy loaded by string based lazy loading(loadChildren: './path/to/module#Module')  without using the `import('...')` syntax but you have to include the lazy-loaded routes in your tsconfig file to make the lazy-loaded files a part of the compilation.
+In Angular version 8, the string syntax for the `loadChildren` route specification [was deprecated](https://angular.io/guide/deprecations#loadchildren-string-syntax) in favor of the `import()` syntax. However, you can opt into using string-based lazy loading (`loadChildren: './path/to/module#Module'`) by including the lazy-loaded routes in your `tsconfig` file, which includes the lazy-loaded files in the compilation.
 
-It is an opt-in this behaviour. As by default the CLI will generate projects which stricter file inclusions intended to be used with the `import()` lazy syntax.
-
-Note: It is a deprecated syntax and will be removed in version 11 for details please refer [guide](guide/deprecations#loadChildren).
+By default the CLI will generate projects which stricter file inclusions intended to be used with the `import()` syntax.
 
 </div>
 

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -110,7 +110,6 @@ By default the CLI will generate projects which stricter file inclusions intende
 
 </div>
 
-
 ### Add another feature module
 
 Use the same command to create a second lazy-loaded feature module with routing, along with its stub component.


### PR DESCRIPTION
after angular version 8 string based lazy loading is not activated by default it is an opt in behaviour in which you have to add the lazy loaded routes in the tsconfig file for compilation. Aded a note too that it will be removed in version 11.

Fixes #35652

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
No details that string-based lazy loading is opt-in after Version 9

Issue Number: #35652


## What is the new behavior?
Added details that string-based lazy loading is opt-in after version 9

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
