### PR TITLE
fix(language-service): resolve the variable from the template context first

### DIFF
--- a/packages/language-service/src/expression_diagnostics.ts
+++ b/packages/language-service/src/expression_diagnostics.ts
@@ -91,10 +91,8 @@ function getVarDeclarations(
       continue;
     }
     for (const variable of current.variables) {
-      let symbol = info.members.get(variable.value);
-      if (!symbol) {
-        symbol = getVariableTypeFromDirectiveContext(variable.value, info.query, current);
-      }
+      let symbol = getVariableTypeFromDirectiveContext(variable.value, info.query, current);
+
       const kind = info.query.getTypeKind(symbol);
       if (kind === BuiltinType.Any || kind === BuiltinType.Unbound) {
         // For special cases such as ngFor and ngIf, the any type is not very useful.

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -170,6 +170,8 @@ export class TemplateReference {
   primitiveIndexType: {[name: string]: string} = {};
   anyValue: any;
   optional?: string;
+  // Use to test the `index` variable conflict between the `ngFor` and component context.
+  index = null;
   myClick(event: any) {}
 }
 


### PR DESCRIPTION
fixed: https://github.com/angular/vscode-ng-language-service/issues/670

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
