### PR TITLE
fix(ngcc): correctly identify the package of targeted entry-points

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -30,7 +30,7 @@ import {PathMappings} from '../utils';
 export function getBasePaths(
     sourceDirectory: AbsoluteFsPath, pathMappings: PathMappings | undefined): AbsoluteFsPath[] {
   const fs = getFileSystem();
-  let basePaths = [sourceDirectory];
+  const basePaths = [sourceDirectory];
   if (pathMappings) {
     const baseUrl = resolve(pathMappings.baseUrl);
     Object.values(pathMappings.paths).forEach(paths => paths.forEach(path => {


### PR DESCRIPTION
In some scenarios, such as yarn workspaces, the node_modules
folder containing the target entry-point is not contained by
the original basePath passed to ngcc.

In this case, we were not computing the package path for  secondary
entry-points correctly, instead assuming that the path was the primary
entry-point.

I optimistically suggest that is PR will fix #35747,  #18637 and #36060. But I need to actually go through and check.
