### PR TITLE
fix(elements): correctly handle `SimpleChange#firstChange` for pre-existing inputs and setting inputs to `undefined`

### DIFF
--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -133,7 +133,11 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
       return;
     }
 
-    if (strictEquals(value, this.getInputValue(property))) {
+    // Ignore the value if it is strictly equal to the current value, except if it is `undefined`
+    // and this is the first change to the value (because an explicit `undefined` _is_ strictly
+    // equal to not having a value set at all, but we still need to record this as a change).
+    if (strictEquals(value, this.getInputValue(property)) &&
+        !((value === undefined) && this.unchangedInputs.has(property))) {
       return;
     }
 

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -93,21 +93,21 @@ describe('ComponentFactoryNgElementStrategy', () => {
 
     it('should call ngOnChanges with the change', () => {
       expectSimpleChanges(componentRef.instance.simpleChanges[0], {
-        fooFoo: new SimpleChange(undefined, 'fooFoo-1', false),
-        falsyNull: new SimpleChange(undefined, null, false),
-        falsyEmpty: new SimpleChange(undefined, '', false),
-        falsyFalse: new SimpleChange(undefined, false, false),
-        falsyZero: new SimpleChange(undefined, 0, false),
+        fooFoo: new SimpleChange(undefined, 'fooFoo-1', true),
+        falsyNull: new SimpleChange(undefined, null, true),
+        falsyEmpty: new SimpleChange(undefined, '', true),
+        falsyFalse: new SimpleChange(undefined, false, true),
+        falsyZero: new SimpleChange(undefined, 0, true),
       });
     });
 
     it('should call ngOnChanges with proper firstChange value', fakeAsync(() => {
-         strategy.setInputValue('falsyUndefined', 'notanymore');
+         strategy.setInputValue('fooFoo', 'fooFoo-2');
          strategy.setInputValue('barBar', 'barBar-1');
          tick(16);  // scheduler waits 16ms if RAF is unavailable
          (strategy as any).detectChanges();
          expectSimpleChanges(componentRef.instance.simpleChanges[1], {
-           falsyUndefined: new SimpleChange(undefined, 'notanymore', false),
+           fooFoo: new SimpleChange('fooFoo-1', 'fooFoo-2', false),
            barBar: new SimpleChange(undefined, 'barBar-1', true),
          });
        }));
@@ -296,9 +296,9 @@ function expectSimpleChanges(actual: SimpleChanges, expected: SimpleChanges) {
   Object.keys(expected).forEach(key => {
     expect(actual[key]).toBeTruthy(`Change should have included key ${key}`);
     if (actual[key]) {
-      expect(actual[key].previousValue).toBe(expected[key].previousValue);
-      expect(actual[key].currentValue).toBe(expected[key].currentValue);
-      expect(actual[key].firstChange).toBe(expected[key].firstChange);
+      expect(actual[key].previousValue).toBe(expected[key].previousValue, `${key}.previousValue`);
+      expect(actual[key].currentValue).toBe(expected[key].currentValue, `${key}.currentValue`);
+      expect(actual[key].firstChange).toBe(expected[key].firstChange, `${key}.firstChange`);
     }
   });
 }

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -94,6 +94,7 @@ describe('ComponentFactoryNgElementStrategy', () => {
     it('should call ngOnChanges with the change', () => {
       expectSimpleChanges(componentRef.instance.simpleChanges[0], {
         fooFoo: new SimpleChange(undefined, 'fooFoo-1', true),
+        falsyUndefined: new SimpleChange(undefined, undefined, true),
         falsyNull: new SimpleChange(undefined, null, true),
         falsyEmpty: new SimpleChange(undefined, '', true),
         falsyFalse: new SimpleChange(undefined, false, true),
@@ -104,11 +105,13 @@ describe('ComponentFactoryNgElementStrategy', () => {
     it('should call ngOnChanges with proper firstChange value', fakeAsync(() => {
          strategy.setInputValue('fooFoo', 'fooFoo-2');
          strategy.setInputValue('barBar', 'barBar-1');
+         strategy.setInputValue('falsyUndefined', 'notanymore');
          tick(16);  // scheduler waits 16ms if RAF is unavailable
          (strategy as any).detectChanges();
          expectSimpleChanges(componentRef.instance.simpleChanges[1], {
            fooFoo: new SimpleChange('fooFoo-1', 'fooFoo-2', false),
            barBar: new SimpleChange(undefined, 'barBar-1', true),
+           falsyUndefined: new SimpleChange(undefined, 'notanymore', false),
          });
        }));
   });


### PR DESCRIPTION
This PR contains the following fixes (see individual commit messages for details):
- Correctly set `SimpleChange#firstChange` for pre-existing inputs.
- Correctly handle setting inputs to `undefined`.

Jira issue: [FW-2007][1]

Fixes #36130.

[1]: https://angular-team.atlassian.net/browse/FW-2007

[FW-2007]: https://angular-team.atlassian.net/browse/FW-2007