### PR TITLE
docs(common): Add missing entry for NgForOfContext.count

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -85,6 +85,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * more complex then a property access, for example when using the async pipe (`userStreams |
  * async`).
  * - `index: number`: The index of the current item in the iterable.
+ * - `count: number`: The length of the iterable.
  * - `first: boolean`: True when the item is the first item in the iterable.
  * - `last: boolean`: True when the item is the last item in the iterable.
  * - `even: boolean`: True when the item has an even index in the iterable.

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -203,6 +203,17 @@ let thisArg: any;
          detectChangesAndExpectText('0123456789');
        }));
 
+    it('should display count correctly', async(() => {
+         const template = '<span *ngFor="let item of items; let len=count">{{len}}</span>';
+         fixture = createTestComponent(template);
+
+         getComponent().items = [0, 1, 2];
+         detectChangesAndExpectText('333');
+
+         getComponent().items = [4, 3, 2, 1, 0, -1];
+         detectChangesAndExpectText('666666');
+       }));
+
     it('should display first item correctly', async(() => {
          const template =
              '<span *ngFor="let item of items; let isFirst=first">{{isFirst.toString()}}</span>';


### PR DESCRIPTION
`count` is available in `NgForOfContext` but it's missing in the docs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
