### PR TITLE
fix(dev-infra): do not run the `lock-closed` GitHub action on forks

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lock_closed:
+    if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
       - uses: angular/dev-infra/github-actions/lock-closed@66462f6


### PR DESCRIPTION
Previously, the `lock-closed` GitHub action, which runs daily and locks closed inactive issues, was run on each fork of the `angular/angular` repo. While the action is a [no-op on forks][1], it make still fail from time to time, generating a confusing notification e-mail for the fork owner.

This commit configures the `lock-closed` action to only run on the main `angular/angular` repository (using the method suggested [here][2]).

[1]: https://github.com/angular/dev-infra/blob/13b25d383/github-actions/lock-closed/src/main.ts#L117
[2]: https://github.community/t5/GitHub-Actions/Do-not-run-cron-workflows-in-forks/td-p/46756
