### PR TITLE
fix(zone.js): UNPATCHED_EVENTS and PASSIVE_EVENTS should be string[] not boolean

### DIFF
--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -512,7 +512,7 @@ interface ZoneGlobalConfigurations {
    * Users can achieve this goal by defining `__zone_symbol__UNPATCHED_EVENTS = ['scroll',
    * 'mousemove'];` before importing `zone.js`.
    */
-  __zone_symbol__UNPATCHED_EVENTS?: boolean;
+  __zone_symbol__UNPATCHED_EVENTS?: string[];
 
   /**
    * Define the event names of the passive listeners.
@@ -528,7 +528,7 @@ interface ZoneGlobalConfigurations {
    *
    * The preceding code makes all scroll event listeners passive.
    */
-  __zone_symbol__PASSIVE_EVENTS?: boolean;
+  __zone_symbol__PASSIVE_EVENTS?: string[];
 
   /**
    * Disable wrapping uncaught promise rejection.


### PR DESCRIPTION
`__zone_symbol__UNPATCHED_EVENTS` and `__zone_symbol__PASSIVE_EVENTS` should be string[] type not boolean.
For example:
```
const config = window as ZoneGlobalConfigurations;
config.__zone_symbol__UNPATCHED_EVENTS = ['scroll'];
config.__zone_symbol__PASSIVE_EVENTS = ['scroll'];
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


Thank @tonivj5 for posting the issue.