### PR TITLE
docs: add background color to code font styles

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -186,6 +186,19 @@ code {
   color: $darkgray;
 }
 
+h1, h2, h3, h4, h5, h6, p, ol, ul, table {
+  code {
+    background-color: $backgroundgray;
+    color: $darkgray;
+    padding: 0 3px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    border: 1px solid $lightgray;
+  }
+}
+
+
 .sidenav-content a {
   color: $blue;
   &:hover {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when we use code font, there is no obvious difference in background color and the font family doesn't set the code font apart substantially from the body copy. Because of this, sometimes it's hard to tell if a word is in code font or not. We used to have a background on the code font, but it went away (maybe about a year to 1.5 years ago, but I think it was unintentional).

Issue Number: N/A


## What is the new behavior?

Adds a background color and 3px padding left and right to the code elements in headers, tables, lists, and paragraphs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

These colors pass the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/?fcolor=444444&bcolor=F1F1F1).

### **As the style currently is:**
![image](https://user-images.githubusercontent.com/4116963/77590407-06813d80-6ec4-11ea-8681-50293d7aa3e7.png)

### **What this PR introduces:**
![image](https://user-images.githubusercontent.com/4116963/77590725-c53d5d80-6ec4-11ea-964f-498b4f175b60.png)
