### PR TITLE
Clarify observables doc with new titles and tooltips

### DIFF
--- a/aio/content/guide/observables.md
+++ b/aio/content/guide/observables.md
@@ -1,15 +1,13 @@
 # Using observables to pass values
 
 Observables provide support for passing messages between parts of your application.
-They offer significant benefits over other techniques for event handling, asynchronous programming, and handling multiple values.
+They are used frequently in Angular and are the recommended technique for event handling, asynchronous programming, and handling multiple values.
 
 The observer pattern is a software design pattern in which an object, called the *subject*, maintains a list of its dependents, called *observers*, and notifies them automatically of state changes.
-This is similar (but not identical) to the [publish/subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) design pattern.
+This pattern is similar (but not identical) to the [publish/subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) design pattern.
 
 Observables are declarative&mdash;that is, you define a function for publishing values, but it is not executed until a consumer subscribes to it.
 The subscribed consumer then receives notifications until the function completes, or until they unsubscribe.
-
-Observables are declarative. You define a function for producing values, but that function is not executed until a consumer makes a request to receive notifications. The act of subscribing creates an observer. The observer then receives notifications of new values until the function completes, or until they unsubscribe.
 
 An observable can deliver multiple values of any type&mdash;literals, messages, or events, depending on the context. The API for receiving values is the same whether the values are delivered synchronously or asynchronously. Because setup and teardown logic are both handled by the observable, your application code only needs to worry about subscribing to consume values, and when done, unsubscribing. Whether the stream was keystrokes, an HTTP response, or an interval timer, the interface for listening to values and stopping listening is the same.
 

--- a/aio/content/guide/observables.md
+++ b/aio/content/guide/observables.md
@@ -1,9 +1,15 @@
+# Using observables to pass values
 
-# Observables
+Observables provide support for passing messages between parts of your application.
+They offer significant benefits over other techniques for event handling, asynchronous programming, and handling multiple values.
 
-Observables provide support for passing messages between publishers and subscribers in your application. Observables offer significant benefits over other techniques for event handling, asynchronous programming, and handling multiple values.
+The observer pattern is a software design pattern in which an object, called the *subject*, maintains a list of its dependents, called *observers*, and notifies them automatically of state changes.
+This is similar (but not identical) to the [publish/subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) design pattern.
 
-Observables are declarative&mdash;that is, you define a function for publishing values, but it is not executed until a consumer subscribes to it. The subscribed consumer then receives notifications until the function completes, or until they unsubscribe.
+Observables are declarative&mdash;that is, you define a function for publishing values, but it is not executed until a consumer subscribes to it.
+The subscribed consumer then receives notifications until the function completes, or until they unsubscribe.
+
+Observables are declarative. You define a function for producing values, but that function is not executed until a consumer makes a request to receive notifications. The act of subscribing creates an observer. The observer then receives notifications of new values until the function completes, or until they unsubscribe.
 
 An observable can deliver multiple values of any type&mdash;literals, messages, or events, depending on the context. The API for receiving values is the same whether the values are delivered synchronously or asynchronously. Because setup and teardown logic are both handled by the observable, your application code only needs to worry about subscribing to consume values, and when done, unsubscribing. Whether the stream was keystrokes, an HTTP response, or an interval timer, the interface for listening to values and stopping listening is the same.
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -272,28 +272,28 @@
           "children": [
             {
               "url": "guide/observables",
-              "title": "Observables",
-              "tooltip": ""
+              "title": "Observables Overview",
+              "tooltip": "Using observables to pass values synchronously or asynchronously."
             },
             {
               "url": "guide/rx-library",
               "title": "The RxJS Library",
-              "tooltip": ""
+              "tooltip": "The RxJS library provides useful operators."
             },
             {
               "url": "guide/observables-in-angular",
               "title": "Observables in Angular",
-              "tooltip": ""
+              "tooltip": "How Angular subsystems make us of observables."
             },
             {
               "url": "guide/practical-observable-usage",
               "title": "Practical Usage",
-              "tooltip": ""
+              "tooltip": "Domains in which observables are useful."
             },
             {
               "url": "guide/comparing-observables",
               "title": "Compare to Other Techniques",
-              "tooltip": ""
+              "tooltip": "How observables compare to promises and other message passing techniques."
             }
           ]
         },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The title is not task oriented, the pub/sub terminology is not introduced.
In the left nav, main page title is too cryptic, no tooltips to describe other pages in section

Issue Number: N/A


## What is the new behavior?
- change page title to be task oriented
- edit intro to make pub/sub model clearer
- clarify left-nav entries

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

