### PR TITLE
test(core): re-enable test on Sauce Labs

### DIFF
--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -87,15 +87,6 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
-    tags = [
-        # FIXME: fix on saucelabs
-        # IE 11.0.0 (Windows 8.1.0.0) ivy NgModule providers should throw when the aliased provider does not exist FAILED
-        #     Error: Expected function to throw an exception with message 'R3InjectorError(SomeModule)[car -> SportsCar]:
-        #     NullInjectorError: No provider for Car!', but it threw an exception with message 'R3InjectorError(SomeModule)[car -> Car]:
-        #     NullInjectorError: No provider for Car!'.
-        #         at <Jasmine>
-        "fixme-saucelabs-ivy",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -794,7 +794,7 @@ function declareTests(config?: {useJit: boolean}) {
         const injector = createInjector([{provide: 'car', useExisting: SportsCar}]);
         let errorMsg = `NullInjectorError: No provider for ${stringify(SportsCar)}!`;
         if (ivyEnabled) {
-          errorMsg = `R3InjectorError(SomeModule)[car -> SportsCar]: \n  ` + errorMsg;
+          errorMsg = `R3InjectorError(SomeModule)[car -> ${stringify(SportsCar)}]: \n  ` + errorMsg;
         }
         expect(() => injector.get('car')).toThrowError(errorMsg);
       });


### PR DESCRIPTION
I was not able to reproduce IE 10/11 failure of the disabled
tests on SauceLabs any more. I did some cleanup of the test
in question but I doubt it was the root cause of the problem.