### PR TITLE
docs: remove speeding update ngcc section

### DIFF
--- a/aio/content/guide/ivy.md
+++ b/aio/content/guide/ivy.md
@@ -43,29 +43,6 @@ CLI commands run `ngcc` as needed when performing an Angular build.
 
 For more information on how to publish libraries see [Publishing your Library](guide/creating-libraries#publishing-your-library).
 
-{@a speeding-up-ngcc-compilation}
-### Speeding up ngcc compilation
-
-The standalone `ngcc` program can run in parallel over your third party modules, making it more efficient than letting Angular CLI run it as needed.
-
-You can run `ngcc` after each installation of node_modules by adding a `postinstall` [npm script](https://docs.npmjs.com/misc/scripts):
-
-<code-example language="json" header="package.json">
-{
-  "scripts": {
-    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
-  }
-}
-</code-example>
-
-<div class="alert is-important">
-
-The `postinstall` script will run on every installation of `node_modules`, including those performed by `ng update` and `ng add`.
-
-If you perform multiple installs in a row, this can end up being slower than letting Angular CLI run `ngcc` on builds.
-
-</div>
-
 {@a maintaining-library-compatibility}
 ### Maintaining library compatibility
 
@@ -92,8 +69,9 @@ You can run `ngcc` after each installation of node_modules by adding a `postinst
 
 <div class="alert is-important">
 
-Don't use `--create-ivy-entry-points` as this will cause Node not to resolve the Ivy version of the packages correctly.
-
+ * The `postinstall` script will run on every installation of `node_modules`, including those performed by `ng update` and `ng add`.
+ * Don't use `--create-ivy-entry-points` as this will cause Node not to resolve the Ivy version of the packages correctly.
+ 
 </div>
 
 {@a opting-out-of-angular-ivy}


### PR DESCRIPTION
In version 9.1, this is no longer needed as in the CLI, NGCC async has been integrated which will run during `ng build/ng serve/ng test`.

Reference: TOOL-1340
