### PR TITLE
ci: cache downloaded bazel version in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,13 @@ version: 2.1
 # **NOTE 1 **: If you change the cache key prefix, also sync the cache_key_fallback to match.
 # **NOTE 2 **: Keep the static part of the cache key as prefix to enable correct fallbacks.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_3: &cache_key v4-angular-node-12-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
-var_4: &cache_key_fallback v4-angular-node-12-
-var_3_win: &cache_key_win v5-angular-win-node-12-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
-var_4_win: &cache_key_win_fallback v5-angular-win-node-12-
+var_3: &cache_key v4-angular-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
+# We invalidate the cache if the Bazel version changes because otherwise the `bazelisk` cache
+# folder will contain all previously used versions and ultimately cause the cache restoring to
+# be slower due to its growing size.
+var_4: &cache_key_fallback v4-angular-node-12-{{ checksum ".bazelversion" }}
+var_3_win: &cache_key_win v5-angular-win-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
+var_4_win: &cache_key_win_fallback v5-angular-win-node-12-{{ checksum ".bazelversion" }}
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
@@ -539,6 +542,7 @@ jobs:
             - "node_modules"
             - "aio/node_modules"
             - "~/bazel_repository_cache"
+            - "~/.cache/bazelisk"
 
   # Build the ivy npm packages.
   build-ivy-npm-packages:


### PR DESCRIPTION
Similarly to what is done in `angular/components`, we should
cache the downloaded Bazel version (from `bazelisk`).

This reduces the overhead of downloading Bazel, and also avoids
the dependency on the external download server. We should avoid
external server dependencies as much as possible (see how the yarn
registry was flaky in the past).