### PR TITLE
fix(compiler): set structural directive input as `null` when binding is empty

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -841,7 +841,7 @@ describe('compiler compliance', () => {
           selectors: [["my-component"]],
           decls: 3,
           vars: 0,
-          consts: [["foo", ""], [${AttributeMarker.Template}, "if"]],
+          consts: [["foo", ""], [${AttributeMarker.TemplateUnboundAttrs}, "if"]],
           template:  function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "ul", null, 0);
@@ -1316,8 +1316,8 @@ describe('compiler compliance', () => {
           }
           const $_c4$ = [[["span", "title", "tofirst"]], "*"];
           …
-          consts: [["id", "second", ${AttributeMarker.Template}, "ngIf"], ["id", "third", ${
-            AttributeMarker.Template}, "ngIf"], ["id", "second"], ["id", "third"]],
+          consts: [["id", "second", ${AttributeMarker.TemplateBindings}, "ngIf"], ["id", "third", ${
+            AttributeMarker.TemplateBindings}, "ngIf"], ["id", "second"], ["id", "third"]],
           template: function Cmp_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵprojectionDef($_c4$);
@@ -1437,7 +1437,7 @@ describe('compiler compliance', () => {
             selectors: [["my-app"]],
             decls: 2,
             vars: 0,
-            consts: [["ngProjectAs", "[title]", 5, ["", "title", ""]]],
+            consts: [["ngProjectAs", "[title]", ${AttributeMarker.ProjectAs}, ["", "title", ""]]],
             template: function MyApp_Template(rf, ctx) {
                 if (rf & 1) {
                     $r3$.ɵɵelementStart(0, "simple");
@@ -1489,7 +1489,8 @@ describe('compiler compliance', () => {
             selectors: [["my-app"]],
             decls: 2,
             vars: 0,
-            consts: [["ngProjectAs", "[title],[header]", 5, ["", "title", ""]]],
+            consts: [["ngProjectAs", "[title],[header]", ${
+            AttributeMarker.ProjectAs}, ["", "title", ""]]],
             template: function MyApp_Template(rf, ctx) {
                 if (rf & 1) {
                     $r3$.ɵɵelementStart(0, "simple");
@@ -1533,7 +1534,7 @@ describe('compiler compliance', () => {
             vars: 1,
             consts: [
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"], ${
-            AttributeMarker.Template}, "ngIf"],
+            AttributeMarker.TemplateBindings}, "ngIf"],
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]]
             ],
             template: function MyApp_Template(rf, ctx) {
@@ -2394,7 +2395,8 @@ describe('compiler compliance', () => {
           selectors: [["my-component"]],
           decls: 6,
           vars: 1,
-          consts: [["foo", ""], [${AttributeMarker.Template}, "if"], ["baz", ""], ["bar", ""]],
+          consts: [["foo", ""], [${
+          AttributeMarker.TemplateUnboundAttrs}, "if"], ["baz", ""], ["bar", ""]],
           template:  function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelement(0, "div", null, 0);
@@ -2471,8 +2473,9 @@ describe('compiler compliance', () => {
       }
 
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], ["foo", ""], [${
-          AttributeMarker.Template}, "ngIf"]],
+      consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+          AttributeMarker.TemplateBindings}, "ngForOf"], ["foo", ""], [${
+          AttributeMarker.TemplateBindings}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 1, "div", 0);
@@ -2681,7 +2684,8 @@ describe('compiler compliance', () => {
                 selectors: [["my-component"]],
                 decls: 2,
                 vars: 1,
-                consts: [[${AttributeMarker.Template}, "for", "forOf"]],
+                consts: [[${AttributeMarker.TemplateUnboundAttrs}, "for", ${
+            AttributeMarker.TemplateBindings}, "forOf"]],
                 template:  function MyComponent_Template(rf, ctx){
                   if (rf & 1) {
                     $r3$.ɵɵnamespaceSVG();
@@ -2767,7 +2771,8 @@ describe('compiler compliance', () => {
             selectors: [["my-component"]],
             decls: 2,
             vars: 1,
-            consts: [[${AttributeMarker.Template}, "for", "forOf"]],
+            consts: [[${AttributeMarker.TemplateUnboundAttrs}, "for", ${
+            AttributeMarker.TemplateBindings}, "forOf"]],
             template:  function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵelementStart(0, "ul");
@@ -2871,7 +2876,8 @@ describe('compiler compliance', () => {
             selectors: [["my-component"]],
             decls: 2,
             vars: 1,
-            consts: [[${AttributeMarker.Template}, "for", "forOf"]],
+            consts: [[${AttributeMarker.TemplateUnboundAttrs}, "for", ${
+            AttributeMarker.TemplateBindings}, "forOf"]],
             template:  function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵelementStart(0, "ul");

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -250,7 +250,7 @@ describe('compiler compliance: directives', () => {
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
-          consts: [["directiveA", "", ${AttributeMarker.Template}, "ngIf"], ["directiveA", ""]],
+          consts: [["directiveA", "", ${AttributeMarker.TemplateBindings}, "ngIf"], ["directiveA", ""]],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵtemplate(0, MyComponent_ng_container_0_Template, 2, 0, "ng-container", 0);
@@ -341,7 +341,7 @@ describe('compiler compliance: directives', () => {
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               …
-              consts: [[${AttributeMarker.Template}, "someDirective"]],
+              consts: [[${AttributeMarker.TemplateUnboundAttrs}, "someDirective"]],
               template: function MyComponent_Template(rf, ctx) {
                   if (rf & 1) {
                       $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", 0);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -250,7 +250,8 @@ describe('compiler compliance: directives', () => {
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
-          consts: [["directiveA", "", ${AttributeMarker.TemplateBindings}, "ngIf"], ["directiveA", ""]],
+          consts: [["directiveA", "", ${
+          AttributeMarker.TemplateBindings}, "ngIf"], ["directiveA", ""]],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵtemplate(0, MyComponent_ng_container_0_Template, 2, 0, "ng-container", 0);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -389,7 +389,8 @@ describe('i18n support in the template compiler', () => {
               }
             }
             …
-            consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.I18n}, "title"]],
+            consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${
+             AttributeMarker.I18n}, "Hello"]],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_Template, 2, 0, undefined, 0);
@@ -469,7 +470,8 @@ describe('i18n support in the template compiler', () => {
               }
             }
             …
-            consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.Bindings}, "title"]],
+            consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${
+                 AttributeMarker.Bindings}, "title"]],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_Template, 2, 1, undefined, 0);
@@ -760,8 +762,8 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-              AttributeMarker.I18n}, "title"]],
+        consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+              AttributeMarker.TemplateBindings}, "ngForOf"], [${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -977,8 +979,8 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-              AttributeMarker.I18n}, "title"]],
+        consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+              AttributeMarker.TemplateBindings}, "ngForOf"], [${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -1667,7 +1669,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -1726,9 +1728,9 @@ describe('i18n support in the template compiler', () => {
         decls: 3,
         vars: 2,
         consts: [["src", "logo.png"], ["src", "logo.png", ${
-              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+              AttributeMarker.TemplateBindings}, "ngIf"], ["src", "logo.png", ${
               AttributeMarker.Bindings}, "title", ${
-              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+              AttributeMarker.TemplateBindings}, "ngIf"], ["src", "logo.png", ${
               AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -1872,7 +1874,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 2,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -1934,7 +1936,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 3, 1, "div", 0);
@@ -2730,7 +2732,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 2,
         vars: 2,
-        consts: [[4, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_0_Template, 1, 0, undefined, 0);
@@ -2965,8 +2967,9 @@ describe('i18n support in the template compiler', () => {
         decls: 4,
         vars: 3,
         consts: [["title", "icu only", ${
-          AttributeMarker.Template}, "ngIf"], ["title", "icu and text", ${
-          AttributeMarker.Template}, "ngIf"], ["title", "icu only"], ["title", "icu and text"]],
+          AttributeMarker.TemplateBindings}, "ngIf"], ["title", "icu and text", ${
+          AttributeMarker
+              .TemplateBindings}, "ngIf"], ["title", "icu only"], ["title", "icu and text"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -3289,7 +3292,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 3,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -3481,7 +3484,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 2,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -3571,7 +3574,7 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 4,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -155,7 +155,8 @@ describe('compiler compliance: listen()', () => {
           }
         }
         // ...
-        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${AttributeMarker.Bindings}, "click"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${
+        AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 3, 0, "div", 0);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -155,7 +155,7 @@ describe('compiler compliance: listen()', () => {
           }
         }
         // ...
-        consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.Bindings}, "click"]],
+        consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 3, 0, "div", 0);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -103,9 +103,11 @@ describe('compiler compliance: template', () => {
         }
       }
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+      consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"], [${
         AttributeMarker.Bindings}, "title", "click", ${
-        AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+        AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"], [${
         AttributeMarker.Bindings}, "title", "click"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
@@ -161,7 +163,8 @@ describe('compiler compliance: template', () => {
         }
         // ...
         consts: [[${AttributeMarker.Bindings}, "click", ${
-        AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
+        AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", 0);
@@ -265,7 +268,8 @@ describe('compiler compliance: template', () => {
         }
       }
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"]],
+      consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_span_0_Template, 2, 2, "span", 0);
@@ -333,8 +337,9 @@ describe('compiler compliance: template', () => {
       }
 
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-        AttributeMarker.Template}, "ngIf"]],
+      consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"], [${
+        AttributeMarker.TemplateBindings}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", 0);
@@ -416,7 +421,8 @@ describe('compiler compliance: template', () => {
         }
       }
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"]],
+      consts: [[${AttributeMarker.TemplateUnboundAttrs}, "ngFor", ${
+        AttributeMarker.TemplateBindings}, "ngForOf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", 0);
@@ -626,7 +632,8 @@ describe('compiler compliance: template', () => {
 
        // Main template should just contain *ngIf property.
        const expectedMainTemplate = `
-          consts: [[4, "ngIf"], [3, "dir"]],
+          consts: [[${AttributeMarker.TemplateBindings}, "ngIf"], [${
+           AttributeMarker.Bindings}, "dir"]],
           template: function TestComp_Template(rf, ctx) {
             if (rf & 1) {
               $i0$.ɵɵtemplate(0, $TestComp_0_Template$, 1, 1, undefined, 0);
@@ -832,7 +839,7 @@ describe('compiler compliance: template', () => {
       }
 
       // ...
-      consts: [[${AttributeMarker.Template}, "ngIf"]],
+      consts: [[${AttributeMarker.TemplateBindings}, "ngIf"]],
       template: function MyComponent_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", 0);

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4270,8 +4270,8 @@ runInEachFileSystem(os => {
       env.driveMain();
 
       // Include `dir` into static attribute list in case of empty args
-      expect(env.getContents('test-no-args.js')).toContain('consts: [["dir", "", 4, "dir"]]');
-      expect(env.getContents('test-empty-exp.js')).toContain('consts: [["dir", "", 4, "dir"]]');
+      expect(env.getContents('test-no-args.js')).toContain('consts: [[4, "dir"]]');
+      expect(env.getContents('test-empty-exp.js')).toContain('consts: [[4, "dir"]]');
 
       // Generate `property` instruction for false-y values
       expect(env.getContents('test-empty-str.js')).toContain(`ɵɵproperty("dir", "")`);

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4251,33 +4251,35 @@ runInEachFileSystem(os => {
       });
     });
 
-    it('should generate `property` instructions for structural directive inputs for empty and false-y values',
-       () => {
-         const getComponentWithTemplate = (template: string) => `
-            import {Component} from '@angular/core';
-            @Component({
-              template: \`${template}\`
-            })
-            export class App {}
-          `;
-         env.write('test-no-args.ts', getComponentWithTemplate('<div *dir></div>'));
-         env.write('test-empty-exp.ts', getComponentWithTemplate('<div *dir=""></div>'));
-         env.write('test-empty-str.ts', getComponentWithTemplate(`<div *dir="''"></div>`));
-         env.write('test-undefined.ts', getComponentWithTemplate('<div *dir="undefined"></div>'));
-         env.write('test-false.ts', getComponentWithTemplate('<div *dir="false"></div>'));
-         env.write('test-null.ts', getComponentWithTemplate('<div *dir="null"></div>'));
-         env.write('test-zero.ts', getComponentWithTemplate('<div *dir="0"></div>'));
+    it('should handle structural directive inputs for empty and false-y values', () => {
+      const getComponentWithTemplate = (template: string) => `
+        import {Component} from '@angular/core';
+        @Component({
+          template: \`${template}\`
+        })
+        export class App {}
+      `;
+      env.write('test-no-args.ts', getComponentWithTemplate('<div *dir></div>'));
+      env.write('test-empty-exp.ts', getComponentWithTemplate('<div *dir=""></div>'));
+      env.write('test-empty-str.ts', getComponentWithTemplate(`<div *dir="''"></div>`));
+      env.write('test-undefined.ts', getComponentWithTemplate('<div *dir="undefined"></div>'));
+      env.write('test-false.ts', getComponentWithTemplate('<div *dir="false"></div>'));
+      env.write('test-null.ts', getComponentWithTemplate('<div *dir="null"></div>'));
+      env.write('test-zero.ts', getComponentWithTemplate('<div *dir="0"></div>'));
 
-         env.driveMain();
+      env.driveMain();
 
-         expect(env.getContents('test-no-args.js')).toContain('ɵɵproperty("dir", null)');
-         expect(env.getContents('test-empty-exp.js')).toContain('ɵɵproperty("dir", null)');
-         expect(env.getContents('test-empty-str.js')).toContain(`ɵɵproperty("dir", "")`);
-         expect(env.getContents('test-undefined.js')).toContain('ɵɵproperty("dir", undefined)');
-         expect(env.getContents('test-false.js')).toContain('ɵɵproperty("dir", false)');
-         expect(env.getContents('test-null.js')).toContain('ɵɵproperty("dir", null)');
-         expect(env.getContents('test-zero.js')).toContain('ɵɵproperty("dir", 0)');
-       });
+      // Include `dir` into static attribute list in case of empty args
+      expect(env.getContents('test-no-args.js')).toContain('consts: [["dir", "", 4, "dir"]]');
+      expect(env.getContents('test-empty-exp.js')).toContain('consts: [["dir", "", 4, "dir"]]');
+
+      // Generate `property` instruction for false-y values
+      expect(env.getContents('test-empty-str.js')).toContain(`ɵɵproperty("dir", "")`);
+      expect(env.getContents('test-undefined.js')).toContain('ɵɵproperty("dir", undefined)');
+      expect(env.getContents('test-false.js')).toContain('ɵɵproperty("dir", false)');
+      expect(env.getContents('test-null.js')).toContain('ɵɵproperty("dir", null)');
+      expect(env.getContents('test-zero.js')).toContain('ɵɵproperty("dir", 0)');
+    });
 
     it('should wrap "inputs" and "outputs" keys if they contain unsafe characters', () => {
       env.write(`test.ts`, `

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4251,6 +4251,34 @@ runInEachFileSystem(os => {
       });
     });
 
+    it('should generate `property` instructions for structural directive inputs for empty and false-y values',
+       () => {
+         const getComponentWithTemplate = (template: string) => `
+            import {Component} from '@angular/core';
+            @Component({
+              template: \`${template}\`
+            })
+            export class App {}
+          `;
+         env.write('test-no-args.ts', getComponentWithTemplate('<div *dir></div>'));
+         env.write('test-empty-exp.ts', getComponentWithTemplate('<div *dir=""></div>'));
+         env.write('test-empty-str.ts', getComponentWithTemplate(`<div *dir="''"></div>`));
+         env.write('test-undefined.ts', getComponentWithTemplate('<div *dir="undefined"></div>'));
+         env.write('test-false.ts', getComponentWithTemplate('<div *dir="false"></div>'));
+         env.write('test-null.ts', getComponentWithTemplate('<div *dir="null"></div>'));
+         env.write('test-zero.ts', getComponentWithTemplate('<div *dir="0"></div>'));
+
+         env.driveMain();
+
+         expect(env.getContents('test-no-args.js')).toContain('ɵɵproperty("dir", null)');
+         expect(env.getContents('test-empty-exp.js')).toContain('ɵɵproperty("dir", null)');
+         expect(env.getContents('test-empty-str.js')).toContain(`ɵɵproperty("dir", "")`);
+         expect(env.getContents('test-undefined.js')).toContain('ɵɵproperty("dir", undefined)');
+         expect(env.getContents('test-false.js')).toContain('ɵɵproperty("dir", false)');
+         expect(env.getContents('test-null.js')).toContain('ɵɵproperty("dir", null)');
+         expect(env.getContents('test-zero.js')).toContain('ɵɵproperty("dir", 0)');
+       });
+
     it('should wrap "inputs" and "outputs" keys if they contain unsafe characters', () => {
       env.write(`test.ts`, `
       import {Directive, Input} from '@angular/core';

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -496,8 +496,11 @@ export const enum AttributeMarker {
    * ```
    * ['dirA', '', AttributeMarker.Bindings, 'dirB']
    * ```
+   *
+   * TODO: update docs to describe `StaticTemplateAttrs` and `BoundTemplateAttrs`
    */
-  Template = 4,
+  StaticTemplateAttrs = 4,
+  BoundTemplateAttrs = 5,
 
   /**
    * Signals that the following attribute is `ngProjectAs` and its value is a parsed `CssSelector`.
@@ -514,7 +517,7 @@ export const enum AttributeMarker {
    * ['attr', 'value', AttributeMarker.ProjectAs, ['', 'title', '']]
    * ```
    */
-  ProjectAs = 5,
+  ProjectAs = 6,
 
   /**
    * Signals that the following attribute will be translated by runtime i18n
@@ -530,5 +533,5 @@ export const enum AttributeMarker {
    * ```
    * var _c1 = ['moo', 'car', AttributeMarker.I18n, 'foo', 'bar'];
    */
-  I18n = 6,
+  I18n = 7,
 }

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -497,10 +497,10 @@ export const enum AttributeMarker {
    * ['dirA', '', AttributeMarker.Bindings, 'dirB']
    * ```
    *
-   * TODO: update docs to describe `StaticTemplateAttrs` and `BoundTemplateAttrs`
+   * TODO: update docs to describe `TemplateUnboundAttrs` and `TemplateBindings`
    */
-  StaticTemplateAttrs = 4,
-  BoundTemplateAttrs = 5,
+  TemplateUnboundAttrs = 4,
+  TemplateBindings = 5,
 
   /**
    * Signals that the following attribute is `ngProjectAs` and its value is a parsed `CssSelector`.

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -220,7 +220,9 @@ class HtmlAstToIvyAst implements html.Visitor {
       attrs.bound.forEach(attr => templateAttrs.push(attr));
       const hoistedAttrs = parsedElement instanceof t.Element ?
           {
-            attributes: parsedElement.attributes,
+            // Include extracted literal attributes into the set of hoisted attributes, since they
+            // can act as inputs to directives.
+            attributes: [...parsedElement.attributes, ...attrs.literal],
             inputs: parsedElement.inputs,
             outputs: parsedElement.outputs,
           } :

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -220,9 +220,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       attrs.bound.forEach(attr => templateAttrs.push(attr));
       const hoistedAttrs = parsedElement instanceof t.Element ?
           {
-            // Include extracted literal attributes into the set of hoisted attributes, since they
-            // can act as inputs to directives.
-            attributes: [...parsedElement.attributes, ...attrs.literal],
+            attributes: parsedElement.attributes,
             inputs: parsedElement.inputs,
             outputs: parsedElement.outputs,
           } :

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1340,20 +1340,20 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     if (templateAttrs.length) {
-      const staticAttrs: t.TextAttribute[] = [];
+      const textAttrs: t.TextAttribute[] = [];
       const boundAttrs: t.BoundAttribute[] = [];
       templateAttrs.forEach((attr) => {
         if (attr instanceof t.TextAttribute) {
-          staticAttrs.push(attr);
+          textAttrs.push(attr);
         } else {
           boundAttrs.push(attr);
         }
       });
-      if (staticAttrs.length > 0) {
-        addTemplateAttrs(core.AttributeMarker.StaticTemplateAttrs, staticAttrs);
+      if (textAttrs.length > 0) {
+        addTemplateAttrs(core.AttributeMarker.TemplateUnboundAttrs, textAttrs);
       }
       if (boundAttrs.length > 0) {
-        addTemplateAttrs(core.AttributeMarker.BoundTemplateAttrs, boundAttrs);
+        addTemplateAttrs(core.AttributeMarker.TemplateBindings, boundAttrs);
       }
     }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1298,6 +1298,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       }
     }
 
+    function addTemplateAttrs(
+        marker: core.AttributeMarker, attrs: (t.TextAttribute | t.BoundAttribute)[]) {
+      attrExprs.push(o.literal(marker));
+      attrs.forEach(attr => addAttrExpr(attr.name));
+    }
+
     // it's important that this occurs before BINDINGS and TEMPLATE because once `elementStart`
     // comes across the BINDINGS or TEMPLATE markers then it will continue reading each value as
     // as single property value cell by cell.
@@ -1334,8 +1340,21 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     if (templateAttrs.length) {
-      attrExprs.push(o.literal(core.AttributeMarker.Template));
-      templateAttrs.forEach(attr => addAttrExpr(attr.name));
+      const staticAttrs: t.TextAttribute[] = [];
+      const boundAttrs: t.BoundAttribute[] = [];
+      templateAttrs.forEach((attr) => {
+        if (attr instanceof t.TextAttribute) {
+          staticAttrs.push(attr);
+        } else {
+          boundAttrs.push(attr);
+        }
+      });
+      if (staticAttrs.length > 0) {
+        addTemplateAttrs(core.AttributeMarker.StaticTemplateAttrs, staticAttrs);
+      }
+      if (boundAttrs.length > 0) {
+        addTemplateAttrs(core.AttributeMarker.BoundTemplateAttrs, boundAttrs);
+      }
     }
 
     if (i18nAttrs.length) {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1299,7 +1299,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     function addTemplateAttrs(
-        marker: core.AttributeMarker, attrs: (t.TextAttribute | t.BoundAttribute)[]) {
+        marker: core.AttributeMarker, attrs: (t.TextAttribute|t.BoundAttribute)[]) {
       attrExprs.push(o.literal(marker));
       attrs.forEach(attr => addAttrExpr(attr.name));
     }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1069,18 +1069,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             });
           }
         }
-      } else if (input instanceof t.TextAttribute && input.value === '') {
-        // Special case for structural directives with no or empty expressions,
-        // e.g. `<input *dir>` or `<input *dir="">`. We generate `property` instruction in these
-        // cases to set `dir` inputs to be aligned with View Engine behavior. Such attributes are
-        // represented using t.TextAttribute with empty string as a value, see `extractAttributes`
-        // function in `r3_template_transform.ts`.
-        this.allocateBindingSlots(null);
-        propertyBindings.push({
-          name: input.name,
-          sourceSpan: input.sourceSpan,
-          value: () => o.NULL_EXPR,
-        });
       }
     });
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1581,11 +1581,12 @@ function generateInitialInputs(inputs: {[key: string]: string}, attrs: TAttribut
       } else {
         // Skip until the `TemplateUnboundAttrs` marker (if present) or until the end of `attrs`
         // array.
-        while (i < attrs.length && attrs[i + 1] !== AttributeMarker.TemplateUnboundAttrs) i++;
+        while (i < attrs.length && attrs[i] !== AttributeMarker.TemplateUnboundAttrs) i++;
       }
     } else {
       if (inputs.hasOwnProperty(attrName as string)) {
         if (inputsToStore === null) inputsToStore = [];
+        // TODO: document default value choice for unbound template attrs
         const value = isUnboundTemplateAttr ? '' : attrs[i + 1] as string;
         inputsToStore.push(attrName as string, inputs[attrName as string], value);
       }

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1554,7 +1554,7 @@ function setInputsFromAttrs<T>(
 function generateInitialInputs(inputs: {[key: string]: string}, attrs: TAttributes): InitialInputs|
     null {
   let inputsToStore: InitialInputs|null = null;
-  let isStaticTemplateAttrs = false;
+  let isUnboundTemplateAttr = false;
   let i = 0;
   while (i < attrs.length) {
     let attrName = attrs[i];
@@ -1566,32 +1566,32 @@ function generateInitialInputs(inputs: {[key: string]: string}, attrs: TAttribut
       // Skip over the `ngProjectAs` value.
       i += 2;
       continue;
-    } else if (attrName === AttributeMarker.StaticTemplateAttrs) {
+    } else if (attrName === AttributeMarker.TemplateUnboundAttrs) {
       // Skip marker itself and shift `attrName` to the first item in the section.
       i++;
       attrName = attrs[i];
-      isStaticTemplateAttrs = true;
+      isUnboundTemplateAttr = true;
     }
 
     if (typeof attrName === 'number') {
-      // If we hit an attribute marker and we already seen the `StaticTemplateAttrs` marker, we exit
-      // since none of other items in attrs array is a valid input.
-      if (isStaticTemplateAttrs) {
+      // If we hit an attribute marker and we already seen the `TemplateUnboundAttrs` marker, we
+      // exit since none of other items in the attrs array is a valid input.
+      if (isUnboundTemplateAttr) {
         break;
       } else {
-        // Skip until the `StaticTemplateAttrs` marker (if present) or until the end of `attrs`
+        // Skip until the `TemplateUnboundAttrs` marker (if present) or until the end of `attrs`
         // array.
-        while (i < attrs.length && attrs[i + 1] !== AttributeMarker.StaticTemplateAttrs) i++;
+        while (i < attrs.length && attrs[i + 1] !== AttributeMarker.TemplateUnboundAttrs) i++;
       }
     } else {
       if (inputs.hasOwnProperty(attrName as string)) {
         if (inputsToStore === null) inputsToStore = [];
-        const value = isStaticTemplateAttrs ? '' : attrs[i + 1] as string;
+        const value = isUnboundTemplateAttr ? '' : attrs[i + 1] as string;
         inputsToStore.push(attrName as string, inputs[attrName as string], value);
       }
 
       // TODO: add comment
-      i += isStaticTemplateAttrs ? 1 : 2;
+      i += isUnboundTemplateAttr ? 1 : 2;
     }
   }
   return inputsToStore;

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -195,10 +195,10 @@ export const enum AttributeMarker {
    * ['dirA', '', AttributeMarker.Bindings, 'dirB']
    * ```
    *
-   * TODO: update docs to describe `StaticTemplateAttrs` and `BoundTemplateAttrs`
+   * TODO: update docs to describe `TemplateUnboundAttrs` and `TemplateBindings`
    */
-  StaticTemplateAttrs = 4,
-  BoundTemplateAttrs = 5,
+  TemplateUnboundAttrs = 4,
+  TemplateBindings = 5,
 
   /**
    * Signals that the following attribute is `ngProjectAs` and its value is a parsed `CssSelector`.

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -194,8 +194,11 @@ export const enum AttributeMarker {
    * ```
    * ['dirA', '', AttributeMarker.Bindings, 'dirB']
    * ```
+   *
+   * TODO: update docs to describe `StaticTemplateAttrs` and `BoundTemplateAttrs`
    */
-  Template = 4,
+  StaticTemplateAttrs = 4,
+  BoundTemplateAttrs = 5,
 
   /**
    * Signals that the following attribute is `ngProjectAs` and its value is a parsed `CssSelector`.
@@ -212,7 +215,7 @@ export const enum AttributeMarker {
    * ['attr', 'value', AttributeMarker.ProjectAs, ['', 'title', '']]
    * ```
    */
-  ProjectAs = 5,
+  ProjectAs = 6,
 
   /**
    * Signals that the following attribute will be translated by runtime i18n
@@ -228,7 +231,7 @@ export const enum AttributeMarker {
    * ```
    * var _c1 = ['moo', 'car', AttributeMarker.I18n, 'foo', 'bar'];
    */
-  I18n = 6,
+  I18n = 7,
 }
 
 /**

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -298,11 +298,11 @@ function matchTemplateAttribute(attrs: TAttributes, name: string): number {
   while (i < attrs.length) {
     const attr = attrs[i];
     if (typeof attr === 'number') {  // AttributeMarker
-      const _isTemplateAttrsSection = isTemplateAttrsSection;
+      const wasInTemplateAttrsSection = isTemplateAttrsSection;
       isTemplateAttrsSection = isTemplateAttributeMarker(attr);
       // If we were in a template attrs section and came across non-template marker, that means that
       // the template attrs section is over, so we should exit the function.
-      if (_isTemplateAttrsSection && !isTemplateAttrsSection) {
+      if (wasInTemplateAttrsSection && !isTemplateAttrsSection) {
         return -1;
       }
     } else if (isTemplateAttrsSection && attrs[i] === name) {

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -294,18 +294,18 @@ function getNameOnlyMarkerIndex(nodeAttrs: TAttributes) {
 
 function matchTemplateAttribute(attrs: TAttributes, name: string): number {
   let i = 0;
-  let isTemplateSection = false;
+  let isTemplateAttrsSection = false;
   while (i < attrs.length) {
     const attr = attrs[i];
     if (typeof attr === 'number') {  // AttributeMarker
-      const _isTemplateSection = isTemplateSection;
-      isTemplateSection = isTemplateAttributeMarker(attr);
+      const _isTemplateAttrsSection = isTemplateAttrsSection;
+      isTemplateAttrsSection = isTemplateAttributeMarker(attr);
       // If we were in a template attrs section and came across non-template marker, that means that
       // the template attrs section is over, so we should exit the function.
-      if (_isTemplateSection && !isTemplateSection) {
+      if (_isTemplateAttrsSection && !isTemplateAttrsSection) {
         return -1;
       }
-    } else if (isTemplateSection && attrs[i] === name) {
+    } else if (isTemplateAttrsSection && attrs[i] === name) {
       return i;
     }
     i++;

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -96,9 +96,15 @@ export function setUpAttributes(renderer: Renderer3, native: RElement, attrs: TA
  * @param marker The attribute marker to test.
  * @returns true if the marker is a "name-only" marker (e.g. `Bindings`, `Template` or `I18n`).
  */
-export function isNameOnlyAttributeMarker(marker: string|AttributeMarker|CssSelector) {
-  return marker === AttributeMarker.Bindings || marker === AttributeMarker.Template ||
+export function isNameOnlyAttributeMarker(marker: string|AttributeMarker|CssSelector): boolean {
+  return marker === AttributeMarker.Bindings || isTemplateAttributeMarker(marker) ||
       marker === AttributeMarker.I18n;
+}
+
+// TODO: add docs for this function.
+export function isTemplateAttributeMarker(marker: string|AttributeMarker|CssSelector): boolean {
+  return marker === AttributeMarker.StaticTemplateAttrs ||
+      marker === AttributeMarker.BoundTemplateAttrs;
 }
 
 export function isAnimationProp(name: string): boolean {

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -103,8 +103,8 @@ export function isNameOnlyAttributeMarker(marker: string|AttributeMarker|CssSele
 
 // TODO: add docs for this function.
 export function isTemplateAttributeMarker(marker: string|AttributeMarker|CssSelector): boolean {
-  return marker === AttributeMarker.StaticTemplateAttrs ||
-      marker === AttributeMarker.BoundTemplateAttrs;
+  return marker === AttributeMarker.TemplateUnboundAttrs ||
+      marker === AttributeMarker.TemplateBindings;
 }
 
 export function isAnimationProp(name: string): boolean {

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -592,7 +592,9 @@ describe('directives', () => {
       const dirInstances: StructuralDir[] = [];
       @Directive({selector: '[dir]'})
       class StructuralDir {
-        constructor() { dirInstances.push(this); }
+        constructor() {
+          dirInstances.push(this);
+        }
         @Input() dir: any;
       }
 
@@ -646,21 +648,27 @@ describe('directives', () => {
         /** @internal */
         _dirOf: any;
 
-        constructor() { dirInstances.push(this); }
+        constructor() {
+          dirInstances.push(this);
+        }
 
         @Input()
         set dir(value: any) {
           this._dir = value;
           callsCount.dir++;
         }
-        get dir() { return this._dir; }
+        get dir() {
+          return this._dir;
+        }
 
         @Input()
         set dirOf(value: any) {
           this._dirOf = value;
           callsCount.dirOf++;
         }
-        get dirOf() { return this._dirOf; }
+        get dirOf() {
+          return this._dirOf;
+        }
       }
 
       @Component({
@@ -714,7 +722,9 @@ describe('directives', () => {
         /** @internal */
         _dirUnboundInputA: any;
 
-        constructor() { dirInstance = this; }
+        constructor() {
+          dirInstance = this;
+        }
 
         @Input() dirOf: any;  // bound input
 
@@ -723,7 +733,9 @@ describe('directives', () => {
           this._dirUnboundInputA = value;
           staticAttrSetCallsCount++;
         }
-        get dirUnboundInputA() { return this._dirUnboundInputA; }
+        get dirUnboundInputA() {
+          return this._dirUnboundInputA;
+        }
       }
 
       @Component({
@@ -742,22 +754,22 @@ describe('directives', () => {
 
       // Verify that unbound input is set in creation mode in Ivy.
       // In View Engine such static attrs are set in update mode.
-      expect(dirInstance !.dirUnboundInputA).toBe(ivyEnabled ? '' : undefined);
+      expect(dirInstance!.dirUnboundInputA).toBe(ivyEnabled ? '' : undefined);
       expect(staticAttrSetCallsCount).toBe(ivyEnabled ? 1 : 0);
 
       // Verify that bound input is not *yet* set, since it's a creation mode
-      expect(dirInstance !.dirOf).toBe(undefined);
+      expect(dirInstance!.dirOf).toBe(undefined);
 
       fixture.detectChanges();
 
       // Verify that bound input value is preserved.
       // Check that static attribute setter was not called again in Ivy and in View Engine it's
       // called once at this point.
-      expect(dirInstance !.dirUnboundInputA).toBe(ivyEnabled ? '' : null);
+      expect(dirInstance!.dirUnboundInputA).toBe(ivyEnabled ? '' : null);
       expect(staticAttrSetCallsCount).toBe(1);
 
       // Verify that bound input value is now set
-      expect(dirInstance !.dirOf).toEqual([1, 2, 3]);
+      expect(dirInstance!.dirOf).toEqual([1, 2, 3]);
     });
 
     it('should set the directive input only, shadowing the title property of the div, for `[title]="value"`',

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -640,7 +640,10 @@ describe('directives', () => {
 
       @Directive({selector: '[dir]'})
       class StructuralDir {
+        /** @internal */
         _dir: any;
+
+        /** @internal */
         _dirOf: any;
 
         constructor() { dirInstances.push(this); }
@@ -649,14 +652,14 @@ describe('directives', () => {
         set dir(value: any) {
           this._dir = value;
           callsCount.dir++;
-        };
+        }
         get dir() { return this._dir; }
 
         @Input()
         set dirOf(value: any) {
           this._dirOf = value;
           callsCount.dirOf++;
-        };
+        }
         get dirOf() { return this._dirOf; }
       }
 

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -587,6 +587,46 @@ describe('directives', () => {
       expect(div.getAttribute('title')).toBe('a');
     });
 
+    it('should set structural directive input for empty and false-y values', () => {
+      const dirInstances: StructuralDir[] = [];
+      @Directive({selector: '[dir]'})
+      class StructuralDir {
+        constructor() { dirInstances.push(this); }
+        @Input() dir: any;
+      }
+
+      @Component({
+        template: `
+          <div *dir></div>
+          <div *dir=""></div>
+          <div *dir="''"></div>
+          <div *dir="undefined"></div>
+          <div *dir="false"></div>
+          <div *dir="null"></div>
+          <div *dir="0"></div>
+        `,
+      })
+      class App {
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [App, StructuralDir],
+      });
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const expectedInput = [
+        null,       // *dir
+        null,       // *dir=""
+        '',         // *dir="''"
+        undefined,  // *dir="undefined"
+        false,      // *dir="false"
+        null,       // *dir="null"
+        0,          // *dir="0"
+      ];
+      dirInstances.forEach((instance, index) => expect(instance.dir).toBe(expectedInput[index]));
+    });
+
     it('should set the directive input only, shadowing the title property of the div, for `[title]="value"`',
        () => {
          @Component({template: `<div dir-with-title [title]="value"></div>`})

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -183,7 +183,7 @@ it('should not invoke renderer destroy method for embedded views', () => {
       decls: 3,
       vars: 1,
       directives: [NgIf],
-      consts: [[AttributeMarker.Template, 'ngIf']],
+      consts: [[AttributeMarker.TemplateBindings, 'ngIf']],
       /**
        *  <div>Root view</div>
        *  <div *ngIf="visible">Child view</div>
@@ -409,7 +409,7 @@ describe('recursive components', () => {
       selectors: [['ng-if-tree']],
       decls: 3,
       vars: 3,
-      consts: [[AttributeMarker.Bindings, 'data', AttributeMarker.Template, 'ngIf']],
+      consts: [[AttributeMarker.Bindings, 'data', AttributeMarker.TemplateBindings, 'ngIf']],
       template:
           (rf: RenderFlags, ctx: NgIfTree) => {
             if (rf & RenderFlags.Create) {

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -290,7 +290,10 @@ describe('instructions', () => {
           selectors: [['nested-loops']],
           decls: 1,
           vars: 1,
-          consts: [[AttributeMarker.Template, 'ngFor', 'ngForOf']],
+          consts: [[
+            AttributeMarker.TemplateUnboundAttrs, 'ngFor', AttributeMarker.TemplateBindings,
+            'ngForOf'
+          ]],
           template:
               function ToDoAppComponent_Template(rf: RenderFlags, ctx: NestedLoops) {
                 if (rf & RenderFlags.Create) {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -1404,7 +1404,7 @@ describe('query', () => {
                 (ctx.query = tmp as QueryList<any>);
           }
         },
-        [], [], undefined, [[AttributeMarker.Template, 'someDir'], ['foo', '']]);
+        [], [], undefined, [[AttributeMarker.TemplateUnboundAttrs, 'someDir'], ['foo', '']]);
 
     const fixture = new ComponentFixture(AppComponent);
     expect(fixture.component.query.length).toBe(1);


### PR DESCRIPTION
Prior to this commit, inputs for structural directives that do not have a binding (e.g. `<input *dir>`) were not set, which is different from View Engine behavior that set such inputs (with `null`). This commit updates the logic to set structural directive inputs as `null` when binding is empty. Corresponding tests were also added to verify the behavior in the described case as well as behavior in case of other false-y values.

Fixes #35726.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No