### PR TITLE
fix(zone.js): fix wrongly bundle rxjs.

### DIFF
--- a/packages/zone.js/rollup-es5.config.js
+++ b/packages/zone.js/rollup-es5.config.js
@@ -27,6 +27,23 @@ module.exports = {
     }),
     commonjs(),
   ],
-  external: ['electron'],
-  output: {globals: {electron: 'electron'}, banner},
+  external: id => {
+    if (/build-esm/.test(id)) {
+      return false;
+    }
+    return /rxjs/.test(id) || /electron/.test(id);
+  },
+  output: {
+    globals: {
+      electron: 'electron',
+      'rxjs/Observable': 'Rx',
+      'rxjs/Subscriber': 'Rx',
+      'rxjs/Subscription': 'Rx',
+      'rxjs/Scheduler': 'Rx.Scheduler',
+      'rxjs/scheduler/asap': 'Rx.Scheduler',
+      'rxjs/scheduler/async': 'Rx.Scheduler',
+      'rxjs/symbol/rxSubscriber': 'Rx.Symbol'
+    },
+    banner
+  },
 }

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -53,6 +53,13 @@ describe('Zone.js npm_package', () => {
          () => { expect(shx.cat('zone_externs.js')).toContain('Externs for zone.js'); });
     });
 
+    describe('rxjs patch', () => {
+      it('should not contain rxjs source', () => {
+        expect(shx.cat('zone-patch-rxjs.js'))
+            .not.toContain('_enable_super_gross_mode_that_will_cause_bad_things');
+      });
+    });
+
     describe('es5', () => {
       it('zone.js(es5) should not contain es6 spread code',
          () => { expect(shx.cat('zone.js')).not.toContain('let value of values'); });


### PR DESCRIPTION
Close #35878.

Before zone.js 0.10, the rollup config when bundling `zone-patch-rxjs.js` defines
`rxjs` library into `externs` and `globals` configurations, so rollup will not bundle
`rxjs` source code into `zone-patch-rxjs.js` bundle.

From zone.js 0.10, we use bazel to build zone.js and the `externals` and `globals` configurations
are not correct, so the final bundle of `zone-patch-rxjs` is not correct. The source code of `rxjs` is also bundled, https://unpkg.com/zone.js@0.10.2/dist/zone-patch-rxjs.js

this PR recover the old rollup configurations. So the `zone-patch-rxjs.js` will only include the 
source code from `zone.js`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


