### PR TITLE
Change "Bootstrapping" page title 

### DIFF
--- a/aio/content/guide/bootstrapping.md
+++ b/aio/content/guide/bootstrapping.md
@@ -1,4 +1,4 @@
-# Bootstrapping
+# App root module
 
 #### Prerequisites
 
@@ -7,12 +7,12 @@ A basic understanding of the following:
 
 <hr />
 
-An `NgModule` describes how the application parts fit together.
-Every application has at least one Angular module, the _root_ module
-that you bootstrap to launch the application.
-By convention, it is usually called `AppModule`.
+An NgModule describes how the application parts fit together.
+Every application has at least one Angular module, the _root_ module,
+which must be present for bootstrapping the application on launch.
+By convention and by default, this NgModule is named `AppModule`.
 
-If you use the [Angular CLI](cli) to generate an app, the default `AppModule` is as follows:
+When you use the [Angular CLI](cli) command `ng new` to generate an app, the default `AppModule` is as follows.
 
 ```typescript
 /* JavaScript imports */

--- a/aio/content/guide/bootstrapping.md
+++ b/aio/content/guide/bootstrapping.md
@@ -1,4 +1,4 @@
-# App root module
+# Launching your app with a root module
 
 #### Prerequisites
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -313,7 +313,7 @@
             },
             {
               "url": "guide/bootstrapping",
-              "title": "App Root NgModule",
+              "title": "Launching Apps with a Root Module",
               "tooltip": "Tell Angular how to construct and bootstrap the app in the root \"AppModule\"."
             },
             {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The page explains how the AppModule is required for bootstrapping.  it is part of the discussion of ngModules. 
The title "Bootstrapping" has it backwards - you have to have already read it to understand that it is about the AppModule.

Issue Number: https://angular-team.atlassian.net/browse/DOCS-732


## What is the new behavior?

- Retitles page "App root module" 
- Minor edits in text for clarity.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No