### PR TITLE
test(router): use pageYOffset in testing when scrollY is not available

### DIFF
--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -44,21 +44,6 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
-    tags = [
-        # FIXME: fix on saucelabs
-        # IE 11.0.0 (Windows 8.1.0.0) bootstrap should restore the scrolling position FAILED
-        # IE 10.0.0 (Windows 8.0.0) bootstrap should restore the scrolling position FAILED
-        #   Error: Expected undefined to equal 5000.
-        #       at <Jasmine>
-        #   Error: Expected undefined to equal 3000.
-        #       at <Jasmine>
-        #   Error: Expected undefined to equal 0.
-        #       at <Jasmine>
-        #   Error: Expected false to be true.
-        #       at <Jasmine>
-        "fixme-saucelabs-ivy",
-        "fixme-saucelabs-ve",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -298,24 +298,27 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa');
     window.scrollTo(0, 5000);
 
+    // IE 9/10/11 use non-standard pageYOffset instead of scrollY
+    const getScrollY = () => window.scrollY !== undefined ? window.scrollY : window.pageYOffset;
+
     await router.navigateByUrl('/fail');
-    expect(window.scrollY).toEqual(5000);
+    expect(getScrollY()).toEqual(5000);
 
     await router.navigateByUrl('/bb');
     window.scrollTo(0, 3000);
 
-    expect(window.scrollY).toEqual(3000);
+    expect(getScrollY()).toEqual(3000);
 
     await router.navigateByUrl('/cc');
-    expect(window.scrollY).toEqual(0);
+    expect(getScrollY()).toEqual(0);
 
     await router.navigateByUrl('/aa#marker2');
-    expect(window.scrollY >= 5900).toBe(true);
+    expect(getScrollY() >= 5900).toBe(true);
     expect(window.scrollY < 6000).toBe(true);  // offset
 
     await router.navigateByUrl('/aa#marker3');
-    expect(window.scrollY >= 8900).toBe(true);
-    expect(window.scrollY < 9000).toBe(true);
+    expect(getScrollY() >= 8900).toBe(true);
+    expect(getScrollY() < 9000).toBe(true);
     done();
   });
 


### PR DESCRIPTION
IE 9, 10, and 11 use the non-standard name `pageYOffset` instead of `scrollY`.
https://caniuse.com/#search=scrolly
