### PR TITLE
fix(compiler): support directive inputs with interpolations on `<ng-template>`s

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -403,6 +403,86 @@ describe('i18n support in the template compiler', () => {
          verify(input, output);
        });
 
+    it('should support i18n attributes with interpolations on explicit <ng-template> elements',
+       () => {
+         const input = `
+           <ng-template i18n-title title="Hello {{ name }}"></ng-template>
+         `;
+
+         const output = String.raw `
+           var $I18N_0$;
+           if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
+             const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS_1$ = goog.getMsg("Hello {$interpolation}", {
+               "interpolation": "\uFFFD0\uFFFD"
+              });
+             $I18N_0$ = $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS_1$;
+           }
+           else {
+             $I18N_0$ = $localize \`Hello $` +
+             String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+           }
+           const $_c2$ = ["title", $I18N_0$];
+           …
+           consts: [[${AttributeMarker.Bindings}, "title"]],
+           template: function MyComponent_Template(rf, ctx) {
+             if (rf & 1) {
+               $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 0, 0, "ng-template", 0);
+               $r3$.ɵɵi18nAttributes(1, $_c2$);
+             }
+             if (rf & 2) {
+               $r3$.ɵɵi18nExp(ctx.name);
+               $r3$.ɵɵi18nApply(1);
+             }
+           }
+         `;
+         verify(input, output);
+       });
+
+    it('should support i18n attributes with interpolations on explicit <ng-template> elements with structural directives',
+       () => {
+         const input = `
+            <ng-template *ngIf="true" i18n-title title="Hello {{ name }}"></ng-template>
+          `;
+
+         const output = String.raw `
+            var $I18N_0$;
+            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
+              const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS__1$ = goog.getMsg("Hello {$interpolation}", {
+                "interpolation": "\uFFFD0\uFFFD"
+              });
+              $I18N_0$ = $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS__1$;
+            }
+            else {
+              $I18N_0$ = $localize \`Hello $` +
+             String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+            }
+            const $_c2$ = ["title", $I18N_0$];
+            …
+            function MyComponent_0_Template(rf, ctx) {
+              if (rf & 1) {
+                $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 0, 0, "ng-template", 1);
+                $r3$.ɵɵi18nAttributes(1, $_c2$);
+              }
+              if (rf & 2) {
+                const $ctx_r2$ = $r3$.ɵɵnextContext();
+                $r3$.ɵɵi18nExp($ctx_r2$.name);
+                $r3$.ɵɵi18nApply(1);
+              }
+            }
+            …
+            consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.Bindings}, "title"]],
+            template: function MyComponent_Template(rf, ctx) {
+              if (rf & 1) {
+                $r3$.ɵɵtemplate(0, MyComponent_0_Template, 2, 1, undefined, 0);
+              }
+              if (rf & 2) {
+                $r3$.ɵɵproperty("ngIf", true);
+              }
+            },
+          `;
+         verify(input, output);
+       });
+
     it('should not create translations for empty attributes', () => {
       const input = `
         <div id="static" i18n-title="m|d" title></div>

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -341,6 +341,78 @@ describe('directives', () => {
 
   });
 
+  describe('inputs', () => {
+    it('should allow directive inputs (as a prop binding) on <ng-template>', () => {
+      let dirInstance: WithInput;
+      @Directive({selector: '[dir]'})
+      class WithInput {
+        constructor() { dirInstance = this; }
+        @Input() dir: string = '';
+      }
+
+      @Component({
+        selector: 'my-app',
+        template: '<ng-template [dir]="message"></ng-template>',
+      })
+      class TestComp {
+        message = 'Hello';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComp, WithInput]});
+      const fixture = TestBed.createComponent(TestComp);
+      fixture.detectChanges();
+
+      expect(dirInstance !.dir).toBe('Hello');
+    });
+
+    it('should allow directive inputs (as an interpolated prop) on <ng-template>', () => {
+      let dirInstance: WithInput;
+      @Directive({selector: '[dir]'})
+      class WithInput {
+        constructor() { dirInstance = this; }
+        @Input() dir: string = '';
+      }
+
+      @Component({
+        selector: 'my-app',
+        template: '<ng-template dir="{{ message }}"></ng-template>',
+      })
+      class TestComp {
+        message = 'Hello';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComp, WithInput]});
+      const fixture = TestBed.createComponent(TestComp);
+      fixture.detectChanges();
+
+      expect(dirInstance !.dir).toBe('Hello');
+    });
+
+    it('should allow directive inputs (as an interpolated prop) on <ng-template> with structural directives',
+       () => {
+         let dirInstance: WithInput;
+         @Directive({selector: '[dir]'})
+         class WithInput {
+           constructor() { dirInstance = this; }
+           @Input() dir: string = '';
+         }
+
+         @Component({
+           selector: 'my-app',
+           template: '<ng-template *ngIf="true" dir="{{ message }}"></ng-template>',
+         })
+         class TestComp {
+           message = 'Hello';
+         }
+
+         TestBed.configureTestingModule({declarations: [TestComp, WithInput]});
+         const fixture = TestBed.createComponent(TestComp);
+         fixture.detectChanges();
+
+         expect(dirInstance !.dir).toBe('Hello');
+       });
+  });
+
   describe('outputs', () => {
     @Directive({selector: '[out]'})
     class TestDir {

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1423,6 +1423,57 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(titleDirInstances[0].title).toBe('Bonjour');
     });
 
+    it('should allow directive inputs (as an interpolated prop) on <ng-template>', () => {
+      loadTranslations({[computeMsgId('Hello {$INTERPOLATION}')]: 'Bonjour {$INTERPOLATION}'});
+
+      let dirInstance: WithInput;
+      @Directive({selector: '[dir]'})
+      class WithInput {
+        constructor() { dirInstance = this; }
+        @Input() dir: string = '';
+      }
+
+      @Component({
+        selector: 'my-app',
+        template: '<ng-template i18n-dir dir="Hello {{ name }}"></ng-template>',
+      })
+      class TestComp {
+        name = 'Angular';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComp, WithInput]});
+      const fixture = TestBed.createComponent(TestComp);
+      fixture.detectChanges();
+
+      expect(dirInstance !.dir).toBe('Bonjour Angular');
+    });
+
+    it('should allow directive inputs (as an interpolated prop) on <ng-template> with structural directives',
+       () => {
+         loadTranslations({[computeMsgId('Hello {$INTERPOLATION}')]: 'Bonjour {$INTERPOLATION}'});
+
+         let dirInstance: WithInput;
+         @Directive({selector: '[dir]'})
+         class WithInput {
+           constructor() { dirInstance = this; }
+           @Input() dir: string = '';
+         }
+
+         @Component({
+           selector: 'my-app',
+           template: '<ng-template *ngIf="true" i18n-dir dir="Hello {{ name }}"></ng-template>',
+         })
+         class TestComp {
+           name = 'Angular';
+         }
+
+         TestBed.configureTestingModule({declarations: [TestComp, WithInput]});
+         const fixture = TestBed.createComponent(TestComp);
+         fixture.detectChanges();
+
+         expect(dirInstance !.dir).toBe('Bonjour Angular');
+       });
+
     it('should apply i18n attributes during second template pass', () => {
       loadTranslations({[computeMsgId('Set')]: 'Set'});
       @Directive({

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1448,7 +1448,8 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(dirInstance !.dir).toBe('Bonjour Angular');
     });
 
-    it('should allow directive inputs (as an interpolated prop) on <ng-template> with structural directives',
+    it('should allow directive inputs (as interpolated props)' +
+           'on <ng-template> with structural directives present',
        () => {
          loadTranslations({[computeMsgId('Hello {$INTERPOLATION}')]: 'Bonjour {$INTERPOLATION}'});
 


### PR DESCRIPTION
Prior to this commit, Ivy compiler didn't handle directive inputs with interpolations located on `<ng-template>` elements (e.g. `<ng-template dir="{{ field }}">`). That was the case for regular inputs as well as inputs that should be processed via i18n subsystem (e.g. `<ng-template i18n-dir dir="Hello {{ name }}">`). This commit adds support for such expressions for explicit `<ng-template>`s as well as a number of tests to confirm the behavior.

Fixes #35752.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No