### PR TITLE
build: update to latest `@bazel/ibazel` version v0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@angular/cli": "9.0.3",
     "@bazel/bazelisk": "^1.3.0",
     "@bazel/buildifier": "^0.29.0",
-    "@bazel/ibazel": "^0.12.2",
+    "@bazel/ibazel": "^0.12.3",
     "@octokit/graphql": "^4.3.1",
     "@types/minimist": "^1.2.0",
     "@yarnpkg/lockfile": "^1.1.0",

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -39,7 +39,7 @@ function addDevDependenciesToPackageJson(options: Schema) {
     const devDependencies: [string, string][] = [
       ['@angular/bazel', angularCore.version],
       ['@bazel/bazel', '2.1.0'],
-      ['@bazel/ibazel', '0.12.2'],
+      ['@bazel/ibazel', '0.12.3'],
       ['@bazel/karma', '1.4.1'],
       ['@bazel/protractor', '1.4.1'],
       ['@bazel/rollup', '1.4.1'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,10 +1070,10 @@
     "@bazel/buildifier-linux_x64" "0.29.0"
     "@bazel/buildifier-win32_x64" "0.29.0"
 
-"@bazel/ibazel@^0.12.2":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.2.tgz#98a290dbf8025076dd3040eab4f13a3d7e99357c"
-  integrity sha512-CktVREceZn+6VokQ7A2qByuXBSGRM0THuyv68JUShHYyCkYS94nYMZEIe5NXk12CRzcpMLfZGD5Gdtr+jWs9pw==
+"@bazel/ibazel@^0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.3.tgz#c8c82647f920cd529c7793c50e087e1a754a5973"
+  integrity sha512-dyx62Uo5kogrxFmqFNpGvbavfr8yjmuQlOyZczOuA60piULwlUsO7Oh3/1OUWKDSXaMMqHhFQfpdl+z0HjI6TQ==
 
 "@bazel/jasmine@1.4.1":
   version "1.4.1"


### PR DESCRIPTION
Updates to the latest `@bazel/ibazel` version that properly
resolves local `@bazel/bazelisk` installations.

The support for this temporarily broke from `0.12.0` to `0.12.2`.
https://github.com/bazelbuild/bazel-watcher/issues/352.