### PR TITLE
fix(core): prevent unknown property check for AOT-compiled components

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1038,6 +1038,12 @@ export function setNgReflectProperties(
 function validateProperty(
     tView: TView, lView: LView, element: RElement|RComment, propName: string,
     tNode: TNode): boolean {
+  // If `schemas` is set to `null`, that's an indication that this Component was compiled in AOT
+  // mode where this check happens at compile time. In JIT mode, `schemas` is always present and
+  // defined as an array (as an empty array in case `schemas` field is not defined) and we should
+  // execute the check below.
+  if (tView.schemas === null) return true;
+
   // The property is considered valid if the element matches the schema, it exists on the element
   // or it is synthetic, and we are in a browser context (web worker nodes should be skipped).
   if (matchingSchemas(tView, lView, tNode.tagName) || propName in element ||


### PR DESCRIPTION
Prior to this commit, the unknown property check was unnecessarily invoked for AOT-compiled components (for these components, the check happens at compile time). This commit updates the code to avoid unknown property verification for AOT-compiled components by checking whether schemas information is present (as a way to detect whether this is JIT or AOT compiled component).

Note: there is a similar check performed for unknown elements check as well (added in https://github.com/angular/angular/pull/34024).

Resolves #35945.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No