### PR TITLE
fix(core): fix memory leak caused by chrome dev tool.

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -177,6 +177,13 @@ export function attachPatchData(target: any, data: LView | LContext) {
   target[MONKEY_PATCH_KEY_NAME] = data;
 }
 
+/**
+ * Clear the monkey-patched data from the given target
+ */
+export function detachPatchData(target: any) {
+  target[MONKEY_PATCH_KEY_NAME] = null;
+}
+
 export function isComponentInstance(instance: any): boolean {
   return instance && instance.constructor && instance.constructor.ɵcmp;
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -11,7 +11,7 @@ import {ViewEncapsulation} from '../metadata/view';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertDomNode, assertEqual, assertString} from '../util/assert';
 import {assertLContainer, assertLView, assertTNodeForLView} from './assert';
-import {attachPatchData} from './context_discovery';
+import {attachPatchData, detachPatchData} from './context_discovery';
 import {ACTIVE_INDEX, ActiveIndexFlag, CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS, NATIVE, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {NodeInjectorFactory} from './interfaces/injector';
@@ -106,6 +106,14 @@ function applyToElementOrContainer(
       nativeInsertBefore(renderer, parent, rNode, beforeNode || null);
     } else if (action === WalkTNodeTreeAction.Detach) {
       nativeRemoveNode(renderer, rNode, isComponent);
+      // Clear __ngContext__ from node to avoid memory leak.
+      // In Chrome, if the chrome dev tool is open, the last
+      // clicked element will be kept in the memory event the element
+      // is removed from it's parentNode, it will make memory
+      // analyze very difficult, so we clear the __ngContext__
+      // here, for details, please check this issue,
+      // https://github.com/angular/angular/issues/35575
+      detachPatchData(rNode);
     } else if (action === WalkTNodeTreeAction.Destroy) {
       ngDevMode && ngDevMode.rendererDestroyNode++;
       (renderer as ProceduralRenderer3).destroyNode !(rNode);


### PR DESCRIPTION
Close #35575

In ivy, Angular attaches lView data to the DOM node, and when the DOM node is removed ,
the DOM node and the attached lView data should be garbage collected. But in Chrome,
if the chrome dev tools is opened, the last clicked dom element will be kept in the memory,
and because the DOM node holds the instance of the lView data, and the lView data holds the
component data, so a lot of data is kept in the memory which will cause memory leak and also
make memory analyze with memory snapshot difficult.

So this PR will clear the attached lView data(__ngContext__) from the DOM node when the DOM
node is detached.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

@mhevery , please review, thank you.