### PR TITLE
build: fix @bazel/bazel to bazelisk leftovers

### DIFF
--- a/.vscode/recommended-launch.json
+++ b/.vscode/recommended-launch.json
@@ -34,7 +34,7 @@
       "name": "IVY:packages/core/test/acceptance",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/.bin/bazel",
+      "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",
@@ -51,7 +51,7 @@
       "name": "IVY:packages/core/test/render3",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/.bin/bazel",
+      "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",
@@ -68,7 +68,7 @@
       "name": "IVY:packages/core/test",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/.bin/bazel",
+      "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",

--- a/.vscode/recommended-tasks.json
+++ b/.vscode/recommended-tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "IVY:packages/core/test/...",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",
@@ -23,7 +23,7 @@
     {
       "label": "VE:packages/core/test/...",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "packages/core/test",
@@ -39,7 +39,7 @@
     {
       "label": "IVY:packages/core/test/acceptance",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",
@@ -54,7 +54,7 @@
     {
       "label": "VE:packages/core/test/acceptance",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "packages/core/test/acceptance",
@@ -68,7 +68,7 @@
     {
       "label": "IVY:packages/core/test",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",
@@ -83,7 +83,7 @@
     {
       "label": "VE:packages/core/test",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "packages/core/test",
@@ -97,7 +97,7 @@
     {
       "label": "IVY:packages/core/test/render3",
       "type": "shell",
-      "command": "${workspaceFolder}/node_modules/.bin/bazel",
+      "command": "${workspaceFolder}/node_modules/.bin/bazelisk",
       "args": [
         "test",
         "--config=ivy",

--- a/scripts/release/publish-latest
+++ b/scripts/release/publish-latest
@@ -7,8 +7,8 @@ set -u -e -o pipefail
 # Publish them to npm (tagged next)
 
 # We need to resolve the Bazel binary in the node modules because running Bazel
-# through `yarn bazel` causes additional output that throws off the command stdout.
-BAZEL_BIN=$(yarn bin)/bazel
+# through `yarn bazelisk` causes additional output that throws off the command stdout.
+BAZEL_BIN=$(yarn bin)/bazelisk
 # Build into a distinct output location so that artifacts from previous builds are not reused
 BAZEL_OUTPUT_BASE=$(mktemp -d -t angular-release-latest.XXXXXXX)
 BAZEL="$BAZEL_BIN --output_base=$BAZEL_OUTPUT_BASE"

--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -7,8 +7,8 @@ set -u -e -o pipefail
 # Publish them to npm (tagged next)
 
 # We need to resolve the Bazel binary in the node modules because running Bazel
-# through `yarn bazel` causes additional output that throws off the command stdout.
-BAZEL_BIN=$(yarn bin)/bazel
+# through `yarn bazelisk` causes additional output that throws off the command stdout.
+BAZEL_BIN=$(yarn bin)/bazelisk
 # Build into a distinct output location so that artifacts from previous builds are not reused
 BAZEL_OUTPUT_BASE=$(mktemp -d -t angular-release-next.XXXXXXX)
 BAZEL="$BAZEL_BIN --output_base=$BAZEL_OUTPUT_BASE"


### PR DESCRIPTION
Follow-up for https://github.com/angular/angular/pull/36078. A few leftovers from from `@bazel/bazel` to
`@bazel/bazelisk` migration are still there. This commit fixes those, so
that the repository no longer relies on `@bazel/bazel`.