### PR TITLE
Make page titles and toc descriptions task-oriented

### DIFF
--- a/aio/content/guide/architecture-components.md
+++ b/aio/content/guide/architecture-components.md
@@ -1,4 +1,4 @@
-# Introduction to components
+# Introduction to components and templates
 
 A *component* controls a patch of screen called a *view*.
 For example, individual components define and control each of the following views from the [Tutorial](tutorial):

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -1,4 +1,4 @@
-# Server interaction through HTTP
+# Communicating with backend services using HTTP
 
 Most front-end applications communicate with backend services over the HTTP protocol. Modern browsers support two different APIs for making HTTP requests: the `XMLHttpRequest` interface and the `fetch()` API.
 

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -1,4 +1,4 @@
-# HttpClient
+# Server interaction through HTTP
 
 Most front-end applications communicate with backend services over the HTTP protocol. Modern browsers support two different APIs for making HTTP requests: the `XMLHttpRequest` interface and the `fetch()` API.
 

--- a/aio/content/guide/providers.md
+++ b/aio/content/guide/providers.md
@@ -1,4 +1,4 @@
-# Providers
+# Provider dependencies in modules
 
 A provider is an instruction to the [Dependency Injection](/guide/dependency-injection) system on how to obtain a value for a dependency. Most of the time, these dependencies are services that you create and provide.
 

--- a/aio/content/guide/providers.md
+++ b/aio/content/guide/providers.md
@@ -1,4 +1,4 @@
-# Provider dependencies in modules
+# Providing dependencies in modules
 
 A provider is an instruction to the [Dependency Injection](/guide/dependency-injection) system on how to obtain a value for a dependency. Most of the time, these dependencies are services that you create and provide.
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -1,6 +1,6 @@
-# Routing and navigation
+# In-app navigation with routing
 
-The Angular **`Router`** enables navigation from one [view](guide/glossary#view) to the next
+The Angular **`Router`** enables navigation from one [view](guide/glossary#view "View definition") to the next
 as users perform application tasks.
 
 This guide covers the router's primary features, illustrating them through the evolution
@@ -3306,7 +3306,7 @@ The `redirectUrl` property stores the URL that the user wanted to access so you 
 
 <div class="alert is-helpful">
 
-To keep things simple, this example redirects unauthenticated users to `/admin`. 
+To keep things simple, this example redirects unauthenticated users to `/admin`.
 
 </div>
 

--- a/aio/content/guide/schematics.md
+++ b/aio/content/guide/schematics.md
@@ -1,4 +1,4 @@
-# Code generation with schematics
+# Generating code using schematics
 
 A schematic is a template-based code generator that supports complex logic.
 It is a set of instructions for transforming a software project by generating or modifying code.

--- a/aio/content/guide/schematics.md
+++ b/aio/content/guide/schematics.md
@@ -1,4 +1,4 @@
-# Schematics
+# Code generation with schematics
 
 A schematic is a template-based code generator that supports complex logic.
 It is a set of instructions for transforming a software project by generating or modifying code.

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -338,8 +338,8 @@
             },
             {
               "url": "guide/providers",
-              "title": "Providers",
-              "tooltip": "Providers and NgModules."
+              "title": "Providing Dependencies",
+              "tooltip": "Providing dependencies to NgModules."
             },
             {
               "url": "guide/singleton-services",
@@ -401,7 +401,7 @@
         },
         {
           "url": "guide/http",
-          "title": "HttpClient",
+          "title": "Server interaction with HTTP",
           "tooltip": "Use HTTP to talk to a remote server."
         },
         {
@@ -557,12 +557,12 @@
         },
         {
           "title": "Schematics",
-          "tooltip": "Understanding schematics.",
+          "tooltip": "Understanding schematics for code generation.",
           "children": [
             {
               "url": "guide/schematics",
               "title": "Schematics Overview",
-              "tooltip": "Understand how schematics are used in Angular."
+              "tooltip": "How the CLI uses schematics to generate code."
             },
             {
               "url": "guide/schematics-authoring",

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -401,7 +401,7 @@
         },
         {
           "url": "guide/http",
-          "title": "Server interaction with HTTP",
+          "title": "Access Servers over HTTP",
           "tooltip": "Use HTTP to talk to a remote server."
         },
         {
@@ -557,7 +557,7 @@
         },
         {
           "title": "Schematics",
-          "tooltip": "Understanding schematics for code generation.",
+          "tooltip": "Using CLI schematics for code generation.",
           "children": [
             {
               "url": "guide/schematics",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Many page titles are cryptic and feature-oriented

Issue Number: N/A


## What is the new behavior?
Updates page titles and their corresponding TOC entries to be more task-oriented.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
 