### PR TITLE
docs(zone.js): Typos on zone.md file and fixes on code examples.

### DIFF
--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -117,12 +117,13 @@ To understand how change detection works, first consider when the application ne
 })
 export class AppComponent implements OnInit {
   data = 'initial value';
+  serverUrl = 'SERVER_URL';
   constructor(private httpClient: HttpClient) {}
 
   ngOnInit() {
-    this.httpClient.get(serverUrl).subscribe(response => {
+    this.httpClient.get(this.serverUrl).subscribe(response => {
       // user does not need to trigger change detection manually
-      data = response.data;
+      this.data = response.data;
     });
   }
 }
@@ -141,7 +142,7 @@ export class AppComponent implements OnInit {
   ngOnInit() {
     setTimeout(() => {
       // user does not need to trigger change detection manually
-      data = 'value updated';
+      this.data = 'value updated';
     });
   }
 }
@@ -160,7 +161,7 @@ export class AppComponent implements OnInit {
   ngOnInit() {
     Promise.resolve(1).then(v => {
       // user does not need to trigger change detection manually
-      data = v;
+      this.data = v;
     });
   }
 }
@@ -200,7 +201,7 @@ func.apply(ctx2);
 The value of `this` in the callback of `setTimeout` might differ depending on when `setTimeout` is called.
 Thus you can lose the context in asynchronous operations.
 
-A zone provides a new zone context other than `this`, the zone context persists across asynchronous operations.
+A zone provides a new zone context other than `this`, the zone context that persists across asynchronous operations.
 In the following example, the new zone context is called `zoneThis`.
 
 ```javascript
@@ -257,8 +258,6 @@ The Zone Task concept is very similar to the Javascript VM Task concept.
 - `microTask`: such as `Promise.then()`.
 - `eventTask`: such as `element.addEventListener()`.
 
-The `onInvoke` hook triggers when a synchronize function is executed in a Zone.
-
 These hooks trigger under the following circumstances:
 
 - `onScheduleTask`: triggers when a new asynchronous task is scheduled, such as when you call `setTimeout()`.
@@ -266,7 +265,7 @@ These hooks trigger under the following circumstances:
 - `onHasTask`: triggers when the status of one kind of task inside a zone changes from stable to unstable or from unstable to stable. A status of stable means there are no tasks inside the Zone, while unstable means a new task is scheduled in the zone.
 - `onInvoke`: triggers when a synchronize function is going to execute in the zone.
 
-With these hooks, `Zone` can monitor the status of all synchronize and asynchronous operations inside a zone.
+With these hooks, `Zone` can monitor the status of all synchronous and asynchronous operations inside a zone.
 
 The above example returns the following output.
 

--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -263,7 +263,7 @@ These hooks trigger under the following circumstances:
 - `onScheduleTask`: triggers when a new asynchronous task is scheduled, such as when you call `setTimeout()`.
 - `onInvokeTask`: triggers when an asynchronous task is about to execute, such as when the callback of `setTimeout()` is about to execute.
 - `onHasTask`: triggers when the status of one kind of task inside a zone changes from stable to unstable or from unstable to stable. A status of stable means there are no tasks inside the Zone, while unstable means a new task is scheduled in the zone.
-- `onInvoke`: triggers when a synchronize function is going to execute in the zone.
+- `onInvoke`: triggers when a synchronous function is going to execute in the zone.
 
 With these hooks, `Zone` can monitor the status of all synchronous and asynchronous operations inside a zone.
 


### PR DESCRIPTION
1. During reading the documentation I found some code examples that were refering to the class properties via methods, but without specifying the context `this`.
2. The 'onInvoke' hook was duplicated
3. A minor typo on `Zones and execution contexts` section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
