### PR TITLE
fix(ngcc): correctly detect imported TypeScript helpers

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/delegating_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/delegating_host.ts
@@ -32,7 +32,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
 
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
     if (isFromDtsFile(id)) {
-      return this.tsHost.getDeclarationOfIdentifier(id);
+      return this.addKnownDeclaration(this.tsHost.getDeclarationOfIdentifier(id));
     }
     return this.ngccHost.getDeclarationOfIdentifier(id);
   }
@@ -60,7 +60,13 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
 
   getExportsOfModule(module: ts.Node): Map<string, Declaration>|null {
     if (isFromDtsFile(module)) {
-      return this.tsHost.getExportsOfModule(module);
+      const exportMap = this.tsHost.getExportsOfModule(module);
+
+      if (exportMap !== null) {
+        exportMap.forEach(decl => this.addKnownDeclaration(decl));
+      }
+
+      return exportMap;
     }
     return this.ngccHost.getExportsOfModule(module);
   }
@@ -153,5 +159,9 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
 
   getEndOfClass(classSymbol: NgccClassSymbol): ts.Node {
     return this.ngccHost.getEndOfClass(classSymbol);
+  }
+
+  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
+    return this.ngccHost.addKnownDeclaration(decl);
   }
 }

--- a/packages/compiler-cli/ngcc/src/host/delegating_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/delegating_host.ts
@@ -32,7 +32,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
 
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
     if (isFromDtsFile(id)) {
-      return this.addKnownDeclaration(this.tsHost.getDeclarationOfIdentifier(id));
+      return this.detectKnownDeclaration(this.tsHost.getDeclarationOfIdentifier(id));
     }
     return this.ngccHost.getDeclarationOfIdentifier(id);
   }
@@ -63,7 +63,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
       const exportMap = this.tsHost.getExportsOfModule(module);
 
       if (exportMap !== null) {
-        exportMap.forEach(decl => this.addKnownDeclaration(decl));
+        exportMap.forEach(decl => this.detectKnownDeclaration(decl));
       }
 
       return exportMap;
@@ -161,7 +161,10 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
     return this.ngccHost.getEndOfClass(classSymbol);
   }
 
-  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
-    return this.ngccHost.addKnownDeclaration(decl);
+  detectKnownDeclaration(decl: null): null;
+  detectKnownDeclaration<T extends Declaration>(decl: T): T;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null {
+    return this.ngccHost.detectKnownDeclaration(decl);
   }
 }

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -599,10 +599,11 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
    * @param decl The `Declaration` to check.
    * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
    */
-  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
-    if (decl !== null && decl.known === null &&
-        // For some reason, TS cannot infer that `decl` is not `null`chere :/
-        this.isJavaScriptObjectDeclaration(decl!)) {
+  detectKnownDeclaration(decl: null): null;
+  detectKnownDeclaration<T extends Declaration>(decl: T): T;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null {
+    if (decl !== null && decl.known === null && this.isJavaScriptObjectDeclaration(decl)) {
       // If the identifier resolves to the global JavaScript `Object`, update the declaration to
       // denote it as the known `JsGlobalObject` declaration.
       decl.known = KnownDeclaration.JsGlobalObject;
@@ -620,7 +621,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
    */
   protected getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
       |null {
-    return this.addKnownDeclaration(super.getDeclarationOfSymbol(symbol, originalId));
+    return this.detectKnownDeclaration(super.getDeclarationOfSymbol(symbol, originalId));
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -8,13 +8,13 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, ConcreteDeclaration, CtorParameter, Declaration, Decorator, KnownDeclaration, TypeScriptReflectionHost, TypeValueReference, isDecoratorIdentifier, reflectObjectLiteral,} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, ConcreteDeclaration, CtorParameter, Declaration, Decorator, isDecoratorIdentifier, KnownDeclaration, reflectObjectLiteral, TypeScriptReflectionHost, TypeValueReference,} from '../../../src/ngtsc/reflection';
 import {isWithinPackage} from '../analysis/util';
 import {Logger} from '../logging/logger';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined, stripDollarSuffix} from '../utils';
 
-import {ClassSymbol, ModuleWithProvidersFunction, NgccClassSymbol, NgccReflectionHost, PRE_R3_MARKER, SwitchableVariableDeclaration, isSwitchableVariableDeclaration} from './ngcc_host';
+import {ClassSymbol, isSwitchableVariableDeclaration, ModuleWithProvidersFunction, NgccClassSymbol, NgccReflectionHost, PRE_R3_MARKER, SwitchableVariableDeclaration} from './ngcc_host';
 
 export const DECORATORS = 'decorators' as ts.__String;
 export const PROP_DECORATORS = 'propDecorators' as ts.__String;
@@ -346,22 +346,12 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
     // The identifier may have been of an additional class assignment such as `MyClass_1` that was
     // present as alias for `MyClass`. If so, resolve such aliases to their original declaration.
-    if (superDeclaration !== null && superDeclaration.node !== null) {
+    if (superDeclaration !== null && superDeclaration.node !== null &&
+        superDeclaration.known === null) {
       const aliasedIdentifier = this.resolveAliasedClassIdentifier(superDeclaration.node);
       if (aliasedIdentifier !== null) {
         return this.getDeclarationOfIdentifier(aliasedIdentifier);
       }
-    }
-
-    // If the identifier resolves to the global JavaScript `Object`, return a
-    // declaration that denotes it as the known `JsGlobalObject` declaration.
-    if (superDeclaration !== null && this.isJavaScriptObjectDeclaration(superDeclaration)) {
-      return {
-        known: KnownDeclaration.JsGlobalObject,
-        expression: id,
-        viaModule: null,
-        node: null,
-      };
     }
 
     return superDeclaration;
@@ -511,8 +501,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       return null;
     }
     if (!isNamedDeclaration(declaration)) {
-      throw new Error(
-          `Cannot get the dts file for a declaration that has no name: ${declaration.getText()} in ${declaration.getSourceFile().fileName}`);
+      throw new Error(`Cannot get the dts file for a declaration that has no name: ${
+          declaration.getText()} in ${declaration.getSourceFile().fileName}`);
     }
 
     // Try to retrieve the dts declaration from the public map
@@ -520,7 +510,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       this.publicDtsDeclarationMap = this.computePublicDtsDeclarationMap(this.src, this.dts);
     }
     if (this.publicDtsDeclarationMap.has(declaration)) {
-      return this.publicDtsDeclarationMap.get(declaration) !;
+      return this.publicDtsDeclarationMap.get(declaration)!;
     }
 
     // No public export, try the private map
@@ -528,7 +518,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       this.privateDtsDeclarationMap = this.computePrivateDtsDeclarationMap(this.src, this.dts);
     }
     if (this.privateDtsDeclarationMap.has(declaration)) {
-      return this.privateDtsDeclarationMap.get(declaration) !;
+      return this.privateDtsDeclarationMap.get(declaration)!;
     }
 
     // No declaration found at all
@@ -602,7 +592,36 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     return last;
   }
 
+  /**
+   * Check whether a `Declaration` corresponds with a known declaration, such as `Object`, and set
+   * its `known` property to the appropriate `KnownDeclaration`.
+   *
+   * @param decl The `Declaration` to check.
+   * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
+   */
+  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
+    if (decl !== null && decl.known === null &&
+        // For some reason, TS cannot infer that `decl` is not `null`chere :/
+        this.isJavaScriptObjectDeclaration(decl!)) {
+      // If the identifier resolves to the global JavaScript `Object`, update the declaration to
+      // denote it as the known `JsGlobalObject` declaration.
+      decl.known = KnownDeclaration.JsGlobalObject;
+    }
+
+    return decl;
+  }
+
+
   ///////////// Protected Helpers /////////////
+
+  /**
+   * Resolve a `ts.Symbol` to its declaration and detect whether it corresponds with a known
+   * declaration.
+   */
+  protected getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
+      |null {
+    return this.addKnownDeclaration(super.getDeclarationOfSymbol(symbol, originalId));
+  }
 
   /**
    * Finds the identifier of the actual class declaration for a potentially aliased declaration of a
@@ -618,7 +637,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected resolveAliasedClassIdentifier(declaration: ts.Declaration): ts.Identifier|null {
     this.ensurePreprocessed(declaration.getSourceFile());
     return this.aliasedClassDeclarations.has(declaration) ?
-        this.aliasedClassDeclarations.get(declaration) ! :
+        this.aliasedClassDeclarations.get(declaration)! :
         null;
   }
 
@@ -674,7 +693,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     this.aliasedClassDeclarations.set(aliasedDeclaration.node, declaration.name);
   }
 
-  /** Get the top level statements for a module.
+  /**
+   * Get the top level statements for a module.
    *
    * In ES5 and ES2015 this is just the top level statements of the file.
    * @param sourceFile The module whose statements we want.
@@ -728,7 +748,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   protected acquireDecoratorInfo(classSymbol: NgccClassSymbol): DecoratorInfo {
     const decl = classSymbol.declaration.valueDeclaration;
     if (this.decoratorCache.has(decl)) {
-      return this.decoratorCache.get(decl) !;
+      return this.decoratorCache.get(decl)!;
     }
 
     // Extract decorators from static properties and `__decorate` helper calls, then merge them
@@ -757,7 +777,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
    * none of the static properties exist.
    */
   protected computeDecoratorInfoFromStaticProperties(classSymbol: NgccClassSymbol): {
-    classDecorators: Decorator[] | null; memberDecorators: Map<string, Decorator[]>| null;
+    classDecorators: Decorator[]|null; memberDecorators: Map<string, Decorator[]>| null;
     constructorParamInfo: ParamInfo[] | null;
   } {
     let classDecorators: Decorator[]|null = null;
@@ -1026,7 +1046,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
             // The helper arg was reflected to represent an actual decorator.
             if (this.isFromCore(entry.decorator)) {
               const decorators =
-                  memberDecorators.has(memberName) ? memberDecorators.get(memberName) ! : [];
+                  memberDecorators.has(memberName) ? memberDecorators.get(memberName)! : [];
               decorators.push(entry.decorator);
               memberDecorators.set(memberName, decorators);
             }
@@ -1193,7 +1213,6 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     if (ts.isArrayLiteralExpression(decoratorsArray)) {
       // Add each decorator that is imported from `@angular/core` into the `decorators` array
       decoratorsArray.elements.forEach(node => {
-
         // If the decorator is not an object literal expression then we are not interested
         if (ts.isObjectLiteralExpression(node)) {
           // We are only interested in objects of the form: `{ type: DecoratorType, args: [...] }`
@@ -1201,14 +1220,15 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
           // Is the value of the `type` property an identifier?
           if (decorator.has('type')) {
-            let decoratorType = decorator.get('type') !;
+            let decoratorType = decorator.get('type')!;
             if (isDecoratorIdentifier(decoratorType)) {
               const decoratorIdentifier =
                   ts.isIdentifier(decoratorType) ? decoratorType : decoratorType.name;
               decorators.push({
                 name: decoratorIdentifier.text,
                 identifier: decoratorType,
-                import: this.getImportOfIdentifier(decoratorIdentifier), node,
+                import: this.getImportOfIdentifier(decoratorIdentifier),
+                node,
                 args: getDecoratorArgs(node),
               });
             }
@@ -1347,7 +1367,13 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     const type: ts.TypeNode = (node as any).type || null;
     return {
       node,
-      implementation: node, kind, type, name, nameNode, value, isStatic,
+      implementation: node,
+      kind,
+      type,
+      name,
+      nameNode,
+      value,
+      isStatic,
       decorators: decorators || []
     };
   }
@@ -1362,7 +1388,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       ts.ParameterDeclaration[]|null {
     const members = classSymbol.implementation.members;
     if (members && members.has(CONSTRUCTOR)) {
-      const constructorSymbol = members.get(CONSTRUCTOR) !;
+      const constructorSymbol = members.get(CONSTRUCTOR)!;
       // For some reason the constructor does not have a `valueDeclaration` ?!?
       const constructor = constructorSymbol.declarations &&
           constructorSymbol.declarations[0] as ts.ConstructorDeclaration | undefined;
@@ -1424,7 +1450,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
         name: getNameText(nameNode),
         nameNode,
         typeValueReference,
-        typeNode: null, decorators
+        typeNode: null,
+        decorators
       };
     });
   }
@@ -1473,9 +1500,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
                     ts.isObjectLiteralExpression(element) ? reflectObjectLiteral(element) : null)
             .map(paramInfo => {
               const typeExpression =
-                  paramInfo && paramInfo.has('type') ? paramInfo.get('type') ! : null;
+                  paramInfo && paramInfo.has('type') ? paramInfo.get('type')! : null;
               const decoratorInfo =
-                  paramInfo && paramInfo.has('decorators') ? paramInfo.get('decorators') ! : null;
+                  paramInfo && paramInfo.has('decorators') ? paramInfo.get('decorators')! : null;
               const decorators = decoratorInfo &&
                   this.reflectDecorators(decoratorInfo)
                       .filter(decorator => this.isFromCore(decorator));
@@ -1619,7 +1646,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     if (fileExports !== null) {
       for (const [exportName, {node: declaration}] of fileExports) {
         if (declaration !== null && dtsDeclarationMap.has(exportName)) {
-          declarationMap.set(declaration, dtsDeclarationMap.get(exportName) !);
+          declarationMap.set(declaration, dtsDeclarationMap.get(exportName)!);
         }
       }
     }
@@ -1670,15 +1697,17 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
     const ngModuleDeclaration = this.getDeclarationOfExpression(ngModuleValue);
     if (!ngModuleDeclaration || ngModuleDeclaration.node === null) {
-      throw new Error(
-          `Cannot find a declaration for NgModule ${ngModuleValue.getText()} referenced in "${declaration!.getText()}"`);
+      throw new Error(`Cannot find a declaration for NgModule ${
+          ngModuleValue.getText()} referenced in "${declaration!.getText()}"`);
     }
     if (!hasNameIdentifier(ngModuleDeclaration.node)) {
       return null;
     }
     return {
       name,
-      ngModule: ngModuleDeclaration as ConcreteDeclaration<ClassDeclaration>, declaration, container
+      ngModule: ngModuleDeclaration as ConcreteDeclaration<ClassDeclaration>,
+      declaration,
+      container
     };
   }
 
@@ -1705,7 +1734,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       return null;
     }
 
-    const exportDecl = namespaceExports.get(expression.name.text) !;
+    const exportDecl = namespaceExports.get(expression.name.text)!;
     return {...exportDecl, viaModule: namespaceDecl.viaModule};
   }
 
@@ -1737,8 +1766,8 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 ///////////// Exported Helpers /////////////
 
 export type ParamInfo = {
-  decorators: Decorator[] | null,
-  typeExpression: ts.Expression | null
+  decorators: Decorator[]|null,
+  typeExpression: ts.Expression|null
 };
 
 /**
@@ -1782,7 +1811,7 @@ export interface DecoratorCall {
  * ], SomeDirective);
  * ```
  */
-export type DecorateHelperEntry = ParameterTypes | ParameterDecorators | DecoratorCall;
+export type DecorateHelperEntry = ParameterTypes|ParameterDecorators|DecoratorCall;
 
 /**
  * The recorded decorator information of a single class. This information is cached in the host.
@@ -1811,7 +1840,7 @@ interface DecoratorInfo {
  * A statement node that represents an assignment.
  */
 export type AssignmentStatement =
-    ts.ExpressionStatement & {expression: {left: ts.Identifier, right: ts.Expression}};
+    ts.ExpressionStatement&{expression: {left: ts.Identifier, right: ts.Expression}};
 
 /**
  * Test whether a statement node is an assignment statement.

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -267,8 +267,11 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    * @param decl The `Declaration` to check.
    * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
    */
-  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
-    decl = super.addKnownDeclaration(decl);
+  detectKnownDeclaration(decl: null): null;
+  detectKnownDeclaration<T extends Declaration>(decl: T): T;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null {
+    decl = super.detectKnownDeclaration(decl);
 
     if (decl !== null && decl.known === null && decl.node !== null) {
       decl.known = getTsHelperFnFromDeclaration(decl.node);

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,10 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, Parameter, isNamedVariableDeclaration, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, isNamedVariableDeclaration, Parameter, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {getNameText, getTsHelperFnFromDeclaration, hasNameIdentifier} from '../utils';
 
-import {Esm2015ReflectionHost, ParamInfo, getPropertyValueFromSymbol, isAssignment, isAssignmentStatement} from './esm2015_host';
+import {Esm2015ReflectionHost, getPropertyValueFromSymbol, isAssignment, isAssignmentStatement, ParamInfo} from './esm2015_host';
 import {NgccClassSymbol} from './ngcc_host';
 
 
@@ -81,12 +81,13 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
   getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier {
     const innerClass = this.getInnerFunctionDeclarationFromClassDeclaration(clazz);
     if (innerClass === undefined) {
-      throw new Error(
-          `getInternalNameOfClass() called on a non-ES5 class: expected ${clazz.name.text} to have an inner class declaration`);
+      throw new Error(`getInternalNameOfClass() called on a non-ES5 class: expected ${
+          clazz.name.text} to have an inner class declaration`);
     }
     if (innerClass.name === undefined) {
       throw new Error(
-          `getInternalNameOfClass() called on a class with an anonymous inner declaration: expected a name on:\n${innerClass.getText()}`);
+          `getInternalNameOfClass() called on a class with an anonymous inner declaration: expected a name on:\n${
+              innerClass.getText()}`);
     }
     return innerClass.name;
   }
@@ -98,14 +99,15 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
   getEndOfClass(classSymbol: NgccClassSymbol): ts.Node {
     const iifeBody = getIifeBody(classSymbol.declaration.valueDeclaration);
     if (!iifeBody) {
-      throw new Error(
-          `Compiled class declaration is not inside an IIFE: ${classSymbol.name} in ${classSymbol.declaration.valueDeclaration.getSourceFile().fileName}`);
+      throw new Error(`Compiled class declaration is not inside an IIFE: ${classSymbol.name} in ${
+          classSymbol.declaration.valueDeclaration.getSourceFile().fileName}`);
     }
 
     const returnStatementIndex = iifeBody.statements.findIndex(ts.isReturnStatement);
     if (returnStatementIndex === -1) {
       throw new Error(
-          `Compiled class wrapper IIFE does not have a return statement: ${classSymbol.name} in ${classSymbol.declaration.valueDeclaration.getSourceFile().fileName}`);
+          `Compiled class wrapper IIFE does not have a return statement: ${classSymbol.name} in ${
+              classSymbol.declaration.valueDeclaration.getSourceFile().fileName}`);
     }
 
     // Return the statement before the IIFE return statement
@@ -190,7 +192,8 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
     const superDeclaration = super.getDeclarationOfIdentifier(id);
 
-    if (superDeclaration === null || superDeclaration.node === null) {
+    if (superDeclaration === null || superDeclaration.node === null ||
+        superDeclaration.known !== null) {
       return superDeclaration;
     }
 
@@ -200,7 +203,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
         super.getDeclarationOfIdentifier(outerClassNode.name) :
         superDeclaration;
 
-    if (!declaration || declaration.node === null) {
+    if (declaration === null || declaration.node === null || declaration.known !== null) {
       return declaration;
     }
 
@@ -257,23 +260,25 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
     return {node, body: statements || null, parameters};
   }
 
-
-  ///////////// Protected Helpers /////////////
   /**
-   * Resolve a `ts.Symbol` to its declaration and detect whether it corresponds with a known
-   * TypeScript helper function.
+   * Check whether a `Declaration` corresponds with a known declaration, such as a TypeScript helper
+   * function, and set its `known` property to the appropriate `KnownDeclaration`.
+   *
+   * @param decl The `Declaration` to check.
+   * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
    */
-  protected getDeclarationOfSymbol(symbol: ts.Symbol, originalId: ts.Identifier|null): Declaration
-      |null {
-    const superDeclaration = super.getDeclarationOfSymbol(symbol, originalId);
+  addKnownDeclaration<T extends Declaration|null>(decl: T): T {
+    decl = super.addKnownDeclaration(decl);
 
-    if (superDeclaration !== null && superDeclaration.node !== null &&
-        superDeclaration.known === null) {
-      superDeclaration.known = getTsHelperFnFromDeclaration(superDeclaration.node);
+    if (decl !== null && decl.known === null && decl.node !== null) {
+      decl.known = getTsHelperFnFromDeclaration(decl.node);
     }
 
-    return superDeclaration;
+    return decl;
   }
+
+
+  ///////////// Protected Helpers /////////////
 
   /**
    * Get the inner function declaration of an ES5-style class.
@@ -368,9 +373,9 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
     if (expression && ts.isArrayLiteralExpression(expression)) {
       const elements = expression.elements;
       return elements.map(reflectArrayElement).map(paramInfo => {
-        const typeExpression = paramInfo && paramInfo.has('type') ? paramInfo.get('type') ! : null;
+        const typeExpression = paramInfo && paramInfo.has('type') ? paramInfo.get('type')! : null;
         const decoratorInfo =
-            paramInfo && paramInfo.has('decorators') ? paramInfo.get('decorators') ! : null;
+            paramInfo && paramInfo.has('decorators') ? paramInfo.get('decorators')! : null;
         const decorators = decoratorInfo && this.reflectDecorators(decoratorInfo);
         return {typeExpression, decorators};
       });
@@ -634,7 +639,7 @@ function getReturnIdentifier(body: ts.Block): ts.Identifier|undefined {
   return undefined;
 }
 
-function getReturnStatement(declaration: ts.Expression | undefined): ts.ReturnStatement|undefined {
+function getReturnStatement(declaration: ts.Expression|undefined): ts.ReturnStatement|undefined {
   return declaration && ts.isFunctionExpression(declaration) ?
       declaration.body.statements.find(ts.isReturnStatement) :
       undefined;

--- a/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
@@ -7,12 +7,12 @@
  */
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ConcreteDeclaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ConcreteDeclaration, Declaration, Decorator, ReflectionHost} from '../../../src/ngtsc/reflection';
 
 export const PRE_R3_MARKER = '__PRE_R3__';
 export const POST_R3_MARKER = '__POST_R3__';
 
-export type SwitchableVariableDeclaration = ts.VariableDeclaration & {initializer: ts.Identifier};
+export type SwitchableVariableDeclaration = ts.VariableDeclaration&{initializer: ts.Identifier};
 export function isSwitchableVariableDeclaration(node: ts.Node):
     node is SwitchableVariableDeclaration {
   return ts.isVariableDeclaration(node) && !!node.initializer &&
@@ -47,7 +47,7 @@ export interface ModuleWithProvidersFunction {
  * The symbol corresponding to a "class" declaration. I.e. a `ts.Symbol` whose `valueDeclaration` is
  * a `ClassDeclaration`.
  */
-export type ClassSymbol = ts.Symbol & {valueDeclaration: ClassDeclaration};
+export type ClassSymbol = ts.Symbol&{valueDeclaration: ClassDeclaration};
 
 /**
  * A representation of a class that accounts for the potential existence of two `ClassSymbol`s for a
@@ -128,4 +128,13 @@ export interface NgccReflectionHost extends ReflectionHost {
    * @param classSymbol The class whose statements we want.
    */
   getEndOfClass(classSymbol: NgccClassSymbol): ts.Node;
+
+  /**
+   * Check whether a `Declaration` corresponds with a known declaration and set its `known` property
+   * to the appropriate `KnownDeclaration`.
+   *
+   * @param decl The `Declaration` to check or `null` if there is no declaration.
+   * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
+   */
+  addKnownDeclaration<T extends Declaration|null>(decl: T): T;
 }

--- a/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/ngcc_host.ts
@@ -136,5 +136,5 @@ export interface NgccReflectionHost extends ReflectionHost {
    * @param decl The `Declaration` to check or `null` if there is no declaration.
    * @return The passed in `Declaration` (potentially enhanced with a `KnownDeclaration`).
    */
-  addKnownDeclaration<T extends Declaration|null>(decl: T): T;
+  detectKnownDeclaration<T extends Declaration>(decl: T|null): T|null;
 }

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -9,11 +9,13 @@
 import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
-import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
+import {ClassMemberKind, CtorParameter, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {DelegatingReflectionHost} from '../../src/host/delegating_host';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
+import {BundleProgram} from '../../src/packages/bundle_program';
 import {MockLogger} from '../helpers/mock_logger';
 import {getRootFiles, makeTestBundleProgram, makeTestDtsBundleProgram} from '../helpers/utils';
 
@@ -21,7 +23,6 @@ import {expectTypeValueReferencesForParameters} from './util';
 
 runInEachFileSystem(() => {
   describe('Esm2015ReflectionHost', () => {
-
     let _: typeof absoluteFrom;
 
     let SOME_DIRECTIVE_FILE: TestFile;
@@ -47,6 +48,12 @@ runInEachFileSystem(() => {
     let MODULE_WITH_PROVIDERS_PROGRAM: TestFile[];
     let NAMESPACED_IMPORT_FILE: TestFile;
     let INDEX_SIGNATURE_PROP_FILE: TestFile;
+
+    // Helpers
+    const createHost = (bundle: BundleProgram, ngccHost: Esm2015ReflectionHost) => {
+      const tsHost = new TypeScriptReflectionHost(bundle.program.getTypeChecker());
+      return new DelegatingReflectionHost(tsHost, ngccHost);
+    };
 
     beforeEach(() => {
       _ = absoluteFrom;
@@ -720,10 +727,10 @@ runInEachFileSystem(() => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators).toBeDefined();
         expect(decorators.length).toEqual(1);
@@ -731,7 +738,7 @@ runInEachFileSystem(() => {
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+        expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
       });
@@ -739,10 +746,10 @@ runInEachFileSystem(() => {
       it('should find the decorators on an aliased class', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
         const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators).toBeDefined();
         expect(decorators.length).toEqual(1);
@@ -750,7 +757,7 @@ runInEachFileSystem(() => {
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+        expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
       });
@@ -758,7 +765,7 @@ runInEachFileSystem(() => {
       it('should return null if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(functionNode);
@@ -768,7 +775,7 @@ runInEachFileSystem(() => {
       it('should return null if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
@@ -778,7 +785,7 @@ runInEachFileSystem(() => {
       it('should ignore `decorators` if it is not an array literal', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedClassDeclaration);
@@ -789,11 +796,11 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
             isNamedClassDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -802,11 +809,11 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedClassDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -815,10 +822,10 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isNamedClassDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -827,10 +834,10 @@ runInEachFileSystem(() => {
       it('should have import information on decorators', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
         expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
@@ -840,11 +847,12 @@ runInEachFileSystem(() => {
         it('should be an empty array if decorator has no `args` property', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedClassDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -854,11 +862,12 @@ runInEachFileSystem(() => {
         it('should be an empty array if decorator\'s `args` has no property assignment', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
               isNamedClassDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -868,11 +877,12 @@ runInEachFileSystem(() => {
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -885,43 +895,43 @@ runInEachFileSystem(() => {
       it('should find decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const input1 = members.find(member => member.name === 'input1') !;
+        const input1 = members.find(member => member.name === 'input1')!;
         expect(input1.kind).toEqual(ClassMemberKind.Property);
         expect(input1.isStatic).toEqual(false);
-        expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
-        expect(input1.decorators ![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
+        expect(input1.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
 
-        const input2 = members.find(member => member.name === 'input2') !;
+        const input2 = members.find(member => member.name === 'input2')!;
         expect(input2.kind).toEqual(ClassMemberKind.Property);
         expect(input2.isStatic).toEqual(false);
-        expect(input2.decorators !.map(d => d.name)).toEqual(['Input']);
-        expect(input2.decorators ![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input2.decorators!.map(d => d.name)).toEqual(['Input']);
+        expect(input2.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
       });
 
       it('should find non decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
+        const instanceProperty = members.find(member => member.name === 'instanceProperty')!;
         expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
         expect(instanceProperty.isStatic).toEqual(false);
-        expect(ts.isBinaryExpression(instanceProperty.implementation !)).toEqual(true);
-        expect(instanceProperty.value !.getText()).toEqual(`'instance'`);
+        expect(ts.isBinaryExpression(instanceProperty.implementation!)).toEqual(true);
+        expect(instanceProperty.value!.getText()).toEqual(`'instance'`);
       });
 
       it('should handle equally named getter/setter pairs correctly', () => {
         loadTestFiles([ACCESSORS_FILE]);
         const bundle = makeTestBundleProgram(ACCESSORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, ACCESSORS_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
@@ -930,50 +940,50 @@ runInEachFileSystem(() => {
             members.filter(member => member.name === 'setterAndGetter');
         expect(combinedSetter.kind).toEqual(ClassMemberKind.Setter);
         expect(combinedSetter.isStatic).toEqual(false);
-        expect(ts.isSetAccessor(combinedSetter.implementation !)).toEqual(true);
+        expect(ts.isSetAccessor(combinedSetter.implementation!)).toEqual(true);
         expect(combinedSetter.value).toBeNull();
-        expect(combinedSetter.decorators !.map(d => d.name)).toEqual(['Input']);
+        expect(combinedSetter.decorators!.map(d => d.name)).toEqual(['Input']);
         expect(combinedGetter.kind).toEqual(ClassMemberKind.Getter);
         expect(combinedGetter.isStatic).toEqual(false);
-        expect(ts.isGetAccessor(combinedGetter.implementation !)).toEqual(true);
+        expect(ts.isGetAccessor(combinedGetter.implementation!)).toEqual(true);
         expect(combinedGetter.value).toBeNull();
-        expect(combinedGetter.decorators !.map(d => d.name)).toEqual([]);
+        expect(combinedGetter.decorators!.map(d => d.name)).toEqual([]);
       });
 
       it('should find static methods on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const staticMethod = members.find(member => member.name === 'staticMethod') !;
+        const staticMethod = members.find(member => member.name === 'staticMethod')!;
         expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
         expect(staticMethod.isStatic).toEqual(true);
-        expect(ts.isMethodDeclaration(staticMethod.implementation !)).toEqual(true);
+        expect(ts.isMethodDeclaration(staticMethod.implementation!)).toEqual(true);
       });
 
       it('should find static properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const staticProperty = members.find(member => member.name === 'staticProperty') !;
+        const staticProperty = members.find(member => member.name === 'staticProperty')!;
         expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
         expect(staticProperty.isStatic).toEqual(true);
-        expect(ts.isPropertyAccessExpression(staticProperty.implementation !)).toEqual(true);
-        expect(staticProperty.value !.getText()).toEqual(`'static'`);
+        expect(ts.isPropertyAccessExpression(staticProperty.implementation!)).toEqual(true);
+        expect(staticProperty.value!.getText()).toEqual(`'static'`);
       });
 
       it('should ignore index signature properties', () => {
         loadTestFiles([INDEX_SIGNATURE_PROP_FILE]);
         const logger = new MockLogger();
         const bundle = makeTestBundleProgram(INDEX_SIGNATURE_PROP_FILE.name);
-        const host = new Esm2015ReflectionHost(logger, false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(logger, false, bundle));
         const classNode = getDeclaration(
             bundle.program, INDEX_SIGNATURE_PROP_FILE.name, 'IndexSignatureClass',
             isNamedClassDeclaration);
@@ -986,7 +996,7 @@ runInEachFileSystem(() => {
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => {
@@ -997,7 +1007,7 @@ runInEachFileSystem(() => {
       it('should return an empty array if there are no prop decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
@@ -1009,7 +1019,8 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
            const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const classNode = getDeclaration(
                bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                isNamedClassDeclaration);
@@ -1021,13 +1032,13 @@ runInEachFileSystem(() => {
       it('should ignore prop decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
             isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
@@ -1036,13 +1047,13 @@ runInEachFileSystem(() => {
       it('should ignore prop decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
@@ -1051,13 +1062,13 @@ runInEachFileSystem(() => {
       it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
             isNamedClassDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
@@ -1067,13 +1078,14 @@ runInEachFileSystem(() => {
         it('should be an empty array if prop decorator has no `args` property', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedClassDeclaration);
           const members = host.getMembersOfClass(classNode);
-          const prop = members.find(m => m.name === 'prop') !;
-          const decorators = prop.decorators !;
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Input');
@@ -1084,13 +1096,14 @@ runInEachFileSystem(() => {
            () => {
              loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
              const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-             const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+             const host =
+                 createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
              const classNode = getDeclaration(
                  bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedClassDeclaration);
              const members = host.getMembersOfClass(classNode);
-             const prop = members.find(m => m.name === 'prop') !;
-             const decorators = prop.decorators !;
+             const prop = members.find(m => m.name === 'prop')!;
+             const decorators = prop.decorators!;
 
              expect(decorators.length).toBe(1);
              expect(decorators[0].name).toBe('Input');
@@ -1100,13 +1113,14 @@ runInEachFileSystem(() => {
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
           const members = host.getMembersOfClass(classNode);
-          const prop = members.find(m => m.name === 'prop') !;
-          const decorators = prop.decorators !;
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Input');
@@ -1120,10 +1134,10 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters).toBeDefined();
         expect(parameters.map(parameter => parameter.name)).toEqual([
@@ -1136,11 +1150,11 @@ runInEachFileSystem(() => {
       it('should accept `ctorParameters` as an array', () => {
         loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
         const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
             isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters).toBeDefined();
         expect(parameters.map(parameter => parameter.name)).toEqual(['arg1']);
@@ -1150,10 +1164,12 @@ runInEachFileSystem(() => {
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        expect(() => { host.getConstructorParameters(functionNode); })
+        expect(() => {
+          host.getConstructorParameters(functionNode);
+        })
             .toThrowError(
                 'Attempted to get constructor parameters of a non-class: "function foo() {}"');
       });
@@ -1161,7 +1177,7 @@ runInEachFileSystem(() => {
       it('should return `null` if there is no constructor', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const parameters = host.getConstructorParameters(classNode);
@@ -1171,11 +1187,11 @@ runInEachFileSystem(() => {
       it('should return an array even if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
             isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters).toEqual(jasmine.any(Array));
         expect(parameters.length).toEqual(1);
@@ -1186,7 +1202,7 @@ runInEachFileSystem(() => {
       it('should return an empty array if there are no constructor parameters', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
             isNamedClassDeclaration);
@@ -1198,11 +1214,11 @@ runInEachFileSystem(() => {
       it('should ignore decorators that are not imported from core', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotFromCore',
             isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters.length).toBe(1);
         expect(parameters[0]).toEqual(jasmine.objectContaining<CtorParameter>({
@@ -1214,11 +1230,11 @@ runInEachFileSystem(() => {
       it('should ignore `ctorParameters` if it is not an arrow function', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrowFunction',
             isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters.length).toBe(1);
         expect(parameters[0]).toEqual(jasmine.objectContaining<CtorParameter>({
@@ -1230,11 +1246,11 @@ runInEachFileSystem(() => {
       it('should ignore `ctorParameters` if it does not return an array literal', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters.length).toBe(1);
         expect(parameters[0]).toEqual(jasmine.objectContaining<CtorParameter>({
@@ -1257,7 +1273,8 @@ runInEachFileSystem(() => {
 
           loadTestFiles([file]);
           const bundle = makeTestBundleProgram(file.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode =
               getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
           return host.getConstructorParameters(classNode);
@@ -1279,7 +1296,7 @@ runInEachFileSystem(() => {
             super(arguments);
           }`);
 
-          expect(parameters !.length).toBe(0);
+          expect(parameters!.length).toBe(0);
         });
 
         it('does not consider constructors with parameters as synthesized', () => {
@@ -1288,7 +1305,7 @@ runInEachFileSystem(() => {
             super(...arguments);
           }`);
 
-          expect(parameters !.length).toBe(1);
+          expect(parameters!.length).toBe(1);
         });
 
         it('does not consider manual super calls as synthesized', () => {
@@ -1297,7 +1314,7 @@ runInEachFileSystem(() => {
             super();
           }`);
 
-          expect(parameters !.length).toBe(0);
+          expect(parameters!.length).toBe(0);
         });
 
         it('does not consider empty constructors as synthesized', () => {
@@ -1305,7 +1322,7 @@ runInEachFileSystem(() => {
           constructor() {
           }`);
 
-          expect(parameters !.length).toBe(0);
+          expect(parameters!.length).toBe(0);
         });
       });
 
@@ -1313,18 +1330,19 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
-          expect(parameters !.length).toBe(2);
-          expect(parameters ![0]).toEqual(jasmine.objectContaining<CtorParameter>({
+          expect(parameters!.length).toBe(2);
+          expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
             name: 'arg1',
             decorators: null,
           }));
-          expect(parameters ![1]).toEqual(jasmine.objectContaining<CtorParameter>({
+          expect(parameters![1]).toEqual(jasmine.objectContaining<CtorParameter>({
             name: 'arg2',
             decorators: jasmine.any(Array) as any
           }));
@@ -1333,12 +1351,13 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
@@ -1347,12 +1366,13 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
@@ -1361,11 +1381,12 @@ runInEachFileSystem(() => {
         it('should have import information on decorators', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
           const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
-          const parameters = host.getConstructorParameters(classNode) !;
-          const decorators = parameters[2].decorators !;
+          const parameters = host.getConstructorParameters(classNode)!;
+          const decorators = parameters[2].decorators!;
 
           expect(decorators.length).toEqual(1);
           expect(decorators[0].import).toEqual({name: 'Inject', from: '@angular/core'});
@@ -1376,13 +1397,14 @@ runInEachFileSystem(() => {
         it('should be an empty array if param decorator has no `args` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          expect(parameters !.length).toBe(1);
-          const decorators = parameters ![0].decorators !;
+          expect(parameters!.length).toBe(1);
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Inject');
@@ -1393,12 +1415,13 @@ runInEachFileSystem(() => {
            () => {
              loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
              const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+             const host =
+                 createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
              const classNode = getDeclaration(
                  bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedClassDeclaration);
              const parameters = host.getConstructorParameters(classNode);
-             const decorators = parameters ![0].decorators !;
+             const decorators = parameters![0].decorators!;
 
              expect(decorators.length).toBe(1);
              expect(decorators[0].name).toBe('Inject');
@@ -1408,12 +1431,13 @@ runInEachFileSystem(() => {
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+          const host =
+              createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedClassDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Inject');
@@ -1427,61 +1451,62 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([FUNCTION_BODY_FILE]);
            const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
 
            const fooNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-           const fooDef = host.getDefinitionOfFunction(fooNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration)!;
+           const fooDef = host.getDefinitionOfFunction(fooNode)!;
            expect(fooDef.node).toBe(fooNode);
-           expect(fooDef.body !.length).toEqual(1);
-           expect(fooDef.body ![0].getText()).toEqual(`return x;`);
+           expect(fooDef.body!.length).toEqual(1);
+           expect(fooDef.body![0].getText()).toEqual(`return x;`);
            expect(fooDef.parameters.length).toEqual(1);
            expect(fooDef.parameters[0].name).toEqual('x');
            expect(fooDef.parameters[0].initializer).toBe(null);
 
            const barNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-           const barDef = host.getDefinitionOfFunction(barNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration)!;
+           const barDef = host.getDefinitionOfFunction(barNode)!;
            expect(barDef.node).toBe(barNode);
-           expect(barDef.body !.length).toEqual(1);
-           expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
-           expect(barDef.body ![0].getText()).toEqual(`return x + y;`);
+           expect(barDef.body!.length).toEqual(1);
+           expect(ts.isReturnStatement(barDef.body![0])).toBeTruthy();
+           expect(barDef.body![0].getText()).toEqual(`return x + y;`);
            expect(barDef.parameters.length).toEqual(2);
            expect(barDef.parameters[0].name).toEqual('x');
            expect(fooDef.parameters[0].initializer).toBe(null);
            expect(barDef.parameters[1].name).toEqual('y');
-           expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
+           expect(barDef.parameters[1].initializer!.getText()).toEqual('42');
 
            const bazNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-           const bazDef = host.getDefinitionOfFunction(bazNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration)!;
+           const bazDef = host.getDefinitionOfFunction(bazNode)!;
            expect(bazDef.node).toBe(bazNode);
-           expect(bazDef.body !.length).toEqual(3);
+           expect(bazDef.body!.length).toEqual(3);
            expect(bazDef.parameters.length).toEqual(1);
            expect(bazDef.parameters[0].name).toEqual('x');
            expect(bazDef.parameters[0].initializer).toBe(null);
 
            const quxNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-           const quxDef = host.getDefinitionOfFunction(quxNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration)!;
+           const quxDef = host.getDefinitionOfFunction(quxNode)!;
            expect(quxDef.node).toBe(quxNode);
-           expect(quxDef.body !.length).toEqual(2);
+           expect(quxDef.body!.length).toEqual(2);
            expect(quxDef.parameters.length).toEqual(1);
            expect(quxDef.parameters[0].name).toEqual('x');
            expect(quxDef.parameters[0].initializer).toBe(null);
 
            const mooNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'moo', isNamedFunctionDeclaration) !;
-           const mooDef = host.getDefinitionOfFunction(mooNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'moo', isNamedFunctionDeclaration)!;
+           const mooDef = host.getDefinitionOfFunction(mooNode)!;
            expect(mooDef.node).toBe(mooNode);
-           expect(mooDef.body !.length).toEqual(3);
+           expect(mooDef.body!.length).toEqual(3);
            expect(mooDef.parameters).toEqual([]);
 
            const juuNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'juu', isNamedFunctionDeclaration) !;
-           const juuDef = host.getDefinitionOfFunction(juuNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'juu', isNamedFunctionDeclaration)!;
+           const juuDef = host.getDefinitionOfFunction(juuNode)!;
            expect(juuDef.node).toBe(juuNode);
-           expect(juuDef.body !.length).toEqual(2);
+           expect(juuDef.body!.length).toEqual(2);
            expect(juuDef.parameters).toEqual([]);
          });
     });
@@ -1490,7 +1515,7 @@ runInEachFileSystem(() => {
       it('should find the import of an identifier', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/b.js'), 'b', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
@@ -1501,7 +1526,7 @@ runInEachFileSystem(() => {
       it('should find the name by which the identifier was exported, not imported', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/b.js'), 'c', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
@@ -1512,7 +1537,7 @@ runInEachFileSystem(() => {
       it('should return null if the identifier was not imported', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/b.js'), 'd', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
@@ -1526,61 +1551,63 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(classNode.name);
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(classNode);
-        expect(actualDeclaration !.viaModule).toBe(null);
+        expect(actualDeclaration!.node).toBe(classNode);
+        expect(actualDeclaration!.viaModule).toBe(null);
       });
 
       it('should return the declaration of an externally defined identifier', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedClassDeclaration);
-        const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
-        const identifierOfDirective = ((classDecorators[0].node as ts.ObjectLiteralExpression)
-                                           .properties[0] as ts.PropertyAssignment)
-                                          .initializer as ts.Identifier;
+        const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
+        const identifierOfDirective =
+            ((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as
+             ts.PropertyAssignment)
+                .initializer as ts.Identifier;
 
         const expectedDeclarationNode = getDeclaration(
             bundle.program, _('/node_modules/@angular/core/index.d.ts'), 'Directive',
             isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+        expect(actualDeclaration!.viaModule).toBe('@angular/core');
       });
 
       it('should return the source-file of an import namespace', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([NAMESPACED_IMPORT_FILE]);
         const bundle = makeTestBundleProgram(NAMESPACED_IMPORT_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, NAMESPACED_IMPORT_FILE.name, 'SomeDirective', ts.isClassDeclaration);
-        const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
-        const identifier = (((classDecorators[0].node as ts.ObjectLiteralExpression)
-                                 .properties[0] as ts.PropertyAssignment)
-                                .initializer as ts.PropertyAccessExpression)
-                               .expression as ts.Identifier;
+        const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
+        const identifier =
+            (((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as
+              ts.PropertyAssignment)
+                 .initializer as ts.PropertyAccessExpression)
+                .expression as ts.Identifier;
 
         const expectedDeclarationNode =
             getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+        expect(actualDeclaration!.viaModule).toBe('@angular/core');
       });
 
       it('should return the original declaration of an aliased class', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
         const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classDeclaration = getDeclaration(
             bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass', ts.isVariableDeclaration);
         const usageOfAliasedClass = getDeclaration(
@@ -1588,7 +1615,7 @@ runInEachFileSystem(() => {
             ts.isVariableDeclaration);
         const aliasedClassIdentifier = usageOfAliasedClass.initializer as ts.Identifier;
         expect(aliasedClassIdentifier.text).toBe('AliasedClass_1');
-        expect(host.getDeclarationOfIdentifier(aliasedClassIdentifier) !.node)
+        expect(host.getDeclarationOfIdentifier(aliasedClassIdentifier)!.node)
             .toBe(classDeclaration);
       });
     });
@@ -1598,11 +1625,11 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/b.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.keys())).toEqual([
+        expect(Array.from(exportDeclarations!.keys())).toEqual([
           'Directive',
           'a',
           'b',
@@ -1614,8 +1641,8 @@ runInEachFileSystem(() => {
         ]);
 
         const values =
-            Array.from(exportDeclarations !.values())
-                .map(declaration => [declaration.node !.getText(), declaration.viaModule]);
+            Array.from(exportDeclarations!.values())
+                .map(declaration => [declaration.node!.getText(), declaration.viaModule]);
         expect(values).toEqual([
           [`Directive: FnWithArg<(clazz: any) => any>`, null],
           [`a = 'a'`, null],
@@ -1633,21 +1660,22 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES2015 class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeDefined();
-        expect(classSymbol !.declaration.valueDeclaration).toBe(node);
-        expect(classSymbol !.implementation.valueDeclaration).toBe(node);
+        expect(classSymbol!.declaration.valueDeclaration).toBe(node);
+        expect(classSymbol!.implementation.valueDeclaration).toBe(node);
       });
 
       it('should return the class symbol for a class expression (outer variable declaration)',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
            const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const outerNode = getDeclaration(
                bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass',
                isNamedVariableDeclaration);
@@ -1655,36 +1683,37 @@ runInEachFileSystem(() => {
            const classSymbol = host.getClassSymbol(outerNode);
 
            expect(classSymbol).toBeDefined();
-           expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+           expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
          });
 
       it('should return the class symbol for a class expression (inner class expression)', () => {
         loadTestFiles([CLASS_EXPRESSION_FILE]);
         const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const outerNode = getDeclaration(
             bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const innerNode = (outerNode.initializer as ts.ClassExpression);
         const classSymbol = host.getClassSymbol(innerNode);
 
         expect(classSymbol).toBeDefined();
-        expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-        expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+        expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+        expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
       });
 
       it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
            const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const outerNode = getDeclaration(
                bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass',
                isNamedVariableDeclaration);
            const innerNode = (outerNode.initializer as ts.ClassExpression);
 
-           const innerSymbol = host.getClassSymbol(innerNode) !;
-           const outerSymbol = host.getClassSymbol(outerNode) !;
+           const innerSymbol = host.getClassSymbol(innerNode)!;
+           const outerSymbol = host.getClassSymbol(outerNode)!;
            expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
            expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
          });
@@ -1692,7 +1721,7 @@ runInEachFileSystem(() => {
       it('should return undefined if node is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const classSymbol = host.getClassSymbol(node);
@@ -1708,7 +1737,8 @@ runInEachFileSystem(() => {
            };
            loadTestFiles([testFile]);
            const bundle = makeTestBundleProgram(testFile.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const node =
                getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
            const classSymbol = host.getClassSymbol(node);
@@ -1721,7 +1751,7 @@ runInEachFileSystem(() => {
       it('should return true if a given node is a TS class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.isClass(node)).toBe(true);
@@ -1731,7 +1761,8 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
            const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const node = getDeclaration(
                bundle.program, CLASS_EXPRESSION_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
            expect(host.isClass(node)).toBe(true);
@@ -1741,7 +1772,8 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([CLASS_EXPRESSION_FILE]);
            const bundle = makeTestBundleProgram(CLASS_EXPRESSION_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const node = getDeclaration(
                bundle.program, CLASS_EXPRESSION_FILE.name, 'AliasedClass',
                ts.isVariableDeclaration);
@@ -1751,7 +1783,7 @@ runInEachFileSystem(() => {
       it('should return false if a given node is a TS function declaration', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(host.isClass(node)).toBe(false);
@@ -1766,7 +1798,7 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(false);
@@ -1781,7 +1813,7 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(true);
@@ -1797,7 +1829,7 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         expect(host.hasBaseClass(classNode)).toBe(true);
@@ -1812,7 +1844,7 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
         expect(host.getBaseClassExpression(classNode)).toBe(null);
@@ -1827,10 +1859,10 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
-        const baseIdentifier = host.getBaseClassExpression(classNode) !;
+        const baseIdentifier = host.getBaseClassExpression(classNode)!;
         if (!ts.isIdentifier(baseIdentifier)) {
           throw new Error(`Expected ${baseIdentifier.getText()} to be an identifier.`);
         }
@@ -1847,10 +1879,10 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        const baseIdentifier = host.getBaseClassExpression(classNode) !;
+        const baseIdentifier = host.getBaseClassExpression(classNode)!;
         if (!ts.isIdentifier(baseIdentifier)) {
           throw new Error(`Expected ${baseIdentifier.getText()} to be an identifier.`);
         }
@@ -1868,10 +1900,11 @@ runInEachFileSystem(() => {
            };
            loadTestFiles([file]);
            const bundle = makeTestBundleProgram(file.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const classNode =
                getDeclaration(bundle.program, file.name, 'TestClass', isNamedClassDeclaration);
-           const baseExpression = host.getBaseClassExpression(classNode) !;
+           const baseExpression = host.getBaseClassExpression(classNode)!;
            expect(baseExpression.getText()).toEqual('foo()');
          });
     });
@@ -1881,7 +1914,8 @@ runInEachFileSystem(() => {
         loadTestFiles(ARITY_CLASSES);
         const bundle = makeTestBundleProgram(ARITY_CLASSES[0].name);
         const dts = makeTestBundleProgram(ARITY_CLASSES[1].name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
         const noTypeParamClass = getDeclaration(
             bundle.program, _('/src/class.js'), 'NoTypeParam', isNamedClassDeclaration);
         expect(host.getGenericArityOfClass(noTypeParamClass)).toBe(0);
@@ -1899,10 +1933,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([MARKER_FILE]);
            const bundle = makeTestBundleProgram(MARKER_FILE.name);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, MARKER_FILE.name);
            const declarations = host.getSwitchableDeclarations(file);
-           expect(declarations.map(d => [d.name.getText(), d.initializer !.getText()])).toEqual([
+           expect(declarations.map(d => [d.name.getText(), d.initializer!.getText()])).toEqual([
              ['compileNgModuleFactory', 'compileNgModuleFactory__PRE_R3__']
            ]);
          });
@@ -1912,7 +1947,7 @@ runInEachFileSystem(() => {
       it('should return an array of all classes in the given source file', () => {
         loadTestFiles(DECORATED_FILES);
         const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
         const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
@@ -1930,31 +1965,31 @@ runInEachFileSystem(() => {
       it('should return decorators of class symbol', () => {
         loadTestFiles(DECORATED_FILES);
         const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
         const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
         expect(classDecoratorsPrimary.length).toEqual(3);
-        expect(classDecoratorsPrimary[0] !.map(d => d.name)).toEqual(['Directive']);
-        expect(classDecoratorsPrimary[1] !.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsPrimary[0]!.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsPrimary[1]!.map(d => d.name)).toEqual(['Directive']);
         expect(classDecoratorsPrimary[2]).toBe(null);
 
         const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
         const classDecoratorsSecondary =
             classSymbolsSecondary.map(s => host.getDecoratorsOfSymbol(s));
         expect(classDecoratorsSecondary.length).toEqual(1);
-        expect(classDecoratorsSecondary[0] !.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsSecondary[0]!.map(d => d.name)).toEqual(['Directive']);
       });
 
       it('should return a cloned array on each invocation', () => {
         loadTestFiles(DECORATED_FILES);
         const bundle = makeTestBundleProgram(getRootFiles(DECORATED_FILES)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const classDecl =
-            getDeclaration(bundle.program, DECORATED_FILES[0].name, 'A', ts.isClassDeclaration) !;
-        const classSymbol = host.getClassSymbol(classDecl) !;
+            getDeclaration(bundle.program, DECORATED_FILES[0].name, 'A', ts.isClassDeclaration)!;
+        const classSymbol = host.getClassSymbol(classDecl)!;
 
         const firstResult = host.getDecoratorsOfSymbol(classSymbol);
         const secondResult = host.getDecoratorsOfSymbol(classSymbol);
@@ -1972,10 +2007,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
                bundle.program, _('/ep/src/class1.js'), 'Class1', isNamedClassDeclaration);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find the dts declaration for exported functions', () => {
@@ -1985,10 +2021,11 @@ runInEachFileSystem(() => {
         const dts = makeTestDtsBundleProgram(_('/ep/typings/func1.d.ts'), _('/'));
         const mooFn = getDeclaration(
             bundle.program, _('/ep/src/func1.js'), 'mooFn', isNamedFunctionDeclaration);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
+        expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
       });
 
       it('should return null if there is no matching class in the matching dts file', () => {
@@ -1999,7 +2036,8 @@ runInEachFileSystem(() => {
         const missingClass = getDeclaration(
             bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
             isNamedClassDeclaration);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2012,7 +2050,8 @@ runInEachFileSystem(() => {
         const missingClass = getDeclaration(
             bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
             isNamedClassDeclaration);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2026,9 +2065,10 @@ runInEachFileSystem(() => {
             getRootFiles(TYPINGS_DTS_FILES)[0], false, [_('/ep/typings/shadow-class.d.ts')]);
         const shadowClass = getDeclaration(
             bundle.program, _('/ep/src/shadow-class.js'), 'ShadowClass', isNamedClassDeclaration);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
-        const dtsDecl = host.getDtsDeclaration(shadowClass) !;
+        const dtsDecl = host.getDtsDeclaration(shadowClass)!;
         expect(dtsDecl).not.toBeNull();
         expect(dtsDecl.getSourceFile().fileName).toEqual(_('/ep/typings/shadow-class.d.ts'));
       });
@@ -2054,7 +2094,8 @@ runInEachFileSystem(() => {
         const missingClass = getDeclaration(
             bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
             isNamedClassDeclaration);
-        const host = new TestEsm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new TestEsm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
         expect(host.getDtsDeclaration(missingClass)).toBeNull();
       });
@@ -2067,10 +2108,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
                bundle.program, _('/ep/src/flat-file.js'), 'Class1', isNamedClassDeclaration);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find aliased exports', () => {
@@ -2080,7 +2122,8 @@ runInEachFileSystem(() => {
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const sourceClass = getDeclaration(
             bundle.program, _('/ep/src/flat-file.js'), 'SourceClass', isNamedClassDeclaration);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
         const dtsDeclaration = host.getDtsDeclaration(sourceClass);
         if (dtsDeclaration === null) {
@@ -2102,11 +2145,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const internalClass = getDeclaration(
                bundle.program, _('/ep/src/internal.js'), 'InternalClass', isNamedClassDeclaration);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(internalClass);
-           expect(dtsDeclaration !.getSourceFile().fileName)
-               .toEqual(_('/ep/typings/internal.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/internal.d.ts'));
          });
 
       it('should match publicly and internal exported classes correctly, even if they have the same name',
@@ -2115,18 +2158,19 @@ runInEachFileSystem(() => {
            loadTestFiles(TYPINGS_DTS_FILES);
            const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle, dts));
 
            const class2 = getDeclaration(
                bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedClassDeclaration);
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
-           expect(class2DtsDeclaration !.getSourceFile().fileName)
+           expect(class2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/class2.d.ts'));
 
            const internalClass2 = getDeclaration(
                bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedClassDeclaration);
            const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
-           expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
+           expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/internal.d.ts'));
          });
     });
@@ -2135,7 +2179,7 @@ runInEachFileSystem(() => {
       it('should return the name of the class (there is no separate inner class in ES2015)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.getInternalNameOfClass(node).text).toEqual('EmptyClass');
@@ -2146,7 +2190,7 @@ runInEachFileSystem(() => {
       it('should return the name of the class (there is no separate inner class in ES2015)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.getAdjacentNameOfClass(node).text).toEqual('EmptyClass');
@@ -2158,10 +2202,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
            const fns = host.getModuleWithProvidersFunctions(file);
-           expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
+           expect(fns.map(fn => [fn.declaration.name!.getText(), fn.ngModule.node.name.text]))
                .toEqual([
                  ['ngModuleIdentifier', 'InternalModule'],
                  ['ngModuleWithEmptyProviders', 'InternalModule'],
@@ -2175,10 +2220,11 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+           const host =
+               createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
-           expect(fn.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
+           expect(fn.map(fn => [fn.declaration.name!.getText(), fn.ngModule.node.name.text]))
                .toEqual([
                  ['ngModuleIdentifier', 'InternalModule'],
                  ['ngModuleWithEmptyProviders', 'InternalModule'],
@@ -2192,13 +2238,12 @@ runInEachFileSystem(() => {
       it('should resolve aliased module references to their original declaration', () => {
         loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
         const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/src/aliased_class.js'));
         const fn = host.getModuleWithProvidersFunctions(file);
-        expect(fn.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
-            .toEqual([
-              ['forRoot', 'AliasedModule'],
-            ]);
+        expect(fn.map(fn => [fn.declaration.name!.getText(), fn.ngModule.node.name.text])).toEqual([
+          ['forRoot', 'AliasedModule'],
+        ]);
       });
     });
 
@@ -2224,8 +2269,8 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([testFile]);
         const bundle = makeTestBundleProgram(testFile.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
-        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name) !)[0];
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
+        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name)!)[0];
         const endOfClass = host.getEndOfClass(classSymbol);
         expect(endOfClass.getText())
             .toEqual(
@@ -2247,8 +2292,8 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([testFile]);
         const bundle = makeTestBundleProgram(testFile.name);
-        const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle);
-        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name) !)[0];
+        const host = createHost(bundle, new Esm2015ReflectionHost(new MockLogger(), false, bundle));
+        const classSymbol = host.findClassSymbols(bundle.program.getSourceFile(testFile.name)!)[0];
         const endOfClass = host.getEndOfClass(classSymbol);
         expect(endOfClass.getText())
             .toEqual(

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -9,12 +9,15 @@
 import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
-import {TestFile, runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, Import, InlineDeclaration, KnownDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
+import {ClassMemberKind, CtorParameter, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
+import {DelegatingReflectionHost} from '../../src/host/delegating_host';
 import {getIifeBody} from '../../src/host/esm5_host';
-import {UmdReflectionHost, parseStatementForUmdModule} from '../../src/host/umd_host';
+import {NgccReflectionHost} from '../../src/host/ngcc_host';
+import {parseStatementForUmdModule, UmdReflectionHost} from '../../src/host/umd_host';
+import {BundleProgram} from '../../src/packages/bundle_program';
 import {MockLogger} from '../helpers/mock_logger';
 import {getRootFiles, makeTestBundleProgram} from '../helpers/utils';
 
@@ -44,6 +47,12 @@ runInEachFileSystem(() => {
     let TYPINGS_SRC_FILES: TestFile[];
     let TYPINGS_DTS_FILES: TestFile[];
     let MODULE_WITH_PROVIDERS_PROGRAM: TestFile[];
+
+    // Helpers
+    const createHost = (bundle: BundleProgram, ngccHost: UmdReflectionHost) => {
+      const tsHost = new TypeScriptReflectionHost(bundle.program.getTypeChecker());
+      return new DelegatingReflectionHost(tsHost, ngccHost);
+    };
 
     beforeEach(() => {
       _ = absoluteFrom;
@@ -1084,10 +1093,10 @@ runInEachFileSystem(() => {
       it('should find the decorators on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators).toBeDefined();
         expect(decorators.length).toEqual(1);
@@ -1095,7 +1104,7 @@ runInEachFileSystem(() => {
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+        expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
       });
@@ -1103,11 +1112,11 @@ runInEachFileSystem(() => {
       it('should find the decorators on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
             isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators).toBeDefined();
         expect(decorators.length).toEqual(1);
@@ -1115,7 +1124,7 @@ runInEachFileSystem(() => {
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
         expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args !.map(arg => arg.getText())).toEqual([
+        expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
       });
@@ -1123,7 +1132,7 @@ runInEachFileSystem(() => {
       it('should return null if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(functionNode);
@@ -1133,7 +1142,7 @@ runInEachFileSystem(() => {
       it('should return null if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode);
@@ -1143,7 +1152,7 @@ runInEachFileSystem(() => {
       it('should ignore `decorators` if it is not an array literal', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
@@ -1154,11 +1163,11 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
             isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1167,11 +1176,11 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1180,11 +1189,11 @@ runInEachFileSystem(() => {
       it('should ignore decorator elements whose `type` value is not an identifier', () => {
         loadTestFiles([INVALID_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier',
             isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1193,11 +1202,11 @@ runInEachFileSystem(() => {
       it('should have import information on decorators', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
         expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
@@ -1206,32 +1215,32 @@ runInEachFileSystem(() => {
       it('should find decorated members on a class at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const input1 = members.find(member => member.name === 'input1') !;
+        const input1 = members.find(member => member.name === 'input1')!;
         expect(input1.kind).toEqual(ClassMemberKind.Property);
         expect(input1.isStatic).toEqual(false);
-        expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
 
-        const input2 = members.find(member => member.name === 'input2') !;
+        const input2 = members.find(member => member.name === 'input2')!;
         expect(input2.kind).toEqual(ClassMemberKind.Property);
         expect(input2.isStatic).toEqual(false);
-        expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
       });
 
       describe('(returned decorators `args`)', () => {
         it('should be an empty array if decorator has no `args` property', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -1241,11 +1250,11 @@ runInEachFileSystem(() => {
         it('should be an empty array if decorator\'s `args` has no property assignment', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
               isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -1255,11 +1264,11 @@ runInEachFileSystem(() => {
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Directive');
@@ -1272,70 +1281,70 @@ runInEachFileSystem(() => {
       it('should find decorated members on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const input1 = members.find(member => member.name === 'input1') !;
+        const input1 = members.find(member => member.name === 'input1')!;
         expect(input1.kind).toEqual(ClassMemberKind.Property);
         expect(input1.isStatic).toEqual(false);
-        expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
 
-        const input2 = members.find(member => member.name === 'input2') !;
+        const input2 = members.find(member => member.name === 'input2')!;
         expect(input2.kind).toEqual(ClassMemberKind.Property);
         expect(input2.isStatic).toEqual(false);
-        expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
       });
 
       it('should find non decorated properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
+        const instanceProperty = members.find(member => member.name === 'instanceProperty')!;
         expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
         expect(instanceProperty.isStatic).toEqual(false);
-        expect(ts.isBinaryExpression(instanceProperty.implementation !)).toEqual(true);
-        expect(instanceProperty.value !.getText()).toEqual(`'instance'`);
+        expect(ts.isBinaryExpression(instanceProperty.implementation!)).toEqual(true);
+        expect(instanceProperty.value!.getText()).toEqual(`'instance'`);
       });
 
       it('should find static methods on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const staticMethod = members.find(member => member.name === 'staticMethod') !;
+        const staticMethod = members.find(member => member.name === 'staticMethod')!;
         expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
         expect(staticMethod.isStatic).toEqual(true);
-        expect(ts.isFunctionExpression(staticMethod.implementation !)).toEqual(true);
+        expect(ts.isFunctionExpression(staticMethod.implementation!)).toEqual(true);
       });
 
       it('should find static properties on a class', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
 
-        const staticProperty = members.find(member => member.name === 'staticProperty') !;
+        const staticProperty = members.find(member => member.name === 'staticProperty')!;
         expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
         expect(staticProperty.isStatic).toEqual(true);
-        expect(ts.isPropertyAccessExpression(staticProperty.implementation !)).toEqual(true);
-        expect(staticProperty.value !.getText()).toEqual(`'static'`);
+        expect(ts.isPropertyAccessExpression(staticProperty.implementation!)).toEqual(true);
+        expect(staticProperty.value!.getText()).toEqual(`'static'`);
       });
 
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(() => {
@@ -1346,7 +1355,7 @@ runInEachFileSystem(() => {
       it('should return an empty array if there are no prop decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
@@ -1358,7 +1367,7 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
            const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const classNode = getDeclaration(
                bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
                isNamedVariableDeclaration);
@@ -1370,13 +1379,13 @@ runInEachFileSystem(() => {
       it('should ignore prop decorator elements that are not object literals', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1385,13 +1394,13 @@ runInEachFileSystem(() => {
       it('should ignore prop decorator elements that have no `type` property', () => {
         loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1401,13 +1410,13 @@ runInEachFileSystem(() => {
     it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
       loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
       const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-      const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+      const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
       const classNode = getDeclaration(
           bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
           isNamedVariableDeclaration);
       const members = host.getMembersOfClass(classNode);
-      const prop = members.find(m => m.name === 'prop') !;
-      const decorators = prop.decorators !;
+      const prop = members.find(m => m.name === 'prop')!;
+      const decorators = prop.decorators!;
 
       expect(decorators.length).toBe(1);
       expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1416,11 +1425,11 @@ runInEachFileSystem(() => {
     it('should have import information on decorators', () => {
       loadTestFiles([SOME_DIRECTIVE_FILE]);
       const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-      const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+      const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
       const classNode = getDeclaration(
           bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
-      const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+      const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
       expect(decorators.length).toEqual(1);
       expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
@@ -1430,13 +1439,13 @@ runInEachFileSystem(() => {
       it('should be an empty array if prop decorator has no `args` property', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0].name).toBe('Input');
@@ -1446,13 +1455,13 @@ runInEachFileSystem(() => {
       it('should be an empty array if prop decorator\'s `args` has no property assignment', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0].name).toBe('Input');
@@ -1462,13 +1471,13 @@ runInEachFileSystem(() => {
       it('should be an empty array if `args` property value is not an array literal', () => {
         loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
         const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop') !;
-        const decorators = prop.decorators !;
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0].name).toBe('Input');
@@ -1480,16 +1489,16 @@ runInEachFileSystem(() => {
       it('should find the decorated constructor parameters', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
-        expect(parameters !.map(parameter => parameter.name)).toEqual([
+        expect(parameters!.map(parameter => parameter.name)).toEqual([
           '_viewContainer', '_template', 'injected'
         ]);
-        expectTypeValueReferencesForParameters(parameters !, [
+        expectTypeValueReferencesForParameters(parameters!, [
           'ViewContainerRef',
           'TemplateRef',
           null,
@@ -1499,17 +1508,17 @@ runInEachFileSystem(() => {
       it('should find the decorated constructor parameters at the top level', () => {
         loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
-        expect(parameters !.map(parameter => parameter.name)).toEqual([
+        expect(parameters!.map(parameter => parameter.name)).toEqual([
           '_viewContainer', '_template', 'injected'
         ]);
-        expectTypeValueReferencesForParameters(parameters !, [
+        expectTypeValueReferencesForParameters(parameters!, [
           'ViewContainerRef',
           'TemplateRef',
           null,
@@ -1519,11 +1528,11 @@ runInEachFileSystem(() => {
       it('should accept `ctorParameters` as an array', () => {
         loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
         const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
             isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode) !;
+        const parameters = host.getConstructorParameters(classNode)!;
 
         expect(parameters).toBeDefined();
         expect(parameters.map(parameter => parameter.name)).toEqual(['arg1']);
@@ -1533,10 +1542,12 @@ runInEachFileSystem(() => {
       it('should throw if the symbol is not a class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const functionNode = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        expect(() => { host.getConstructorParameters(functionNode); })
+        expect(() => {
+          host.getConstructorParameters(functionNode);
+        })
             .toThrowError(
                 'Attempted to get constructor parameters of a non-class: "function foo() {}"');
       });
@@ -1547,22 +1558,22 @@ runInEachFileSystem(() => {
       it('should return an array even if there are no decorators', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toEqual(jasmine.any(Array));
-        expect(parameters !.length).toEqual(1);
-        expect(parameters ![0].name).toEqual('foo');
-        expect(parameters ![0].decorators).toBe(null);
+        expect(parameters!.length).toEqual(1);
+        expect(parameters![0].name).toEqual('foo');
+        expect(parameters![0].decorators).toBe(null);
       });
 
       it('should return an empty array if there are no constructor parameters', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
             isNamedVariableDeclaration);
@@ -1577,14 +1588,14 @@ runInEachFileSystem(() => {
       it('should ignore `ctorParameters` if it does not return an array literal', () => {
         loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
         const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
             isNamedVariableDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
-        expect(parameters !.length).toBe(1);
-        expect(parameters ![0]).toEqual(jasmine.objectContaining<CtorParameter>({
+        expect(parameters!.length).toBe(1);
+        expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
           name: 'arg1',
           decorators: null,
         }));
@@ -1594,18 +1605,18 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements that are not object literals', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
 
-          expect(parameters !.length).toBe(2);
-          expect(parameters ![0]).toEqual(jasmine.objectContaining<CtorParameter>({
+          expect(parameters!.length).toBe(2);
+          expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
             name: 'arg1',
             decorators: null,
           }));
-          expect(parameters ![1]).toEqual(jasmine.objectContaining<CtorParameter>({
+          expect(parameters![1]).toEqual(jasmine.objectContaining<CtorParameter>({
             name: 'arg2',
             decorators: jasmine.any(Array) as any
           }));
@@ -1614,12 +1625,12 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements that have no `type` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
@@ -1628,12 +1639,12 @@ runInEachFileSystem(() => {
         it('should ignore param decorator elements whose `type` value is not an identifier', () => {
           loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
@@ -1642,7 +1653,7 @@ runInEachFileSystem(() => {
         it('should use `getImportOfIdentifier()` to retrieve import info', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
           const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
               isNamedVariableDeclaration);
@@ -1651,7 +1662,7 @@ runInEachFileSystem(() => {
                           .and.returnValue(mockImportInfo);
 
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![2].decorators !;
+          const decorators = parameters![2].decorators!;
 
           expect(decorators.length).toEqual(1);
           expect(decorators[0].import).toBe(mockImportInfo);
@@ -1662,13 +1673,13 @@ runInEachFileSystem(() => {
         it('should be an empty array if param decorator has no `args` property', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          expect(parameters !.length).toBe(1);
-          const decorators = parameters ![0].decorators !;
+          expect(parameters!.length).toBe(1);
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Inject');
@@ -1679,12 +1690,13 @@ runInEachFileSystem(() => {
            () => {
              loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
              const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
              const classNode = getDeclaration(
                  bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
                  isNamedVariableDeclaration);
              const parameters = host.getConstructorParameters(classNode);
-             const decorators = parameters ![0].decorators !;
+             const decorators = parameters![0].decorators!;
 
              expect(decorators.length).toBe(1);
              expect(decorators[0].name).toBe('Inject');
@@ -1694,12 +1706,12 @@ runInEachFileSystem(() => {
         it('should be an empty array if `args` property value is not an array literal', () => {
           loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
           const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
               isNamedVariableDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters ![0].decorators !;
+          const decorators = parameters![0].decorators!;
 
           expect(decorators.length).toBe(1);
           expect(decorators[0].name).toBe('Inject');
@@ -1713,45 +1725,45 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([FUNCTION_BODY_FILE]);
            const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
            const fooNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration) !;
-           const fooDef = host.getDefinitionOfFunction(fooNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration)!;
+           const fooDef = host.getDefinitionOfFunction(fooNode)!;
            expect(fooDef.node).toBe(fooNode);
-           expect(fooDef.body !.length).toEqual(1);
-           expect(fooDef.body ![0].getText()).toEqual(`return x;`);
+           expect(fooDef.body!.length).toEqual(1);
+           expect(fooDef.body![0].getText()).toEqual(`return x;`);
            expect(fooDef.parameters.length).toEqual(1);
            expect(fooDef.parameters[0].name).toEqual('x');
            expect(fooDef.parameters[0].initializer).toBe(null);
 
            const barNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration) !;
-           const barDef = host.getDefinitionOfFunction(barNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration)!;
+           const barDef = host.getDefinitionOfFunction(barNode)!;
            expect(barDef.node).toBe(barNode);
-           expect(barDef.body !.length).toEqual(1);
-           expect(ts.isReturnStatement(barDef.body ![0])).toBeTruthy();
-           expect(barDef.body ![0].getText()).toEqual(`return x + y;`);
+           expect(barDef.body!.length).toEqual(1);
+           expect(ts.isReturnStatement(barDef.body![0])).toBeTruthy();
+           expect(barDef.body![0].getText()).toEqual(`return x + y;`);
            expect(barDef.parameters.length).toEqual(2);
            expect(barDef.parameters[0].name).toEqual('x');
            expect(fooDef.parameters[0].initializer).toBe(null);
            expect(barDef.parameters[1].name).toEqual('y');
-           expect(barDef.parameters[1].initializer !.getText()).toEqual('42');
+           expect(barDef.parameters[1].initializer!.getText()).toEqual('42');
 
            const bazNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration) !;
-           const bazDef = host.getDefinitionOfFunction(bazNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration)!;
+           const bazDef = host.getDefinitionOfFunction(bazNode)!;
            expect(bazDef.node).toBe(bazNode);
-           expect(bazDef.body !.length).toEqual(3);
+           expect(bazDef.body!.length).toEqual(3);
            expect(bazDef.parameters.length).toEqual(1);
            expect(bazDef.parameters[0].name).toEqual('x');
            expect(bazDef.parameters[0].initializer).toBe(null);
 
            const quxNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration) !;
-           const quxDef = host.getDefinitionOfFunction(quxNode) !;
+               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration)!;
+           const quxDef = host.getDefinitionOfFunction(quxNode)!;
            expect(quxDef.node).toBe(quxNode);
-           expect(quxDef.body !.length).toEqual(2);
+           expect(quxDef.body!.length).toEqual(2);
            expect(quxDef.parameters.length).toEqual(1);
            expect(quxDef.parameters[0].name).toEqual('x');
            expect(quxDef.parameters[0].initializer).toBe(null);
@@ -1762,7 +1774,7 @@ runInEachFileSystem(() => {
       it('should find the import of an identifier', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
         const identifier =
@@ -1772,14 +1784,14 @@ runInEachFileSystem(() => {
             null;
 
         expect(identifier).not.toBe(null);
-        const importOfIdent = host.getImportOfIdentifier(identifier !);
+        const importOfIdent = host.getImportOfIdentifier(identifier!);
         expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
       });
 
       it('should return null if the identifier was not imported', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
@@ -1790,7 +1802,7 @@ runInEachFileSystem(() => {
       it('should handle factory functions not wrapped in parentheses', () => {
         loadTestFiles(IMPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const variableNode =
             getDeclaration(bundle.program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
         const identifier =
@@ -1800,7 +1812,7 @@ runInEachFileSystem(() => {
             null;
 
         expect(identifier).not.toBe(null);
-        const importOfIdent = host.getImportOfIdentifier(identifier !);
+        const importOfIdent = host.getImportOfIdentifier(identifier!);
         expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
       });
     });
@@ -1808,24 +1820,25 @@ runInEachFileSystem(() => {
     describe('getDeclarationOfIdentifier', () => {
       // Helpers
       const createTestForTsHelper =
-          (host: UmdReflectionHost, factoryFn: ts.FunctionExpression,
+          (host: NgccReflectionHost, factoryFn: ts.FunctionExpression,
            getHelperDeclaration: (factoryFn: ts.FunctionExpression, name: string) =>
                ts.Declaration) =>
               (varName: string, helperName: string, knownAs: KnownDeclaration,
-               viaModule: string | null = null) => {
+               viaModule: string|null = null) => {
                 const node = getVariableDeclaration(factoryFn, varName);
                 const helperIdentifier = getIdentifierFromCallExpression(node);
                 const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                 expect(helperDeclaration).toEqual({
                   known: knownAs,
-                  node: getHelperDeclaration(factoryFn, helperName), viaModule,
+                  node: getHelperDeclaration(factoryFn, helperName),
+                  viaModule,
                 });
               };
 
       const getFunctionDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
           factoryFn.body.statements.filter(ts.isFunctionDeclaration)
-              .find(decl => (decl.name !== undefined) && (decl.name.text === name)) !;
+              .find(decl => (decl.name !== undefined) && (decl.name.text === name))!;
 
       const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
         if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
@@ -1839,16 +1852,16 @@ runInEachFileSystem(() => {
       const getVariableDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
           factoryFn.body.statements.filter(ts.isVariableStatement)
               .map(stmt => stmt.declarationList.declarations[0])
-              .find(decl => ts.isIdentifier(decl.name) && (decl.name.text === name)) !;
+              .find(decl => ts.isIdentifier(decl.name) && (decl.name.text === name))!;
 
       it('should return the declaration of a locally defined identifier', () => {
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
-        const ctrDecorators = host.getConstructorParameters(classNode) !;
-        const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
+        const ctrDecorators = host.getConstructorParameters(classNode)!;
+        const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
                                                local: true,
                                                expression: ts.Identifier,
                                                defaultImportStatement: null,
@@ -1859,8 +1872,8 @@ runInEachFileSystem(() => {
             isNamedVariableDeclaration);
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe(null);
+        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+        expect(actualDeclaration!.viaModule).toBe(null);
       });
 
       it('should return the correct declaration for an outer alias identifier', () => {
@@ -1884,7 +1897,7 @@ runInEachFileSystem(() => {
 
         loadTestFiles([PROGRAM_FILE]);
         const bundle = makeTestBundleProgram(PROGRAM_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const expectedDeclaration = getDeclaration(
             bundle.program, PROGRAM_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
@@ -1895,28 +1908,29 @@ runInEachFileSystem(() => {
 
         expect(aliasIdentifier.getText()).toBe('AliasedClass_1');
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(expectedDeclaration);
+        expect(actualDeclaration!.node).toBe(expectedDeclaration);
       });
 
       it('should return the source-file of an import namespace', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles([SOME_DIRECTIVE_FILE]);
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
-        const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
-        const identifierOfDirective = (((classDecorators[0].node as ts.ObjectLiteralExpression)
-                                            .properties[0] as ts.PropertyAssignment)
-                                           .initializer as ts.PropertyAccessExpression)
-                                          .expression as ts.Identifier;
+        const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
+        const identifierOfDirective =
+            (((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as
+              ts.PropertyAssignment)
+                 .initializer as ts.PropertyAccessExpression)
+                .expression as ts.Identifier;
 
         const expectedDeclarationNode =
             getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+        expect(actualDeclaration!.viaModule).toBe('@angular/core');
       });
 
       it('should recognize TypeScript helpers (as function declarations)', () => {
@@ -1940,9 +1954,9 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0]) !;
+            getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
         const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
 
@@ -1972,9 +1986,9 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0]) !;
+            getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
         const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
 
@@ -2004,9 +2018,9 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0]) !;
+            getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
         const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
 
@@ -2036,9 +2050,9 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0]) !;
+            getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
         const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
 
@@ -2076,9 +2090,9 @@ runInEachFileSystem(() => {
 
         const [testFile, tslibFile] = files;
         const bundle = makeTestBundleProgram(testFile.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, testFile.name).statements[0]) !;
+            getSourceFileOrError(bundle.program, testFile.name).statements[0])!;
         const tslibSourceFile = getSourceFileOrError(bundle.program, tslibFile.name);
 
         const testForHelper = createTestForTsHelper(host, factoryFn, () => tslibSourceFile);
@@ -2094,12 +2108,12 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/b_module.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
               ['a', `a = 'a'`, '/a_module'],
@@ -2122,12 +2136,12 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
               ['a', `a = 'a'`, _('/b_module')],
@@ -2150,13 +2164,13 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file =
             getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
               ['a', `a = 'a'`, _('/b_module')],
@@ -2179,11 +2193,11 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles([INLINE_EXPORT_FILE]);
         const bundle = makeTestBundleProgram(INLINE_EXPORT_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, INLINE_EXPORT_FILE.name);
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        const decl = exportDeclarations !.get('directives') as InlineDeclaration;
+        const decl = exportDeclarations!.get('directives') as InlineDeclaration;
         expect(decl).not.toBeUndefined();
         expect(decl.node).toBeNull();
         expect(decl.expression).toBeDefined();
@@ -2201,9 +2215,9 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([tslib]);
         const bundle = makeTestBundleProgram(tslib.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const sf = getSourceFileOrError(bundle.program, tslib.name);
-        const exportDeclarations = host.getExportsOfModule(sf) !;
+        const exportDeclarations = host.getExportsOfModule(sf)!;
 
         expect([...exportDeclarations].map(([exportName, {known}]) => [exportName, known]))
             .toEqual([
@@ -2219,26 +2233,26 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES2015 class', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         const classSymbol = host.getClassSymbol(node);
 
         expect(classSymbol).toBeDefined();
-        expect(classSymbol !.declaration.valueDeclaration).toBe(node);
-        expect(classSymbol !.implementation.valueDeclaration).toBe(node);
+        expect(classSymbol!.declaration.valueDeclaration).toBe(node);
+        expect(classSymbol!.implementation.valueDeclaration).toBe(node);
       });
 
       it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
               ['a', `a = 'a'`, _('/b_module')],
@@ -2261,13 +2275,13 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file =
             getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
               ['a', `a = 'a'`, _('/b_module')],
@@ -2290,12 +2304,12 @@ runInEachFileSystem(() => {
         loadFakeCore(getFileSystem());
         loadTestFiles(EXPORTS_FILES);
         const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports_with_require.js'));
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations !.entries())
-                   .map(entry => [entry[0], entry[1].node !.getText(), entry[1].viaModule]))
+        expect(Array.from(exportDeclarations!.entries())
+                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
             .toEqual([
               ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
               ['a', `a = 'a'`, _('/b_module')],
@@ -2317,42 +2331,42 @@ runInEachFileSystem(() => {
       it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const outerNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+        const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
         const classSymbol = host.getClassSymbol(outerNode);
 
         expect(classSymbol).toBeDefined();
-        expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-        expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+        expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+        expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
       });
 
       it('should return the class symbol for an ES5 class (inner function declaration)', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const outerNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+        const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
         const classSymbol = host.getClassSymbol(innerNode);
 
         expect(classSymbol).toBeDefined();
-        expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-        expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+        expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+        expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
       });
 
       it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
            const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const outerNode = getDeclaration(
                bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-           const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+           const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
 
-           const innerSymbol = host.getClassSymbol(innerNode) !;
-           const outerSymbol = host.getClassSymbol(outerNode) !;
+           const innerSymbol = host.getClassSymbol(innerNode)!;
+           const outerSymbol = host.getClassSymbol(outerNode)!;
            expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
            expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
          });
@@ -2361,37 +2375,37 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
            const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const outerNode = getDeclaration(
                bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
-           const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+           const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
            const classSymbol = host.getClassSymbol(outerNode);
 
            expect(classSymbol).toBeDefined();
-           expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+           expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
          });
 
       it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
          () => {
            loadTestFiles([SIMPLE_CLASS_FILE]);
            const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const outerNode = getDeclaration(
                bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
                isNamedVariableDeclaration);
-           const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+           const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
            const classSymbol = host.getClassSymbol(outerNode);
 
            expect(classSymbol).toBeDefined();
-           expect(classSymbol !.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol !.implementation.valueDeclaration).toBe(innerNode);
+           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+           expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
          });
 
       it('should return undefined if node is not an ES5 class', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         const classSymbol = host.getClassSymbol(node);
@@ -2406,7 +2420,7 @@ runInEachFileSystem(() => {
         };
         loadTestFiles([testFile]);
         const bundle = makeTestBundleProgram(testFile.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node =
             getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
         const classSymbol = host.getClassSymbol(node);
@@ -2419,7 +2433,7 @@ runInEachFileSystem(() => {
       it('should return true if a given node is a TS class declaration', () => {
         loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
         expect(host.isClass(node)).toBe(true);
@@ -2428,7 +2442,7 @@ runInEachFileSystem(() => {
       it('should return true if a given node is the outer variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
         expect(host.isClass(node)).toBe(true);
@@ -2437,17 +2451,17 @@ runInEachFileSystem(() => {
       it('should return true if a given node is the inner variable declaration of a class', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const outerNode = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
-        const innerNode = getIifeBody(outerNode) !.statements.find(isNamedFunctionDeclaration) !;
+        const innerNode = getIifeBody(outerNode)!.statements.find(isNamedFunctionDeclaration)!;
         expect(host.isClass(innerNode)).toBe(true);
       });
 
       it('should return false if a given node is a function declaration', () => {
         loadTestFiles([FOO_FUNCTION_FILE]);
         const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const node = getDeclaration(
             bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
         expect(host.isClass(node)).toBe(false);
@@ -2463,7 +2477,7 @@ runInEachFileSystem(() => {
 
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         return host.hasBaseClass(classNode);
@@ -2510,7 +2524,7 @@ runInEachFileSystem(() => {
 
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
         const expression = host.getBaseClassExpression(classNode);
@@ -2532,7 +2546,7 @@ runInEachFileSystem(() => {
           function TestClass() {}
           return TestClass;
         }(BaseClass));`);
-        expect(identifier !.text).toBe('BaseClass');
+        expect(identifier!.text).toBe('BaseClass');
       });
 
       it('should find the base class of an IIFE with a unique name generated for the _super parameter',
@@ -2547,7 +2561,7 @@ runInEachFileSystem(() => {
           function TestClass() {}
           return TestClass;
         }(BaseClass));`);
-           expect(identifier !.text).toBe('BaseClass');
+           expect(identifier!.text).toBe('BaseClass');
          });
 
       it('should not find a base class for an IIFE without parameter', () => {
@@ -2582,10 +2596,10 @@ runInEachFileSystem(() => {
 
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode =
             getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        const expression = host.getBaseClassExpression(classNode) !;
+        const expression = host.getBaseClassExpression(classNode)!;
         expect(expression.getText()).toBe('foo()');
       });
     });
@@ -2594,7 +2608,7 @@ runInEachFileSystem(() => {
       it('should return an array of all classes in the given source file', () => {
         loadTestFiles(DECORATED_FILES);
         const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
         const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
@@ -2612,21 +2626,21 @@ runInEachFileSystem(() => {
       it('should return decorators of class symbol', () => {
         loadTestFiles(DECORATED_FILES);
         const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
         const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
 
         const classSymbolsPrimary = host.findClassSymbols(primaryFile);
         const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
         expect(classDecoratorsPrimary.length).toEqual(2);
-        expect(classDecoratorsPrimary[0] !.map(d => d.name)).toEqual(['Directive']);
-        expect(classDecoratorsPrimary[1] !.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsPrimary[0]!.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsPrimary[1]!.map(d => d.name)).toEqual(['Directive']);
 
         const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
         const classDecoratorsSecondary =
             classSymbolsSecondary.map(s => host.getDecoratorsOfSymbol(s));
         expect(classDecoratorsSecondary.length).toEqual(1);
-        expect(classDecoratorsSecondary[0] !.map(d => d.name)).toEqual(['Directive']);
+        expect(classDecoratorsSecondary[0]!.map(d => d.name)).toEqual(['Directive']);
       });
     });
 
@@ -2639,10 +2653,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
                bundle.program, _('/ep/src/class1.js'), 'Class1', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find the dts declaration for exported functions', () => {
@@ -2652,10 +2667,11 @@ runInEachFileSystem(() => {
         const dts = makeTestBundleProgram(_('/ep/typings/func1.d.ts'));
         const mooFn = getDeclaration(
             bundle.program, _('/ep/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
         const dtsDeclaration = host.getDtsDeclaration(mooFn);
-        expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
+        expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
       });
 
       it('should return null if there is no matching class in the matching dts file', () => {
@@ -2665,7 +2681,8 @@ runInEachFileSystem(() => {
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const missingClass = getDeclaration(
             bundle.program, _('/ep/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
 
@@ -2677,7 +2694,8 @@ runInEachFileSystem(() => {
         const missingClass = getDeclaration(
             bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
             ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
         expect(host.getDtsDeclaration(missingClass)).toBe(null);
       });
@@ -2690,10 +2708,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
                bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find the dts file that contains a matching class declaration, even if the source files do not match',
@@ -2704,10 +2723,11 @@ runInEachFileSystem(() => {
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
            const class1 = getDeclaration(
                bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
            const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration !.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
          });
 
       it('should find aliased exports', () => {
@@ -2717,7 +2737,8 @@ runInEachFileSystem(() => {
         const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
         const sourceClass = getDeclaration(
             bundle.program, _('/ep/src/flat-file.js'), 'SourceClass', ts.isVariableDeclaration);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+        const host =
+            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
         const dtsDeclaration = host.getDtsDeclaration(sourceClass);
         if (dtsDeclaration === null) {
@@ -2737,18 +2758,19 @@ runInEachFileSystem(() => {
            loadTestFiles(TYPINGS_DTS_FILES);
            const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
            const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
            const class2 = getDeclaration(
                bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedVariableDeclaration);
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
-           expect(class2DtsDeclaration !.getSourceFile().fileName)
+           expect(class2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/class2.d.ts'));
 
            const internalClass2 = getDeclaration(
                bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedVariableDeclaration);
            const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
-           expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
+           expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/internal.d.ts'));
          });
 
@@ -2762,14 +2784,15 @@ runInEachFileSystem(() => {
                bundle.program, _('/ep/src/class2.js'), 'Class2', ts.isVariableDeclaration);
            const internalClass2 = getDeclaration(
                bundle.program, _('/ep/src/internal.js'), 'Class2', ts.isVariableDeclaration);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle, dts);
+           const host =
+               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
 
            const class2DtsDeclaration = host.getDtsDeclaration(class2);
-           expect(class2DtsDeclaration !.getSourceFile().fileName)
+           expect(class2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/class2.d.ts'));
 
            const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
-           expect(internalClass2DtsDeclaration !.getSourceFile().fileName)
+           expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
                .toEqual(_('/ep/typings/internal.d.ts'));
          });
     });
@@ -2778,7 +2801,7 @@ runInEachFileSystem(() => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const emptyClass = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
@@ -2802,7 +2825,7 @@ runInEachFileSystem(() => {
       it('should return the name of the inner class declaration', () => {
         loadTestFiles([SIMPLE_CLASS_FILE]);
         const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const emptyClass = getDeclaration(
             bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
@@ -2827,10 +2850,10 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/functions.js'));
            const fns = host.getModuleWithProvidersFunctions(file);
-           expect(fns.map(fn => [fn.declaration.name !.getText(), fn.ngModule.node.name.text]))
+           expect(fns.map(fn => [fn.declaration.name!.getText(), fn.ngModule.node.name.text]))
                .toEqual([
                  ['ngModuleIdentifier', 'InternalModule'],
                  ['ngModuleWithEmptyProviders', 'InternalModule'],
@@ -2843,7 +2866,7 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/methods.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
@@ -2870,7 +2893,7 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/outer_aliased_class.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([
@@ -2883,7 +2906,7 @@ runInEachFileSystem(() => {
          () => {
            loadTestFiles(MODULE_WITH_PROVIDERS_PROGRAM);
            const bundle = makeTestBundleProgram(getRootFiles(MODULE_WITH_PROVIDERS_PROGRAM)[0]);
-           const host = new UmdReflectionHost(new MockLogger(), false, bundle);
+           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const file = getSourceFileOrError(bundle.program, _('/src/inner_aliased_class.js'));
            const fn = host.getModuleWithProvidersFunctions(file);
            expect(fn.map(fn => [fn.declaration.getText(), fn.ngModule.node.name.text])).toEqual([


### PR DESCRIPTION
The `NgccReflectionHost`'s have logic for detecting certain known declarations (such as `Object.assign()` and TypeScript helpers), which allows the `PartialEvaluator` to evaluate expressions it would not be able to evaluate otherwise.

In #36089, `DelegatingReflectionHost` was introduced, which delegates to a TypeScript `ReflectionptHost` when reflecting on TypeScript files, which for ngcc's case means `.d.ts` files of dependencies. As a result, ngcc lost the ability to detect imported TypeScript helpers from `tslib`, because `DelegatingReflectionHost` was not able to apply the known declaration detection logic while reflecting on `tslib`'s `.d.ts` files.

This commit fixes this by ensuring `DelegatingReflectionHost` calls the `NgccReflectionHost`'s `addKnownDeclaration()` method as necessary, even when using the TypeScript `ReflectionHost`.

##
This is needed for angular/ngcc-validation#1029.
