### PR TITLE
build(docs-infra): do not include CI-specific config in docs examples ZIP archives

### DIFF
--- a/aio/content/examples/i18n/zipper.json
+++ b/aio/content/examples/i18n/zipper.json
@@ -1,11 +1,9 @@
 {
-  "files":[
+  "files": [
     "!dist/",
     "!**/*.d.ts",
     "!src/**/*.js",
     "!doc-files/**/*",
     "**/*.xlf"
-  ],
-  "removeSystemJsConfig": true,
-  "type": "i18n"
+  ]
 }

--- a/aio/content/examples/universal/zipper.json
+++ b/aio/content/examples/universal/zipper.json
@@ -1,9 +1,7 @@
 {
-  "files":[
+  "files": [
     "!dist/",
     "!**/*.d.ts",
     "!**/src/**/*.js"
-  ],
-  "removeSystemJsConfig": false,
-  "type": "universal"
+  ]
 }

--- a/aio/tools/example-zipper/README.md
+++ b/aio/tools/example-zipper/README.md
@@ -59,21 +59,6 @@ The problem is that not all examples have a stackblitz but they could offer a zi
 In those cases, you can create a `zipper.json` file with the same syntax. It will be ignored by the
 stackblitz tool.
 
-## Choosing the zip "type"
-
-In both `stackblitz.json` and `zipper.json` you can use two extra properties for the zipper configuration:
-
-```
-{
-  ...
-  "removeSystemJsConfig": true,
-  "type": "testing"
-}
-```
-
-This would generate a zip for a testing application and it will also remove everything related with
-SystemJS.
-
 ## Executing the zip generation
 
 `generateZips.js` will create a zip for each `stackblitz.json`  or `zipper.json` it finds.

--- a/aio/tools/example-zipper/exampleZipper.js
+++ b/aio/tools/example-zipper/exampleZipper.js
@@ -112,7 +112,7 @@ class ExampleZipper {
       '!**/npm-debug.log',
       '!**/example-config.json',
       '!**/wallaby.js',
-      '!e2e/protractor-puppeteer.conf.js',
+      '!**/e2e/protractor-puppeteer.conf.js',
       // AOT related files
       '!**/aot/**/*.*',
       '!**/*-aot.*'


### PR DESCRIPTION
In #35381, a new Protractor config file was introduced in docs examples, `protractor-puppeteer.conf.js`, that was only supposed to be used on CI and not be shipped with the ZIP archives provided for users to download and experiment with the docs examples locally.

The logic to ignore the `protractor-puppeteer.conf.js` file was incorrect, resulting in the file being retained in some examples (e.g. [universal][1]). The problem was not immediately obvious, because most examples explicitly specify all `**/*.js` files as ignored, but for other examples the file was retained in the ZIP archive.

This commit fixes the logic to ensure the file is excluded from all docs examples ZIP archives.

##
This PR also cleans up obsolete properties from `zipper.json` files.
See individual commit messages for more info.

##
Jira issue: [FW-1992][2]

[1]: https://v9.angular.io/generated/zips/universal/universal.zip
[2]: https://angular-team.atlassian.net/browse/FW-1992

[FW-1992]: https://angular-team.atlassian.net/browse/FW-1992