### PR TITLE
fix(common): let `KeyValuePipe` accept type unions with `null`

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -140,9 +140,16 @@ export declare class KeyValuePipe implements PipeTransform {
         [key: string]: V;
     } | Map<string, V>, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>>;
     transform<V>(input: {
+        [key: string]: V;
+    } | Map<string, V> | null, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>> | null;
+    transform<V>(input: {
         [key: number]: V;
     } | Map<number, V>, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>>;
+    transform<V>(input: {
+        [key: number]: V;
+    } | Map<number, V> | null, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>> | null;
     transform<K, V>(input: Map<K, V>, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
+    transform<K, V>(input: Map<K, V> | null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>> | null;
 }
 
 export declare class Location {

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -56,11 +56,22 @@ export class KeyValuePipe implements PipeTransform {
       compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
       Array<KeyValue<string, V>>;
   transform<V>(
+      input: {[key: string]: V}|Map<string, V>|null,
+      compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
+      Array<KeyValue<string, V>>|null;
+  transform<V>(
       input: {[key: number]: V}|Map<number, V>,
       compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number):
       Array<KeyValue<number, V>>;
+  transform<V>(
+      input: {[key: number]: V}|Map<number, V>|null,
+      compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number):
+      Array<KeyValue<number, V>>|null;
   transform<K, V>(input: Map<K, V>, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number):
       Array<KeyValue<K, V>>;
+  transform<K, V>(
+      input: Map<K, V>|null,
+      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>|null;
   transform<K, V>(
       input: null|{[key: string]: V, [key: number]: V}|Map<K, V>,
       compareFn: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number = defaultComparator):

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -63,6 +63,16 @@ describe('KeyValuePipe', () => {
       const transform2 = pipe.transform({1: 3});
       expect(transform1 !== transform2).toEqual(true);
     });
+    it('should accept a type union of an object with string keys and null', () => {
+      let value !: {[key: string]: string} | null;
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      expect(pipe.transform(value)).toEqual(null);
+    });
+    it('should accept a type union of an object with number keys and null', () => {
+      let value !: {[key: number]: string} | null;
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      expect(pipe.transform(value)).toEqual(null);
+    });
   });
 
   describe('Map', () => {
@@ -114,6 +124,11 @@ describe('KeyValuePipe', () => {
       const transform1 = pipe.transform(new Map([[1, 2]]));
       const transform2 = pipe.transform(new Map([[1, 3]]));
       expect(transform1 !== transform2).toEqual(true);
+    });
+    it('should accept a type union of a Map and null', () => {
+      let value !: Map<number, number>| null;
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      expect(pipe.transform(value)).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
`KeyValuePipe` currently accepts `null` values as well as `Map`s and a
few others. However, due to the way in which TS overloads work, a type
of `T|null` will not be accepted by `KeyValuePipe`'s signatures, even
though both `T` and `null` individually would be.

To make this work, each signature that accepts some type `T` has been
duplicated with a second one below it that accepts a `T|null` and
includes `null` in its return type.

Fixes #35743