### PR TITLE
fix(compiler-cli): TypeScript peer dependency range

### DIFF
--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "tslib": "^1.10.0",
-    "typescript": ">=3.6 <3.8"
+    "typescript": ">=3.6 <3.9"
   },
   "engines": {
     "node": ">=10.0"


### PR DESCRIPTION
This commit https://github.com/angular/angular/commit/95c729f introduced TypeScript 3.8 support however it is not reflected in the `peerDependencies` section of the compiler-cli package.

