### PR TITLE
docs: place download section in angular elements to the top of the page

### DIFF
--- a/aio/content/guide/elements.md
+++ b/aio/content/guide/elements.md
@@ -1,5 +1,15 @@
 # Angular elements overview
 
+<div class="alert is-helpful">
+
+  <!--
+    StackBlitz transpiles code to ES5. The live example will not work without a polyfill.
+    Only offer a `.zip` to download for now.
+  -->
+  Download the accompanying full code for this guide from <live-example downloadOnly>here</live-example>.
+
+</div>
+
 _Angular elements_ are Angular components packaged as _custom elements_ (also called Web Components), a web standard for defining new HTML elements in a framework-agnostic way.
 
 [Custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) are a Web Platform feature currently supported by Chrome, Edge (Chromium-based), Firefox, Opera, and Safari, and available in other browsers through polyfills (see [Browser Support](#browser-support)).
@@ -152,12 +162,6 @@ For comparison, the demo shows both methods. One button adds the popup using the
 
   </code-pane>
 </code-tabs>
-
-<!--
-  StackBlitz transpiles code to ES5. The live example will not work without a polyfill.
-  Only offer a `.zip` to download for now.
--->
-You can download the full code for the example <live-example downloadOnly>here</live-example>.
 
 
 ## Typings for custom elements

--- a/aio/content/guide/elements.md
+++ b/aio/content/guide/elements.md
@@ -1,16 +1,12 @@
 # Angular elements overview
 
+_Angular elements_ are Angular components packaged as _custom elements_ (also called Web Components), a web standard for defining new HTML elements in a framework-agnostic way.
+
 <div class="alert is-helpful">
 
-  <!--
-    StackBlitz transpiles code to ES5. The live example will not work without a polyfill.
-    Only offer a `.zip` to download for now.
-  -->
-  Download the accompanying full code for this guide from <live-example downloadOnly>here</live-example>.
+  For the sample app that this page describes, see the <live-example></live-example>.
 
 </div>
-
-_Angular elements_ are Angular components packaged as _custom elements_ (also called Web Components), a web standard for defining new HTML elements in a framework-agnostic way.
 
 [Custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) are a Web Platform feature currently supported by Chrome, Edge (Chromium-based), Firefox, Opera, and Safari, and available in other browsers through polyfills (see [Browser Support](#browser-support)).
 A custom element extends HTML by allowing you to define a tag whose content is created and controlled by JavaScript code.


### PR DESCRIPTION
Previously, the download link to the example for the angular element
guide was in the middle of the page. To make it easier for the user to
find the download link, it has been placed to the top of the page.

This commit partially addresses #35459

Fixes #35459

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #35459


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
