### PR TITLE
docs: adding a note on extra text interpolations and HTML tags in translations to Ivy guide

### DIFF
--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -75,7 +75,9 @@ Please note that these constants are not meant to be used by 3rd party library o
 
 * ICU parsing happens at runtime, so only text, HTML tags and text bindings are allowed inside ICU cases (previously, directives were also permitted inside ICUs).
 
-* Adding extra text bindings (that are not present in the source i18n message extracted from component's template) into translations will trigger runtime error and extra HTML tags will be rendered as plain text (previously it was possible to add extra bindings and HTML tags into translations since templates were re-compiled for each locale).
+* Adding text bindings into i18n translations that are not present in the source template itself will throw a runtime error (previously, including extra bindings in translations was permitted).
+
+* Extra HTML tags in i18n translations that are not present in the source template itself will be rendered as plain text (previously, these tags would render as HTML).
 
 * Providers formatted as `{provide: X}` without a `useValue`, `useFactory`, `useExisting`, or `useClass` property are treated like `{provide: X, useClass: X}` (previously, it defaulted to `{provide: X, useValue: undefined}`).
 

--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -75,6 +75,8 @@ Please note that these constants are not meant to be used by 3rd party library o
 
 * ICU parsing happens at runtime, so only text, HTML tags and text bindings are allowed inside ICU cases (previously, directives were also permitted inside ICUs).
 
+* Translated messages should not contain text bindings or HTML tags that were not present in the source i18n message extracted from component’s template. Since translation parsing in Ivy happens at runtime, extra text bindings will trigger runtime error and extra HTML tags will be rendered as plain text.
+
 * Providers formatted as `{provide: X}` without a `useValue`, `useFactory`, `useExisting`, or `useClass` property are treated like `{provide: X, useClass: X}` (previously, it defaulted to `{provide: X, useValue: undefined}`).
 
 * `DebugElement.attributes` returns `undefined` for attributes that were added and then subsequently removed (previously, attributes added and later removed would have a value of `null`).

--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -75,7 +75,7 @@ Please note that these constants are not meant to be used by 3rd party library o
 
 * ICU parsing happens at runtime, so only text, HTML tags and text bindings are allowed inside ICU cases (previously, directives were also permitted inside ICUs).
 
-* I18n translations parsing happens at runtime (when component's template is already compiled), so adding extra text bindings (that are not present in the source i18n message extracted from component’s template) into translations will trigger runtime error and extra HTML tags will be rendered as plain text.
+* Adding extra text bindings (that are not present in the source i18n message extracted from component's template) into translations will trigger runtime error and extra HTML tags will be rendered as plain text (previously it was possible to add extra bindings and HTML tags into translations since templates were re-compiled for each locale).
 
 * Providers formatted as `{provide: X}` without a `useValue`, `useFactory`, `useExisting`, or `useClass` property are treated like `{provide: X, useClass: X}` (previously, it defaulted to `{provide: X, useValue: undefined}`).
 

--- a/aio/content/guide/ivy-compatibility.md
+++ b/aio/content/guide/ivy-compatibility.md
@@ -75,7 +75,7 @@ Please note that these constants are not meant to be used by 3rd party library o
 
 * ICU parsing happens at runtime, so only text, HTML tags and text bindings are allowed inside ICU cases (previously, directives were also permitted inside ICUs).
 
-* Translated messages should not contain text bindings or HTML tags that were not present in the source i18n message extracted from component’s template. Since translation parsing in Ivy happens at runtime, extra text bindings will trigger runtime error and extra HTML tags will be rendered as plain text.
+* I18n translations parsing happens at runtime (when component's template is already compiled), so adding extra text bindings (that are not present in the source i18n message extracted from component’s template) into translations will trigger runtime error and extra HTML tags will be rendered as plain text.
 
 * Providers formatted as `{provide: X}` without a `useValue`, `useFactory`, `useExisting`, or `useClass` property are treated like `{provide: X, useClass: X}` (previously, it defaulted to `{provide: X, useValue: undefined}`).
 


### PR DESCRIPTION
This commit updates Ivy compatibility guide with additional note on extra text interpolations and HTML tags in translations.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No