### PR TITLE
fix(dev-infra): prep ts-circular-deps to load via node_modules

### DIFF
--- a/dev-infra/ts-circular-dependencies/BUILD.bazel
+++ b/dev-infra/ts-circular-dependencies/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     module_name = "@angular/dev-infra-private/ts-circular-dependencies",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
+        "//dev-infra/utils:config",
         "@npm//@types/glob",
         "@npm//@types/node",
         "@npm//@types/yargs",

--- a/dev-infra/ts-circular-dependencies/index.ts
+++ b/dev-infra/ts-circular-dependencies/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -17,7 +18,9 @@ import {Analyzer, ReferenceChain} from './analyzer';
 import {compareGoldens, convertReferenceChainToGolden, Golden} from './golden';
 import {convertPathToForwardSlash} from './file_system';
 
-const projectDir = join(__dirname, '../../');
+import {getRepoBaseDir} from '../utils/config';
+
+const projectDir = getRepoBaseDir();
 const packagesDir = join(projectDir, 'packages/');
 // The default glob does not capture deprecated packages such as http, or the webworker platform.
 const defaultGlob =

--- a/dev-infra/ts-circular-dependencies/index.ts
+++ b/dev-infra/ts-circular-dependencies/index.ts
@@ -29,10 +29,9 @@ const defaultGlob =
 if (require.main === module) {
   const {_: command, goldenFile, glob, baseDir, warnings} =
       yargs.help()
-          .version(false)
           .strict()
-          .command('check <golden-file>', 'Checks if the circular dependencies have changed.')
-          .command('approve <golden-file>', 'Approves the current circular dependencies.')
+          .command('check <goldenFile>', 'Checks if the circular dependencies have changed.')
+          .command('approve <goldenFile>', 'Approves the current circular dependencies.')
           .demandCommand()
           .option(
               'approve',


### PR DESCRIPTION
To run ts-circular-deps via installed node_modules, we needed to set
the hashbang of the script to be a node environment, and discover the
project directory based on where the script is run rather than the
scripts file location.
