### PR TITLE
feat(router): route initializer

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -15,7 +15,7 @@ export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router} from './router';
-export {ROUTES} from './router_config_loader';
+export {ROUTES, ROUTE_INITIALIZER} from './router_config_loader';
 export {ExtraOptions, InitialNavigation, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
 export {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
 export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} from './router_preloader';

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -6,11 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// TODO(i): switch to fromPromise once it's expored in rxjs
 import {Compiler, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
+import {isPromise} from '@angular/core/src/util/lang';
 import {Observable, from, of } from 'rxjs';
-import {map, mergeMap} from 'rxjs/operators';
+import {mergeMap, switchMap} from 'rxjs/operators';
+
 import {LoadChildren, LoadedRouterConfig, Route, standardizeConfig} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
+
 
 /**
  * The [DI token](guide/glossary/#di-token) for a router configuration.
@@ -18,6 +22,20 @@ import {flatten, wrapIntoObservable} from './utils/collection';
  * @publicApi
  */
 export const ROUTES = new InjectionToken<Route[][]>('ROUTES');
+
+/**
+ * An injection token that allows you to provide one or more initialization functions.
+ * These function are injected when a route is loaded. If any of these functions returns
+ * a Promise, initialization does not complete until the Promise is resolved.
+ *
+ * You can, for example, create a factory function that loads language data
+ * or an external configuration, and provide that function to the `ROUTER_INITIALIZER` token.
+ * That way, the function is executed during the router loading process,
+ * and the needed data is available when the route is loaded.
+ *
+ * @publicApi
+ */
+export const ROUTE_INITIALIZER = new InjectionToken<Array<() => void>>('Router loader Initializer');
 
 export class RouterConfigLoader {
   constructor(
@@ -32,16 +50,42 @@ export class RouterConfigLoader {
 
     const moduleFactory$ = this.loadModuleFactory(route.loadChildren !);
 
-    return moduleFactory$.pipe(map((factory: NgModuleFactory<any>) => {
+    return moduleFactory$.pipe(switchMap((factory: NgModuleFactory<any>) => {
       if (this.onLoadEndListener) {
         this.onLoadEndListener(route);
       }
 
       const module = factory.create(parentInjector);
+      const routeInits: (() => any)[] = module.injector.get(ROUTE_INITIALIZER, () => {});
 
-      return new LoadedRouterConfig(
-          flatten(module.injector.get(ROUTES)).map(standardizeConfig), module);
+      return from(
+          this.runInitializers(routeInits)
+              .then(
+                  () => new LoadedRouterConfig(
+                      flatten(module.injector.get(ROUTES)).map(standardizeConfig), module)));
+
     }));
+  }
+
+  private runInitializers(routeInits: (() => any)[]): Promise<unknown> {
+    return new Promise((res, rej) => {
+      const asyncInitPromises: Promise<any>[] = [];
+
+      if (routeInits) {
+        for (let i = 0; i < routeInits.length; i++) {
+          const initResult = routeInits[i]();
+          if (isPromise(initResult)) {
+            asyncInitPromises.push(initResult);
+          }
+        }
+      }
+
+      Promise.all(asyncInitPromises).then(() => { res(); }).catch(e => { rej(e); });
+
+      if (asyncInitPromises.length === 0) {
+        res();
+      }
+    });
   }
 
   private loadModuleFactory(loadChildren: LoadChildren): Observable<NgModuleFactory<any>> {

--- a/packages/router/test/router_config_loader.spec.ts
+++ b/packages/router/test/router_config_loader.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Compiler, Injector, NgModule} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {ROUTES, ROUTE_INITIALIZER, RouterConfigLoader} from '../src/router_config_loader';
+import {SpyNgModuleFactoryLoader} from '../testing';
+
+describe('router config loader', () => {
+  let routerConfigLoader: RouterConfigLoader;
+
+  beforeEach(() => {
+    routerConfigLoader = new RouterConfigLoader(
+        new SpyNgModuleFactoryLoader(TestBed.inject(Compiler)), TestBed.inject(Compiler));
+
+  });
+
+  it('should load normal routes', async(done) => {
+    @NgModule({providers: [{provide: ROUTES, useValue: {}}]})
+    class TestModule {
+    }
+
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          done();
+        });
+  });
+
+  it('should load routes with initializer', async(done) => {
+    @NgModule({
+      providers: [
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => {}, multi: true},
+        {provide: ROUTES, useValue: {}}
+      ]
+    })
+    class TestModule {
+    }
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          expect(loaded.module.injector.get(ROUTE_INITIALIZER)).toBeDefined();
+          expect(loaded.module.injector.get(ROUTE_INITIALIZER).length).toEqual(1);
+          done();
+        });
+  });
+
+  it('should load routes with multiple initializer', async(done) => {
+    @NgModule({
+      providers: [
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => 1, multi: true},
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => 2, multi: true},
+        {provide: ROUTES, useValue: {}}
+      ]
+    })
+    class TestModule {
+    }
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          expect(loaded.module.injector.get(ROUTE_INITIALIZER).length).toEqual(2);
+          done();
+        });
+  });
+
+
+  it('should load routes with child module initializer', async(done) => {
+    @NgModule({providers: [{provide: ROUTE_INITIALIZER, useFactory: () => () => 2, multi: true}]})
+    class TestChildModule {
+    }
+
+    @NgModule({
+      imports: [TestChildModule],
+      providers: [
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => 1, multi: true},
+        {provide: ROUTES, useValue: {}}
+      ]
+    })
+    class TestModule {
+    }
+
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          expect(loaded.module.injector.get(ROUTE_INITIALIZER).length).toEqual(2);
+          done();
+        });
+  });
+
+
+  it('shouldn\'t initialize lazy loaded child module initializer', async(done) => {
+    @NgModule({providers: [{provide: ROUTE_INITIALIZER, useFactory: () => () => 2, multi: true}]})
+    class TestChildModule {
+    }
+
+    @NgModule({
+      imports: [],
+      providers: [
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => 1, multi: true},
+        {provide: ROUTES, useValue: [{loadChildren: () => TestChildModule}]}
+      ]
+    })
+    class TestModule {
+    }
+
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          expect(loaded.module.injector.get(ROUTE_INITIALIZER).length).toEqual(1);
+          done();
+        });
+  });
+
+  it('should load routes with initializer and wait until they are resolved', async(done) => {
+    let test = false;
+    let initialized = false;
+    @NgModule({
+      providers: [
+        {
+          provide: ROUTE_INITIALIZER,
+          useFactory: () => () => new Promise(
+                          (res, rej) => setTimeout(
+                              () => {
+                                test = true;
+                                res();
+                              },
+                              500)),
+          multi: true
+        },
+        {
+          provide: ROUTE_INITIALIZER,
+          useFactory: () => () => new Promise(
+                          (res, rej) => setTimeout(
+                              () => {
+                                initialized = true;
+                                res();
+                              },
+                              600)),
+          multi: true
+        },
+        {provide: ROUTES, useValue: {}}
+      ]
+    })
+
+    class TestModule {
+    }
+    routerConfigLoader.load(TestBed.inject(Injector), {loadChildren: () => TestModule})
+        .subscribe(loaded => {
+          expect(loaded.module).toBeDefined();
+          expect(test).toBeTruthy();
+          expect(initialized).toBeTruthy();
+          done();
+        });
+  });
+
+  it('should load only his own ROUTE_INITIALIZERS', async(done) => {
+    @NgModule({
+      providers: [
+        {provide: ROUTE_INITIALIZER, useFactory: () => () => {}, multi: true},
+        {provide: ROUTES, useValue: {}}
+      ]
+    })
+    class TestModule {
+    }
+
+    const injector = Injector.create(
+        [{provide: ROUTE_INITIALIZER, useFactory: () => () => {}, multi: true, deps: []}],
+        TestBed.inject(Injector));
+
+    routerConfigLoader.load(injector, {loadChildren: () => TestModule}).subscribe(loaded => {
+      expect(loaded.module).toBeDefined();
+      expect(loaded.module.injector.get(ROUTE_INITIALIZER)).toBeDefined();
+      expect(loaded.module.injector.get(ROUTE_INITIALIZER).length).toEqual(1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This is an initial POC to provide an initialization hook for lazy loaded Modules. Implementation is Open for Discussion!

Additional Docs will be added when a consent about the solution is made.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
A lazy route is now just loaded without being block by initialization logic

Issue Number: #17606


## What is the new behavior?
A lazy route is now loaded with an option being block by initialization logic. If all initialization logic has run, the route gets loaded


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
It introduces a new injection toke ROUTE_INITIALIZER.