### PR TITLE
Update retry-on-error.ts

### DIFF
--- a/aio/content/examples/rx-library/src/retry-on-error.ts
+++ b/aio/content/examples/rx-library/src/retry-on-error.ts
@@ -8,13 +8,13 @@ import { ajax } from 'rxjs/ajax';
 import { map, retry, catchError } from 'rxjs/operators';
 
 const apiData = ajax('/api/data').pipe(
-  retry(3), // Retry up to 3 times before failing
   map(res => {
     if (!res.response) {
       throw new Error('Value expected!');
     }
     return res.response;
   }),
+  retry(3), // Retry up to 3 times before failing
   catchError(err => of([]))
 );
 


### PR DESCRIPTION
docs(docs-infra): move rxjs retry operator after the map operator to retry the 'Value expected!' Error

update rxjs retry example to show a proper useage of the retry operator - rxjs retry operator must be placed after any operator that introduces Errors that are to be retried

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The rxjs retry example shows incorrect usage of the retry operator, retry operator placed before the map operator that generates an error will not be triggered for retry.

Issue Number: N/A


## What is the new behavior?
Rxjs retry operator placed after the map operator, the sequence is then properly retried.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
