### PR TITLE
fix(zone.js): zone.js patch jest should handle done correctly

### DIFF
--- a/packages/zone.js/test/jest/jest.spec.js
+++ b/packages/zone.js/test/jest/jest.spec.js
@@ -6,10 +6,18 @@ function assertInsideSyncDescribeZone() {
 }
 describe('describe', () => {
   assertInsideSyncDescribeZone();
-  beforeEach(() => { assertInsideProxyZone(); });
-  beforeAll(() => { assertInsideProxyZone(); });
-  afterEach(() => { assertInsideProxyZone(); });
-  afterAll(() => { assertInsideProxyZone(); });
+  beforeEach(() => {
+    assertInsideProxyZone();
+  });
+  beforeAll(() => {
+    assertInsideProxyZone();
+  });
+  afterEach(() => {
+    assertInsideProxyZone();
+  });
+  afterAll(() => {
+    assertInsideProxyZone();
+  });
 });
 describe.each([[1, 2]])('describe.each', (arg1, arg2) => {
   assertInsideSyncDescribeZone();
@@ -17,23 +25,78 @@ describe.each([[1, 2]])('describe.each', (arg1, arg2) => {
   expect(arg2).toBe(2);
 });
 describe('test', () => {
-  it('it', () => { assertInsideProxyZone(); });
+  it('it', () => {
+    assertInsideProxyZone();
+  });
   it.each([[1, 2]])('it.each', (arg1, arg2) => {
     assertInsideProxyZone();
     expect(arg1).toBe(1);
     expect(arg2).toBe(2);
   });
-  test('test', () => { assertInsideProxyZone(); });
-  test.each([[]])('test.each', () => { assertInsideProxyZone(); });
+  test('test', () => {
+    assertInsideProxyZone();
+  });
+  test.each([[]])('test.each', () => {
+    assertInsideProxyZone();
+  });
 });
 
-it('it', () => { assertInsideProxyZone(); });
-it.each([[1, 2]])('it.each', (arg1, arg2) => {
+it('it', () => {
+  assertInsideProxyZone();
+});
+it('it with done', done => {
+  assertInsideProxyZone();
+  done();
+});
+
+it.each([[1, 2]])('it.each', (arg1, arg2, done) => {
   assertInsideProxyZone();
   expect(arg1).toBe(1);
   expect(arg2).toBe(2);
+  done();
 });
-test('test', () => { assertInsideProxyZone(); });
-test.each([[]])('test.each', () => { assertInsideProxyZone(); });
+
+it.each([2])('it.each with 1D array', arg1 => {
+  assertInsideProxyZone();
+  expect(arg1).toBe(2);
+});
+
+it.each([2])('it.each with 1D array and done', (arg1, done) => {
+  assertInsideProxyZone();
+  expect(arg1).toBe(2);
+  done();
+});
+
+it.each`
+    foo  | bar
+    ${1} | ${2}
+  `('it.each should work with table as a tagged template literal', ({foo, bar}) => {
+  expect(foo).toBe(1);
+  expect(bar).toBe(2);
+});
+
+it.each`
+    foo  | bar
+    ${1} | ${2}
+  `('it.each should work with table as a tagged template literal with done', ({foo, bar}, done) => {
+  expect(foo).toBe(1);
+  expect(bar).toBe(2);
+  done();
+});
+
+it.each`
+    foo  | bar
+    ${1} | ${2}
+  `('(async) it.each should work with table as a tagged template literal', async ({foo, bar}) => {
+  expect(foo).toBe(1);
+  expect(bar).toBe(2);
+});
+
+test('test', () => {
+  assertInsideProxyZone();
+});
+test.each([[]])('test.each', () => {
+  assertInsideProxyZone();
+});
 
 test.todo('todo');


### PR DESCRIPTION
`zone.js` support jest `test.each()` methods, but it
introduces a bug, which is the `done()` function will not be handled correctly.

```
it('should work with done', done => {
  // done will be undefined.
});
```

The reason is the logic of monkey patching `test` method is different from `jasmine` patch

// jasmine patch
```
return testBody.length === 0
   ? () => testProxyZone.run(testBody, null)
   : done => testProxyZone.run(testBody, null, [done]);
```

// jest patch
```
 return function(...args) {
   return testProxyZone.run(testBody, null, args);
 };
```

the purpose of this change is to handle the following cases.

```
test.each([1, 2])('test.each', (arg1, arg2) => {
  expect(arg1).toBe(1);
  expect(arg2).toBe(2);
});
```

so in jest, it is a little complex, because the `testBody`'s parameter may be bigger than 1, so the
logic in `jasmine`

```
return testBody.length === 0
   ? () => testProxyZone.run(testBody, null)
   : done => testProxyZone.run(testBody, null, [done]);
```
will not work for `test.each` in jest.

So in this PR, I created a dynamic `Function` to return the correct length of paramters (which is required by jest core), to handle
1. normal `test` with or without `done`.
2. each with parameters with or without done.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: The issue is found at `jest-preset-angular` repo here, https://github.com/thymikee/jest-preset-angular/issues/356

