### PR TITLE
fix(animations): allow computeStyle to work on elements created in Node

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -237,3 +237,53 @@ export function hypenatePropsObject(object: {[key: string]: any}): {[key: string
   });
   return newObj;
 }
+
+/**
+ * Returns the computed style for the provided property on the provided element.
+ *
+ * This function uses `window.getComputedStyle` internally to determine the
+ * style value for the element. Firefox doesn't support reading the shorthand
+ * forms of margin/padding and for this reason this function needs to account
+ * for that.
+ */
+export function computeStyle(element: HTMLElement, prop: string): string {
+  const styles = window.getComputedStyle(element);
+
+  // this is casted to any because the `CSSStyleDeclaration` type is a fixed
+  // set of properties and `prop` is a dynamic reference to a property within
+  // the `CSSStyleDeclaration` list.
+  let value = getComputedValue(styles, prop as keyof CSSStyleDeclaration);
+
+  // Firefox returns empty string values for `margin` and `padding` properties
+  // when extracted using getComputedStyle (see similar issue here:
+  // https://github.com/jquery/jquery/issues/3383). In this situation
+  // we want to emulate the value that is returned by creating the top,
+  // right, bottom and left properties as individual style lookups.
+  if (value.length === 0 && (prop === 'margin' || prop === 'padding')) {
+    const t = getComputedValue(styles, (prop + 'Top') as 'marginTop' | 'paddingTop');
+    const r = getComputedValue(styles, (prop + 'Right') as 'marginRight' | 'paddingRight');
+    const b = getComputedValue(styles, (prop + 'Bottom') as 'marginBottom' | 'paddingBottom');
+    const l = getComputedValue(styles, (prop + 'Left') as 'marginLeft' | 'paddingLeft');
+
+    // reconstruct the padding/margin value as `top right bottom left`
+    // we `trim()` the value because if all of the values above are
+    // empty string values then we would like the return value to
+    // also be an empty string.
+    value = `${t} ${r} ${b} ${l}`.trim();
+  }
+
+  return value;
+}
+
+/**
+ * Reads and returns the provided property style from the provided styles collection.
+ *
+ * This function is useful because it will return an empty string in the
+ * event that the value obtained from the styles collection is a non-string
+ * value (which is usually the case if the `styles` object is mocked out).
+ */
+function getComputedValue<K extends keyof CSSStyleDeclaration>(
+    styles: CSSStyleDeclaration, prop: K): string {
+  const value = styles[prop];
+  return typeof value === 'string' ? value : '';
+}

--- a/packages/animations/browser/test/render/shared_spec.ts
+++ b/packages/animations/browser/test/render/shared_spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {computeStyle} from '../../src/render/shared';
+
+describe('shared animations code', () => {
+  if (isNode) return;
+
+  describe('computeStyle', () => {
+    it('should return an empty string if the inner computed style value is not a string', () => {
+      const gcsSpy = spyOn(window, 'getComputedStyle').and.returnValue(() => null);
+      const elementLike = buildActualElement();
+      expect(computeStyle(elementLike, 'width')).toEqual('');
+      expect(computeStyle(elementLike, 'padding')).toEqual('');
+      expect(computeStyle(elementLike, 'margin')).toEqual('');
+      gcsSpy.and.callThrough();
+    });
+
+    it('should compute the margin style into the form top,right,bottom,left', () => {
+      const div = buildActualElement();
+
+      div.style.setProperty('margin', '1px 2px 3px 4px');
+      expect(computeStyle(div, 'margin')).toEqual('1px 2px 3px 4px');
+
+      div.style.setProperty('margin', '0px');
+      div.style.setProperty('margin-top', '10px');
+      div.style.setProperty('margin-right', '20px');
+      div.style.setProperty('margin-bottom', '30px');
+      div.style.setProperty('margin-left', '40px');
+      expect(computeStyle(div, 'margin')).toEqual('10px 20px 30px 40px');
+    });
+
+    it('should compute the padding style into the form top,right,bottom,left', () => {
+      const div = buildActualElement();
+
+      div.style.setProperty('padding', '1px 2px 3px 4px');
+      expect(computeStyle(div, 'padding')).toEqual('1px 2px 3px 4px');
+
+      div.style.setProperty('padding', '0px');
+      div.style.setProperty('padding-top', '10px');
+      div.style.setProperty('padding-right', '20px');
+      div.style.setProperty('padding-bottom', '30px');
+      div.style.setProperty('padding-left', '40px');
+      expect(computeStyle(div, 'padding')).toEqual('10px 20px 30px 40px');
+    });
+  });
+});
+
+/**
+ * Returns a div element that's attached to the body.
+ *
+ * The reason why this function exists is because in order to
+ * compute style values on an element is must be attached within
+ * the body of a webpage.
+ */
+function buildActualElement() {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  return div;
+}


### PR DESCRIPTION
This patch is a follow-up patch to 35c9f0dc2f3665d4f9d9ece328cee4559bbec9c6.
It changes the `computeStyle` function to handle situations where
non string based values are returned from `window.getComputedStyle`.
This situation usually ocurrs in Node-based test environments where
the element or `window.getComputedStyle` is mocked out.