### PR TITLE
build: fix bad pullapprove rule

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -952,7 +952,7 @@ groups:
           'tools/build/**',
           'tools/circular_dependency_test/**',
           'tools/contributing-stats/**',
-          'tools/components/**'
+          'tools/components/**',
           'tools/gulp-tasks/**',
           'tools/ng_rollup_bundle/**',
           'tools/ngcontainer/**',


### PR DESCRIPTION
The dev-infra pull approve group contained a condition with
the glob having a string concatenation rather than a comma
separated list. This corrects this error, and in another PR
we will correct the verification scripts failure to catch
this.
