### PR TITLE
refactor(core): Take advantage of 'assert functions' for `ngDevMode` asserts

### DIFF
--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -15,6 +15,10 @@ import {TNode} from './interfaces/node';
 import {isLContainer, isLView} from './interfaces/type_checks';
 import {LView, TVIEW, TView} from './interfaces/view';
 
+// [Assert functions do not constraint type when they are guarded by a truthy
+// expression.](https://github.com/microsoft/TypeScript/issues/37295)
+
+
 export function assertTNodeForLView(tNode: TNode, lView: LView) {
   tNode.hasOwnProperty('tView_') && assertEqual(
                                         (tNode as any as{tView_: TView}).tView_, lView[TVIEW],

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -85,7 +85,7 @@ export function assertFirstUpdatePass(tView: TView, errMessage?: string) {
  * This is a basic sanity check that an object is probably a directive def. DirectiveDef is
  * an interface, so we can't do a direct instanceof check.
  */
-export function assertDirectiveDef(obj: any): asserts obj is DirectiveDef<any> {
+export function assertDirectiveDef<T>(obj: any): asserts obj is DirectiveDef<T> {
   if (obj.type === undefined || obj.selectors == undefined || obj.inputs === undefined) {
     throwError(
         `Expected a DirectiveDef/ComponentDef and this object does not seem to have the expected shape.`);

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -9,6 +9,8 @@
 import {assertDefined, assertEqual, throwError} from '../util/assert';
 
 import {getComponentDef, getNgModuleDef} from './definition';
+import {LContainer} from './interfaces/container';
+import {DirectiveDef} from './interfaces/definition';
 import {TNode} from './interfaces/node';
 import {isLContainer, isLView} from './interfaces/type_checks';
 import {LView, TVIEW, TView} from './interfaces/view';
@@ -50,20 +52,21 @@ export function assertDataNext(lView: LView, index: number, arr?: any[]) {
       arr.length, index, `index ${index} expected to be at the end of arr (length ${arr.length})`);
 }
 
-export function assertLContainerOrUndefined(value: any): void {
+export function assertLContainerOrUndefined(value: any): asserts value is LContainer|undefined|
+    null {
   value && assertEqual(isLContainer(value), true, 'Expecting LContainer or undefined or null');
 }
 
-export function assertLContainer(value: any): void {
+export function assertLContainer(value: any): asserts value is LContainer {
   assertDefined(value, 'LContainer must be defined');
   assertEqual(isLContainer(value), true, 'Expecting LContainer');
 }
 
-export function assertLViewOrUndefined(value: any): void {
+export function assertLViewOrUndefined(value: any): asserts value is LView|null|undefined {
   value && assertEqual(isLView(value), true, 'Expecting LView or undefined or null');
 }
 
-export function assertLView(value: any) {
+export function assertLView(value: any): asserts value is LView {
   assertDefined(value, 'LView must be defined');
   assertEqual(isLView(value), true, 'Expecting LView');
 }
@@ -82,7 +85,7 @@ export function assertFirstUpdatePass(tView: TView, errMessage?: string) {
  * This is a basic sanity check that an object is probably a directive def. DirectiveDef is
  * an interface, so we can't do a direct instanceof check.
  */
-export function assertDirectiveDef(obj: any) {
+export function assertDirectiveDef(obj: any): asserts obj is DirectiveDef<any> {
   if (obj.type === undefined || obj.selectors == undefined || obj.inputs === undefined) {
     throwError(
         `Expected a DirectiveDef/ComponentDef and this object does not seem to have the expected shape.`);

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -7,14 +7,26 @@
  */
 
 import {assertDefined, assertEqual} from '../util/assert';
-import {TNode, TNodeType} from './interfaces/node';
 
-export function assertNodeType(tNode: TNode, type: TNodeType) {
+import {TContainerNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeType, TProjectionNode} from './interfaces/node';
+
+export function assertNodeType(
+    tNode: TNode, type: TNodeType.Container): asserts tNode is TContainerNode;
+export function assertNodeType(
+    tNode: TNode, type: TNodeType.Element): asserts tNode is TElementNode;
+export function assertNodeType(
+    tNode: TNode, type: TNodeType.ElementContainer): asserts tNode is TElementContainerNode;
+export function assertNodeType(
+    tNode: TNode, type: TNodeType.IcuContainer): asserts tNode is TIcuContainerNode;
+export function assertNodeType(
+    tNode: TNode, type: TNodeType.Projection): asserts tNode is TProjectionNode;
+export function assertNodeType(tNode: TNode, type: TNodeType.View): asserts tNode is TContainerNode;
+export function assertNodeType(tNode: TNode, type: TNodeType): asserts tNode is TNode {
   assertDefined(tNode, 'should be called with a TNode');
   assertEqual(tNode.type, type, `should be a ${typeName(type)}`);
 }
 
-export function assertNodeOfPossibleTypes(tNode: TNode, ...types: TNodeType[]) {
+export function assertNodeOfPossibleTypes(tNode: TNode, ...types: TNodeType[]): void {
   assertDefined(tNode, 'should be called with a TNode');
   const found = types.some(type => tNode.type === type);
   assertEqual(

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -12,19 +12,20 @@
 
 import {stringify} from './stringify';
 
-export function assertNumber(actual: any, msg: string) {
+export function assertNumber(actual: any, msg: string): asserts actual is number {
   if (!(typeof actual === 'number')) {
     throwError(msg, typeof actual, 'number', '===');
   }
 }
 
-export function assertNumberInRange(actual: any, minInclusive: number, maxInclusive: number) {
+export function assertNumberInRange(
+    actual: any, minInclusive: number, maxInclusive: number): asserts actual is number {
   assertNumber(actual, 'Expected a number');
   assertLessThanOrEqual(actual, maxInclusive, 'Expected number to be less than or equal to');
   assertGreaterThanOrEqual(actual, minInclusive, 'Expected number to be greater than or equal to');
 }
 
-export function assertString(actual: any, msg: string) {
+export function assertString(actual: any, msg: string): asserts actual is string {
   if (!(typeof actual === 'string')) {
     throwError(msg, actual === null ? 'null' : typeof actual, 'string', '===');
   }
@@ -36,13 +37,13 @@ export function assertEqual<T>(actual: T, expected: T, msg: string) {
   }
 }
 
-export function assertNotEqual<T>(actual: T, expected: T, msg: string) {
+export function assertNotEqual<T>(actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual != expected)) {
     throwError(msg, actual, expected, '!=');
   }
 }
 
-export function assertSame<T>(actual: T, expected: T, msg: string) {
+export function assertSame<T>(actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual === expected)) {
     throwError(msg, actual, expected, '===');
   }
@@ -54,25 +55,26 @@ export function assertNotSame<T>(actual: T, expected: T, msg: string) {
   }
 }
 
-export function assertLessThan<T>(actual: T, expected: T, msg: string) {
+export function assertLessThan<T>(actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual < expected)) {
     throwError(msg, actual, expected, '<');
   }
 }
 
-export function assertLessThanOrEqual<T>(actual: T, expected: T, msg: string) {
+export function assertLessThanOrEqual<T>(actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual <= expected)) {
     throwError(msg, actual, expected, '<=');
   }
 }
 
-export function assertGreaterThan<T>(actual: T, expected: T, msg: string) {
+export function assertGreaterThan<T>(actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual > expected)) {
     throwError(msg, actual, expected, '>');
   }
 }
 
-export function assertGreaterThanOrEqual<T>(actual: T, expected: T, msg: string) {
+export function assertGreaterThanOrEqual<T>(
+    actual: T, expected: T, msg: string): asserts actual is T {
   if (!(actual >= expected)) {
     throwError(msg, actual, expected, '>=');
   }
@@ -98,7 +100,7 @@ export function throwError(msg: string, actual?: any, expected?: any, comparison
       (comparison == null ? '' : ` [Expected=> ${expected} ${comparison} ${actual} <=Actual]`));
 }
 
-export function assertDomNode(node: any) {
+export function assertDomNode(node: any): asserts node is Node {
   // If we're in a worker, `Node` will not be defined.
   assertEqual(
       (typeof Node !== 'undefined' && node instanceof Node) ||

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -23,8 +23,6 @@ declare global {
    * - The URL contains a `ngDevMode=false` text.
    * Finally, ngDevMode may not have been defined at all.
    */
-  // [Assert functions do not constraint type when they are guarded by a truthy
-  // expression.](https://github.com/microsoft/TypeScript/issues/37295)
   const ngDevMode: null|NgDevModePerfCounters;
   interface NgDevModePerfCounters {
     namedConstructors: boolean;

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -23,6 +23,8 @@ declare global {
    * - The URL contains a `ngDevMode=false` text.
    * Finally, ngDevMode may not have been defined at all.
    */
+  // [Assert functions do not constraint type when they are guarded by a truthy
+  // expression.](https://github.com/microsoft/TypeScript/issues/37295)
   const ngDevMode: null|NgDevModePerfCounters;
   interface NgDevModePerfCounters {
     namedConstructors: boolean;


### PR DESCRIPTION


As of TypeScript 3.7, TypeScript supports [Assert Functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions). This change adds assert types to our `assert*` functions.

We can't fully take advantage of this due to [Assert functions do not constraint type when they are guarded by a truthy expression.](https://github.com/microsoft/TypeScript/issues/37295)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
