### PR TITLE
refactor(dev-infra): fix lint warnings for Pullapprove-related scripts

### DIFF
--- a/dev-infra/pullapprove/group.ts
+++ b/dev-infra/pullapprove/group.ts
@@ -72,13 +72,17 @@ export class PullApproveGroup {
       } else if (condition.match(CONDITION_TYPES.ATTR_LENGTH)) {
         // Currently a noop as we do not take any action on this condition type.
       } else {
-        const errMessage = `Unrecognized condition found, unable to parse the following condition: \n\n` +
-        `From the [${groupName}] group:\n` +
-        ` - ${condition}` +
-        `\n\n` +
-        `Known condition regexs:\n` + 
-        `${Object.entries(CONDITION_TYPES).map(([k, v]) => `  ${k}  -  ${v}`).join('\n')}` +
-        `\n\n`;
+        const errMessage =
+            `Unrecognized condition found, unable to parse the following condition: \n\n` +
+            `From the [${groupName}] group:\n` +
+            ` - ${condition}` +
+            `\n\n` +
+            `Known condition regexs:\n` +
+            `${Object.entries(CONDITION_TYPES).map(([k, v]) => ` ${k} - $ {
+          v
+        }
+        `).join('\n')}` +
+            `\n\n`;
         console.error(errMessage);
         process.exit(1);
       }

--- a/dev-infra/pullapprove/verify.ts
+++ b/dev-infra/pullapprove/verify.ts
@@ -9,10 +9,11 @@ import {readFileSync} from 'fs';
 import * as path from 'path';
 import {cd, exec, set} from 'shelljs';
 
+import {getRepoBaseDir} from '../utils/config';
+
 import {PullApproveGroup} from './group';
 import {logGroup, logHeader} from './logging';
 import {parsePullApproveYaml} from './parse-yaml';
-import {getRepoBaseDir} from '../utils/config';
 
 export function verify() {
   // Exit early on shelljs errors


### PR DESCRIPTION
The `dev-infra` scripts were added to the list of sources that should be verified with clang (https://github.com/angular/angular/commit/b07b6edc2a71346491b2a7827cc3b30faa110397), but the Pullapprove-related scripts that were merged before (https://github.com/angular/angular/commit/83e4a76afa273f9af8f75947ad0c99f98e04c83a) don't pass these checks. This commit updates a couple scripts to have proper formatting.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No