### PR TITLE
fix(compiler): Microsyntax expressions should allow unbound attributes

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -858,6 +858,11 @@ export class _ParseAST {
    */
   private parseDirectiveKeywordBindings(key: TemplateBindingIdentifier): TemplateBinding[] {
     const bindings: TemplateBinding[] = [];
+    if (this.consumeStatementTerminator()) {
+      const sourceSpan = new AbsoluteSourceSpan(key.span.start, this.currentAbsoluteOffset);
+      bindings.push(new ExpressionBinding(sourceSpan, key, null /* value */));
+      return bindings;
+    }
     this.consumeOptionalCharacter(chars.$COLON);  // trackBy: trackByFunction
     const value = this.getDirectiveBoundTarget();
     let spanEnd = this.currentAbsoluteOffset;
@@ -947,10 +952,12 @@ export class _ParseAST {
   }
 
   /**
-   * Consume the optional statement terminator: semicolon or comma.
+   * Consume the optional statement terminator: semicolon or comma, and return
+   * true if it is present.
    */
   private consumeStatementTerminator() {
-    this.consumeOptionalCharacter(chars.$SEMICOLON) || this.consumeOptionalCharacter(chars.$COMMA);
+    return this.consumeOptionalCharacter(chars.$SEMICOLON) ||
+        this.consumeOptionalCharacter(chars.$COMMA);
   }
 
   error(message: string, index: number|null = null) {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -477,6 +477,18 @@ describe('parser', () => {
           ['l-b', 'k-b', true],
         ]);
       });
+
+      it('should support literal attributes', () => {
+        const bindings = parseTemplateBindings('*ngFor="let item of items, of1; of2, of3"');
+        expect(humanize(bindings)).toEqual([
+          ['ngFor', null, false],       // literal attribute
+          ['item', null, true],         // variable binding
+          ['ngForOf', 'items', false],  // bound attribute
+          ['ngForOf1', null, false],    // literal attribute
+          ['ngForOf2', null, false],    // literal attribute
+          ['ngForOf3', null, false],    // literal attribute
+        ]);
+      });
     });
 
     describe('source, key, value spans', () => {
@@ -549,6 +561,19 @@ describe('parser', () => {
           ['of: [1,2,3] | pipe as items; ', 'items', 'of'],
           ['let i=index, ', 'i', 'index'],
           ['count as len, ', 'len', 'count'],
+        ]);
+      });
+
+      it('should map literal attributes', () => {
+        const attr = '*ngFor="let item of items, of1; of2, of3"';
+        const bindings = parseTemplateBindings(attr);
+        expect(humanizeSpans(bindings, attr)).toEqual([
+          ['ngFor="', 'ngFor', null],
+          ['let item ', 'item', null],
+          ['of items, ', 'of', 'items'],
+          ['of1; ', 'of1', null],
+          ['of2, ', 'of2', null],
+          ['of3', 'of3', null],
         ]);
       });
     });


### PR DESCRIPTION
According to the microsyntax grammar [1] that Misko wrote, a `keyExp`
could have an empty `expression` (the RHS). Such binding is known as a
literal attribute or unbound attribute. For example, in
```
*ngFor="let item of items; foo; bar"
```
`ngFor`, `ngForFoo`, and `ngForBar` are literal attributes because the desugared form is
```
<ng-template ngFor let-item [ngForOf]="items" ngForFoo ngForBar>
             ^^^^^                            ^^^^^^^^ ^^^^^^^^
             literal attribute / unbound attribute
```
Currently, the parser allows empty expression for `ngFor` but not `ngForFoo` and `ngForBar`.
This PR fixes the bug.

[1]: https://gist.github.com/mhevery/d3530294cff2e4a1b3fe15ff75d08855