### PR TITLE
fix(compiler): handle type references to namespace imports correctly

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -1436,7 +1436,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
             local: false,
             valueDeclaration: decl.node,
             moduleName: decl.viaModule,
-            name: decl.node.name.text,
+            importedName: decl.node.name.text,
+            nestedPath: null,
           };
         } else {
           typeValueReference = {

--- a/packages/compiler-cli/ngcc/test/host/util.ts
+++ b/packages/compiler-cli/ngcc/test/host/util.ts
@@ -32,7 +32,7 @@ export function expectTypeValueReferencesForParameters(
         }
       } else if (param.typeValueReference !== null) {
         expect(param.typeValueReference.moduleName).toBe(fromModule!);
-        expect(param.typeValueReference.name).toBe(expected);
+        expect(param.typeValueReference.importedName).toBe(expected);
       }
     }
   });

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, ExternalExpr, LiteralExpr, ParseLocation, ParseSourceFile, ParseSourceSpan, R3DependencyMetadata, R3Reference, R3ResolvedDependencyType, WrappedNodeExpr} from '@angular/compiler';
+import {Expression, ExternalExpr, LiteralExpr, ParseLocation, ParseSourceFile, ParseSourceSpan, R3DependencyMetadata, R3Reference, R3ResolvedDependencyType, ReadPropExpr, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../diagnostics';
@@ -137,8 +137,14 @@ export function valueReferenceToExpression(
     }
     return new WrappedNodeExpr(valueRef.expression);
   } else {
-    // TODO(alxhub): this cast is necessary because the g3 typescript version doesn't narrow here.
-    return new ExternalExpr(valueRef as {moduleName: string, name: string});
+    let importExpr: Expression =
+        new ExternalExpr({moduleName: valueRef.moduleName, name: valueRef.importedName});
+    if (valueRef.nestedPath !== null) {
+      for (const property of valueRef.nestedPath) {
+        importExpr = new ReadPropExpr(importExpr, property);
+      }
+    }
+    return importExpr;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -137,10 +137,16 @@ export function valueReferenceToExpression(
     }
     return new WrappedNodeExpr(valueRef.expression);
   } else {
+    // TODO(alxhub): this cast is necessary because the g3 typescript version doesn't narrow here.
+    const ref = valueRef as {
+      moduleName: string;
+      importedName: string;
+      nestedPath: string[]|null;
+    };
     let importExpr: Expression =
-        new ExternalExpr({moduleName: valueRef.moduleName, name: valueRef.importedName});
-    if (valueRef.nestedPath !== null) {
-      for (const property of valueRef.nestedPath) {
+        new ExternalExpr({moduleName: ref.moduleName, name: ref.importedName});
+    if (ref.nestedPath !== null) {
+      for (const property of ref.nestedPath) {
         importExpr = new ReadPropExpr(importExpr, property);
       }
     }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -243,8 +243,24 @@ export type TypeValueReference = {
   local: true; expression: ts.Expression; defaultImportStatement: ts.ImportDeclaration | null;
 }|{
   local: false;
-  name: string;
+
+  /**
+   * The module specifier from which the `importedName` symbol should be imported.
+   */
   moduleName: string;
+
+  /**
+   * The name of the top-level symbol that is imported from `moduleName`. If `nestedPath` is also
+   * present, a nested object is being referenced from the top-level symbol.
+   */
+  importedName: string;
+
+  /**
+   * If present, represents the symbol names that are referenced from the top-level import.
+   * When `null` or empty, the `importedName` itself is the symbol being referenced.
+   */
+  nestedPath: string[]|null;
+
   valueDeclaration: ts.Declaration;
 };
 

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -464,7 +464,7 @@ runInEachFileSystem(() => {
         expect(argExpressionToString(param.typeValueReference.expression)).toEqual(type);
       } else if (!param.typeValueReference.local && typeof type !== 'string') {
         expect(param.typeValueReference.moduleName).toEqual(type.moduleName);
-        expect(param.typeValueReference.name).toEqual(type.name);
+        expect(param.typeValueReference.importedName).toEqual(type.name);
       } else {
         return fail(`Mismatch between typeValueReference and expected type: ${param.name} / ${
             param.typeValueReference.local}`);


### PR DESCRIPTION
fix(compiler): handle type references to namespaced symbols correctly

When the compiler needs to convert a type reference to a value
expression, it may encounter a type that refers to a namespaced symbol.
Such namespaces need to be handled specially as there's various forms
available. Consider a namespace named "ns":

1. One can refer to a namespace by itself: `ns`. A namespace is only
   allowed to be used in a type position if it has been merged with a
   class, but even if this is the case it may not be possible to convert
   that type into a value expression depending on the import form. More
   on this later (case a below)
2. One can refer to a type within the namespace: `ns.Foo`. An import
   needs to be generated to `ns`, from which the `Foo` property can then
   be read.
3. One can refer to a type in a nested namespace within `ns`:
   `ns.Foo.Bar` and possibly even deeper nested. The value
   representation is similar to case 2, but includes additional property
   accesses.

The exact strategy of how to deal with these cases depends on the type
of import used. There's two flavors available:

a. A namespaced import like `import * as ns from 'ns';` that creates
   a local namespace that is irrelevant to the import that needs to be
   generated (as said import would be used instead of the original
   import).

   If the local namespace "ns" itself is referred to in a type position,
   it is invalid to convert it into a value expression. Some JavaScript
   libraries publish a value as default export using `export = MyClass;`
   syntax, however it is illegal to refer to that value using "ns".
   Consequently, such usage in a type position *must* be accompanied by
   an `@Inject` decorator to provide an explicit token.

b. An explicit namespace declaration within a module, that can be
   imported using a named import like `import {ns} from 'ns';` where the
   "ns" module declares a namespace using `declare namespace ns {}`.
   In this case, it's the namespace itself that needs to be imported,
   after which any qualified references into the namespace are converted
   into property accesses.

Before this change, support for namespaces in the type-to-value
conversion was limited and only worked  correctly for a single qualified
name using a namespace import (case 2a). All other cases were either
producing incorrect code or would crash the compiler (case 1a).

Crashing the compiler is not desirable as it does not indicate where
the issue is. Moreover, the result of a type-to-value conversion is
irrelevant when an explicit injection token is provided using `@Inject`,
so referring to a namespace in a type position (case 1) could still be
valid.

This commit introduces logic to the type-to-value conversion to be able
to properly deal with all type references to namespaced symbols.

Fixes #36006
Resolves FW-1995