### PR TITLE
fix(zone.js): zone.js patches rxjs should check null for unsubscribe

### DIFF
--- a/packages/zone.js/test/rxjs/rxjs.Observable.retry.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.Observable.retry.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Observable, of , timer} from 'rxjs';
+import {delayWhen, map, retryWhen} from 'rxjs/operators';
+
+describe('Observable.retryWhen', () => {
+  let log: any[];
+  let observable1: Observable<any>;
+  let defaultTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+
+  beforeEach(() => {
+    log = [];
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  });
+
+  afterEach(() => { jasmine.DEFAULT_TIMEOUT_INTERVAL = defaultTimeout; });
+
+  it('retryWhen func callback should run in the correct zone', (done: DoneFn) => {
+    const constructorZone1: Zone = Zone.current.fork({name: 'Constructor Zone'});
+    const subscriptionZone: Zone = Zone.current.fork({name: 'Subscription Zone'});
+    let isErrorHandled = false;
+    observable1 = constructorZone1.run(() => {
+      return of (1, 2, 3).pipe(
+          map(v => {
+            if (v > 2 && !isErrorHandled) {
+              isErrorHandled = true;
+              throw v;
+            }
+            return v;
+          }),
+          retryWhen(err => err.pipe(delayWhen(v => timer(v)))));
+    });
+
+    subscriptionZone.run(() => {
+      observable1.subscribe(
+          (result: any) => {
+            log.push(result);
+            expect(Zone.current.name).toEqual(subscriptionZone.name);
+          },
+          (err: any) => { fail('should not call error'); },
+          () => {
+            log.push('completed');
+            expect(Zone.current.name).toEqual(subscriptionZone.name);
+            expect(log).toEqual([1, 2, 1, 2, 3, 'completed']);
+            done();
+          });
+    });
+  });
+});

--- a/packages/zone.js/test/rxjs/rxjs.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.spec.ts
@@ -50,5 +50,6 @@ import './rxjs.Observable.map.spec';
 import './rxjs.Observable.race.spec';
 import './rxjs.Observable.sample.spec';
 import './rxjs.Observable.take.spec';
+import './rxjs.Observable.retry.spec';
 import './rxjs.Observable.timeout.spec';
 import './rxjs.Observable.window.spec';


### PR DESCRIPTION
Close #31687, #31684

Zone.js patches rxjs `_subscribe` and `_unsubscribe` methods, but zone.js doesn't do null check,
so in some operator such as `retryWhen`, the `_unsubscribe` will be set to null, and will cause
zone patched version throw error.

In this PR, if `_subscribe` and `_unsubscribe` is null, will not do the patch.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

