### PR TITLE
fix(forms): handle numeric values properly in the validator 

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -299,7 +299,7 @@ export class Validators {
    *
    */
   static minLength(minLength: number): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
+    return (control: AbstractControl): ValidationErrors|null => {
       if (isEmptyInputValue(control.value) || !hasValidLength(control.value)) {
         // don't validate empty values to allow optional controls
         // don't validate values without `length` property
@@ -340,7 +340,7 @@ export class Validators {
    *
    */
   static maxLength(maxLength: number): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
+    return (control: AbstractControl): ValidationErrors|null => {
       return hasValidLength(control.value) && control.value.length > maxLength ?
           {'maxlength': {'requiredLength': maxLength, 'actualLength': control.value.length}} :
           null;

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -232,6 +232,16 @@ describe('Validators', () => {
       expect(Validators.minLength(1)(new FormControl(-1))).toBeNull();
       expect(Validators.minLength(1)(new FormControl(+1))).toBeNull();
     });
+
+    it('should return null when passing an object that contains a length property', () => {
+      const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
+      expect(Validators.minLength(1)(new FormControl(value))).toBeNull();
+    });
+
+    it('should return null when passing a boolean', () => {
+      expect(Validators.minLength(1)(new FormControl(true))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl(false))).toBeNull();
+    });
   });
 
   describe('maxLength', () => {
@@ -257,11 +267,6 @@ describe('Validators', () => {
       });
     });
 
-    it('should return null when passing an object that contains a length property', () => {
-      const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
-      expect(Validators.minLength(1)(new FormControl(value))).toBeNull();
-    });
-
     it('should not error when FormArray has valid length', () => {
       const fa = new FormArray([new FormControl(''), new FormControl('')]);
       expect(Validators.maxLength(2)(fa)).toBeNull();
@@ -284,6 +289,11 @@ describe('Validators', () => {
     it('should return null when passing an object that contains a length property', () => {
       const value = {length: 1, someValue: [1, 2, 3, 4, 5]};
       expect(Validators.maxLength(1)(new FormControl(value))).toBeNull();
+    });
+
+    it('should return null when passing a boolean', () => {
+      expect(Validators.maxLength(1)(new FormControl(true))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl(false))).toBeNull();
     });
   });
 

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -233,9 +233,12 @@ describe('Validators', () => {
       expect(Validators.minLength(1)(new FormControl(+1))).toBeNull();
     });
 
-    it('should return null when passing an object that contains a length property', () => {
+    it('should trigger validation for an object that contains numeric length property', () => {
       const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
       expect(Validators.minLength(1)(new FormControl(value))).toBeNull();
+      expect(Validators.minLength(10)(new FormControl(value))).toEqual({
+        'minlength': {'requiredLength': 10, 'actualLength': 5}
+      });
     });
 
     it('should return null when passing a boolean', () => {
@@ -286,9 +289,12 @@ describe('Validators', () => {
       expect(Validators.maxLength(1)(new FormControl(+1))).toBeNull();
     });
 
-    it('should return null when passing an object that contains a length property', () => {
-      const value = {length: 1, someValue: [1, 2, 3, 4, 5]};
-      expect(Validators.maxLength(1)(new FormControl(value))).toBeNull();
+    it('should trigger validation for an object that contains numeric length property', () => {
+      const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
+      expect(Validators.maxLength(10)(new FormControl(value))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl(value))).toEqual({
+        'maxlength': {'requiredLength': 1, 'actualLength': 5}
+      });
     });
 
     it('should return null when passing a boolean', () => {

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -225,6 +225,13 @@ describe('Validators', () => {
         'minlength': {'requiredLength': 2, 'actualLength': 1}
       });
     });
+
+    it('should always return null with numeric values', () => {
+      expect(Validators.minLength(1)(new FormControl(0))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl(1))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl(-1))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl(+1))).toBeNull();
+    });
   });
 
   describe('maxLength', () => {
@@ -250,6 +257,11 @@ describe('Validators', () => {
       });
     });
 
+    it('should return null when passing an object that contains a length property', () => {
+      const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
+      expect(Validators.minLength(1)(new FormControl(value))).toBeNull();
+    });
+
     it('should not error when FormArray has valid length', () => {
       const fa = new FormArray([new FormControl(''), new FormControl('')]);
       expect(Validators.maxLength(2)(fa)).toBeNull();
@@ -260,6 +272,18 @@ describe('Validators', () => {
       expect(Validators.maxLength(1)(fa)).toEqual({
         'maxlength': {'requiredLength': 1, 'actualLength': 2}
       });
+    });
+
+    it('should always return null with numeric values', () => {
+      expect(Validators.maxLength(1)(new FormControl(0))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl(1))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl(-1))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl(+1))).toBeNull();
+    });
+
+    it('should return null when passing an object that contains a length property', () => {
+      const value = {length: 1, someValue: [1, 2, 3, 4, 5]};
+      expect(Validators.maxLength(1)(new FormControl(value))).toBeNull();
     });
   });
 


### PR DESCRIPTION
Previously, the behaviour of the `minLength` and `maxLength` validator
caused confusion, and making it appear as they work with numeric values.
This commit fixes this, by always passing the validation when a numeric value
is used.

BREAKING CHANGES:

* The `minLength` and `maxLength` validators now verify that a value has
numeric `length` property and invoke validation only if that's the case.
Previously, falsey values without the length property (such as `0` or
`false` values) were triggering validation errors. If your code relies on
the old behavior, you can include other validators such as [min][1] or
[requiredTrue][2] to the list of validators for a particular field.

[1]: https://angular.io/api/forms/Validators#min
[2]: https://angular.io/api/forms/Validators#requiredTrue

Closes #35591

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #35591


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
