### PR TITLE
build(dev-infra): sort contributors alphabetically in `get-data.ts` script

### DIFF
--- a/tools/contributing-stats/get-data.ts
+++ b/tools/contributing-stats/get-data.ts
@@ -119,7 +119,7 @@ async function getAllOrgMembers() {
     hasNextPage = results.organization.membersWithRole.pageInfo.hasNextPage;
     cursor = results.organization.membersWithRole.pageInfo.endCursor;
   }
-  return members;
+  return members.sort();
 }
 
 /**


### PR DESCRIPTION
The `contributing-stats/get-data.ts` script, which is used to retrieve org-wide contribution data, returned the contributors in retrieval order.

This commit ensures contributors are ordered alphabetically, which makes it easier to find the stats for a specific contributor.
