### PR TITLE
fix(forms): number input fires valueChanges twice.

### DIFF
--- a/packages/forms/src/directives/number_value_accessor.ts
+++ b/packages/forms/src/directives/number_value_accessor.ts
@@ -43,11 +43,7 @@ export const NUMBER_VALUE_ACCESSOR: any = {
 @Directive({
   selector:
       'input[type=number][formControlName],input[type=number][formControl],input[type=number][ngModel]',
-  host: {
-    '(change)': 'onChange($event.target.value)',
-    '(input)': 'onChange($event.target.value)',
-    '(blur)': 'onTouched()'
-  },
+  host: {'(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
   providers: [NUMBER_VALUE_ACCESSOR]
 })
 export class NumberValueAccessor implements ControlValueAccessor {

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -149,6 +149,23 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         expect(control.value).toEqual(0);
       });
 
+      it('should ignore the change event', () => {
+        const fixture = initTest(FormControlNumberInput);
+        const control = new FormControl();
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        control.valueChanges.subscribe({
+          next: (value) => {
+            throw 'Input[number] should not react to change event';
+          }
+        });
+        const input = fixture.debugElement.query(By.css('input'));
+
+        input.nativeElement.value = '5';
+        dispatchEvent(input.nativeElement, 'change');
+      });
+
       it('when value is cleared programmatically', () => {
         const fixture = initTest(FormControlNumberInput);
         const control = new FormControl(10);


### PR DESCRIPTION
Prior to this commit, input field of type number used to fire valueChanges twice. First time after typing in the input field and second time when the input field loses the focus.

PR Close #12540

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Input field of type number emits valueChanges twice. First time after typing in the input field and second time when the input field loses the focus.

Issue Number: #12540


## What is the new behavior?
Input field of type number emits valueChanges once.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
