### PR TITLE
fix(bazel): update typescript peer dependency range

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -34,7 +34,7 @@
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
     "@bazel/typescript": ">=1.0.0",
     "terser": "^4.3.1",
-    "typescript": ">=3.6 <3.8",
+    "typescript": ">=3.6 <3.9",
     "rollup": ">=1.20.0",
     "rollup-plugin-commonjs": ">=9.0.0",
     "rollup-plugin-node-resolve": ">=4.2.0",


### PR DESCRIPTION
95c729f5d130a1b903d47304c0aa5b5d0a9b8df2 added support for TypeScript v3.8. Since
these versions are now supported, the `typescript` peer dependency
range in `@angular/bazel` needs to be updated to not report unsatisfied
peer dependencies