### PR TITLE
docs: fix a misleading sentence in component class testing section

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -507,10 +507,11 @@ Consider this `LightswitchComponent` which toggles a light on and off
 You might decide only to test that the `clicked()` method
 toggles the light's _on/off_ state and sets the message appropriately.
 
-This component class has no dependencies.
-To test a service with no dependencies, you create it with `new`, poke at its API,
-and assert expectations on its public state.
-Do the same with the component class.
+This component class has no dependencies. To test these types of classes, follow the same steps as you would for a service that has no dependencies:
+
+1. Create a component using the new keyword.
+2. Poke at its API.
+3. Assert expectations on its public state.
 
 <code-example
   path="testing/src/app/demo/demo.spec.ts"


### PR DESCRIPTION
Docs: Testing -> Component class testing, a misleading sentence.

Fixes #36155

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The current sentence in the Component class testing section looks like: 

This component class has no dependencies. To test a _service_ with no dependencies...

Issue Number: #36155


## What is the new behavior?

The new sentence will look like:

Just like services without dependencies, you create a component...

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
