### PR TITLE
build: ng_rollup_bundle internal rule should support ngcc

### DIFF
--- a/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
+++ b/tools/ng_rollup_bundle/ng_rollup_bundle.bzl
@@ -66,7 +66,7 @@ _NG_ROLLUP_BUNDLE_DEPS_ASPECTS = [esm5_outputs_aspect, ng_rollup_module_mappings
 _NG_ROLLUP_BUNDLE_ATTRS = {
     "build_optimizer": attr.bool(
         doc = """Use build optimizer plugin
-        
+
         Only used if sources are esm5 which depends on value of esm5_sources.""",
         default = True,
     ),
@@ -82,7 +82,7 @@ _NG_ROLLUP_BUNDLE_ATTRS = {
     "entry_point": attr.label(
         doc = """The starting point of the application, passed as the `--input` flag to rollup.
 
-        If the entry JavaScript file belongs to the same package (as the BUILD file), 
+        If the entry JavaScript file belongs to the same package (as the BUILD file),
         you can simply reference it by its relative name to the package directory:
 
         ```
@@ -110,7 +110,7 @@ _NG_ROLLUP_BUNDLE_ATTRS = {
 
         The rule will use the corresponding `.js` output of the ts_library rule as the entry point.
 
-        If the entry point target is a rule, it should produce a single JavaScript entry file that will be passed to the nodejs_binary rule. 
+        If the entry point target is a rule, it should produce a single JavaScript entry file that will be passed to the nodejs_binary rule.
         For example:
 
         ```
@@ -274,6 +274,7 @@ def _write_rollup_config(ctx, root_dir, build_optimizer, filename = "_%s.rollup.
             "TMPL_workspace_name": ctx.workspace_name,
             "TMPL_external": ", ".join(["'%s'" % e for e in external]),
             "TMPL_globals": ", ".join(["'%s': '%s'" % g for g in globals]),
+            "TMPL_ivy_enabled": "true" if ctx.var.get("angular_ivy_enabled", None) == "True" else "false",
         },
     )
 


### PR DESCRIPTION
The `ng_rollup_bundle` rule currently is only consumed in the
Angular framework repository. This means that Angular packages
are built from source, and ngcc is never needed to build rollup
bundles using Ivy.

Though, this rule is planned to be shared with other repositories
to support common benchmark code. This means that ngcc needs to be
handled as these other repositories cannot build Angular from source,
but instead consume Angular through NPM (with ngcc enabling Ivy).

The `ng_rollup_bundle` rule needs to dynamically prioritize `ngcc`
generated main resolution fields if `--define=angular_ivy_enabled=True`
is set (or with the alias: `--config=ivy`).