### PR TITLE
fix(ngcc): use path-mappings from tsconfig in dependency resolution

### DIFF
--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/annotations",
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -121,8 +121,9 @@ if (require.main === module) {
   const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
   const errorOnFailedEntryPoint = options['error-on-failed-entry-point'];
   // yargs is not so great at mixed string+boolean types, so we have to test tsconfig against a
-  // string "false" to capture the `tsconfig=false` option
-  const tsConfigPath = (options['tsconfig'] === 'false') ? null : options['tsconfig'];
+  // string "false" to capture the `tsconfig=false` option.
+  // And we have to convert the option to a string to handle `no-tsconfig`, which will be `false`.
+  const tsConfigPath = `${options['tsconfig']}` === 'false' ? null : options['tsconfig'];
 
   (async() => {
     try {

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -92,6 +92,19 @@ if (require.main === module) {
             type: 'boolean',
             default: false,
           })
+          .option('tsconfig', {
+            describe:
+                'A path to a tsconfig.json file that will be used to configure the Angular compiler and module resolution used by ngcc.\n' +
+                'If not provided, ngcc will attempt to read a `tsconfig.json` file from the folder above that given by the `-s` option.\n' +
+                'Set to false (via `--no-tsconfig`) if you do not want ngcc to use any `tsconfig.json` file.',
+            type: 'string',
+            default: '',
+          })
+          .option('no-tsconfig', {
+            describe: 'This option is to support forcing ngcc not to use any `tsconfig.json` file.',
+            type: 'boolean',
+            hidden: true,
+          })
           .strict()
           .help()
           .parse(args);
@@ -113,6 +126,9 @@ if (require.main === module) {
   const enableI18nLegacyMessageIdFormat = options['legacy-message-ids'];
   const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
   const errorOnFailedEntryPoint = options['error-on-failed-entry-point'];
+  // yargs is not so great at mixed string+boolean types, so we have to test tsconfig against a
+  // string "false" to capture the `no-tsconfig` option
+  const tsConfigPath = (options['tsconfig'] === 'false') ? null : options['tsconfig'];
 
   (async() => {
     try {
@@ -126,7 +142,7 @@ if (require.main === module) {
         createNewEntryPointFormats,
         logger,
         enableI18nLegacyMessageIdFormat,
-        async: options['async'], invalidateEntryPointManifest, errorOnFailedEntryPoint,
+        async: options['async'], invalidateEntryPointManifest, errorOnFailedEntryPoint, tsConfigPath
       });
 
       if (logger) {

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -98,12 +98,6 @@ if (require.main === module) {
                 'If not provided, ngcc will attempt to read a `tsconfig.json` file from the folder above that given by the `-s` option.\n' +
                 'Set to false (via `--no-tsconfig`) if you do not want ngcc to use any `tsconfig.json` file.',
             type: 'string',
-            default: '',
-          })
-          .option('no-tsconfig', {
-            describe: 'This option is to support forcing ngcc not to use any `tsconfig.json` file.',
-            type: 'boolean',
-            hidden: true,
           })
           .strict()
           .help()
@@ -127,7 +121,7 @@ if (require.main === module) {
   const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
   const errorOnFailedEntryPoint = options['error-on-failed-entry-point'];
   // yargs is not so great at mixed string+boolean types, so we have to test tsconfig against a
-  // string "false" to capture the `no-tsconfig` option
+  // string "false" to capture the `tsconfig=false` option
   const tsConfigPath = (options['tsconfig'] === 'false') ? null : options['tsconfig'];
 
   (async() => {


### PR DESCRIPTION
When computing the dependencies between packages which are not in
node_modules, we may need to rely upon path-mappings to find the path
to the imported entry-point.

This commit allows ngcc to use the path-mappings from a tsconfig
file to find dependencies. By default any tsconfig.json file in the directory
above the `basePath` is loaded but it is possible to use a path to a
specific file by providing the `tsConfigPath` property to mainNgcc,
or to turn off loading any tsconfig file by setting `tsConfigPath` to `null`.
At the command line this is controlled via the `--tsconfig` option.

Fixes #36119
