### PR TITLE
fix(zone.js): fix 2 bluebird test cases for each/mapSeries

### DIFF
--- a/packages/zone.js/test/extra/bluebird.spec.ts
+++ b/packages/zone.js/test/extra/bluebird.spec.ts
@@ -283,8 +283,8 @@ describe('bluebird promise', () => {
       BluebirdPromise
           .each(
               BluebirdPromise.map(arr, (item: number) => BluebirdPromise.resolve(item)),
-              (r: number[], idx: number) => {
-                expect(r[idx] === arr[idx]);
+              (r: number, idx: number) => {
+                expect(r).toBe(arr[idx]);
                 expect(Zone.current.name).toEqual('bluebird');
               })
           .then((r: any) => {
@@ -304,8 +304,8 @@ describe('bluebird promise', () => {
       BluebirdPromise
           .mapSeries(
               BluebirdPromise.map(arr, (item: number) => BluebirdPromise.resolve(item)),
-              (r: number[], idx: number) => {
-                expect(r[idx] === arr[idx]);
+              (r: number, idx: number) => {
+                expect(r).toBe(arr[idx]);
                 expect(Zone.current.name).toEqual('bluebird');
               })
           .then((r: any) => {


### PR DESCRIPTION
`Bluebird.each` and `Bluebird.mapSeries` will accept a callback with `value` parameter,
the `value` should be the item in the array, not array itself.

For example:
```
const arr = [1, 2];
Bluebird.each(arr, function(value, idx) {
  console.log(`value: ${value}, idx: ${idx}`);
})
```

the output will be
```
value: 1, idx: 0
value: 2, idx: 1
```

This PR fix the test cases for `each` and `mapSeries` APIs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
