### PR TITLE
build: enable forms tests on IE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,11 +894,11 @@ workflows:
       # This isn't strictly necessary as there is no artifact dependency, but helps economize
       # CI resources by not attempting to build when we know should fail.
       - test_win:
-          # <<: *skip_on_pull_requests
+          <<: *skip_on_pull_requests
           requires:
             - test
       - test_ivy_aot_win:
-          # <<: *skip_on_pull_requests
+          <<: *skip_on_pull_requests
           requires:
             - test_ivy_aot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,11 +894,11 @@ workflows:
       # This isn't strictly necessary as there is no artifact dependency, but helps economize
       # CI resources by not attempting to build when we know should fail.
       - test_win:
-          <<: *skip_on_pull_requests
+          # <<: *skip_on_pull_requests
           requires:
             - test
       - test_ivy_aot_win:
-          <<: *skip_on_pull_requests
+          # <<: *skip_on_pull_requests
           requires:
             - test_ivy_aot
 

--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -35,14 +35,6 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
-    tags = [
-        # FIXME: fix on saucelabs
-        # IE 11.0.0 (Windows 8.1.0.0) template-driven forms integration tests basic functionality should report properties which are written outside of template bindings FAILED
-        #   InvalidStateError: InvalidStateError
-        # IE 10.0.0 (Windows 8.0.0) template-driven forms integration tests basic functionality should report properties which are written outside of template bindings FAILED
-        #   InvalidStateError: InvalidStateError
-        "fixme-saucelabs-ivy",
-    ],
     deps = [
         ":test_lib",
     ],


### PR DESCRIPTION
Enables running the `forms` unit tests against IE on Saucelabs. It seems like original failures have been resolved.

**Note:** these tests usually don't run against PRs, but I've verified that they pass by:
1. Running them against IE on my local machine.
2. Enabling them for PRs temporarily (see the first commit).