### PR TITLE
fix(language-service): fix calculation of pipe spans

### DIFF
--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -260,6 +260,28 @@ describe('definitions', () => {
     }
   });
 
+  // https://github.com/angular/vscode-ng-language-service/issues/677
+  it('should be able to find a pipe with arguments', () => {
+    mockHost.override(TEST_TEMPLATE, `{{birthday | «date»: "MM/dd/yy"}}`);
+
+    const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'date');
+    const result = ngService.getDefinitionAndBoundSpan(TEST_TEMPLATE, marker.start);
+
+    expect(result).toBeDefined();
+    const {textSpan, definitions} = result !;
+    expect(textSpan).toEqual(marker);
+
+    expect(definitions).toBeDefined();
+    expect(definitions !.length).toBe(1);
+
+    const refFileName = '/node_modules/@angular/common/common.d.ts';
+    for (const def of definitions !) {
+      expect(def.fileName).toBe(refFileName);
+      expect(def.name).toBe('date');
+      expect(def.kind).toBe('pipe');
+    }
+  });
+
   describe('in structural directive', () => {
     it('should be able to find the directive', () => {
       mockHost.override(
@@ -445,29 +467,5 @@ describe('definitions', () => {
     expect(def.name).toBe('name');
     expect(def.kind).toBe('property');
     expect(def.textSpan).toEqual(mockHost.getDefinitionMarkerFor(fileName, 'name'));
-  });
-
-  describe('regression tests', () => {
-    // https://github.com/angular/vscode-ng-language-service/issues/677
-    it('should be able to find a pipe with arguments', () => {
-      mockHost.override(TEST_TEMPLATE, `{{birthday | «date»: "MM/dd/yy"}}`);
-
-      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'date');
-      const result = ngService.getDefinitionAndBoundSpan(TEST_TEMPLATE, marker.start);
-
-      expect(result).toBeDefined();
-      const {textSpan, definitions} = result !;
-      expect(textSpan).toEqual(marker);
-
-      expect(definitions).toBeDefined();
-      expect(definitions !.length).toBe(1);
-
-      const refFileName = '/node_modules/@angular/common/common.d.ts';
-      for (const def of definitions !) {
-        expect(def.fileName).toBe(refFileName);
-        expect(def.name).toBe('date');
-        expect(def.kind).toBe('pipe');
-      }
-    });
   });
 });

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -234,22 +234,19 @@ describe('definitions', () => {
   it('should be able to find a pipe', () => {
     const fileName = mockHost.addCode(`
       @Component({
-        template: '<div *ngIf="~{start-my}input | «async»~{end-my}"></div>'
+        template: '<div *ngIf="input | «async»"></div>'
       })
       export class MyComponent {
         input: EventEmitter;
       }`);
 
-    // Get the marker for «test» in the code added above.
+    // Get the marker for «async» in the code added above.
     const marker = mockHost.getReferenceMarkerFor(fileName, 'async');
-
     const result = ngService.getDefinitionAndBoundSpan(fileName, marker.start);
+
     expect(result).toBeDefined();
     const {textSpan, definitions} = result !;
-
-    // Get the marker for bounded text in the code added above
-    const boundedText = mockHost.getLocationMarkerFor(fileName, 'my');
-    expect(textSpan).toEqual(boundedText);
+    expect(textSpan).toEqual(marker);
 
     expect(definitions).toBeDefined();
     expect(definitions !.length).toBe(4);
@@ -448,5 +445,29 @@ describe('definitions', () => {
     expect(def.name).toBe('name');
     expect(def.kind).toBe('property');
     expect(def.textSpan).toEqual(mockHost.getDefinitionMarkerFor(fileName, 'name'));
+  });
+
+  describe('regression tests', () => {
+    // https://github.com/angular/vscode-ng-language-service/issues/677
+    it('should be able to find a pipe with arguments', () => {
+      mockHost.override(TEST_TEMPLATE, `{{birthday | «date»: "MM/dd/yy"}}`);
+
+      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'date');
+      const result = ngService.getDefinitionAndBoundSpan(TEST_TEMPLATE, marker.start);
+
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result !;
+      expect(textSpan).toEqual(marker);
+
+      expect(definitions).toBeDefined();
+      expect(definitions !.length).toBe(1);
+
+      const refFileName = '/node_modules/@angular/common/common.d.ts';
+      for (const def of definitions !) {
+        expect(def.fileName).toBe(refFileName);
+        expect(def.name).toBe('date');
+        expect(def.kind).toBe('pipe');
+      }
+    });
   });
 });

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -138,6 +138,19 @@ describe('hover', () => {
       expect(toText(displayParts)).toBe('(property) TemplateReference.heroes: Hero[]');
     });
 
+    it('should work for pipes', () => {
+      mockHost.override(TEST_TEMPLATE, `
+        <p>The hero's birthday is {{birthday | «date»: "MM/dd/yy"}}</p>`);
+      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'date');
+      const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+      expect(quickInfo).toBeTruthy();
+      const {textSpan, displayParts} = quickInfo !;
+      expect(textSpan).toEqual(marker);
+      expect(toText(displayParts))
+          .toBe(
+              '(pipe) date: (value: any, format?: string | undefined, timezone?: string | undefined, locale?: string | undefined) => string | null');
+    });
+
     it('should work for the $any() cast function', () => {
       const content = mockHost.override(TEST_TEMPLATE, '<div>{{$any(title)}}</div>');
       const position = content.indexOf('$any');

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -171,6 +171,7 @@ export class TemplateReference {
   anyValue: any;
   optional?: string;
   myClick(event: any) {}
+  birthday = new Date();
 }
 
 @Component({


### PR DESCRIPTION
This commit accomplishes two tasks:

- Fixes the span of queried pipes to only be applied on pipe names
- By consequence, fixes how pipes are located in arguments (previously,
  pipes with arguments could not be found because the span of a pipe
  uses a relative span, while the template position is absolute)

The screenshots attached to the PR for this commit demonstrate the
change.

<img width="1068" alt="Screen Shot 2020-03-09 at 10 26 25 PM" src="https://user-images.githubusercontent.com/20735482/76282501-1ad30280-6255-11ea-88e0-cdb4af2950cc.png">
<img width="1068" alt="Screen Shot 2020-03-09 at 10 26 41 PM" src="https://user-images.githubusercontent.com/20735482/76282508-1e668980-6255-11ea-9c2d-94d6690af72a.png">
<img width="1068" alt="Screen Shot 2020-03-09 at 10 26 46 PM" src="https://user-images.githubusercontent.com/20735482/76282514-1eff2000-6255-11ea-85a9-e3a3151db3ca.png">

Closes https://github.com/angular/vscode-ng-language-service/issues/677

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No