### PR TITLE
build: fix ts-api-guardian golden approval not working on windows

### DIFF
--- a/tools/ts-api-guardian/lib/main.ts
+++ b/tools/ts-api-guardian/lib/main.ts
@@ -17,13 +17,6 @@ export function generateGoldenFile(
     entrypoint: string, outFile: string, options: SerializationOptions = {}): void {
   const output = publicApi(entrypoint, options);
 
-  // BUILD_WORKSPACE_DIRECTORY environment variable is only available during bazel
-  // run executions. This workspace directory allows us to generate golden files directly
-  // in the source file tree rather than via a symlink.
-  if (process.env['BUILD_WORKSPACE_DIRECTORY']) {
-    outFile = path.join(process.env['BUILD_WORKSPACE_DIRECTORY'], outFile);
-  }
-
   ensureDirectory(path.dirname(outFile));
   fs.writeFileSync(outFile, output);
 }
@@ -36,7 +29,8 @@ export function verifyAgainstGoldenFile(
   if (actual === expected) {
     return '';
   } else {
-    const patch = createPatch(goldenFile, expected, actual, 'Golden file', 'Generated API');
+    const displayFileName = path.relative(process.cwd(), goldenFile);
+    const patch = createPatch(displayFileName, expected, actual, 'Golden file', 'Generated API');
 
     // Remove the header of the patch
     const start = patch.indexOf('\n', patch.indexOf('\n') + 1) + 1;


### PR DESCRIPTION
Currently on Windows, it's not possible to approve goldens in
`ts-api-guardian`. This is because paths are resolved relatively
to the working directory. In Windows, golden files are resolved
to the actual workspace directory. The current logic tries to
compute a relative path to the runfile from the working directory.

This causes the file paths to have a lot of parent directory
path segments. Eventually, when joined with the build workspace
directory, the paths end up being incorrect. e.g.

```
fileName = ../../../../../../projects/angular/golden/<..>/common.d.ts`
outFile = BUILD_WORKSPACE_DIR + fileName;
```

To fix this, we no longer deal with confusing relative paths, but
instead always use absolute file system paths.

Additionally, this fixes that new goldens are generated at the wrong
location on all platforms.